### PR TITLE
build(): faster builds by using the diff TS broccoli.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,18 +5,18 @@ var path = require('path');
 require('ts-node/register');
 
 var mergeTrees = require('broccoli-merge-trees');
-var Angular2App = require('angular-cli/lib/broccoli/angular2-app');
+var BroccoliTypescript = require('./tools/broccoli/broccoli-typescript').default;
 var BroccoliSass = require('broccoli-sass');
 var broccoliAutoprefixer = require('broccoli-autoprefixer');
 var BroccoliTs2Dart = require('./tools/broccoli/broccoli-ts2dart').default;
+var Funnel = require('broccoli-funnel');
 
 var autoprefixerOptions = require('./build/autoprefixer-options');
 
 module.exports = function(defaults) {
-  var demoAppCssTree = new BroccoliSass(['src/demo-app'], './demo-app.scss', 'demo-app/demo-app.css');
-  var demoCssTree = getCssTree('demo-app');
-  var componentCssTree = getCssTree('components');
-  var angularAppTree = new Angular2App(defaults);
+  var cssTree = getCssTree('src');
+
+  var tsAppTree = getAppTree('src/');
   var dartAppTree = new BroccoliTs2Dart('src/', {
     generateLibraryName: true,
     generateSourceMap: false,
@@ -24,34 +24,87 @@ module.exports = function(defaults) {
   });
 
   return mergeTrees([
-    angularAppTree.toTree(),
-    componentCssTree,
-    demoAppCssTree,
-    demoCssTree,
+    tsAppTree,
+    cssTree,
     dartAppTree,
   ]);
 };
 
+/**
+ * Get the tree for all TypeScript sources.
+ */
+function getAppTree(folder) {
+  var options = JSON.parse(fs.readFileSync(path.join(folder, 'tsconfig.json'), 'utf-8'))
+                    .compilerOptions;
+  var tsTree = new BroccoliTypescript(folder, options);
+  var tsSrcTree = new Funnel(folder, {
+    include: ['**/*.ts'],
+    allowEmpty: true
+  });
+
+  var jsTree = new Funnel(folder, {
+    include: ['**/*.js'],
+    allowEmpty: true
+  });
+
+  var assetTree = new Funnel(folder, {
+    include: ['**/*.*'],
+    exclude: ['**/*.ts', '**/*.js', 'src/tsconfig.json'],
+    allowEmpty: true
+  });
+
+  var vendorJsTree = new Funnel('node_modules', {
+    files: [
+      'angular2/bundles/angular2-polyfills.js',
+      'angular2/bundles/angular2.dev.js',
+      'angular2/bundles/http.dev.js',
+      'angular2/bundles/router.dev.js',
+      'angular2/bundles/upgrade.dev.js',
+      'rxjs/bundles/Rx.js',
+      'systemjs/dist/system.src.js',
+      'systemjs/dist/system-polyfills.src.js'
+    ],
+    destDir: 'vendor'
+  });
+
+  return mergeTrees([assetTree, tsSrcTree, tsTree, jsTree, vendorJsTree], { overwrite: true });
+}
+
+
+
+/** Walk a directory and return a list of file names. */
+function walk(dir) {
+  const dirs = fs.readdirSync(dir)
+      .filter(file => fs.statSync(path.join(dir, file)).isDirectory());
+  if (!dirs.length) {
+    return [dir];
+  }
+
+  return dirs.reduce((previous, current) => {
+      return previous.concat(walk(path.join(dir, current)));
+  }, [dir]);
+}
+
+
+
 /** Gets the tree for all of the components' CSS. */
-function getCssTree(folder) {
-  var srcPath = `src/${folder}/`;
-  var components = fs.readdirSync(srcPath)
-    .filter(file => fs.statSync(path.join(srcPath, file)).isDirectory());
+function getCssTree(root) {
+  const trees = walk(root)
+      .reduce((previous, current) => {
+        const dir = current.startsWith(root) ? current.substr(root.length) : current;
+        const scssFiles = fs.readdirSync(current)
+            .filter(file => path.extname(file) === '.scss')
+            .map(file => path.basename(file, '.scss'));
 
-  var componentCssTrees = components.reduce((trees, component) => {
-    // We want each individual scss file to be compiled into a corresponding css file
-    // so that they can be individually included in styleUrls.
-    var scssFiles = fs.readdirSync(path.join(srcPath, component))
-        .filter(file => path.extname(file) === '.scss')
-        .map(file => path.basename(file, '.scss'));
-
-    return scssFiles.map(fileName => {
-      return BroccoliSass(
-          [`${srcPath}/${component}`, 'src/core/style'], // Directories w/ scss sources
-          `./${fileName}.scss`,                              // Root scss input file
-          `${folder}/${component}/${fileName}.css`);        // Css output file
-    }).concat(trees);
+        return scssFiles.map(filename => {
+          return new BroccoliSass(
+            [current, 'src/core/style'],
+            path.join('.', filename + '.scss'),
+            path.join(dir, filename + '.css')
+          );
+        }).concat(previous);
   }, []);
-  return broccoliAutoprefixer(mergeTrees(componentCssTrees), autoprefixerOptions);
+
+  return broccoliAutoprefixer(mergeTrees(trees), autoprefixerOptions);
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "angular2": "2.0.0-beta.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
+    "fs-extra": "^0.26.5",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "systemjs": "0.19.4",


### PR DESCRIPTION
Broccoli itself isn't properly checking diffs and as such takes a long
time to rebuild the app. Angular built a diffing broccoli wrapper that
does that effectively.

With this PR now the slowest tree is the TS2Dart one.

## Before this change:

Hot start:

| Slowest Trees                                 | Total
|----------------------------------------------|---------------------|
|DiffingTSCompiler                             | 1605ms|
|TSToDartTranspiler                            | 855ms|
|  SassCompiler                                  | 311ms
|    SassCompiler                                  | 293ms
----
Refresh:

| Slowest Trees                                 | Total
|----------------------------------------------|---------------------
|DiffingTSCompiler                             | 1169ms
|TSToDartTranspiler                            | 832ms

----
## With the new instances

Hot start:

|Slowest Trees                                 | Total
|----------------------------------------------|---------------------
|TSToDartTranspiler                            | 692ms
|DiffingTSCompiler                             | 684ms
|AutoprefixerFilter                            | 90ms

----
Refresh:

| Slowest Trees                                 | Total
|----------------------------------------------|---------------------
|TSToDartTranspiler                            | 526ms
|DiffingTSCompiler                             | 61ms