### PR TITLE
chore(): change all components to onPush detection

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,4 +1,4 @@
-import {Component, View, ViewEncapsulation, Input, Attribute, HostBinding, HostListener} from 'angular2/core';
+import {Component, ViewEncapsulation, Input, HostBinding, HostListener, ChangeDetectionStrategy} from 'angular2/core';
 
 // TODO(jelbourn): Ink ripples.
 // TODO(jelbourn): Make the `isMouseDown` stuff done with one global listener.
@@ -17,7 +17,8 @@ import {Component, View, ViewEncapsulation, Input, Attribute, HostBinding, HostL
   },
   templateUrl: './components/button/button.html',
   styleUrls: ['./components/button/button.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdButton {
   color: string;

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -1,4 +1,4 @@
-import {Component, View, ViewEncapsulation} from 'angular2/core';
+import {Component, ViewEncapsulation, ChangeDetectionStrategy} from 'angular2/core';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
 
 /*
@@ -23,7 +23,8 @@ While you can use this component alone, it also provides a number of preset styl
   selector: 'md-card',
   templateUrl: './components/card/card.html',
   styleUrls: ['./components/card/card.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdCard {}
 
@@ -44,7 +45,8 @@ TODO(kara): update link to demo site when it exists
 @Component({
   selector: 'md-card-header',
   templateUrl: '/components/card/card-header.html',
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdCardHeader {}
 
@@ -62,7 +64,8 @@ TODO(kara): update link to demo site when it exists
 @Component({
   selector: 'md-card-title-group',
   templateUrl: './components/card/card-title-group.html',
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdCardTitleGroup {}
 

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -8,15 +8,11 @@ import {
   HostBinding,
   HostListener,
   Input,
-  View,
-  ViewEncapsulation,
-  OnChanges,
   Optional,
   Output,
-  Query,
   QueryList,
-  SimpleChange,
-  Type
+  Type,
+  ChangeDetectionStrategy
 } from 'angular2/core';
 import {PromiseWrapper} from 'angular2/src/facade/promise';
 import {BaseException} from 'angular2/src/facade/exceptions';
@@ -50,6 +46,7 @@ export class MdDuplicatedSidenavException extends BaseException {
 @Component({
   selector: 'md-sidenav',
   template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdSidenav {
   /** Alignment of the sidenav (direction neutral); whether 'start' or 'end'. */
@@ -250,6 +247,7 @@ export class MdSidenav {
   directives: [MdSidenav],
   templateUrl: './components/sidenav/sidenav.html',
   styleUrls: ['./components/sidenav/sidenav.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdSidenavLayout implements AfterContentInit {
   @ContentChildren(MdSidenav) private sidenavs_: QueryList<MdSidenav>;


### PR DESCRIPTION
R: @hansl @kara 
CC: @robertmesserle 

This is something I'd forgot to mention earlier. The general idea here is that the `onPush` strategy tells Angular to only check the component and its view children when either one of its `@Input` properties change or when an event is handled. For components that only bind either primitives or immutable objects, this should "just work" and speed up change detection. As far as I can tell, all of the components so far just bind primitives (or nothing at all, for cards).