### PR TITLE
feat(text-field): text-field creation (no styles)

### DIFF
--- a/src/components/text-field/text-field.html
+++ b/src/components/text-field/text-field.html
@@ -1,0 +1,2 @@
+<label [attr.for]="domId"><ng-content></ng-content></label>
+<input id="{{domId}}" type="text"/>

--- a/src/components/text-field/text-field.spec.ts
+++ b/src/components/text-field/text-field.spec.ts
@@ -1,0 +1,145 @@
+import {
+  inject,
+  injectAsync,
+  ComponentFixture,
+  TestComponentBuilder,
+  beforeEachProviders,
+} from 'angular2/testing';
+import {
+  it,
+  iit,
+  describe,
+  ddescribe,
+  expect,
+  beforeEach,
+} from '../../core/facade/testing';
+import {provide, Component, DebugElement} from 'angular2/core';
+import {By} from 'angular2/platform/browser';
+
+import {MdTextField} from './text-field';
+import {AsyncTestFn, FunctionWithParamTokens} from 'angular2/testing';
+
+export function main() {
+  describe('MdTextField', () => {
+    // let builder: TestComponentBuilder;
+    //
+    // beforeEach(inject([TestComponentBuilder], (tcb:TestComponentBuilder) => {
+    //   builder = tcb;
+    // }));
+    //
+    // // General button tests
+    // it('should apply class based on color attribute', (done:() => void) => {
+    //   return builder.createAsync(TestApp).then((fixture) => {
+    //     let testComponent = fixture.debugElement.componentInstance;
+    //     let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+    //     let aDebugElement = fixture.debugElement.query(By.css('a'));
+    //
+    //     testComponent.buttonColor = 'primary';
+    //     fixture.detectChanges();
+    //     expect(buttonDebugElement.nativeElement.classList.contains('md-primary')).toBe(true);
+    //     expect(aDebugElement.nativeElement.classList.contains('md-primary')).toBe(true);
+    //
+    //     testComponent.buttonColor = 'accent';
+    //     fixture.detectChanges();
+    //     expect(buttonDebugElement.nativeElement.classList.contains('md-accent')).toBe(true);
+    //     expect(aDebugElement.nativeElement.classList.contains('md-accent')).toBe(true);
+    //     done();
+    //   });
+    // });
+    //
+    // // Regular button tests
+    // describe('button[md-button]', () => {
+    //   it('should handle a click on the button', (done:() => void) => {
+    //     return builder.createAsync(TestApp).then((fixture) => {
+    //       let testComponent = fixture.debugElement.componentInstance;
+    //       let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+    //
+    //       buttonDebugElement.nativeElement.click();
+    //       expect(testComponent.clickCount).toBe(1);
+    //       done();
+    //     });
+    //   });
+    //
+    //   it('should not increment if disabled', (done:() => void) => {
+    //     return builder.createAsync(TestApp).then((fixture) => {
+    //       let testComponent = fixture.debugElement.componentInstance;
+    //       let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+    //
+    //       testComponent.isDisabled = true;
+    //       fixture.detectChanges();
+    //
+    //       buttonDebugElement.nativeElement.click();
+    //
+    //       expect(testComponent.clickCount).toBe(0);
+    //       done();
+    //     });
+    //   });
+    //
+    // });
+    //
+    // // Anchor button tests
+    // describe('a[md-button]', () => {
+    //   it('should not redirect if disabled',(done:() => void)=>{
+    //     return builder.createAsync(TestApp).then((fixture) => {
+    //       let testComponent = fixture.debugElement.componentInstance;
+    //       let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+    //
+    //       testComponent.isDisabled = true;
+    //       fixture.detectChanges();
+    //
+    //       buttonDebugElement.nativeElement.click();
+    //       // will error if page reloads
+    //       done();
+    //     });
+    //   });
+    //
+    //   it('should remove tabindex if disabled', (done:() => void) => {
+    //     return builder.createAsync(TestApp).then((fixture) => {
+    //       let testComponent = fixture.debugElement.componentInstance;
+    //       let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+    //       expect(buttonDebugElement.nativeElement.getAttribute('tabIndex')).toBe(null);
+    //
+    //       testComponent.isDisabled = true;
+    //       fixture.detectChanges();
+    //       expect(buttonDebugElement.nativeElement.getAttribute('tabIndex')).toBe('-1');
+    //       done();
+    //     });
+    //   });
+    //
+    //   it('should add aria-disabled attribute if disabled', (done:() => void) => {
+    //     return builder.createAsync(TestApp).then((fixture) => {
+    //       let testComponent = fixture.debugElement.componentInstance;
+    //       let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+    //       fixture.detectChanges();
+    //       expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled')).toBe('false');
+    //
+    //       testComponent.isDisabled = true;
+    //       fixture.detectChanges();
+    //       expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled')).toBe('true');
+    //       done();
+    //     });
+    //   });
+    //
+    // });
+  });
+}
+
+/** Shortcut function to use instead of `injectAsync` for less boilerplate on each `it`. */
+function testAsync(fn: Function): FunctionWithParamTokens {
+  return injectAsync([], fn);
+}
+
+/** Test component that contains an MdButton. */
+@Component({
+  selector: 'test-app',
+  template: `
+    <div md-text-field>
+      Go
+    </div>
+  `,
+  directives: [MdTextField]
+})
+class TestApp {
+}
+
+

--- a/src/components/text-field/text-field.ts
+++ b/src/components/text-field/text-field.ts
@@ -1,0 +1,54 @@
+import {
+  Component,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+} from 'angular2/core';
+
+@Component({
+  selector: '[md-text-field], [md-text-field-floating-label]',
+  inputs: ['color'],
+  host: {
+    '[class.md-textfield-focus]': 'isKeyboardFocused',
+    '[class]': 'setClassList()',
+    '(focus)': 'setKeyboardFocus()',
+    '(blur)': 'removeKeyboardFocus()'
+  },
+  templateUrl: './components/text-field/text-field.html',
+  styleUrls: ['./components/text-field/text-field.css'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MdTextField {
+  color: string;
+  private domId: string;
+
+  constructor() {
+    this.domId = this.uuid();
+  }
+
+  /** Whether the button has focus from the keyboard (not the mouse). Used for class binding. */
+  isKeyboardFocused: boolean = false;
+
+  setClassList() {
+    return `md-${this.color}`;
+  }
+
+  setKeyboardFocus($event: any) {
+    this.isKeyboardFocused = true;
+  }
+
+  removeKeyboardFocus() {
+    this.isKeyboardFocused = false;
+  }
+
+  s4(): string {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+
+  uuid(): string {
+    return this.s4() + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' +
+      this.s4() + '-' + this.s4() + this.s4() + this.s4();
+  }
+}

--- a/src/demo-app/demo-app.html
+++ b/src/demo-app/demo-app.html
@@ -5,6 +5,7 @@
   <li><a [routerLink]="['CardDemo']">Card demo</a></li>
   <li><a [routerLink]="['SidenavDemo']">Sidenav demo</a></li>
   <li><a [routerLink]="['ProgressCircleDemo']">Progress Circle demo</a></li>
+  <li><a [routerLink]="['TextFieldDemo']">Text Field demo</a></li>
 </ul>
 <button md-raised-button (click)="root.dir = (root.dir == 'rtl' ? 'ltr' : 'rtl')">
   {{root.dir.toUpperCase()}}

--- a/src/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app.ts
@@ -3,6 +3,7 @@ import {CardDemo} from './card/card-demo';
 import {ButtonDemo} from './button/button-demo';
 import {SidenavDemo} from './sidenav/sidenav-demo';
 import {ProgressCircleDemo} from './progress-circle/progress-circle-demo';
+import {TextFieldDemo} from './text-field/text-field-demo';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 import {Dir} from '../directives/dir/dir';
 import {MdButton} from '../components/button/button';
@@ -27,5 +28,6 @@ export class Home {}
   {path: '/card', name: 'CardDemo', component: CardDemo},
   {path: '/sidenav', name: 'SidenavDemo', component: SidenavDemo},
   {path: '/progress-circle', name: 'ProgressCircleDemo', component: ProgressCircleDemo},
+  {path: '/text-field', name: 'TextFieldDemo', component: TextFieldDemo},
 ])
 export class DemoApp { }

--- a/src/demo-app/text-field/text-field-demo.html
+++ b/src/demo-app/text-field/text-field-demo.html
@@ -1,0 +1,3 @@
+<section>
+    <div md-text-field>Some label</div>
+</section>

--- a/src/demo-app/text-field/text-field-demo.scss
+++ b/src/demo-app/text-field/text-field-demo.scss
@@ -1,0 +1,5 @@
+section {
+  background-color: #f7f7f7;
+  margin: 8px;
+}
+

--- a/src/demo-app/text-field/text-field-demo.ts
+++ b/src/demo-app/text-field/text-field-demo.ts
@@ -1,0 +1,12 @@
+import {Component} from 'angular2/core';
+import {MdTextField} from '../../components/text-field/text-field';
+
+@Component({
+    selector: 'text-field-demo',
+    templateUrl: 'demo-app/text-field/text-field-demo.html',
+    styleUrls: ['demo-app/text-field/text-field-demo.css'],
+    directives: [MdTextField]
+})
+export class TextFieldDemo {
+
+}


### PR DESCRIPTION
Hi, I had a mind to try and contribute to material2

This PR is nowhere near ready but I was wondering if you were interested.

If so I have a few of questions
* I had based myself on the md-button attribute directive, but I think in this case I should do something more like the md-card component. Agreed?
* for text-field, you need label and input to be linked by their id. I propose to use a uuid. any thoughts?
* I have had problems with the ts2dart transpiler. for uuid, I originally used the full code of angular2-uuid. But it was using `typeof` that does not seem supported. Any comment on that. Do you find that's a blocker sometimes?
* I had originally put the uuid code in a separate helper class/file. the ts2dart compiler complained of syntax issues where it generated some `library 'folder_name'; class uuid` kind of syntax (I know nothing about dart). Does that ring a bell? Was I doing something wrong?

That's all for a first pass :)

Remark: the jasmine tests don't seem to pass on a fresh check-out of the code. Some sidenav tests are failing