### PR TITLE
fix(): remove all async/waiting from the sidenav specs.

### DIFF
--- a/src/components/sidenav/sidenav-transitions.scss
+++ b/src/components/sidenav/sidenav-transitions.scss
@@ -1,0 +1,27 @@
+/**
+ * We separate transitions to be able to disable them in unit tests, by simply not loading this file.
+ */
+@import "variables";
+
+
+:host {
+  transition: margin-left $swift-ease-out-duration $swift-ease-out-timing-function,
+              margin-right $swift-ease-out-duration $swift-ease-out-timing-function;
+
+  & > .md-sidenav-backdrop {
+    &.md-sidenav-shown {
+      transition: background-color $swift-ease-out-duration $swift-ease-out-timing-function;
+    }
+  }
+
+  & > md-content {
+    transition: margin-left $swift-ease-out-duration $swift-ease-out-timing-function,
+                margin-right $swift-ease-out-duration $swift-ease-out-timing-function,
+                left $swift-ease-out-duration $swift-ease-out-timing-function,
+                right $swift-ease-out-duration $swift-ease-out-timing-function;
+  }
+
+  > md-sidenav {
+    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
+  }
+}

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -58,9 +58,6 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
   // Hide the sidenavs when they're closed.
   overflow-x: hidden;
 
-  transition: margin-left $swift-ease-out-duration $swift-ease-out-timing-function,
-              margin-right $swift-ease-out-duration $swift-ease-out-timing-function;
-
   & > .md-sidenav-backdrop {
     position: absolute;
     top: 0;
@@ -83,7 +80,6 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
     &.md-sidenav-shown {
       visibility: visible;
       background-color: $md-sidenav-backdrop-color;
-      transition: background-color $swift-ease-out-duration $swift-ease-out-timing-function;
     }
   }
 
@@ -91,10 +87,6 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
     @include md-stacking-context();
 
     display: block;
-    transition: margin-left $swift-ease-out-duration $swift-ease-out-timing-function,
-                margin-right $swift-ease-out-duration $swift-ease-out-timing-function,
-                left $swift-ease-out-duration $swift-ease-out-timing-function,
-                right $swift-ease-out-duration $swift-ease-out-timing-function;
   }
 
   > md-sidenav {
@@ -107,8 +99,6 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
     z-index: 3;
 
     background-color: $md-sidenav-background-color;
-
-    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 
     @include md-sidenav-transition(0, -100%);
 

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -11,6 +11,7 @@ import {
   Output,
   QueryList,
   Type,
+  View,
   ChangeDetectionStrategy
 } from 'angular2/core';
 import {PromiseWrapper, ObservableWrapper, EventEmitter} from 'angular2/src/facade/async';
@@ -155,7 +156,7 @@ export class MdSidenav {
    * @param e The event.
    * @private
    */
-  @HostListener('transitionend', ['$event']) private onTransitionEnd_(e: any) {
+  @HostListener('transitionend', ['$event']) onTransitionEnd(e: any) {
     if (e.target == this.elementRef_.nativeElement
         // Simpler version to check for prefixes.
         && e.propertyName.endsWith('transform')) {
@@ -241,12 +242,17 @@ export class MdSidenav {
  */
 @Component({
   selector: 'md-sidenav-layout',
-  directives: [MdSidenav],
-  templateUrl: './components/sidenav/sidenav.html',
-  styleUrls: ['./components/sidenav/sidenav.css'],
   // Do not use ChangeDetectionStrategy.OnPush. It does not work for this component because
   // technically it is a sibling of MdSidenav (on the content tree) and isn't updated when MdSidenav
   // changes its state.
+})
+@View({
+  directives: [MdSidenav],
+  templateUrl: './components/sidenav/sidenav.html',
+  styleUrls: [
+    './components/sidenav/sidenav.css',
+    './components/sidenav/sidenav-transitions.css',
+  ],
 })
 export class MdSidenavLayout implements AfterContentInit {
   @ContentChildren(MdSidenav) private sidenavs_: QueryList<MdSidenav>;
@@ -269,10 +275,10 @@ export class MdSidenavLayout implements AfterContentInit {
   }
 
 
-
   /** The sidenav at the start/end alignment, independent of direction. */
   private start_: MdSidenav;
   private end_: MdSidenav;
+
   /**
    * The sidenav at the left/right. When direction changes, these will change as well.
    * They're used as aliases for the above to set the left/right style properly.

--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -27,7 +27,7 @@ export type AliasMap = { [name: string]: string[] };
 const configuration: { [name: string]: ConfigurationInfo } = {
   'Chrome':       { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Firefox':      { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'ChromeBeta':   { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'ChromeBeta':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'FirefoxBeta':  { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'ChromeDev':    { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},
   'FirefoxDev':   { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},


### PR DESCRIPTION
We have to separate transitions from sidenav because we don't actually remove the hook listener and as such `onTransitionEnd_` _could_ get called from the browser. There's a bunch of override methods missing from the Angular testing, and we can't wait on their implementation.

This will become moot with `ngAnimate`, so I think it's fine.