### PR TITLE
chore(): remove duplicate cache declaration in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ sudo: false
 node_js:
   - '4.2.3'
 
-cache:
-  directories:
-    - $HOME/.pub-cache
-
 env:
   global:
   - LOGS_DIR=/tmp/angular-material2-build/logs


### PR DESCRIPTION
The `.travis.yml` is currently containg two cache sections, but there is only need of one.

So I removed the unnecessary section and kept the second.

```yml
 cache:
   directories:
     - node_modules
     - $HOME/.pub-cache
```