### PR TITLE
build(coverage): enable dev js code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "ng build",
     "dartanalyzer": "cd dist/dart && pub install && cd ../.. && ts-node scripts/ci/dart_analyzer",
     "demo-app": "cd src && ng serve",
+    "reinstall": "git clean -dfx -e '.*'",
     "test": "karma start test/karma.conf.js",
     "tslint" : "tslint -c tslint.json 'src/**/*.ts'",
     "typings": "typings install --ambient"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma": "^0.13.15",
     "karma-browserstack-launcher": "^0.1.7",
     "karma-chrome-launcher": "^0.2.1",
+    "karma-coverage": "^0.5.5",
     "karma-dart": "^0.3.0",
     "karma-firefox-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.6",

--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -13,6 +13,7 @@ export function config(config) {
     frameworks: ['jasmine'],
     plugins: [
       require('karma-jasmine'),
+      require('karma-coverage'),
       require('karma-browserstack-launcher'),
       require('karma-sauce-launcher'),
       require('karma-chrome-launcher'),
@@ -57,12 +58,23 @@ export function config(config) {
     customLaunchers: customLaunchers,
 
     exclude: [],
-    preprocessors: {},
-    reporters: ['dots'],
+    preprocessors: {
+      'dist/**/!(*spec).js': ['coverage']
+    }
+    reporters: ['dots', 'coverage'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+
+    coverageReporter: {
+      dir: 'coverage/',
+      reporters: [
+        { type: 'text-summary' },
+        { type: 'json', subdir: '.', file: 'coverage-final.json' },
+        { type: 'html' }
+      ]
+    },
 
     sauceLabs: {
       testName: 'material2',
@@ -89,7 +101,7 @@ export function config(config) {
     browserNoActivityTimeout: 100000,
     browsers: ['Chrome'],
 
-    singleRun: false
+    singleRun: true
   });
 
   if (process.env['TRAVIS']) {


### PR DESCRIPTION
Phase 1 of #128 - JavaScript coverage for local development
  
Adds the following npm devDependencies
    - karma-coverage
    - rimraf
  Adds the following npm scripts both convienence items
    - postinstall: installs typings & runs npm prune
    - reinstall: cleans cache, generated content, node_modules & runs reinstall
  Enables JavaScript coverage reporting with multiple outputs
    - Reports code coverage at the commandline
    - Generates an HTML coverage report
    - Generates a coverage.json for future coverage history