### PR TITLE
chore(): move `dir` directive to core

### DIFF
--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -18,7 +18,7 @@ import {PromiseWrapper, ObservableWrapper, EventEmitter} from 'angular2/src/faca
 import {iterateListLike} from 'angular2/src/facade/collection';
 import {BaseException} from 'angular2/src/facade/exceptions';
 import {CONST_EXPR, isPresent} from 'angular2/src/facade/lang';
-import {Dir} from '../../directives/dir/dir';
+import {Dir} from '../../core/rtl/dir';
 import {OneOf} from '../../core/annotations/one-of';
 
 

--- a/src/core/rtl/dir.ts
+++ b/src/core/rtl/dir.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from 'angular2/src/facade/async';
 import {Directive, HostBinding, Output, Input} from 'angular2/core';
-import {OneOf} from '../../core/annotations/one-of';
+import {OneOf} from '../annotations/one-of';
 
 
 /**

--- a/src/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app.ts
@@ -5,7 +5,7 @@ import {ButtonDemo} from './button/button-demo';
 import {SidenavDemo} from './sidenav/sidenav-demo';
 import {ProgressCircleDemo} from './progress-circle/progress-circle-demo';
 import {CheckboxDemo} from './checkbox/checkbox-demo';
-import {Dir} from '../directives/dir/dir';
+import {Dir} from '../core/rtl/dir';
 import {MdButton} from '../components/button/button';
 import {PortalDemo} from './portal/portal-demo';
 

--- a/src/index.html
+++ b/src/index.html
@@ -30,10 +30,6 @@
           format: 'register',
           defaultExtension: 'js'
         },
-        'directives': {
-          format: 'register',
-          defaultExtension: 'js'
-        },
         'core': {
           format: 'register',
           defaultExtension: 'js'


### PR DESCRIPTION
R: @hansl 

Move the `dir` directive under `core/` so that our releases are only concerned with `core/` and `components/`.