### PR TITLE
feat(portal): add DomPortalHost

### DIFF
--- a/src/core/platform/browser/browser_adapter.dart
+++ b/src/core/platform/browser/browser_adapter.dart
@@ -1,0 +1,536 @@
+library angular.core.facade.dom;
+
+import 'dart:html';
+import 'package:angular2/platform/common_dom.dart' show setRootDomAdapter;
+import 'generic_browser_adapter.dart' show GenericBrowserDomAdapter;
+import 'package:angular2/src/facade/browser.dart';
+import 'package:angular2/src/facade/lang.dart' show isBlank, isPresent;
+import 'dart:js' as js;
+
+// WARNING: Do not expose outside this class. Parsing HTML using this
+// sanitizer is a security risk.
+class _IdentitySanitizer implements NodeTreeSanitizer {
+  void sanitizeTree(Node node) {}
+}
+
+final _identitySanitizer = new _IdentitySanitizer();
+
+final _keyCodeToKeyMap = const {
+  8: 'Backspace',
+  9: 'Tab',
+  12: 'Clear',
+  13: 'Enter',
+  16: 'Shift',
+  17: 'Control',
+  18: 'Alt',
+  19: 'Pause',
+  20: 'CapsLock',
+  27: 'Escape',
+  32: ' ',
+  33: 'PageUp',
+  34: 'PageDown',
+  35: 'End',
+  36: 'Home',
+  37: 'ArrowLeft',
+  38: 'ArrowUp',
+  39: 'ArrowRight',
+  40: 'ArrowDown',
+  45: 'Insert',
+  46: 'Delete',
+  65: 'a',
+  66: 'b',
+  67: 'c',
+  68: 'd',
+  69: 'e',
+  70: 'f',
+  71: 'g',
+  72: 'h',
+  73: 'i',
+  74: 'j',
+  75: 'k',
+  76: 'l',
+  77: 'm',
+  78: 'n',
+  79: 'o',
+  80: 'p',
+  81: 'q',
+  82: 'r',
+  83: 's',
+  84: 't',
+  85: 'u',
+  86: 'v',
+  87: 'w',
+  88: 'x',
+  89: 'y',
+  90: 'z',
+  91: 'OS',
+  93: 'ContextMenu',
+  96: '0',
+  97: '1',
+  98: '2',
+  99: '3',
+  100: '4',
+  101: '5',
+  102: '6',
+  103: '7',
+  104: '8',
+  105: '9',
+  106: '*',
+  107: '+',
+  109: '-',
+  110: '.',
+  111: '/',
+  112: 'F1',
+  113: 'F2',
+  114: 'F3',
+  115: 'F4',
+  116: 'F5',
+  117: 'F6',
+  118: 'F7',
+  119: 'F8',
+  120: 'F9',
+  121: 'F10',
+  122: 'F11',
+  123: 'F12',
+  144: 'NumLock',
+  145: 'ScrollLock'
+};
+
+final bool _supportsTemplateElement = () {
+  try {
+    return new TemplateElement().content != null;
+  } catch (_) {
+    return false;
+  }
+}();
+
+class BrowserDomAdapter extends GenericBrowserDomAdapter {
+  js.JsFunction _setProperty;
+  js.JsFunction _getProperty;
+  js.JsFunction _hasProperty;
+  Map<String, bool> _hasPropertyCache;
+  BrowserDomAdapter() {
+    _hasPropertyCache = new Map();
+    _setProperty = js.context.callMethod(
+        'eval', ['(function(el, prop, value) { el[prop] = value; })']);
+    _getProperty = js.context
+        .callMethod('eval', ['(function(el, prop) { return el[prop]; })']);
+    _hasProperty = js.context
+        .callMethod('eval', ['(function(el, prop) { return prop in el; })']);
+  }
+  static void makeCurrent() {
+    setRootDomAdapter(new BrowserDomAdapter());
+  }
+
+  bool hasProperty(Element element, String name) {
+    // Always return true as the serverside version html_adapter.dart does so.
+    // TODO: change this once we have schema support.
+    // Note: This nees to kept in sync with html_adapter.dart!
+    return true;
+  }
+
+  void setProperty(Element element, String name, Object value) {
+    var cacheKey = "${element.tagName}.${name}";
+    var hasProperty = this._hasPropertyCache[cacheKey];
+    if (hasProperty == null) {
+      hasProperty = this._hasProperty.apply([element, name]);
+      this._hasPropertyCache[cacheKey] = hasProperty;
+    }
+    if (hasProperty) {
+      _setProperty.apply([element, name, value]);
+    }
+  }
+
+  getProperty(Element element, String name) =>
+      _getProperty.apply([element, name]);
+
+  invoke(Element element, String methodName, List args) =>
+      this.getProperty(element, methodName).apply(args, thisArg: element);
+
+  // TODO(tbosch): move this into a separate environment class once we have it
+  logError(error) {
+    window.console.error(error);
+  }
+
+  log(error) {
+    window.console.log(error);
+  }
+
+  logGroup(error) {
+    window.console.group(error);
+    this.logError(error);
+  }
+
+  logGroupEnd() {
+    window.console.groupEnd();
+  }
+
+  @override
+  Map<String, String> get attrToPropMap => const <String, String>{
+        'class': 'className',
+        'innerHtml': 'innerHTML',
+        'readonly': 'readOnly',
+        'tabindex': 'tabIndex',
+      };
+
+  Element query(String selector) => document.querySelector(selector);
+
+  Element querySelector(el, String selector) => el.querySelector(selector);
+
+  ElementList querySelectorAll(el, String selector) =>
+      el.querySelectorAll(selector);
+
+  void on(EventTarget element, String event, callback(arg)) {
+    // due to https://code.google.com/p/dart/issues/detail?id=17406
+    // addEventListener misses zones so we use element.on.
+    element.on[event].listen(callback);
+  }
+
+  Function onAndCancel(EventTarget element, String event, callback(arg)) {
+    // due to https://code.google.com/p/dart/issues/detail?id=17406
+    // addEventListener misses zones so we use element.on.
+    var subscription = element.on[event].listen(callback);
+    return subscription.cancel;
+  }
+
+  void dispatchEvent(EventTarget el, Event evt) {
+    el.dispatchEvent(evt);
+  }
+
+  MouseEvent createMouseEvent(String eventType) =>
+      new MouseEvent(eventType, canBubble: true);
+  Event createEvent(String eventType) => new Event(eventType, canBubble: true);
+  void preventDefault(Event evt) {
+    evt.preventDefault();
+  }
+
+  bool isPrevented(Event evt) {
+    return evt.defaultPrevented;
+  }
+
+  String getInnerHTML(Element el) => el.innerHtml;
+  String getOuterHTML(Element el) => el.outerHtml;
+  void setInnerHTML(Element el, String value) {
+    el.innerHtml = value;
+  }
+
+  String nodeName(Node el) => el.nodeName;
+  String nodeValue(Node el) => el.nodeValue;
+  String type(InputElement el) => el.type;
+  Node content(TemplateElement el) =>
+      _supportsTemplateElement ? el.content : el;
+  Node firstChild(el) => el.firstChild;
+  Node nextSibling(Node el) => el.nextNode;
+  Element parentElement(Node el) => el.parentNode;
+  List<Node> childNodes(Node el) => el.childNodes;
+  List childNodesAsList(Node el) => childNodes(el).toList();
+  void clearNodes(Node el) {
+    el.nodes = const [];
+  }
+
+  void appendChild(Node el, Node node) {
+    el.append(node);
+  }
+
+  void removeChild(el, Node node) {
+    node.remove();
+  }
+
+  void replaceChild(Node el, Node newNode, Node oldNode) {
+    oldNode.replaceWith(newNode);
+  }
+
+  ChildNode remove(ChildNode el) {
+    return el..remove();
+  }
+
+  void insertBefore(Node el, node) {
+    el.parentNode.insertBefore(node, el);
+  }
+
+  void insertAllBefore(Node el, Iterable<Node> nodes) {
+    el.parentNode.insertAllBefore(nodes, el);
+  }
+
+  void insertAfter(Node el, Node node) {
+    el.parentNode.insertBefore(node, el.nextNode);
+  }
+
+  String getText(Node el) => el.text;
+  void setText(Node el, String value) {
+    el.text = value;
+  }
+
+  String getValue(el) => el.value;
+  void setValue(el, String value) {
+    el.value = value;
+  }
+
+  bool getChecked(InputElement el) => el.checked;
+  void setChecked(InputElement el, bool isChecked) {
+    el.checked = isChecked;
+  }
+
+  Comment createComment(String text) {
+    return new Comment(text);
+  }
+
+  TemplateElement createTemplate(String html) {
+    var t = new TemplateElement();
+    // We do not sanitize because templates are part of the application code
+    // not user code.
+    t.setInnerHtml(html, treeSanitizer: _identitySanitizer);
+    return t;
+  }
+
+  Element createElement(String tagName, [HtmlDocument doc = null]) {
+    if (doc == null) doc = document;
+    return doc.createElement(tagName);
+  }
+
+  Element createElementNS(String ns, String tagName, [HtmlDocument doc = null]) {
+    if (doc == null) doc = document;
+    return doc.createElementNS(ns, tagName);
+  }
+
+  Text createTextNode(String text, [HtmlDocument doc = null]) {
+    return new Text(text);
+  }
+
+  createScriptTag(String attrName, String attrValue,
+      [HtmlDocument doc = null]) {
+    if (doc == null) doc = document;
+    var el = doc.createElement('SCRIPT');
+    el.setAttribute(attrName, attrValue);
+    return el;
+  }
+
+  StyleElement createStyleElement(String css, [HtmlDocument doc = null]) {
+    if (doc == null) doc = document;
+    var el = doc.createElement('STYLE');
+    el.text = css;
+    return el;
+  }
+
+  ShadowRoot createShadowRoot(Element el) => el.createShadowRoot();
+  ShadowRoot getShadowRoot(Element el) => el.shadowRoot;
+  Element getHost(Element el) => (el as ShadowRoot).host;
+  clone(Node node) => node.clone(true);
+  List<Node> getElementsByClassName(Element element, String name) =>
+      element.getElementsByClassName(name);
+  List<Node> getElementsByTagName(Element element, String name) =>
+      element.querySelectorAll(name);
+  List<String> classList(Element element) => element.classes.toList();
+  void addClass(Element element, String className) {
+    element.classes.add(className);
+  }
+
+  void removeClass(Element element, String className) {
+    element.classes.remove(className);
+  }
+
+  bool hasClass(Element element, String className) =>
+      element.classes.contains(className);
+
+  void setStyle(Element element, String styleName, String styleValue) {
+    element.style.setProperty(styleName, styleValue);
+  }
+
+  bool hasStyle(Element element, String styleName, [String styleValue]) {
+    var value = this.getStyle(element, styleName);
+    return isPresent(styleValue) ? value == styleValue : value.length > 0;
+  }
+
+  void removeStyle(Element element, String styleName) {
+    element.style.removeProperty(styleName);
+  }
+
+  String getStyle(Element element, String styleName) {
+    return element.style.getPropertyValue(styleName);
+  }
+
+  String tagName(Element element) => element.tagName;
+
+  Map<String, String> attributeMap(Element element) {
+    var result = {};
+    result.addAll(element.attributes);
+    // TODO(tbosch): element.getNamespacedAttributes() somehow does not return the attribute value
+    var xlinkHref = element.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+    if (xlinkHref != null) {
+      result['xlink:href'] = xlinkHref;
+    }
+    return result;
+  }
+
+  bool hasAttribute(Element element, String attribute) =>
+      element.attributes.containsKey(attribute);
+
+  bool hasAttributeNS(Element element, String ns, String attribute) =>
+      element.getAttributeNS(ns, attribute) != null;
+
+  String getAttribute(Element element, String attribute) =>
+      element.getAttribute(attribute);
+
+  String getAttributeNS(Element element, String ns, String attribute) =>
+      element.getAttributeNS(ns, attribute);
+
+  void setAttribute(Element element, String name, String value) {
+    element.setAttribute(name, value);
+  }
+
+  void setAttributeNS(Element element, String ns, String name, String value) {
+    element.setAttributeNS(ns, name, value);
+  }
+
+  void removeAttribute(Element element, String name) {
+    //there is no removeAttribute method as of now in Dart:
+    //https://code.google.com/p/dart/issues/detail?id=19934
+    element.attributes.remove(name);
+  }
+
+  void removeAttributeNS(Element element, String ns, String name) {
+    element.getNamespacedAttributes(ns).remove(name);
+  }
+
+  Node templateAwareRoot(Element el) => el is TemplateElement ? el.content : el;
+
+  HtmlDocument createHtmlDocument() =>
+      document.implementation.createHtmlDocument('fakeTitle');
+
+  HtmlDocument defaultDoc() => document;
+  Rectangle getBoundingClientRect(el) => el.getBoundingClientRect();
+  String getTitle() => document.title;
+  void setTitle(String newTitle) {
+    document.title = newTitle;
+  }
+
+  bool elementMatches(n, String selector) =>
+      n is Element && n.matches(selector);
+  bool isTemplateElement(Element el) => el is TemplateElement;
+  bool isTextNode(Node node) => node.nodeType == Node.TEXT_NODE;
+  bool isCommentNode(Node node) => node.nodeType == Node.COMMENT_NODE;
+  bool isElementNode(Node node) => node.nodeType == Node.ELEMENT_NODE;
+  bool hasShadowRoot(Node node) {
+    return node is Element && node.shadowRoot != null;
+  }
+
+  bool isShadowRoot(Node node) {
+    return node is ShadowRoot;
+  }
+
+  Node importIntoDoc(Node node) {
+    return document.importNode(node, true);
+  }
+
+  Node adoptNode(Node node) {
+    return document.adoptNode(node);
+  }
+
+  String getHref(AnchorElement element) {
+    return element.href;
+  }
+
+  String getEventKey(KeyboardEvent event) {
+    int keyCode = event.keyCode;
+    return _keyCodeToKeyMap.containsKey(keyCode)
+        ? _keyCodeToKeyMap[keyCode]
+        : 'Unidentified';
+  }
+
+  getGlobalEventTarget(String target) {
+    if (target == "window") {
+      return window;
+    } else if (target == "document") {
+      return document;
+    } else if (target == "body") {
+      return document.body;
+    }
+  }
+
+  getHistory() {
+    return window.history;
+  }
+
+  getLocation() {
+    return window.location;
+  }
+
+  String getBaseHref() {
+    var href = getBaseElementHref();
+    if (href == null) {
+      return null;
+    }
+    return _relativePath(href);
+  }
+
+  resetBaseElement() {
+    baseElement = null;
+  }
+
+  String getUserAgent() {
+    return window.navigator.userAgent;
+  }
+
+  void setData(Element element, String name, String value) {
+    element.dataset[name] = value;
+  }
+
+  String getData(Element element, String name) {
+    return element.dataset[name];
+  }
+
+  getComputedStyle(elem) => elem.getComputedStyle();
+
+  // TODO(tbosch): move this into a separate environment class once we have it
+  setGlobalVar(String path, value) {
+    var parts = path.split('.');
+    var obj = js.context;
+    while (parts.length > 1) {
+      var name = parts.removeAt(0);
+      if (obj.hasProperty(name)) {
+        obj = obj[name];
+      } else {
+        obj = obj[name] = new js.JsObject(js.context['Object']);
+      }
+    }
+    obj[parts.removeAt(0)] = value;
+  }
+
+  requestAnimationFrame(callback) {
+    return window.requestAnimationFrame(callback);
+  }
+
+  cancelAnimationFrame(id) {
+    window.cancelAnimationFrame(id);
+  }
+
+  num performanceNow() {
+    return window.performance.now();
+  }
+
+  parse(s) {
+    throw 'not implemented';
+  }
+}
+
+var baseElement = null;
+String getBaseElementHref() {
+  if (baseElement == null) {
+    baseElement = document.querySelector('base');
+    if (baseElement == null) {
+      return null;
+    }
+  }
+  return baseElement.getAttribute('href');
+}
+
+// based on urlUtils.js in AngularJS 1
+AnchorElement _urlParsingNode = null;
+String _relativePath(String url) {
+  if (_urlParsingNode == null) {
+    _urlParsingNode = new AnchorElement();
+  }
+  _urlParsingNode.href = url;
+  var pathname = _urlParsingNode.pathname;
+  return (pathname[0] == '/') ? pathname : '/${pathname}';
+}

--- a/src/core/platform/browser/browser_adapter.ts
+++ b/src/core/platform/browser/browser_adapter.ts
@@ -1,0 +1,622 @@
+import {ListWrapper} from 'angular2/src/facade/collection';
+import {isBlank, isPresent, global, setValueOnPath, DateWrapper} from 'angular2/src/facade/lang';
+import {GenericBrowserDomAdapter} from './generic_browser_adapter';
+import {setRootDomAdapter} from '../dom/dom_adapter';
+
+var _attrToPropMap: {[key: string]: string} = {
+  'class': 'className',
+  'innerHtml': 'innerHTML',
+  'readonly': 'readOnly',
+  'tabindex': 'tabIndex'
+};
+
+const DOM_KEY_LOCATION_NUMPAD = 3;
+
+// Map to convert some key or keyIdentifier values to what will be returned by getEventKey
+var _keyMap: any = {
+  // The following values are here for cross-browser compatibility and to match the W3C standard
+  // cf http://www.w3.org/TR/DOM-Level-3-Events-key/
+  '\b': 'Backspace',
+  '\t': 'Tab',
+  '\x7F': 'Delete',
+  '\x1B': 'Escape',
+  'Del': 'Delete',
+  'Esc': 'Escape',
+  'Left': 'ArrowLeft',
+  'Right': 'ArrowRight',
+  'Up': 'ArrowUp',
+  'Down': 'ArrowDown',
+  'Menu': 'ContextMenu',
+  'Scroll': 'ScrollLock',
+  'Win': 'OS'
+};
+
+// There is a bug in Chrome for numeric keypad keys:
+// https://code.google.com/p/chromium/issues/detail?id=155654
+// 1, 2, 3 ... are reported as A, B, C ...
+var _chromeNumKeyPadMap: any = {
+  'A': '1',
+  'B': '2',
+  'C': '3',
+  'D': '4',
+  'E': '5',
+  'F': '6',
+  'G': '7',
+  'H': '8',
+  'I': '9',
+  'J': '*',
+  'K': '+',
+  'M': '-',
+  'N': '.',
+  'O': '/',
+  '\x60': '0',
+  '\x90': 'NumLock'
+};
+
+/**
+ * A `DomAdapter` powered by full browser DOM APIs.
+ */
+/* tslint:disable:requireParameterType */
+export class BrowserDomAdapter extends GenericBrowserDomAdapter {
+  parse(templateHtml: string) {
+    throw new Error('parse not implemented');
+  }
+
+  static makeCurrent() {
+    setRootDomAdapter(new BrowserDomAdapter());
+  }
+
+  hasProperty(element: any, name: string): boolean {
+    return name in element;
+  }
+
+  setProperty(el: /*element*/ any, name: string, value: any) {
+    el[name] = value;
+  }
+
+  getProperty(el: /*element*/ any, name: string): any {
+    return el[name];
+  }
+
+  invoke(el: /*element*/ any, methodName: string, args: any[]): any {
+    el[methodName].apply(el, args);
+  }
+
+  // TODO(tbosch): move this into a separate environment class once we have it
+  logError(error: any) {
+    if (window.console.error) {
+      window.console.error(error);
+    } else {
+      window.console.log(error);
+    }
+  }
+
+  log(error: any) {
+    window.console.log(error);
+  }
+
+  logGroup(error: any) {
+    if (window.console.group) {
+      window.console.group(error);
+      this.logError(error);
+    } else {
+      window.console.log(error);
+    }
+  }
+
+  logGroupEnd() {
+    if (window.console.groupEnd) {
+      window.console.groupEnd();
+    }
+  }
+
+  get _attrToPropMap(): {[key: string]: string} {
+    return _attrToPropMap;
+  }
+
+  query(selector: string): any {
+    return document.querySelector(selector);
+  }
+
+  querySelector(el: any, selector: string): HTMLElement {
+    return el.querySelector(selector);
+  }
+
+  querySelectorAll(el: any, selector: string): any[] {
+    return el.querySelectorAll(selector);
+  }
+
+  on(el: any, evt: any, listener: any) {
+    el.addEventListener(evt, listener, false);
+  }
+
+  onAndCancel(el: any, evt: any, listener: any): Function {
+    el.addEventListener(evt, listener, false);
+    // Needed to follow Dart's subscription semantic, until fix of
+    // https://code.google.com/p/dart/issues/detail?id=17406
+    return () => {
+      el.removeEventListener(evt, listener, false);
+    };
+  }
+
+  dispatchEvent(el: any, evt: any) {
+    el.dispatchEvent(evt);
+  }
+
+  createMouseEvent(eventType: string): MouseEvent {
+    var evt: MouseEvent = document.createEvent('MouseEvent');
+    evt.initEvent(eventType, true, true);
+    return evt;
+  }
+
+  createEvent(eventType: any): Event {
+    var evt: Event = document.createEvent('Event');
+    evt.initEvent(eventType, true, true);
+    return evt;
+  }
+
+  preventDefault(evt: Event) {
+    evt.preventDefault();
+    evt.returnValue = false;
+  }
+
+  isPrevented(evt: Event): boolean {
+    return evt.defaultPrevented || isPresent(evt.returnValue) && !evt.returnValue;
+  }
+
+  getInnerHTML(el: any): string {
+    return el.innerHTML;
+  }
+
+  getOuterHTML(el: any): string {
+    return el.outerHTML;
+  }
+
+  nodeName(node: Node): string {
+    return node.nodeName;
+  }
+
+  nodeValue(node: Node): string {
+    return node.nodeValue;
+  }
+
+  type(node: HTMLInputElement): string {
+    return node.type;
+  }
+
+  content(node: Node): Node {
+    if (this.hasProperty(node, 'content')) {
+      return (<any>node).content;
+    } else {
+      return node;
+    }
+  }
+
+  firstChild(el: any): Node {
+    return el.firstChild;
+  }
+
+  nextSibling(el: any): Node {
+    return el.nextSibling;
+  }
+
+  parentElement(el: any): Node {
+    return el.parentNode;
+  }
+
+  childNodes(el: any): Node[] {
+    return el.childNodes;
+  }
+
+  childNodesAsList(el: any): any[] {
+    var childNodes = el.childNodes;
+    var res = ListWrapper.createFixedSize(childNodes.length);
+    for (var i = 0; i < childNodes.length; i++) {
+      res[i] = childNodes[i];
+    }
+    return res;
+  }
+
+  clearNodes(el: any): any {
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
+  }
+
+  appendChild(el: any, node: any) {
+    el.appendChild(node);
+  }
+
+  removeChild(el: any, node: any) {
+    el.removeChild(node);
+  }
+
+  replaceChild(el: Node, newChild: any, oldChild: any) {
+    el.replaceChild(newChild, oldChild);
+  }
+
+  remove(node: any): Node {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+    return node;
+  }
+
+  insertBefore(el: any, node: any) {
+    el.parentNode.insertBefore(node, el);
+  }
+
+  insertAllBefore(el: any, nodes: any) {
+    nodes.forEach((n: any) => el.parentNode.insertBefore(n, el));
+  }
+
+  insertAfter(el: any, node: any) {
+    el.parentNode.insertBefore(node, el.nextSibling);
+  }
+
+  setInnerHTML(el: any, value: any) {
+    el.innerHTML = value;
+  }
+
+  getText(el: any): string {
+    return el.textContent;
+  }
+
+  // TODO(vicb): removed Element type because it does not support StyleElement
+  setText(el: any, value: string) {
+    el.textContent = value;
+  }
+
+  getValue(el: any): string {
+    return el.value;
+  }
+
+  setValue(el: any, value: string) {
+    el.value = value;
+  }
+
+  getChecked(el: any): boolean {
+    return el.checked;
+  }
+
+  setChecked(el: any, value: boolean) {
+    el.checked = value;
+  }
+
+  createComment(text: string): Comment {
+    return document.createComment(text);
+  }
+
+  createTemplate(html: string): HTMLElement {
+    var t = document.createElement('template');
+    t.innerHTML = html;
+    return t;
+  }
+
+  createElement(tagName: string, doc = document): HTMLElement {
+    return doc.createElement(tagName);
+  }
+
+  createElementNS(ns: string, tagName: string, doc = document): Element {
+    return doc.createElementNS(ns, tagName);
+  }
+
+  createTextNode(text: string, doc = document): Text {
+    return doc.createTextNode(text);
+  }
+
+  createScriptTag(attrName: string, attrValue: string, doc = document): HTMLScriptElement {
+    var el = <HTMLScriptElement>doc.createElement('SCRIPT');
+    el.setAttribute(attrName, attrValue);
+    return el;
+  }
+
+  createStyleElement(css: string, doc = document): HTMLStyleElement {
+    var style = <HTMLStyleElement>doc.createElement('style');
+    this.appendChild(style, this.createTextNode(css));
+    return style;
+  }
+
+  createShadowRoot(el: HTMLElement): DocumentFragment {
+    return (<any>el).createShadowRoot();
+  }
+
+  getShadowRoot(el: HTMLElement): DocumentFragment {
+    return (<any>el).shadowRoot;
+  }
+
+  getHost(el: HTMLElement): HTMLElement {
+    return (<any>el).host;
+  }
+
+  clone(node: Node): Node {
+    return node.cloneNode(true);
+  }
+
+  getElementsByClassName(element: any, name: string): HTMLElement[] {
+    return element.getElementsByClassName(name);
+  }
+
+  getElementsByTagName(element: any, name: string): HTMLElement[] {
+    return element.getElementsByTagName(name);
+  }
+
+  classList(element: any): any[] {
+    return <any[]>Array.prototype.slice.call(element.classList, 0);
+  }
+
+  addClass(element: any, className: string) {
+    element.classList.add(className);
+  }
+
+  removeClass(element: any, className: string) {
+    element.classList.remove(className);
+  }
+
+  hasClass(element: any, className: string): boolean {
+    return element.classList.contains(className);
+  }
+
+  setStyle(element: any, styleName: string, styleValue: string) {
+    element.style[styleName] = styleValue;
+  }
+
+  removeStyle(element: any, stylename: string) {
+    element.style[stylename] = null;
+  }
+
+  getStyle(element: any, stylename: string): string {
+    return element.style[stylename];
+  }
+
+  hasStyle(element: any, styleName: string, styleValue: string = null): boolean {
+    var value = this.getStyle(element, styleName) || '';
+    return styleValue ? value == styleValue : value.length > 0;
+  }
+
+  tagName(element: any): string {
+    return element.tagName;
+  }
+
+  attributeMap(element: any): Map<string, string> {
+    var res = new Map<string, string>();
+    var elAttrs = element.attributes;
+    for (var i = 0; i < elAttrs.length; i++) {
+      var attrib = elAttrs[i];
+      res.set(attrib.name, attrib.value);
+    }
+    return res;
+  }
+
+  hasAttribute(element: any, attribute: string): boolean {
+    return element.hasAttribute(attribute);
+  }
+
+  hasAttributeNS(element: any, ns: string, attribute: string): boolean {
+    return element.hasAttributeNS(ns, attribute);
+  }
+
+  getAttribute(element: any, attribute: string): string {
+    return element.getAttribute(attribute);
+  }
+
+  getAttributeNS(element: any, ns: string, name: string): string {
+    return element.getAttributeNS(ns, name);
+  }
+
+  setAttribute(element: any, name: string, value: string) {
+    element.setAttribute(name, value);
+  }
+
+  setAttributeNS(element: any, ns: string, name: string, value: string) {
+    element.setAttributeNS(ns, name, value);
+  }
+
+  removeAttribute(element: any, attribute: string) {
+    element.removeAttribute(attribute);
+  }
+
+  removeAttributeNS(element: any, ns: string, name: string) {
+    element.removeAttributeNS(ns, name);
+  }
+
+  templateAwareRoot(el: any): any {
+    return this.isTemplateElement(el) ? this.content(el) : el;
+  }
+
+  createHtmlDocument(): HTMLDocument {
+    return document.implementation.createHTMLDocument('fakeTitle');
+  }
+
+  defaultDoc(): HTMLDocument {
+    return document;
+  }
+
+  getBoundingClientRect(el: any): any {
+    try {
+      return el.getBoundingClientRect();
+    } catch (e) {
+      return {top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0};
+    }
+  }
+
+  getTitle(): string {
+    return document.title;
+  }
+
+  setTitle(newTitle: string) {
+    document.title = newTitle || '';
+  }
+
+  elementMatches(n: any, selector: string): boolean {
+    var matches = false;
+    if (n instanceof HTMLElement) {
+      if (n.matches) {
+        matches = n.matches(selector);
+      } else if (n.msMatchesSelector) {
+        matches = n.msMatchesSelector(selector);
+      } else if (n.webkitMatchesSelector) {
+        matches = n.webkitMatchesSelector(selector);
+      }
+    }
+    return matches;
+  }
+
+  isTemplateElement(el: any): boolean {
+    return el instanceof HTMLElement && el.nodeName == 'TEMPLATE';
+  }
+
+  isTextNode(node: Node): boolean {
+    return node.nodeType === Node.TEXT_NODE;
+  }
+
+  isCommentNode(node: Node): boolean {
+    return node.nodeType === Node.COMMENT_NODE;
+  }
+
+  isElementNode(node: Node): boolean {
+    return node.nodeType === Node.ELEMENT_NODE;
+  }
+
+  hasShadowRoot(node: any): boolean {
+    return node instanceof HTMLElement && isPresent(node.shadowRoot);
+  }
+
+  isShadowRoot(node: any): boolean {
+    return node instanceof DocumentFragment;
+  }
+
+  importIntoDoc(node: Node): any {
+    var toImport = node;
+    if (this.isTemplateElement(node)) {
+      toImport = this.content(node);
+    }
+    return document.importNode(toImport, true);
+  }
+
+  adoptNode(node: Node): any {
+    return document.adoptNode(node);
+  }
+
+  getHref(el: Element): string {
+    return (<any>el).href;
+  }
+
+  getEventKey(event: any): string {
+    var key: any = event.key;
+    if (isBlank(key)) {
+      key = event.keyIdentifier;
+      // keyIdentifier is defined in the old draft of DOM Level 3 Events implemented by Chrome and
+      // Safari
+      // cf
+      if (isBlank(key)) {
+        return 'Unidentified';
+      }
+      if (key.startsWith('U+')) {
+        key = String.fromCharCode(parseInt(key.substring(2), 16));
+        if (event.location === DOM_KEY_LOCATION_NUMPAD && _chromeNumKeyPadMap.hasOwnProperty(key)) {
+          // There is a bug in Chrome for numeric keypad keys:
+          // https://code.google.com/p/chromium/issues/detail?id=155654
+          // 1, 2, 3 ... are reported as A, B, C ...
+          key = _chromeNumKeyPadMap[key];
+        }
+      }
+    }
+    if (_keyMap.hasOwnProperty(key)) {
+      key = _keyMap[key];
+    }
+    return key;
+  }
+
+  getGlobalEventTarget(target: string): EventTarget {
+    if (target == 'window') {
+      return window;
+    } else if (target == 'document') {
+      return document;
+    } else if (target == 'body') {
+      return document.body;
+    }
+  }
+
+  getHistory(): History {
+    return window.history;
+  }
+
+  getLocation(): Location {
+    return window.location;
+  }
+
+  getBaseHref(): string {
+    var href = getBaseElementHref();
+    if (isBlank(href)) {
+      return null;
+    }
+    return relativePath(href);
+  }
+
+  resetBaseElement(): void {
+    baseElement = null;
+  }
+
+  getUserAgent(): string {
+    return window.navigator.userAgent;
+  }
+
+  setData(element: any, name: string, value: string) {
+    this.setAttribute(element, 'data-' + name, value);
+  }
+
+  getData(element: any, name: string): string {
+    return this.getAttribute(element, 'data-' + name);
+  }
+
+  getComputedStyle(element: any): any {
+    return getComputedStyle(element);
+  }
+
+  // TODO(tbosch): move this into a separate environment class once we have it
+  setGlobalVar(path: string, value: any) {
+    setValueOnPath(global, path, value);
+  }
+
+  requestAnimationFrame(callback: any): number {
+    return window.requestAnimationFrame(callback);
+  }
+
+  cancelAnimationFrame(id: number) {
+    window.cancelAnimationFrame(id);
+  }
+
+  performanceNow(): number {
+    // performance.now() is not available in all browsers, see
+    // http://caniuse.com/#search=performance.now
+    if (isPresent(window.performance) && isPresent(window.performance.now)) {
+      return window.performance.now();
+    } else {
+      return DateWrapper.toMillis(DateWrapper.now());
+    }
+  }
+}
+
+
+var baseElement: any = null;
+function getBaseElementHref(): string {
+  if (isBlank(baseElement)) {
+    baseElement = document.querySelector('base');
+    if (isBlank(baseElement)) {
+      return null;
+    }
+  }
+  return baseElement.getAttribute('href');
+}
+
+// based on urlUtils.js in AngularJS 1
+var urlParsingNode: any = null;
+function relativePath(url: any): string {
+  if (isBlank(urlParsingNode)) {
+    urlParsingNode = document.createElement('a');
+  }
+  urlParsingNode.setAttribute('href', url);
+  return (urlParsingNode.pathname.charAt(0) === '/') ? urlParsingNode.pathname :
+  '/' + urlParsingNode.pathname;
+}

--- a/src/core/platform/browser/generic_browser_adapter.ts
+++ b/src/core/platform/browser/generic_browser_adapter.ts
@@ -1,0 +1,77 @@
+import {StringMapWrapper} from 'angular2/src/facade/collection';
+import {isPresent, isFunction, Type} from 'angular2/src/facade/lang';
+import {DomAdapter} from 'angular2/src/platform/dom/dom_adapter';
+import {XHRImpl} from 'angular2/src/platform/browser/xhr_impl';
+
+
+/**
+ * Provides DOM operations in any browser environment.
+ */
+export abstract class GenericBrowserDomAdapter extends DomAdapter {
+  private _animationPrefix: string = null;
+  private _transitionEnd: string = null;
+
+  constructor() {
+    super();
+    try {
+      var element = this.createElement('div', this.defaultDoc());
+      if (isPresent(this.getStyle(element, 'animationName'))) {
+        this._animationPrefix = '';
+      } else {
+        var domPrefixes = ['Webkit', 'Moz', 'O', 'ms'];
+        for (var i = 0; i < domPrefixes.length; i++) {
+          if (isPresent(this.getStyle(element, domPrefixes[i] + 'AnimationName'))) {
+            this._animationPrefix = '-' + domPrefixes[i].toLowerCase() + '-';
+            break;
+          }
+        }
+      }
+      var transEndEventNames: {[key: string]: string} = {
+        WebkitTransition: 'webkitTransitionEnd',
+        MozTransition: 'transitionend',
+        OTransition: 'oTransitionEnd otransitionend',
+        transition: 'transitionend'
+      };
+      StringMapWrapper.forEach(transEndEventNames, (value: string, key: string) => {
+        if (isPresent(this.getStyle(element, key))) {
+          this._transitionEnd = value;
+        }
+      });
+    } catch (e) {
+      this._animationPrefix = null;
+      this._transitionEnd = null;
+    }
+  }
+
+  getXHR(): Type {
+    return XHRImpl;
+  }
+
+  getDistributedNodes(el: HTMLElement): Node[] {
+    return (<any>el).getDistributedNodes();
+  }
+
+  resolveAndSetHref(el: HTMLAnchorElement, baseUrl: string, href: string) {
+    el.href = href == null ? baseUrl : baseUrl + '/../' + href;
+  }
+
+  supportsDOMEvents(): boolean {
+    return true;
+  }
+
+  supportsNativeShadowDOM(): boolean {
+    return isFunction((<any>this.defaultDoc().body).createShadowRoot);
+  }
+
+  getAnimationPrefix(): string {
+    return isPresent(this._animationPrefix) ? this._animationPrefix : '';
+  }
+
+  getTransitionEnd(): string {
+    return isPresent(this._transitionEnd) ? this._transitionEnd : '';
+  }
+
+  supportsAnimation(): boolean {
+    return isPresent(this._animationPrefix) && isPresent(this._transitionEnd);
+  }
+}

--- a/src/core/platform/dom/dom_adapter.ts
+++ b/src/core/platform/dom/dom_adapter.ts
@@ -1,0 +1,259 @@
+import {isBlank, Type} from 'angular2/src/facade/lang';
+
+export var DOM: DomAdapter = null;
+
+export function setRootDomAdapter(adapter: DomAdapter) {
+  if (isBlank(DOM)) {
+    DOM = adapter;
+  }
+}
+
+/* tslint:disable:requireParameterType */
+/**
+ * Provides DOM operations in an environment-agnostic way.
+ */
+export abstract class DomAdapter {
+  abstract hasProperty(element: any, name: string): boolean;
+
+  abstract setProperty(el: Element, name: string, value: any): void;
+
+  abstract getProperty(el: Element, name: string): any;
+
+  abstract invoke(el: Element, methodName: string, args: any[]): any;
+
+  abstract logError(error: any): void;
+
+  abstract log(error: any): void;
+
+  abstract logGroup(error: any): void;
+
+  abstract logGroupEnd(): void;
+
+  /** @deprecated */
+  abstract getXHR(): Type;
+
+  /**
+   * Maps attribute names to their corresponding property names for cases
+   * where attribute name doesn't match property name.
+   */
+  get attrToPropMap(): {[key: string]: string} {
+    return this._attrToPropMap;
+  };
+
+  set attrToPropMap(value: {[key: string]: string}) {
+    this._attrToPropMap = value;
+  };
+
+  /** @internal */
+  _attrToPropMap: {[key: string]: string};
+
+  abstract parse(templateHtml: string): any;
+
+  abstract query(selector: string): any;
+
+  abstract querySelector(el: any, selector: string): HTMLElement;
+
+  abstract querySelectorAll(el: any, selector: string): any[];
+
+  abstract on(el: any, evt: any, listener: any): void;
+
+  abstract onAndCancel(el: any, evt: any, listener: any): Function;
+
+  abstract dispatchEvent(el: any, evt: any): void;
+
+  abstract createMouseEvent(eventType: any): any;
+
+  abstract createEvent(eventType: string): any;
+
+  abstract preventDefault(evt: any): void;
+
+  abstract isPrevented(evt: any): boolean;
+
+  abstract getInnerHTML(el: any): string;
+
+  abstract getOuterHTML(el: any): string;
+
+  abstract nodeName(node: any): string;
+
+  abstract nodeValue(node: any): string;
+
+  abstract type(node: any): string;
+
+  abstract content(node: any): any;
+
+  abstract firstChild(el: any): Node;
+
+  abstract nextSibling(el: any): Node;
+
+  abstract parentElement(el: any): Node;
+
+  abstract childNodes(el: any): Node[];
+
+  abstract childNodesAsList(el: any): Node[];
+
+  abstract clearNodes(el: any): void;
+
+  abstract appendChild(el: any, node: any): void;
+
+  abstract removeChild(el: any, node: any): void;
+
+  abstract replaceChild(el: any, newNode: any, oldNode: any): void;
+
+  abstract remove(el: any): Node;
+
+  abstract insertBefore(el: any, node: any): void;
+
+  abstract insertAllBefore(el: any, nodes: any): void;
+
+  abstract insertAfter(el: any, node: any): void;
+
+  abstract setInnerHTML(el: any, value: any): void;
+
+  abstract getText(el: any): string;
+
+  abstract setText(el: any, value: string): void;
+
+  abstract getValue(el: any): string;
+
+  abstract setValue(el: any, value: string): void;
+
+  abstract getChecked(el: any): boolean;
+
+  abstract setChecked(el: any, value: boolean): void;
+
+  abstract createComment(text: string): any;
+
+  abstract createTemplate(html: any): HTMLElement;
+
+  abstract createElement(tagName: any, doc?: any): HTMLElement;
+
+  abstract createElementNS(ns: string, tagName: string, doc?: any): Element;
+
+  abstract createTextNode(text: string, doc?: any): Text;
+
+  abstract createScriptTag(attrName: string, attrValue: string, doc?: any): HTMLElement;
+
+  abstract createStyleElement(css: string, doc?: any): HTMLStyleElement;
+
+  abstract createShadowRoot(el: any): any;
+
+  abstract getShadowRoot(el: any): any;
+
+  abstract getHost(el: any): any;
+
+  abstract getDistributedNodes(el: any): Node[];
+
+  abstract clone /*<T extends Node>*/(node: Node /*T*/): Node /*T*/;
+
+  abstract getElementsByClassName(element: any, name: string): HTMLElement[];
+
+  abstract getElementsByTagName(element: any, name: string): HTMLElement[];
+
+  abstract classList(element: any): any[];
+
+  abstract addClass(element: any, className: string): void;
+
+  abstract removeClass(element: any, className: string): void;
+
+  abstract hasClass(element: any, className: string): boolean;
+
+  abstract setStyle(element: any, styleName: string, styleValue: string): void;
+
+  abstract removeStyle(element: any, styleName: string): void;
+
+  abstract getStyle(element: any, styleName: string): string;
+
+  abstract hasStyle(element: any, styleName: string, styleValue?: string): boolean;
+
+  abstract tagName(element: any): string;
+
+  abstract attributeMap(element: any): Map<string, string>;
+
+  abstract hasAttribute(element: any, attribute: string): boolean;
+
+  abstract hasAttributeNS(element: any, ns: string, attribute: string): boolean;
+
+  abstract getAttribute(element: any, attribute: string): string;
+
+  abstract getAttributeNS(element: any, ns: string, attribute: string): string;
+
+  abstract setAttribute(element: any, name: string, value: string): void;
+
+  abstract setAttributeNS(element: any, ns: string, name: string, value: string): void;
+
+  abstract removeAttribute(element: any, attribute: string): void;
+
+  abstract removeAttributeNS(element: any, ns: string, attribute: string): void;
+
+  abstract templateAwareRoot(el: any): any;
+
+  abstract createHtmlDocument(): HTMLDocument;
+
+  abstract defaultDoc(): HTMLDocument;
+
+  abstract getBoundingClientRect(el: any): any;
+
+  abstract getTitle(): string;
+
+  abstract setTitle(newTitle: string): void;
+
+  abstract elementMatches(n: any, selector: string): boolean;
+
+  abstract isTemplateElement(el: any): boolean;
+
+  abstract isTextNode(node: any): boolean;
+
+  abstract isCommentNode(node: any): boolean;
+
+  abstract isElementNode(node: any): boolean;
+
+  abstract hasShadowRoot(node: any): boolean;
+
+  abstract isShadowRoot(node: any): boolean;
+
+  abstract importIntoDoc /*<T extends Node>*/(node: Node /*T*/): Node /*T*/;
+
+  abstract adoptNode /*<T extends Node>*/(node: Node /*T*/): Node /*T*/;
+
+  abstract getHref(element: any): string;
+
+  abstract getEventKey(event: any): string;
+
+  abstract resolveAndSetHref(element: any, baseUrl: string, href: string): any;
+
+  abstract supportsDOMEvents(): boolean;
+
+  abstract supportsNativeShadowDOM(): boolean;
+
+  abstract getGlobalEventTarget(target: string): any;
+
+  abstract getHistory(): History;
+
+  abstract getLocation(): Location;
+
+  abstract getBaseHref(): string;
+
+  abstract resetBaseElement(): void;
+
+  abstract getUserAgent(): string;
+
+  abstract setData(element: any, name: string, value: string): void;
+
+  abstract getComputedStyle(element: any): any;
+
+  abstract getData(element: any, name: string): string;
+
+  abstract setGlobalVar(name: string, value: any): void;
+
+  abstract requestAnimationFrame(callback: any): number;
+
+  abstract cancelAnimationFrame(id: any): void;
+
+  abstract performanceNow(): number;
+
+  abstract getAnimationPrefix(): string;
+
+  abstract getTransitionEnd(): string;
+
+  abstract supportsAnimation(): boolean;
+}

--- a/src/core/portal/dom-portal-host.ts
+++ b/src/core/portal/dom-portal-host.ts
@@ -1,0 +1,54 @@
+import {DynamicComponentLoader, AppViewManager, ComponentRef} from 'angular2/core';
+import {BasePortalHost, ComponentPortal, TemplatePortal} from './portal';
+import {MdComponentPortalAttachedToDomWithoutOriginException} from './portal-exceptions';
+
+
+/**
+ * A PortalHost for attaching portals to an arbitrary DOM element outside of the Angular
+ * application context.
+ *
+ * This is the only part of the portal core that directly touches the DOM.
+ */
+export class DomPortalHost extends BasePortalHost {
+  constructor(
+      private _hostDomElement: Element,
+      private _componentLoader: DynamicComponentLoader,
+      private _viewManager: AppViewManager) {
+    super();
+  }
+
+  /** Attach the given ComponentPortal to DOM element using the DynamicComponentLoader. */
+  attachComponentPortal(portal: ComponentPortal): Promise<ComponentRef> {
+    if (portal.origin == null) {
+      throw new MdComponentPortalAttachedToDomWithoutOriginException();
+    }
+
+    return this._componentLoader.loadNextToLocation(portal.component, portal.origin).then(ref => {
+      this._hostDomElement.appendChild(ref.hostView.rootNodes[0]);
+      this.setDisposeFn(() => ref.dispose());
+      return ref;
+    });
+  }
+
+  attachTemplatePortal(portal: TemplatePortal): Promise<Map<string, any>> {
+    let viewContainer = this._viewManager.getViewContainer(portal.templateRef.elementRef);
+    let viewRef = viewContainer.createEmbeddedView(portal.templateRef);
+    // TODO(jelbourn): locals don't currently work with DomPortalHost; investigate whether there
+    // is a bug in Angular.
+    portal.locals.forEach((v, k) => viewRef.setLocal(k, v));
+
+    viewRef.rootNodes.forEach(rootNode => {
+      this._hostDomElement.appendChild(rootNode);
+    });
+
+    this.setDisposeFn((() => {
+      let index = viewContainer.indexOf(viewRef);
+      if (index != -1) {
+        viewContainer.remove(index);
+      }
+    }));
+
+    // TODO(jelbourn): Return locals from view.
+    return Promise.resolve(new Map<string, any>());
+  }
+}

--- a/src/core/portal/portal-exceptions.ts
+++ b/src/core/portal/portal-exceptions.ts
@@ -1,0 +1,55 @@
+import {BaseException} from 'angular2/src/facade/exceptions';
+
+
+/** Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin. */
+export class MdComponentPortalAttachedToDomWithoutOriginException extends BaseException {
+  constructor() {
+      super(
+          'A ComponentPortal must have an origin set when attached to a DomPortalHost ' +
+          'because the DOM element is not part of the Angular application context.');
+  }
+}
+
+/** Exception thrown when attmepting to attach a null portal to a host. */
+export class MdNullPortalException extends BaseException {
+  constructor() {
+      super('Must provide a portal to attach');
+  }
+}
+
+/** Exception thrown when attmepting to attach a portal to a host that is already attached. */
+export class MdPortalAlreadyAttachedException extends BaseException {
+  constructor() {
+      super('Host already has a portal attached');
+  }
+}
+
+/** Exception thrown when attmepting to attach a portal to an already-disposed host. */
+export class MdPortalHostAlreadyDisposedException extends BaseException {
+  constructor() {
+      super('This PortalHost has already been disposed');
+  }
+}
+
+/** Exception thrown when attmepting to attach an unknown portal type. */
+export class MdUnknownPortalTypeException extends BaseException {
+  constructor() {
+      super(
+        'Attempting to attach an unknown Portal type. ' +
+        'BasePortalHost accepts either a ComponentPortal or a TemplatePortal.');
+  }
+}
+
+/** Exception thrown when attmepting to attach a portal to a null host. */
+export class MdNullPortalHostException extends BaseException {
+  constructor() {
+      super('Attmepting to attach a portal to a null PortalHost');
+  }
+}
+
+/** Exception thrown when attmepting to detach a portal that is not attached. */
+export class MdNoPortalAttachedException extends BaseException {
+  constructor() {
+      super('Attmepting to detach a portal that is not attached to a host');
+  }
+}

--- a/src/core/portal/portal.spec.ts
+++ b/src/core/portal/portal.spec.ts
@@ -11,203 +11,342 @@ import {
   expect,
   beforeEach,
 } from '../../core/facade/testing';
-import {Component, ViewChildren, QueryList} from 'angular2/core';
+import {Component, ViewChildren, QueryList, ElementRef} from 'angular2/core';
 import {TemplatePortalDirective} from './portal-directives';
 import {Portal} from './portal';
 import {ComponentPortal} from './portal';
 import {PortalHostDirective} from './portal-directives';
 import {fakeAsync} from 'angular2/testing';
 import {flushMicrotasks} from 'angular2/testing';
+import {DynamicComponentLoader} from 'angular2/core';
+import {AppViewManager} from 'angular2/core';
+import {DomPortalHost} from './dom-portal-host';
+import {BrowserDomAdapter} from '../platform/browser/browser_adapter';
+import {DOM} from '../platform/dom/dom_adapter';
+
 
 
 export function main() {
-  describe('Portal directives', () => {
+  describe('Portals', () => {
     let builder: TestComponentBuilder;
 
     beforeEach(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
       builder = tcb;
+      BrowserDomAdapter.makeCurrent();
     }));
 
-    it('should load a component into the portal', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+    describe('PortalHostDirective', () => {
+      it('should load a component into the portal', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      // Set the selectedHost to be a ComponentPortal.
-      let testAppComponent = appFixture.debugElement.componentInstance;
-      testAppComponent.selectedPortal = new ComponentPortal(PizzaMsg);
-      appFixture.detectChanges();
+        // Set the selectedHost to be a ComponentPortal.
+        let testAppComponent = appFixture.debugElement.componentInstance;
+        testAppComponent.selectedPortal = new ComponentPortal(PizzaMsg);
+        appFixture.detectChanges();
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Pizza');
-    }));
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Pizza');
+      }));
 
-    it('should load a <template> portal', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+      it('should load a <template> portal', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      let testAppComponent = appFixture.debugElement.componentInstance;
+        let testAppComponent = appFixture.debugElement.componentInstance;
 
-      // Detect changes initially so that the component's ViewChildren are resolved.
-      appFixture.detectChanges();
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
 
-      // Set the selectedHost to be a TemplatePortal.
-      testAppComponent.selectedPortal = testAppComponent.cakePortal;
-      appFixture.detectChanges();
+        // Set the selectedHost to be a TemplatePortal.
+        testAppComponent.selectedPortal = testAppComponent.cakePortal;
+        appFixture.detectChanges();
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Cake');
-    }));
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Cake');
+      }));
 
-    it('should load a <template> portal with the `*` sugar', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+      it('should load a <template> portal with the `*` sugar', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      let testAppComponent = appFixture.debugElement.componentInstance;
+        let testAppComponent = appFixture.debugElement.componentInstance;
 
-      // Detect changes initially so that the component's ViewChildren are resolved.
-      appFixture.detectChanges();
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
 
-      // Set the selectedHost to be a TemplatePortal (with the `*` syntax).
-      testAppComponent.selectedPortal = testAppComponent.piePortal;
-      appFixture.detectChanges();
+        // Set the selectedHost to be a TemplatePortal (with the `*` syntax).
+        testAppComponent.selectedPortal = testAppComponent.piePortal;
+        appFixture.detectChanges();
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Pie');
-    }));
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Pie');
+      }));
 
-    it('should load a <template> portal with a binding', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+      it('should load a <template> portal with a binding', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      let testAppComponent = appFixture.debugElement.componentInstance;
+        let testAppComponent = appFixture.debugElement.componentInstance;
 
-      // Detect changes initially so that the component's ViewChildren are resolved.
-      appFixture.detectChanges();
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
 
-      // Set the selectedHost to be a TemplatePortal.
-      testAppComponent.selectedPortal = testAppComponent.portalWithBinding;
-      appFixture.detectChanges();
+        // Set the selectedHost to be a TemplatePortal.
+        testAppComponent.selectedPortal = testAppComponent.portalWithBinding;
+        appFixture.detectChanges();
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
 
-      // Now that the portal is attached, change detection has to happen again in order
-      // for the bindings to update.
-      appFixture.detectChanges();
+        // Now that the portal is attached, change detection has to happen again in order
+        // for the bindings to update.
+        appFixture.detectChanges();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Banana');
-    }));
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Banana');
 
-    it('should load a <template> portal with extra locals', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+        // When updating the binding value.
+        testAppComponent.fruit = 'Mango';
+        appFixture.detectChanges();
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        // Expect the new value to be reflected in the rendered output.
+        expect(hostContainer.textContent).toContainError('Mango');
+      }));
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+      it('should load a <template> portal with extra locals', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      let testAppComponent = appFixture.debugElement.componentInstance;
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Detect changes initially so that the component's ViewChildren are resolved.
-      appFixture.detectChanges();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      let locals = new Map<string, string>();
-      locals.set('appetizer', 'Samosa');
+        let testAppComponent = appFixture.debugElement.componentInstance;
 
-      let templatePortal = testAppComponent.portalWithLocals;
-      templatePortal.locals = locals;
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
 
-      // Set the selectedHost to be a TemplatePortal.
-      testAppComponent.selectedPortal = templatePortal;
-      appFixture.detectChanges();
+        let locals = new Map<string, string>();
+        locals.set('appetizer', 'Samosa');
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
+        let templatePortal = testAppComponent.portalWithLocals;
+        templatePortal.locals = locals;
 
-      // Now that the portal is attached, change detection has to happen again in order
-      // for the bindings to update.
-      appFixture.detectChanges();
+        // Set the selectedHost to be a TemplatePortal.
+        testAppComponent.selectedPortal = templatePortal;
+        appFixture.detectChanges();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Samosa');
-    }));
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
 
-    it('should change the attached portal', fakeAsyncTest(() => {
-      let appFixture: ComponentFixture;
+        // Now that the portal is attached, change detection has to happen again in order
+        // for the bindings to update.
+        appFixture.detectChanges();
 
-      builder.createAsync(PortalTestApp).then(fixture => {
-        appFixture = fixture;
-      });
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Samosa');
+      }));
 
-      // Flush the async creation of the PortalTestApp.
-      flushMicrotasks();
+      it('should change the attached portal', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
 
-      let testAppComponent = appFixture.debugElement.componentInstance;
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
 
-      // Detect changes initially so that the component's ViewChildren are resolved.
-      appFixture.detectChanges();
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
 
-      // Set the selectedHost to be a ComponentPortal.
-      testAppComponent.selectedPortal = testAppComponent.piePortal;
-      appFixture.detectChanges();
+        let testAppComponent = appFixture.debugElement.componentInstance;
 
-      // Flush the attachment of the Portal.
-      flushMicrotasks();
-      appFixture.detectChanges();
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
 
-      // Expect that the content of the attached portal is present.
-      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
-      expect(hostContainer.textContent).toContain('Pie');
+        // Set the selectedHost to be a ComponentPortal.
+        testAppComponent.selectedPortal = testAppComponent.piePortal;
+        appFixture.detectChanges();
 
-      testAppComponent.selectedPortal = new ComponentPortal(PizzaMsg);
-      appFixture.detectChanges();
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
+        appFixture.detectChanges();
 
-      flushMicrotasks();
+        // Expect that the content of the attached portal is present.
+        let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+        expect(hostContainer.textContent).toContain('Pie');
 
-      expect(hostContainer.textContent).toContain('Pizza');
-    }));
+        testAppComponent.selectedPortal = new ComponentPortal(PizzaMsg);
+        appFixture.detectChanges();
 
+        flushMicrotasks();
+
+        expect(hostContainer.textContent).toContain('Pizza');
+      }));
+    });
+
+    describe('DomPortalHost', function() {
+      let componentLoader: DynamicComponentLoader;
+      let viewManager: AppViewManager;
+      let someElementRef: ElementRef;
+      let someDomElement: HTMLElement;
+      let host: DomPortalHost;
+
+      beforeEach(inject(
+          [DynamicComponentLoader, AppViewManager],
+          fakeAsync((dcl: DynamicComponentLoader, avm: AppViewManager) => {
+        viewManager = avm;
+        componentLoader = dcl;
+        someDomElement = DOM.createElement('div');
+        host = new DomPortalHost(someDomElement, componentLoader, viewManager);
+
+        builder.createAsync(ArbitraryElementRefComponent).then(fixture => {
+          someElementRef = fixture.componentInstance.elementRef;
+        });
+
+        flushMicrotasks();
+      })));
+
+      it('should attach and detach a component portal', fakeAsyncTest(() => {
+        let portal = new ComponentPortal(PizzaMsg, someElementRef);
+
+        let componentInstance: PizzaMsg;
+        portal.attach(host).then(ref => {
+          componentInstance = ref.instance;
+        });
+
+        flushMicrotasks();
+
+        expect(componentInstance).toBeAnInstanceOf(PizzaMsg);
+        expect(someDomElement.textContent).toContain('Pizza');
+
+        host.detach();
+        flushMicrotasks();
+
+        expect(someDomElement.innerHTML).toBe('');
+      }));
+
+      it('should attach and detach a template portal', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
+
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
+
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
+        appFixture.detectChanges();
+
+        appFixture.componentInstance.cakePortal.attach(host);
+        flushMicrotasks();
+
+        expect(someDomElement.textContent).toContain('Cake');
+      }));
+
+      it('should attach and detach a template portal with a binding', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
+
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
+
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
+
+        let testAppComponent = appFixture.debugElement.componentInstance;
+
+        // Detect changes initially so that the component's ViewChildren are resolved.
+        appFixture.detectChanges();
+
+        // Attach the TemplatePortal.
+        testAppComponent.portalWithBinding.attach(host);
+        appFixture.detectChanges();
+
+        // Flush the attachment of the Portal.
+        flushMicrotasks();
+
+        // Now that the portal is attached, change detection has to happen again in order
+        // for the bindings to update.
+        appFixture.detectChanges();
+
+        // Expect that the content of the attached portal is present.
+        expect(someDomElement.textContent).toContain('Banana');
+
+        // When updating the binding value.
+        testAppComponent.fruit = 'Mango';
+        appFixture.detectChanges();
+
+        // Expect the new value to be reflected in the rendered output.
+        expect(someDomElement.textContent).toContainError('Mango');
+
+        host.detach();
+        expect(someDomElement.innerHTML).toBe('');
+      }));
+
+      it('should change the attached portal', fakeAsyncTest(() => {
+        let appFixture: ComponentFixture;
+
+        builder.createAsync(PortalTestApp).then(fixture => {
+          appFixture = fixture;
+        });
+
+        // Flush the async creation of the PortalTestApp.
+        flushMicrotasks();
+        appFixture.detectChanges();
+
+        appFixture.componentInstance.piePortal.attach(host);
+        flushMicrotasks();
+
+        expect(someDomElement.textContent).toContain('Pie');
+
+        host.detach();
+        flushMicrotasks();
+
+        host.attach(new ComponentPortal(PizzaMsg, someElementRef));
+        flushMicrotasks();
+
+        expect(someDomElement.textContent).toContain('Pizza');
+      }));
+    });
   });
 }
 
@@ -218,6 +357,15 @@ export function main() {
   template: '<p>Pizza</p>',
 })
 class PizzaMsg {}
+
+/** Simple component to grab an arbitrary ElementRef */
+@Component({
+  selector: 'some-placeholder',
+  template: '<p>Hello</p>'
+})
+class ArbitraryElementRefComponent {
+  constructor(public elementRef: ElementRef) { }
+}
 
 
 /** Test-bed component that contains a portal host and a couple of template portals. */

--- a/src/core/portal/portal.ts
+++ b/src/core/portal/portal.ts
@@ -2,7 +2,14 @@ import {TemplateRef, Type} from 'angular2/core';
 import {ElementRef} from 'angular2/core';
 import {ComponentRef} from 'angular2/core';
 
-import {BaseException} from 'angular2/src/facade/exceptions';
+import {
+  MdNullPortalHostException,
+  MdPortalAlreadyAttachedException,
+  MdNoPortalAttachedException,
+  MdNullPortalException,
+  MdPortalHostAlreadyDisposedException,
+  MdUnknownPortalTypeException
+} from './portal-exceptions';
 
 
 /**
@@ -15,11 +22,11 @@ export abstract class Portal<T> {
   /** Attach this portal to a host. */
   attach(host: PortalHost): Promise<T> {
     if (host == null) {
-      throw new BaseException('Attempting to attach a portal to a null host');
+      throw new MdNullPortalHostException();
     }
 
     if (host.hasAttached()) {
-      throw new BaseException('Host already has a portal attached');
+      throw new MdPortalAlreadyAttachedException();
     }
 
     this._attachedHost = host;
@@ -30,7 +37,7 @@ export abstract class Portal<T> {
   detach(): Promise<void> {
     let host = this._attachedHost;
     if (host == null) {
-      throw new BaseException('Portal has no host from which to detach');
+      throw new MdNoPortalAttachedException();
     }
 
     this._attachedHost = null;
@@ -145,15 +152,15 @@ export abstract class BasePortalHost implements PortalHost {
 
   attach(portal: Portal<any>): Promise<any> {
     if (portal == null) {
-      throw new BaseException('Must provide a portal to attach');
+      throw new MdNullPortalException();
     }
 
     if (this.hasAttached()) {
-      throw new BaseException('A portal is already attached');
+      throw new MdPortalAlreadyAttachedException();
     }
 
     if (this._isDisposed) {
-      throw new BaseException('This PortalHost has already been disposed');
+      throw new MdPortalHostAlreadyDisposedException();
     }
 
     if (portal instanceof ComponentPortal) {
@@ -164,9 +171,7 @@ export abstract class BasePortalHost implements PortalHost {
       return this.attachTemplatePortal(portal);
     }
 
-    throw new BaseException(
-        'Attempting to attach an unknown Portal type. ' +
-        'BasePortalHost accepts either a ComponentPortal or a TemplatePortal.');
+    throw new MdUnknownPortalTypeException();
   }
 
   abstract attachComponentPortal(portal: ComponentPortal): Promise<ComponentRef>;


### PR DESCRIPTION
R: @hansl @kara 

All of the stuff in `platform/` is copied from `angular/angular` and is, for our purposes, the facades necessary for DOM manipulation. (I also had to get rid of implicit `any` and make it pass tslint... ugh). I talked with Tobias and Misko about how much this sucks, and their answer is https://github.com/angular/angular/issues/7561. For now copying this stuff unblocks progress.

`DomPortalHost` is the last part of the `portal/` code needed for overlays. It's will be used when opening an overlay in the attaching of the overlay element to the document body.

Setting `locals` for a `TemplatePortal` attached to a `DomPortalHost` does not work; I spent quite a while trying to figure out why and came up short. I'm going to follow up with Tobias on that, but in the meantime it's not a blocking issue. 