### PR TITLE
build(): change tsconfig to always use commonjs modules

### DIFF
--- a/scripts/release/stage-release.sh
+++ b/scripts/release/stage-release.sh
@@ -12,15 +12,8 @@ set -ex
 rm -rf ./dist
 rm -rf ./deploy
 
-# For packaging for npm only, replace the TypeScript module format to commonjs.
-# Creates a tscongig.json.backup with the original file that we'll use to restore after building.
-sed -i.backup 's|"module": ".+"|"module": "commonjs"|g' ./src/tsconfig.json
-
 # Perform a build with the modified tsconfig.json.
 ng build
-
-# Return tsconfig.json to its original state.
-mv -f ./src/tsconfig.json.backup ./src/tsconfig.json
 
 # Inline the css and html into the component ts files.
 ./node_modules/gulp/bin/gulp.js inline-resources

--- a/src/index.html
+++ b/src/index.html
@@ -23,15 +23,15 @@
     System.config({
       packages: {
         'demo-app': {
-          format: 'register',
+          format: 'cjs',
           defaultExtension: 'js'
         },
         'components': {
-          format: 'register',
+          format: 'cjs',
           defaultExtension: 'js'
         },
         'core': {
-          format: 'register',
+          format: 'cjs',
           defaultExtension: 'js'
         },
       }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "mapRoot": "",
-    "module": "system",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,


### PR DESCRIPTION
R: @hansl 

This reduces the complexity of the release staging script and will prevent things like #167 from happening again. Demo site works exactly the same with the new config.