### PR TITLE
chore: add conventional changelog script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dartanalyzer": "cd dist/dart && pub install && cd ../.. && ts-node scripts/ci/dart_analyzer",
     "demo-app": "ng serve",
     "test": "karma start test/karma.conf.js",
-    "tslint" : "tslint -c tslint.json 'src/**/*.ts'",
+    "tslint": "tslint -c tslint.json 'src/**/*.ts'",
     "typings": "typings install --ambient",
     "e2e": "protractor ./protractor.conf.js"
   },
@@ -33,6 +33,7 @@
     "zone.js": "0.5.15"
   },
   "devDependencies": {
+    "add-stream": "^1.0.0",
     "angular-cli": "^0.0.24",
     "angular-cli-github-pages": "^0.2.0",
     "broccoli-autoprefixer": "^4.1.0",
@@ -41,6 +42,7 @@
     "broccoli-sass": "^0.7.0",
     "broccoli-source": "^1.1.0",
     "browserstacktunnel-wrapper": "^1.4.2",
+    "conventional-changelog": "^1.1.0",
     "ember-cli-inject-live-reload": "^1.3.0",
     "fs-extra": "^0.26.5",
     "glob": "^6.0.4",

--- a/scripts/release/update-changelog.js
+++ b/scripts/release/update-changelog.js
@@ -1,0 +1,45 @@
+'use strict';
+/**
+ * Creates a conventional changelog from the current git repository / metadata.
+ */
+
+var fs = require('fs');
+var addStream = require('add-stream');
+var cl = require('conventional-changelog');
+var inStream = fs.createReadStream('CHANGELOG.md');
+
+/**
+ * When the command line argument `--force` is provided, then the full changelog will created and overwritten.
+ * By default, it will only create the changelog from the latest tag to head and prepends it to the changelog.
+ */
+var isForce = process.argv.indexOf('--force') !== -1;
+
+inStream.on('error', function(err) {
+  console.error('An error occurred, while reading the previous changelog file.\n' +
+    'If there is no previous changelog, then you should create an empty file or use the `--force` flag.\n' + err);
+
+  process.exit(1);
+});
+
+var config = {
+  preset: 'angular',
+  releaseCount: isForce ? 0 : 1
+};
+
+var stream = cl(config)
+  .on('error', function(err) {
+    console.error('An error occurred while generating the changelog: ' + err);
+  })
+  .pipe(!isForce && addStream(inStream) || getOutputStream());
+
+// When we are pre-pending the new changelog, then we need to wait for the input stream to be ending,
+// otherwise we can't write into the same destination.
+if (!isForce) {
+  inStream.on('end', function() {
+    stream.pipe(getOutputStream());
+  });
+}
+
+function getOutputStream() {
+  return fs.createWriteStream('CHANGELOG.md');
+}


### PR DESCRIPTION
* The script prepends the new conventional changelog from the latest tag to HEAD.
* When using the `--force` flag, the complete changelog will be generated and overwrites, when present the previous changelog.

@jelbourn Let me know, if you have imagined differently about that. 

Fixes #171.