### PR TITLE
fix(checkbox): Ensure consistent mixedmark rendering across browsers

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -298,7 +298,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
   @extend %md-checkbox-mark;
 
   background-color: $md-checkbox-mark-color;
-  height: $md-checkbox-mark-stroke-size;
+  height: floor($md-checkbox-mark-stroke-size);
   opacity: 0;
   transform: scaleX(0) rotate(0deg);
 }


### PR DESCRIPTION
This commit ensures that the mixedmark renders the same across browsers
by truncating the height of the mixedmark to an integer value.

Fixes #174