### PR TITLE
fix(radio): export the dispatcher in radio.ts

### DIFF
--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -15,9 +15,8 @@ import {
   forwardRef
 } from 'angular2/core';
 
-import {Event} from 'angular2/src/facade/browser';
-
 import {MdRadioDispatcher} from './radio_dispatcher';
+export {MdRadioDispatcher} from './radio_dispatcher';
 
 // TODO(mtlin):
 // Ink ripple is currently placeholder.


### PR DESCRIPTION
R: @kara 

This will let consumers of the npm package simply do 
```ts
import {MdRadioDispatcher} from '@angular2-material/radio';
```
instead of 
```ts
import {MdRadioDispatcher} from '@angular2-material/radio/radio_dispatcher';
```