### PR TITLE
chore: travis should only build pushes on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ addons:
     packages:
       - libstdc++6
 
+branches:
+  only:
+  - master
+
 env:
   global:
   - LOGS_DIR=/tmp/angular-material2-build/logs


### PR DESCRIPTION
As discussed with @jelbourn, I will submit a new PR, because we're not able to reopen the old PR.

We are trying to find the issue with CI branch restriction.