### PR TITLE
fix(ci): fix flakiness by inlining html & css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,6 @@ var inlineNg2Template = require('gulp-inline-ng2-template');
 
 gulp.task('inline-resources', function(){
   gulp.src('./dist/components/**/*.js')
-      .pipe(inlineNg2Template({base: './dist'}))
+      .pipe(inlineNg2Template({base: './dist', target: 'es5'}))
       .pipe(gulp.dest('./dist/components'));
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",
     "typings": "typings install --ambient",
     "postinstall": "npm run typings",
-    "e2e": "protractor ./protractor.conf.js"
+    "e2e": "protractor ./protractor.conf.js",
+    "inline-resources": "gulp inline-resources"
   },
   "version": "2.0.0-alpha.1",
   "license": "MIT",

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -15,6 +15,7 @@ is_dart && source scripts/ci/sources/env_dart.sh
 
 start_tunnel
 npm run build
+npm run inline-resources
 echo
 is_dart && pub install
 

--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -195,7 +195,10 @@ export function main() {
       });
 
       it('sets "aria-checked" to be "true" on the host element', function() {
-        let el = fixture.debugElement.query(By.css('.md-checkbox'));
+        let el = fixture.debugElement.query(By.css('md-checkbox'));
+        controller.isIndeterminate = false;
+        controller.isChecked = true;
+        fixture.detectChanges();
         expect(el.nativeElement.getAttribute('aria-checked')).toEqual('true');
       });
 

--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -28,7 +28,7 @@ const configuration: { [name: string]: ConfigurationInfo } = {
   'Chrome':       { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Firefox':      { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'ChromeBeta':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
-  'FirefoxBeta':  { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'FirefoxBeta':  { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
   'ChromeDev':    { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},
   'FirefoxDev':   { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},
   'IE9':          { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},


### PR DESCRIPTION
I was eating empanadas and working on the overlay, which prompted me to look at the portal spec. A part of my brain said:
"You know, I've never seen this test flake."
And another part responded:
"Of course it doesn't flake, it doesn't have a tem-".
"Oh."

So I've fixed the flakiness by inlining all the templates and CSS. After I did this, one of the checkbox tests was actually failing, so I fixed that too. 

This also has the pleasant side effect of making the tests in all browsers significantly faster.

Also, I removed firefox beta because all it does is make the SauceLabs optional task take forever to finish failing.