### PR TITLE
fix(e2e): removes screenshot directory and code to generate screenshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Files ending with `.screenshot.png` will be stored using `git-lfs` rather than stored in the git repository
-*.screenshot.png filter=lfs diff=lfs merge=lfs -text

--- a/e2e/index.e2e.js
+++ b/e2e/index.e2e.js
@@ -5,7 +5,6 @@ describe('hello, protractor', function () {
     browser.get('/');
     it('should have a title', function () {
       expect(browser.getTitle()).toBe('Material2');
-      screenshot('demo page: index');
     });
   });
 });

--- a/screenshots/demo page: index.screenshot.png
+++ b/screenshots/demo page: index.screenshot.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:606958be9d1e0ec1cc3b5e361feee28d0b1bf52b0008c8afb0f03b21a5353a9e
-size 23924


### PR DESCRIPTION
also removes git-lfs from repo
fixes #228 
