### PR TITLE
fix(checkbox): Remove GPU layer promotion for mark elements

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -202,9 +202,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  */
 %md-checkbox-mark {
   $width-padding-inset: 2 * $md-checkbox-border-width;
-
   width: calc(100% - #{$width-padding-inset});
-  will-change: opacity, transform;
 }
 
 /**


### PR DESCRIPTION
This commit removes the CSS that promotes checkmarks to the GPU layer,
due to an issue in Chrome which makes transitions appear incorrect when
the promotions are applied.