### PR TITLE
chore: add firebase.json for testing

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,12 @@
+{
+  "firebase": "material2-test",
+  "public": "dist",
+  "ignore": [
+    "firebase.json",
+    "**/.*",
+    "**/node_modules/**",
+    "tmp",
+    "deploy",
+    "typings"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typings": "typings install --ambient",
     "postinstall": "npm run typings",
     "e2e": "protractor test/protractor.conf.js",
-    "inline-resources": "gulp inline-resources"
+    "inline-resources": "gulp inline-resources",
+    "deploy": "firebase deploy"
   },
   "version": "2.0.0-alpha.2",
   "license": "MIT",
@@ -45,6 +46,7 @@
     "browserstacktunnel-wrapper": "^1.4.2",
     "conventional-changelog": "^1.1.0",
     "ember-cli-inject-live-reload": "^1.3.0",
+    "firebase-tools": "^2.2.1",
     "fs-extra": "^0.26.5",
     "glob": "^6.0.4",
     "gulp": "^3.9.1",


### PR DESCRIPTION
R: @kara 

FYI: @hansl @robertmesserle 

This gives us an quick-and-easy way to push our local changes to a publicly reachable place. You just run `firebase deploy` from your project root and it will push your most recent build up to https://material2-test.firebaseapp.com.

While it's possible we collide in doing this, it's unlikely with just the few of us doing it.