### PR TITLE
fix(icon): export icon registry as part of icon

### DIFF
--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -11,7 +11,7 @@ import {
     AfterViewChecked
 } from '@angular/core';
 import {MdIconRegistry} from './icon-registry';
-
+export {MdIconRegistry} from './icon-registry';
 
 
 /** Exception thrown when an invalid icon name is passed to an md-icon component. */

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -1,6 +1,5 @@
 import {Component, ViewEncapsulation} from '@angular/core';
-import {MdIcon} from '../../components/icon/icon';
-import {MdIconRegistry} from '../../components/icon/icon-registry';
+import {MdIcon, MdIconRegistry} from '../../components/icon/icon';
 
 @Component({
   selector: 'md-icon-demo',


### PR DESCRIPTION
Currently, if you want to use `md-icon`, you have to import `MdIcon` and `MdIconRegistry` from separate files.  This PR consolidates the import, so you can do:

`import {MdIcon, MdIconRegistry} from '@angular2-material/icon'`

instead of:

```
import {MdIcon} from '@angular2-material/icon'
import {MdIconRegistry} from '@angular2-material/icon/icon-registry'
```
