### PR TITLE
fix(sidenav): fullscreen sidenavs should not scroll

### DIFF
--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -64,6 +64,10 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
   // TODO(hansl): Update this with a more robust solution.
   &[fullscreen] {
     @include md-sidenav-fullscreen();
+
+    &.md-sidenav-opened {
+      overflow: hidden;
+    }
   }
 
   // Need this to take up space in the layout.
@@ -108,6 +112,9 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
     bottom: 0;
     z-index: 3;
     min-width: 5%;
+
+    // TODO(kara): revisit scrolling behavior for sidenavs
+    overflow-y: auto;
 
     background-color: $md-sidenav-background-color;
 

--- a/src/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app.scss
@@ -9,13 +9,13 @@
   }
 
   md-sidenav {
-    width: 15%;
+    min-width: 15%;
 
     [md-button] {
       width: 100%;
-      position: absolute;
+      position: relative;
       bottom: 0;
-      margin-bottom: 24px;
+      margin: 24px 0;
     }
   }
 
@@ -40,4 +40,3 @@
     font-size: 20px;
   }
 }
-


### PR DESCRIPTION
r: @jelbourn 

This PR ensures that it's not possible to scroll past the sidenav backdrop when the sidenav is open.