### PR TITLE
feat(input): add ability to hide text divider

### DIFF
--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -15,6 +15,18 @@ At the time of writing this README, the `[type]` attribute is copied to the actu
 
 The valid `type` attribute values are any supported by your browser, with the exception of `file`, `checkbox` and `radio`. File inputs aren't supported for now, while check boxes and radio buttons have their own components.
 
+## Text Divider
+
+You can choose to show or hide the text divider line under the `<input>`. By default the text divider will always be `true`.
+
+To hide the text divider:
+
+#### Example
+
+```html
+<md-input placeholder="Hiding the text divider" [textDivider]="false">
+</md-input>
+```
 
 
 ## Prefix and Suffix

--- a/src/components/input/input.html
+++ b/src/components/input/input.html
@@ -40,7 +40,7 @@
     <div class="md-input-suffix"><ng-content select="[md-suffix]"></ng-content></div>
   </div>
 
-  <div class="md-input-underline"
+  <div *ngIf="textDivider" class="md-input-underline"
        [class.md-disabled]="disabled">
     <span class="md-input-ripple"
           [class.md-focused]="focused"

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -239,6 +239,14 @@ export function main() {
           expect(typeof fixture.componentInstance.value).toBe('number');
         });
     });
+
+    it('should NOT display text divider under input', () => {
+      return builder.createAsync(MdInputNoTextDividerTestController)
+        .then(fixture => {
+          fixture.detectChanges();
+          expect(fixture.debugElement.query(By.css('.md-input-underline'))).toBeFalsy();
+        });
+    });
   });
 }
 
@@ -387,3 +395,15 @@ class MdInputAriaTestController {
   ariaLabel: string = 'label';
   ariaDisabled: boolean = true;
 }
+
+@Component({
+  selector: 'text-input-controller',
+  template: `
+    <md-input [textDivider]="false">
+    </md-input>
+  `,
+  directives: [MdInput]
+})
+class MdInputNoTextDividerTestController {
+}
+

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -139,6 +139,7 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   @Input() @BooleanFieldValue() required: boolean = false;
   @Input() @BooleanFieldValue() spellcheck: boolean = false;
   @Input() type: string = 'text';
+  @Input() @BooleanFieldValue() textDivider: boolean = true;
 
   get value(): any { return this._value; };
   @Input() set value(v: any) {

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -27,6 +27,16 @@
 </md-card>
 
 <md-card class="demo-card demo-basic">
+  <md-toolbar color="primary">Text Divider</md-toolbar>
+  <md-card-content>
+    <md-input class="demo-full-width" placeholder="Example 1 (with text divider)">
+    </md-input>
+    <md-input class="demo-full-width" placeholder="Example 2 (no text divider)" [textDivider]="false">
+    </md-input>
+  </md-card-content>
+</md-card>
+
+<md-card class="demo-card demo-basic">
   <md-toolbar color="primary">Prefix + Suffix</md-toolbar>
   <md-card-content>
     <md-input placeholder="amount" align="end">


### PR DESCRIPTION
@hansl @kara @jelbourn 

Adds the ability to show or hide the underline beneath the input (just like with the floating placeholder)

<img width="1358" alt="screen shot 2016-05-06 at 10 40 37 pm" src="https://cloud.githubusercontent.com/assets/3433118/15090471/c6e13b5c-13dd-11e6-8185-81f306cfafcc.png">
