### PR TITLE
docs(): add reference to a plunker template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,6 +14,8 @@ This repository's issues are reserved for feature requests and bug reports.
 please provide steps to reproduce and if possible a minimal demo of the problem**
 via https://plnkr.co or similar.
 
+Plunker Template: http://plnkr.co/edit/o077B6uEiiIgkC0S06dd?p=preview
+
 
 * **What is the expected behavior?**
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Also see our [`Good for community contribution`](https://github.com/angular/mate
 
 #### Quick links
 [Google group](https://groups.google.com/forum/#!forum/angular-material2),
-[Contributing](https://github.com/angular/material2/blob/master/CONTRIBUTING.md)
+[Contributing](https://github.com/angular/material2/blob/master/CONTRIBUTING.md),
+[Plunker Template](http://plnkr.co/edit/o077B6uEiiIgkC0S06dd?p=preview)
 
 ## The goal of Angular Material
 Our goal is to build a set of high-quality UI components built with Angular 2 and TypeScript, 


### PR DESCRIPTION
* Adds a basic Plunker Template for Angular Material 2.

Fixes #309.