### PR TITLE
chore(icons): use individual RxJS imports

### DIFF
--- a/src/components/icon/icon-registry.ts
+++ b/src/components/icon/icon-registry.ts
@@ -1,6 +1,14 @@
 import {Injectable} from '@angular/core';
 import {Http} from '@angular/http';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/share';
+import 'rxjs/add/operator/finally';
+import 'rxjs/add/operator/catch';
 import {MdError} from '../../core/errors/error';
 
 


### PR DESCRIPTION
using `rxjs/Rx` import brings in the entire RxJS library (300+ KB) - this changes to import only the required operators.