### PR TITLE
chore(release): update release script to use npm not gulp

### DIFF
--- a/scripts/release/stage-release.sh
+++ b/scripts/release/stage-release.sh
@@ -16,7 +16,7 @@ rm -rf ./deploy
 ng build
 
 # Inline the css and html into the component ts files.
-./node_modules/gulp/bin/gulp.js inline-resources
+npm run inline-resources
 
 # deploy/ serves as a working directory to stage the release.
 mkdir deploy


### PR DESCRIPTION
r: @hansl @robertmesserle @jelbourn 

We no longer have a gulpfile, so we have to update the release script to use the npm script, not gulp.