### PR TITLE
fix(gestures): export gesture config as part of core

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -4,3 +4,6 @@ export * from './rtl/dir';
 // Portals
 export * from './portal/portal';
 export * from './portal/portal-directives';
+
+// Gestures
+export * from './gestures/MdGestureConfig';


### PR DESCRIPTION
r: @jelbourn @hansl @robertmesserle 

`MdGestureConfig` is intended to be publicly available, but it wasn't being exported as part of core.