### PR TITLE
feat(stepper): add stepper component

### DIFF
--- a/src/components/stepper/README.md
+++ b/src/components/stepper/README.md
@@ -1,0 +1,60 @@
+# MdStepper
+`MdStepper` is a component to display different steps.
+
+### Screenshots
+![image](https://gyazo.com/4676abfe372d01c76e64f4ac074adb41)
+
+## `<md-stepper>`
+### Bound Properties
+
+| Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| `mode` | `"linear" | "nonlinear"` | Changes the behaviour of the `stepper` | 'linear' |
+
+### Examples
+A linear stepper would have the following markup:
+```html
+<md-stepper mode="linear">
+    <md-step label="Step one">
+      Content
+    </md-step>
+</md-stepper>
+```
+
+A non-linear stepper would have this markup:
+```html
+<md-stepper mode="nonlinear">
+    <md-step label="Step one">
+      Content
+    </md-step>
+</md-stepper>
+```
+
+## `<md-step>`
+### Bound Properties
+
+| Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| `label` | `string` | Sets the `step` title | '' |
+| `editable` | `boolean` | Toggles editability after `step` is completed | true |
+| `valid` | `boolean` | Sets validity of the `step` | true |
+| `optional` | `boolean` | Makes the `step` optional | false |
+
+### Examples
+
+A not-editable step would have following markup:
+```html
+  <md-step label="Step one" editable="false">
+    Content
+  </md-step>
+```
+
+You can toggle the validity of the step by using:
+```html
+  <md-step label="Step one" [valid]="myVariable">
+    Content
+  </md-step>
+```
+
+## Theming
+The `md-stepper` is using the `primary` palette for its styling.

--- a/src/components/stepper/package.json
+++ b/src/components/stepper/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@angular2-material/stepper",
+  "version": "2.0.0-alpha.5",
+  "description": "Angular 2 Material stepper",
+  "main": "./stepper.js",
+  "typings": "./stepper.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/material2.git"
+  },
+  "keywords": [
+    "angular",
+    "material",
+    "material design",
+    "components",
+    "stepper",
+    "tutorial"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angular/material2/issues"
+  },
+  "homepage": "https://github.com/angular/material2#readme",
+  "peerDependencies": {
+    "@angular2-material/core": "2.0.0-alpha.4"
+  }
+}

--- a/src/components/stepper/step.html
+++ b/src/components/stepper/step.html
@@ -1,0 +1,3 @@
+<div class="md-step-content" [class.md-active]="active" [class.md-left]="isLeft" [class.md-right]="isRight">
+  <ng-content></ng-content>
+</div>

--- a/src/components/stepper/step.scss
+++ b/src/components/stepper/step.scss
@@ -1,0 +1,27 @@
+.md-step-content {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: auto;
+  opacity: 0;
+  will-change: transform;
+  transition-duration: 0.5s;
+  transition-property: opacity, transform;
+  width: 100%;
+  padding: 24px;
+
+  &.md-active {
+    opacity: 1;
+    position: relative;
+  }
+
+  &.md-right {
+    transform: translate3d(120%, 0, 0);
+    opacity: 0;
+  }
+
+  &.md-left {
+    transform: translate3d(-120%, 0, 0);
+    opacity: 0;
+  }
+}

--- a/src/components/stepper/stepper.html
+++ b/src/components/stepper/stepper.html
@@ -1,0 +1,32 @@
+<div class="md-step-header">
+  <div class="md-steps">
+    <div *ngFor="let step of steps" class="md-step" (click)="selectStep(step)">
+      <div class="md-stepper-item-container">
+        <div class="md-stepper-circle-container">
+          <div *ngIf="!step.completed" class="md-step-circle" [class.md-active]="step.active || step.completed">
+            {{ steps.indexOf(step) + 1 }}
+          </div>
+          <div *ngIf="step.completed" class="md-step-circle" [class.md-active]="step.active || step.completed">
+            <md-icon class="md-step-icon">{{ step._stepperIconLigature }}</md-icon>
+          </div>
+        </div>
+        <div class="md-step-label">
+          <span class="md-step-title" [class.md-active]="step.active || step.completed">{{ step.label }}</span>
+          <br>
+          <span *ngIf="step.optional" class="md-step-optional">Optional</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="md-step-content-container">
+  <ng-content></ng-content>
+</div>
+<div class="md-navigation-buttons">
+  <button md-button [disabled]="!currentStep.valid || !getPreviousEditableStep(currentStep)" (click)="selectPreviousStep()">
+    BACK
+  </button>
+  <button md-button color="primary" [disabled]="!currentStep.valid || !getNextEditableStep(currentStep)" (click)="selectNextStep()">
+    CONTINUE
+  </button>
+</div>

--- a/src/components/stepper/stepper.scss
+++ b/src/components/stepper/stepper.scss
@@ -1,0 +1,114 @@
+//TODO(): Just added temporarily
+@import "default-theme";
+
+$md-step-circle-size: 24px !default;
+$md-step-line-height: 1px !default;
+
+.md-stepper {
+  display: block;
+  margin: 0;
+  overflow: hidden;
+}
+
+.md-step-header {
+  position: relative;
+  overflow: hidden;
+  height: 72px;
+  display: block;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.38);
+}
+
+.md-steps {
+  display: flex;
+  min-width: 100%;
+  align-content: stretch;
+}
+
+.md-stepper-item-container {
+  display: flex;
+  cursor: pointer;
+}
+
+//Before and after create the connection lines between the components
+.md-step {
+  display: inline-flex;
+  flex-basis: 100%;
+
+  &::before {
+    background: rgba(0, 0, 0, 0.38);
+    display: inline-flex;
+    height: $md-step-line-height;
+    content: '';
+    flex-grow: 1;
+    align-self: center;
+  }
+
+  &:first-child::before {
+    display: none;
+  }
+
+  &::after {
+    background: rgba(0, 0, 0, 0.38);
+    display: inline-flex;
+    height: $md-step-line-height;
+    content: '';
+    flex-grow: 1;
+    align-self: center;
+  }
+
+  &:last-child::after {
+    display: none;
+  }
+}
+
+.md-stepper-circle-container {
+  padding: 24px 8px 24px 24px;
+}
+
+.md-step-circle {
+  display: block;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.38);
+  width: $md-step-circle-size;
+  height: $md-step-circle-size;
+  color: rgba(255, 255, 255, 1);
+  background-clip: content-box;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 24px;
+
+  &.md-active {
+    background-color: md-color($md-primary);
+  }
+}
+
+.md-step-label {
+  padding-right: 8px;
+  align-self: center;
+}
+
+.md-step-title {
+  font-size: 14px;
+
+  &.md-active {
+    font-weight: bold;
+  }
+}
+
+.md-step-optional {
+  align-self: center;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.md-step-content-container {
+  position: relative;
+  display: block;
+}
+
+.md-navigation-buttons {
+  width: 100%;
+  height: auto;
+  display: inline-flex;
+  justify-content: space-between;
+}

--- a/src/components/stepper/stepper.ts
+++ b/src/components/stepper/stepper.ts
@@ -1,0 +1,129 @@
+import {
+  Component,
+  Input,
+  ViewEncapsulation,
+  ContentChild,
+  Renderer,
+  ElementRef
+} from '@angular/core';
+import { BooleanFieldValue } from '@angular2-material/core/annotations/field-value';
+import { MdIcon, MdIconRegistry } from '@angular2-material/icon/icon';
+import { NgFormModel } from '@angular/common';
+
+@Component({
+  selector: 'md-stepper',
+  templateUrl: 'stepper.html',
+  styleUrls: ['stepper.css'],
+  providers: [MdIconRegistry],
+  directives: [MdIcon],
+  encapsulation: ViewEncapsulation.None
+})
+export class MdStepper {
+
+  steps: MdStep[] = [];
+
+  @Input() mode: 'linear' | 'nonlinear' = 'nonlinear';
+
+  addStep(step: MdStep): void {
+    if (this.steps.length === 0) step.active = true;
+    this.steps.push(step);
+  }
+
+  //To check if all steps are completed before a specific step
+  allStepsBeforeCompleted(step: MdStep): boolean {
+    for (var i = this.steps.indexOf(this.currentStep); i < this.steps.indexOf(step); i++) {
+      if (!this.steps[i].completed && !this.steps[i].optional) return false;
+    }
+    return true;
+  }
+
+  selectStep(step: MdStep): void {
+    this.currentStep.completed = this.currentStep.valid ? true : false;
+    if (this.mode === 'linear') {
+      if (!this.currentStep.valid) return;
+      if (!this.allStepsBeforeCompleted) return;
+    }
+    if (step.completed && !step.editable) return;
+    this.steps.forEach((step) => {
+      step.active = false;
+    });
+    step.active = true;
+  }
+
+  get currentStep(): MdStep {
+    return this.steps.filter(step => step.active)[0];
+  }
+
+  selectNextStep(step: MdStep): void {
+    var nextEditableStep = this.getNextEditableStep(step);
+    if (nextEditableStep) this.selectStep(nextEditableStep);
+  }
+
+  selectPreviousStep(step: MdStep): void {
+    var previousEditableStep = this.getPreviousEditableStep(step);
+    if (previousEditableStep) this.selectStep(previousEditableStep);
+  }
+
+
+  getNextEditableStep(step: MdStep): MdStep {
+    if (this.steps.indexOf(this.currentStep) === this.steps.length - 1) return undefined;
+    for (var i = this.steps.indexOf(this.currentStep) + 1; i < this.steps.length; i++) {
+      if (this.steps[i].isTargetable) {
+        return this.steps[i];
+      }
+    }
+    return undefined;
+  }
+
+  getPreviousEditableStep(step: MdStep): MdStep {
+    if (this.steps.indexOf(this.currentStep) === 0) return;
+    for (var i = this.steps.indexOf(this.currentStep) - 1; i >= 0; i--) {
+      if (this.steps[i].isTargetable) {
+        return this.steps[i];
+      }
+    }
+    return;
+  }
+}
+
+@Component({
+  selector: 'md-step',
+  templateUrl: 'step.html',
+  styleUrls: ['step.css'],
+  encapsulation: ViewEncapsulation.None
+})
+export class MdStep {
+
+  active: boolean = false;
+  completed: boolean = false;
+
+  @Input() @BooleanFieldValue() optional: boolean = false;
+  @Input() @BooleanFieldValue() editable: boolean = true;
+  @Input() @BooleanFieldValue() valid: boolean = true;
+  @Input() label: string = '';
+
+  constructor(private steps: MdStepper) {
+    steps.addStep(this);
+  }
+
+  get isLeft(): boolean {
+    return this.steps.steps.indexOf(this) < this.steps.steps.indexOf(this.steps.currentStep);
+  }
+
+  get isRight(): boolean {
+    return this.steps.steps.indexOf(this) > this.steps.steps.indexOf(this.steps.currentStep);
+  }
+
+  get isTargetable(): boolean {
+    return !this.editable && this.completed ? false : true;
+  }
+
+  private get _stepperIconLigature(): string {
+    return (!this.active && this.completed) ? 'done' : 'create';
+  }
+}
+
+export const MD_STEPPER_DIRECTIVES: any[] = [
+  MdStepper,
+  MdStep
+];

--- a/src/components/stepper/stepper.ts
+++ b/src/components/stepper/stepper.ts
@@ -2,13 +2,9 @@ import {
   Component,
   Input,
   ViewEncapsulation,
-  ContentChild,
-  Renderer,
-  ElementRef
 } from '@angular/core';
 import { BooleanFieldValue } from '@angular2-material/core/annotations/field-value';
 import { MdIcon, MdIconRegistry } from '@angular2-material/icon/icon';
-import { NgFormModel } from '@angular/common';
 
 @Component({
   selector: 'md-stepper',
@@ -25,14 +21,16 @@ export class MdStepper {
   @Input() mode: 'linear' | 'nonlinear' = 'nonlinear';
 
   addStep(step: MdStep): void {
-    if (this.steps.length === 0) step.active = true;
+    if (this.steps.length === 0) {
+      step.active = true;
+    }
     this.steps.push(step);
   }
 
-  //To check if all steps are completed before a specific step
+  // To check if all steps are completed before a specific step
   allStepsBeforeCompleted(step: MdStep): boolean {
     for (var i = this.steps.indexOf(this.currentStep); i < this.steps.indexOf(step); i++) {
-      if (!this.steps[i].completed && !this.steps[i].optional) return false;
+      if (!this.steps[i].completed && !this.steps[i].optional) { return false; }
     }
     return true;
   }
@@ -40,12 +38,12 @@ export class MdStepper {
   selectStep(step: MdStep): void {
     this.currentStep.completed = this.currentStep.valid ? true : false;
     if (this.mode === 'linear') {
-      if (!this.currentStep.valid) return;
-      if (!this.allStepsBeforeCompleted) return;
+      if (!this.currentStep.valid) { return; }
+      if (!this.allStepsBeforeCompleted) { return; }
     }
-    if (step.completed && !step.editable) return;
-    this.steps.forEach((step) => {
-      step.active = false;
+    if (step.completed && !step.editable) { return; }
+    this.steps.forEach((step1) => {
+      step1.active = false;
     });
     step.active = true;
   }
@@ -56,27 +54,31 @@ export class MdStepper {
 
   selectNextStep(step: MdStep): void {
     var nextEditableStep = this.getNextEditableStep(step);
-    if (nextEditableStep) this.selectStep(nextEditableStep);
+    if (nextEditableStep) {
+      this.selectStep(nextEditableStep);
+    }
   }
 
   selectPreviousStep(step: MdStep): void {
     var previousEditableStep = this.getPreviousEditableStep(step);
-    if (previousEditableStep) this.selectStep(previousEditableStep);
+    if (previousEditableStep) {
+      this.selectStep(previousEditableStep);
+    }
   }
 
 
   getNextEditableStep(step: MdStep): MdStep {
-    if (this.steps.indexOf(this.currentStep) === this.steps.length - 1) return undefined;
+    if (this.steps.indexOf(this.currentStep) === this.steps.length - 1) { return; }
     for (var i = this.steps.indexOf(this.currentStep) + 1; i < this.steps.length; i++) {
       if (this.steps[i].isTargetable) {
         return this.steps[i];
       }
     }
-    return undefined;
+    return;
   }
 
   getPreviousEditableStep(step: MdStep): MdStep {
-    if (this.steps.indexOf(this.currentStep) === 0) return;
+    if (this.steps.indexOf(this.currentStep) === 0) { return; }
     for (var i = this.steps.indexOf(this.currentStep) - 1; i >= 0; i--) {
       if (this.steps[i].isTargetable) {
         return this.steps[i];

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -17,6 +17,7 @@
       <a md-list-item [routerLink]="['radio']">Radio</a>
       <a md-list-item [routerLink]="['sidenav']">Sidenav</a>
       <a md-list-item [routerLink]="['slide-toggle']">Slide Toggle</a>
+      <a md-list-item [routerLink]="['stepper']">Stepper</a>
       <a md-list-item [routerLink]="['toolbar']">Toolbar</a>
       <a md-list-item [routerLink]="['tab-group']">Tab Group</a>
     </md-nav-list>

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -26,6 +26,7 @@ import {GesturesDemo} from '../gestures/gestures-demo';
 import {GridListDemo} from '../grid-list/grid-list-demo';
 import {TabGroupDemo} from '../tab-group/tab-group-demo';
 import {SlideToggleDemo} from '../slide-toggle/slide-toggle-demo';
+import {StepperDemo} from '../stepper/stepper-demo';
 
 @Component({
   selector: 'home',
@@ -60,6 +61,7 @@ export class Home {}
   new Route({path: '/radio', component: RadioDemo}),
   new Route({path: '/sidenav', component: SidenavDemo}),
   new Route({path: '/slide-toggle', component: SlideToggleDemo}),
+  new Route({path: '/stepper', component: StepperDemo}),
   new Route({path: '/progress-circle', component: ProgressCircleDemo}),
   new Route({path: '/progress-bar', component: ProgressBarDemo}),
   new Route({path: '/portal', component: PortalDemo}),

--- a/src/demo-app/stepper/stepper-demo.html
+++ b/src/demo-app/stepper/stepper-demo.html
@@ -1,0 +1,31 @@
+<h1>Stepper Demo</h1>
+<h3>Linear stepper</h3>
+<div class="demo-stepper-layout">
+  <md-stepper mode="linear">
+    <md-step label="Step one" [valid]="slideToggleLinear">
+      <md-slide-toggle [(ngModel)]="slideToggleLinear">
+        Toggle the slider to finish this step
+      </md-slide-toggle>
+    </md-step>
+    <md-step *ngFor="let step of steps" label="{{ step.label }}" optional="{{ step.optional }}" editable="{{ step.editable }}">
+      <div>
+        {{ step.content }}
+      </div>
+    </md-step>
+  </md-stepper>
+</div>
+<h3>Non-linear stepper</h3>
+<div class="demo-stepper-layout">
+  <md-stepper mode="nonlinear">
+    <md-step label="Step one" [valid]="slideToggleNonlinear">
+      <md-slide-toggle [(ngModel)]="slideToggleNonlinear">
+        Toggle the slider to finish this step
+      </md-slide-toggle>
+    </md-step>
+    <md-step *ngFor="let step of steps" label="{{ step.label }}" optional="{{ step.optional }}" editable="{{ step.editable }}">
+      <div>
+        {{ step.content }}
+      </div>
+    </md-step>
+  </md-stepper>
+</div>

--- a/src/demo-app/stepper/stepper-demo.scss
+++ b/src/demo-app/stepper/stepper-demo.scss
@@ -1,0 +1,3 @@
+.demo-stepper-layout {
+  border: 3px solid black;
+}

--- a/src/demo-app/stepper/stepper-demo.ts
+++ b/src/demo-app/stepper/stepper-demo.ts
@@ -16,8 +16,15 @@ import { MdSlideToggle } from '@angular2-material/slide-toggle/slide-toggle';
 export class StepperDemo {
 
   steps = [
-    { label: 'Step Two', optional: 'false', editable: 'false', content: 'This is the content of the second step. ATTENTION: This step is not editable after it is completed!' },
-    { label: 'Step Three', optional: 'true', editable: 'true', content: 'This is the content of the third step.' },
-    { label: 'Step Four', optional: 'false', editable: 'true', content: 'This is the content of the fourth step' }
+    { label: 'Step Two', optional: 'false', editable: 'false',
+      content: 'This is the content of the second step.' +
+        'ATTENTION: This step is not editable after it is completed!'
+    },
+    { label: 'Step Three', optional: 'true', editable: 'true',
+      content: 'This is the content of the third step.'
+    },
+    { label: 'Step Four', optional: 'false', editable: 'true',
+      content: 'This is the content of the fourth step'
+    }
   ];
 }

--- a/src/demo-app/stepper/stepper-demo.ts
+++ b/src/demo-app/stepper/stepper-demo.ts
@@ -1,0 +1,23 @@
+import {
+  Component,
+  ViewEncapsulation
+} from '@angular/core';
+import { MD_STEPPER_DIRECTIVES } from '@angular2-material/stepper/stepper';
+import { MdSlideToggle } from '@angular2-material/slide-toggle/slide-toggle';
+
+@Component({
+  moduleId: module.id,
+  selector: 'stepper-demo',
+  templateUrl: 'stepper-demo.html',
+  styleUrls: ['stepper-demo.css'],
+  directives: [MD_STEPPER_DIRECTIVES, MdSlideToggle],
+  encapsulation: ViewEncapsulation.None
+})
+export class StepperDemo {
+
+  steps = [
+    { label: 'Step Two', optional: 'false', editable: 'false', content: 'This is the content of the second step. ATTENTION: This step is not editable after it is completed!' },
+    { label: 'Step Three', optional: 'true', editable: 'true', content: 'This is the content of the third step.' },
+    { label: 'Step Four', optional: 'false', editable: 'true', content: 'This is the content of the fourth step' }
+  ];
+}

--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -18,6 +18,7 @@ const components = [
   'radio',
   'sidenav',
   'slide-toggle',
+  'stepper',
   'tab-group',
   'toolbar'
 ];


### PR DESCRIPTION
Add a stepper component, which matches the google material specs pretty good: https://www.google.com/design/spec/components/steppers.html

Types of steppers: 
- [X] Linear Stepper
- [X] Non-Linear Stepper
- [X] Horizontal Stepper
- [ ] Vertical Stepper
- [ ] Mobile Stepper

Types of steps:
- [X] Editable/Non-editable
- [X] Optional

Also it has an swipe animation and navigation buttons at the bottom. Here is a screenshot from my component and one from the specs to show the similarity:

![image](https://cloud.githubusercontent.com/assets/10695477/15483660/1680d48c-2136-11e6-854b-d0b6c4939337.png)

![image](https://cloud.githubusercontent.com/assets/10695477/15483283/3ab9ffd8-2134-11e6-826d-867608ec5c44.png)