### PR TITLE
chore(): use core-js instead of es6-shim

### DIFF
--- a/angular-cli-build.js
+++ b/angular-cli-build.js
@@ -84,8 +84,7 @@ function _buildAppTree(defaults) {
   return new Angular2App(defaults, inputNode, {
     sourceDir: sourceDir,
     polyfills: [
-      'vendor/es6-shim/es6-shim.js',
-      'vendor/reflect-metadata/Reflect.js',
+      'vendor/core-js/client/core.js',
       'vendor/systemjs/dist/system.src.js',
       'vendor/zone.js/dist/zone.js',
       'vendor/hammerjs/hammer.min.js'
@@ -100,8 +99,7 @@ function _buildAppTree(defaults) {
       'systemjs/dist/system-polyfills.js',
       'systemjs/dist/system.src.js',
       'zone.js/dist/*.js',
-      'es6-shim/es6-shim.js',
-      'reflect-metadata/*.js',
+      'core-js/client/core.js',
       'rxjs/**/*.js',
       '@angular/**/*.js',
       'hammerjs/*.min.+(js|js.map)'

--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "@angular/platform-browser": "2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/router": "2.0.0-rc.1",
-    "es6-promise": "^3.0.2",
-    "es6-shim": "^0.35.0",
+    "core-js": "^2.4.0",
     "hammerjs": "^2.0.8",
-    "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
     "systemjs": "0.19.26",
     "zone.js": "0.6.12"

--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -19,8 +19,7 @@ export function config(config) {
       require('karma-firefox-launcher'),
     ],
     files: [
-      {pattern: 'dist/vendor/es6-shim/es6-shim.js', included: true, watched: false},
-      {pattern: 'dist/vendor/reflect-metadata/Reflect.js', included: true, watched: false},
+      {pattern: 'dist/vendor/core-js/client/core.js', included: true, watched: false},
       {pattern: 'dist/vendor/systemjs/dist/system-polyfills.js', included: true, watched: false},
       {pattern: 'dist/vendor/systemjs/dist/system.src.js', included: true, watched: false},
       {pattern: 'dist/vendor/zone.js/dist/zone.js', included: true, watched: false},

--- a/typings.json
+++ b/typings.json
@@ -6,7 +6,7 @@
     "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#26c98c8a9530c44f8c801ccc3b2057e2101187ee"
   },
   "ambientDependencies": {
-    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
+    "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#de8e80dfe5360fef44d00c41257d5ef37add000a"
   }
 }


### PR DESCRIPTION
Replace es6-shim, es6-promise and reflect-metadata with core-js, because it coveres all required dependencies / shims in one single dependency / library.

@jelbourn - Not sure, with replacing the reflect-metadata dependency with core-js (https://github.com/zloirock/core-js/issues/152).

Closes #477.