### PR TITLE
chore(): update typings dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ts-node": "^0.7.3",
     "tslint": "^3.5.0",
     "typescript": "^1.9.0-dev",
-    "typings": "^0.8.1",
+    "typings": "^1.0.4",
     "which": "^1.2.4"
   }
 }

--- a/src/demo-app/typings.d.ts
+++ b/src/demo-app/typings.d.ts
@@ -1,3 +1,3 @@
-/// <reference path="../../typings/browser.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 declare var module: { id: string };

--- a/src/e2e-app/typings.d.ts
+++ b/src/e2e-app/typings.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/browser.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 declare var module: { id: string };
 

--- a/typings.json
+++ b/typings.json
@@ -2,11 +2,12 @@
   "name": "material2",
   "dependencies": {},
   "devDependencies": {},
-  "ambientDevDependencies": {
-    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#26c98c8a9530c44f8c801ccc3b2057e2101187ee"
+  "globalDevDependencies": {
+    "jasmine": "registry:dt/jasmine#2.2.0+20160505161446"
   },
-  "ambientDependencies": {
+  "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
-    "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#de8e80dfe5360fef44d00c41257d5ef37add000a"
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
+    "hammerjs": "registry:dt/hammerjs#2.0.4+20160417130828"
   }
 }


### PR DESCRIPTION
* Typings recently released the 1.0 version, which contained some breaking changes.
   The new typings versions >= 1.0 are no longer supporting the `ambient` name. (It's now `global`)

Official details / information can be found here
- https://github.com/typings/typings#updating-from-0x-to-10