### PR TITLE
fix(list): removes outline from focus state

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -202,6 +202,7 @@ md-nav-list {
     cursor: pointer;
 
     &:hover, &.md-list-item-focus {
+      outline: none;
       background: md-color($md-background, 'hover');
     }
   }


### PR DESCRIPTION
R: @jelbourn @kara

When I added the new focus state for list items, I forgot to remove the default outline.