### PR TITLE
fix(demo-app): resolve mapping paths in relative.

### DIFF
--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -25,9 +25,9 @@ const components = [
 
 /** Map relative paths to URLs. */
 const map: any = {
-  '@angular2-material/core': '/core',
+  '@angular2-material/core': 'core',
 };
-components.forEach(name => map[`@angular2-material/${name}`] = `/components/${name}`);
+components.forEach(name => map[`@angular2-material/${name}`] = `components/${name}`);
 
 
 /** User packages configuration. */

--- a/src/e2e-app/system-config.ts
+++ b/src/e2e-app/system-config.ts
@@ -25,9 +25,9 @@ const components = [
 
 /** Map relative paths to URLs. */
 const map: any = {
-  '@angular2-material/core': '/core',
+  '@angular2-material/core': 'core',
 };
-components.forEach(name => map[`@angular2-material/${name}`] = `/components/${name}`);
+components.forEach(name => map[`@angular2-material/${name}`] = `components/${name}`);
 
 
 /** User packages configuration. */


### PR DESCRIPTION
* Currently, the demo app is mapping its core and components absolutely (`/`), which is working perfectly for the served application
* This commit changes the absolute mapping paths to relative paths.<br/>
  This allows developers, to serve the demo-app in sub-directories (not only in the root).

Notice, that all other mappings in the configurations are also relative, so it will also restore consistency.

This is also required for some bundlers, for example SystemJS Builder is not able to build a bundle of the demo app, with absolute paths, because the baseURL may have changed.

This is a required commit, for the Live Preview (#533), because I'm planning to bundle the output, to accelerate deploy and load time.

References #553