### PR TITLE
perf(progress-circle): clean up animation on destroy

### DIFF
--- a/src/components/progress-circle/progress-circle.spec.ts
+++ b/src/components/progress-circle/progress-circle.spec.ts
@@ -74,6 +74,27 @@ describe('MdProgressCircular', () => {
         done();
       });
   });
+
+  it('should clean up the indeterminate animation when the element is destroyed',
+    (done: () => void) => {
+      let template = `<md-progress-circle
+                        mode="indeterminate"
+                        *ngIf="!isHidden"></md-progress-circle>`;
+
+      builder
+        .overrideTemplate(TestApp, template)
+        .createAsync(TestApp)
+        .then((fixture) => {
+          fixture.detectChanges();
+          let progressElement = getChildDebugElement(fixture.debugElement, 'md-progress-circle');
+          expect(progressElement.componentInstance.interdeterminateInterval).toBeTruthy();
+
+          fixture.debugElement.componentInstance.isHidden = true;
+          fixture.detectChanges();
+          expect(progressElement.componentInstance.interdeterminateInterval).toBeFalsy();
+          done();
+        });
+    });
 });
 
 


### PR DESCRIPTION
The indeterminate animation is based on an interval that keeps running, even after the element has been destroyed.
This change cleans up when the element is destroyed.

Also adds an extra null check for `performance.now`.