### PR TITLE
fix(slide-toggle): apply typography styles to slide-toggle

### DIFF
--- a/src/components/slide-toggle/slide-toggle.scss
+++ b/src/components/slide-toggle/slide-toggle.scss
@@ -86,7 +86,15 @@ $md-slide-toggle-margin: 16px !default;
   }
 }
 
-// The label is our root container for the slide-toggle / switch indicator and label text.
+// The content element is responsible for the users content.
+// It will apply the given typography styles and align at the end of the slide-toggle.
+.md-slide-toggle-content {
+  font-size: $md-body-font-size-base;
+  font-family: $md-font-family;
+  font-weight: 500;
+}
+
+// The label element is our root container for the slide-toggle / switch indicator and label text.
 // It has to be a label, to support accessibility for the visual hidden input.
 .md-slide-toggle-label {
   display: flex;


### PR DESCRIPTION
* The slide-toggle didn't apply any typography styles to the content element
   Now it applies the configurable typography variables.

Before: 
![image](https://cloud.githubusercontent.com/assets/4987015/15806444/b90baff8-2b43-11e6-8987-c45ab0f404ca.png)


After: 
![image](https://cloud.githubusercontent.com/assets/4987015/15805676/ca942cc6-2b31-11e6-851e-3d805b46e223.png)

Fixes #633.