### PR TITLE
fix inline-resources regex so it can find references in a component's minified js.

### DIFF
--- a/scripts/release/inline-resources.js
+++ b/scripts/release/inline-resources.js
@@ -62,7 +62,7 @@ for (let arg of process.argv.slice(2)) {
  * @return {string} The content with all templates inlined.
  */
 function inlineTemplate(filePath, content) {
-  return content.replace(/templateUrl:\s*'([^']+\.html)'/g, function(m, templateUrl) {
+  return content.replace(/templateUrl:\s*'([^']+?\.html)'/g, function(m, templateUrl) {
     const templateFile = path.join(path.dirname(filePath), templateUrl);
     const templateContent = fs.readFileSync(templateFile, 'utf-8');
     const shortenedTemplate = templateContent


### PR DESCRIPTION
---
### Overview
Modify the regex used to identify and replace templateUrl references so that it's not greedy. This means that components can be included in a bundle and the resources can still be inlined.

### Changes
* modified the regex `/templateUrl:\s*'([^']+\.html)'/g` to include the greedy modifier resulting in `/templateUrl:\s*'([^']+?\.html)'/g`

### Additional Notes
* bundled components will still have resource references that are relative to the directory the component started in. For this reason any components that don't exist in the same directory as the bundle will throw errors about not being able to find the reference resource.
