### PR TITLE
fix(slide-toggle): visual hidden input should not bubble click

### DIFF
--- a/src/components/checkbox/checkbox.html
+++ b/src/components/checkbox/checkbox.html
@@ -11,7 +11,8 @@
            [attr.aria-labelledby]="ariaLabelledby"
            (focus)="onInputFocus()"
            (blur)="onInputBlur()"
-           (change)="onInteractionEvent($event)">
+           (change)="onInteractionEvent($event)"
+           (click)="onInputClick($event)">
     <div class="md-ink-ripple"></div>
     <div class="md-checkbox-frame"></div>
     <div class="md-checkbox-background">

--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -183,6 +183,26 @@ describe('MdCheckbox', () => {
       expect(checkboxNativeElement.classList).toContain('md-checkbox-align-end');
     });
 
+    it('should not trigger the click event multiple times', () => {
+      // By default, when clicking on a label element, a generated click will be dispatched
+      // on the associated input element.
+      // Since we're using a label element and a visual hidden input, this behavior can led
+      // to an issue, where the click events on the checkbox are getting executed twice.
+
+      spyOn(testComponent, 'onCheckboxClick');
+
+      expect(inputElement.checked).toBe(false);
+      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+
+      labelElement.click();
+      fixture.detectChanges();
+
+      expect(checkboxNativeElement.classList).toContain('md-checkbox-checked');
+      expect(inputElement.checked).toBe(true);
+
+      expect(testComponent.onCheckboxClick).toHaveBeenCalledTimes(1);
+    });
+
     it('should emit a change event when the `checked` value changes', () => {
       // TODO(jelbourn): this *should* work with async(), but fixture.whenStable currently doesn't
       // know to look at pending macro tasks.
@@ -463,7 +483,8 @@ describe('MdCheckbox', () => {
         [checked]="isChecked" 
         [indeterminate]="isIndeterminate" 
         [disabled]="isDisabled"
-        (change)="changeCount = changeCount + 1">
+        (change)="changeCount = changeCount + 1"
+        (click)="onCheckboxClick($event)">
       Simple checkbox
     </md-checkbox>
   </div>`
@@ -476,6 +497,8 @@ class SingleCheckbox {
   parentElementClicked: boolean = false;
   parentElementKeyedUp: boolean = false;
   lastKeydownEvent: Event = null;
+
+  onCheckboxClick(event: Event) {}
 }
 
 /** Simple component for testing an MdCheckbox with ngModel and ngControl. */

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -278,6 +278,18 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
     }
   }
 
+  /** @internal */
+  onInputClick(event: Event) {
+    // We have to stop propagation for click events on the visual hidden input element.
+    // By default, when a user clicks on a label element, a generated click event will be
+    // dispatched on the associated input element. Since we are using a label element as our
+    // root container, the click event on the `checkbox` will be executed twice.
+    // The real click event will bubble up, and the generated click event also tries to bubble up.
+    // This will lead to multiple click events.
+    // Preventing bubbling for the second event will solve that issue.
+    event.stopPropagation();
+  }
+
   private _getAnimationClassForCheckStateTransition(
       oldState: TransitionCheckState, newState: TransitionCheckState): string {
     var animSuffix: string;

--- a/src/components/slide-toggle/slide-toggle.html
+++ b/src/components/slide-toggle/slide-toggle.html
@@ -18,7 +18,7 @@
            (blur)="onInputBlur()"
            (focus)="onInputFocus()"
            (change)="onChangeEvent($event)"
-           (click)="onTouched(); $event.stopPropagation()">
+           (click)="onInputClick($event)">
   </div>
   <span class="md-slide-toggle-content">
     <ng-content></ng-content>

--- a/src/components/slide-toggle/slide-toggle.html
+++ b/src/components/slide-toggle/slide-toggle.html
@@ -17,7 +17,8 @@
            [attr.aria-labelledby]="ariaLabelledby"
            (blur)="onInputBlur()"
            (focus)="onInputFocus()"
-           (change)="onChangeEvent($event)">
+           (change)="onChangeEvent($event)"
+           (click)="onTouched(); $event.stopPropagation()">
   </div>
   <span class="md-slide-toggle-content">
     <ng-content></ng-content>

--- a/src/components/slide-toggle/slide-toggle.spec.ts
+++ b/src/components/slide-toggle/slide-toggle.spec.ts
@@ -97,6 +97,24 @@ describe('MdSlideToggle', () => {
       expect(slideToggle.checked).toBe(true);
     });
 
+    it('should not trigger the click event multiple times', () => {
+      spyOn(testComponent, 'onSlideClick');
+
+      expect(slideToggle.checked).toBe(false);
+      expect(slideToggleElement.classList).not.toContain('md-checked');
+
+      // Mostly the users will click on the slide-toggle container which will emit in some cases the
+      // click event multiple times.
+      (<HTMLElement> labelElement.querySelector('.md-slide-toggle-container')).click();
+
+      fixture.detectChanges();
+
+      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggle.checked).toBe(true);
+
+      expect(testComponent.onSlideClick).toHaveBeenCalledTimes(1);
+    });
+
     it('should add a suffix to the inputs id', () => {
       testComponent.slideId = 'myId';
       fixture.detectChanges();
@@ -268,7 +286,8 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
     <md-slide-toggle [(ngModel)]="slideModel" [disabled]="isDisabled" [color]="slideColor" 
                      [id]="slideId" [checked]="slideChecked" [name]="slideName" 
                      [aria-label]="slideLabel" [ariaLabel]="slideLabel" 
-                     [ariaLabelledby]="slideLabelledBy" (change)="lastEvent = $event">
+                     [ariaLabelledby]="slideLabelledBy" (change)="lastEvent = $event"
+                     (click)="onSlideClick($event)">
       <span>Test Slide Toggle</span>
     </md-slide-toggle>
   `,
@@ -284,4 +303,6 @@ class SlideToggleTestApp {
   slideLabel: string;
   slideLabelledBy: string;
   lastEvent: MdSlideToggleChange;
+
+  onSlideClick(event: Event) {}
 }

--- a/src/components/slide-toggle/slide-toggle.spec.ts
+++ b/src/components/slide-toggle/slide-toggle.spec.ts
@@ -98,15 +98,17 @@ describe('MdSlideToggle', () => {
     });
 
     it('should not trigger the click event multiple times', () => {
+      // By default, when clicking on a label element, a generated click will be dispatched
+      // on the associated input element.
+      // Since we're using a label element and a visual hidden input, this behavior can led
+      // to an issue, where the click events on the slide-toggle are getting executed twice.
+
       spyOn(testComponent, 'onSlideClick');
 
       expect(slideToggle.checked).toBe(false);
       expect(slideToggleElement.classList).not.toContain('md-checked');
 
-      // Mostly the users will click on the slide-toggle container which will emit in some cases the
-      // click event multiple times.
-      (<HTMLElement> labelElement.querySelector('.md-slide-toggle-container')).click();
-
+      labelElement.click();
       fixture.detectChanges();
 
       expect(slideToggleElement.classList).toContain('md-checked');

--- a/src/components/slide-toggle/slide-toggle.ts
+++ b/src/components/slide-toggle/slide-toggle.ts
@@ -38,7 +38,6 @@ let nextId = 0;
     '[class.md-disabled]': 'disabled',
     // This md-slide-toggle prefix will change, once the temporary ripple is removed.
     '[class.md-slide-toggle-focused]': '_hasFocus',
-    '(click)': 'onTouched()',
     '(mousedown)': 'setMousedown()'
   },
   templateUrl: 'slide-toggle.html',

--- a/src/components/slide-toggle/slide-toggle.ts
+++ b/src/components/slide-toggle/slide-toggle.ts
@@ -92,6 +92,20 @@ export class MdSlideToggle implements ControlValueAccessor {
   }
 
   /** @internal */
+  onInputClick(event: Event) {
+    this.onTouched();
+
+    // We have to stop propagation for click events on the visual hidden input element.
+    // By default, when a user clicks on a label element, a generated click event will be
+    // dispatched on the associated input element. Since we are using a label element as our
+    // root container, the click event on the `slide-toggle` will be executed twice.
+    // The real click event will bubble up, and the generated click event also tries to bubble up.
+    // This will lead to multiple click events.
+    // Preventing bubbling for the second event will solve that issue.
+    event.stopPropagation();
+  }
+
+  /** @internal */
   setMousedown() {
     // We only *show* the focus style when focus has come to the button via the keyboard.
     // The Material Design spec is silent on this topic, and without doing this, the


### PR DESCRIPTION
* Currently the (click) event gets called twice.
  This is caused by the bubbling of the (click) event on the input.

Actually the second click will be called by the label element.
The browsers default behavior is, to trigger a click on the input, once the label got clicked.

This is in my opinion the correct approach, because we don't want to depend on the `click` event, instead of the `change` event.

- https://github.com/angular/angular/blob/master/modules/%40angular/common/src/forms-deprecated/directives/checkbox_value_accessor.ts


Fixes #671.