### PR TITLE
fix(overlay): make sure div is always removed after tests

### DIFF
--- a/src/core/overlay/position/viewport-ruler.spec.ts
+++ b/src/core/overlay/position/viewport-ruler.spec.ts
@@ -46,6 +46,7 @@ describe('ViewportRuler', () => {
     // successfully constrain its size. As such, skip assertions in environments where the
     // window size has changed since the start of the test.
     if (window.innerWidth > startingWindowWidth || window.innerHeight > startingWindowHeight) {
+      document.body.removeChild(veryLargeElement);
       return;
     }
 
@@ -78,6 +79,7 @@ describe('ViewportRuler', () => {
     // successfully constrain its size. As such, skip assertions in environments where the
     // window size has changed since the start of the test.
     if (window.innerWidth > startingWindowWidth || window.innerHeight > startingWindowHeight) {
+      document.body.removeChild(veryLargeElement);
       return;
     }
 


### PR DESCRIPTION
This was causing some mkInkRipple positioning tests to fail on mobile Safari (e.g. https://travis-ci.org/angular/material2/jobs/138190850), figured it would be useful to fix separately.