### PR TITLE
chore: fix deprecated error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",
     "stylelint": "stylelint 'src/**/*.scss' --config stylelint-config.json --syntax scss",
     "check-circular-deps": "madge --circular ./dist",
-    "typings": "typings install --ambient",
+    "typings": "typings install --global",
     "postinstall": "npm run typings",
     "e2e": "protractor",
     "inline-resources": "node ./scripts/release/inline-resources.js ./dist/components",


### PR DESCRIPTION
When you run `npm run typings` you get the following error:

```console
typings ERR! deprecated The "ambient" flag is deprecated. Please use "global" instead
```

This PR fixes that error.