### PR TITLE
fix(checkbox): should match native checkbox behavior

### DIFF
--- a/src/components/checkbox/checkbox.html
+++ b/src/components/checkbox/checkbox.html
@@ -1,6 +1,6 @@
 <label class="md-checkbox-layout">
   <div class="md-checkbox-inner-container">
-    <input class="md-checkbox-input" type="checkbox"
+    <input #input class="md-checkbox-input" type="checkbox"
            [id]="inputId"
            [checked]="checked"
            [disabled]="disabled"

--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -213,6 +213,9 @@ describe('MdCheckbox', () => {
         promiseCompleter.resolve();
       });
 
+      // Events are only triggered when the element has focus
+      checkboxInstance.hasFocus = true;
+
       testComponent.isChecked = true;
       fixture.detectChanges();
 
@@ -296,9 +299,24 @@ describe('MdCheckbox', () => {
       });
     }));
 
+    it('should NOT call the change event when it doesn\'t have focus', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(testComponent.lastEvent).toBeUndefined();
+
+      checkboxInstance.checked = true;
+      fixture.detectChanges();
+
+      tick();
+
+      expect(testComponent.lastEvent).toBeUndefined();
+    }));
+
     it('should call the change event on first change after initialization', fakeAsync(() => {
       fixture.detectChanges();
       expect(testComponent.lastEvent).toBeUndefined();
+
+      // Events are only triggered when the element has focus
+      checkboxInstance.hasFocus = true;
 
       checkboxInstance.checked = true;
       fixture.detectChanges();
@@ -311,6 +329,9 @@ describe('MdCheckbox', () => {
     it('should not emit a DOM event to the change output', async(() => {
       fixture.detectChanges();
       expect(testComponent.lastEvent).toBeUndefined();
+
+      // Events are only triggered when the element has focus
+      checkboxInstance.hasFocus = true;
 
       // Trigger the click on the inputElement, because the input will probably
       // emit a DOM event to the change output.

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -7,6 +7,7 @@ import {
     Output,
     Provider,
     Renderer,
+    ViewChild,
     ViewEncapsulation,
     forwardRef,
     AfterContentInit
@@ -113,6 +114,8 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
   /** Event emitted when the checkbox's `checked` value changes. */
   @Output() change: EventEmitter<MdCheckboxChange> = new EventEmitter<MdCheckboxChange>();
 
+  @ViewChild('input') _inputElement: ElementRef;
+
   /** Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor. */
   onTouched: () => any = () => {};
 
@@ -149,7 +152,7 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
           this._checked ? TransitionCheckState.Checked : TransitionCheckState.Unchecked);
 
       // Only fire a change event if this isn't the first time the checked property is ever set.
-      if (this._isInitialized) {
+      if (this._isInitialized && this.hasFocus) {
         this._emitChangeEvent();
       }
     }
@@ -177,6 +180,7 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
     this._indeterminate = indeterminate;
     if (this._indeterminate) {
       this._transitionCheckState(TransitionCheckState.Indeterminate);
+      this._checked = false;
     } else {
       this._transitionCheckState(
           this.checked ? TransitionCheckState.Checked : TransitionCheckState.Unchecked);

--- a/src/demo-app/checkbox/checkbox-demo.ts
+++ b/src/demo-app/checkbox/checkbox-demo.ts
@@ -48,13 +48,18 @@ export class MdCheckboxDemoNestedChecklist {
         : task.completed;
   }
 
-  someComplete(tasks: Task[]): boolean {
-    const numComplete = tasks.filter(t => t.completed).length;
-    return numComplete > 0 && numComplete < tasks.length;
+  someComplete(task: Task): boolean {
+    const subtasks = task.subtasks;
+    const numComplete = subtasks.filter(t => t.completed).length;
+    return numComplete > 0 && numComplete < subtasks.length;
   }
 
-  setAllCompleted(tasks: Task[], completed: boolean) {
-    tasks.forEach(t => t.completed = completed);
+  setAllCompleted(task: Task) {
+    task.subtasks.forEach(t => t.completed = task.completed);
+  }
+
+  resetParent(task: Task) {
+    task.completed = this.allComplete(task);
   }
 }
 

--- a/src/demo-app/checkbox/nested-checklist.html
+++ b/src/demo-app/checkbox/nested-checklist.html
@@ -2,14 +2,13 @@
 <ul>
   <li *ngFor="let task of tasks">
     <md-checkbox [(ngModel)]="task.completed"
-                 [checked]="allComplete(task)"
-                 [indeterminate]="someComplete(task.subtasks)"
-                 (change)="setAllCompleted(task.subtasks, $event)">
+                 [indeterminate]="someComplete(task)"
+                 (change)="setAllCompleted(task)">
       <h3>{{task.name}}</h3>
     </md-checkbox>
     <ul>
       <li *ngFor="let subtask of task.subtasks">
-        <md-checkbox [(ngModel)]="subtask.completed">
+        <md-checkbox [(ngModel)]="subtask.completed" (change)="resetParent(task)">
           {{subtask.name}}
         </md-checkbox>
       </li>


### PR DESCRIPTION
closes #575 

This appears to work, but I am trying a few different approaches before settling on one.

This approach has one small difference between native behavior: when indeterminate is set to true, the `checked` value is set to false.  This is not how native checkboxes work, but will only ever be seen if you check the `checked` value via JS while `indeterminate` is true.