### PR TITLE
feat(slide-toggle): add drag functionality to thumb

### DIFF
--- a/src/components/slide-toggle/slide-toggle.html
+++ b/src/components/slide-toggle/slide-toggle.html
@@ -1,7 +1,13 @@
 <label class="md-slide-toggle-label">
+
   <div class="md-slide-toggle-container">
     <div class="md-slide-toggle-bar"></div>
-    <div class="md-slide-toggle-thumb-container">
+
+    <div class="md-slide-toggle-thumb-container"
+         (slidestart)="_onDragStart($event)"
+         (slide)="_onDrag($event)"
+         (slideend)="_onDragEnd($event)">
+
       <div class="md-slide-toggle-thumb">
         <div class="md-ink-ripple"></div>
       </div>

--- a/src/components/slide-toggle/slide-toggle.scss
+++ b/src/components/slide-toggle/slide-toggle.scss
@@ -129,6 +129,12 @@ $md-slide-toggle-margin: 16px !default;
 
   transition: $swift-linear;
   transition-property: transform;
+
+  // Once the thumb container is being dragged around, we remove the transition duration to
+  // make the drag feeling fast and not delayed.
+  &.md-dragging {
+    transition-duration: 0ms;
+  }
 }
 
 // The thumb will be elevated from the slide-toggle bar.

--- a/src/components/slide-toggle/slide-toggle.ts
+++ b/src/components/slide-toggle/slide-toggle.ts
@@ -61,12 +61,6 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   private _isInitialized: boolean = false;
   private _slideRenderer: SlideToggleRenderer = null;
 
-  // State of the current drag, which holds required variables for the drag.
-  private _dragState: {
-    barWidth: number;
-    percentage?: number;
-  };
-
   @Input() @BooleanFieldValue() disabled: boolean = false;
   @Input() name: string = null;
   @Input() id: string = this._uniqueId;
@@ -242,7 +236,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 }
 
 /**
- * Renderer for the Slide Toggle component, which separates DOM modification in it's own class
+ * Renderer for the Slide Toggle component, which separates DOM modification in its own class
  */
 class SlideToggleRenderer {
 

--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -20,6 +20,7 @@ export function config(config) {
     ],
     files: [
       {pattern: 'dist/vendor/core-js/client/core.js', included: true, watched: false},
+      {pattern: 'dist/vendor/hammerjs/hammer.min.js', included: true, watched: false},
       {pattern: 'dist/vendor/systemjs/dist/system-polyfills.js', included: true, watched: false},
       {pattern: 'dist/vendor/systemjs/dist/system.src.js', included: true, watched: false},
       {pattern: 'dist/vendor/zone.js/dist/zone.js', included: true, watched: false},


### PR DESCRIPTION
This adds the dragging functionality to the `slide-toggle`.

It works pretty neat. Also tested on older touch devices. Seems like HammerJS is doing a pretty good job.

FYI: I intentionally didn't use the `class` / `style` bindings, because we don't want to trigger a change detection for each Drag Event.