### PR TITLE
feat(dialog): inital framework for md-dialog

### DIFF
--- a/src/components/dialog/dialog-config.ts
+++ b/src/components/dialog/dialog-config.ts
@@ -1,0 +1,19 @@
+import {ViewContainerRef} from '@angular/core';
+
+/** Valid ARIA roles for a dialog element. */
+export type DialogRole = 'dialog' | 'alertdialog'
+
+
+
+/**
+ * Configuration for opening a modal dialog with the MdDialog service.
+ */
+export class MdDialogConfig {
+  viewContainerRef: ViewContainerRef;
+
+  /** The ARIA role of the dialog element. */
+  role: DialogRole = 'dialog';
+
+  // TODO(jelbourn): add configuration for size, clickOutsideToClose, lifecycle hooks,
+  // ARIA labelling.
+}

--- a/src/components/dialog/dialog-container.html
+++ b/src/components/dialog/dialog-container.html
@@ -1,0 +1,1 @@
+<template portalHost></template>

--- a/src/components/dialog/dialog-container.scss
+++ b/src/components/dialog/dialog-container.scss
@@ -1,0 +1,8 @@
+@import 'elevation';
+
+:host {
+  // TODO(jelbourn): add real Material Design dialog styles.
+  display: block;
+  background: deeppink;
+  @include md-elevation(2);
+}

--- a/src/components/dialog/dialog-container.ts
+++ b/src/components/dialog/dialog-container.ts
@@ -50,7 +50,11 @@ export class MdDialogContainer extends BasePortalHost implements AfterViewInit {
 
         this._deferredAttachPortal = null;
         this._deferredAttachCompleter = null;
-      }, () => this._deferredAttachCompleter.reject());
+      }, () => {
+        this._deferredAttachCompleter.reject();
+        this._deferredAttachCompleter = null;
+        this._deferredAttachPortal = null;
+      });
     }
   }
 

--- a/src/components/dialog/dialog-container.ts
+++ b/src/components/dialog/dialog-container.ts
@@ -61,6 +61,10 @@ export class MdDialogContainer extends BasePortalHost implements AfterViewInit {
       // The @ViewChild query for the portalHost is not resolved until AfterViewInit, but this
       // function may be called before this lifecycle event. As such, we defer the attachment of
       // the portal until AfterViewInit.
+      if (this._deferredAttachCompleter) {
+        this._deferredAttachCompleter.reject();
+      }
+
       this._deferredAttachPortal = portal;
       this._deferredAttachCompleter = new PromiseCompleter();
       return this._deferredAttachCompleter.promise;

--- a/src/components/dialog/dialog-container.ts
+++ b/src/components/dialog/dialog-container.ts
@@ -1,0 +1,73 @@
+import {Component, ComponentRef, ViewChild, AfterViewInit} from '@angular/core';
+import {
+  BasePortalHost,
+  ComponentPortal,
+  TemplatePortal
+} from '@angular2-material/core/portal/portal';
+import {PortalHostDirective} from '@angular2-material/core/portal/portal-directives';
+import {PromiseCompleter} from '@angular2-material/core/async/promise-completer';
+import {MdDialogConfig} from './dialog-config';
+
+
+/**
+ * Internal component that wraps user-provided dialog content.
+ */
+@Component({
+  moduleId: module.id,
+  selector: 'md-dialog-container',
+  templateUrl: 'dialog-container.html',
+  styleUrls: ['dialog-container.css'],
+  directives: [PortalHostDirective],
+  host: {
+    'class': 'md-dialog-container',
+    '[attr.role]': 'dialogConfig?.role'
+  }
+})
+export class MdDialogContainer extends BasePortalHost implements AfterViewInit {
+  /** The portal host inside of this container into which the dialog content will be loaded. */
+  @ViewChild(PortalHostDirective) private _portalHost: PortalHostDirective;
+
+  /**
+   * Completer used to resolve the promise for cases when a portal is attempted to be attached,
+   * but AfterViewInit has not yet occured.
+   */
+  private _deferredAttachCompleter: PromiseCompleter<ComponentRef<any>>;
+
+  /** Portal to be attached upon AfterViewInit. */
+  private _deferredAttachPortal: ComponentPortal<any>;
+
+  /** The dialog configuration. */
+  dialogConfig: MdDialogConfig;
+
+  /** TODO: internal */
+  ngAfterViewInit() {
+    // If there was an attempted call to `attachComponentPortal` before this lifecycle stage,
+    // we actually perform the attachment now that the `@ViewChild` is resolved.
+    if (this._deferredAttachCompleter) {
+      this.attachComponentPortal(this._deferredAttachPortal).then(componentRef => {
+        this._deferredAttachCompleter.resolve(componentRef);
+
+        this._deferredAttachPortal = null;
+        this._deferredAttachCompleter = null;
+      });
+    }
+  }
+
+  /** Attach a portal as content to this dialog container. */
+  attachComponentPortal<T>(portal: ComponentPortal<T>): Promise<ComponentRef<T>> {
+    if (this._portalHost) {
+      return this._portalHost.attachComponentPortal(portal);
+    } else {
+      // The @ViewChild query for the portalHost is not resolved until AfterViewInit, but this
+      // function may be called before this lifecycle event. As such, we defer the attachment of
+      // the portal until AfterViewInit.
+      this._deferredAttachPortal = portal;
+      this._deferredAttachCompleter = new PromiseCompleter();
+      return this._deferredAttachCompleter.promise;
+    }
+  }
+
+  attachTemplatePortal(portal: TemplatePortal): Promise<Map<string, any>> {
+    throw Error('Not yet implemented');
+  }
+}

--- a/src/components/dialog/dialog-errors.ts
+++ b/src/components/dialog/dialog-errors.ts
@@ -1,0 +1,8 @@
+import {MdError} from '@angular2-material/core/errors/error';
+
+/** Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin. */
+export class MdDialogContentAlreadyAttachedError extends MdError {
+  constructor() {
+      super('Attempting to attach dialog content after content is already attached');
+  }
+}

--- a/src/components/dialog/dialog-injector.ts
+++ b/src/components/dialog/dialog-injector.ts
@@ -1,0 +1,16 @@
+import {Injector} from '@angular/core';
+import {MdDialogRef} from './dialog-ref';
+
+
+/** Custom injector type specifically for instantiating components with a dialog. */
+export class DialogInjector implements Injector {
+  constructor(private _dialogRef: MdDialogRef<any>, private _parentInjector: Injector) { }
+
+  get(token: any, notFoundValue?: any): any {
+    if (token === MdDialogRef) {
+      return this._dialogRef;
+    }
+
+    return this._parentInjector.get(token, notFoundValue);
+  }
+}

--- a/src/components/dialog/dialog-ref.ts
+++ b/src/components/dialog/dialog-ref.ts
@@ -1,0 +1,9 @@
+/**
+ * Reference to a dialog opened via the MdDialog service.
+ */
+export class MdDialogRef<T> {
+  /** The instance of component opened into the dialog. */
+  componentInstance: T;
+
+  // TODO(jelbourn): Add methods to resize, close, and get results from the dialog.
+}

--- a/src/components/dialog/dialog.spec.ts
+++ b/src/components/dialog/dialog.spec.ts
@@ -1,0 +1,132 @@
+import {
+  it,
+  describe,
+  expect,
+  beforeEach,
+  inject,
+  fakeAsync,
+  async,
+  beforeEachProviders,
+} from '@angular/core/testing';
+import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {
+  Component,
+  Directive,
+  ViewChild,
+  provide,
+  ViewContainerRef,
+  ChangeDetectorRef,
+} from '@angular/core';
+import {MdDialog} from './dialog';
+import {OVERLAY_PROVIDERS, OVERLAY_CONTAINER_TOKEN} from '@angular2-material/core/overlay/overlay';
+import {MdDialogConfig} from './dialog-config';
+import {MdDialogRef} from './dialog-ref';
+
+
+
+describe('MdDialog', () => {
+  let builder: TestComponentBuilder;
+  let dialog: MdDialog;
+  let overlayContainerElement: HTMLElement;
+
+  let testViewContainerRef: ViewContainerRef;
+  let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
+
+  beforeEachProviders(() => [
+    OVERLAY_PROVIDERS,
+    MdDialog,
+    provide(OVERLAY_CONTAINER_TOKEN, {
+      useFactory: () => {
+        overlayContainerElement = document.createElement('div');
+        return overlayContainerElement;
+      }
+    })
+  ]);
+
+  let deps = [TestComponentBuilder, MdDialog];
+  beforeEach(inject(deps, fakeAsync((tcb: TestComponentBuilder, d: MdDialog) => {
+    builder = tcb;
+    dialog = d;
+  })));
+
+  beforeEach(async(() => {
+    builder.createAsync(ComponentWithChildViewContainer).then(fixture => {
+      viewContainerFixture = fixture;
+
+      viewContainerFixture.detectChanges();
+      testViewContainerRef = fixture.componentInstance.childViewContainer;
+    });
+  }));
+
+  it('should open a dialog with a component', async(() => {
+    let config = new MdDialogConfig();
+    config.viewContainerRef = testViewContainerRef;
+
+    dialog.open(PizzaMsg, config).then(dialogRef => {
+      expect(overlayContainerElement.textContent).toContain('Pizza');
+      expect(dialogRef.componentInstance).toEqual(jasmine.any(PizzaMsg));
+      expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
+
+      viewContainerFixture.detectChanges();
+      let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
+      expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
+    });
+
+    detectChangesForDialogOpen(viewContainerFixture);
+  }));
+
+  it('should apply the configured role to the dialog element', async(() => {
+    let config = new MdDialogConfig();
+    config.viewContainerRef = testViewContainerRef;
+    config.role = 'alertdialog';
+
+    dialog.open(PizzaMsg, config).then(dialogRef => {
+      viewContainerFixture.detectChanges();
+
+      let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
+      expect(dialogContainerElement.getAttribute('role')).toBe('alertdialog');
+    });
+
+    detectChangesForDialogOpen(viewContainerFixture);
+  }));
+});
+
+
+/** Runs the necessary detectChanges for a dialog to complete its opening. */
+function detectChangesForDialogOpen(fixture: ComponentFixture<ComponentWithChildViewContainer>) {
+  // TODO(jelbourn): figure out why the test zone is "stable" when where are still pending
+  // tasks, such that we have to use `setTimeout` to run the second round of change detection.
+  // Two rounds of change detection are necessary: one to *create* the dialog container, and
+  // another to cause the lifecycle events of the container to run and load the dialog content.
+  fixture.detectChanges();
+  setTimeout(() => fixture.detectChanges(), 50);
+}
+
+@Directive({selector: 'dir-with-view-container'})
+class DirectiveWithViewContainer {
+  constructor(public viewContainerRef: ViewContainerRef) { }
+}
+
+@Component({
+  selector: 'arbitrary-component',
+  template: `<dir-with-view-container></dir-with-view-container>`,
+  directives: [DirectiveWithViewContainer],
+})
+class ComponentWithChildViewContainer {
+  @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+
+  constructor(public changeDetectorRef: ChangeDetectorRef) { }
+
+  get childViewContainer() {
+    return this.childWithViewContainer.viewContainerRef;
+  }
+}
+
+/** Simple component for testing ComponentPortal. */
+@Component({
+  selector: 'pizza-msg',
+  template: '<p>Pizza</p>',
+})
+class PizzaMsg {
+  constructor(public dialogRef: MdDialogRef<PizzaMsg>) { }
+}

--- a/src/components/dialog/dialog.spec.ts
+++ b/src/components/dialog/dialog.spec.ts
@@ -1,19 +1,14 @@
 import {
-  it,
-  describe,
-  expect,
-  beforeEach,
   inject,
   fakeAsync,
   async,
-  beforeEachProviders,
+  addProviders,
 } from '@angular/core/testing';
 import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 import {
   Component,
   Directive,
   ViewChild,
-  provide,
   ViewContainerRef,
   ChangeDetectorRef,
 } from '@angular/core';
@@ -32,16 +27,16 @@ describe('MdDialog', () => {
   let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
 
-  beforeEachProviders(() => [
-    OVERLAY_PROVIDERS,
-    MdDialog,
-    provide(OVERLAY_CONTAINER_TOKEN, {
-      useFactory: () => {
+  beforeEach(() => {
+    addProviders([
+      OVERLAY_PROVIDERS,
+      MdDialog,
+      {provide: OVERLAY_CONTAINER_TOKEN, useFactory: () => {
         overlayContainerElement = document.createElement('div');
         return overlayContainerElement;
-      }
-    })
-  ]);
+      }}
+    ]);
+  });
 
   let deps = [TestComponentBuilder, MdDialog];
   beforeEach(inject(deps, fakeAsync((tcb: TestComponentBuilder, d: MdDialog) => {

--- a/src/components/dialog/dialog.spec.ts
+++ b/src/components/dialog/dialog.spec.ts
@@ -89,7 +89,7 @@ describe('MdDialog', () => {
 
 /** Runs the necessary detectChanges for a dialog to complete its opening. */
 function detectChangesForDialogOpen(fixture: ComponentFixture<ComponentWithChildViewContainer>) {
-  // TODO(jelbourn): figure out why the test zone is "stable" when where are still pending
+  // TODO(jelbourn): figure out why the test zone is "stable" when there are still pending
   // tasks, such that we have to use `setTimeout` to run the second round of change detection.
   // Two rounds of change detection are necessary: one to *create* the dialog container, and
   // another to cause the lifecycle events of the container to run and load the dialog content.

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -1,0 +1,113 @@
+import {Injector, ComponentRef, Injectable} from '@angular/core';
+import {Overlay} from '@angular2-material/core/overlay/overlay';
+import {OverlayRef} from '@angular2-material/core/overlay/overlay-ref';
+import {OverlayState} from '@angular2-material/core/overlay/overlay-state';
+import {ComponentPortal} from '@angular2-material/core/portal/portal';
+import {ComponentType} from '@angular2-material/core/overlay/generic-component-type';
+import {MdDialogConfig} from './dialog-config';
+import {MdDialogRef} from './dialog-ref';
+import {DialogInjector} from './dialog-injector';
+import {MdDialogContainer} from './dialog-container';
+
+
+export {MdDialogConfig} from './dialog-config';
+export {MdDialogRef} from './dialog-ref';
+
+
+// TODO(jelbourn): add shortcuts for `alert` and `confirm`.
+// TODO(jelbourn): add support for opening with a TemplateRef
+// TODO(jelbourn): add `closeAll` method
+// TODO(jelbourn): add backdrop
+// TODO(jelbourn): default dialog config
+// TODO(jelbourn): focus trapping
+// TODO(jelbourn): potentially change API from accepting component constructor to component factory.
+
+
+
+/**
+ * Service to open Material Design modal dialogs.
+ */
+@Injectable()
+export class MdDialog {
+  constructor(private _overlay: Overlay, private _injector: Injector) { }
+
+  /**
+   * Opens a modal dialog containing the given component.
+   * @param component Type of the component to load into the load.
+   * @param config
+   */
+  open<T>(component: ComponentType<T>, config: MdDialogConfig): Promise<MdDialogRef<T>> {
+    return this._createOverlay(config)
+        .then(overlayRef => this._attachDialogContainer(overlayRef, config))
+        .then(containerRef => this._attachDialogContent(component, containerRef));
+  }
+
+  /**
+   * Creates the overlay into which the dialog will be loaded.
+   * @param dialogConfig The dialog configuration.
+   * @returns A promise resolving to the OverlayRef for the created overlay.
+   */
+  private _createOverlay(dialogConfig: MdDialogConfig): Promise<OverlayRef> {
+    let overlayState = this._getOverlayState(dialogConfig);
+    return this._overlay.create(overlayState);
+  }
+
+  /**
+   * Attaches an MdDialogContainer to a dialog's already-created overlay.
+   * @param overlayRef Reference to the dialog's underlying overlay.
+   * @param config The dialog configuration.
+   * @returns A promise resolving to a ComponentRef for the attached container.
+   */
+  private _attachDialogContainer(overlayRef: OverlayRef, config: MdDialogConfig):
+      Promise<ComponentRef<MdDialogContainer>> {
+    let containerPortal = new ComponentPortal(MdDialogContainer, config.viewContainerRef);
+    return overlayRef.attach(containerPortal).then(containerRef => {
+      // Pass the config directly to the container so that it can consume any relevant settings.
+      containerRef.instance.dialogConfig = config;
+      return containerRef;
+    });
+  }
+
+  /**
+   * Attaches the user-provided component to the already-created MdDialogContainer.
+   * @param component The type of component being loaded into the dialog.
+   * @param containerRef Reference to the wrapping MdDialogContainer.
+   * @returns A promise resolving to the MdDialogRef that should be returned to the user.
+   */
+  private _attachDialogContent<T>(
+      component: ComponentType<T>,
+      containerRef: ComponentRef<MdDialogContainer>): Promise<MdDialogRef<T>> {
+    let dialogContainer = containerRef.instance;
+
+    // Create a reference to the dialog we're creating in order to give the user a handle
+    // to modify and close it.
+    let dialogRef = new MdDialogRef();
+
+    // We create an injector specifically for the component we're instantiating so that it can
+    // inject the MdDialogRef. This allows a component loaded inside of a dialog to close itself
+    // and, optionally, to return a value.
+    let dialogInjector = new DialogInjector(dialogRef, this._injector);
+
+    let contentPortal = new ComponentPortal(component, null, dialogInjector);
+    return dialogContainer.attachComponentPortal(contentPortal).then(contentRef => {
+      dialogRef.componentInstance = contentRef.instance;
+      return dialogRef;
+    });
+  }
+
+  /**
+   * Creates an overlay state from a dialog config.
+   * @param dialogConfig The dialog configuration.
+   * @returns The overlay configuration.
+   */
+  private _getOverlayState(dialogConfig: MdDialogConfig): OverlayState {
+    let state = new OverlayState();
+
+    state.positionStrategy = this._overlay.position()
+        .global()
+        .centerHorizontally()
+        .centerVertically();
+
+    return state;
+  }
+}

--- a/src/core/overlay/generic-component-type.ts
+++ b/src/core/overlay/generic-component-type.ts
@@ -1,0 +1,4 @@
+
+export interface ComponentType<T> {
+  new (...args: any[]): T;
+}

--- a/src/core/overlay/overlay-ref.ts
+++ b/src/core/overlay/overlay-ref.ts
@@ -12,9 +12,15 @@ export class OverlayRef implements PortalHost {
       private _state: OverlayState) { }
 
   attach(portal: Portal<any>): Promise<any> {
-    return this._portalHost.attach(portal).then(() => {
+    let attachPromise = this._portalHost.attach(portal);
+
+    // Don't chain the .then() call in the return because we want the result of portalHost.attach
+    // to be returned from this method.
+    attachPromise.then(() => {
       this._updatePosition();
     });
+
+    return attachPromise;
   }
 
   detach(): Promise<any> {

--- a/src/core/overlay/overlay.spec.ts
+++ b/src/core/overlay/overlay.spec.ts
@@ -23,7 +23,7 @@ import {ViewportRuler} from './position/viewport-ruler';
 describe('Overlay', () => {
   let builder: TestComponentBuilder;
   let overlay: Overlay;
-  let componentPortal: ComponentPortal;
+  let componentPortal: ComponentPortal<PizzaMsg>;
   let templatePortal: TemplatePortal;
   let overlayContainerElement: HTMLElement;
 

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -82,9 +82,7 @@ export class Overlay {
    * @returns A portal host for the given DOM element.
    */
   private _createPortalHost(pane: HTMLElement): DomPortalHost {
-    return new DomPortalHost(
-        pane,
-        this._componentResolver);
+    return new DomPortalHost(pane, this._componentResolver);
   }
 
   /**

--- a/src/core/portal/dom-portal-host.ts
+++ b/src/core/portal/dom-portal-host.ts
@@ -17,14 +17,16 @@ export class DomPortalHost extends BasePortalHost {
   }
 
   /** Attach the given ComponentPortal to DOM element using the ComponentResolver. */
-  attachComponentPortal(portal: ComponentPortal): Promise<ComponentRef<any>> {
+  attachComponentPortal<T>(portal: ComponentPortal<T>): Promise<ComponentRef<T>> {
     if (portal.viewContainerRef == null) {
       throw new MdComponentPortalAttachedToDomWithoutOriginError();
     }
 
     return this._componentResolver.resolveComponent(portal.component).then(componentFactory => {
       let ref = portal.viewContainerRef.createComponent(
-          componentFactory, portal.viewContainerRef.length, portal.viewContainerRef.parentInjector);
+          componentFactory,
+          portal.viewContainerRef.length,
+          portal.injector || portal.viewContainerRef.parentInjector);
 
       let hostView = <EmbeddedViewRef<any>> ref.hostView;
       this._hostDomElement.appendChild(hostView.rootNodes[0]);

--- a/src/core/portal/portal-directives.ts
+++ b/src/core/portal/portal-directives.ts
@@ -59,7 +59,7 @@ export class PortalHostDirective extends BasePortalHost {
   }
 
   /** Attach the given ComponentPortal to this PortlHost using the ComponentResolver. */
-  attachComponentPortal(portal: ComponentPortal): Promise<ComponentRef<any>> {
+  attachComponentPortal<T>(portal: ComponentPortal<T>): Promise<ComponentRef<T>> {
     portal.setAttachedHost(this);
 
     // If the portal specifies an origin, use that as the logical location of the component
@@ -70,7 +70,8 @@ export class PortalHostDirective extends BasePortalHost {
 
     return this._componentResolver.resolveComponent(portal.component).then(componentFactory => {
       let ref = viewContainerRef.createComponent(
-          componentFactory, viewContainerRef.length, viewContainerRef.parentInjector);
+          componentFactory, viewContainerRef.length,
+          portal.injector || viewContainerRef.parentInjector);
 
       this.setDisposeFn(() => ref.destroy());
       return ref;
@@ -93,7 +94,7 @@ export class PortalHostDirective extends BasePortalHost {
     let maybeDetach = this.hasAttached() ? this.detach() : Promise.resolve(null);
 
     maybeDetach.then(() => {
-      if (p != null) {
+      if (p) {
         this.attach(p);
         this._portal = p;
       }

--- a/src/core/portal/portal.spec.ts
+++ b/src/core/portal/portal.spec.ts
@@ -268,7 +268,7 @@ describe('Portals', () => {
       flushMicrotasks();
       appFixture.detectChanges();
 
-      expect(componentInstance).toBeAnInstanceOf(PizzaMsg);
+      expect(componentInstance).toEqual(jasmine.any(PizzaMsg));
       expect(someDomElement.textContent).toContain('Pizza');
       expect(someDomElement.textContent).toContain('Chocolate');
 

--- a/src/core/portal/portal.spec.ts
+++ b/src/core/portal/portal.spec.ts
@@ -9,7 +9,9 @@ import {
   ViewChildren,
   QueryList,
   ViewContainerRef,
-  ComponentResolver
+  ComponentResolver,
+  Optional,
+  Injector,
 } from '@angular/core';
 import {TemplatePortalDirective, PortalHostDirective} from './portal-directives';
 import {Portal, ComponentPortal} from './portal';
@@ -45,6 +47,34 @@ describe('Portals', () => {
       // Expect that the content of the attached portal is present.
       let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
       expect(hostContainer.textContent).toContain('Pizza');
+    }));
+
+    it('should load a component into the portal with a given injector', fakeAsync(() => {
+      let appFixture: ComponentFixture<PortalTestApp>;
+
+      builder.createAsync(PortalTestApp).then(fixture => {
+        appFixture = fixture;
+      });
+
+      // Flush the async creation of the PortalTestApp.
+      flushMicrotasks();
+
+      // Create a custom injector for the component.
+      let chocolateInjector = new ChocolateInjector(appFixture.componentInstance.injector);
+
+      // Set the selectedHost to be a ComponentPortal.
+      let testAppComponent = appFixture.debugElement.componentInstance;
+      testAppComponent.selectedPortal = new ComponentPortal(PizzaMsg, null, chocolateInjector);
+      appFixture.detectChanges();
+
+      // Flush the attachment of the Portal.
+      flushMicrotasks();
+      appFixture.detectChanges();
+
+      // Expect that the content of the attached portal is present.
+      let hostContainer = appFixture.nativeElement.querySelector('.portal-container');
+      expect(hostContainer.textContent).toContain('Pizza');
+      expect(hostContainer.textContent).toContain('Chocolate');
     }));
 
     it('should load a <template> portal', fakeAsync(() => {
@@ -178,6 +208,7 @@ describe('Portals', () => {
   describe('DomPortalHost', function () {
     let componentLoader: ComponentResolver;
     let someViewContainerRef: ViewContainerRef;
+    let someInjector: Injector;
     let someDomElement: HTMLElement;
     let host: DomPortalHost;
 
@@ -208,6 +239,38 @@ describe('Portals', () => {
 
       expect(componentInstance).toEqual(jasmine.any(PizzaMsg));
       expect(someDomElement.textContent).toContain('Pizza');
+
+      host.detach();
+      flushMicrotasks();
+
+      expect(someDomElement.innerHTML).toBe('');
+    }));
+
+    it('should attach and detach a component portal with a given injector', fakeAsync(() => {
+      let appFixture: ComponentFixture<ArbitraryViewContainerRefComponent>;
+      builder.createAsync(ArbitraryViewContainerRefComponent).then(fixture => {
+        appFixture = fixture;
+        someViewContainerRef = fixture.componentInstance.viewContainerRef;
+        someInjector = fixture.componentInstance.injector;
+      });
+
+      flushMicrotasks();
+
+
+      let chocolateInjector = new ChocolateInjector(someInjector);
+      let portal = new ComponentPortal(PizzaMsg, someViewContainerRef, chocolateInjector);
+
+      let componentInstance: PizzaMsg;
+      portal.attach(host).then(ref => {
+        componentInstance = ref.instance;
+      });
+
+      flushMicrotasks();
+      appFixture.detectChanges();
+
+      expect(componentInstance).toBeAnInstanceOf(PizzaMsg);
+      expect(someDomElement.textContent).toContain('Pizza');
+      expect(someDomElement.textContent).toContain('Chocolate');
 
       host.detach();
       flushMicrotasks();
@@ -305,12 +368,27 @@ describe('Portals', () => {
 });
 
 
+class Chocolate {
+  toString() {
+    return 'Chocolate';
+  }
+}
+
+class ChocolateInjector {
+  constructor(public parentInjector: Injector) { }
+
+  get(token: any) {
+    return token === Chocolate ? new Chocolate() : this.parentInjector.get(token);
+  }
+}
+
 /** Simple component for testing ComponentPortal. */
 @Component({
   selector: 'pizza-msg',
-  template: '<p>Pizza</p>',
+  template: '<p>Pizza</p><p>{{snack}}</p>',
 })
 class PizzaMsg {
+  constructor(@Optional() public snack: Chocolate) { }
 }
 
 /** Simple component to grab an arbitrary ViewContainerRef */
@@ -319,8 +397,7 @@ class PizzaMsg {
   template: '<p>Hello</p>'
 })
 class ArbitraryViewContainerRefComponent {
-  constructor(public viewContainerRef: ViewContainerRef) {
-  }
+  constructor(public viewContainerRef: ViewContainerRef, public injector: Injector) { }
 }
 
 
@@ -344,6 +421,8 @@ class PortalTestApp {
   @ViewChildren(TemplatePortalDirective) portals: QueryList<TemplatePortalDirective>;
   selectedPortal: Portal<any>;
   fruit: string = 'Banana';
+
+  constructor(public injector: Injector) { }
 
   get cakePortal() {
     return this.portals.first;

--- a/src/core/portal/portal.ts
+++ b/src/core/portal/portal.ts
@@ -1,4 +1,10 @@
-import {TemplateRef, Type, ViewContainerRef, ElementRef, ComponentRef} from '@angular/core';
+import {
+    TemplateRef,
+    ViewContainerRef,
+    ElementRef,
+    ComponentRef,
+    Injector
+} from '@angular/core';
 import {
     MdNullPortalHostError,
     MdPortalAlreadyAttachedError,
@@ -7,6 +13,7 @@ import {
     MdPortalHostAlreadyDisposedError,
     MdUnknownPortalTypeError
 } from './portal-errors';
+import {ComponentType} from '../overlay/generic-component-type';
 
 
 
@@ -60,21 +67,28 @@ export abstract class Portal<T> {
 /**
  * A `ComponentPortal` is a portal that instantiates some Component upon attachment.
  */
-export class ComponentPortal extends Portal<ComponentRef<any>> {
+export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
   /** The type of the component that will be instantiated for attachment. */
-  public component: Type;
+  component: ComponentType<T>;
 
   /**
    * [Optional] Where the attached component should live in Angular's *logical* component tree.
    * This is different from where the component *renders*, which is determined by the PortalHost.
    * The origin necessary when the host is outside of the Angular application context.
    */
-  public viewContainerRef: ViewContainerRef;
+  viewContainerRef: ViewContainerRef;
 
-  constructor(component: Type, viewContainerRef: ViewContainerRef = null) {
+  /** [Optional] Injector used for the instantiation of the component. */
+  injector: Injector;
+
+  constructor(
+      component: ComponentType<T>,
+      viewContainerRef: ViewContainerRef = null,
+      injector: Injector = null) {
     super();
     this.component = component;
     this.viewContainerRef = viewContainerRef;
+    this.injector = injector;
   }
 }
 
@@ -176,7 +190,7 @@ export abstract class BasePortalHost implements PortalHost {
     throw new MdUnknownPortalTypeError();
   }
 
-  abstract attachComponentPortal(portal: ComponentPortal): Promise<ComponentRef<any>>;
+  abstract attachComponentPortal<T>(portal: ComponentPortal<T>): Promise<ComponentRef<T>>;
 
   abstract attachTemplatePortal(portal: TemplatePortal): Promise<Map<string, any>>;
 

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -5,6 +5,7 @@
       <a md-list-item [routerLink]="['button-toggle']">Button Toggle</a>
       <a md-list-item [routerLink]="['card']">Card</a>
       <a md-list-item [routerLink]="['checkbox']">Checkbox</a>
+      <a md-list-item [routerLink]="['dialog']">Dialog</a>
       <a md-list-item [routerLink]="['gestures']">Gestures</a>
       <a md-list-item [routerLink]="['grid-list']">Grid List</a>
       <a md-list-item [routerLink]="['icon']">Icon</a>

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -21,6 +21,7 @@ import {SidenavDemo} from '../sidenav/sidenav-demo';
 import {RadioDemo} from '../radio/radio-demo';
 import {CardDemo} from '../card/card-demo';
 import {MenuDemo} from '../menu/menu-demo';
+import {DialogDemo} from '../dialog/dialog-demo';
 
 
 
@@ -47,6 +48,7 @@ export const routes: RouterConfig = [
   {path: 'tabs', component: TabsDemo},
   {path: 'button-toggle', component: ButtonToggleDemo},
   {path: 'baseline', component: BaselineDemo},
+  {path: 'dialog', component: DialogDemo},
 ];
 
 export const DEMO_APP_ROUTE_PROVIDER = provideRouter(routes);

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -1,0 +1,3 @@
+<h1>Dialog demo</h1>
+
+<button (click)="open()" [disabled]="dialogRef">Open dialog</button>

--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -1,0 +1,3 @@
+.demo-dialog {
+  color: rebeccapurple;
+}

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,0 +1,34 @@
+import {Component, ViewContainerRef} from '@angular/core';
+import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular2-material/dialog/dialog';
+import {OVERLAY_PROVIDERS} from '@angular2-material/core/overlay/overlay';
+
+@Component({
+  moduleId: module.id,
+  selector: 'dialog-demo',
+  templateUrl: 'dialog-demo.html',
+  styleUrls: ['dialog-demo.css'],
+  providers: [MdDialog, OVERLAY_PROVIDERS]
+})
+export class DialogDemo {
+  dialogRef: MdDialogRef<JazzDialog>;
+
+  constructor(
+      public dialog: MdDialog,
+      public viewContainerRef: ViewContainerRef) { }
+
+  open() {
+    let config = new MdDialogConfig();
+    config.viewContainerRef = this.viewContainerRef;
+
+    this.dialog.open(JazzDialog, config).then(ref => {
+      this.dialogRef = ref;
+    });
+  }
+}
+
+
+@Component({
+  selector: 'demo-jazz-dialog',
+  template: `<p>It's Jazz!</p>`
+})
+export class JazzDialog { }

--- a/src/demo-app/portal/portal-demo.ts
+++ b/src/demo-app/portal/portal-demo.ts
@@ -39,4 +39,4 @@ export class PortalDemo {
   selector: 'science-joke',
   template: `<p> 100 kilopascals go into a bar. </p>`
 })
-class ScienceJoke { }
+export class ScienceJoke { }

--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -6,6 +6,7 @@ const components = [
   'button',
   'card',
   'checkbox',
+  'dialog',
   'grid-list',
   'icon',
   'input',


### PR DESCRIPTION
R: @hansl @kara @robertmesserle 
CC: @iveysaur

* Adds the ability to pass a custom injector with `ComponentPortal`
* Adds `MdDialog` service that can open a dialog (and literally nothing else). Additional APIs will come in subsequent PRs. Dialog is also yet unstyled.


The `setTimeout` hack in the dialog tests is an unfortunate consequence of an issue with either zones or (more likely) the testing infrastructure built on top of it. I'm going to sit down with Misko when he gets back from vacation to get to the root of it. 