### PR TITLE
chore: remove all @internal to fix offline compile

### DIFF
--- a/src/components/button-toggle/button-toggle.html
+++ b/src/components/button-toggle/button-toggle.html
@@ -1,11 +1,11 @@
 <label [attr.for]="inputId" class="md-button-toggle-label">
   <input #input class="md-button-toggle-input"
-         [type]="type"
+         [type]="_type"
          [id]="inputId"
          [checked]="checked"
          [disabled]="disabled"
          [name]="name"
-         (change)="onInputChange($event)">
+         (change)="_onInputChange($event)">
 
   <div class="md-button-toggle-label-content">
     <ng-content></ng-content>

--- a/src/components/button-toggle/button-toggle.ts
+++ b/src/components/button-toggle/button-toggle.ts
@@ -81,7 +81,7 @@ export class MdButtonToggleGroup implements ControlValueAccessor {
 
   /** Child button toggle buttons. */
   @ContentChildren(forwardRef(() => MdButtonToggle))
-  private _buttonToggles: QueryList<MdButtonToggle> = null;
+  _buttonToggles: QueryList<MdButtonToggle> = null;
 
   @Input()
   get name(): string {
@@ -219,11 +219,8 @@ export class MdButtonToggle implements OnInit {
   /** Whether or not this button toggle is checked. */
   private _checked: boolean = false;
 
-  /**
-   * Type of the button toggle. Either 'radio' or 'checkbox'.
-   * @internal
-   */
-  type: ToggleType;
+  /** Type of the button toggle. Either 'radio' or 'checkbox'. */
+  _type: ToggleType;
 
   /** The unique ID for this button toggle. */
   @HostBinding()
@@ -269,18 +266,17 @@ export class MdButtonToggle implements OnInit {
         }
       });
 
-      this.type = 'radio';
+      this._type = 'radio';
       this.name = this.buttonToggleGroup.name;
       this._isSingleSelector = true;
     } else {
       // Even if there is no group at all, treat the button toggle as a checkbox so it can be
       // toggled on or off.
-      this.type = 'checkbox';
+      this._type = 'checkbox';
       this._isSingleSelector = false;
     }
   }
 
-  /** @internal */
   ngOnInit() {
     if (this.id == null) {
       this.id = `md-button-toggle-${_uniqueIdCounter++}`;
@@ -359,11 +355,8 @@ export class MdButtonToggle implements OnInit {
     this.checked = !this.checked;
   }
 
-  /**
-   * Checks the button toggle due to an interaction with the underlying native input.
-   * @internal
-   */
-  onInputChange(event: Event) {
+  /** Checks the button toggle due to an interaction with the underlying native input. */
+  _onInputChange(event: Event) {
     event.stopPropagation();
 
     if (this._isSingleSelector) {

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -21,9 +21,9 @@ import {
   inputs: ['color'],
   host: {
     '[class.md-button-focus]': 'isKeyboardFocused',
-    '(mousedown)': 'setMousedown()',
-    '(focus)': 'setKeyboardFocus()',
-    '(blur)': 'removeKeyboardFocus()',
+    '(mousedown)': '_setMousedown()',
+    '(focus)': '_setKeyboardFocus()',
+    '(blur)': '_removeKeyboardFocus()',
   },
   templateUrl: 'button.html',
   styleUrls: ['button.css'],
@@ -34,12 +34,12 @@ export class MdButton {
   private _color: string;
 
   /** Whether the button has focus from the keyboard (not the mouse). Used for class binding. */
-  isKeyboardFocused: boolean = false;
+  _isKeyboardFocused: boolean = false;
 
   /** Whether a mousedown has occurred on this element in the last 100ms. */
-  isMouseDown: boolean = false;
+  _isMouseDown: boolean = false;
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer) { }
+  constructor(private _elementRef: ElementRef, private _renderer: Renderer) { }
 
   get color(): string {
     return this._color;
@@ -49,14 +49,13 @@ export class MdButton {
     this._updateColor(value);
   }
 
-  /** @internal */
-  setMousedown() {
+  _setMousedown() {
     // We only *show* the focus style when focus has come to the button via the keyboard.
     // The Material Design spec is silent on this topic, and without doing this, the
     // button continues to look :active after clicking.
     // @see http://marcysutton.com/button-focus-hell/
-    this.isMouseDown = true;
-    setTimeout(() => { this.isMouseDown = false; }, 100);
+    this._isMouseDown = true;
+    setTimeout(() => { this._isMouseDown = false; }, 100);
   }
 
   _updateColor(newColor: string) {
@@ -67,23 +66,21 @@ export class MdButton {
 
   _setElementColor(color: string, isAdd: boolean) {
     if (color != null && color != '') {
-      this.renderer.setElementClass(this.elementRef.nativeElement, `md-${color}`, isAdd);
+      this._renderer.setElementClass(this._elementRef.nativeElement, `md-${color}`, isAdd);
     }
   }
 
-  /** @internal */
-  setKeyboardFocus() {
-    this.isKeyboardFocused = !this.isMouseDown;
+  _setKeyboardFocus() {
+    this._isKeyboardFocused = !this._isMouseDown;
   }
 
-  /** @internal */
-  removeKeyboardFocus() {
-    this.isKeyboardFocused = false;
+  _removeKeyboardFocus() {
+    this._isKeyboardFocused = false;
   }
 
   /** TODO(hansl): e2e test this function. */
   focus() {
-    this.elementRef.nativeElement.focus();
+    this._elementRef.nativeElement.focus();
   }
 }
 
@@ -92,11 +89,11 @@ export class MdButton {
   selector: 'a[md-button], a[md-raised-button], a[md-icon-button], a[md-fab], a[md-mini-fab]',
   inputs: ['color'],
   host: {
-    '[class.md-button-focus]': 'isKeyboardFocused',
-    '(mousedown)': 'setMousedown()',
-    '(focus)': 'setKeyboardFocus()',
-    '(blur)': 'removeKeyboardFocus()',
-    '(click)': 'haltDisabledEvents($event)',
+    '[class.md-button-focus]': '_isKeyboardFocused',
+    '(mousedown)': '_setMousedown()',
+    '(focus)': '_setKeyboardFocus()',
+    '(blur)': '_removeKeyboardFocus()',
+    '(click)': '_haltDisabledEvents($event)',
   },
   templateUrl: 'button.html',
   styleUrls: ['button.css'],
@@ -129,8 +126,7 @@ export class MdAnchor extends MdButton {
     this._disabled = (value != null && value != false) ? true : null;
   }
 
-  /** @internal */
-  haltDisabledEvents(event: Event) {
+  _haltDisabledEvents(event: Event) {
     // A disabled button shouldn't apply any actions
     if (this.disabled) {
       event.preventDefault();

--- a/src/components/checkbox/checkbox.html
+++ b/src/components/checkbox/checkbox.html
@@ -9,10 +9,10 @@
            [indeterminate]="indeterminate"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
-           (focus)="onInputFocus()"
-           (blur)="onInputBlur()"
-           (change)="onInteractionEvent($event)"
-           (click)="onInputClick($event)">
+           (focus)="_onInputFocus()"
+           (blur)="_onInputBlur()"
+           (change)="_onInteractionEvent($event)"
+           (click)="_onInputClick($event)">
     <div class="md-ink-ripple"></div>
     <div class="md-checkbox-frame"></div>
     <div class="md-checkbox-background">

--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -122,12 +122,12 @@ describe('MdCheckbox', () => {
       expect(checkboxInstance.checked).toBe(false);
       expect(checkboxInstance.indeterminate).toBe(true);
 
-      checkboxInstance.onInteractionEvent(<Event>{stopPropagation: () => {}});
+      checkboxInstance._onInteractionEvent(<Event>{stopPropagation: () => {}});
 
       expect(checkboxInstance.checked).toBe(true);
       expect(checkboxInstance.indeterminate).toBe(false);
 
-      checkboxInstance.onInteractionEvent(<Event>{stopPropagation: () => {}});
+      checkboxInstance._onInteractionEvent(<Event>{stopPropagation: () => {}});
       fixture.detectChanges();
 
       expect(checkboxInstance.checked).toBe(false);

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -237,19 +237,13 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
     this.change.emit(event);
   }
 
-  /**
-   * Informs the component when the input has focus so that we can style accordingly
-   * @internal
-   */
-  onInputFocus() {
+  /** Informs the component when the input has focus so that we can style accordingly */
+  _onInputFocus() {
     this.hasFocus = true;
   }
 
-  /**
-   * Informs the component when we lose focus in order to style accordingly
-   * @internal
-   */
-  onInputBlur() {
+  /** Informs the component when we lose focus in order to style accordingly */
+  _onInputBlur() {
     this.hasFocus = false;
     this.onTouched();
   }
@@ -265,9 +259,8 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
    * Event handler for checkbox input element.
    * Toggles checked state if element is not disabled.
    * @param event
-   * @internal
    */
-  onInteractionEvent(event: Event) {
+  _onInteractionEvent(event: Event) {
     // We always have to stop propagation on the change event.
     // Otherwise the change event, from the input element, will bubble up and
     // emit its event object to the `change` output.
@@ -278,8 +271,7 @@ export class MdCheckbox implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  /** @internal */
-  onInputClick(event: Event) {
+  _onInputClick(event: Event) {
     // We have to stop propagation for click events on the visual hidden input element.
     // By default, when a user clicks on a label element, a generated click event will be
     // dispatched on the associated input element. Since we are using a label element as our

--- a/src/components/grid-list/grid-list-measure.ts
+++ b/src/components/grid-list/grid-list-measure.ts
@@ -1,7 +1,7 @@
 
 /**
  * Converts values into strings. Falsy values become empty strings.
- * @internal
+ * TODO: internal
  */
 export function coerceToString(value: string | number): string {
   return `${value || ''}`;
@@ -9,7 +9,7 @@ export function coerceToString(value: string | number): string {
 
 /**
  * Converts a value that might be a string into a number.
- * @internal
+ * TODO: internal
  */
 export function coerceToNumber(value: string | number): number {
   return typeof value === 'string' ? parseInt(value, 10) : value;

--- a/src/components/grid-list/grid-list.ts
+++ b/src/components/grid-list/grid-list.ts
@@ -55,7 +55,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   private _tileStyler: TileStyler;
 
   /** Query list of tiles that are being rendered. */
-  @ContentChildren(MdGridTile) private _tiles: QueryList<MdGridTile>;
+  @ContentChildren(MdGridTile) _tiles: QueryList<MdGridTile>;
 
   constructor(
       private _renderer: Renderer,
@@ -139,14 +139,11 @@ export class MdGridList implements OnInit, AfterContentChecked {
       let tile = tiles[i];
       this._tileStyler.setStyle(tile, pos.row, pos.col);
     }
-    this.setListStyle(this._tileStyler.getComputedHeight());
+    this._setListStyle(this._tileStyler.getComputedHeight());
   }
 
-  /**
-   * Sets style on the main grid-list element, given the style name and value.
-   * @internal
-   */
-  setListStyle(style: [string, string]): void {
+  /** Sets style on the main grid-list element, given the style name and value. */
+  _setListStyle(style: [string, string]): void {
     if (style) {
       this._renderer.setElementStyle(this._element.nativeElement, style[0], style[1]);
     }

--- a/src/components/grid-list/grid-tile.ts
+++ b/src/components/grid-list/grid-tile.ts
@@ -43,11 +43,11 @@ export class MdGridTile {
     this._colspan = coerceToNumber(value);
   }
 
-  /** Sets the style of the grid-tile element.  Needs to be set manually to avoid
+  /**
+   * Sets the style of the grid-tile element.  Needs to be set manually to avoid
    * "Changed after checked" errors that would occur with HostBinding.
-   * @internal
    */
-  setStyle(property: string, value: string): void {
+  _setStyle(property: string, value: string): void {
     this._renderer.setElementStyle(this._element.nativeElement, property, value);
   }
 

--- a/src/components/grid-list/tile-coordinator.ts
+++ b/src/components/grid-list/tile-coordinator.ts
@@ -134,9 +134,7 @@ export class TileCoordinator {
   }
 }
 
-/** Simple data structure for tile position (row, col).
- * @internal
- */
+/** Simple data structure for tile position (row, col). */
 export class TilePosition {
   constructor(public row: number, public col: number) {}
 }

--- a/src/components/grid-list/tile-styler.ts
+++ b/src/components/grid-list/tile-styler.ts
@@ -2,8 +2,11 @@ import {MdGridTile} from './grid-tile';
 import {TileCoordinator} from './tile-coordinator';
 import {MdGridListBadRatioError} from './grid-list-errors';
 
-/* Sets the style properties for an individual tile, given the position calculated by the
-* Tile Coordinator. */
+/**
+ * Sets the style properties for an individual tile, given the position calculated by the
+ * Tile Coordinator.
+ * TODO: internal
+ */
 export class TileStyler {
   _gutterSize: string;
   _rows: number = 0;
@@ -11,10 +14,10 @@ export class TileStyler {
   _cols: number;
   _direction: string;
 
-  /** Adds grid-list layout info once it is available. Cannot be processed in the constructor
+  /**
+   * Adds grid-list layout info once it is available. Cannot be processed in the constructor
    * because these properties haven't been calculated by that point.
-   * @internal
-   * */
+   */
   init(_gutterSize: string, tracker: TileCoordinator, cols: number, direction: string): void {
     this._gutterSize = normalizeUnits(_gutterSize);
     this._rows = tracker.rowCount;
@@ -26,7 +29,6 @@ export class TileStyler {
   /**
    * Computes the amount of space a single 1x1 tile would take up (width or height).
    * Used as a basis for other calculations.
-   * @internal
    * @param sizePercent Percent of the total grid-list space that one 1x1 tile would take up.
    * @param gutterFraction Fraction of the gutter size taken up by one 1x1 tile.
    * @return The size of a 1x1 tile as an expression that can be evaluated via CSS calc().
@@ -43,7 +45,6 @@ export class TileStyler {
 
   /**
    * Gets The horizontal or vertical position of a tile, e.g., the 'top' or 'left' property value.
-   * @internal
    * @param offset Number of tiles that have already been rendered in the row/column.
    * @param baseSize Base size of a 1x1 tile (as computed in getBaseTileSize).
    * @return Position of the tile as a CSS calc() expression.
@@ -57,7 +58,6 @@ export class TileStyler {
 
   /**
    * Gets the actual size of a tile, e.g., width or height, taking rowspan or colspan into account.
-   * @internal
    * @param baseSize Base size of a 1x1 tile (as computed in getBaseTileSize).
    * @param span The tile's rowspan or colspan.
    * @return Size of the tile as a CSS calc() expression.
@@ -67,9 +67,7 @@ export class TileStyler {
   }
 
 
-  /** Gets the style properties to be applied to a tile for the given row and column index.
-   * @internal
-   */
+  /** Gets the style properties to be applied to a tile for the given row and column index. */
   setStyle(tile: MdGridTile, rowIndex: number, colIndex: number): void {
     // Percent of the available horizontal space that one column takes up.
     let percentWidthPerTile = 100 / this._cols;
@@ -82,9 +80,7 @@ export class TileStyler {
     this.setRowStyles(tile, rowIndex, percentWidthPerTile, gutterWidthFractionPerTile);
   }
 
-  /** Sets the horizontal placement of the tile in the list.
-   * @internal
-   */
+  /** Sets the horizontal placement of the tile in the list. */
   setColStyles(tile: MdGridTile, colIndex: number, percentWidth: number,
                gutterWidth: number) {
     // Base horizontal size of a column.
@@ -93,58 +89,54 @@ export class TileStyler {
     // The width and horizontal position of each tile is always calculated the same way, but the
     // height and vertical position depends on the rowMode.
     let side = this._direction === 'ltr' ? 'left' : 'right';
-    tile.setStyle(side, this.getTilePosition(baseTileWidth, colIndex));
-    tile.setStyle('width', calc(this.getTileSize(baseTileWidth, tile.colspan)));
+    tile._setStyle(side, this.getTilePosition(baseTileWidth, colIndex));
+    tile._setStyle('width', calc(this.getTileSize(baseTileWidth, tile.colspan)));
   }
 
-  /** Calculates the total size taken up by gutters across one axis of a list.
-   * @internal
-   */
+  /** Calculates the total size taken up by gutters across one axis of a list. */
   getGutterSpan(): string {
     return `${this._gutterSize} * (${this._rowspan} - 1)`;
   }
 
-  /** Calculates the total size taken up by tiles across one axis of a list.
-   * @internal
-   */
+  /** Calculates the total size taken up by tiles across one axis of a list. */
   getTileSpan(tileHeight: string): string {
     return `${this._rowspan} * ${this.getTileSize(tileHeight, 1)}`;
   }
 
-  /** Sets the vertical placement of the tile in the list.
-  * This method will be implemented by each type of TileStyler.
-* @internal
-*/
+  /**
+   * Sets the vertical placement of the tile in the list.
+   * This method will be implemented by each type of TileStyler.
+   */
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number, gutterWidth: number) {}
 
-  /** Calculates the computed height and returns the correct style property to set.
-  * This method will be implemented by each type of TileStyler.
-* @internal
-*/
+  /**
+   * Calculates the computed height and returns the correct style property to set.
+   * This method will be implemented by each type of TileStyler.
+   */
   getComputedHeight(): [string, string] { return null; }
 }
 
 
-/*  This type of styler is instantiated when the user passes in a fixed row height
-*   Example <md-grid-list cols="3" rowHeight="100px"> */
+/**
+ * This type of styler is instantiated when the user passes in a fixed row height.
+ * Example <md-grid-list cols="3" rowHeight="100px">
+ * TODO: internal
+ */
 export class FixedTileStyler extends TileStyler {
 
   constructor(public fixedRowHeight: string) { super(); }
 
-  /** @internal */
   init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string) {
     super.init(gutterSize, tracker, cols, direction);
     this.fixedRowHeight = normalizeUnits(this.fixedRowHeight);
   }
 
-  /** @internal */
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
-    tile.setStyle('top', this.getTilePosition(this.fixedRowHeight, rowIndex));
-    tile.setStyle('height', calc(this.getTileSize(this.fixedRowHeight, tile.rowspan)));
+    tile._setStyle('top', this.getTilePosition(this.fixedRowHeight, rowIndex));
+    tile._setStyle('height', calc(this.getTileSize(this.fixedRowHeight, tile.rowspan)));
   }
 
-  /** @internal */
   getComputedHeight(): [string, string] {
     return [
       'height', calc(`${this.getTileSpan(this.fixedRowHeight)} + ${this.getGutterSpan()}`)
@@ -152,8 +144,12 @@ export class FixedTileStyler extends TileStyler {
   }
 }
 
-/*  This type of styler is instantiated when the user passes in a width:height ratio
- *  for the row height.  Example <md-grid-list cols="3" rowHeight="3:1"> */
+
+/**
+ * This type of styler is instantiated when the user passes in a width:height ratio
+ * for the row height.  Example <md-grid-list cols="3" rowHeight="3:1">
+ * TODO: internal
+ */
 export class RatioTileStyler extends TileStyler {
 
   /** Ratio width:height given by user to determine row height.*/
@@ -165,7 +161,6 @@ export class RatioTileStyler extends TileStyler {
     this._parseRatio(value);
   }
 
-  /** @internal */
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     let percentHeightPerTile = percentWidth / this.rowHeightRatio;
@@ -174,18 +169,16 @@ export class RatioTileStyler extends TileStyler {
     // Use paddingTop and marginTop to maintain the given aspect ratio, as
     // a percentage-based value for these properties is applied versus the *width* of the
     // containing block. See http://www.w3.org/TR/CSS2/box.html#margin-properties
-    tile.setStyle('marginTop', this.getTilePosition(this.baseTileHeight, rowIndex));
-    tile.setStyle('paddingTop', calc(this.getTileSize(this.baseTileHeight, tile.rowspan)));
+    tile._setStyle('marginTop', this.getTilePosition(this.baseTileHeight, rowIndex));
+    tile._setStyle('paddingTop', calc(this.getTileSize(this.baseTileHeight, tile.rowspan)));
   }
 
-  /** @internal */
   getComputedHeight(): [string, string] {
     return [
       'paddingBottom', calc(`${this.getTileSpan(this.baseTileHeight)} + ${this.getGutterSpan()}`)
     ];
   }
 
-  /** @internal */
   private _parseRatio(value: string): void {
     let ratioParts = value.split(':');
 
@@ -202,7 +195,6 @@ export class RatioTileStyler extends TileStyler {
  *  by the number of rows.  Example <md-grid-list cols="3" rowHeight="fit"> */
 export class FitTileStyler extends TileStyler {
 
-  /** @internal */
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     // Percent of the available vertical space that one row takes up.
@@ -214,19 +206,17 @@ export class FitTileStyler extends TileStyler {
     // Base vertical size of a column.
     let baseTileHeight = this.getBaseTileSize(percentHeightPerTile, gutterHeightPerTile);
 
-    tile.setStyle('top', this.getTilePosition(baseTileHeight, rowIndex));
-    tile.setStyle('height', calc(this.getTileSize(baseTileHeight, tile.rowspan)));
+    tile._setStyle('top', this.getTilePosition(baseTileHeight, rowIndex));
+    tile._setStyle('height', calc(this.getTileSize(baseTileHeight, tile.rowspan)));
   }
 }
 
-/** Wraps a CSS string in a calc function
- * @internal
- */
+
+/** Wraps a CSS string in a calc function */
 function calc(exp: string): string { return `calc(${exp})`; }
 
-/** Appends pixels to a CSS string if no units are given.
- * @internal
- */
+
+/** Appends pixels to a CSS string if no units are given. */
 function normalizeUnits(value: string): string {
   return (value.match(/px|em|rem/)) ? value : value + 'px';
 }

--- a/src/components/icon/icon-registry.ts
+++ b/src/components/icon/icon-registry.ts
@@ -29,14 +29,10 @@ export class MdIconSvgTagNotFoundError extends MdError {
   }
 }
 
-/**
-  * Configuration for an icon, including the URL and possibly the cached SVG element.
-  * @internal
-  */
+/** Configuration for an icon, including the URL and possibly the cached SVG element. */
 class SvgIconConfig {
   svgElement: SVGElement = null;
-  constructor(public url: string) {
-  }
+  constructor(public url: string) { }
 }
 
 /** Returns the cache key to use for an icon namespace and name. */

--- a/src/components/input/input.html
+++ b/src/components/input/input.html
@@ -28,10 +28,10 @@
              [attr.tabindex]="tabIndex"
              [type]="type"
              [attr.name]="name"
-             (focus)="handleFocus($event)"
-             (blur)="handleBlur($event)"
+             (focus)="_handleFocus($event)"
+             (blur)="_handleBlur($event)"
              [(ngModel)]="value"
-             (change)="handleChange($event)">
+             (change)="_handleChange($event)">
 
       <label class="md-input-placeholder"
              [attr.for]="inputId"
@@ -40,7 +40,7 @@
              [class.md-float]="floatingPlaceholder"
              [class.md-accent]="dividerColor == 'accent'"
              [class.md-warn]="dividerColor == 'warn'"
-             *ngIf="hasPlaceholder()">
+             *ngIf="_hasPlaceholder()">
         <ng-content select="md-placeholder"></ng-content>
         {{placeholder}}
         <span class="md-placeholder-required" *ngIf="required">*</span>

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -278,12 +278,12 @@ describe('MdInput', function () {
         expect(testComponent.onFocus).not.toHaveBeenCalled();
         expect(testComponent.onBlur).not.toHaveBeenCalled();
 
-        inputComponent.handleFocus(fakeEvent);
+        inputComponent._handleFocus(fakeEvent);
         tick();
         expect(testComponent.onFocus).toHaveBeenCalledWith(fakeEvent);
 
 
-        inputComponent.handleBlur(fakeEvent);
+        inputComponent._handleBlur(fakeEvent);
         tick();
         expect(testComponent.onBlur).toHaveBeenCalledWith(fakeEvent);
       })();

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -123,8 +123,8 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   /**
    * Content directives.
    */
-  @ContentChild(MdPlaceholder) private _placeholderChild: MdPlaceholder;
-  @ContentChildren(MdHint) private _hintChildren: QueryList<MdHint>;
+  @ContentChild(MdPlaceholder) _placeholderChild: MdPlaceholder;
+  @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
 
   /** Readonly properties. */
   get focused() { return this._focused; }
@@ -185,37 +185,33 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   // This is to remove the `align` property of the `md-input` itself. Otherwise HTML5
   // might place it as RTL when we don't want to. We still want to use `align` as an
   // Input though, so we use HostBinding.
-  @HostBinding('attr.align') private get _align(): any { return null; }
+  @HostBinding('attr.align') get _align(): any { return null; }
 
 
-  @ViewChild('input') private _inputElement: ElementRef;
+  @ViewChild('input') _inputElement: ElementRef;
 
   /** Set focus on input */
   focus() {
     this._inputElement.nativeElement.focus();
   }
 
-  /** @internal */
-  handleFocus(event: FocusEvent) {
+  _handleFocus(event: FocusEvent) {
     this._focused = true;
     this._focusEmitter.emit(event);
   }
 
-  /** @internal */
-  handleBlur(event: FocusEvent) {
+  _handleBlur(event: FocusEvent) {
     this._focused = false;
     this._onTouchedCallback();
     this._blurEmitter.emit(event);
   }
 
-  /** @internal */
-  handleChange(event: Event) {
+  _handleChange(event: Event) {
     this.value = (<HTMLInputElement>event.target).value;
     this._onTouchedCallback();
   }
 
-  /** @internal */
-  hasPlaceholder(): boolean {
+  _hasPlaceholder(): boolean {
     return !!this.placeholder || this._placeholderChild != null;
   }
 

--- a/src/components/list/list-item.html
+++ b/src/components/list/list-item.html
@@ -1,4 +1,4 @@
-<div class="md-list-item" [class.md-list-item-focus]="hasFocus">
+<div class="md-list-item" [class.md-list-item-focus]="_hasFocus">
   <ng-content select="[md-list-avatar],[md-list-icon]"></ng-content>
   <div class="md-list-text"><ng-content select="[md-line]"></ng-content></div>
   <ng-content></ng-content>

--- a/src/components/list/list.spec.ts
+++ b/src/components/list/list.spec.ts
@@ -33,11 +33,11 @@ describe('MdList', () => {
           fixture.detectChanges();
           expect(listItemDiv.nativeElement.classList).not.toContain('md-list-item-focus');
 
-          listItem.componentInstance.handleFocus();
+          listItem.componentInstance._handleFocus();
           fixture.detectChanges();
           expect(listItemDiv.nativeElement.classList).toContain('md-list-item-focus');
 
-          listItem.componentInstance.handleBlur();
+          listItem.componentInstance._handleBlur();
           fixture.detectChanges();
           expect(listItemDiv.nativeElement.classList).not.toContain('md-list-item-focus');
         });

--- a/src/components/list/list.ts
+++ b/src/components/list/list.ts
@@ -30,22 +30,21 @@ export class MdListAvatar {}
   selector: 'md-list-item, a[md-list-item]',
   host: {
     'role': 'listitem',
-    '(focus)': 'handleFocus()',
-    '(blur)': 'handleBlur()',
+    '(focus)': '_handleFocus()',
+    '(blur)': '_handleBlur()',
   },
   templateUrl: 'list-item.html',
   encapsulation: ViewEncapsulation.None
 })
 export class MdListItem implements AfterContentInit {
-  /** @internal */
-  hasFocus: boolean = false;
+  _hasFocus: boolean = false;
 
-  _lineSetter: MdLineSetter;
+  private _lineSetter: MdLineSetter;
 
   @ContentChildren(MdLine) _lines: QueryList<MdLine>;
 
   @ContentChild(MdListAvatar)
-  private set _hasAvatar(avatar: MdListAvatar) {
+  set _hasAvatar(avatar: MdListAvatar) {
     this._renderer.setElementClass(this._element.nativeElement, 'md-list-avatar', avatar != null);
   }
 
@@ -56,14 +55,12 @@ export class MdListItem implements AfterContentInit {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }
 
-  /** @internal */
-  handleFocus() {
-    this.hasFocus = true;
+  _handleFocus() {
+    this._hasFocus = true;
   }
 
-  /** @internal */
-  handleBlur() {
-    this.hasFocus = false;
+  _handleBlur() {
+    this._hasFocus = false;
   }
 }
 

--- a/src/components/progress-bar/progress-bar.html
+++ b/src/components/progress-bar/progress-bar.html
@@ -1,5 +1,5 @@
 <!-- The background div is named as such because it appears below the other divs and is not sized based on values. -->
 <div class="md-progress-bar-background"></div>
-<div class="md-progress-bar-buffer" [ngStyle]="bufferTransform()"></div>
-<div class="md-progress-bar-primary md-progress-bar-fill" [ngStyle]="primaryTransform()"></div>
+<div class="md-progress-bar-buffer" [ngStyle]="_bufferTransform()"></div>
+<div class="md-progress-bar-primary md-progress-bar-fill" [ngStyle]="_primaryTransform()"></div>
 <div class="md-progress-bar-secondary md-progress-bar-fill"></div>

--- a/src/components/progress-bar/progress-bar.spec.ts
+++ b/src/components/progress-bar/progress-bar.spec.ts
@@ -88,27 +88,27 @@ describe('MdProgressBar', () => {
         let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
         let progressComponent = progressElement.componentInstance;
 
-        expect(progressComponent.primaryTransform()).toEqual({ transform: 'scaleX(0)' });
-        expect(progressComponent.bufferTransform()).toBe(undefined);
+        expect(progressComponent._primaryTransform()).toEqual({ transform: 'scaleX(0)' });
+        expect(progressComponent._bufferTransform()).toBe(undefined);
 
         progressComponent.value = 40;
-        expect(progressComponent.primaryTransform()).toEqual({ transform: 'scaleX(0.4)' });
-        expect(progressComponent.bufferTransform()).toBe(undefined);
+        expect(progressComponent._primaryTransform()).toEqual({ transform: 'scaleX(0.4)' });
+        expect(progressComponent._bufferTransform()).toBe(undefined);
 
         progressComponent.value = 35;
         progressComponent.bufferValue = 55;
-        expect(progressComponent.primaryTransform()).toEqual({ transform: 'scaleX(0.35)' });
-        expect(progressComponent.bufferTransform()).toBe(undefined);
+        expect(progressComponent._primaryTransform()).toEqual({ transform: 'scaleX(0.35)' });
+        expect(progressComponent._bufferTransform()).toBe(undefined);
 
         progressComponent.mode = 'buffer';
-        expect(progressComponent.primaryTransform()).toEqual({ transform: 'scaleX(0.35)' });
-        expect(progressComponent.bufferTransform()).toEqual({ transform: 'scaleX(0.55)' });
+        expect(progressComponent._primaryTransform()).toEqual({ transform: 'scaleX(0.35)' });
+        expect(progressComponent._bufferTransform()).toEqual({ transform: 'scaleX(0.55)' });
 
 
         progressComponent.value = 60;
         progressComponent.bufferValue = 60;
-        expect(progressComponent.primaryTransform()).toEqual({ transform: 'scaleX(0.6)' });
-        expect(progressComponent.bufferTransform()).toEqual({ transform: 'scaleX(0.6)' });
+        expect(progressComponent._primaryTransform()).toEqual({ transform: 'scaleX(0.6)' });
+        expect(progressComponent._bufferTransform()).toEqual({ transform: 'scaleX(0.6)' });
         done();
       });
   });

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -63,11 +63,8 @@ export class MdProgressBar {
   @HostBinding('attr.mode')
   mode: 'determinate' | 'indeterminate' | 'buffer' | 'query' = 'determinate';
 
-  /**
-   * Gets the current transform value for the progress bar's primary indicator.
-   * @internal
-   */
-  primaryTransform() {
+  /** Gets the current transform value for the progress bar's primary indicator. */
+  _primaryTransform() {
     let scale = this.value / 100;
     return {transform: `scaleX(${scale})`};
   }
@@ -75,9 +72,8 @@ export class MdProgressBar {
   /**
    * Gets the current transform value for the progress bar's buffer indicator.  Only used if the
    * progress mode is set to buffer, otherwise returns an undefined, causing no transformation.
-   * @internal
    */
-  bufferTransform() {
+  _bufferTransform() {
     if (this.mode == 'buffer') {
       let scale = this.bufferValue / 100;
       return {transform: `scaleX(${scale})`};

--- a/src/components/progress-circle/progress-circle.ts
+++ b/src/components/progress-circle/progress-circle.ts
@@ -35,8 +35,8 @@ type EasingFn = (currentTime: number, startValue: number,
   selector: 'md-progress-circle',
   host: {
     'role': 'progressbar',
-    '[attr.aria-valuemin]': 'ariaValueMin',
-    '[attr.aria-valuemax]': 'ariaValueMax',
+    '[attr.aria-valuemin]': '_ariaValueMin',
+    '[attr.aria-valuemax]': '_ariaValueMax',
   },
   templateUrl: 'progress-circle.html',
   styleUrls: ['progress-circle.css'],
@@ -53,23 +53,20 @@ export class MdProgressCircle implements OnDestroy {
    * Values for aria max and min are only defined as numbers when in a determinate mode.  We do this
    * because voiceover does not report the progress indicator as indeterminate if the aria min
    * and/or max value are number values.
-   *
-   * @internal
    */
-  get ariaValueMin() {
+  get _ariaValueMin() {
     return this.mode == 'determinate' ? 0 : null;
   }
 
-  /** @internal */
-  get ariaValueMax() {
+  get _ariaValueMax() {
     return this.mode == 'determinate' ? 100 : null;
   }
 
-  /** @internal */
+  /** TODO: internal */
   get interdeterminateInterval() {
     return this._interdeterminateInterval;
   }
-  /** @internal */
+  /** TODO: internal */
   set interdeterminateInterval(interval: number) {
     clearInterval(this._interdeterminateInterval);
     this._interdeterminateInterval = interval;
@@ -77,6 +74,8 @@ export class MdProgressCircle implements OnDestroy {
 
   /** The current path value, representing the progres circle. */
   private _currentPath: string;
+
+  /** TODO: internal */
   get currentPath() {
     return this._currentPath;
   }

--- a/src/components/radio/radio.html
+++ b/src/components/radio/radio.html
@@ -15,9 +15,9 @@
           [name]="name"
           [attr.aria-label]="ariaLabel"
           [attr.aria-labelledby]="ariaLabelledby"
-          (change)="onInputChange($event)"
-          (focus)="onInputFocus()"
-          (blur)="onInputBlur()" />
+          (change)="_onInputChange($event)"
+          (focus)="_onInputFocus()"
+          (blur)="_onInputBlur()">
 
   <!-- The label content for radio control. -->
   <div class="md-radio-label-content" [class.md-radio-align-end]="align == 'end'">

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -96,7 +96,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Child radio buttons. */
   @ContentChildren(forwardRef(() => MdRadioButton))
-  private _radios: QueryList<MdRadioButton> = null;
+  _radios: QueryList<MdRadioButton> = null;
 
   @Input()
   get name(): string {
@@ -168,9 +168,8 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /**
    * Mark this group as being "touched" (for ngModel). Meant to be called by the contained
    * radio buttons upon their blur.
-   * @internal
    */
-  touch() {
+  _touch() {
     if (this.onTouched) {
       this.onTouched();
     }
@@ -241,12 +240,12 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   styleUrls: ['radio.css'],
   encapsulation: ViewEncapsulation.None,
   host: {
-    '(click)': 'onClick($event)'
+    '(click)': '_onClick($event)'
   }
 })
 export class MdRadioButton implements OnInit {
   @HostBinding('class.md-radio-focused')
-  private _isFocused: boolean;
+  _isFocused: boolean;
 
   /** Whether this radio is checked. */
   private _checked: boolean = false;
@@ -375,8 +374,7 @@ export class MdRadioButton implements OnInit {
     this.change.emit(event);
   }
 
-  /** @internal */
-  onClick(event: Event) {
+  _onClick(event: Event) {
     if (this.disabled) {
       event.preventDefault();
       event.stopPropagation();
@@ -387,7 +385,7 @@ export class MdRadioButton implements OnInit {
       // Propagate the change one-way via the group, which will in turn mark this
       // button as checked.
       this.radioGroup.selected = this;
-      this.radioGroup.touch();
+      this.radioGroup._touch();
     } else {
       this.checked = true;
     }
@@ -397,25 +395,22 @@ export class MdRadioButton implements OnInit {
    * We use a hidden native input field to handle changes to focus state via keyboard navigation,
    * with visual rendering done separately. The native element is kept in sync with the overall
    * state of the component.
-   * @internal
    */
-  onInputFocus() {
+  _onInputFocus() {
     this._isFocused = true;
   }
 
-  /** @internal */
-  onInputBlur() {
+  _onInputBlur() {
     this._isFocused = false;
     if (this.radioGroup) {
-      this.radioGroup.touch();
+      this.radioGroup._touch();
     }
   }
 
   /**
    * Checks the radio due to an interaction with the underlying native <input type="radio">
-   * @internal
    */
-  onInputChange(event: Event) {
+  _onInputChange(event: Event) {
     // We always have to stop propagation on the change event.
     // Otherwise the change event, from the input element, will bubble up and
     // emit its event object to the `change` output.
@@ -423,7 +418,7 @@ export class MdRadioButton implements OnInit {
 
     this.checked = true;
     if (this.radioGroup) {
-      this.radioGroup.touch();
+      this.radioGroup._touch();
     }
   }
 }

--- a/src/components/sidenav/sidenav.html
+++ b/src/components/sidenav/sidenav.html
@@ -1,8 +1,8 @@
-<div class="md-sidenav-backdrop" (click)="closeModalSidenav()"
-     [class.md-sidenav-shown]="isShowingBackdrop()"></div>
+<div class="md-sidenav-backdrop" (click)="_closeModalSidenav()"
+     [class.md-sidenav-shown]="_isShowingBackdrop()"></div>
 
 <ng-content select="md-sidenav"></ng-content>
 
-<md-content [ngStyle]="getStyles()">
+<md-content [ngStyle]="_getStyles()">
   <ng-content></ng-content>
 </md-content>

--- a/src/components/sidenav/sidenav.spec.ts
+++ b/src/components/sidenav/sidenav.spec.ts
@@ -49,7 +49,7 @@ function createFixture(appType: Type, builder: TestComponentBuilder,
 
 function endSidenavTransition(fixture: ComponentFixture<any>) {
   let sidenav: any = fixture.debugElement.query(By.directive(MdSidenav)).componentInstance;
-  sidenav.onTransitionEnd({
+  sidenav._onTransitionEnd({
     target: (<any>sidenav)._elementRef.nativeElement,
     propertyName: 'transform'
   });

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -37,7 +37,7 @@ export class MdDuplicatedSidenavError extends MdError {
   selector: 'md-sidenav',
   template: '<ng-content></ng-content>',
   host: {
-    '(transitionend)': 'onTransitionEnd($event)',
+    '(transitionend)': '_onTransitionEnd($event)',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -142,9 +142,8 @@ export class MdSidenav {
    * When transition has finished, set the internal state for classes and emit the proper event.
    * The event passed is actually of type TransitionEvent, but that type is not available in
    * Android so we use any.
-   * @internal
    */
-  onTransitionEnd(transitionEvent: TransitionEvent) {
+  _onTransitionEnd(transitionEvent: TransitionEvent) {
     if (transitionEvent.target == this._elementRef.nativeElement
         // Simpler version to check for prefixes.
         && transitionEvent.propertyName.endsWith('transform')) {
@@ -174,37 +173,33 @@ export class MdSidenav {
     }
   }
 
-  @HostBinding('class.md-sidenav-closing') private get _isClosing() {
+  @HostBinding('class.md-sidenav-closing') get _isClosing() {
     return !this._opened && this._transition;
   }
-  @HostBinding('class.md-sidenav-opening') private get _isOpening() {
+  @HostBinding('class.md-sidenav-opening') get _isOpening() {
     return this._opened && this._transition;
   }
-  @HostBinding('class.md-sidenav-closed') private get _isClosed() {
+  @HostBinding('class.md-sidenav-closed') get _isClosed() {
     return !this._opened && !this._transition;
   }
-  @HostBinding('class.md-sidenav-opened') private get _isOpened() {
+  @HostBinding('class.md-sidenav-opened') get _isOpened() {
     return this._opened && !this._transition;
   }
-  @HostBinding('class.md-sidenav-end') private get _isEnd() {
+  @HostBinding('class.md-sidenav-end') get _isEnd() {
     return this.align == 'end';
   }
-  @HostBinding('class.md-sidenav-side') private get _modeSide() {
+  @HostBinding('class.md-sidenav-side') get _modeSide() {
     return this.mode == 'side';
   }
-  @HostBinding('class.md-sidenav-over') private get _modeOver() {
+  @HostBinding('class.md-sidenav-over') get _modeOver() {
     return this.mode == 'over';
   }
-  @HostBinding('class.md-sidenav-push') private get _modePush() {
+  @HostBinding('class.md-sidenav-push') get _modePush() {
     return this.mode == 'push';
   }
 
-  /**
-   * This is public because we need it from MdSidenavLayout, but it's undocumented and should
-   * not be used outside.
-   * @internal
-   */
-  get width() {
+  /** TODO: internal (needed by MdSidenavLayout). */
+  get _width() {
     if (this._elementRef.nativeElement) {
       return this._elementRef.nativeElement.offsetWidth;
     }
@@ -240,7 +235,7 @@ export class MdSidenav {
   ],
 })
 export class MdSidenavLayout implements AfterContentInit {
-  @ContentChildren(MdSidenav) private _sidenavs: QueryList<MdSidenav>;
+  @ContentChildren(MdSidenav) _sidenavs: QueryList<MdSidenav>;
 
   get start() { return this._start; }
   get end() { return this._end; }
@@ -279,7 +274,6 @@ export class MdSidenavLayout implements AfterContentInit {
   * Subscribes to sidenav events in order to set a class on the main layout element when the sidenav
   * is open and the backdrop is visible. This ensures any overflow on the layout element is properly
   * hidden.
-  * @internal
   */
   private _watchSidenavToggle(sidenav: MdSidenav): void {
     if (!sidenav || sidenav.mode === 'side') { return; }
@@ -323,8 +317,7 @@ export class MdSidenavLayout implements AfterContentInit {
     }
   }
 
-  /** @internal */
-  closeModalSidenav() {
+  _closeModalSidenav() {
     if (this._start != null && this._start.mode != 'side') {
       this._start.close();
     }
@@ -333,8 +326,7 @@ export class MdSidenavLayout implements AfterContentInit {
     }
   }
 
-  /** @internal */
-  isShowingBackdrop(): boolean {
+  _isShowingBackdrop(): boolean {
     return (this._isSidenavOpen(this._start) && this._start.mode != 'side')
         || (this._isSidenavOpen(this._end) && this._end.mode != 'side');
   }
@@ -350,26 +342,22 @@ export class MdSidenavLayout implements AfterContentInit {
    * @param mode
    */
   private _getSidenavEffectiveWidth(sidenav: MdSidenav, mode: string): number {
-    return (this._isSidenavOpen(sidenav) && sidenav.mode == mode) ? sidenav.width : 0;
+    return (this._isSidenavOpen(sidenav) && sidenav.mode == mode) ? sidenav._width : 0;
   }
 
-  /** @internal */
-  getMarginLeft() {
+  _getMarginLeft() {
     return this._getSidenavEffectiveWidth(this._left, 'side');
   }
 
-  /** @internal */
-  getMarginRight() {
+  _getMarginRight() {
     return this._getSidenavEffectiveWidth(this._right, 'side');
   }
 
-  /** @internal */
-  getPositionLeft() {
+  _getPositionLeft() {
     return this._getSidenavEffectiveWidth(this._left, 'push');
   }
 
-  /** @internal */
-  getPositionRight() {
+  _getPositionRight() {
     return this._getSidenavEffectiveWidth(this._right, 'push');
   }
 
@@ -377,22 +365,20 @@ export class MdSidenavLayout implements AfterContentInit {
    * Returns the horizontal offset for the content area.  There should never be a value for both
    * left and right, so by subtracting the right value from the left value, we should always get
    * the appropriate offset.
-   * @internal
    */
-  getPositionOffset() {
-    return this.getPositionLeft() - this.getPositionRight();
+  _getPositionOffset() {
+    return this._getPositionLeft() - this._getPositionRight();
   }
 
   /**
    * This is using [ngStyle] rather than separate [style...] properties because [style.transform]
    * doesn't seem to work right now.
-   * @internal
    */
-  getStyles() {
+  _getStyles() {
     return {
-      marginLeft: `${this.getMarginLeft()}px`,
-      marginRight: `${this.getMarginRight()}px`,
-      transform: `translate3d(${this.getPositionOffset()}px, 0, 0)`
+      marginLeft: `${this._getMarginLeft()}px`,
+      marginRight: `${this._getMarginRight()}px`,
+      transform: `translate3d(${this._getPositionOffset()}px, 0, 0)`
     };
   }
 }

--- a/src/components/slide-toggle/slide-toggle.html
+++ b/src/components/slide-toggle/slide-toggle.html
@@ -15,10 +15,10 @@
            [attr.name]="name"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
-           (blur)="onInputBlur()"
-           (focus)="onInputFocus()"
-           (change)="onChangeEvent($event)"
-           (click)="onInputClick($event)">
+           (blur)="_onInputBlur()"
+           (focus)="_onInputFocus()"
+           (change)="_onChangeEvent($event)"
+           (click)="_onInputClick($event)">
   </div>
   <span class="md-slide-toggle-content">
     <ng-content></ng-content>

--- a/src/components/slide-toggle/slide-toggle.ts
+++ b/src/components/slide-toggle/slide-toggle.ts
@@ -88,9 +88,8 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
    * The onChangeEvent method will be also called on click.
    * This is because everything for the slide-toggle is wrapped inside of a label,
    * which triggers a onChange event on click.
-   * @internal
    */
-  onChangeEvent(event: Event) {
+  _onChangeEvent(event: Event) {
     // We always have to stop propagation on the change event.
     // Otherwise the change event, from the input element, will bubble up and
     // emit its event object to the component's `change` output.
@@ -101,8 +100,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  /** @internal */
-  onInputClick(event: Event) {
+  _onInputClick(event: Event) {
     this.onTouched();
 
     // We have to stop propagation for click events on the visual hidden input element.
@@ -115,8 +113,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     event.stopPropagation();
   }
 
-  /** @internal */
-  setMousedown() {
+  _setMousedown() {
     // We only *show* the focus style when focus has come to the button via the keyboard.
     // The Material Design spec is silent on this topic, and without doing this, the
     // button continues to look :active after clicking.
@@ -125,8 +122,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     setTimeout(() => this._isMousedown = false, 100);
   }
 
-  /** @internal */
-  onInputFocus() {
+  _onInputFocus() {
     // Only show the focus / ripple indicator when the focus was not triggered by a mouse
     // interaction on the component.
     if (!this._isMousedown) {
@@ -134,8 +130,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  /** @internal */
-  onInputBlur() {
+  _onInputBlur() {
     this._hasFocus = false;
     this.onTouched();
   }

--- a/src/components/tabs/ink-bar.ts
+++ b/src/components/tabs/ink-bar.ts
@@ -1,9 +1,7 @@
 import {Directive, Renderer, ElementRef} from '@angular/core';
 
-/**
- * The ink-bar is used to display and animate the line underneath the current active tab label.
- * @internal
- */
+
+/** The ink-bar is used to display and animate the line underneath the current active tab label. */
 @Directive({
   selector: 'md-ink-bar',
 })

--- a/src/components/tabs/tab-group.html
+++ b/src/components/tabs/tab-group.html
@@ -3,10 +3,10 @@
      (keydown.arrowLeft)="focusPreviousTab()"
      (keydown.enter)="selectedIndex = focusIndex">
   <div class="md-tab-label" role="tab" md-tab-label-wrapper
-       *ngFor="let tab of tabs; let i = index"
-       [id]="getTabLabelId(i)"
+       *ngFor="let tab of _tabs; let i = index"
+       [id]="_getTabLabelId(i)"
        [tabIndex]="selectedIndex == i ? 0 : -1"
-       [attr.aria-controls]="getTabContentId(i)"
+       [attr.aria-controls]="_getTabContentId(i)"
        [attr.aria-selected]="selectedIndex == i"
        [class.md-active]="selectedIndex == i"
        (click)="focusIndex = selectedIndex = i">
@@ -20,6 +20,6 @@
        [id]="getTabContentId(i)"
        [class.md-active]="selectedIndex == i"
        [attr.aria-labelledby]="getTabLabelId(i)">
-    <template role="tabpanel" [portalHost]="tab.content" *ngIf="selectedIndex == i"></template>
+    <template role="tabpanel" [portalHost]="tab.content" [ngIf]="selectedIndex == i"></template>
   </div>
 </div>

--- a/src/components/tabs/tab-label-wrapper.ts
+++ b/src/components/tabs/tab-label-wrapper.ts
@@ -1,9 +1,7 @@
 import {Directive, ElementRef} from '@angular/core';
 
-/**
- * Used in the `md-tab-group` view to display tab labels
- * @internal
- */
+
+/** Used in the `md-tab-group` view to display tab labels */
 @Directive({
   selector: '[md-tab-label-wrapper]'
 })

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -49,11 +49,10 @@ export class MdTab {
   directives: [PortalHostDirective, MdTabLabelWrapper, MdInkBar, NgIf, NgFor],
 })
 export class MdTabGroup {
-  /** @internal */
-  @ContentChildren(MdTab) tabs: QueryList<MdTab>;
+  @ContentChildren(MdTab) _tabs: QueryList<MdTab>;
 
-  @ViewChildren(MdTabLabelWrapper) private _labelWrappers: QueryList<MdTabLabelWrapper>;
-  @ViewChildren(MdInkBar) private _inkBar: QueryList<MdInkBar>;
+  @ViewChildren(MdTabLabelWrapper) _labelWrappers: QueryList<MdTabLabelWrapper>;
+  @ViewChildren(MdInkBar) _inkBar: QueryList<MdInkBar>;
 
   private _isInitialized: boolean = false;
 
@@ -144,25 +143,19 @@ export class MdTabGroup {
   private _createChangeEvent(index: number): MdTabChangeEvent {
     const event = new MdTabChangeEvent;
     event.index = index;
-    if (this.tabs && this.tabs.length) {
-      event.tab = this.tabs.toArray()[index];
+    if (this._tabs && this._tabs.length) {
+      event.tab = this._tabs.toArray()[index];
     }
     return event;
   }
 
-  /**
-   * Returns a unique id for each tab label element
-   * @internal
-   */
-  getTabLabelId(i: number): string {
+  /** Returns a unique id for each tab label element */
+  _getTabLabelId(i: number): string {
     return `md-tab-label-${this._groupId}-${i}`;
   }
 
-  /**
-   * Returns a unique id for each tab content element
-   * @internal
-   */
-  getTabContentId(i: number): string {
+  /** Returns a unique id for each tab content element */
+  _getTabContentId(i: number): string {
     return `md-tab-content-${this._groupId}-${i}`;
   }
 

--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {FORM_DIRECTIVES, NgFor} from '@angular/common';
 import {MD_BUTTON_TOGGLE_DIRECTIVES} from '@angular2-material/button-toggle/button-toggle';
 import {
   MdUniqueSelectionDispatcher
@@ -10,7 +11,7 @@ import {MdIcon} from '@angular2-material/icon/icon';
   selector: 'button-toggle-demo',
   templateUrl: 'button-toggle-demo.html',
   providers: [MdUniqueSelectionDispatcher],
-  directives: [MD_BUTTON_TOGGLE_DIRECTIVES, MdIcon]
+  directives: [MD_BUTTON_TOGGLE_DIRECTIVES, FORM_DIRECTIVES, MdIcon, NgFor]
 })
 export class ButtonToggleDemo {
   favoritePie = 'Apple';

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -34,7 +34,7 @@ export class OverlayDemo {
   isMenuOpen: boolean = false;
 
   @ViewChildren(TemplatePortalDirective) templatePortals: QueryList<Portal<any>>;
-  @ViewChild(OverlayOrigin) private _overlayOrigin: OverlayOrigin;
+  @ViewChild(OverlayOrigin) _overlayOrigin: OverlayOrigin;
 
   constructor(public overlay: Overlay, public viewContainerRef: ViewContainerRef) { }
 


### PR DESCRIPTION
R: @robertmesserle @hansl @kara 
CC: @iveysaur @DevVersion 

When the code generated by the angular compiler interacts with the component, it does so through its class's public API. If anything is missing from the `.d.ts`, it will be an error when a downstream application tries to compile.

Also fixes some errors with tab's use of `ngIf`