### PR TITLE
docs (getting-started): add missing step for using md-icon

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -145,7 +145,17 @@ bootstrap(MyAppComponent, [
     directives: [MD_CARD_DIRECTIVES, MD_BUTTON_DIRECTIVES, MdIcon],
     providers: [MdIconRegistry]
  ```
-    
+
+- Add the icon package to the list of Material components in your `system-config.ts`:
+
+**src/system-config.ts**
+```ts
+// put the names of any of your Material components here
+const materialPkgs:string[] = [
+  ...
+  'icon'
+];
+```
     
     
     


### PR DESCRIPTION
The getting started doc is missing a step in the "Additional steps for md-icon setup:" section.  This leads to an error in the browser and the app failing to load.