### PR TITLE
doc: Remove mode="side" since it breakes the backtick

### DIFF
--- a/src/demo-app/sidenav/sidenav-demo.html
+++ b/src/demo-app/sidenav/sidenav-demo.html
@@ -1,5 +1,5 @@
 <md-sidenav-layout class="demo-sidenav-layout">
-  <md-sidenav #start (open)="myinput.focus()" mode="side">
+  <md-sidenav #start (open)="myinput.focus()">
     Start Side Drawer
     <br>
     <button md-button (click)="start.close()">Close</button>


### PR DESCRIPTION
Hello,

The `mode="side"` breaks the backtick of the start sidenav and therefore I removed it since it is not a working example, the example [here](https://github.com/angular/material2/tree/master/src/components/sidenav) works just fine though but that's because the `mode="side"` is not present in that example.