### PR TITLE
docs: Update Button docs so they match the output images

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -80,12 +80,13 @@ Output:
 ### Disabling
 
 You can disable any button type through the native `disabled` property.  You can add it directly, or bind it to a property on your
-component class.
+component class by adding `[disabled]="isDisabled"` given that the `isDisabled`
+property exists.
 
 ```html
-<button md-button disabled>off</button>
-<button md-raised-button [disabled]="isDisabled">off</button>
-<button md-mini-fab [disabled]="isDisabled">check circle</button>
+<button md-button disabled>OFF</button>
+<button md-raised-button [disabled]="isDisabled">OFF</button>
+<button md-mini-fab [disabled]="isDisabled"><md-icon>check</md-icon></button>
 ```
 
 Output:


### PR DESCRIPTION
The images found [here](https://github.com/angular/material2/tree/master/src/components/button#disabling) do not match the example code. This pull request updates the code to match those images.