### PR TITLE
docs(md-input): Add backticks around <md-input>

### DIFF
--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -64,7 +64,7 @@ A simple character counter can be made like the following:
 
 ## Divider Color
 
-The divider (line under the <md-input> content) color can be changed by using the `dividerColor` attribute. A value of `primary` is the default and will correspond to your theme primary color. Alternatively, you can specify `accent` or `warn`.
+The divider (line under the `<md-input>` content) color can be changed by using the `dividerColor` attribute. A value of `primary` is the default and will correspond to your theme primary color. Alternatively, you can specify `accent` or `warn`.
 
 #### Example
 


### PR DESCRIPTION
Hey!

This pull request adds backticks (``) around a place where <md-input> were written. This fixes so it actually gets outputted in the docs because as it is now it does not get outputted.