### PR TITLE
Update GETTING_STARTED with missing install step

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -24,7 +24,7 @@ Now that your project has been created, you can install any Angular Material 2 c
 to use through npm. You can see our [list of published packages here](https://www.npmjs.com/~angular2-material).  
 
 ```bash
-npm install --save @angular2-material/core @angular2-material/button
+npm install --save @angular2-material/core @angular2-material/button @angular2-material/card
 ```
 Note: the core module is required as a peer dependency of other components.
 


### PR DESCRIPTION
Later steps require @angular2-material/card package to have been installed but initial npm install step does not include it.