### PR TITLE
fix(slide-toggle): fix runtime exception for incorrect mousedown binding

### DIFF
--- a/src/components/slide-toggle/slide-toggle.ts
+++ b/src/components/slide-toggle/slide-toggle.ts
@@ -39,7 +39,7 @@ let nextId = 0;
     '[class.md-disabled]': 'disabled',
     // This md-slide-toggle prefix will change, once the temporary ripple is removed.
     '[class.md-slide-toggle-focused]': '_hasFocus',
-    '(mousedown)': 'setMousedown()'
+    '(mousedown)': '_setMousedown()'
   },
   templateUrl: 'slide-toggle.html',
   styleUrls: ['slide-toggle.css'],


### PR DESCRIPTION
* Commit fad4ef5 made all internal functions prefixed with an underscore.
  The commit did accidentally miss to add the underscore the `(mousedown)` host binding function, which
  causes a Runtime Exception now.

cc. @jelbourn 