### PR TITLE
chore: changes necessary for adding support for offline compiler

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -20,7 +20,7 @@ import {
             'button[md-fab], button[md-mini-fab]',
   inputs: ['color'],
   host: {
-    '[class.md-button-focus]': 'isKeyboardFocused',
+    '[class.md-button-focus]': '_isKeyboardFocused',
     '(mousedown)': '_setMousedown()',
     '(focus)': '_setKeyboardFocus()',
     '(blur)': '_removeKeyboardFocus()',

--- a/src/components/grid-list/grid-list.spec.ts
+++ b/src/components/grid-list/grid-list.spec.ts
@@ -86,20 +86,20 @@ describe('MdGridList', () => {
 
   it('should divide row height evenly in "fit" mode', async(() => {
     var template = `
-      <md-grid-list cols="1" rowHeight="fit" [style.height.px]="height">
+      <md-grid-list cols="1" rowHeight="fit" [style.height]="height">
         <md-grid-tile></md-grid-tile>
         <md-grid-tile></md-grid-tile>
       </md-grid-list>`;
 
     builder.overrideTemplate(TestGridList, template).createAsync(TestGridList).then(fixture => {
-      fixture.componentInstance.height = 300;
+      fixture.componentInstance.height = '300px';
       fixture.detectChanges();
       let tile = fixture.debugElement.query(By.directive(MdGridTile));
 
       // 149.5 * 2 = 299px + 1px gutter = 300px
       expect(getProp(tile, 'height')).toBe('149.5px');
 
-      fixture.componentInstance.height = 200;
+      fixture.componentInstance.height = '200px';
       fixture.detectChanges();
 
       // 99.5 * 2 = 199px + 1px gutter = 200px
@@ -384,7 +384,7 @@ describe('MdGridList', () => {
 })
 class TestGridList {
   tiles: any[];
-  height: string;
+  height: string | number;
   colspan: number;
   rowspan: number;
 }

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -261,12 +261,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('autocomplete')).toBeNull();
 
-        fixture.componentInstance.autoComplete = 'on';
+        input.autoComplete = 'on';
         fixture.detectChanges();
         expect(el.getAttribute('autocomplete')).toEqual('on');
       });
@@ -310,12 +311,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('autofocus')).toBeNull();
 
-        fixture.componentInstance.autoFocus = true;
+        input.autoFocus = true;
         fixture.detectChanges();
         expect(el.getAttribute('autofocus')).toEqual('');
       });
@@ -342,12 +344,14 @@ describe('MdInput', function () {
     builder.overrideTemplate(MdInputOptionalAttributeController, template)
       .createAsync(MdInputOptionalAttributeController)
       .then(fixture => {
-        fixture.componentInstance.disabled = false;
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+        input.disabled = false;
         fixture.detectChanges();
 
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
         expect(el).not.toBeNull();
+
+        fixture.detectChanges();
         expect(el.getAttribute('disabled')).toEqual(null);
 
         fixture.componentInstance.disabled = true;
@@ -377,15 +381,15 @@ describe('MdInput', function () {
     builder.overrideTemplate(MdInputOptionalAttributeController, template)
       .createAsync(MdInputOptionalAttributeController)
       .then(fixture => {
-        fixture.componentInstance.disabled = false;
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+        input.disabled = false;
         fixture.detectChanges();
 
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
-        expect(el).not.toBeNull();
+        fixture.detectChanges();
         expect(el.getAttribute('list')).toEqual(null);
 
-        fixture.componentInstance.list = 'datalist-id';
+        input.list = 'datalist-id';
         fixture.detectChanges();
         expect(el.getAttribute('list')).toEqual('datalist-id');
       });
@@ -397,19 +401,21 @@ describe('MdInput', function () {
     builder.overrideTemplate(MdInputOptionalAttributeController, template)
       .createAsync(MdInputOptionalAttributeController)
       .then(fixture => {
-        fixture.componentInstance.disabled = false;
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+        input.disabled = false;
         fixture.detectChanges();
 
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
         expect(el).not.toBeNull();
+
+        fixture.detectChanges();
         expect(el.getAttribute('max')).toEqual(null);
 
-        fixture.componentInstance.max = 10;
+        input.max = 10;
         fixture.detectChanges();
         expect(el.getAttribute('max')).toEqual('10');
 
-        fixture.componentInstance.max = '2000-01-02';
+        input.max = '2000-01-02';
         fixture.detectChanges();
         expect(el.getAttribute('max')).toEqual('2000-01-02');
       });
@@ -421,19 +427,20 @@ describe('MdInput', function () {
     builder.overrideTemplate(MdInputOptionalAttributeController, template)
       .createAsync(MdInputOptionalAttributeController)
       .then(fixture => {
-        fixture.componentInstance.disabled = false;
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+        input.disabled = false;
         fixture.detectChanges();
 
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
         expect(el).not.toBeNull();
+        fixture.detectChanges();
         expect(el.getAttribute('min')).toEqual(null);
 
-        fixture.componentInstance.min = 10;
+        input.min = 10;
         fixture.detectChanges();
         expect(el.getAttribute('min')).toEqual('10');
 
-        fixture.componentInstance.min = '2000-01-02';
+        input.min = '2000-01-02';
         fixture.detectChanges();
         expect(el.getAttribute('min')).toEqual('2000-01-02');
       });
@@ -448,11 +455,12 @@ describe('MdInput', function () {
         fixture.detectChanges();
 
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('readonly')).toBeNull();
 
-        fixture.componentInstance.readOnly = true;
+        input.readOnly = true;
         fixture.detectChanges();
         expect(el.getAttribute('readonly')).toEqual('');
       });
@@ -481,12 +489,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('required')).toBeNull();
 
-        fixture.componentInstance.required = true;
+        input.required = true;
         fixture.detectChanges();
         expect(el.getAttribute('required')).toEqual('');
       });
@@ -515,12 +524,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('spellcheck')).toEqual('false');
 
-        fixture.componentInstance.spellCheck = true;
+        input.spellCheck = true;
         fixture.detectChanges();
         expect(el.getAttribute('spellcheck')).toEqual('true');
       });
@@ -549,12 +559,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('step')).toEqual(null);
 
-        fixture.componentInstance.step = 0.5;
+        input.step = 0.5;
         fixture.detectChanges();
         expect(el.getAttribute('step')).toEqual('0.5');
       });
@@ -568,12 +579,13 @@ describe('MdInput', function () {
       .then(fixture => {
         fixture.detectChanges();
 
+        let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
         let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
         expect(el).not.toBeNull();
         expect(el.getAttribute('tabindex')).toEqual(null);
 
-        fixture.componentInstance.tabIndex = 1;
+        input.tabIndex = 1;
         fixture.detectChanges();
         expect(el.getAttribute('tabindex')).toEqual('1');
       });

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -18,6 +18,7 @@ import {
 import {
   NG_VALUE_ACCESSOR,
   ControlValueAccessor,
+  DefaultValueAccessor,
   NgModel,
 } from '@angular/forms';
 import {NgIf} from '@angular/common';
@@ -99,7 +100,7 @@ export class MdHint {
   templateUrl: 'input.html',
   styleUrls: ['input.css'],
   providers: [MD_INPUT_CONTROL_VALUE_ACCESSOR],
-  directives: [NgIf, NgModel],
+  directives: [DefaultValueAccessor, NgIf, NgModel],
   host: {'(click)' : 'focus()'}
 })
 export class MdInput implements ControlValueAccessor, AfterContentInit, OnChanges {
@@ -147,9 +148,9 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   @Input() @BooleanFieldValue() disabled: boolean = false;
   @Input() id: string = `md-input-${nextUniqueId++}`;
   @Input() list: string = null;
-  @Input() max: string = null;
+  @Input() max: string | number = null;
   @Input() maxLength: number = null;
-  @Input() min: string = null;
+  @Input() min: string | number = null;
   @Input() minLength: number = null;
   @Input() placeholder: string = null;
   @Input() @BooleanFieldValue() readOnly: boolean = false;

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -33,7 +33,6 @@ export class MdDuplicatedSidenavError extends MdError {
  * Please refer to README.md for examples on how to use it.
  */
 @Component({
-  moduleId: module.id,
   selector: 'md-sidenav',
   template: '<ng-content></ng-content>',
   host: {


### PR DESCRIPTION
The `module.id` changes aren't going to work with dynamic platform browser in development mode (demo app). Unfortunately, they're necessary to remove to get the metadata extraction working (since metadata cannot execute code).

They will go away with the webpack change to the CLI anyway.