### PR TITLE
fix(): properly build demo-app in production.

### DIFF
--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -2,9 +2,6 @@
  * User Configuration.
  **********************************************************************************************/
 
-System.defaultJSExtensions = true;
-
-
 const components = [
   'button',
   'card',
@@ -35,6 +32,11 @@ components.forEach(name => map[`@angular2-material/${name}`] = `components/${nam
 const packages: any = {
   '@angular2-material/core': {
     format: 'cjs',
+    defaultExtension: 'js'
+  },
+  // Set the default extension for the root package, because otherwise the demo-app can't
+  // be built within the production mode. Due to missing file extensions.
+  '.': {
     defaultExtension: 'js'
   }
 };


### PR DESCRIPTION
* Currently it was not possible to build the demo-app in production, due to the fact that the fileExtensions for the SystemJS Builder were not available.

> This was caused by the deprecated flag `defaultJSExtension`.

@jelbourn - This change is necessary to easily build a production build for the Material Bot.
 > Currently I'm just building normally and then running the SystemJS builder manually + modifying the entry point with jsdom.