### PR TITLE
chore: add extract_metadata task to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     # Order: a slower build first, so that we don't occupy an idle travis worker waiting for others to complete.
     - MODE=lint
     - MODE=circular_deps
+    - MODE=extract_metadata
     - MODE=e2e
     - MODE=saucelabs_required
     - MODE=browserstack_required

--- a/scripts/ci/sources/mode.sh
+++ b/scripts/ci/sources/mode.sh
@@ -12,3 +12,7 @@ is_lint() {
 is_circular_deps_check() {
   [[ "$MODE" = circular_deps ]]
 }
+
+is_extract_metadata() {
+  [[ "$MODE" = extract_metadata ]]
+}


### PR DESCRIPTION
Also inlines resources for e2e tests which should speed them up (and hopefully make them less flaky); the build triggered by `ng serve` would have been clobbering the previous inlining. 