### PR TITLE
fix(input): ensure all of label displays on safari

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -46,7 +46,6 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   display: inline-block;
   position: relative;
   font-family: $md-font-family;
-  overflow: hidden;
 
   // To avoid problems with text-align.
   text-align: left;


### PR DESCRIPTION
Closes #795

@hansl, can you take a look?  The overflow:hidden style added [here](https://github.com/angular/material2/commit/cf2703c91185aee05c12d1791a42d1d9b72ed431) seems to cut off labels in iOS. Removing it fixes the problem, and I can't seem to see any visual difference in major browsers.