### PR TITLE
docs(tabs): fix incorrect select change event name

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -35,4 +35,4 @@ A basic tab group would have the following markup.
 | Name | Type | Description |
 | --- | --- | --- |
 | `focusChange` | `Event` | Fired when focus changes from one label to another |
-| `selectedChange` | `Event` | Fired when the selected tab changes |
+| `selectChange` | `Event` | Fired when the selected tab changes |


### PR DESCRIPTION
* The current documentation didn't match with the source code of the tabs component, which says that the
   attribute should be `selectChange` instead of `selectedChange`

Closes #856