### PR TITLE
chore(menu): change exports to menu.ts

### DIFF
--- a/src/components/menu/menu-directive.ts
+++ b/src/components/menu/menu-directive.ts
@@ -1,0 +1,85 @@
+// TODO(kara): keyboard events for menu navigation
+// TODO(kara): prevent-close functionality
+
+import {
+  Attribute,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+import {MenuPositionX, MenuPositionY} from './menu-positions';
+import {MdMenuInvalidPositionX, MdMenuInvalidPositionY} from './menu-errors';
+
+@Component({
+  moduleId: module.id,
+  selector: 'md-menu',
+  host: {'role': 'menu'},
+  templateUrl: 'menu.html',
+  styleUrls: ['menu.css'],
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'mdMenu'
+})
+export class MdMenu {
+  private _showClickCatcher: boolean = false;
+
+  // config object to be passed into the menu's ngClass
+  private _classList: Object;
+
+  positionX: MenuPositionX = 'after';
+  positionY: MenuPositionY = 'below';
+
+  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+
+  constructor(@Attribute('x-position') posX: MenuPositionX,
+              @Attribute('y-position') posY: MenuPositionY) {
+    if (posX) { this._setPositionX(posX); }
+    if (posY) { this._setPositionY(posY); }
+  }
+
+  /**
+   * This method takes classes set on the host md-menu element and applies them on the
+   * menu template that displays in the overlay container.  Otherwise, it's difficult
+   * to style the containing menu from outside the component.
+   * @param classes list of class names
+   */
+  @Input('class')
+  set classList(classes: string) {
+    this._classList = classes.split(' ').reduce((obj: any, className: string) => {
+      obj[className] = true;
+      return obj;
+    }, {});
+  }
+
+  @Output() close = new EventEmitter;
+
+  /**
+   * This function toggles the display of the menu's click catcher element.
+   * This element covers the viewport when the menu is open to detect clicks outside the menu.
+   * TODO: internal
+   */
+  _setClickCatcher(bool: boolean): void {
+    this._showClickCatcher = bool;
+  }
+
+  private _setPositionX(pos: MenuPositionX): void {
+    if ( pos !== 'before' && pos !== 'after') {
+      throw new MdMenuInvalidPositionX();
+    }
+    this.positionX = pos;
+  }
+
+  private _setPositionY(pos: MenuPositionY): void {
+    if ( pos !== 'above' && pos !== 'below') {
+      throw new MdMenuInvalidPositionY();
+    }
+    this.positionY = pos;
+  }
+
+  private _emitCloseEvent(): void {
+    this.close.emit(null);
+  }
+}

--- a/src/components/menu/menu-trigger.ts
+++ b/src/components/menu/menu-trigger.ts
@@ -9,8 +9,7 @@ import {
     AfterViewInit,
     OnDestroy
 } from '@angular/core';
-import {MdMenu} from './menu';
-import {MdMenuItem, MdMenuAnchor} from './menu-item';
+import {MdMenu} from './menu-directive';
 import {MdMenuMissingError} from './menu-errors';
 import {
     Overlay,
@@ -133,5 +132,3 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
     );
   }
 }
-
-export const MD_MENU_DIRECTIVES = [MdMenu, MdMenuItem, MdMenuTrigger, MdMenuAnchor];

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -2,7 +2,7 @@ import {inject} from '@angular/core/testing';
 import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component} from '@angular/core';
 
-import {MD_MENU_DIRECTIVES} from './menu-trigger';
+import {MD_MENU_DIRECTIVES} from './menu';
 
 describe('MdMenu', () => {
   let builder: TestComponentBuilder;

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,87 +1,9 @@
-// TODO(kara): keyboard events for menu navigation
-// TODO(kara): prevent-close functionality
-// TODO(kara): set position of menu
+import { MdMenu } from './menu-directive';
+import { MdMenuItem, MdMenuAnchor } from './menu-item';
+import { MdMenuTrigger } from './menu-trigger';
 
-import {
-    Attribute,
-    Component,
-    EventEmitter,
-    Input,
-    Output,
-    TemplateRef,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
-import {MenuPositionX, MenuPositionY} from './menu-positions';
-import {MdMenuInvalidPositionX, MdMenuInvalidPositionY} from './menu-errors';
+export { MdMenu } from './menu-directive';
+export { MdMenuItem, MdMenuAnchor } from './menu-item';
+export { MdMenuTrigger } from './menu-trigger';
 
-@Component({
-  moduleId: module.id,
-  selector: 'md-menu',
-  host: {'role': 'menu'},
-  templateUrl: 'menu.html',
-  styleUrls: ['menu.css'],
-  encapsulation: ViewEncapsulation.None,
-  exportAs: 'mdMenu'
-})
-export class MdMenu {
-  private _showClickCatcher: boolean = false;
-
-  // config object to be passed into the menu's ngClass
-  private _classList: Object;
-
-  positionX: MenuPositionX = 'after';
-  positionY: MenuPositionY = 'below';
-
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
-
-  constructor(@Attribute('x-position') posX: MenuPositionX,
-              @Attribute('y-position') posY: MenuPositionY) {
-    if (posX) { this._setPositionX(posX); }
-    if (posY) { this._setPositionY(posY); }
-  }
-
-  /**
-   * This method takes classes set on the host md-menu element and applies them on the
-   * menu template that displays in the overlay container.  Otherwise, it's difficult
-   * to style the containing menu from outside the component.
-   * @param classes list of class names
-   */
-  @Input('class')
-  set classList(classes: string) {
-    this._classList = classes.split(' ').reduce((obj: any, className: string) => {
-      obj[className] = true;
-      return obj;
-    }, {});
-  }
-
-  @Output() close = new EventEmitter;
-
-  /**
-   * This function toggles the display of the menu's click catcher element.
-   * This element covers the viewport when the menu is open to detect clicks outside the menu.
-   * TODO: internal
-   */
-  _setClickCatcher(bool: boolean): void {
-    this._showClickCatcher = bool;
-  }
-
-  private _setPositionX(pos: MenuPositionX): void {
-    if ( pos !== 'before' && pos !== 'after') {
-      throw new MdMenuInvalidPositionX();
-    }
-    this.positionX = pos;
-  }
-
-  private _setPositionY(pos: MenuPositionY): void {
-    if ( pos !== 'above' && pos !== 'below') {
-      throw new MdMenuInvalidPositionY();
-    }
-    this.positionY = pos;
-  }
-
-  private _emitCloseEvent(): void {
-    this.close.emit(null);
-  }
-}
-
+export const MD_MENU_DIRECTIVES = [MdMenu, MdMenuItem, MdMenuTrigger, MdMenuAnchor];

--- a/src/demo-app/menu/menu-demo.ts
+++ b/src/demo-app/menu/menu-demo.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MD_MENU_DIRECTIVES} from '@angular2-material/menu/menu-trigger';
+import {MD_MENU_DIRECTIVES} from '@angular2-material/menu/menu';
 import {MD_ICON_DIRECTIVES} from '@angular2-material/icon/icon';
 import {MD_BUTTON_DIRECTIVES} from '@angular2-material/button/button';
 import {MD_TOOLBAR_DIRECTIVES} from '@angular2-material/toolbar/toolbar';

--- a/src/e2e-app/menu/menu-e2e.ts
+++ b/src/e2e-app/menu/menu-e2e.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MD_MENU_DIRECTIVES} from '@angular2-material/menu/menu-trigger';
+import {MD_MENU_DIRECTIVES} from '@angular2-material/menu/menu';
 
 @Component({
   moduleId: module.id,


### PR DESCRIPTION
This PR moves the menu directive code out of menu.ts and into menu-directive.ts, so menu.ts will be able to export the menu directives.   It's not possible to export them while menu.ts code is present because of our circular dependency check.