### PR TITLE
chore: add script to automatically update plunker bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - MODE=browserstack_required
     - MODE=saucelabs_optional
     - MODE=browserstack_optional
-    - MODE=plunker
+#    - MODE=plunker
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - MODE=browserstack_required
     - MODE=saucelabs_optional
     - MODE=browserstack_optional
-#    - MODE=plunker
+    - MODE=plunker
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,12 @@ env:
     - MODE=browserstack_required
     - MODE=saucelabs_optional
     - MODE=browserstack_optional
+    - MODE=plunker
 
 matrix:
+  fast_finish: true
   allow_failures:
+  - env: "MODE=plunker"
   - env: "MODE=saucelabs_optional"
   - env: "MODE=browserstack_optional"
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",
     "stylelint": "stylelint 'src/**/*.scss' --config stylelint-config.json --syntax scss",
     "check-circular-deps": "madge --circular ./dist",
+    "update-plunker": "node ./scripts/ci/create-plunker-bundle.js",
     "typings": "typings install --global",
     "postinstall": "npm run typings",
     "e2e": "protractor",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "ci:forbidden-identifiers": "node ./scripts/ci/forbidden-identifiers.js",
     "build": "ng build",
+    "build:production": "ng build -prod",
     "demo-app": "ng serve",
     "test": "karma start test/karma.conf.js",
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -46,7 +46,8 @@ elif is_extract_metadata; then
   ./node_modules/.bin/tsc -p ./src/demo-app/
   ./node_modules/.bin/ngc -p ./src/demo-app/
 elif is_plunker; then
-  if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  # Only update the plunker when the firebase access token is available.
+  if [ "$MATERIAL2_PLNKR_TOKEN" = "false" ]; then
     npm run update-plunker
   fi
 else

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -45,8 +45,10 @@ elif is_extract_metadata; then
   # Run `tsc` first so that the directory structure in dist/ matches what ngc expects.
   ./node_modules/.bin/tsc -p ./src/demo-app/
   ./node_modules/.bin/ngc -p ./src/demo-app/
-elif is_plunker && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  npm run update-plunker
+elif is_plunker; then
+  if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+    npm run update-plunker
+  fi
 else
   # Unit tests
   npm run build

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -45,7 +45,7 @@ elif is_extract_metadata; then
   # Run `tsc` first so that the directory structure in dist/ matches what ngc expects.
   ./node_modules/.bin/tsc -p ./src/demo-app/
   ./node_modules/.bin/ngc -p ./src/demo-app/
-elif is_plunker; then
+elif is_plunker && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   npm run update-plunker
 else
   # Unit tests

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -45,6 +45,8 @@ elif is_extract_metadata; then
   # Run `tsc` first so that the directory structure in dist/ matches what ngc expects.
   ./node_modules/.bin/tsc -p ./src/demo-app/
   ./node_modules/.bin/ngc -p ./src/demo-app/
+elif is_plunker; then
+  npm run update-plunker
 else
   # Unit tests
   npm run build

--- a/scripts/ci/create-plunker-bundle.js
+++ b/scripts/ci/create-plunker-bundle.js
@@ -42,8 +42,8 @@ fse.mkdirp(DEPLOY_ROOT);
 fse.copySync(mainFile, path.join(DEPLOY_ROOT, `${baseName}_bundle.js`));
 
 firebase.deploy({
-  firebase: 'material-plunker',
-  token: process.env.MATERIAL_FIREBASE_TOKEN,
+  firebase: 'material2-plnkr',
+  token: process.env.MATERIAL2_PLNKR_TOKEN,
   public: 'dist/plunker-deploy'
 }).then(() => {
   console.log('Firebase: Successfully deployed bundle to firebase.');

--- a/scripts/ci/create-plunker-bundle.js
+++ b/scripts/ci/create-plunker-bundle.js
@@ -7,9 +7,9 @@
  * The bundle will be used to load a Plunker Demo of Angular Material 2.
  */
 
-const spawn = require('child_process').spawnSync;
-const exec = require('child_process').execSync;
-const glob = require('glob').sync;
+const globSync = require('glob').sync;
+const spawnSync = require('child_process').spawnSync;
+const execSync = require('child_process').execSync;
 const firebase = require('firebase-tools');
 const path = require('path');
 const fse = require('fs-extra');
@@ -21,14 +21,14 @@ const DEPLOY_ROOT = path.join(DIST_ROOT, 'plunker-deploy/');
 
 const mainFile = path.join(DIST_ROOT, 'main.js');
 const latestTag = getLatestTag();
-const isRelease = getSHAFromTag(latestTag) === getLatestSHA();
+const isRelease = getShaFromTag(latestTag) === getLatestSha();
 const baseName = isRelease ? latestTag : 'HEAD';
 
 // Remove the distribution folder.
 fse.removeSync(DIST_ROOT);
 
 if (!buildProject()) {
-  console.error("An error occurred while building the project.");
+  console.error('An error occurred while building the project.');
   process.exit(1);
 }
 
@@ -46,17 +46,17 @@ firebase.deploy({
   token: process.env.MATERIAL_FIREBASE_TOKEN,
   public: 'dist/plunker-deploy'
 }).then(() => {
-  console.log("Firebase: Successfully deployed bundle to firebase.");
+  console.log('Firebase: Successfully deployed bundle to firebase.');
   process.exit(0);
 }).catch(err => {
-  console.error("Firebase: An error occurred while deploying to firebase.");
+  console.error('Firebase: An error occurred while deploying to firebase.');
   console.error(err);
   process.exit(1);
 });
 
 function inlineBundle() {
   let filePathFn = (sourceFile) => {
-    let sourceFiles = glob(`**/${sourceFile}`, { cwd: DIST_ROOT });
+    let sourceFiles = globSync(`**/${sourceFile}`, { cwd: DIST_ROOT });
     return path.resolve(DIST_ROOT, sourceFiles[0]);
   };
 
@@ -71,20 +71,20 @@ function inlineBundle() {
 function buildProject() {
   // Note: We can't use spawnSync here, because on some environments the Angular CLI
   // is not added to the System Paths and is only available in the locals.
-  let out = exec('npm run build:production').toString();
+  let out = execSync('npm run build:production').toString();
 
   return out.indexOf('successfully') !== -1;
 }
 
 function getLatestTag() {
-  let latestTagSHA = spawn('git', ['rev-list', '--tags', '--max-count=1']).stdout.toString().trim();
-  return spawn('git', ['describe', '--tags', latestTagSHA]).stdout.toString().trim();
+  let tagSHA = spawnSync('git', ['rev-list', '--tags', '--max-count=1']).stdout.toString().trim();
+  return spawnSync('git', ['describe', '--tags', tagSHA]).stdout.toString().trim();
 }
 
-function getLatestSHA() {
-  return spawn('git', ['rev-parse', 'master'])
+function getLatestSha() {
+  return spawnSync('git', ['rev-parse', 'master'])
 }
 
-function getSHAFromTag(tag) {
-  return spawn('git', ['rev-list', '-1', tag]).stdout.toString().trim();
+function getShaFromTag(tag) {
+  return spawnSync('git', ['rev-list', '-1', tag]).stdout.toString().trim();
 }

--- a/scripts/ci/create-plunker-bundle.js
+++ b/scripts/ci/create-plunker-bundle.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * This script creates a bundle of all components and publishes it to Firebase.
+ * The bundle will be used to load a Plunker Demo of Angular Material 2.
+ */
+
+const spawn = require('child_process').spawnSync;
+const exec = require('child_process').execSync;
+const glob = require('glob').sync;
+const firebase = require('firebase-tools');
+const path = require('path');
+const fse = require('fs-extra');
+const inlineResources = require('../../tools/inline-resources-tools');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DIST_ROOT = path.join(ROOT, 'dist');
+const DEPLOY_ROOT = path.join(DIST_ROOT, 'plunker-deploy/');
+
+const mainFile = path.join(DIST_ROOT, 'main.js');
+const latestTag = getLatestTag();
+const isRelease = getSHAFromTag(latestTag) === getLatestSHA();
+const baseName = isRelease ? latestTag : 'HEAD';
+
+// Remove the distribution folder.
+fse.removeSync(DIST_ROOT);
+
+if (!buildProject()) {
+  console.error("An error occurred while building the project.");
+  process.exit(1);
+}
+
+// Inline the resources into the bundle file.
+inlineBundle();
+
+// Create distribution folder.
+fse.mkdirp(DEPLOY_ROOT);
+
+// Copy the bundle to the deploy folder.
+fse.copySync(mainFile, path.join(DEPLOY_ROOT, `${baseName}_bundle.js`));
+
+firebase.deploy({
+  firebase: 'material-plunker',
+  token: process.env.MATERIAL_FIREBASE_TOKEN,
+  public: 'dist/plunker-deploy'
+}).then(() => {
+  console.log("Firebase: Successfully deployed bundle to firebase.");
+  process.exit(0);
+}).catch(err => {
+  console.error("Firebase: An error occurred while deploying to firebase.");
+  console.error(err);
+  process.exit(1);
+});
+
+function inlineBundle() {
+  let filePathFn = (sourceFile) => {
+    let sourceFiles = glob(`**/${sourceFile}`, { cwd: DIST_ROOT });
+    return path.resolve(DIST_ROOT, sourceFiles[0]);
+  };
+
+  executeInline(inlineResources.inlineStyle);
+  executeInline(inlineResources.inlineTemplate);
+
+  function executeInline(inlineFn) {
+    fse.writeFileSync(mainFile, inlineFn(filePathFn, fse.readFileSync(mainFile).toString()));
+  }
+}
+
+function buildProject() {
+  // Resolve the Angular CLI entry point from the installed node modules.
+  var ngBinary = path.join(ROOT, 'node_modules', 'angular-cli', 'bin', 'ng');
+
+  let out = exec(`node ${ngBinary} build -prod`, {
+    cwd: ROOT
+  }).toString();
+
+  return out.indexOf('successfully') !== -1;
+}
+
+function getLatestTag() {
+  let latestTagSHA = spawn('git', ['rev-list', '--tags', '--max-count=1']).stdout.toString().trim();
+  return spawn('git', ['describe', '--tags', latestTagSHA]).stdout.toString().trim();
+}
+
+function getLatestSHA() {
+  return spawn('git', ['rev-parse', 'master'])
+}
+
+function getSHAFromTag(tag) {
+  return spawn('git', ['rev-list', '-1', tag]).stdout.toString().trim();
+}

--- a/scripts/ci/create-plunker-bundle.js
+++ b/scripts/ci/create-plunker-bundle.js
@@ -69,12 +69,9 @@ function inlineBundle() {
 }
 
 function buildProject() {
-  // Resolve the Angular CLI entry point from the installed node modules.
-  var ngBinary = path.join(ROOT, 'node_modules', 'angular-cli', 'bin', 'ng');
-
-  let out = exec(`node ${ngBinary} build -prod`, {
-    cwd: ROOT
-  }).toString();
+  // Note: We can't use spawnSync here, because on some environments the Angular CLI
+  // is not added to the System Paths and is only available in the locals.
+  let out = exec('npm run build:production').toString();
 
   return out.indexOf('successfully') !== -1;
 }

--- a/scripts/ci/sources/mode.sh
+++ b/scripts/ci/sources/mode.sh
@@ -16,3 +16,7 @@ is_circular_deps_check() {
 is_extract_metadata() {
   [[ "$MODE" = extract_metadata ]]
 }
+
+is_plunker() {
+  [[ "$MODE" = plunker ]]
+}

--- a/tools/inline-resources-tools.js
+++ b/tools/inline-resources-tools.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * Inline the templates for a source file. Simply search for instances of `templateUrl: ...` and
+ * replace with `template: ...` (with the content of the file included).
+ * @param filePath {string|function} The path of the source file.
+ * @param content {string} The source file's content.
+ * @return {string} The content with all templates inlined.
+ */
+function inlineTemplate(filePath, content) {
+
+  // Transform the filePath into a function, to be able to customize the path.
+  if (typeof filePath !== 'function') filePath = () => filePath;
+
+  return content.replace(/templateUrl:\s*(?:'|")(.+?\.html)(?:"|')/g, function(m, templateUrl) {
+    const templateFile = path.join(path.dirname(filePath(templateUrl)), templateUrl);
+
+    if (!fs.existsSync(templateFile)) return;
+
+    const templateContent = fs.readFileSync(templateFile, 'utf-8');
+    const shortenedTemplate = templateContent
+      .replace(/([\n\r]\s*)+/gm, ' ')
+      .replace(/"/g, '\\"');
+
+    return `template: "${shortenedTemplate}"`;
+  });
+}
+
+
+/**
+ * Inline the styles for a source file. Simply search for instances of `styleUrls: [...]` and
+ * replace with `styles: [...]` (with the content of the file included).
+ * @param filePath {string|function} The path of the source file.
+ * @param content {string} The source file's content.
+ * @return {string} The content with all styles inlined.
+ */
+function inlineStyle(filePath, content) {
+
+  // Transform the filePath into a function, to be able to customize the path.
+  if (typeof filePath !== 'function') filePath = () => filePath;
+
+  return content.replace(/styleUrls:\s*(\[[\s\S]*?])/gm, function(m, styleUrls) {
+    const urls = eval(styleUrls);
+
+    let inlineStyles = urls
+      .map(styleUrl => path.join(path.dirname(filePath(styleUrl)), styleUrl))
+      .filter(styleUrl => fs.existsSync(styleUrl))
+      .map(styleFile => {
+        const styleContent = fs.readFileSync(styleFile, 'utf-8');
+        const shortenedStyle = styleContent
+          .replace(/([\n\r]\s*)+/gm, ' ')
+          .replace(/"/g, '\\"');
+
+        return `"${shortenedStyle}"`;
+      });
+
+    return 'styles: [' + inlineStyles.join(',\n') + ']';
+  });
+}
+
+/**
+ * Removes the module ids of the component metadata.
+ * Since the templates and styles are now inlined, the module id has become unnecessary and
+ * can cause unexpected issues.
+ */
+function removeModuleIds(content) {
+  // Match the line feeds as well, because we want to get rid of that line.
+  return content.replace(/^\W+moduleId:\W+module\.id,?[\n|\r]+/gm, '');
+}
+
+module.exports = {
+  inlineStyle: inlineStyle,
+  inlineTemplate: inlineTemplate,
+  removeModuleIds: removeModuleIds
+};

--- a/tools/inline-resources-tools.js
+++ b/tools/inline-resources-tools.js
@@ -6,19 +6,21 @@ const fs = require('fs-extra');
 /**
  * Inline the templates for a source file. Simply search for instances of `templateUrl: ...` and
  * replace with `template: ...` (with the content of the file included).
- * @param filePath {string|function} The path of the source file.
+ * @param filePath {string} The path of the source file.
  * @param content {string} The source file's content.
  * @return {string} The content with all templates inlined.
  */
 function inlineTemplate(filePath, content) {
 
   // Transform the filePath into a function, to be able to customize the path.
-  if (typeof filePath !== 'function') filePath = () => filePath;
+  let fileRootFn = typeof filePath !== 'function' ? () => filePath : filePath;
 
   return content.replace(/templateUrl:\s*(?:'|")(.+?\.html)(?:"|')/g, function(m, templateUrl) {
-    const templateFile = path.join(path.dirname(filePath(templateUrl)), templateUrl);
+    const templateFile = path.join(path.dirname(fileRootFn(templateUrl)), templateUrl);
 
-    if (!fs.existsSync(templateFile)) return;
+    if (!fs.existsSync(templateFile)) {
+      return;
+    }
 
     const templateContent = fs.readFileSync(templateFile, 'utf-8');
     const shortenedTemplate = templateContent
@@ -33,20 +35,20 @@ function inlineTemplate(filePath, content) {
 /**
  * Inline the styles for a source file. Simply search for instances of `styleUrls: [...]` and
  * replace with `styles: [...]` (with the content of the file included).
- * @param filePath {string|function} The path of the source file.
+ * @param filePath {string} The path of the source file.
  * @param content {string} The source file's content.
  * @return {string} The content with all styles inlined.
  */
 function inlineStyle(filePath, content) {
 
   // Transform the filePath into a function, to be able to customize the path.
-  if (typeof filePath !== 'function') filePath = () => filePath;
+  let fileRootFn = typeof filePath !== 'function' ? () => filePath : filePath;
 
   return content.replace(/styleUrls:\s*(\[[\s\S]*?])/gm, function(m, styleUrls) {
     const urls = eval(styleUrls);
 
     let inlineStyles = urls
-      .map(styleUrl => path.join(path.dirname(filePath(styleUrl)), styleUrl))
+      .map(styleUrl => path.join(path.dirname(fileRootFn(styleUrl)), styleUrl))
       .filter(styleUrl => fs.existsSync(styleUrl))
       .map(styleFile => {
         const styleContent = fs.readFileSync(styleFile, 'utf-8');


### PR DESCRIPTION
Adds a script to automatically update the plunker bundle by using the Angular CLI with Production Mode.

The firebase hosting will contain files:
- `HEAD_bundle.js` (Latest Bundle for each commit)
- `2.0.0-alpha.6` (Bundle for that tag)
- etc.

---
Open Points:
- When deploying to firebase, we overwrite the current hosting and loose the old bundles (like for tags)<br/>We need a way to pull the old files or find another approach for hosting

Please give some thoughts @jelbourn 