### PR TITLE
Add support for drawing tick marks on the slider

### DIFF
--- a/src/components/slider/slider.html
+++ b/src/components/slider/slider.html
@@ -6,6 +6,7 @@
       <div class="md-slider-track"></div>
       <div class="md-slider-track md-slider-track-fill"></div>
       <div class="md-slider-tick-container"></div>
+      <div class="md-slider-last-tick-container"></div>
     </div>
     <div class="md-slider-thumb-container">
       <div class="md-slider-thumb-position">

--- a/src/components/slider/slider.html
+++ b/src/components/slider/slider.html
@@ -5,6 +5,7 @@
     <div class="md-slider-track-container">
       <div class="md-slider-track"></div>
       <div class="md-slider-track md-slider-track-fill"></div>
+      <div class="md-slider-tick-container"></div>
     </div>
     <div class="md-slider-thumb-container">
       <div class="md-slider-thumb-position">

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -100,9 +100,6 @@ md-slider *::after {
   left: 0;
   right: 0;
   height: 100%;
-  background: repeating-linear-gradient(
-    90deg, #000000, #000000 2px, transparent 2px, transparent 30px
-  );
 }
 
 .md-slider-thumb-container {

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -95,6 +95,16 @@ md-slider *::after {
   background-color: md-color($md-accent);
 }
 
+.md-slider-tick-container {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg, #000000, #000000 2px, transparent 2px, transparent 30px
+  );
+}
+
 .md-slider-thumb-container {
   position: absolute;
   left: 0;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -95,7 +95,7 @@ md-slider *::after {
   background-color: md-color($md-accent);
 }
 
-.md-slider-tick-container {
+.md-slider-tick-container, .md-slider-last-tick-container {
   position: absolute;
   left: 0;
   right: 0;

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -25,6 +25,8 @@ describe('MdSlider', () => {
         SliderWithMinAndMax,
         SliderWithValue,
         SliderWithStep,
+        SliderWithAutoTickInterval,
+        SliderWithSetTickInterval
       ],
     });
 
@@ -561,13 +563,11 @@ class SliderWithValue { }
 class SliderWithStep { }
 
 @Component({
-  directives: [MD_SLIDER_DIRECTIVES],
   template: `<md-slider step="5" tick-interval="auto"></md-slider>`
 })
 class SliderWithAutoTickInterval { }
 
 @Component({
-  directives: [MD_SLIDER_DIRECTIVES],
   template: `<md-slider step="3" tick-interval="6"></md-slider>`
 })
 class SliderWithSetTickInterval { }

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -464,12 +464,12 @@ describe('MdSlider', () => {
       // toContain is used rather than toBe because FireFox adds 'transparent' to the beginning
       // of the background before the repeating linear gradient.
       expect(tickContainer.style.background).toContain('repeating-linear-gradient(to right, ' +
-      'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 32.6px)');
+          'black, black 2px, transparent 2px, transparent 32.6px)');
     });
 
     it('should draw a tick mark on the end of the track', () => {
-      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, rgb(0, 0, 0), '
-          + 'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, black, black' +
+          ' 2px, transparent 2px, transparent)');
     });
 
     it('should not draw the second to last tick when it is too close to the last tick', () => {
@@ -506,12 +506,12 @@ describe('MdSlider', () => {
       // which is at the position 20.16px and 1px is subtracted to center, giving a tick
       // separation of 19.16px.
       expect(tickContainer.style.background).toContain('repeating-linear-gradient(to right, ' +
-          'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 19.16px)');
+          'black, black 2px, transparent 2px, transparent 19.16px)');
     });
 
     it('should draw a tick mark on the end of the track', () => {
-      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, rgb(0, 0, 0), '
-          + 'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, black, '
+          + 'black 2px, transparent 2px, transparent)');
     });
   });
 });

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -479,7 +479,7 @@ describe('MdSlider', () => {
     });
   });
 
-  fdescribe('slider with set tick interval', () => {
+  describe('slider with set tick interval', () => {
     let fixture: ComponentFixture<SliderWithSetTickInterval>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -461,13 +461,13 @@ describe('MdSlider', () => {
       // both sides. The value 30 will be located at the position 33.6px, and 1px is removed from
       // the tick mark location in order to center the tick. Therefore, the tick separation should
       // be 32.6px.
-      expect(tickContainer.style.background).toBe('repeating-linear-gradient(to right, ' +
+      expect(tickContainer.style.background).toContain('repeating-linear-gradient(to right, ' +
       'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 32.6px)');
     });
 
     it('should draw a tick mark on the end of the track', () => {
-      expect(lastTickContainer.style.background).toBe('linear-gradient(to left, rgb(0, 0, 0), ' +
-          'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, rgb(0, 0, 0), '
+          + 'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
     });
 
     it('should not draw the second to last tick when it is too close to the last tick', () => {
@@ -503,13 +503,13 @@ describe('MdSlider', () => {
       // The slider width is 112px, the first step is at value 18 (step of 3 * tick interval of 6),
       // which is at the position 20.16px and 1px is subtracted to center, giving a tick
       // separation of 19.16px.
-      expect(tickContainer.style.background).toBe('repeating-linear-gradient(to right, ' +
+      expect(tickContainer.style.background).toContain('repeating-linear-gradient(to right, ' +
           'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 19.16px)');
     });
 
     it('should draw a tick mark on the end of the track', () => {
-      expect(lastTickContainer.style.background).toBe('linear-gradient(to left, rgb(0, 0, 0), ' +
-          'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+      expect(lastTickContainer.style.background).toContain('linear-gradient(to left, rgb(0, 0, 0), '
+          + 'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
     });
   });
 });

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -461,6 +461,8 @@ describe('MdSlider', () => {
       // both sides. The value 30 will be located at the position 33.6px, and 1px is removed from
       // the tick mark location in order to center the tick. Therefore, the tick separation should
       // be 32.6px.
+      // toContain is used rather than toBe because FireFox adds 'transparent' to the beginning
+      // of the background before the repeating linear gradient.
       expect(tickContainer.style.background).toContain('repeating-linear-gradient(to right, ' +
       'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 32.6px)');
     });

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -434,6 +434,84 @@ describe('MdSlider', () => {
       expect(Math.round(trackFillDimensions.width)).toBe(Math.round(thumbPosition));
     });
   });
+
+  describe('slider with auto ticks', () => {
+    let fixture: ComponentFixture<SliderWithAutoTickInterval>;
+    let sliderDebugElement: DebugElement;
+    let sliderNativeElement: HTMLElement;
+    let tickContainer: HTMLElement;
+    let lastTickContainer: HTMLElement;
+
+    beforeEach(async(() => {
+      builder.createAsync(SliderWithAutoTickInterval).then(f => {
+        fixture = f;
+        fixture.detectChanges();
+
+        sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+        sliderNativeElement = sliderDebugElement.nativeElement;
+        tickContainer = <HTMLElement>sliderNativeElement.querySelector('.md-slider-tick-container');
+        lastTickContainer =
+            <HTMLElement>sliderNativeElement.querySelector('.md-slider-last-tick-container');
+      });
+    }));
+
+    it('should set the correct tick separation', () => {
+      // The first tick mark is going to be at value 30 as it is the first step after 30px. The
+      // width of the slider is 112px because the minimum width is 128px with padding of 8px on
+      // both sides. The value 30 will be located at the position 33.6px, and 1px is removed from
+      // the tick mark location in order to center the tick. Therefore, the tick separation should
+      // be 32.6px.
+      expect(tickContainer.style.background).toBe('repeating-linear-gradient(to right, ' +
+      'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 32.6px)');
+    });
+
+    it('should draw a tick mark on the end of the track', () => {
+      expect(lastTickContainer.style.background).toBe('linear-gradient(to left, rgb(0, 0, 0), ' +
+          'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+    });
+
+    it('should not draw the second to last tick when it is too close to the last tick', () => {
+      // When the second to last tick is too close (less than half the tick separation) to the last
+      // one, the tick container width is cut by the tick separation, which removes the second to
+      // last tick. Since the width of the slider is 112px and the tick separation is 33.6px, the
+      // tick container width should be 78.4px (112 - 33.6).
+      expect(tickContainer.style.width).toBe('78.4px');
+    });
+  });
+
+  fdescribe('slider with set tick interval', () => {
+    let fixture: ComponentFixture<SliderWithSetTickInterval>;
+    let sliderDebugElement: DebugElement;
+    let sliderNativeElement: HTMLElement;
+    let tickContainer: HTMLElement;
+    let lastTickContainer: HTMLElement;
+
+    beforeEach(async(() => {
+      builder.createAsync(SliderWithSetTickInterval).then(f => {
+        fixture = f;
+        fixture.detectChanges();
+
+        sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+        sliderNativeElement = sliderDebugElement.nativeElement;
+        tickContainer = <HTMLElement>sliderNativeElement.querySelector('.md-slider-tick-container');
+        lastTickContainer =
+            <HTMLElement>sliderNativeElement.querySelector('.md-slider-last-tick-container');
+      });
+    }));
+
+    it('should set the correct tick separation', () => {
+      // The slider width is 112px, the first step is at value 18 (step of 3 * tick interval of 6),
+      // which is at the position 20.16px and 1px is subtracted to center, giving a tick
+      // separation of 19.16px.
+      expect(tickContainer.style.background).toBe('repeating-linear-gradient(to right, ' +
+          'rgb(0, 0, 0), rgb(0, 0, 0) 2px, transparent 2px, transparent 19.16px)');
+    });
+
+    it('should draw a tick mark on the end of the track', () => {
+      expect(lastTickContainer.style.background).toBe('linear-gradient(to left, rgb(0, 0, 0), ' +
+          'rgb(0, 0, 0) 2px, transparent 2px, transparent)');
+    });
+  });
 });
 
 // The transition has to be removed in order to test the updated positions without setTimeout.
@@ -479,6 +557,18 @@ class SliderWithValue { }
   encapsulation: ViewEncapsulation.None
 })
 class SliderWithStep { }
+
+@Component({
+  directives: [MD_SLIDER_DIRECTIVES],
+  template: `<md-slider step="5" tick-interval="auto"></md-slider>`
+})
+class SliderWithAutoTickInterval { }
+
+@Component({
+  directives: [MD_SLIDER_DIRECTIVES],
+  template: `<md-slider step="3" tick-interval="6"></md-slider>`
+})
+class SliderWithSetTickInterval { }
 
 /**
  * Dispatches a click event from an element.

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -370,6 +370,7 @@ export class SliderRenderer {
     // A linear gradient background is used to draw the ticks as it performs better than using
     // canvas or creating many small divs.
     // Subtract 1 from the tick separation to center the tick.
+    // TODO: Perf test this.
     tickContainer.style.background = `repeating-linear-gradient(90deg, #000000, #000000 2px,
     transparent 2px, transparent ${tickSeparation - 1}px)`;
   }

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -53,7 +53,11 @@ export class MdSlider implements AfterContentInit {
   /** The values at which the thumb will snap. */
   @Input() step: number = 1;
 
-  /** How often to show ticks. Defaults to auto which calculates how many to show. */
+  /**
+   * How often to show ticks. Defaults to auto which calculates how many to show.
+   * Relative to the step so that a tick always appears on a step.
+   * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
+   */
   private _tickInterval: 'auto' | number;
 
   /**

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -60,8 +60,7 @@ export class MdSlider implements AfterContentInit {
   @Input() step: number = 1;
 
   /**
-   * How often to show ticks. Defaults to auto which calculates how many to show.
-   * Relative to the step so that a tick always appears on a step.
+   * How often to show ticks. Relative to the step so that a tick always appears on a step.
    * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
    */
   private _tickInterval: 'auto' | number;

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -247,19 +247,31 @@ export class MdSlider implements AfterContentInit {
    * separation constant.
    */
   private _updateAutoTickSeparation() {
-    let width = this._sliderDimensions.width;
+    // We're looking for the multiple of step for which the separation between is greater than the
+    // minimum tick separation.
+    let sliderWidth = this._sliderDimensions.width;
 
-    // This calculates which step is far enough away from the beginning of the slider to draw a tick
-    // at. This value will then be used to draw ticks at every tickStep steps.
-    let tickStep =
-        Math.ceil(MIN_AUTO_TICK_SEPARATION * (this.max - this.min) / (width * this.step));
+    // This is the total "width" of the slider in terms of values.
+    let valueWidth = this.max - this.min;
 
-    // The percentage of the slider where the first tick should go.
-    let tickPercentage = this.calculatePercentage((this.step * tickStep) + this.min);
+    // Calculate how many values exist within 1px on the slider.
+    let valuePerPixel = valueWidth / sliderWidth;
+
+    // Calculate how many values exist in the minimum tick separation (px).
+    let valuePerSeparation = valuePerPixel  * MIN_AUTO_TICK_SEPARATION;
+
+    // Calculate how many steps exist in this separation. This will be the lowest value you can
+    // multiply step by to get a separation that is greater than or equal to the minimum tick
+    // separation.
+    let stepsPerSeparation = Math.ceil(valuePerSeparation / this.step);
+
+    // Get the percentage of the slider for which this tick would be located so we can then draw
+    // it on the slider.
+    let tickPercentage = this.calculatePercentage((this.step * stepsPerSeparation) + this.min);
 
     // The pixel value of the tick is the percentage * the width of the slider. Use this to draw
     // the ticks on the slider.
-    this._renderer.drawTicks(width * tickPercentage);
+    this._renderer.drawTicks(sliderWidth * tickPercentage);
   }
 
   /**

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -370,7 +370,7 @@ export class SliderRenderer {
     transparent 2px, transparent ${tickSeparation - 1}px)`;
     // Add a tick to the very end by starting on the right side and adding a 2px black line.
     lastTickContainer.style.background = `linear-gradient(to left, #000000, #000000 2px,
-    transparent 2px, transparent`;
+    transparent 2px, transparent)`;
 
     // If the second to last tick is too close (a separation of less than half the normal
     // separation), don't show it by decreasing the width of the tick container element.

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -110,7 +110,7 @@ export class MdSlider implements AfterContentInit {
   set tickInterval(v: 'auto' | number) {
     if (v == 'auto') {
       this._tickInterval = v;
-    } else if (typeof this.tickInterval == 'number') {
+    } else {
       this._tickInterval = Number(v);
     }
   }
@@ -367,12 +367,24 @@ export class SliderRenderer {
    */
   drawTicks(tickSeparation: number) {
     let tickContainer = <HTMLElement>this._sliderElement.querySelector('.md-slider-tick-container');
+    let tickContainerWidth = tickContainer.getBoundingClientRect().width;
+    let lastTickContainer =
+        <HTMLElement>this._sliderElement.querySelector('.md-slider-last-tick-container');
     // A linear gradient background is used to draw the ticks as it performs better than using
     // canvas or creating many small divs.
     // Subtract 1 from the tick separation to center the tick.
     // TODO: Perf test this.
-    tickContainer.style.background = `repeating-linear-gradient(90deg, #000000, #000000 2px,
+    tickContainer.style.background = `repeating-linear-gradient(to right, #000000, #000000 2px,
     transparent 2px, transparent ${tickSeparation - 1}px)`;
+    // Add a tick to the very end by starting on the right side and adding a 2px black line.
+    lastTickContainer.style.background = `linear-gradient(to left, #000000, #000000 2px,
+    transparent 2px, transparent`;
+
+    // If the second to last tick is too close (a separation of less than half the normal
+    // separation), don't show it by decreasing the width of the tick container element.
+    if (tickContainerWidth % tickSeparation < (tickSeparation / 2)) {
+      tickContainer.style.width = tickContainerWidth - tickSeparation + 'px';
+    }
   }
 }
 

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -53,6 +53,8 @@ export class MdSlider implements AfterContentInit {
   /** The values at which the thumb will snap. */
   @Input() step: number = 1;
 
+  @Input('tick-interval') _tickInterval: 'auto' | number = 1;
+
   /**
    * Whether or not the thumb is sliding.
    * Used to determine if there should be a transition for the thumb and fill track.

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -243,30 +243,23 @@ export class MdSlider implements AfterContentInit {
   }
 
   /**
-   * Calculates the separation in pixels of tick marks by starting with the assumption every step
-   * needs a tick and eliminating the number of ticks until there is a distance of at least 30px
-   * between each tick.
+   * Calculates the optimal separation in pixels of tick marks based on the minimum auto tick
+   * separation constant.
    */
   private _updateAutoTickSeparation() {
-    // The pixel value for how far apart the ticks should be.
-    let tickSeparation = 0;
-    // Keeps track of how many steps to multiply the slider's step by.
-    let stepCounter = 1;
+    let width = this._sliderDimensions.width;
 
-    while (tickSeparation < MIN_AUTO_TICK_SEPARATION) {
-      // Multiplying the counter and step together determines which step we want to use. This starts
-      // at the first step and moves to second, then third, etc. until we find a good distance.
-      let tickValue = (this.step * stepCounter) + this.min;
+    // This calculates which step is far enough away from the beginning of the slider to draw a tick
+    // at. This value will then be used to draw ticks at every tickStep steps.
+    let tickStep =
+        Math.ceil(MIN_AUTO_TICK_SEPARATION * (this.max - this.min) / (width * this.step));
 
-      // The percentage of the step on the slider is needed in order to calculate the pixel offset
-      // from the beginning of the slider. This offset is the tick separation.
-      let tickPercentage = this.calculatePercentage(tickValue);
-      tickSeparation = this._sliderDimensions.width * tickPercentage;
-      stepCounter++;
-    }
+    // The percentage of the slider where the first tick should go.
+    let tickPercentage = this.calculatePercentage((this.step * tickStep) + this.min);
 
-    // Once a suitable separation for the ticks is found, draw them on the slider.
-    this._renderer.drawTicks(tickSeparation);
+    // The pixel value of the tick is the percentage * the width of the slider. Use this to draw
+    // the ticks on the slider.
+    this._renderer.drawTicks(width * tickPercentage);
   }
 
   /**

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -12,6 +12,12 @@ import {BooleanFieldValue} from '@angular2-material/core/annotations/field-value
 import {applyCssTransform} from '@angular2-material/core/style/apply-transform';
 import {MdGestureConfig} from '@angular2-material/core/core';
 
+/**
+ * Visually, a 30px separation between tick marks looks best. This is very subjective but it is
+ * the default separation we chose.
+ */
+const MIN_AUTO_TICK_SEPARATION = 30;
+
 @Component({
   moduleId: module.id,
   selector: 'md-slider',
@@ -262,9 +268,7 @@ export class MdSlider implements AfterContentInit {
     // Keeps track of how many steps to multiply the slider's step by.
     let stepCounter = 1;
 
-    // Visually, a 30px separation between tick marks looks best. This is very subjective but it is
-    // the default separation we chose.
-    while (tickSeparation < 30) {
+    while (tickSeparation < MIN_AUTO_TICK_SEPARATION) {
       // Multiplying the counter and step together determines which step we want to use. This starts
       // at the first step and moves to second, then third, etc. until we find a good distance.
       let tickValue = (this.step * stepCounter) + this.min;
@@ -374,8 +378,6 @@ export class SliderRenderer {
     let tickContainerWidth = tickContainer.getBoundingClientRect().width;
     let lastTickContainer =
         <HTMLElement>this._sliderElement.querySelector('.md-slider-last-tick-container');
-    // A linear gradient background is used to draw the ticks as it performs better than using
-    // canvas or creating many small divs.
     // Subtract 1 from the tick separation to center the tick.
     // TODO: Perf test this.
     tickContainer.style.background = `repeating-linear-gradient(to right, #000000, #000000 2px,

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -363,11 +363,11 @@ export class SliderRenderer {
         <HTMLElement>this._sliderElement.querySelector('.md-slider-last-tick-container');
     // Subtract 1 from the tick separation to center the tick.
     // TODO: Evaluate the rendering performance of using repeating background gradients.
-    tickContainer.style.background = `repeating-linear-gradient(to right, #000000, #000000 2px,
-    transparent 2px, transparent ${tickSeparation - 1}px)`;
+    tickContainer.style.background = `repeating-linear-gradient(to right, black, black 2px, ` +
+        `transparent 2px, transparent ${tickSeparation - 1}px)`;
     // Add a tick to the very end by starting on the right side and adding a 2px black line.
-    lastTickContainer.style.background = `linear-gradient(to left, #000000, #000000 2px,
-    transparent 2px, transparent)`;
+    lastTickContainer.style.background = `linear-gradient(to left, black, black 2px, transparent ` +
+        `2px, transparent)`;
 
     // If the second to last tick is too close (a separation of less than half the normal
     // separation), don't show it by decreasing the width of the tick container element.

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -134,7 +134,7 @@ export class MdSlider implements AfterContentInit {
   ngAfterContentInit() {
     this._sliderDimensions = this._renderer.getSliderDimensions();
     this.snapToValue();
-    this._calculateTickSeparation();
+    this._updateTickSeparation();
   }
 
   /** TODO: internal */
@@ -231,15 +231,14 @@ export class MdSlider implements AfterContentInit {
   }
 
   /**
-   * Calls the appropriate method for calculating the tick separation depending on what the tick
-   * interval is. If there is no tick interval or the interval is set to something other than a
-   * number or 'auto', nothing happens.
+   * Calculates the separation in pixels of tick marks. If there is no tick interval or the interval
+   * is set to something other than a number or 'auto', nothing happens.
    */
-  private _calculateTickSeparation() {
+  private _updateTickSeparation() {
     if (this._tickInterval == 'auto') {
-      this._calculateAutoTickSeparation();
+      this._updateAutoTickSeparation();
     } else if (Number(this._tickInterval)) {
-      this._calculateTickSeparationFromInterval();
+      this._updateTickSeparationFromInterval();
     }
   }
 
@@ -248,7 +247,7 @@ export class MdSlider implements AfterContentInit {
    * needs a tick and eliminating the number of ticks until there is a distance of at least 30px
    * between each tick.
    */
-  private _calculateAutoTickSeparation() {
+  private _updateAutoTickSeparation() {
     // The pixel value for how far apart the ticks should be.
     let tickSeparation = 0;
     // Keeps track of how many steps to multiply the slider's step by.
@@ -273,7 +272,7 @@ export class MdSlider implements AfterContentInit {
   /**
    * Calculates the separation of tick marks by finding the pixel value of the tickInterval.
    */
-  private _calculateTickSeparationFromInterval() {
+  private _updateTickSeparationFromInterval() {
     // Force tickInterval to be a number so it can be used in calculations.
     let interval: number = <number> this._tickInterval;
     // Calculate the first value a tick will be located at by getting the step at which the interval
@@ -288,8 +287,6 @@ export class MdSlider implements AfterContentInit {
 
   /**
    * Calculates the percentage of the slider that a value is.
-   * @param value The value a percentage is needed for.
-   * @returns {number} The percentage.
    */
   calculatePercentage(value: number) {
     return (value - this.min) / (this.max - this.min);
@@ -297,8 +294,6 @@ export class MdSlider implements AfterContentInit {
 
   /**
    * Calculates the value a percentage of the slider corresponds to.
-   * @param percentage The percentage a value is needed for.
-   * @returns {number} The corresponding value.
    */
   calculateValue(percentage: number) {
     return this.min + (percentage * (this.max - this.min));
@@ -357,15 +352,17 @@ export class SliderRenderer {
 
   /**
    * Draws ticks onto the tick container.
-   * @param tickSeparation How far apart to draw the ticks.
    */
   drawTicks(tickSeparation: number) {
     let tickContainer = <HTMLElement>this._sliderElement.querySelector('.md-slider-tick-container');
     let tickContainerWidth = tickContainer.getBoundingClientRect().width;
+    // An extra element for the last tick is needed because the linear gradient cannot be told to
+    // always draw a tick at the end of the gradient. To get around this, there is a second
+    // container for ticks that has a single tick mark on the very right edge.
     let lastTickContainer =
         <HTMLElement>this._sliderElement.querySelector('.md-slider-last-tick-container');
     // Subtract 1 from the tick separation to center the tick.
-    // TODO: Perf test this.
+    // TODO: Evaluate the rendering performance of using repeating background gradients.
     tickContainer.style.background = `repeating-linear-gradient(to right, #000000, #000000 2px,
     transparent 2px, transparent ${tickSeparation - 1}px)`;
     // Add a tick to the very end by starting on the right side and adding a 2px black line.

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -63,7 +63,7 @@ export class MdSlider implements AfterContentInit {
    * How often to show ticks. Relative to the step so that a tick always appears on a step.
    * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
    */
-  private _tickInterval: 'auto' | number;
+  @Input('tick-interval') private _tickInterval: 'auto' | number;
 
   /**
    * Whether or not the thumb is sliding.
@@ -109,19 +109,6 @@ export class MdSlider implements AfterContentInit {
 
   set max(v: number) {
     this._max = Number(v);
-  }
-
-  @Input('tick-interval')
-  get tickInterval() {
-    return this._tickInterval;
-  }
-
-  set tickInterval(v: 'auto' | number) {
-    if (v == 'auto') {
-      this._tickInterval = v;
-    } else {
-      this._tickInterval = Number(v);
-    }
   }
 
   @Input()
@@ -249,9 +236,9 @@ export class MdSlider implements AfterContentInit {
    * number or 'auto', nothing happens.
    */
   private _calculateTickSeparation() {
-    if (this.tickInterval == 'auto') {
+    if (this._tickInterval == 'auto') {
       this._calculateAutoTickSeparation();
-    } else if (typeof this.tickInterval == 'number') {
+    } else if (Number(this._tickInterval)) {
       this._calculateTickSeparationFromInterval();
     }
   }
@@ -288,7 +275,7 @@ export class MdSlider implements AfterContentInit {
    */
   private _calculateTickSeparationFromInterval() {
     // Force tickInterval to be a number so it can be used in calculations.
-    let interval: number = <number> this.tickInterval;
+    let interval: number = <number> this._tickInterval;
     // Calculate the first value a tick will be located at by getting the step at which the interval
     // lands and adding that to the min.
     let tickValue = (this.step * interval) + this.min;

--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -28,4 +28,5 @@
 </section>
 
 <h1>Slider with set tick interval</h1>
-<md-slider tick-interval="4"></md-slider>
+<md-slider tick-interval="auto"></md-slider>
+<md-slider tick-interval="10"></md-slider>

--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -29,4 +29,4 @@
 
 <h1>Slider with set tick interval</h1>
 <md-slider tick-interval="auto"></md-slider>
-<md-slider tick-interval="10"></md-slider>
+<md-slider tick-interval="9"></md-slider>

--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -26,3 +26,6 @@
   <md-slider min="1" max="100" step="20" #slider5></md-slider>
   {{slider5.value}}
 </section>
+
+<h1>Slider with set tick interval</h1>
+<md-slider tick-interval="4"></md-slider>


### PR DESCRIPTION
Add tick interval to slider. A tick interval of `auto` will find a tick separation of at least 30px, otherwise the tick separation value is calculated by the number given. 

The tick interval is based off of the step, meaning a slider with a step of 3 and a tick interval of 4 will draw ticks every 4 steps/every 12 values.

A tick is always drawn at the end of a slider, with the second to last tick being removed if it is too close to the last one.

A repeating linear background is used to draw the ticks because I believe it is more performant/easier than creating multiple divs or using a canvas. This needs to be tested still.

R: @jelbourn @kara 
CC: @hansl @robertmesserle