### PR TITLE
fix(progress-circle): animation not working

### DIFF
--- a/src/components/progress-circle/progress-circle.ts
+++ b/src/components/progress-circle/progress-circle.ts
@@ -158,9 +158,8 @@ export class MdProgressCircle implements OnDestroy {
     if (animateTo === animateFrom) {
       this.currentPath = getSvgArc(animateTo, rotation);
     } else {
-      let animation = (currentTime: number) => {
-        let elapsedTime = Math.max(
-          0, Math.min((currentTime || Date.now()) - startTime, duration));
+      let animation = () => {
+        let elapsedTime = Math.max(0, Math.min(Date.now() - startTime, duration));
 
         this.currentPath = getSvgArc(
           ease(elapsedTime, animateFrom, changeInValue, duration),


### PR DESCRIPTION
Fixes the progress circle animation not working, because the calculations weren't correct. When 14c1765af4e0859e903baf9b8388ba114f8e9535 was introduced, one of the values uses the time since epoch, whereas the other one is the time since the page was opened.

Fixes #926.