### PR TITLE
chore(changelog): properly name tags for github compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="2.0.0-alpha.7"></a>
-# [2.0.0-alpha.7 wax-umpire](https://github.com/angular/material2/compare/2.0.0-alpha.6...v2.0.0-alpha.7) (2016-08-09)
+# [2.0.0-alpha.7 wax-umpire](https://github.com/angular/material2/compare/2.0.0-alpha.6...2.0.0-alpha.7) (2016-08-09)
 
 
 ### Bug Fixes
@@ -50,7 +50,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.6"></a>
-# [2.0.0-alpha.6 carbonfiber-discotheque](https://github.com/angular/material2/compare/2.0.0-alpha.5...v2.0.0-alpha.6) (2016-06-30)
+# [2.0.0-alpha.6 carbonfiber-discotheque](https://github.com/angular/material2/compare/2.0.0-alpha.5...2.0.0-alpha.6) (2016-06-30)
 
 ### Breaking changes
 * `MdRadioDispatcher` is now `MdUniqueSelectionDispatcher` and is imported from `core`
@@ -110,7 +110,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.5"></a>
-# [2.0.0-alpha.5 granite-gouda](https://github.com/angular/material2/compare/2.0.0-alpha.4...v2.0.0-alpha.5) (2016-05-25)
+# [2.0.0-alpha.5 granite-gouda](https://github.com/angular/material2/compare/2.0.0-alpha.4...2.0.0-alpha.5) (2016-05-25)
 
 
 ### Bug Fixes
@@ -152,7 +152,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.4"></a>
-# [2.0.0-alpha.4 mahogany-tambourine](https://github.com/angular/material2/compare/2.0.0-alpha.3...v2.0.0-alpha.4) (2016-05-04)
+# [2.0.0-alpha.4 mahogany-tambourine](https://github.com/angular/material2/compare/2.0.0-alpha.3...2.0.0-alpha.4) (2016-05-04)
 
 
 ### Bug Fixes
@@ -176,7 +176,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.3"></a>
-# [2.0.0-alpha.3 cotton-candelabrum](https://github.com/angular/material2/compare/2.0.0-alpha.2...v2.0.0-alpha.3) (2016-04-21)
+# [2.0.0-alpha.3 cotton-candelabrum](https://github.com/angular/material2/compare/2.0.0-alpha.2...2.0.0-alpha.3) (2016-04-21)
 
 
 ### Bug Fixes
@@ -198,7 +198,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.2"></a>
-# [2.0.0-alpha.2 diamond-haircut](https://github.com/angular/material2/compare/2.0.0-alpha.1...v2.0.0-alpha.2) (2016-04-06)
+# [2.0.0-alpha.2 diamond-haircut](https://github.com/angular/material2/compare/2.0.0-alpha.1...2.0.0-alpha.2) (2016-04-06)
 
 
 ### Bug Fixes
@@ -231,7 +231,7 @@ The MD_XXX_DIRECTIVES constants are now deprecated and will be removed in alpha.
 
 
 <a name="2.0.0-alpha.1"></a>
-# [2.0.0-alpha.1 nylon-hyperdrive](https://github.com/angular/material2/compare/2.0.0-alpha.0...v2.0.0-alpha.1) (2016-03-16)
+# [2.0.0-alpha.1 nylon-hyperdrive](https://github.com/angular/material2/compare/2.0.0-alpha.0...2.0.0-alpha.1) (2016-03-16)
 
 
 ### Features

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -19,8 +19,13 @@ const npmVersion = require('../../package.json').version;
 const isForce = process.argv.indexOf('--force') !== -1;
 const inStream = fs.createReadStream('CHANGELOG.md');
 const gitTags = getAvailableTags();
-const currentTag = npmVersion === gitTags[1] ? gitTags[0] : npmVersion;
-const previousTag = npmVersion === gitTags[0] ? gitTags[1] : gitTags[0];
+
+// Whether the npm version is later than the most recent tag.
+const isNpmLatest = npmVersion !== gitTags[0];
+// When the npm version is the latest, use the npm version, otherwise use the latest tag.
+const currentTag = isNpmLatest ? npmVersion : gitTags[0];
+// When the npm version is the latest use the most recent tag. Otherwise use the previous tag.
+const previousTag = isNpmLatest ? gitTags[0] : gitTags[1];
 
 inStream.on('error', function(err) {
   console.error('An error occurred, while reading the previous changelog file.\n' +

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -18,7 +18,7 @@ const npmVersion = require('../../package.json').version;
  */
 const isForce = process.argv.indexOf('--force') !== -1;
 const inStream = fs.createReadStream('CHANGELOG.md');
-const gitTags = getTags();
+const gitTags = getAvailableTags();
 const currentTag = npmVersion === gitTags[1] ? gitTags[0] : npmVersion;
 const previousTag = npmVersion === gitTags[0] ? gitTags[1] : gitTags[0];
 
@@ -61,6 +61,6 @@ function getOutputStream() {
  * Resolves available tags over all branches from the repository metadata.
  * @returns {Array.<String>} Array of available tags.
  */
-function getTags() {
+function getAvailableTags() {
   return spawnSync('git', ['tag']).stdout.toString().trim().split('\n').reverse();
 }


### PR DESCRIPTION
* The convention changelog currently auto-prefixes the previous semver tag with a `v`, which causes the github compare links to not work.
* Manually resolve the previous and current tag from the git metadata. (As in angular/material#9264)

> I know the way we resolve the latest / previous tags looks at first glance pretty odd.