### PR TITLE
fix(tabs): change active tab css class from md-active to md-tab-active

### DIFF
--- a/src/components/tabs/tab-group.scss
+++ b/src/components/tabs/tab-group.scss
@@ -60,7 +60,7 @@ $md-tab-bar-height: 48px !default;
   box-sizing: border-box;
   flex-grow: 1;
   flex-shrink: 1;
-  &.md-active {
+  &.md-tab-active {
     display: block;
   }
 }


### PR DESCRIPTION
Reference to the active tab was changed from md-active to
md-tab-active but the css class that set the body of the tab
back to block display was missed during this renaming effort.
This resulted in the body of a tab to always be empty. This
commit changes the css class from md-active to md-tab-active.