### PR TITLE
fix(sideNav): change md-sidenav-layout to md-sidenav-container

### DIFF
--- a/src/components/sidenav/README.md
+++ b/src/components/sidenav/README.md
@@ -1,13 +1,13 @@
 # MdSidenav
 
-MdSidenav is the side navigation component for Material 2. It is composed of two components; `<md-sidenav-layout>` and `<md-sidenav>`.
+MdSidenav is the side navigation component for Material 2. It is composed of two components; `<md-sidenav-container>` and `<md-sidenav>`.
 
 ## Screenshots
 
 <img src="https://material.angularjs.org/material2_assets/sidenav-example.png">
 
 
-## `<md-sidenav-layout>`
+## `<md-sidenav-container>`
 
 The parent component. Contains the code necessary to coordinate one or two sidenav and the backdrop.
 
@@ -27,7 +27,7 @@ The sidenav panel.
 | Name | Type | Description |
 | --- | --- | --- |
 | `align` | `"start"|"end"` | The alignment of this sidenav. In LTR direction, `"start"` will be shown on the left, `"end"` on the right. In RTL, it is reversed. `"start"` is used by default. An exception will be thrown if there are more than 1 sidenav on either side. |
-| `mode` | `"over"|"push"|"side"` | The mode or styling of the sidenav, default being `"over"`. With `"over"` the sidenav will appear above the content, and a backdrop will be shown. With `"push"` the sidenav will push the content of the `<md-sidenav-layout>` to the side, and show a backdrop over it. `"side"` will resize the content and keep the sidenav opened. Clicking the backdrop will close sidenavs that do not have `mode="side"`. |
+| `mode` | `"over"|"push"|"side"` | The mode or styling of the sidenav, default being `"over"`. With `"over"` the sidenav will appear above the content, and a backdrop will be shown. With `"push"` the sidenav will push the content of the `<md-sidenav-container>` to the side, and show a backdrop over it. `"side"` will resize the content and keep the sidenav opened. Clicking the backdrop will close sidenavs that do not have `mode="side"`. |
 | `opened` | `boolean` | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. |
 
 ### Events
@@ -65,7 +65,7 @@ Here's a simple example of using the sidenav:
 
 ```html
 <app>
-  <md-sidenav-layout>
+  <md-sidenav-container>
     <md-sidenav #start (open)="mybutton.focus()">
       Start Sidenav.
       <br>
@@ -77,7 +77,7 @@ Here's a simple example of using the sidenav:
     </md-sidenav>
 
     My regular content. This will be moved into the proper DOM at runtime.
-  </md-sidenav-layout>
+  </md-sidenav-container>
 </app>
 ```
 

--- a/src/components/sidenav/sidenav.spec.ts
+++ b/src/components/sidenav/sidenav.spec.ts
@@ -231,23 +231,23 @@ describe('MdSidenav', () => {
 
 
 /** Test component that contains an MdSidenavLayout but no MdSidenav. */
-@Component({template: `<md-sidenav-layout></md-sidenav-layout>`})
+@Component({template: `<md-sidenav-container></md-sidenav-container>`})
 class SidenavLayoutNoSidenavTestApp { }
 
 /** Test component that contains an MdSidenavLayout and 2 MdSidenav on the same side. */
 @Component({
   template: `
-    <md-sidenav-layout>
+    <md-sidenav-container>
       <md-sidenav> </md-sidenav>
       <md-sidenav> </md-sidenav>
-    </md-sidenav-layout>`,
+    </md-sidenav-container>`,
 })
 class SidenavLayoutTwoSidenavTestApp { }
 
 /** Test component that contains an MdSidenavLayout and one MdSidenav. */
 @Component({
   template: `
-    <md-sidenav-layout>
+    <md-sidenav-container>
       <md-sidenav #sidenav align="start"
                   (open-start)="openStart()"
                   (open)="open()"
@@ -257,7 +257,7 @@ class SidenavLayoutTwoSidenavTestApp { }
       </md-sidenav>
       <button (click)="sidenav.open()" class="open"></button>
       <button (click)="sidenav.close()" class="close"></button>
-    </md-sidenav-layout>`,
+    </md-sidenav-container>`,
 })
 class BasicTestApp {
   openStartCount: number = 0;
@@ -284,20 +284,20 @@ class BasicTestApp {
 
 @Component({
   template: `
-    <md-sidenav-layout>
+    <md-sidenav-container>
       <md-sidenav #sidenav mode="side" opened="false">
         Closed Sidenav.
       </md-sidenav>
-    </md-sidenav-layout>`,
+    </md-sidenav-container>`,
 })
 class SidenavSetToOpenedFalse { }
 
 @Component({
   template: `
-    <md-sidenav-layout>
+    <md-sidenav-container>
       <md-sidenav #sidenav mode="side" opened="true">
         Closed Sidenav.
       </md-sidenav>
-    </md-sidenav-layout>`,
+    </md-sidenav-container>`,
 })
 class SidenavSetToOpenedTrue { }

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -216,14 +216,14 @@ export class MdSidenav {
 }
 
 /**
- * <md-sidenav-layout> component.
+ * <md-sidenav-container> component.
  *
  * This is the parent component to one or two <md-sidenav>s that validates the state internally
  * and coordinate the backdrop and content styling.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-sidenav-layout',
+  selector: 'md-sidenav-container',
   // Do not use ChangeDetectionStrategy.OnPush. It does not work for this component because
   // technically it is a sibling of MdSidenav (on the content tree) and isn't updated when MdSidenav
   // changes its state.
@@ -280,7 +280,7 @@ export class MdSidenavLayout implements AfterContentInit {
     sidenav.onClose.subscribe(() => this._setLayoutClass(sidenav, false));
   }
 
-  /* Toggles the 'md-sidenav-opened' class on the main 'md-sidenav-layout' element. */
+  /* Toggles the 'md-sidenav-opened' class on the main 'md-sidenav-container' element. */
   private _setLayoutClass(sidenav: MdSidenav, bool: boolean): void {
     this._renderer.setElementClass(this._element.nativeElement, 'md-sidenav-opened', bool);
   }

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -1,4 +1,4 @@
-<md-sidenav-layout class="demo-root" fullscreen>
+<md-sidenav-container class="demo-root" fullscreen>
   <md-sidenav #start>
     <md-nav-list>
       <a md-list-item [routerLink]="['button']">Button</a>
@@ -47,4 +47,4 @@
       <router-outlet></router-outlet>
     </div>
   </div>
-</md-sidenav-layout>
+</md-sidenav-container>

--- a/src/demo-app/sidenav/sidenav-demo.html
+++ b/src/demo-app/sidenav/sidenav-demo.html
@@ -1,4 +1,4 @@
-<md-sidenav-layout class="demo-sidenav-layout">
+<md-sidenav-container class="demo-sidenav-layout">
   <md-sidenav #start (open)="myinput.focus()" mode="side">
     Start Side Drawer
     <br>
@@ -32,6 +32,6 @@
     <button md-raised-button class="md-primary">HELLO</button>
     <button md-fab class="md-accent">HI</button>
   </div>
-</md-sidenav-layout>
+</md-sidenav-container>
 
 <h2>Content after Sidenav</h2>


### PR DESCRIPTION
- Previous container's name (md-sidenav-layout) conflicted with names for Material Layout API and features.
- Change demo-app accordingly.
  Fixes #1055
