### PR TITLE
fix checkbox: add fixed width to checkbox

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -240,6 +240,7 @@ md-checkbox {
   vertical-align: middle;
   white-space: nowrap;
   width: $md-checkbox-size;
+  flex: 0 0 $md-checkbox-size;
 
   [dir='rtl'] & {
     margin: {


### PR DESCRIPTION
add fixed width to the checkbox so they do not squish if the parent
wrapper has a fixed width and the label text is too long.

closes #1097
