### PR TITLE
feat: add `forRoot` to modules

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -39,8 +39,8 @@ import {TabsDemo} from './tabs/tab-group-demo';
     BrowserModule,
     FormsModule,
     HttpModule,
-    MaterialModule,
-    RouterModule.forRoot(DEMO_APP_ROUTES)
+    RouterModule.forRoot(DEMO_APP_ROUTES),
+    MaterialModule.forRoot(),
   ],
   declarations: [
     BaselineDemo,

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,13 +1,11 @@
 import {Component, ViewContainerRef} from '@angular/core';
 import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular2-material/dialog/dialog';
-import {OVERLAY_PROVIDERS} from '@angular2-material/core/overlay/overlay';
 
 @Component({
   moduleId: module.id,
   selector: 'dialog-demo',
   templateUrl: 'dialog-demo.html',
   styleUrls: ['dialog-demo.css'],
-  providers: [MdDialog, OVERLAY_PROVIDERS]
 })
 export class DialogDemo {
   dialogRef: MdDialogRef<JazzDialog>;

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -10,7 +10,6 @@ import {
     Overlay,
     OverlayState,
     OverlayOrigin,
-    OVERLAY_PROVIDERS,
     ComponentPortal,
     Portal,
     TemplatePortalDirective,
@@ -22,7 +21,6 @@ import {
   selector: 'overlay-demo',
   templateUrl: 'overlay-demo.html',
   styleUrls: ['overlay-demo.css'],
-  providers: [OVERLAY_PROVIDERS],
   encapsulation: ViewEncapsulation.None,
 })
 export class OverlayDemo {

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -13,8 +13,8 @@ import {E2E_APP_ROUTES} from './e2e-app/routes';
 @NgModule({
   imports: [
     BrowserModule,
-    MaterialModule,
     RouterModule.forRoot(E2E_APP_ROUTES),
+    MaterialModule.forRoot(),
   ],
   declarations: [
     E2EApp,

--- a/src/lib/all/all.ts
+++ b/src/lib/all/all.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {MdButtonToggleModule} from '@angular2-material/button-toggle/button-toggle';
 import {MdButtonModule} from '@angular2-material/button/button';
 import {MdCheckboxModule} from '@angular2-material/checkbox/checkbox';
@@ -52,8 +52,45 @@ const MATERIAL_MODULES = [
 ];
 
 @NgModule({
-  imports: MATERIAL_MODULES,
+  imports: [
+    MdButtonModule,
+    MdCardModule,
+    MdCheckboxModule,
+    MdGridListModule,
+    MdInputModule,
+    MdListModule,
+    MdProgressBarModule,
+    MdProgressCircleModule,
+    MdRippleModule,
+    MdSidenavModule,
+    MdSliderModule,
+    MdSlideToggleModule,
+    MdTabsModule,
+    MdToolbarModule,
+    PortalModule,
+    RtlModule,
+
+    // These modules include providers.
+    MdButtonToggleModule.forRoot(),
+    MdDialogModule.forRoot(),
+    MdIconModule.forRoot(),
+    MdMenuModule.forRoot(),
+    MdRadioModule.forRoot(),
+    MdTooltipModule.forRoot(),
+    OverlayModule.forRoot(),
+  ],
   exports: MATERIAL_MODULES,
   providers: [MdLiveAnnouncer]
 })
-export class MaterialModule { }
+export class MaterialRootModule { }
+
+
+@NgModule({
+  imports: MATERIAL_MODULES,
+  exports: MATERIAL_MODULES,
+})
+export class MaterialModule {
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: MaterialRootModule};
+  }
+}

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -20,7 +20,7 @@ describe('MdButtonToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdButtonToggleModule, FormsModule],
+      imports: [MdButtonToggleModule.forRoot(), FormsModule],
       declarations: [
         ButtonTogglesInsideButtonToggleGroup,
         ButtonToggleGroupWithNgModel,

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -1,5 +1,6 @@
 import {
     NgModule,
+    ModuleWithProviders,
     Component,
     ContentChildren,
     Directive,
@@ -385,18 +386,17 @@ export class MdButtonToggle implements OnInit {
   }
 }
 
-/** @deprecated */
-export const MD_BUTTON_TOGGLE_DIRECTIVES = [
-  MdButtonToggleGroup,
-  MdButtonToggleGroupMultiple,
-  MdButtonToggle
-];
-
 
 @NgModule({
   imports: [FormsModule],
-  exports: MD_BUTTON_TOGGLE_DIRECTIVES,
-  declarations: MD_BUTTON_TOGGLE_DIRECTIVES,
-  providers: [MdUniqueSelectionDispatcher],
+  exports: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
+  declarations: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
 })
-export class MdButtonToggleModule { }
+export class MdButtonToggleModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdButtonToggleModule,
+      providers: [MdUniqueSelectionDispatcher]
+    };
+  }
+}

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -156,13 +156,9 @@ export class MdAnchor extends MdButton {
 }
 
 
-/** @deprecated */
-export const MD_BUTTON_DIRECTIVES: any[] = [MdButton, MdAnchor];
-
-
 @NgModule({
   imports: [CommonModule, MdRippleModule],
-  exports: MD_BUTTON_DIRECTIVES,
-  declarations: MD_BUTTON_DIRECTIVES,
+  exports: [MdButton, MdAnchor],
+  declarations: [MdButton, MdAnchor],
 })
 export class MdButtonModule { }

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -74,12 +74,9 @@ TODO(kara): update link to demo site when it exists
 })
 export class MdCardTitleGroup {}
 
-/** @deprecated */
-export const MD_CARD_DIRECTIVES: any[] = [MdCard, MdCardHeader, MdCardTitleGroup];
-
 
 @NgModule({
-  exports: MD_CARD_DIRECTIVES,
-  declarations: MD_CARD_DIRECTIVES,
+  exports: [MdCard, MdCardHeader, MdCardTitleGroup],
+  declarations: [MdCard, MdCardHeader, MdCardTitleGroup],
 })
 export class MdCardModule { }

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -304,12 +304,9 @@ export class MdCheckbox implements ControlValueAccessor {
   }
 }
 
-/** @deprecated */
-export const MD_CHECKBOX_DIRECTIVES = [MdCheckbox];
-
 
 @NgModule({
-  exports: MD_CHECKBOX_DIRECTIVES,
-  declarations: MD_CHECKBOX_DIRECTIVES,
+  exports: [MdCheckbox],
+  declarations: [MdCheckbox],
 })
 export class MdCheckboxModule { }

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {MdLineModule} from './line/line';
 import {RtlModule} from './rtl/dir';
 import {MdRippleModule} from './ripple/ripple';
@@ -20,7 +20,6 @@ export {
 export {
   PortalHostDirective,
   TemplatePortalDirective,
-  PORTAL_DIRECTIVES,
   PortalModule,
 } from './portal/portal-directives';
 export {DomPortalHost} from './portal/dom-portal-host';
@@ -33,7 +32,6 @@ export {OverlayState} from './overlay/overlay-state';
 export {
   ConnectedOverlayDirective,
   OverlayOrigin,
-  OVERLAY_DIRECTIVES,
   OverlayModule,
 } from './overlay/overlay-directives';
 export {
@@ -45,7 +43,7 @@ export {
 export {MdGestureConfig} from './gestures/MdGestureConfig';
 
 // Ripple
-export {MD_RIPPLE_DIRECTIVES, MdRipple, MdRippleModule} from './ripple/ripple';
+export {MdRipple, MdRippleModule} from './ripple/ripple';
 
 // a11y
 export {
@@ -62,17 +60,15 @@ export {
 export {MdLineModule, MdLine, MdLineSetter} from './line/line';
 
 
-const coreModules = [
-  MdLineModule,
-  RtlModule,
-  MdRippleModule,
-  PortalModule,
-  OverlayModule,
-];
-
 @NgModule({
-  imports: coreModules,
-  exports: coreModules,
-  providers: [MdLiveAnnouncer],
+  imports: [MdLineModule, RtlModule, MdRippleModule, PortalModule, OverlayModule],
+  exports: [MdLineModule, RtlModule, MdRippleModule, PortalModule, OverlayModule],
 })
-export class MdCoreModule { }
+export class MdCoreModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdCoreModule,
+      providers: [MdLiveAnnouncer]
+    };
+  }
+}

--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -11,7 +11,7 @@ describe('Overlay directives', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule],
+      imports: [OverlayModule.forRoot()],
       declarations: [ConnectedOverlayDirectiveTest],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -1,5 +1,6 @@
 import {
     NgModule,
+    ModuleWithProviders,
     Directive,
     TemplateRef,
     ViewContainerRef,
@@ -14,6 +15,7 @@ import {TemplatePortal} from '../portal/portal';
 import {OverlayState} from './overlay-state';
 import {ConnectionPositionPair} from './position/connected-position';
 import {PortalModule} from '../portal/portal-directives';
+
 
 /** Default set of positions for the overlay. Follows the behavior of a dropdown. */
 let defaultPositionList = [
@@ -104,13 +106,16 @@ export class ConnectedOverlayDirective implements OnInit, OnDestroy {
 }
 
 
-export const OVERLAY_DIRECTIVES = [ConnectedOverlayDirective, OverlayOrigin];
-
-
 @NgModule({
   imports: [PortalModule],
-  exports: OVERLAY_DIRECTIVES,
-  declarations: OVERLAY_DIRECTIVES,
-  providers: OVERLAY_PROVIDERS,
+  exports: [ConnectedOverlayDirective, OverlayOrigin],
+  declarations: [ConnectedOverlayDirective, OverlayOrigin],
 })
-export class OverlayModule { }
+export class OverlayModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: OverlayModule,
+      providers: OVERLAY_PROVIDERS,
+    };
+  }
+}

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -17,7 +17,7 @@ describe('Overlay', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, PortalModule, OverlayTestModule],
+      imports: [OverlayModule.forRoot(), PortalModule, OverlayTestModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -82,7 +82,6 @@ export class Overlay {
   }
 }
 
-
 /** Providers for Overlay and its related injectables. */
 export const OVERLAY_PROVIDERS = [
   ViewportRuler,
@@ -90,4 +89,3 @@ export const OVERLAY_PROVIDERS = [
   Overlay,
   OverlayContainer,
 ];
-

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -102,11 +102,9 @@ export class PortalHostDirective extends BasePortalHost {
   }
 }
 
-export const PORTAL_DIRECTIVES = [TemplatePortalDirective, PortalHostDirective];
-
 
 @NgModule({
-  exports: PORTAL_DIRECTIVES,
-  declarations: PORTAL_DIRECTIVES,
+  exports: [TemplatePortalDirective, PortalHostDirective],
+  declarations: [TemplatePortalDirective, PortalHostDirective],
 })
 export class PortalModule { }

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -168,12 +168,9 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
   // TODO: Reactivate the background div if the user drags out and back in.
 }
 
-/** @deprecated */
-export const MD_RIPPLE_DIRECTIVES = [MdRipple];
-
 
 @NgModule({
-  exports: MD_RIPPLE_DIRECTIVES,
-  declarations: MD_RIPPLE_DIRECTIVES,
+  exports: [MdRipple],
+  declarations: [MdRipple],
 })
 export class MdRippleModule { }

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -15,7 +15,7 @@ describe('MdDialog', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdDialogModule, DialogTestModule],
+      imports: [MdDialogModule.forRoot(), DialogTestModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -1,4 +1,4 @@
-import {NgModule, Injector, ComponentRef, Injectable} from '@angular/core';
+import {NgModule, ModuleWithProviders, Injector, ComponentRef, Injectable} from '@angular/core';
 import {
   Overlay,
   OverlayModule,
@@ -6,6 +6,7 @@ import {
   OverlayRef,
   OverlayState,
   ComponentPortal,
+  OVERLAY_PROVIDERS,
 } from '@angular2-material/core/core';
 import {ComponentType} from '@angular2-material/core/overlay/generic-component-type';
 import {MdDialogConfig} from './dialog-config';
@@ -122,6 +123,12 @@ export class MdDialog {
   exports: [MdDialogContainer],
   declarations: [MdDialogContainer],
   entryComponents: [MdDialogContainer],
-  providers: [MdDialog],
 })
-export class MdDialogModule { }
+export class MdDialogModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdDialogModule,
+      providers: [MdDialog, OVERLAY_PROVIDERS],
+    };
+  }
+}

--- a/src/lib/grid-list/README.md
+++ b/src/lib/grid-list/README.md
@@ -7,14 +7,17 @@ See Material Design spec [here](https://www.google.com/design/spec/components/gr
 
 ### Simple grid list
 
-To use `md-grid-list`, first import the grid list directives and add them to your component's directives 
-array:
+To use `md-grid-list`, import the MdGridList module into your application's NgModule:
 
-```javascript
-@Component({
+*my-app-module.ts*
+```ts
+import {MdGridListModule} from '@angular2-material/gridlist/gridlist';
+
+@NgModule({
+  imports: [MdGridListModule],
   ...
-  directives: [MD_GRID_LIST_DIRECTIVES]
 })
+export class MyAppModule {}
 ```
 
 In your template, create an `md-grid-list` element and specify the number of columns you want for

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -152,13 +152,9 @@ export class MdGridList implements OnInit, AfterContentChecked {
 }
 
 
-/** @deprecated */
-export const MD_GRID_LIST_DIRECTIVES: any[] = [MdGridList, MdGridTile, MdGridTileText];
-
-
 @NgModule({
   imports: [MdLineModule],
-  exports: [MD_GRID_LIST_DIRECTIVES, MdLineModule],
-  declarations: MD_GRID_LIST_DIRECTIVES,
+  exports: [MdGridList, MdGridTile, MdGridTileText, MdLineModule],
+  declarations: [MdGridList, MdGridTile, MdGridTileText],
 })
 export class MdGridListModule { }

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -39,7 +39,7 @@ describe('MdIcon', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdIconModule],
+      imports: [MdIconModule.forRoot()],
       declarations: [
         MdIconLigatureTestApp,
         MdIconLigatureWithAriaBindingTestApp,

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -1,5 +1,6 @@
 import {
     NgModule,
+    ModuleWithProviders,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -225,14 +226,17 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
   }
 }
 
-/** @deprecated */
-export const MD_ICON_DIRECTIVES = [MdIcon];
-
 
 @NgModule({
   imports: [HttpModule],
-  exports: MD_ICON_DIRECTIVES,
-  declarations: MD_ICON_DIRECTIVES,
-  providers: [MdIconRegistry],
+  exports: [MdIcon],
+  declarations: [MdIcon],
 })
-export class MdIconModule { }
+export class MdIconModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdIconModule,
+      providers: [MdIconRegistry],
+    };
+  }
+}

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -307,13 +307,10 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   }
 }
 
-/** @deprecated */
-export const MD_INPUT_DIRECTIVES = [MdPlaceholder, MdInput, MdHint];
-
 
 @NgModule({
-  declarations: MD_INPUT_DIRECTIVES,
+  declarations: [MdPlaceholder, MdInput, MdHint],
   imports: [CommonModule, FormsModule],
-  exports: MD_INPUT_DIRECTIVES,
+  exports: [MdPlaceholder, MdInput, MdHint],
 })
 export class MdInputModule { }

--- a/src/lib/list/README.md
+++ b/src/lib/list/README.md
@@ -7,13 +7,17 @@
 
 ### Simple list
 
-To use `md-list`, first import the list directives and add them to your component's directives array:
+To use `md-list`, import the MdList module into your application's NgModule:
 
-```javascript
-@Component({
+*my-app-module.ts*
+```ts
+import {MdLisTModule} from '@angular2-material/list/list';
+
+@NgModule({
+  imports: [MdListModule],
   ...
-  directives: [MD_LIST_DIRECTIVES]
 })
+export class MyAppModule {}
 ```
 
 In your template, create an `md-list` element and wrap each of your items in an `md-list-item` tag.

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -65,13 +65,10 @@ export class MdListItem implements AfterContentInit {
   }
 }
 
-/** @deprecated */
-export const MD_LIST_DIRECTIVES = [MdList, MdListItem, MdListAvatar];
-
 
 @NgModule({
   imports: [MdLineModule],
-  exports: [MD_LIST_DIRECTIVES, MdLineModule],
-  declarations: MD_LIST_DIRECTIVES,
+  exports: [MdList, MdListItem, MdListAvatar, MdLineModule],
+  declarations: [MdList, MdListItem, MdListAvatar],
 })
 export class MdListModule { }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -15,7 +15,6 @@ import {
     Overlay,
     OverlayState,
     OverlayRef,
-    OVERLAY_PROVIDERS,
     TemplatePortal
 } from '@angular2-material/core/core';
 import {
@@ -33,7 +32,6 @@ import {
 @Directive({
   selector: '[md-menu-trigger-for]',
   host: {'aria-haspopup': 'true'},
-  providers: [OVERLAY_PROVIDERS],
   exportAs: 'mdMenuTrigger'
 })
 export class MdMenuTrigger implements AfterViewInit, OnDestroy {

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -7,7 +7,7 @@ describe('MdMenu', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdMenuModule],
+      imports: [MdMenuModule.forRoot()],
       declarations: [TestMenu],
     });
 

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,21 +1,24 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {OverlayModule} from '@angular2-material/core/core';
+import {OverlayModule, OVERLAY_PROVIDERS} from '@angular2-material/core/core';
 import {MdMenu} from './menu-directive';
 import {MdMenuItem, MdMenuAnchor} from './menu-item';
 import {MdMenuTrigger} from './menu-trigger';
-
 export {MdMenu} from './menu-directive';
 export {MdMenuItem, MdMenuAnchor} from './menu-item';
 export {MdMenuTrigger} from './menu-trigger';
 
-/** @deprecated */
-export const MD_MENU_DIRECTIVES = [MdMenu, MdMenuItem, MdMenuTrigger, MdMenuAnchor];
-
 
 @NgModule({
   imports: [OverlayModule, CommonModule],
-  exports: MD_MENU_DIRECTIVES,
-  declarations: MD_MENU_DIRECTIVES,
+  exports: [MdMenu, MdMenuItem, MdMenuTrigger, MdMenuAnchor],
+  declarations: [MdMenu, MdMenuItem, MdMenuTrigger, MdMenuAnchor],
 })
-export class MdMenuModule { }
+export class MdMenuModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdMenuModule,
+      providers: OVERLAY_PROVIDERS,
+    };
+  }
+}

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -86,12 +86,10 @@ function clamp(v: number, min = 0, max = 100) {
   return Math.max(min, Math.min(max, v));
 }
 
-/** @deprecated */
-export const MD_PROGRESS_BAR_DIRECTIVES = [MdProgressBar];
 
 @NgModule({
   imports: [CommonModule],
-  exports: MD_PROGRESS_BAR_DIRECTIVES,
-  declarations: MD_PROGRESS_BAR_DIRECTIVES,
+  exports: [MdProgressBar],
+  declarations: [MdProgressBar],
 })
 export class MdProgressBarModule { }

--- a/src/lib/progress-circle/progress-circle.ts
+++ b/src/lib/progress-circle/progress-circle.ts
@@ -313,12 +313,9 @@ function getSvgArc(currentValue: number, rotation: number) {
   return `M${start}A${pathRadius},${pathRadius} 0 ${largeArcFlag},${arcSweep} ${end}`;
 }
 
-/** @deprecated */
-export const MD_PROGRESS_CIRCLE_DIRECTIVES = [MdProgressCircle, MdSpinner];
-
 
 @NgModule({
-  exports: MD_PROGRESS_CIRCLE_DIRECTIVES,
-  declarations: MD_PROGRESS_CIRCLE_DIRECTIVES,
+  exports: [MdProgressCircle, MdSpinner],
+  declarations: [MdProgressCircle, MdSpinner],
 })
 export class MdProgressCircleModule { }

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -9,7 +9,7 @@ describe('MdRadio', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdRadioModule, FormsModule],
+      imports: [MdRadioModule.forRoot(), FormsModule],
       declarations: [
         RadiosInsideRadioGroup,
         RadioGroupWithNgModel,

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -13,6 +13,7 @@ import {
   ViewEncapsulation,
   forwardRef,
   NgModule,
+  ModuleWithProviders,
 } from '@angular/core';
 import {
   NG_VALUE_ACCESSOR,
@@ -420,14 +421,16 @@ export class MdRadioButton implements OnInit {
   }
 }
 
-/** @deprecated */
-export const MD_RADIO_DIRECTIVES = [MdRadioGroup, MdRadioButton];
-
 
 @NgModule({
-  exports: MD_RADIO_DIRECTIVES,
-  declarations: MD_RADIO_DIRECTIVES,
-  providers: [MdUniqueSelectionDispatcher]
+  exports: [MdRadioGroup, MdRadioButton],
+  declarations: [MdRadioGroup, MdRadioButton],
 })
 export class MdRadioModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdRadioModule,
+      providers: [MdUniqueSelectionDispatcher],
+    };
+  }
 }

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -387,13 +387,9 @@ export class MdSidenavLayout implements AfterContentInit {
 }
 
 
-/** @deprecated */
-export const MD_SIDENAV_DIRECTIVES = [MdSidenavLayout, MdSidenav];
-
-
 @NgModule({
   imports: [CommonModule],
-  exports: MD_SIDENAV_DIRECTIVES,
-  declarations: MD_SIDENAV_DIRECTIVES,
+  exports: [MdSidenavLayout, MdSidenav],
+  declarations: [MdSidenavLayout, MdSidenav],
 })
 export class MdSidenavModule { }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -9,6 +9,7 @@ import {
   EventEmitter,
   AfterContentInit,
   NgModule,
+  ModuleWithProviders,
 } from '@angular/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {
@@ -298,16 +299,17 @@ class SlideToggleRenderer {
 
 }
 
-/** @deprecated */
-export const MD_SLIDE_TOGGLE_DIRECTIVES = [MdSlideToggle];
-
 
 @NgModule({
   imports: [FormsModule],
-  exports: MD_SLIDE_TOGGLE_DIRECTIVES,
-  declarations: MD_SLIDE_TOGGLE_DIRECTIVES,
-  providers: [
-    {provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig},
-  ],
+  exports: [MdSlideToggle],
+  declarations: [MdSlideToggle],
 })
-export class MdSlideToggleModule { }
+export class MdSlideToggleModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSlideToggleModule,
+      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig}]
+    };
+  }
+}

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -1,5 +1,6 @@
 import {
   NgModule,
+  ModuleWithProviders,
   Component,
   ElementRef,
   HostBinding,
@@ -449,16 +450,20 @@ export class SliderRenderer {
   }
 }
 
-/** @deprecated */
-export const MD_SLIDER_DIRECTIVES = [MdSlider];
-
 
 @NgModule({
   imports: [FormsModule],
-  exports: MD_SLIDER_DIRECTIVES,
-  declarations: MD_SLIDER_DIRECTIVES,
+  exports: [MdSlider],
+  declarations: [MdSlider],
   providers: [
     {provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig},
   ],
 })
-export class MdSliderModule { }
+export class MdSliderModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSliderModule,
+      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig}]
+    };
+  }
+}

--- a/src/lib/tabs/tabs.ts
+++ b/src/lib/tabs/tabs.ts
@@ -232,13 +232,11 @@ export class MdTabGroup {
   }
 }
 
-/** @deprecated */
-export const MD_TABS_DIRECTIVES = [MdTabGroup, MdTabLabel, MdTabContent, MdTab];
-export const TABS_INTERNAL_DIRECTIVES = [MdInkBar, MdTabLabelWrapper];
 
 @NgModule({
   imports: [CommonModule, PortalModule],
-  exports: [MD_TABS_DIRECTIVES],
-  declarations: [MD_TABS_DIRECTIVES, TABS_INTERNAL_DIRECTIVES],
+  // Don't export MdInkBar or MdTabLabelWrapper, as they are internal implementatino details.
+  exports: [MdTabGroup, MdTabLabel, MdTabContent, MdTab],
+  declarations: [MdTabGroup, MdTabLabel, MdTabContent, MdTab, MdInkBar, MdTabLabelWrapper],
 })
 export class MdTabsModule { }

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -45,12 +45,9 @@ export class MdToolbar {
 
 }
 
-/** @deprecated */
-export const MD_TOOLBAR_DIRECTIVES = [MdToolbar];
-
 
 @NgModule({
-  exports: MD_TOOLBAR_DIRECTIVES,
-  declarations: MD_TOOLBAR_DIRECTIVES,
+  exports: [MdToolbar],
+  declarations: [MdToolbar],
 })
 export class MdToolbarModule { }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -11,7 +11,7 @@ describe('MdTooltip', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTooltipModule],
+      imports: [MdTooltipModule.forRoot()],
       declarations: [BasicTooltipDemo],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -1,5 +1,6 @@
 import {
     NgModule,
+    ModuleWithProviders,
     Component,
     Directive,
     Input,
@@ -15,6 +16,7 @@ import {
   ComponentPortal,
   OverlayConnectionPosition,
   OriginConnectionPosition,
+  OVERLAY_PROVIDERS,
 } from '@angular2-material/core/core';
 
 export type TooltipPosition = 'before' | 'after' | 'above' | 'below';
@@ -188,14 +190,18 @@ export class TooltipComponent {
   message: string;
 }
 
-/** @deprecated */
-export const MD_TOOLTIP_DIRECTIVES = [MdTooltip];
-
 
 @NgModule({
   imports: [OverlayModule],
-  exports: [MD_TOOLTIP_DIRECTIVES, TooltipComponent],
-  declarations: [MD_TOOLTIP_DIRECTIVES, TooltipComponent],
+  exports: [MdTooltip, TooltipComponent],
+  declarations: [MdTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
 })
-export class MdTooltipModule { }
+export class MdTooltipModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdTooltipModule,
+      providers: OVERLAY_PROVIDERS,
+    };
+  }
+}

--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -12,7 +12,7 @@
 
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
-    "number-zero-length-no-unit": true,
+    "length-zero-no-unit": true,
 
     "string-no-newline": true,
     "string-quotes": "single",


### PR DESCRIPTION
R: @kara @hansl 

Also remove deprecated `MD_XXX_DIRECTIVES`. 

 @robwormald or @IgorMinar can one of you take a look at this and make sure I'm doing "the right thing" WRT use of `forRoot`, especially as it pertains to the `MaterialModule`?

