### PR TITLE
chore(ci): finish different matrixes in fast finish mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     - MODE=browserstack_optional
 
 matrix:
+  fast_finish: true
   allow_failures:
   - env: "MODE=saucelabs_optional"
   - env: "MODE=browserstack_optional"


### PR DESCRIPTION
- Travis CI runs the optional tasks in "waiting" mode, which means that the whole build is only ready once the optional tasks are also ready.
- The Travis Fast Finish mode will mark the build as finished, once all "required" tasks have finished (https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)

FYI: I decided to make this now an extra PR, because #913 has still open questions, and the build right now keeps running ~6-7 minutes extra. (https://travis-ci.org/angular/material2/builds/156389515)