### PR TITLE
docs(tabs): remove invalid property in documentation

### DIFF
--- a/src/lib/tabs/README.md
+++ b/src/lib/tabs/README.md
@@ -1,6 +1,20 @@
 # MdTabGroup
 Tab groups allow the user to organize their content by labels such that only one tab is visible at any given time.
 
+## `<md-tab-group>`
+### Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `selectedIndex` | `number` | The index of the currently active tab. |
+
+### Events
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `focusChange` | `Event` | Fired when focus changes from one label to another |
+| `selectChange` | `Event` | Fired when the selected tab changes |
+
 ### Examples
 A basic tab group would have the following markup.
 ```html
@@ -22,17 +36,12 @@ A basic tab group would have the following markup.
 </md-tab-group>
 ```
 
-## `<md-tab-group>`
-### Properties
+It is also possible to specifiy the active tab by using the `selectedIndex` property.
 
-| Name | Type | Description |
-| --- | --- | --- |
-| `selectedIndex` | `number` | The index of the currently active tab. |
-| `focusIndex` | `number` | The index of the currently active tab. |
+```html
+<md-tab-group [selectedIndex]="1">
+  ...
+</md-tab-group>
+```
 
-### Events
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `focusChange` | `Event` | Fired when focus changes from one label to another |
-| `selectChange` | `Event` | Fired when the selected tab changes |
+Notice that the `index` starts counting from `zero`.

--- a/src/lib/tabs/README.md
+++ b/src/lib/tabs/README.md
@@ -44,4 +44,4 @@ It is also possible to specifiy the active tab by using the `selectedIndex` prop
 </md-tab-group>
 ```
 
-Notice that the `index` starts counting from `zero`.
+**Note**: The index always starts counting from `zero`.


### PR DESCRIPTION
* The `focusIndex` has been removed, and was actually the same as the `selectedIndex` from the description as well.
* Also added a quick example for the `selectedIndex`

Fixes #1134