### PR TITLE
fix(button-toggle): toggle group should not emit an initial change event.

### DIFF
--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -306,11 +306,11 @@ describe('MdButtonToggle', () => {
       buttonToggleNativeElements =
           buttonToggleDebugElements.map(debugEl => debugEl.nativeElement);
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
+
+      fixture.detectChanges();
     }));
 
     it('should update the model before firing change event', fakeAsync(() => {
-      fixture.detectChanges();
-
       expect(testComponent.modelValue).toBeUndefined();
       expect(testComponent.lastEvent).toBeUndefined();
 

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -25,6 +25,7 @@ describe('MdButtonToggle', () => {
         ButtonTogglesInsideButtonToggleGroup,
         ButtonToggleGroupWithNgModel,
         ButtonTogglesInsideButtonToggleGroupMultiple,
+        ButtonToggleGroupWithInitialValue,
         StandaloneButtonToggle,
       ],
     });
@@ -305,11 +306,11 @@ describe('MdButtonToggle', () => {
       buttonToggleNativeElements =
           buttonToggleDebugElements.map(debugEl => debugEl.nativeElement);
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
-
-      fixture.detectChanges();
     }));
 
     it('should update the model before firing change event', fakeAsync(() => {
+      fixture.detectChanges();
+
       expect(testComponent.modelValue).toBeUndefined();
       expect(testComponent.lastEvent).toBeUndefined();
 
@@ -320,6 +321,29 @@ describe('MdButtonToggle', () => {
       expect(testComponent.modelValue).toBe('red');
       expect(testComponent.lastEvent.value).toBe('red');
     }));
+
+  });
+
+  describe('with initial value and change event', () => {
+
+    it('should not fire an initial change event', async(() => {
+      let fixture = TestBed.createComponent(ButtonToggleGroupWithInitialValue);
+      let testComponent = fixture.debugElement.componentInstance;
+      let groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
+      let groupInstance: MdButtonToggleGroup = groupDebugElement.injector.get(MdButtonToggleGroup);
+
+      fixture.detectChanges();
+
+      expect(groupInstance.value).toBe('red');
+      expect(testComponent.lastEvent).toBeFalsy();
+
+      groupInstance.value = 'green';
+      fixture.detectChanges();
+
+      expect(groupInstance.value).toBe('green');
+      expect(testComponent.lastEvent.value).toBe('green');
+    }));
+
   });
 
   describe('inside of a multiple selection group', () => {
@@ -532,3 +556,15 @@ class ButtonTogglesInsideButtonToggleGroupMultiple {
   `
 })
 class StandaloneButtonToggle { }
+
+@Component({
+  template: `
+  <md-button-toggle-group (change)="lastEvent = $event" value="red">
+    <md-button-toggle value="red">Value Red</md-button-toggle>
+    <md-button-toggle value="green">Value Green</md-button-toggle>
+  </md-button-toggle-group>
+  `
+})
+class ButtonToggleGroupWithInitialValue {
+  lastEvent: MdButtonToggleChange;
+}

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -12,7 +12,8 @@ import {
     Output,
     QueryList,
     ViewEncapsulation,
-    forwardRef
+    forwardRef,
+    AfterViewInit
 } from '@angular/core';
 import {
     NG_VALUE_ACCESSOR,
@@ -55,7 +56,7 @@ export class MdButtonToggleChange {
     'role': 'radiogroup',
   },
 })
-export class MdButtonToggleGroup implements ControlValueAccessor {
+export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor {
   /** The value for the button toggle group. Should match currently selected button toggle. */
   private _value: any = null;
 
@@ -67,6 +68,9 @@ export class MdButtonToggleGroup implements ControlValueAccessor {
 
   /** The currently selected button toggle, should match the value. */
   private _selected: MdButtonToggle = null;
+
+  /** Whether the button toggle group is initialized or not. */
+  private _isInitialized: boolean = false;
 
   /** The method to be called in order to update ngModel. */
   private _controlValueAccessorChangeFn: (value: any) => void = (value) => {};
@@ -83,6 +87,11 @@ export class MdButtonToggleGroup implements ControlValueAccessor {
   /** Child button toggle buttons. */
   @ContentChildren(forwardRef(() => MdButtonToggle))
   _buttonToggles: QueryList<MdButtonToggle> = null;
+
+  /** TODO: internal */
+  ngAfterViewInit() {
+    this._isInitialized = true;
+  }
 
   @Input()
   get name(): string {
@@ -114,7 +123,12 @@ export class MdButtonToggleGroup implements ControlValueAccessor {
       this._value = newValue;
 
       this._updateSelectedButtonToggleFromValue();
-      this._emitChangeEvent();
+
+      // Only emit a change event if the view is completely initialized.
+      // We don't want to emit a change event for the initial values.
+      if (this._isInitialized) {
+        this._emitChangeEvent();
+      }
     }
   }
 

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -12,8 +12,7 @@ import {
     Output,
     QueryList,
     ViewEncapsulation,
-    forwardRef,
-    AfterViewInit
+    forwardRef
 } from '@angular/core';
 import {
     NG_VALUE_ACCESSOR,
@@ -56,7 +55,7 @@ export class MdButtonToggleChange {
     'role': 'radiogroup',
   },
 })
-export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor {
+export class MdButtonToggleGroup implements OnInit, ControlValueAccessor {
   /** The value for the button toggle group. Should match currently selected button toggle. */
   private _value: any = null;
 
@@ -89,7 +88,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
   /** TODO: internal */
-  ngAfterViewInit() {
+  ngOnInit() {
     this._isInitialized = true;
   }
 

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -12,7 +12,8 @@ import {
     Output,
     QueryList,
     ViewEncapsulation,
-    forwardRef
+    forwardRef,
+    AfterViewInit
 } from '@angular/core';
 import {
     NG_VALUE_ACCESSOR,
@@ -55,7 +56,7 @@ export class MdButtonToggleChange {
     'role': 'radiogroup',
   },
 })
-export class MdButtonToggleGroup implements OnInit, ControlValueAccessor {
+export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor {
   /** The value for the button toggle group. Should match currently selected button toggle. */
   private _value: any = null;
 
@@ -88,7 +89,7 @@ export class MdButtonToggleGroup implements OnInit, ControlValueAccessor {
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
   /** TODO: internal */
-  ngOnInit() {
+  ngAfterViewInit() {
     this._isInitialized = true;
   }
 


### PR DESCRIPTION
This is the addition of https://github.com/angular/material2/commit/23a61ab8687d5e4f962c39423ed095959d2da82c, which was only taking care of the `ButtonToggle` itself, and not of the group.

Since the `md-button-toggle-group` does not contain any underlaying input element, and we can't use the `emit event if native input does`  approach, we need to wait for the component view to be ready.

References #1125