### PR TITLE
fix(md-card): add md-card-footer

### DIFF
--- a/src/demo-app/card/card-demo.html
+++ b/src/demo-app/card/card-demo.html
@@ -13,7 +13,7 @@
 
   <md-card>
     <md-card-subtitle>Subtitle</md-card-subtitle>
-    <md-card-title>Card with title</md-card-title>
+    <md-card-title>Card with title and footer</md-card-title>
     <md-card-content>
       <p>This is supporting text.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -22,6 +22,9 @@
       <button md-button>LIKE</button>
       <button md-button>SHARE</button>
     </md-card-actions>
+    <md-card-footer>
+      <md-progress-bar mode="indeterminate"></md-progress-bar>
+    </md-card-footer>
   </md-card>
 
   <md-card>

--- a/src/lib/card/README.md
+++ b/src/lib/card/README.md
@@ -27,7 +27,7 @@ We also provide a number of preset sections that you can mix and match within th
   * `<md-card-content>`: main content section, intended for blocks of text
   * `<img md-card-image>`: stretches image to container width
   * `<md-card-actions>`: wraps and styles buttons
-  * `<md-card-footer>`: anchors section to bottom of card
+  * `<md-card-footer>`: anchors section to bottom of card (e.g progress bar)
 
 Example markup for a card with section presets:
 

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -76,9 +76,9 @@ md-card-actions {
 
 md-card-footer {
   position: absolute;
-  min-height: 5px;
   width: 100%;
-  bottom: 0; 
+  min-height: 5px;
+  bottom: 0;
   left: 0;
 }
 

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -76,7 +76,10 @@ md-card-actions {
 
 md-card-footer {
   position: absolute;
-  bottom: 0;
+  min-height: 5px;
+  width: 100%;
+  bottom: 0; 
+  left: 0;
 }
 
 md-card-actions {

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -40,6 +40,14 @@ export class MdCardSubtitle {}
 })
 export class MdCardActions {}
 
+/**
+ * Footer of a card, needed as it's used as a selector in the API.
+ */
+@Directive({
+  selector: 'md-card-footer'
+})
+export class MdCardFooter {}
+
 
 /*
 
@@ -118,11 +126,11 @@ export class MdCardTitleGroup {}
 @NgModule({
   exports: [
     MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
-    MdCardActions
+    MdCardActions, MdCardFooter
   ],
   declarations: [
     MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
-    MdCardActions
+    MdCardActions, MdCardFooter
   ],
 })
 export class MdCardModule {


### PR DESCRIPTION
#### Bug, feature request, or proposal:

Bug

#### What is the expected behavior?

md-card-footer directive is missing.

`@Directive({
    selector: 'md-card-footer'
})
export class MdCardFooter { }
`

#### What is the current behavior?

`zone.js?1473057816570:484 Unhandled Promise rejection: Template parse errors:
'md-card-footer' is not a known element:`

When using footer, the directive is not found

#### What are the steps to reproduce?

Add `md-card-footer` to the demo-app

#### What is the use-case or motivation for changing an existing behavior?

For adding a progress-bar add the bottom:
https://material.google.com/components/progress-activity.html#progress-activity-behavior

#### Which versions of Angular, Material, OS, browsers are affected?

Angular 2.0.0 RC.6 and Material2 alpha.8

#### Is there anything else we should know?