### PR TITLE
feat(slide-toggle): forward focus and blur event

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -21,8 +21,8 @@
            [attr.name]="name"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
-           (blur)="_onInputBlur()"
-           (focus)="_onInputFocus()"
+           (blur)="_onInputBlur($event)"
+           (focus)="_onInputFocus($event)"
            (change)="_onChangeEvent($event)"
            (click)="_onInputClick($event)">
   </div>

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -318,6 +318,22 @@ describe('MdSlideToggle', () => {
       expect(slideToggleElement.classList).toContain('md-slide-toggle-focused');
     });
 
+    it('should forward the focus event', () => {
+      spyOn(testComponent, 'onSlideFocus');
+
+      dispatchFocusChangeEvent('focus', inputElement);
+
+      expect(testComponent.onSlideFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward the blur event', () => {
+      spyOn(testComponent, 'onSlideBlur');
+
+      dispatchFocusChangeEvent('blur', inputElement);
+
+      expect(testComponent.onSlideBlur).toHaveBeenCalledTimes(1);
+    });
+
   });
 
   describe('custom template', () => {
@@ -350,7 +366,9 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
     <md-slide-toggle [(ngModel)]="slideModel" [disabled]="isDisabled" [color]="slideColor" 
                      [id]="slideId" [checked]="slideChecked" [name]="slideName" 
                      [ariaLabel]="slideLabel" [ariaLabelledby]="slideLabelledBy" 
-                     (change)="onSlideChange($event)"
+                     (change)="onSlideChange($event)" 
+                     (focus)="onSlideFocus($event)"
+                     (blur)="onSlideBlur($event)"
                      (click)="onSlideClick($event)">
       <span>Test Slide Toggle</span>
     </md-slide-toggle>`,
@@ -366,6 +384,8 @@ class SlideToggleTestApp {
   slideLabelledBy: string;
   lastEvent: MdSlideToggleChange;
 
+  onSlideFocus(event: FocusEvent) {}
+  onSlideBlur(event: FocusEvent) {}
   onSlideClick(event: Event) {}
   onSlideChange(event: MdSlideToggleChange) {
     this.lastEvent = event;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -61,7 +61,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   private _uniqueId = `md-slide-toggle-${++nextId}`;
   private _checked: boolean = false;
   private _color: string;
-  _hasFocus: boolean = false;
+  private _hasFocus: boolean = false;
   private _isMousedown: boolean = false;
   private _slideRenderer: SlideToggleRenderer = null;
 
@@ -129,17 +129,21 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     setTimeout(() => this._isMousedown = false, 100);
   }
 
-  _onInputFocus() {
+  _onInputFocus(event: Event) {
     // Only show the focus / ripple indicator when the focus was not triggered by a mouse
     // interaction on the component.
     if (!this._isMousedown) {
       this._hasFocus = true;
     }
+
+    this._forwardEvent(event);
   }
 
-  _onInputBlur() {
+  _onInputBlur(event: Event) {
     this._hasFocus = false;
+
     this.onTouched();
+    this._forwardEvent(event);
   }
 
   /**
@@ -211,6 +215,11 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     this._change.emit(event);
   }
 
+  /** Forwards a given element to the component element */
+  private _forwardEvent(event: Event) {
+    // We need a timeout here, because the event is still being dispatched right now.
+    setTimeout(() => this._elementRef.nativeElement.dispatchEvent(event));
+  }
 
   /** TODO: internal */
   _onDragStart() {


### PR DESCRIPTION
This is an older draft and could resolve the focus / blur event issue for components with an underlaying input element.

> It is also possible to use a normal Angular '@Output` instead. 