### PR TITLE
refactor(all): rename the prefix from Md to Mat.

### DIFF
--- a/e2e/components/menu/menu-page.ts
+++ b/e2e/components/menu/menu-page.ts
@@ -6,7 +6,7 @@ export class MenuPage {
     browser.get('/menu');
   }
 
-  menu() { return element(by.css('.md-menu')); }
+  menu() { return element(by.css('.mat-menu')); }
 
   start() { return element(by.id('start')); }
 
@@ -17,7 +17,7 @@ export class MenuPage {
   body() { return element(by.tagName('body')); }
 
   items(index: number) {
-    return element.all(by.css('[md-menu-item]')).get(index);
+    return element.all(by.css('[mat-menu-item]')).get(index);
   }
 
   textArea() { return element(by.id('text')); }
@@ -28,11 +28,11 @@ export class MenuPage {
 
   combinedTrigger() { return element(by.id('combined-t')); }
 
-  beforeMenu() { return element(by.css('.md-menu.before')); }
+  beforeMenu() { return element(by.css('.mat-menu.before')); }
 
-  aboveMenu() { return element(by.css('.md-menu.above')); }
+  aboveMenu() { return element(by.css('.mat-menu.above')); }
 
-  combinedMenu() { return element(by.css('.md-menu.combined')); }
+  combinedMenu() { return element(by.css('.mat-menu.combined')); }
 
   // TODO(kara): move to common testing utility
   pressKey(key: any): void {
@@ -46,7 +46,7 @@ export class MenuPage {
   }
 
   expectMenuPresent(expected: boolean) {
-    return browser.isElementPresent(by.css('.md-menu')).then((isPresent) => {
+    return browser.isElementPresent(by.css('.mat-menu')).then((isPresent) => {
       expect(isPresent).toBe(expected);
     });
   }

--- a/e2e/components/menu/menu.e2e.ts
+++ b/e2e/components/menu/menu.e2e.ts
@@ -62,7 +62,7 @@ describe('menu', () => {
   it('should mirror classes on host to menu template in overlay', () => {
     page.trigger().click();
     page.menu().getAttribute('class').then((classes) => {
-      expect(classes).toEqual('md-menu custom');
+      expect(classes).toEqual('mat-menu custom');
     });
   });
 

--- a/e2e/components/tabs/tabs.e2e.ts
+++ b/e2e/components/tabs/tabs.e2e.ts
@@ -9,9 +9,9 @@ describe('tabs', () => {
 
     beforeEach(() => {
       browser.get('/tabs');
-      tabGroup = element(by.css('md-tab-group'));
-      tabLabels = element.all(by.css('.md-tab-label'));
-      tabBodies = element.all(by.css('.md-tab-body'));
+      tabGroup = element(by.css('mat-tab-group'));
+      tabLabels = element.all(by.css('.mat-tab-label'));
+      tabBodies = element.all(by.css('.mat-tab-body'));
     });
 
     it('should change tabs when the label is clicked', () => {
@@ -78,7 +78,7 @@ function getFocusStates(elements: ElementArrayFinder) {
  * @returns {webdriver.promise.Promise<Promise<boolean>[]>|webdriver.promise.Promise<T[]>}
  */
 function getActiveStates(elements: ElementArrayFinder) {
-  return getClassStates(elements, 'md-tab-active');
+  return getClassStates(elements, 'mat-tab-active');
 }
 
 /**

--- a/src/demo-app/baseline/baseline-demo.html
+++ b/src/demo-app/baseline/baseline-demo.html
@@ -1,35 +1,35 @@
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Basic Forms</md-toolbar>
-  <md-card-content>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Basic Forms</mat-toolbar>
+  <mat-card-content>
     Text Before |
-    <md-checkbox>Checkbox Label</md-checkbox>
+    <mat-checkbox>Checkbox Label</mat-checkbox>
     | Text 1 |
-    <md-radio-button value="option_1">Radio 1</md-radio-button>
+    <mat-radio-button value="option_1">Radio 1</mat-radio-button>
     | Text 2 |
-    <md-radio-button value="option_2">Radio 2</md-radio-button>
+    <mat-radio-button value="option_2">Radio 2</mat-radio-button>
     | Text 3 |
-    <md-radio-button value="option_3">Radio 3</md-radio-button>
+    <mat-radio-button value="option_3">Radio 3</mat-radio-button>
     | Text 4 |
-    <md-input>Label</md-input>
+    <mat-input>Label</mat-input>
     | Text After
-  </md-card-content>
-</md-card>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Headers</md-toolbar>
-  <md-card-content>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Headers</mat-toolbar>
+  <mat-card-content>
     <h1>
       Text Before |
-      <md-checkbox>Checkbox Label</md-checkbox>
+      <mat-checkbox>Checkbox Label</mat-checkbox>
       | Text 1 |
-      <md-radio-button value="option_1">Radio 1</md-radio-button>
+      <mat-radio-button value="option_1">Radio 1</mat-radio-button>
       | Text 2 |
-      <md-radio-button value="option_2">Radio 2</md-radio-button>
+      <mat-radio-button value="option_2">Radio 2</mat-radio-button>
       | Text 3 |
-      <md-radio-button value="option_3">Radio 3</md-radio-button>
+      <mat-radio-button value="option_3">Radio 3</mat-radio-button>
       | Text 4 |
-      <md-input>Label</md-input>
+      <mat-input>Label</mat-input>
       | Text After
     </h1>
-  </md-card-content>
-</md-card>
+  </mat-card-content>
+</mat-card>

--- a/src/demo-app/baseline/baseline-demo.scss
+++ b/src/demo-app/baseline/baseline-demo.scss
@@ -2,7 +2,7 @@
 .demo-basic {
   padding: 0;
 }
-.demo-basic md-card-content {
+.demo-basic mat-card-content {
   padding: 16px;
 }
 .demo-full-width {

--- a/src/demo-app/button-toggle/button-toggle-demo.html
+++ b/src/demo-app/button-toggle/button-toggle-demo.html
@@ -14,13 +14,13 @@
 <section class="demo-section">
   <mat-button-toggle-group name="checkbox" disabled>
     <mat-button-toggle value="bold">
-      <mat-icon class="mat-24">format_bold</mat-icon>
+      <mat-icon class="md-24">format_bold</mat-icon>
     </mat-button-toggle>
     <mat-button-toggle value="italic">
-      <mat-icon class="mat-24">format_italic</mat-icon>
+      <mat-icon class="md-24">format_italic</mat-icon>
     </mat-button-toggle>
     <mat-button-toggle value="underline">
-      <mat-icon class="mat-24">format_underline</mat-icon>
+      <mat-icon class="md-24">format_underline</mat-icon>
     </mat-button-toggle>
   </mat-button-toggle-group>
 </section>

--- a/src/demo-app/button-toggle/button-toggle-demo.html
+++ b/src/demo-app/button-toggle/button-toggle-demo.html
@@ -1,49 +1,49 @@
 <h1>Exclusive Selection</h1>
 
 <section class="demo-section">
-  <md-button-toggle-group name="alignment">
-    <md-button-toggle value="left"><md-icon>format_align_left</md-icon></md-button-toggle>
-    <md-button-toggle value="center"><md-icon>format_align_center</md-icon></md-button-toggle>
-    <md-button-toggle value="right"><md-icon>format_align_right</md-icon></md-button-toggle>
-    <md-button-toggle value="justify" disabled><md-icon>format_align_justify</md-icon></md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group name="alignment">
+    <mat-button-toggle value="left"><mat-icon>format_align_left</mat-icon></mat-button-toggle>
+    <mat-button-toggle value="center"><mat-icon>format_align_center</mat-icon></mat-button-toggle>
+    <mat-button-toggle value="right"><mat-icon>format_align_right</mat-icon></mat-button-toggle>
+    <mat-button-toggle value="justify" disabled><mat-icon>format_align_justify</mat-icon></mat-button-toggle>
+  </mat-button-toggle-group>
 </section>
 
 <h1>Disabled Group</h1>
 
 <section class="demo-section">
-  <md-button-toggle-group name="checkbox" disabled>
-    <md-button-toggle value="bold">
-      <md-icon class="md-24">format_bold</md-icon>
-    </md-button-toggle>
-    <md-button-toggle value="italic">
-      <md-icon class="md-24">format_italic</md-icon>
-    </md-button-toggle>
-    <md-button-toggle value="underline">
-      <md-icon class="md-24">format_underline</md-icon>
-    </md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group name="checkbox" disabled>
+    <mat-button-toggle value="bold">
+      <mat-icon class="mat-24">format_bold</mat-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="italic">
+      <mat-icon class="mat-24">format_italic</mat-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="underline">
+      <mat-icon class="mat-24">format_underline</mat-icon>
+    </mat-button-toggle>
+  </mat-button-toggle-group>
 </section>
 
 <h1>Multiple Selection</h1>
 <section class="demo-section">
-  <md-button-toggle-group multiple>
-    <md-button-toggle>Flour</md-button-toggle>
-    <md-button-toggle>Eggs</md-button-toggle>
-    <md-button-toggle>Sugar</md-button-toggle>
-    <md-button-toggle disabled>Milk (disabled)</md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group multiple>
+    <mat-button-toggle>Flour</mat-button-toggle>
+    <mat-button-toggle>Eggs</mat-button-toggle>
+    <mat-button-toggle>Sugar</mat-button-toggle>
+    <mat-button-toggle disabled>Milk (disabled)</mat-button-toggle>
+  </mat-button-toggle-group>
 </section>
 
 <h1>Single Toggle</h1>
-<md-button-toggle>Yes</md-button-toggle>
+<mat-button-toggle>Yes</mat-button-toggle>
 
 <h1>Dynamic Exclusive Selection</h1>
 <section class="demo-section">
-  <md-button-toggle-group name="pies" [(ngModel)]="favoritePie">
-    <md-button-toggle *ngFor="let pie of pieOptions" [value]="pie">
+  <mat-button-toggle-group name="pies" [(ngModel)]="favoritePie">
+    <mat-button-toggle *ngFor="let pie of pieOptions" [value]="pie">
       {{pie}}
-    </md-button-toggle>
-  </md-button-toggle-group>
+    </mat-button-toggle>
+  </mat-button-toggle-group>
   <p>Your favorite type of pie is: {{favoritePie}}</p>
 </section>

--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -1,11 +1,11 @@
 import {Component} from '@angular/core';
-import {MdUniqueSelectionDispatcher} from '@angular2-material/core';
+import {MatUniqueSelectionDispatcher} from '@angular2-material/core';
 
 @Component({
   moduleId: module.id,
   selector: 'button-toggle-demo',
   templateUrl: 'button-toggle-demo.html',
-  providers: [MdUniqueSelectionDispatcher],
+  providers: [MatUniqueSelectionDispatcher],
 })
 export class ButtonToggleDemo {
   favoritePie = 'Apple';

--- a/src/demo-app/button/button-demo.html
+++ b/src/demo-app/button/button-demo.html
@@ -1,92 +1,92 @@
 <div class="demo-button">
   <section>
-    <button md-button>flat</button>
-    <button md-raised-button>raised</button>
-    <button md-fab>
-      <md-icon class="md-24">check</md-icon>
+    <button mat-button>flat</button>
+    <button mat-raised-button>raised</button>
+    <button mat-fab>
+      <mat-icon class="mat-24">check</mat-icon>
     </button>
-    <button md-mini-fab>
-      <md-icon class="md-24">check</md-icon>
+    <button mat-mini-fab>
+      <mat-icon class="mat-24">check</mat-icon>
     </button>
   </section>
 
   <section>
-    <a href="http://www.google.com" md-button color="primary">SEARCH</a>
-    <a href="http://www.google.com" md-raised-button>SEARCH</a>
-    <a href="http://www.google.com" md-fab>
-      <md-icon class="md-24">check</md-icon>
+    <a href="http://www.google.com" mat-button color="primary">SEARCH</a>
+    <a href="http://www.google.com" mat-raised-button>SEARCH</a>
+    <a href="http://www.google.com" mat-fab>
+      <mat-icon class="mat-24">check</mat-icon>
     </a>
-    <a href="http://www.google.com" md-mini-fab>
-      <md-icon class="md-24">check</md-icon>
+    <a href="http://www.google.com" mat-mini-fab>
+      <mat-icon class="mat-24">check</mat-icon>
     </a>
   </section>
 
   <section>
-    <button md-button color="primary">primary</button>
-    <button md-button color="accent">accent</button>
-    <button md-button color="warn">warn</button>
+    <button mat-button color="primary">primary</button>
+    <button mat-button color="accent">accent</button>
+    <button mat-button color="warn">warn</button>
   </section>
 
   <section>
-    <button md-raised-button color="primary">primary</button>
-    <button md-raised-button color="accent">accent</button>
-    <button md-raised-button color="warn">warn</button>
+    <button mat-raised-button color="primary">primary</button>
+    <button mat-raised-button color="accent">accent</button>
+    <button mat-raised-button color="warn">warn</button>
   </section>
 
   <section>
-    <button md-fab color="primary">
-      <md-icon class="md-24">home</md-icon>
+    <button mat-fab color="primary">
+      <mat-icon class="mat-24">home</mat-icon>
     </button>
-    <button md-fab color="accent">
-      <md-icon class="md-24">favorite</md-icon>
+    <button mat-fab color="accent">
+      <mat-icon class="mat-24">favorite</mat-icon>
     </button>
-    <button md-fab color="warn">
-      <md-icon class="md-24">feedback</md-icon>
+    <button mat-fab color="warn">
+      <mat-icon class="mat-24">feedback</mat-icon>
     </button>
   </section>
 
   <section>
-    <button md-icon-button color="primary">
-      <md-icon class="md-24">menu</md-icon>
+    <button mat-icon-button color="primary">
+      <mat-icon class="mat-24">menu</mat-icon>
     </button>
 
-    <button md-icon-button color="accent">
-      <md-icon class="md-24">favorite</md-icon>
+    <button mat-icon-button color="accent">
+      <mat-icon class="mat-24">favorite</mat-icon>
     </button>
 
-    <button md-icon-button>
-      <md-icon class="md-24">more_vert</md-icon>
+    <button mat-icon-button>
+      <mat-icon class="mat-24">more_vert</mat-icon>
     </button>
   </section>
 
   <section>
     <div>
       <p>isDisabled: {{isDisabled}}, clickCounter: <span>{{clickCounter}}</span></p>
-      <button md-raised-button (click)="isDisabled=!isDisabled">
+      <button mat-raised-button (click)="isDisabled=!isDisabled">
         Disable buttons
       </button>
-      <button md-raised-button (click)="button1.focus()">Focus 1</button>
-      <button md-raised-button (click)="button2.focus()">Focus 2</button>
-      <button md-raised-button (click)="button3.focus()">Focus 3</button>
+      <button mat-raised-button (click)="button1.focus()">Focus 1</button>
+      <button mat-raised-button (click)="button2.focus()">Focus 2</button>
+      <button mat-raised-button (click)="button3.focus()">Focus 3</button>
     </div>
-    <button md-button #button1 [disabled]="isDisabled" (click)="clickCounter=clickCounter+1">off</button>
-    <button md-button color="primary" [disabled]="isDisabled">off</button>
-    <a href="http://www.google.com" #button2 md-button color="accent" [disabled]="isDisabled">off</a>
-    <button md-raised-button #button3 color="primary" [disabled]="isDisabled">off</button>
-    <button md-mini-fab [disabled]="isDisabled">
-      <md-icon class="md-24">check</md-icon>
+    <button mat-button #button1 [disabled]="isDisabled" (click)="clickCounter=clickCounter+1">off</button>
+    <button mat-button color="primary" [disabled]="isDisabled">off</button>
+    <a href="http://www.google.com" #button2 mat-button color="accent" [disabled]="isDisabled">off</a>
+    <button mat-raised-button #button3 color="primary" [disabled]="isDisabled">off</button>
+    <button mat-mini-fab [disabled]="isDisabled">
+      <mat-icon class="mat-24">check</mat-icon>
     </button>
 
-    <button md-icon-button color="accent" [disabled]="isDisabled">
-      <md-icon class="md-24">favorite</md-icon>
+    <button mat-icon-button color="accent" [disabled]="isDisabled">
+      <mat-icon class="mat-24">favorite</mat-icon>
     </button>
   </section>
   <section>
-    <a href="http://www.google.com" md-button color="primary">SEARCH</a>
-    <button md-button>DANCE</button>
+    <a href="http://www.google.com" mat-button color="primary">SEARCH</a>
+    <button mat-button>DANCE</button>
   </section>
   <section>
-    <a href="http://www.google.com" md-raised-button color="primary">SEARCH</a>
-    <button md-raised-button>DANCE</button>
+    <a href="http://www.google.com" mat-raised-button color="primary">SEARCH</a>
+    <button mat-raised-button>DANCE</button>
   </section>
 </div>

--- a/src/demo-app/button/button-demo.html
+++ b/src/demo-app/button/button-demo.html
@@ -3,10 +3,10 @@
     <button mat-button>flat</button>
     <button mat-raised-button>raised</button>
     <button mat-fab>
-      <mat-icon class="mat-24">check</mat-icon>
+      <mat-icon class="md-24">check</mat-icon>
     </button>
     <button mat-mini-fab>
-      <mat-icon class="mat-24">check</mat-icon>
+      <mat-icon class="md-24">check</mat-icon>
     </button>
   </section>
 
@@ -14,10 +14,10 @@
     <a href="http://www.google.com" mat-button color="primary">SEARCH</a>
     <a href="http://www.google.com" mat-raised-button>SEARCH</a>
     <a href="http://www.google.com" mat-fab>
-      <mat-icon class="mat-24">check</mat-icon>
+      <mat-icon class="md-24">check</mat-icon>
     </a>
     <a href="http://www.google.com" mat-mini-fab>
-      <mat-icon class="mat-24">check</mat-icon>
+      <mat-icon class="md-24">check</mat-icon>
     </a>
   </section>
 
@@ -35,27 +35,27 @@
 
   <section>
     <button mat-fab color="primary">
-      <mat-icon class="mat-24">home</mat-icon>
+      <mat-icon class="md-24">home</mat-icon>
     </button>
     <button mat-fab color="accent">
-      <mat-icon class="mat-24">favorite</mat-icon>
+      <mat-icon class="md-24">favorite</mat-icon>
     </button>
     <button mat-fab color="warn">
-      <mat-icon class="mat-24">feedback</mat-icon>
+      <mat-icon class="md-24">feedback</mat-icon>
     </button>
   </section>
 
   <section>
     <button mat-icon-button color="primary">
-      <mat-icon class="mat-24">menu</mat-icon>
+      <mat-icon class="md-24">menu</mat-icon>
     </button>
 
     <button mat-icon-button color="accent">
-      <mat-icon class="mat-24">favorite</mat-icon>
+      <mat-icon class="md-24">favorite</mat-icon>
     </button>
 
     <button mat-icon-button>
-      <mat-icon class="mat-24">more_vert</mat-icon>
+      <mat-icon class="md-24">more_vert</mat-icon>
     </button>
   </section>
 
@@ -74,11 +74,11 @@
     <a href="http://www.google.com" #button2 mat-button color="accent" [disabled]="isDisabled">off</a>
     <button mat-raised-button #button3 color="primary" [disabled]="isDisabled">off</button>
     <button mat-mini-fab [disabled]="isDisabled">
-      <mat-icon class="mat-24">check</mat-icon>
+      <mat-icon class="md-24">check</mat-icon>
     </button>
 
     <button mat-icon-button color="accent" [disabled]="isDisabled">
-      <mat-icon class="mat-24">favorite</mat-icon>
+      <mat-icon class="md-24">favorite</mat-icon>
     </button>
   </section>
   <section>

--- a/src/demo-app/card/card-demo.html
+++ b/src/demo-app/card/card-demo.html
@@ -1,58 +1,58 @@
 <div class="demo-card-container">
-  <md-card>
+  <mat-card>
     Hello
-  </md-card>
+  </mat-card>
 
-  <md-card>
-    <md-card-title-group>
-        <md-card-title>Card with title</md-card-title>
-        <md-card-subtitle>Subtitle</md-card-subtitle>
-        <img md-card-md-image>
-    </md-card-title-group>
-  </md-card>
+  <mat-card>
+    <mat-card-title-group>
+        <mat-card-title>Card with title</mat-card-title>
+        <mat-card-subtitle>Subtitle</mat-card-subtitle>
+        <img mat-card-mat-image>
+    </mat-card-title-group>
+  </mat-card>
 
-  <md-card>
-    <md-card-subtitle>Subtitle</md-card-subtitle>
-    <md-card-title>Card with title</md-card-title>
-    <md-card-content>
+  <mat-card>
+    <mat-card-subtitle>Subtitle</mat-card-subtitle>
+    <mat-card-title>Card with title</mat-card-title>
+    <mat-card-content>
       <p>This is supporting text.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </md-card-content>
-    <md-card-actions>
-      <button md-button>LIKE</button>
-      <button md-button>SHARE</button>
-    </md-card-actions>
-  </md-card>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-button>LIKE</button>
+      <button mat-button>SHARE</button>
+    </mat-card-actions>
+  </mat-card>
 
-  <md-card>
-    <img md-card-image src="https://material.angularjs.org/latest/img/washedout.png">
-    <md-card-title>Content Title</md-card-title>
-    <md-card-content>
+  <mat-card>
+    <img mat-card-image src="https://material.angularjs.org/latest/img/washedout.png">
+    <mat-card-title>Content Title</mat-card-title>
+    <mat-card-content>
       <p>Here is some content</p>
-    </md-card-content>
-    <md-card-actions align="end">
-      <button md-button>LIKE</button>
-      <button md-button>SHARE</button>
-    </md-card-actions>
-  </md-card>
+    </mat-card-content>
+    <mat-card-actions align="end">
+      <button mat-button>LIKE</button>
+      <button mat-button>SHARE</button>
+    </mat-card-actions>
+  </mat-card>
 
-  <md-card>
-    <md-card-header>
-      <img md-card-avatar>
-      <md-card-title>Header title</md-card-title>
-      <md-card-subtitle>Header subtitle</md-card-subtitle>
-    </md-card-header>
-    <img md-card-image src="https://material.angularjs.org/latest/img/washedout.png">
-    <md-card-content>
+  <mat-card>
+    <mat-card-header>
+      <img mat-card-avatar>
+      <mat-card-title>Header title</mat-card-title>
+      <mat-card-subtitle>Header subtitle</mat-card-subtitle>
+    </mat-card-header>
+    <img mat-card-image src="https://material.angularjs.org/latest/img/washedout.png">
+    <mat-card-content>
       <p>Here is some content</p>
-    </md-card-content>
-  </md-card>
+    </mat-card-content>
+  </mat-card>
 
-  <md-card class="demo-card-blue md-card-flat">
-    <md-card-title>Easily customizable</md-card-title>
-    <md-card-actions>
-      <button md-button>First</button>
-      <button md-button>Second</button>
-    </md-card-actions>
-  </md-card>
+  <mat-card class="demo-card-blue mat-card-flat">
+    <mat-card-title>Easily customizable</mat-card-title>
+    <mat-card-actions>
+      <button mat-button>First</button>
+      <button mat-button>Second</button>
+    </mat-card-actions>
+  </mat-card>
 </div>

--- a/src/demo-app/card/card-demo.html
+++ b/src/demo-app/card/card-demo.html
@@ -7,7 +7,7 @@
     <mat-card-title-group>
         <mat-card-title>Card with title</mat-card-title>
         <mat-card-subtitle>Subtitle</mat-card-subtitle>
-        <img mat-card-mat-image>
+        <img mat-card-md-image>
     </mat-card-title-group>
   </mat-card>
 

--- a/src/demo-app/card/card-demo.scss
+++ b/src/demo-app/card/card-demo.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: column nowrap;
 
-  md-card {
+  mat-card {
     margin: 0 16px 16px 0;
     width: 350px;
   }
@@ -15,7 +15,7 @@
 .demo-card-blue {
   background-color: #b0becc;
 
-  md-card-actions {
+  mat-card-actions {
     display: flex;
     flex-direction: column;
   }

--- a/src/demo-app/checkbox/checkbox-demo.html
+++ b/src/demo-app/checkbox/checkbox-demo.html
@@ -1,6 +1,6 @@
-<h1>md-checkbox: Basic Example</h1>
+<h1>mat-checkbox: Basic Example</h1>
 <form>
-<md-checkbox [(ngModel)]="isChecked"
+<mat-checkbox [(ngModel)]="isChecked"
               name="cb"
              (change)="isIndeterminate = false"
              [indeterminate]="isIndeterminate"
@@ -8,7 +8,7 @@
              [align]="alignment">
   Do you want to <em>foobar</em> the <em>bazquux</em>?
 
-</md-checkbox> - <strong>{{printResult()}}</strong>
+</mat-checkbox> - <strong>{{printResult()}}</strong>
 </form>
 <div class="demo-checkboxes">
 <input id="indeterminate-toggle"
@@ -41,4 +41,4 @@
 </div>
 
 <h1>Nested Checklist</h1>
-<md-checkbox-demo-nested-checklist></md-checkbox-demo-nested-checklist>
+<mat-checkbox-demo-nested-checklist></mat-checkbox-demo-nested-checklist>

--- a/src/demo-app/checkbox/checkbox-demo.ts
+++ b/src/demo-app/checkbox/checkbox-demo.ts
@@ -9,7 +9,7 @@ export interface Task {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-checkbox-demo-nested-checklist',
+  selector: 'mat-checkbox-demo-nested-checklist',
   styles: [`
     li {
       margin-bottom: 4px;
@@ -17,7 +17,7 @@ export interface Task {
   `],
   templateUrl: 'nested-checklist.html',
 })
-export class MdCheckboxDemoNestedChecklist {
+export class MatCheckboxDemoNestedChecklist {
   tasks: Task[] = [
     {
       name: 'Reminders',
@@ -58,7 +58,7 @@ export class MdCheckboxDemoNestedChecklist {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-checkbox-demo',
+  selector: 'mat-checkbox-demo',
   templateUrl: 'checkbox-demo.html',
   styleUrls: ['checkbox-demo.css'],
 })

--- a/src/demo-app/checkbox/nested-checklist.html
+++ b/src/demo-app/checkbox/nested-checklist.html
@@ -1,17 +1,17 @@
 <h2>Tasks</h2>
 <ul>
   <li *ngFor="let task of tasks">
-    <md-checkbox [(ngModel)]="task.completed"
+    <mat-checkbox [(ngModel)]="task.completed"
                  [checked]="allComplete(task)"
                  [indeterminate]="someComplete(task.subtasks)"
                  (change)="setAllCompleted(task.subtasks, $event.checked)">
       <h3>{{task.name}}</h3>
-    </md-checkbox>
+    </mat-checkbox>
     <ul>
       <li *ngFor="let subtask of task.subtasks">
-        <md-checkbox [(ngModel)]="subtask.completed">
+        <mat-checkbox [(ngModel)]="subtask.completed">
           {{subtask.name}}
-        </md-checkbox>
+        </mat-checkbox>
       </li>
     </ul>
   </li>

--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -25,7 +25,7 @@ import {OverlayDemo, SpagettiPanel, RotiniPanel} from './overlay/overlay-demo';
 import {SlideToggleDemo} from './slide-toggle/slide-toggle-demo';
 import {ToolbarDemo} from './toolbar/toolbar-demo';
 import {ButtonDemo} from './button/button-demo';
-import {MdCheckboxDemoNestedChecklist, CheckboxDemo} from './checkbox/checkbox-demo';
+import {MatCheckboxDemoNestedChecklist, CheckboxDemo} from './checkbox/checkbox-demo';
 import {SliderDemo} from './slider/slider-demo';
 import {SidenavDemo} from './sidenav/sidenav-demo';
 import {PortalDemo, ScienceJoke} from './portal/portal-demo';
@@ -58,7 +58,7 @@ import {TabsDemo} from './tabs/tab-group-demo';
     JazzDialog,
     ListDemo,
     LiveAnnouncerDemo,
-    MdCheckboxDemoNestedChecklist,
+    MatCheckboxDemoNestedChecklist,
     MenuDemo,
     OverlayDemo,
     PortalDemo,

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -33,7 +33,7 @@
   <div>
     <mat-toolbar color="primary">
       <button mat-icon-button (click)="start.open()">
-        <mat-icon class="mat-24" >menu</mat-icon>
+        <mat-icon class="md-24" >menu</mat-icon>
       </button>
       <div class="demo-toolbar">
         <h1>Angular Material 2 Demos</h1>

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -1,50 +1,50 @@
-<md-sidenav-layout class="demo-root" fullscreen>
-  <md-sidenav #start>
-    <md-nav-list>
-      <a md-list-item [routerLink]="['button']">Button</a>
-      <a md-list-item [routerLink]="['button-toggle']">Button Toggle</a>
-      <a md-list-item [routerLink]="['card']">Card</a>
-      <a md-list-item [routerLink]="['checkbox']">Checkbox</a>
-      <a md-list-item [routerLink]="['dialog']">Dialog</a>
-      <a md-list-item [routerLink]="['gestures']">Gestures</a>
-      <a md-list-item [routerLink]="['grid-list']">Grid List</a>
-      <a md-list-item [routerLink]="['icon']">Icon</a>
-      <a md-list-item [routerLink]="['input']">Input</a>
-      <a md-list-item [routerLink]="['list']">List</a>
-      <a md-list-item [routerLink]="['menu']">Menu</a>
-      <a md-list-item [routerLink]="['live-announcer']">Live Announcer</a>
-      <a md-list-item [routerLink]="['overlay']">Overlay</a>
-      <a md-list-item [routerLink]="['portal']">Portal</a>
-      <a md-list-item [routerLink]="['progress-bar']">Progress Bar</a>
-      <a md-list-item [routerLink]="['progress-circle']">Progress Circle</a>
-      <a md-list-item [routerLink]="['radio']">Radio</a>
-      <a md-list-item [routerLink]="['ripple']">Ripple</a>
-      <a md-list-item [routerLink]="['sidenav']">Sidenav</a>
-      <a md-list-item [routerLink]="['slider']">Slider</a>
-      <a md-list-item [routerLink]="['slide-toggle']">Slide Toggle</a>
-      <a md-list-item [routerLink]="['tabs']">Tabs</a>
-      <a md-list-item [routerLink]="['toolbar']">Toolbar</a>
-      <a md-list-item [routerLink]="['tooltip']">Tooltip</a>
+<mat-sidenav-layout class="demo-root" fullscreen>
+  <mat-sidenav #start>
+    <mat-nav-list>
+      <a mat-list-item [routerLink]="['button']">Button</a>
+      <a mat-list-item [routerLink]="['button-toggle']">Button Toggle</a>
+      <a mat-list-item [routerLink]="['card']">Card</a>
+      <a mat-list-item [routerLink]="['checkbox']">Checkbox</a>
+      <a mat-list-item [routerLink]="['dialog']">Dialog</a>
+      <a mat-list-item [routerLink]="['gestures']">Gestures</a>
+      <a mat-list-item [routerLink]="['grid-list']">Grid List</a>
+      <a mat-list-item [routerLink]="['icon']">Icon</a>
+      <a mat-list-item [routerLink]="['input']">Input</a>
+      <a mat-list-item [routerLink]="['list']">List</a>
+      <a mat-list-item [routerLink]="['menu']">Menu</a>
+      <a mat-list-item [routerLink]="['live-announcer']">Live Announcer</a>
+      <a mat-list-item [routerLink]="['overlay']">Overlay</a>
+      <a mat-list-item [routerLink]="['portal']">Portal</a>
+      <a mat-list-item [routerLink]="['progress-bar']">Progress Bar</a>
+      <a mat-list-item [routerLink]="['progress-circle']">Progress Circle</a>
+      <a mat-list-item [routerLink]="['radio']">Radio</a>
+      <a mat-list-item [routerLink]="['ripple']">Ripple</a>
+      <a mat-list-item [routerLink]="['sidenav']">Sidenav</a>
+      <a mat-list-item [routerLink]="['slider']">Slider</a>
+      <a mat-list-item [routerLink]="['slide-toggle']">Slide Toggle</a>
+      <a mat-list-item [routerLink]="['tabs']">Tabs</a>
+      <a mat-list-item [routerLink]="['toolbar']">Toolbar</a>
+      <a mat-list-item [routerLink]="['tooltip']">Tooltip</a>
       <hr>
-      <a md-list-item [routerLink]="['baseline']">Baseline</a>
-    </md-nav-list>
-    <button md-button (click)="start.close()">CLOSE</button>
-  </md-sidenav>
+      <a mat-list-item [routerLink]="['baseline']">Baseline</a>
+    </mat-nav-list>
+    <button mat-button (click)="start.close()">CLOSE</button>
+  </mat-sidenav>
   <div>
-    <md-toolbar color="primary">
-      <button md-icon-button (click)="start.open()">
-        <md-icon class="md-24" >menu</md-icon>
+    <mat-toolbar color="primary">
+      <button mat-icon-button (click)="start.open()">
+        <mat-icon class="mat-24" >menu</mat-icon>
       </button>
       <div class="demo-toolbar">
         <h1>Angular Material 2 Demos</h1>
-        <button md-button (click)="root.dir = (root.dir == 'rtl' ? 'ltr' : 'rtl')" title="Toggle between RTL and LTR">
+        <button mat-button (click)="root.dir = (root.dir == 'rtl' ? 'ltr' : 'rtl')" title="Toggle between RTL and LTR">
           {{root.dir.toUpperCase()}}
         </button>
       </div>
-    </md-toolbar>
+    </mat-toolbar>
 
     <div #root="$implicit" dir="ltr" class="demo-content">
       <router-outlet></router-outlet>
     </div>
   </div>
-</md-sidenav-layout>
+</mat-sidenav-layout>

--- a/src/demo-app/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app/demo-app.scss
@@ -8,10 +8,10 @@ body {
     -moz-osx-font-smoothing: grayscale;
   }
 
-  md-sidenav {
+  mat-sidenav {
     min-width: 15%;
 
-    [md-button] {
+    [mat-button] {
       width: 100%;
       position: relative;
       bottom: 0;
@@ -23,8 +23,8 @@ body {
     padding: 32px;
   }
 
-  md-toolbar {
-    md-icon {
+  mat-toolbar {
+    mat-icon {
       cursor: pointer;
     }
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,5 +1,5 @@
 import {Component, ViewContainerRef} from '@angular/core';
-import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular2-material/dialog';
+import {MatDialog, MatDialogConfig, MatDialogRef} from '@angular2-material/dialog';
 
 @Component({
   moduleId: module.id,
@@ -8,15 +8,15 @@ import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular2-material/dialog';
   styleUrls: ['dialog-demo.css'],
 })
 export class DialogDemo {
-  dialogRef: MdDialogRef<JazzDialog>;
+  dialogRef: MatDialogRef<JazzDialog>;
   lastCloseResult: string;
 
   constructor(
-      public dialog: MdDialog,
+      public dialog: MatDialog,
       public viewContainerRef: ViewContainerRef) { }
 
   open() {
-    let config = new MdDialogConfig();
+    let config = new MatDialogConfig();
     config.viewContainerRef = this.viewContainerRef;
 
     this.dialogRef = this.dialog.open(JazzDialog, config);
@@ -37,5 +37,5 @@ export class DialogDemo {
   <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>`
 })
 export class JazzDialog {
-  constructor(public dialogRef: MdDialogRef<JazzDialog>) { }
+  constructor(public dialogRef: MatDialogRef<JazzDialog>) { }
 }

--- a/src/demo-app/grid-list/grid-list-demo.html
+++ b/src/demo-app/grid-list/grid-list-demo.html
@@ -1,91 +1,91 @@
 <div class="demo-grid-list">
-  <md-card>
-    <md-card-title>Basic grid list</md-card-title>
-    <md-card-content class="demo-basic-list">
-      <md-grid-list cols="4" [rowHeight]="basicRowHeight">
-        <md-grid-tile> One </md-grid-tile>
-        <md-grid-tile> Two </md-grid-tile>
-        <md-grid-tile> Three </md-grid-tile>
-        <md-grid-tile> Four </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
+  <mat-card>
+    <mat-card-title>Basic grid list</mat-card-title>
+    <mat-card-content class="demo-basic-list">
+      <mat-grid-list cols="4" [rowHeight]="basicRowHeight">
+        <mat-grid-tile> One </mat-grid-tile>
+        <mat-grid-tile> Two </mat-grid-tile>
+        <mat-grid-tile> Three </mat-grid-tile>
+        <mat-grid-tile> Four </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+  </mat-card>
 
-  <md-card>
-    <md-card-title>Fixed-height grid list</md-card-title>
-    <md-card-content>
-      <md-grid-list [cols]="fixedCols" [rowHeight]="fixedRowHeight">
-        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
+  <mat-card>
+    <mat-card-title>Fixed-height grid list</mat-card-title>
+    <mat-card-content>
+      <mat-grid-list [cols]="fixedCols" [rowHeight]="fixedRowHeight">
+        <mat-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
                       [style.background]="tile.color">
           {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+    <mat-card-actions>
       <p>Change list cols: <input type="number" [(ngModel)]="fixedCols"></p>
       <p>Change row height: <input type="number" [(ngModel)]="fixedRowHeight"></p>
-      <button md-button (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
-    </md-card-actions>
-  </md-card>
+      <button mat-button (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
+    </mat-card-actions>
+  </mat-card>
 
-  <md-card>
-    <md-card-title>Ratio-height grid list</md-card-title>
-    <md-card-content class="demo-ratio-list">
-      <md-grid-list cols="2" [rowHeight]="ratio" gutterSize="4px">
-        <md-grid-tile *ngFor="let tile of tiles" [style.background]="'lightblue'">
+  <mat-card>
+    <mat-card-title>Ratio-height grid list</mat-card-title>
+    <mat-card-content class="demo-ratio-list">
+      <mat-grid-list cols="2" [rowHeight]="ratio" gutterSize="4px">
+        <mat-grid-tile *ngFor="let tile of tiles" [style.background]="'lightblue'">
           {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+    <mat-card-actions>
       <p>Change ratio: <input [(ngModel)]="ratio"></p>
-    </md-card-actions>
-  </md-card>
+    </mat-card-actions>
+  </mat-card>
 
-  <md-card>
-    <md-card-title>Fit-height grid list</md-card-title>
-    <md-card-content class="demo-fit-list">
-      <md-grid-list cols="2" rowHeight="fit" [gutterSize]="ratioGutter"
+  <mat-card>
+    <mat-card-title>Fit-height grid list</mat-card-title>
+    <mat-card-content class="demo-fit-list">
+      <mat-grid-list cols="2" rowHeight="fit" [gutterSize]="ratioGutter"
                     [style.height]="fitListHeight">
-        <md-grid-tile *ngFor="let tile of tiles" [style.background]="'#F1EBBA'">
+        <mat-grid-tile *ngFor="let tile of tiles" [style.background]="'#F1EBBA'">
           {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+    <mat-card-actions>
       <p>Change list height: <input [(ngModel)]="fitListHeight"></p>
       <p>Change gutter: <input type="number" [(ngModel)]="ratioGutter"></p>
-    </md-card-actions>
-  </md-card>
+    </mat-card-actions>
+  </mat-card>
 
-  <md-card>
-    <md-card-title>Grid list with header</md-card-title>
-    <md-card-content>
-      <md-grid-list cols="3" rowHeight="200px">
-        <md-grid-tile *ngFor="let dog of dogs" style="background:gray">
-          <md-grid-tile-header>
-            <md-icon md-grid-avatar>info_outline</md-icon>
+  <mat-card>
+    <mat-card-title>Grid list with header</mat-card-title>
+    <mat-card-content>
+      <mat-grid-list cols="3" rowHeight="200px">
+        <mat-grid-tile *ngFor="let dog of dogs" style="background:gray">
+          <mat-grid-tile-header>
+            <mat-icon mat-grid-avatar>info_outline</mat-icon>
             {{dog.name}}
-          </md-grid-tile-header>
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
+          </mat-grid-tile-header>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+  </mat-card>
 
-  <md-card>
-    <md-card-title>Grid list with footer</md-card-title>
-    <md-card-content>
-      <md-grid-list cols="3" rowHeight="200px">
-        <md-grid-tile *ngFor="let dog of dogs">
+  <mat-card>
+    <mat-card-title>Grid list with footer</mat-card-title>
+    <mat-card-content>
+      <mat-grid-list cols="3" rowHeight="200px">
+        <mat-grid-tile *ngFor="let dog of dogs">
           <img [alt]="dog.name" src="https://material.angularjs.org/material2_assets/ngconf/{{dog.name}}.png">
-          <md-grid-tile-footer>
-            <h3 md-line>{{dog.name}}</h3>
-            <span md-line>Human: {{dog.human}}</span>
-            <md-icon>star_border</md-icon>
-          </md-grid-tile-footer>
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
+          <mat-grid-tile-footer>
+            <h3 mat-line>{{dog.name}}</h3>
+            <span mat-line>Human: {{dog.human}}</span>
+            <mat-icon>star_border</mat-icon>
+          </mat-grid-tile-footer>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </mat-card-content>
+  </mat-card>
 </div>
 

--- a/src/demo-app/grid-list/grid-list-demo.scss
+++ b/src/demo-app/grid-list/grid-list-demo.scss
@@ -1,7 +1,7 @@
 .demo-grid-list {
   width: 1100px;
 
-  md-card {
+  mat-card {
     margin: 16px 0;
   }
 
@@ -9,7 +9,7 @@
     margin: 16px;
   }
 
-  .demo-basic-list md-grid-tile {
+  .demo-basic-list mat-grid-tile {
     background: rgba(0, 0, 0, 0.32);
   }
 

--- a/src/demo-app/grid-list/grid-list-demo.ts
+++ b/src/demo-app/grid-list/grid-list-demo.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MdIconRegistry} from '@angular2-material/icon';
+import {MatIconRegistry} from '@angular2-material/icon';
 
 
 @Component({
@@ -7,7 +7,7 @@ import {MdIconRegistry} from '@angular2-material/icon';
   selector: 'grid-list-demo',
   templateUrl: 'grid-list-demo.html',
   styleUrls: ['grid-list-demo.css'],
-  providers: [MdIconRegistry]
+  providers: [MatIconRegistry]
 })
 export class GridListDemo {
   tiles: any[] = [

--- a/src/demo-app/icon/icon-demo.html
+++ b/src/demo-app/icon/icon-demo.html
@@ -5,29 +5,29 @@
 
   <p>
     From URL:
-    <md-icon svgSrc="/icon/assets/search-icon.svg"></md-icon>
+    <mat-icon svgSrc="/icon/assets/search-icon.svg"></mat-icon>
   </p>
 
   <p>
-    By name registered with MdIconProvider:
-    <md-icon svgIcon="thumb-up" class="green"></md-icon>
-    <md-icon svgIcon="thumb-up"></md-icon>
+    By name registered with MatIconProvider:
+    <mat-icon svgIcon="thumb-up" class="green"></mat-icon>
+    <mat-icon svgIcon="thumb-up"></mat-icon>
   </p>
 
   <p>
     From icon set:
-    <md-icon svgIcon="core:alarm"></md-icon>
-    <md-icon svgIcon="core:accessibility"></md-icon>
-    <md-icon svgIcon="core:alarm"></md-icon>
+    <mat-icon svgIcon="core:alarm"></mat-icon>
+    <mat-icon svgIcon="core:accessibility"></mat-icon>
+    <mat-icon svgIcon="core:alarm"></mat-icon>
   </p>
 
   <p>
     Ligature from Material Icons font:
-    <md-icon>home</md-icon>
+    <mat-icon>home</mat-icon>
   </p>
 
   <p>
     Custom icon font and CSS:
-    <md-icon fontSet="fontawesome" fontIcon="fa-birthday-cake"></md-icon>
+    <mat-icon fontSet="fontawesome" fontIcon="fa-birthday-cake"></mat-icon>
   </p>
 </div>

--- a/src/demo-app/icon/icon-demo.scss
+++ b/src/demo-app/icon/icon-demo.scss
@@ -1,7 +1,7 @@
-.demo-icon md-icon {
+.demo-icon mat-icon {
   color: purple;
 }
 
-.demo-icon md-icon.green {
+.demo-icon mat-icon.green {
   color: green;
 }

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -1,17 +1,17 @@
 import {Component, ViewEncapsulation} from '@angular/core';
-import {MdIconRegistry} from '@angular2-material/icon';
+import {MatIconRegistry} from '@angular2-material/icon';
 
 @Component({
   moduleId: module.id,
-  selector: 'md-icon-demo',
+  selector: 'mat-icon-demo',
   templateUrl: 'icon-demo.html',
   styleUrls: ['icon-demo.css'],
-  viewProviders: [MdIconRegistry],
+  viewProviders: [MatIconRegistry],
   encapsulation: ViewEncapsulation.None,
 })
 export class IconDemo {
-  constructor(mdIconRegistry: MdIconRegistry) {
-    mdIconRegistry
+  constructor(matIconRegistry: MatIconRegistry) {
+    matIconRegistry
         .addSvgIcon('thumb-up', '/icon/assets/thumbup-icon.svg')
         .addSvgIconSetInNamespace('core', '/icon/assets/core-icon-set.svg')
         .registerFontClassAlias('fontawesome', 'fa');

--- a/src/demo-app/index.html
+++ b/src/demo-app/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="@angular2-material/core/style/core.css" rel="stylesheet">
 
-  <!-- FontAwesome for md-icon demo. -->
+  <!-- FontAwesome for mat-icon demo. -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 </head>
 <body>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -1,140 +1,140 @@
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Basic</md-toolbar>
-  <md-card-content>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Basic</mat-toolbar>
+  <mat-card-content>
     <form>
-      <md-input class="demo-full-width" placeholder="Company (disabled)" disabled value="Google">
-      </md-input>
+      <mat-input class="demo-full-width" placeholder="Company (disabled)" disabled value="Google">
+      </mat-input>
 
       <table style="width: 100%" cellspacing="0"><tr>
-        <td><md-input placeholder="First name" style="width: 100%"></md-input></td>
-        <td><md-input placeholder="Long Last Name That Will Be Truncated" style="width: 100%"></md-input></td>
+        <td><mat-input placeholder="First name" style="width: 100%"></mat-input></td>
+        <td><mat-input placeholder="Long Last Name That Will Be Truncated" style="width: 100%"></mat-input></td>
       </tr></table>
       <p>
-        <md-input class="demo-full-width" placeholder="Address" value="1600 Amphitheatre Pkway"></md-input>
-        <md-input class="demo-full-width" placeholder="Address 2"></md-input>
+        <mat-input class="demo-full-width" placeholder="Address" value="1600 Amphitheatre Pkway"></mat-input>
+        <mat-input class="demo-full-width" placeholder="Address 2"></mat-input>
       </p>
       <table style="width: 100%" cellspacing="0"><tr>
-        <td><md-input class="demo-full-width" placeholder="City" value="Mountain View"></md-input></td>
-        <td><md-input class="demo-full-width" placeholder="State" maxLength="2" value="CA"></md-input></td>
-        <td><md-input #postalCode class="demo-full-width" maxLength="5"
+        <td><mat-input class="demo-full-width" placeholder="City" value="Mountain View"></mat-input></td>
+        <td><mat-input class="demo-full-width" placeholder="State" maxLength="2" value="CA"></mat-input></td>
+        <td><mat-input #postalCode class="demo-full-width" maxLength="5"
                       placeholder="Postal Code"
                       value="94043">
-          <md-hint align="end">{{postalCode.characterCount}} / 5</md-hint>
-        </md-input></td>
+          <mat-hint align="end">{{postalCode.characterCount}} / 5</mat-hint>
+        </mat-input></td>
       </tr></table>
     </form>
-  </md-card-content>
-</md-card>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Prefix + Suffix</md-toolbar>
-  <md-card-content>
-    <md-input placeholder="amount" align="end">
-      <span md-prefix>$&nbsp;</span>
-      <span md-suffix>.00</span>
-    </md-input>
-  </md-card-content>
-</md-card>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Prefix + Suffix</mat-toolbar>
+  <mat-card-content>
+    <mat-input placeholder="amount" align="end">
+      <span mat-prefix>$&nbsp;</span>
+      <span mat-suffix>.00</span>
+    </mat-input>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Divider Colors</md-toolbar>
-  <md-card-content>
-    <md-input dividerColor="primary" placeholder="Default Color" value="example"></md-input>
-    <md-input dividerColor="accent" placeholder="Accent Color" value="example"></md-input>
-    <md-input dividerColor="warn" placeholder="Warn Color" value="example"></md-input>
-  </md-card-content>
-</md-card>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Divider Colors</mat-toolbar>
+  <mat-card-content>
+    <mat-input dividerColor="primary" placeholder="Default Color" value="example"></mat-input>
+    <mat-input dividerColor="accent" placeholder="Accent Color" value="example"></mat-input>
+    <mat-input dividerColor="warn" placeholder="Warn Color" value="example"></mat-input>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card demo-basic">
-  <md-toolbar color="primary">Hints</md-toolbar>
-  <md-card-content>
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Hints</mat-toolbar>
+  <mat-card-content>
     <p>
-      <md-input placeholder="Character count (100 max)" maxLength="100" class="demo-full-width"
+      <mat-input placeholder="Character count (100 max)" maxLength="100" class="demo-full-width"
                 value="Hello world. How are you?"
                 #characterCountHintExample>
-        <md-hint align="end">{{characterCountHintExample.characterCount}} / 100</md-hint>
-      </md-input>
+        <mat-hint align="end">{{characterCountHintExample.characterCount}} / 100</mat-hint>
+      </mat-input>
     </p>
-  </md-card-content>
-</md-card>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card">
-  <md-card-title>
-    Hello <md-input [(ngModel)]="name" type="text" placeholder="First name"></md-input>,
+<mat-card class="demo-card">
+  <mat-card-title>
+    Hello <mat-input [(ngModel)]="name" type="text" placeholder="First name"></mat-input>,
     how are you?
-  </md-card-title>
-  <md-card-content>
+  </mat-card-title>
+  <mat-card-content>
     <p>
-      <md-input disabled placeholder="Disabled field" value="Value"></md-input>
-      <md-input required placeholder="Required field"></md-input>
+      <mat-input disabled placeholder="Disabled field" value="Value"></mat-input>
+      <mat-input required placeholder="Required field"></mat-input>
     </p>
     <p>
-      <md-input placeholder="100% width placeholder" style="width: 100%"></md-input>
+      <mat-input placeholder="100% width placeholder" style="width: 100%"></mat-input>
     </p>
     <p>
-      <md-input placeholder="Character count (100 max)" maxLength="100" style="width: 100%"
+      <mat-input placeholder="Character count (100 max)" maxLength="100" style="width: 100%"
                 #input>
-        <md-hint align="end">{{input.characterCount}} / 100</md-hint>
-      </md-input>
+        <mat-hint align="end">{{input.characterCount}} / 100</mat-hint>
+      </mat-input>
     </p>
     <p>
-      <md-input placeholder="Show Hint Label" style="width: 100%"
-                hintLabel="Hint label"></md-input>
-    </p>
-
-    <p>
-      <md-input>
-        <md-placeholder>
-          I <md-icon class="demo-icons">favorite</md-icon> <b>bold</b> placeholder
-        </md-placeholder>
-        <md-hint>
-          I also <md-icon class="demo-icons">home</md-icon> <i>italic</i> hint labels
-        </md-hint>
-      </md-input>
-    </p>
-    <p>
-      <md-input placeholder="Show Hint Label With Character Count" style="width: 100%"
-                hintLabel="Hint label" characterCounter></md-input>
-    </p>
-    <p>
-      <md-checkbox [(ngModel)]="dividerColor">Check to change the divider color:</md-checkbox>
-      <md-input [dividerColor]="dividerColor ? 'primary' : 'accent'"
-                [placeholder]="dividerColor ? 'Primary color' : 'Accent color'"></md-input>
-    </p>
-    <p>
-      <md-checkbox [(ngModel)]="requiredField"> Check to make required:</md-checkbox>
-      <md-input [required]="requiredField"
-                [placeholder]="requiredField ? 'Required field' : 'Not required field'"></md-input>
-    </p>
-    <p>
-      <md-checkbox [(ngModel)]="floatingLabel"> Check to make floating label:</md-checkbox>
-      <md-input [floatingPlaceholder]="floatingLabel"
-                [placeholder]="floatingLabel ? 'Floating label' : 'Not floating label'"></md-input>
+      <mat-input placeholder="Show Hint Label" style="width: 100%"
+                hintLabel="Hint label"></mat-input>
     </p>
 
     <p>
-      <md-input placeholder="Prefixed" value="example">
-        <div md-prefix>Example:&nbsp;</div>
-      </md-input>
-      <md-input placeholder="Suffixed" value="123" align="end">
-        <span md-suffix>.00 €</span>
-      </md-input>
+      <mat-input>
+        <mat-placeholder>
+          I <mat-icon class="demo-icons">favorite</mat-icon> <b>bold</b> placeholder
+        </mat-placeholder>
+        <mat-hint>
+          I also <mat-icon class="demo-icons">home</mat-icon> <i>italic</i> hint labels
+        </mat-hint>
+      </mat-input>
+    </p>
+    <p>
+      <mat-input placeholder="Show Hint Label With Character Count" style="width: 100%"
+                hintLabel="Hint label" characterCounter></mat-input>
+    </p>
+    <p>
+      <mat-checkbox [(ngModel)]="dividerColor">Check to change the divider color:</mat-checkbox>
+      <mat-input [dividerColor]="dividerColor ? 'primary' : 'accent'"
+                [placeholder]="dividerColor ? 'Primary color' : 'Accent color'"></mat-input>
+    </p>
+    <p>
+      <mat-checkbox [(ngModel)]="requiredField"> Check to make required:</mat-checkbox>
+      <mat-input [required]="requiredField"
+                [placeholder]="requiredField ? 'Required field' : 'Not required field'"></mat-input>
+    </p>
+    <p>
+      <mat-checkbox [(ngModel)]="floatingLabel"> Check to make floating label:</mat-checkbox>
+      <mat-input [floatingPlaceholder]="floatingLabel"
+                [placeholder]="floatingLabel ? 'Floating label' : 'Not floating label'"></mat-input>
+    </p>
+
+    <p>
+      <mat-input placeholder="Prefixed" value="example">
+        <div mat-prefix>Example:&nbsp;</div>
+      </mat-input>
+      <mat-input placeholder="Suffixed" value="123" align="end">
+        <span mat-suffix>.00 €</span>
+      </mat-input>
       <br/>
       Both:
-      <md-input #email placeholder="Email Address" value="angular-core" align="end">
-        <span md-prefix><md-icon [class.primary]="email.focused" class="demo-icons demo-transform">email</md-icon>&nbsp;</span>
-        <span md-suffix class="demo-transform" [class.primary]="email.focused">&nbsp;@gmail.com</span>
-      </md-input>
+      <mat-input #email placeholder="Email Address" value="angular-core" align="end">
+        <span mat-prefix><mat-icon [class.primary]="email.focused" class="demo-icons demo-transform">email</mat-icon>&nbsp;</span>
+        <span mat-suffix class="demo-transform" [class.primary]="email.focused">&nbsp;@gmail.com</span>
+      </mat-input>
     </p>
 
     <p>
-      Empty: <md-input></md-input>
-      <label>Label: <md-input></md-input></label>
+      Empty: <mat-input></mat-input>
+      <label>Label: <mat-input></mat-input></label>
     </p>
-  </md-card-content>
-</md-card>
+  </mat-card-content>
+</mat-card>
 
-<md-card class="demo-card">
+<mat-card class="demo-card">
   <table width="100%">
     <thead>
       <td>Table</td>
@@ -148,7 +148,7 @@
     <tr *ngFor="let item of items; let i = index">
       <td>{{i+1}}</td>
       <td>
-        <md-input type="number" placeholder="value" aria-label="hello" [(ngModel)]="items[i].value"></md-input>
+        <mat-input type="number" placeholder="value" aria-label="hello" [(ngModel)]="items[i].value"></mat-input>
       </td>
       <td>
         <input type="number" [(ngModel)]="items[i].value">
@@ -156,4 +156,4 @@
       <td>{{item.value}}</td>
     </tr>
   </table>
-</md-card>
+</mat-card>

--- a/src/demo-app/input/input-demo.scss
+++ b/src/demo-app/input/input-demo.scss
@@ -1,7 +1,7 @@
 .demo-basic {
   padding: 0;
 }
-.demo-basic md-card-content {
+.demo-basic mat-card-content {
   padding: 16px;
 }
 .demo-full-width {

--- a/src/demo-app/list/list-demo.html
+++ b/src/demo-app/list/list-demo.html
@@ -1,104 +1,104 @@
 
-<h1>md-list demo</h1>
+<h1>mat-list demo</h1>
 
-<button md-raised-button (click)="thirdLine=!thirdLine" class="demo-button">Show third line</button>
+<button mat-raised-button (click)="thirdLine=!thirdLine" class="demo-button">Show third line</button>
 
 <div class="demo">
   <div>
     <h2>Normal lists</h2>
 
-    <md-list>
-      <h3 md-subheader>Items</h3>
-      <md-list-item *ngFor="let item of items">
+    <mat-list>
+      <h3 mat-subheader>Items</h3>
+      <mat-list-item *ngFor="let item of items">
         {{item}}
-      </md-list-item>
-    </md-list>
+      </mat-list-item>
+    </mat-list>
 
-    <md-list>
-      <md-list-item *ngFor="let contact of contacts">
-        <h3 md-line>{{contact.name}}</h3>
-        <p md-line *ngIf="thirdLine">extra line</p>
-        <p md-line class="demo-secondary-text">{{contact.headline}}</p>
-      </md-list-item>
-    </md-list>
+    <mat-list>
+      <mat-list-item *ngFor="let contact of contacts">
+        <h3 mat-line>{{contact.name}}</h3>
+        <p mat-line *ngIf="thirdLine">extra line</p>
+        <p mat-line class="demo-secondary-text">{{contact.headline}}</p>
+      </mat-list-item>
+    </mat-list>
 
-    <md-list>
-      <h3 md-subheader>Today</h3>
-      <md-list-item *ngFor="let message of messages">
-        <img md-list-avatar [src]="message.image" alt="Image of {{message.from}}">
-        <h4 md-line>{{message.from}}</h4>
-        <p md-line>
+    <mat-list>
+      <h3 mat-subheader>Today</h3>
+      <mat-list-item *ngFor="let message of messages">
+        <img mat-list-avatar [src]="message.image" alt="Image of {{message.from}}">
+        <h4 mat-line>{{message.from}}</h4>
+        <p mat-line>
           <span>{{message.subject}} -- </span>
           <span class="demo-secondary-text">{{message.message}}</span>
         </p>
-      </md-list-item>
-      <md-divider></md-divider>
-      <md-list-item *ngFor="let message of messages">
-        <h4 md-line>{{message.from}}</h4>
-        <p md-line> {{message.subject}} </p>
-        <p md-line class="demo-secondary-text">{{message.message}} </p>
-      </md-list-item>
-    </md-list>
+      </mat-list-item>
+      <mat-divider></mat-divider>
+      <mat-list-item *ngFor="let message of messages">
+        <h4 mat-line>{{message.from}}</h4>
+        <p mat-line> {{message.subject}} </p>
+        <p mat-line class="demo-secondary-text">{{message.message}} </p>
+      </mat-list-item>
+    </mat-list>
   </div>
 
   <div>
     <h2>Dense lists</h2>
-    <md-list dense>
-      <h3 md-subheader>Items</h3>
-      <md-list-item *ngFor="let item of items">
+    <mat-list dense>
+      <h3 mat-subheader>Items</h3>
+      <mat-list-item *ngFor="let item of items">
         {{item}}
-      </md-list-item>
-    </md-list>
+      </mat-list-item>
+    </mat-list>
 
-    <md-list dense>
-      <md-list-item *ngFor="let contact of contacts">
-        <h3 md-line>{{contact.name}}</h3>
-        <p md-line class="demo-secondary-text">{{contact.headline}}</p>
-      </md-list-item>
-    </md-list>
+    <mat-list dense>
+      <mat-list-item *ngFor="let contact of contacts">
+        <h3 mat-line>{{contact.name}}</h3>
+        <p mat-line class="demo-secondary-text">{{contact.headline}}</p>
+      </mat-list-item>
+    </mat-list>
 
-    <md-list dense>
-      <h3 md-subheader>Today</h3>
-      <md-list-item *ngFor="let message of messages">
-        <img md-list-avatar [src]="message.image" alt="Image of {{message.from}}">
-        <h4 md-line>{{message.from}}</h4>
-        <p md-line> {{message.subject}} </p>
-        <p md-line class="demo-secondary-text">{{message.message}} </p>
-      </md-list-item>
-    </md-list>
+    <mat-list dense>
+      <h3 mat-subheader>Today</h3>
+      <mat-list-item *ngFor="let message of messages">
+        <img mat-list-avatar [src]="message.image" alt="Image of {{message.from}}">
+        <h4 mat-line>{{message.from}}</h4>
+        <p mat-line> {{message.subject}} </p>
+        <p mat-line class="demo-secondary-text">{{message.message}} </p>
+      </mat-list-item>
+    </mat-list>
   </div>
   <div>
     <h2>Nav lists</h2>
-    <md-nav-list>
-      <a md-list-item *ngFor="let link of links" href="http://www.google.com">
+    <mat-nav-list>
+      <a mat-list-item *ngFor="let link of links" href="http://www.google.com">
         {{ link.name }}
       </a>
-    </md-nav-list>
+    </mat-nav-list>
     <div *ngIf="infoClicked">
       More info!
     </div>
-    <md-nav-list>
-      <md-list-item *ngFor="let link of links">
-        <a md-line href="http://www.google.com">{{ link.name }}</a>
-        <button md-icon-button (click)="infoClicked=!infoClicked">
-          <md-icon>info</md-icon>
+    <mat-nav-list>
+      <mat-list-item *ngFor="let link of links">
+        <a mat-line href="http://www.google.com">{{ link.name }}</a>
+        <button mat-icon-button (click)="infoClicked=!infoClicked">
+          <mat-icon>info</mat-icon>
         </button>
-      </md-list-item>
-    </md-nav-list>
-    <md-nav-list>
-      <a md-list-item *ngFor="let link of links" href="http://www.google.com">
-        <md-icon md-list-icon>folder</md-icon>
-        <span md-line>{{ link.name }}</span>
-        <span md-line class="demo-secondary-text"> Description </span>
+      </mat-list-item>
+    </mat-nav-list>
+    <mat-nav-list>
+      <a mat-list-item *ngFor="let link of links" href="http://www.google.com">
+        <mat-icon mat-list-icon>folder</mat-icon>
+        <span mat-line>{{ link.name }}</span>
+        <span mat-line class="demo-secondary-text"> Description </span>
       </a>
-    </md-nav-list>
-    <md-nav-list dense>
-      <md-list-item *ngFor="let link of links">
-        <a md-line href="http://www.google.com">{{ link.name }}</a>
-        <button md-icon-button (click)="infoClicked=!infoClicked">
-          <md-icon class="material-icons">info</md-icon>
+    </mat-nav-list>
+    <mat-nav-list dense>
+      <mat-list-item *ngFor="let link of links">
+        <a mat-line href="http://www.google.com">{{ link.name }}</a>
+        <button mat-icon-button (click)="infoClicked=!infoClicked">
+          <mat-icon class="material-icons">info</mat-icon>
         </button>
-      </md-list-item>
-    </md-nav-list>
+      </mat-list-item>
+    </mat-nav-list>
   </div>
 </div>

--- a/src/demo-app/list/list-demo.scss
+++ b/src/demo-app/list/list-demo.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-flow: row wrap;
 
-  md-list, md-nav-list {
+  mat-list, mat-nav-list {
     border: 1px solid rgba(0, 0, 0, 0.12);
     width: 350px;
     margin: 20px 20px 0 0;
@@ -13,11 +13,11 @@
     margin-top: 20px;
   }
 
-  md-icon {
+  mat-icon {
     color: rgba(0, 0, 0, 0.12);
   }
 
-  [md-list-icon] {
+  [mat-list-icon] {
     color: white;
     background: rgba(0, 0, 0, 0.3);
   }

--- a/src/demo-app/live-announcer/live-announcer-demo.html
+++ b/src/demo-app/live-announcer/live-announcer-demo.html
@@ -1,5 +1,5 @@
 <div class="demo-live-announcer">
 
-  <button md-button (click)="announceText('Hey Google')">Announce Text</button>
+  <button mat-button (click)="announceText('Hey Google')">Announce Text</button>
 
 </div>

--- a/src/demo-app/live-announcer/live-announcer-demo.ts
+++ b/src/demo-app/live-announcer/live-announcer-demo.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MdLiveAnnouncer} from '@angular2-material/core';
+import {MatLiveAnnouncer} from '@angular2-material/core';
 
 @Component({
   moduleId: module.id,
@@ -8,7 +8,7 @@ import {MdLiveAnnouncer} from '@angular2-material/core';
 })
 export class LiveAnnouncerDemo {
 
-  constructor(private live: MdLiveAnnouncer) {}
+  constructor(private live: MatLiveAnnouncer) {}
 
   announceText(message: string) {
     this.live.announce(message);

--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -2,62 +2,62 @@
   <div class="menu-section">
     <p>You clicked on: {{ selected }}</p>
 
-    <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="menu">
-        <md-icon>more_vert</md-icon>
+    <mat-toolbar>
+      <button mat-icon-button [mat-menu-trigger-for]="menu">
+        <mat-icon>more_vert</mat-icon>
       </button>
-    </md-toolbar>
+    </mat-toolbar>
 
-    <md-menu #menu="mdMenu">
-      <button md-menu-item *ngFor="let item of items" (click)="select(item.text)" [disabled]="item.disabled">
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item *ngFor="let item of items" (click)="select(item.text)" [disabled]="item.disabled">
         {{ item.text }}
       </button>
-    </md-menu>
+    </mat-menu>
   </div>
   <div class="menu-section">
     <p> Clicking these will navigate:</p>
-    <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="anchorMenu">
-        <md-icon>more_vert</md-icon>
+    <mat-toolbar>
+      <button mat-icon-button [mat-menu-trigger-for]="anchorMenu">
+        <mat-icon>more_vert</mat-icon>
       </button>
-    </md-toolbar>
+    </mat-toolbar>
 
-    <md-menu #anchorMenu="mdMenu">
-      <a md-menu-item *ngFor="let item of items" href="http://www.google.com" [disabled]="item.disabled">
+    <mat-menu #anchorMenu="matMenu">
+      <a mat-menu-item *ngFor="let item of items" href="http://www.google.com" [disabled]="item.disabled">
         {{ item.text }}
       </a>
-    </md-menu>
+    </mat-menu>
   </div>
   <div class="menu-section">
     <p>
       Position x: before
     </p>
-    <md-toolbar class="end-icon">
-      <button md-icon-button [md-menu-trigger-for]="posXMenu">
-        <md-icon>more_vert</md-icon>
+    <mat-toolbar class="end-icon">
+      <button mat-icon-button [mat-menu-trigger-for]="posXMenu">
+        <mat-icon>more_vert</mat-icon>
       </button>
-    </md-toolbar>
+    </mat-toolbar>
 
-    <md-menu x-position="before" #posXMenu="mdMenu" class="before">
-      <button md-menu-item *ngFor="let item of items" [disabled]="item.disabled">
+    <mat-menu x-position="before" #posXMenu="matMenu" class="before">
+      <button mat-menu-item *ngFor="let item of items" [disabled]="item.disabled">
         {{ item.text }}
       </button>
-    </md-menu>
+    </mat-menu>
   </div>
   <div class="menu-section">
     <p>
       Position y: above
     </p>
-    <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="posYMenu">
-        <md-icon>more_vert</md-icon>
+    <mat-toolbar>
+      <button mat-icon-button [mat-menu-trigger-for]="posYMenu">
+        <mat-icon>more_vert</mat-icon>
       </button>
-    </md-toolbar>
+    </mat-toolbar>
 
-    <md-menu y-position="above" #posYMenu="mdMenu">
-      <button md-menu-item *ngFor="let item of items" [disabled]="item.disabled">
+    <mat-menu y-position="above" #posYMenu="matMenu">
+      <button mat-menu-item *ngFor="let item of items" [disabled]="item.disabled">
         {{ item.text }}
       </button>
-    </md-menu>
+    </mat-menu>
   </div>
 </div>

--- a/src/demo-app/progress-bar/progress-bar-demo.html
+++ b/src/demo-app/progress-bar/progress-bar-demo.html
@@ -1,37 +1,37 @@
 <h1>Determinate</h1>
 <div class="demo-progress-bar-container">
-  <md-progress-bar mode="determinate"
+  <mat-progress-bar mode="determinate"
                    [value]="determinateProgressValue"
                    color="primary"
-                   class="demo-progress-bar-margins"></md-progress-bar>
+                   class="demo-progress-bar-margins"></mat-progress-bar>
 </div>
 <span>Value: {{determinateProgressValue}}</span>
-<button md-raised-button (click)="stepDeterminateProgressVal(10)">Increase</button>
-<button md-raised-button (click)="stepDeterminateProgressVal(-10)">Decrease</button>
+<button mat-raised-button (click)="stepDeterminateProgressVal(10)">Increase</button>
+<button mat-raised-button (click)="stepDeterminateProgressVal(-10)">Decrease</button>
 <h1>Buffer</h1>
 <div class="demo-progress-bar-container">
-  <md-progress-bar [value]="bufferProgressValue"
+  <mat-progress-bar [value]="bufferProgressValue"
                    [bufferValue]="bufferBufferValue"
                    mode="buffer"
                    color="warn"
-                   class="demo-progress-bar-margins"></md-progress-bar>
+                   class="demo-progress-bar-margins"></mat-progress-bar>
 </div>
 <span>Value: {{bufferProgressValue}}</span>
-<button md-raised-button (click)="stepBufferProgressVal(10)">Increase</button>
-<button md-raised-button (click)="stepBufferProgressVal(-10)">Decrease</button>
+<button mat-raised-button (click)="stepBufferProgressVal(10)">Increase</button>
+<button mat-raised-button (click)="stepBufferProgressVal(-10)">Decrease</button>
 <span class="demo-progress-bar-spacer"></span>
 <span>Buffer Value: {{bufferBufferValue}}</span>
-<button md-raised-button (click)="stepBufferBufferVal(10)">Increase</button>
-<button md-raised-button (click)="stepBufferBufferVal(-10)">Decrease</button>
+<button mat-raised-button (click)="stepBufferBufferVal(10)">Increase</button>
+<button mat-raised-button (click)="stepBufferBufferVal(-10)">Decrease</button>
 
 <h1>Indeterminate</h1>
 <div class="demo-progress-bar-container">
-  <md-progress-bar mode="indeterminate"
-                   class="demo-progress-bar-margins"></md-progress-bar>
+  <mat-progress-bar mode="indeterminate"
+                   class="demo-progress-bar-margins"></mat-progress-bar>
 </div>
 
 <h1>Query</h1>
 <div class="demo-progress-bar-container">
-  <md-progress-bar mode="query"
-                   class="demo-progress-bar-margins"></md-progress-bar>
+  <mat-progress-bar mode="query"
+                   class="demo-progress-bar-margins"></mat-progress-bar>
 </div>

--- a/src/demo-app/progress-circle/progress-circle-demo.html
+++ b/src/demo-app/progress-circle/progress-circle-demo.html
@@ -1,21 +1,21 @@
 <h1>Determinate</h1>
 <div class="demo-progress-circle">
-  <md-progress-circle mode="determinate"
+  <mat-progress-circle mode="determinate"
                       [value]="progressValue"
-                      class="md-primary"></md-progress-circle>
-  <md-progress-circle [value]="progressValue"
-                      color="accent"></md-progress-circle>
+                      class="mat-primary"></mat-progress-circle>
+  <mat-progress-circle [value]="progressValue"
+                      color="accent"></mat-progress-circle>
 </div>
 <span>Value: {{progressValue}}</span>
-<button md-raised-button (click)="step(10)">Increase</button>
-<button md-raised-button (click)="step(-10)">Decrease</button>
+<button mat-raised-button (click)="step(10)">Increase</button>
+<button mat-raised-button (click)="step(-10)">Decrease</button>
 
 
 
 <h1>Indeterminate</h1>
 <div class="demo-progress-circle">
-  <md-progress-circle mode="indeterminate"></md-progress-circle>
-  <md-progress-circle mode="indeterminate"
-                      color="accent"></md-progress-circle>
-  <md-spinner></md-spinner>
+  <mat-progress-circle mode="indeterminate"></mat-progress-circle>
+  <mat-progress-circle mode="indeterminate"
+                      color="accent"></mat-progress-circle>
+  <mat-spinner></mat-spinner>
 </div>

--- a/src/demo-app/progress-circle/progress-circle-demo.scss
+++ b/src/demo-app/progress-circle/progress-circle-demo.scss
@@ -1,8 +1,8 @@
 .demo-progress-circle {
   width: 100%;
 
-  md-progress-circle,
-  md-spinner {
+  mat-progress-circle,
+  mat-spinner {
     display: inline-block;
   }
 

--- a/src/demo-app/radio/radio-demo.html
+++ b/src/demo-app/radio/radio-demo.html
@@ -1,33 +1,33 @@
 <h1>Basic Example</h1>
 <section class="demo-section">
-  <md-radio-button name="group1">Option 1</md-radio-button>
-  <md-radio-button name="group1">Option 2</md-radio-button>
-  <md-radio-button name="group1" disabled="true">Option 3 (disabled)</md-radio-button>
+  <mat-radio-button name="group1">Option 1</mat-radio-button>
+  <mat-radio-button name="group1">Option 2</mat-radio-button>
+  <mat-radio-button name="group1" disabled="true">Option 3 (disabled)</mat-radio-button>
 </section>
 <h1>Dynamic Example</h1>
 <section class="demo-section">
   <div>
     <span>isDisabled: {{isDisabled}}</span>
-    <button md-raised-button (click)="isDisabled=!isDisabled" class="demo-button">
+    <button mat-raised-button (click)="isDisabled=!isDisabled" class="demo-button">
       Disable buttons
     </button>
   </div>
   <div>
-    <span><md-checkbox [(ngModel)]="isAlignEnd">Align end</md-checkbox></span>
+    <span><mat-checkbox [(ngModel)]="isAlignEnd">Align end</mat-checkbox></span>
   </div>
-  <md-radio-group name="my_options" [disabled]="isDisabled" [align]="isAlignEnd ? 'end' : 'start'">
-    <md-radio-button value="option_1">Option 1</md-radio-button>
-    <md-radio-button value="option_2">Option 2</md-radio-button>
-    <md-radio-button value="option_3">Option 3</md-radio-button>
-  </md-radio-group>
+  <mat-radio-group name="my_options" [disabled]="isDisabled" [align]="isAlignEnd ? 'end' : 'start'">
+    <mat-radio-button value="option_1">Option 1</mat-radio-button>
+    <mat-radio-button value="option_2">Option 2</mat-radio-button>
+    <mat-radio-button value="option_3">Option 3</mat-radio-button>
+  </mat-radio-group>
 </section>
 <h1>Favorite Season Example</h1>
 <h2>Dynamic Example with two-way data-binding</h2>
 <section class="demo-section">
-  <md-radio-group name="more_options" [(ngModel)]="favoriteSeason">
-    <md-radio-button *ngFor="let season of seasonOptions" name="more_options" [value]="season">
+  <mat-radio-group name="more_options" [(ngModel)]="favoriteSeason">
+    <mat-radio-button *ngFor="let season of seasonOptions" name="more_options" [value]="season">
       {{season}}
-    </md-radio-button>
-  </md-radio-group>
+    </mat-radio-button>
+  </mat-radio-group>
   <p>Your favorite season is: {{favoriteSeason}}</p>
 </section>

--- a/src/demo-app/radio/radio-demo.scss
+++ b/src/demo-app/radio/radio-demo.scss
@@ -8,7 +8,7 @@
   margin: 8px;
   padding: 16px;
 
-  md-radio-button {
+  mat-radio-button {
     margin: 8px;
   }
 }

--- a/src/demo-app/ripple/ripple-demo.html
+++ b/src/demo-app/ripple/ripple-demo.html
@@ -1,51 +1,51 @@
-<!-- Use <md-card>? -->
+<!-- Use <mat-card>? -->
 <div class="demo-ripple">
   <section>
-    <md-checkbox [(ngModel)]="disableButtonRipples">Disable button ripples</md-checkbox>
-    <button md-button [disableRipple]="disableButtonRipples">flat</button>
-    <button md-raised-button [disableRipple]="disableButtonRipples">raised</button>
-    <button md-fab [disableRipple]="disableButtonRipples">
-      <md-icon>check</md-icon>
+    <mat-checkbox [(ngModel)]="disableButtonRipples">Disable button ripples</mat-checkbox>
+    <button mat-button [disableRipple]="disableButtonRipples">flat</button>
+    <button mat-raised-button [disableRipple]="disableButtonRipples">raised</button>
+    <button mat-fab [disableRipple]="disableButtonRipples">
+      <mat-icon>check</mat-icon>
     </button>
-    <button md-mini-fab [disableRipple]="disableButtonRipples">
-      <md-icon>check</md-icon>
+    <button mat-mini-fab [disableRipple]="disableButtonRipples">
+      <mat-icon>check</mat-icon>
     </button>
   </section>
 
   <section>
-    <div class="demo-ripple-checkbox-option"><md-checkbox [(ngModel)]="centered">Centered</md-checkbox></div>
-    <div class="demo-ripple-checkbox-option"><md-checkbox [(ngModel)]="unbounded">Unbounded</md-checkbox></div>
-    <div class="demo-ripple-checkbox-option"><md-checkbox [(ngModel)]="disabled">Disabled</md-checkbox></div>
-    <div class="demo-ripple-checkbox-option"><md-checkbox [(ngModel)]="rounded">Rounded container (flaky in Firefox)</md-checkbox></div>
+    <div class="demo-ripple-checkbox-option"><mat-checkbox [(ngModel)]="centered">Centered</mat-checkbox></div>
+    <div class="demo-ripple-checkbox-option"><mat-checkbox [(ngModel)]="unbounded">Unbounded</mat-checkbox></div>
+    <div class="demo-ripple-checkbox-option"><mat-checkbox [(ngModel)]="disabled">Disabled</mat-checkbox></div>
+    <div class="demo-ripple-checkbox-option"><mat-checkbox [(ngModel)]="rounded">Rounded container (flaky in Firefox)</mat-checkbox></div>
   </section>
   <section>
     Speed
-    <md-radio-group [(ngModel)]="rippleSpeed">
-      <md-radio-button name="demo-ripple-options" value="0.1">Slow</md-radio-button>
-      <md-radio-button name="demo-ripple-options" value="1">Normal</md-radio-button>
-      <md-radio-button name="demo-ripple-options" value="4">Fast</md-radio-button>
-    </md-radio-group>
+    <mat-radio-group [(ngModel)]="rippleSpeed">
+      <mat-radio-button name="demo-ripple-options" value="0.1">Slow</mat-radio-button>
+      <mat-radio-button name="demo-ripple-options" value="1">Normal</mat-radio-button>
+      <mat-radio-button name="demo-ripple-options" value="4">Fast</mat-radio-button>
+    </mat-radio-group>
   </section>
   <section>
-    <md-input placeholder="Max radius" aria-label="radius" [(ngModel)]="maxRadius"></md-input>
-    <md-input placeholder="Ripple color" aria-label="color" [(ngModel)]="rippleColor"></md-input>
-    <md-input placeholder="Ripple background" aria-label="background" [(ngModel)]="rippleBackgroundColor"></md-input>
+    <mat-input placeholder="Max radius" aria-label="radius" [(ngModel)]="maxRadius"></mat-input>
+    <mat-input placeholder="Ripple color" aria-label="color" [(ngModel)]="rippleColor"></mat-input>
+    <mat-input placeholder="Ripple background" aria-label="background" [(ngModel)]="rippleBackgroundColor"></mat-input>
   </section>
   <section>
-    <button md-raised-button (click)="doManualRipple()">Manual ripple</button>
+    <button mat-raised-button (click)="doManualRipple()">Manual ripple</button>
   </section>
   <section>
     <div class="demo-ripple-container"
         [class.demo-ripple-disabled]="disabled"
         [class.demo-ripple-rounded]="rounded"
-        md-ripple
-        [md-ripple-centered]="centered"
-        [md-ripple-disabled]="disabled"
-        [md-ripple-unbounded]="unbounded"
-        [md-ripple-max-radius]="maxRadius"
-        [md-ripple-color]="rippleColor"
-        [md-ripple-background-color]="rippleBackgroundColor"
-        [md-ripple-speed-factor]="rippleSpeed">
+        mat-ripple
+        [mat-ripple-centered]="centered"
+        [mat-ripple-disabled]="disabled"
+        [mat-ripple-unbounded]="unbounded"
+        [mat-ripple-max-radius]="maxRadius"
+        [mat-ripple-color]="rippleColor"
+        [mat-ripple-background-color]="rippleBackgroundColor"
+        [mat-ripple-speed-factor]="rippleSpeed">
       Click me
     </div>
   </section>

--- a/src/demo-app/ripple/ripple-demo.ts
+++ b/src/demo-app/ripple/ripple-demo.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {MdRipple} from '@angular2-material/core';
+import {MatRipple} from '@angular2-material/core';
 
 
 @Component({
@@ -9,7 +9,7 @@ import {MdRipple} from '@angular2-material/core';
   styleUrls: ['ripple-demo.css'],
 })
 export class RippleDemo {
-  @ViewChild(MdRipple) manualRipple: MdRipple;
+  @ViewChild(MatRipple) manualRipple: MatRipple;
 
   centered = false;
   disabled = false;

--- a/src/demo-app/sidenav/sidenav-demo.html
+++ b/src/demo-app/sidenav/sidenav-demo.html
@@ -1,37 +1,37 @@
-<md-sidenav-layout class="demo-sidenav-layout">
-  <md-sidenav #start (open)="myinput.focus()" mode="side">
+<mat-sidenav-layout class="demo-sidenav-layout">
+  <mat-sidenav #start (open)="myinput.focus()" mode="side">
     Start Side Drawer
     <br>
-    <button md-button (click)="start.close()">Close</button>
+    <button mat-button (click)="start.close()">Close</button>
     <br>
-    <button md-button (click)="end.open()">Open End Side</button>
+    <button mat-button (click)="end.open()">Open End Side</button>
     <br>
-    <button md-button
+    <button mat-button
             (click)="start.mode = (start.mode == 'push' ? 'over' : (start.mode == 'over' ? 'side' : 'push'))">Toggle Mode</button>
     <div>Mode: {{start.mode}}</div>
     <br>
     <input #myinput>
-  </md-sidenav>
+  </mat-sidenav>
 
-  <md-sidenav #end align="end">
+  <mat-sidenav #end align="end">
     End Side Drawer
     <br>
-    <button md-button (click)="end.close()">Close</button>
-  </md-sidenav>
+    <button mat-button (click)="end.close()">Close</button>
+  </mat-sidenav>
 
   <div class="demo-sidenav-content">
     <h1>My Content</h1>
 
     <div>
       <header>Sidenav</header>
-      <button md-button (click)="start.toggle()">Toggle Start Side Drawer</button>
-      <button md-button (click)="end.toggle()">Toggle End Side Drawer</button>
+      <button mat-button (click)="start.toggle()">Toggle Start Side Drawer</button>
+      <button mat-button (click)="end.toggle()">Toggle End Side Drawer</button>
     </div>
 
-    <button md-button>HELLO</button>
-    <button md-raised-button class="md-primary">HELLO</button>
-    <button md-fab class="md-accent">HI</button>
+    <button mat-button>HELLO</button>
+    <button mat-raised-button class="mat-primary">HELLO</button>
+    <button mat-fab class="mat-accent">HI</button>
   </div>
-</md-sidenav-layout>
+</mat-sidenav-layout>
 
 <h2>Content after Sidenav</h2>

--- a/src/demo-app/sidenav/sidenav-demo.scss
+++ b/src/demo-app/sidenav/sidenav-demo.scss
@@ -1,7 +1,7 @@
 .demo-sidenav-layout {
   border: 3px solid black;
 
-  md-sidenav {
+  mat-sidenav {
     padding: 10px;
   }
 }

--- a/src/demo-app/slide-toggle/slide-toggle-demo.html
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.html
@@ -1,14 +1,14 @@
 <div>
 
-  <md-slide-toggle color="primary" [(ngModel)]="firstToggle">
+  <mat-slide-toggle color="primary" [(ngModel)]="firstToggle">
     Default Slide Toggle
-  </md-slide-toggle>
+  </mat-slide-toggle>
 
-  <md-slide-toggle [(ngModel)]="firstToggle" disabled>
+  <mat-slide-toggle [(ngModel)]="firstToggle" disabled>
     Disabled Slide Toggle
-  </md-slide-toggle>
+  </mat-slide-toggle>
 
-  <md-slide-toggle [disabled]="firstToggle">
+  <mat-slide-toggle [disabled]="firstToggle">
     Disable Bound
-  </md-slide-toggle>
+  </mat-slide-toggle>
 </div>

--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -1,29 +1,29 @@
 <h1>Default Slider</h1>
-Label <md-slider #slidey></md-slider>
+Label <mat-slider #slidey></mat-slider>
 {{slidey.value}}
 
 <h1>Slider with Min and Max</h1>
-<md-slider min="5" max="7" #slider2></md-slider>
+<mat-slider min="5" max="7" #slider2></mat-slider>
 {{slider2.value}}
 
 <h1>Disabled Slider</h1>
-<md-slider disabled #slider3></md-slider>
+<mat-slider disabled #slider3></mat-slider>
 {{slider3.value}}
 
 <h1>Slider with set value</h1>
-<md-slider value="43"></md-slider>
+<mat-slider value="43"></mat-slider>
 
 <h1>Slider with step defined</h1>
-<md-slider min="1" max="100" step="20" #slider5></md-slider>
+<mat-slider min="1" max="100" step="20" #slider5></mat-slider>
 {{slider5.value}}
 
 <h1>Slider with set tick interval</h1>
-<md-slider tick-interval="auto"></md-slider>
-<md-slider tick-interval="9"></md-slider>
+<mat-slider tick-interval="auto"></mat-slider>
+<mat-slider tick-interval="9"></mat-slider>
 
 <h1>Slider with Thumb Label</h1>
-<md-slider thumb-label></md-slider>
+<mat-slider thumb-label></mat-slider>
 
 <h1>Slider with two-way binding</h1>
-<md-slider [(ngModel)]="demo" step="40"></md-slider>
+<mat-slider [(ngModel)]="demo" step="40"></mat-slider>
 <input [(ngModel)]="demo">

--- a/src/demo-app/tabs/tab-group-demo.html
+++ b/src/demo-app/tabs/tab-group-demo.html
@@ -1,29 +1,29 @@
 <h1>Tab Group Demo</h1>
 
-<md-tab-group class="demo-tab-group">
-  <md-tab *ngFor="let tab of tabs; let i = index" [disabled]="i == 1">
-    <template md-tab-label>{{tab.label}}</template>
-    <template md-tab-content>
+<mat-tab-group class="demo-tab-group">
+  <mat-tab *ngFor="let tab of tabs; let i = index" [disabled]="i == 1">
+    <template mat-tab-label>{{tab.label}}</template>
+    <template mat-tab-content>
       {{tab.content}}
       <br>
       <br>
       <br>
-      <md-input placeholder="Tab Label" [(ngModel)]="tab.label"></md-input>
+      <mat-input placeholder="Tab Label" [(ngModel)]="tab.label"></mat-input>
     </template>
-  </md-tab>
-</md-tab-group>
+  </mat-tab>
+</mat-tab-group>
 
 <h1>Async Tabs</h1>
 
-<md-tab-group class="demo-tab-group">
-  <md-tab *ngFor="let tab of asyncTabs | async; let i = index" [disabled]="i == 1">
-    <template md-tab-label>{{tab.label}}</template>
-    <template md-tab-content>
+<mat-tab-group class="demo-tab-group">
+  <mat-tab *ngFor="let tab of asyncTabs | async; let i = index" [disabled]="i == 1">
+    <template mat-tab-label>{{tab.label}}</template>
+    <template mat-tab-content>
       {{tab.content}}
       <br>
       <br>
       <br>
-      <md-input placeholder="Tab Label" [(ngModel)]="tab.label"></md-input>
+      <mat-input placeholder="Tab Label" [(ngModel)]="tab.label"></mat-input>
     </template>
-  </md-tab>
-</md-tab-group>
+  </mat-tab>
+</mat-tab-group>

--- a/src/demo-app/tabs/tab-group-demo.scss
+++ b/src/demo-app/tabs/tab-group-demo.scss
@@ -1,9 +1,9 @@
 .demo-tab-group {
   border: 1px solid #e0e0e0;
-  .md-tab-header {
+  .mat-tab-header {
     background: #f9f9f9;
   }
-  .md-tab-body {
+  .mat-tab-body {
     padding: 12px;
   }
 }

--- a/src/demo-app/toolbar/toolbar-demo.html
+++ b/src/demo-app/toolbar/toolbar-demo.html
@@ -1,68 +1,68 @@
 <div class="demo-toolbar">
 
   <p>
-    <md-toolbar>
-      <md-icon class="demo-toolbar-icon">menu</md-icon>
+    <mat-toolbar>
+      <mat-icon class="demo-toolbar-icon">menu</mat-icon>
       <span>Default Toolbar</span>
 
       <span class="demo-fill-remaining"></span>
 
-      <md-icon>code</md-icon>
-    </md-toolbar>
+      <mat-icon>code</mat-icon>
+    </mat-toolbar>
   </p>
 
   <p>
-    <md-toolbar color="primary">
-      <md-icon class="demo-toolbar-icon">menu</md-icon>
+    <mat-toolbar color="primary">
+      <mat-icon class="demo-toolbar-icon">menu</mat-icon>
       <span>Primary Toolbar</span>
 
       <span class="demo-fill-remaining"></span>
 
-      <md-icon>code</md-icon>
-    </md-toolbar>
+      <mat-icon>code</mat-icon>
+    </mat-toolbar>
   </p>
 
   <p>
-    <md-toolbar color="accent">
-      <md-icon class="demo-toolbar-icon">menu</md-icon>
+    <mat-toolbar color="accent">
+      <mat-icon class="demo-toolbar-icon">menu</mat-icon>
       <span>Accent Toolbar</span>
 
       <span class="demo-fill-remaining"></span>
 
-      <md-icon>code</md-icon>
-    </md-toolbar>
+      <mat-icon>code</mat-icon>
+    </mat-toolbar>
   </p>
 
   <p>
-    <md-toolbar color="accent">
+    <mat-toolbar color="accent">
       <span>Custom Toolbar</span>
-      <md-toolbar-row>
+      <mat-toolbar-row>
         <span>Second Line</span>
-      </md-toolbar-row>
-    </md-toolbar>
+      </mat-toolbar-row>
+    </mat-toolbar>
   </p>
 
   <p>
-    <md-toolbar color="primary">
+    <mat-toolbar color="primary">
       <span>Custom Toolbar</span>
 
-      <md-toolbar-row>
+      <mat-toolbar-row>
         <span>Second Line</span>
 
         <span class="demo-fill-remaining"></span>
 
-        <md-icon class="demo-toolbar-icon">verified_user</md-icon>
-      </md-toolbar-row>
+        <mat-icon class="demo-toolbar-icon">verified_user</mat-icon>
+      </mat-toolbar-row>
 
-      <md-toolbar-row>
+      <mat-toolbar-row>
         <span>Third Line</span>
 
         <span class="demo-fill-remaining"></span>
 
-        <md-icon class="demo-toolbar-icon">favorite</md-icon>
-        <md-icon class="demo-toolbar-icon">delete</md-icon>
-      </md-toolbar-row>
-    </md-toolbar>
+        <mat-icon class="demo-toolbar-icon">favorite</mat-icon>
+        <mat-icon class="demo-toolbar-icon">delete</mat-icon>
+      </mat-toolbar-row>
+    </mat-toolbar>
   </p>
 
 </div>

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -2,19 +2,19 @@
   <h1>Tooltip Demo</h1>
   <p class="centered">
     <button
-        md-raised-button
+        mat-raised-button
         color="primary"
-        md-tooltip="to see a tooltip"
+        mat-tooltip="to see a tooltip"
         [tooltip-position]="position">
       Mouse over this link
     </button>
   </p>
   <p>
-    <md-radio-group [(ngModel)]="position">
-      <md-radio-button value="below">Below</md-radio-button>
-      <md-radio-button value="above">Above</md-radio-button>
-      <md-radio-button value="before">Before</md-radio-button>
-      <md-radio-button value="after">After</md-radio-button>
-    </md-radio-group>
+    <mat-radio-group [(ngModel)]="position">
+      <mat-radio-button value="below">Below</mat-radio-button>
+      <mat-radio-button value="above">Above</mat-radio-button>
+      <mat-radio-button value="before">Before</mat-radio-button>
+      <mat-radio-button value="after">After</mat-radio-button>
+    </mat-radio-group>
   </p>
 </div>

--- a/src/demo-app/tooltip/tooltip-demo.scss
+++ b/src/demo-app/tooltip/tooltip-demo.scss
@@ -2,7 +2,7 @@
   .centered {
     text-align: center;
   }
-  md-radio-button {
+  mat-radio-button {
     display: block;
   }
 }

--- a/src/e2e-app/button/button-e2e.html
+++ b/src/e2e-app/button/button-e2e.html
@@ -5,32 +5,32 @@
       isDisabled: {{isDisabled}}, clickCounter:
       <span id="click-counter">{{clickCounter}}</span>
     </p>
-    <button md-raised-button (click)="isDisabled=!isDisabled" id="disable-toggle">
+    <button mat-raised-button (click)="isDisabled=!isDisabled" id="disable-toggle">
       Disable buttons
     </button>
   </div>
 
-  <button md-button [disabled]="isDisabled" (click)="clickCounter=clickCounter+1" id="test-button">
+  <button mat-button [disabled]="isDisabled" (click)="clickCounter=clickCounter+1" id="test-button">
     off
   </button>
 
-  <button md-button color="primary" [disabled]="isDisabled">
+  <button mat-button color="primary" [disabled]="isDisabled">
     off
   </button>
 
-  <a href="http://www.google.com" md-button color="accent" [disabled]="isDisabled">
+  <a href="http://www.google.com" mat-button color="accent" [disabled]="isDisabled">
     off
   </a>
 
-  <button md-raised-button color="primary" [disabled]="isDisabled">
+  <button mat-raised-button color="primary" [disabled]="isDisabled">
     off
   </button>
 
-  <button md-mini-fab [disabled]="isDisabled">
-    <md-icon class="md-24">check</md-icon>
+  <button mat-mini-fab [disabled]="isDisabled">
+    <mat-icon class="mat-24">check</mat-icon>
   </button>
 
-  <button md-icon-button color="accent" [disabled]="isDisabled">
-    <md-icon class="md-24">favorite</md-icon>
+  <button mat-icon-button color="accent" [disabled]="isDisabled">
+    <mat-icon class="mat-24">favorite</mat-icon>
   </button>
 </section>

--- a/src/e2e-app/button/button-e2e.html
+++ b/src/e2e-app/button/button-e2e.html
@@ -27,10 +27,10 @@
   </button>
 
   <button mat-mini-fab [disabled]="isDisabled">
-    <mat-icon class="mat-24">check</mat-icon>
+    <mat-icon class="md-24">check</mat-icon>
   </button>
 
   <button mat-icon-button color="accent" [disabled]="isDisabled">
-    <mat-icon class="mat-24">favorite</mat-icon>
+    <mat-icon class="md-24">favorite</mat-icon>
   </button>
 </section>

--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -1,6 +1,6 @@
-<a md-list-item [routerLink]="['button']">Button</a>
-<a md-list-item [routerLink]="['icon']">Icon</a>
-<a md-list-item [routerLink]="['menu']">Menu</a>
-<a md-list-item [routerLink]="['tabs']">Tabs</a>
+<a mat-list-item [routerLink]="['button']">Button</a>
+<a mat-list-item [routerLink]="['icon']">Icon</a>
+<a mat-list-item [routerLink]="['menu']">Menu</a>
+<a mat-list-item [routerLink]="['tabs']">Tabs</a>
 
 <router-outlet></router-outlet>

--- a/src/e2e-app/icon/icon-e2e.html
+++ b/src/e2e-app/icon/icon-e2e.html
@@ -1,3 +1,3 @@
 <section>
-  <mat-icon class="mat-24" id="test-icon">favorite</mat-icon>
+  <mat-icon class="md-24" id="test-icon">favorite</mat-icon>
 </section>

--- a/src/e2e-app/icon/icon-e2e.html
+++ b/src/e2e-app/icon/icon-e2e.html
@@ -1,3 +1,3 @@
 <section>
-  <md-icon class="md-24" id="test-icon">favorite</md-icon>
+  <mat-icon class="mat-24" id="test-icon">favorite</mat-icon>
 </section>

--- a/src/e2e-app/index.html
+++ b/src/e2e-app/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="@angular2-material/core/style/core.css" rel="stylesheet">
 
-  <!-- FontAwesome for md-icon demo. -->
+  <!-- FontAwesome for mat-icon demo. -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 </head>
 <body>

--- a/src/e2e-app/menu/menu-e2e.html
+++ b/src/e2e-app/menu/menu-e2e.html
@@ -2,35 +2,35 @@
   <div style="float:left">
     <div id="text">{{ selected }}</div>
     <button id="start">START</button>
-    <button [md-menu-trigger-for]="menu" id="trigger">TRIGGER</button>
-    <button [md-menu-trigger-for]="menu" id="trigger-two">TRIGGER 2</button>
+    <button [mat-menu-trigger-for]="menu" id="trigger">TRIGGER</button>
+    <button [mat-menu-trigger-for]="menu" id="trigger-two">TRIGGER 2</button>
 
-    <md-menu #menu="mdMenu" class="custom">
-      <button md-menu-item (click)="selected='one'">One</button>
-      <button md-menu-item (click)="selected='two'">Two</button>
-      <button md-menu-item (click)="selected='three'" disabled>Three</button>
-      <button md-menu-item>Four</button>
-    </md-menu>
+    <mat-menu #menu="matMenu" class="custom">
+      <button mat-menu-item (click)="selected='one'">One</button>
+      <button mat-menu-item (click)="selected='two'">Two</button>
+      <button mat-menu-item (click)="selected='three'" disabled>Three</button>
+      <button mat-menu-item>Four</button>
+    </mat-menu>
 
-    <button [md-menu-trigger-for]="beforeMenu" id="before-t">
+    <button [mat-menu-trigger-for]="beforeMenu" id="before-t">
       BEFORE
     </button>
-    <md-menu x-position="before" class="before" #beforeMenu="mdMenu">
-      <button md-menu-item>Item</button>
-    </md-menu>
+    <mat-menu x-position="before" class="before" #beforeMenu="matMenu">
+      <button mat-menu-item>Item</button>
+    </mat-menu>
 
     <div class="bottom-row">
-      <button [md-menu-trigger-for]="aboveMenu" id="above-t">ABOVE</button>
-      <md-menu y-position="above" class="above" #aboveMenu="mdMenu">
-        <button md-menu-item>Item</button>
-      </md-menu>
+      <button [mat-menu-trigger-for]="aboveMenu" id="above-t">ABOVE</button>
+      <mat-menu y-position="above" class="above" #aboveMenu="matMenu">
+        <button mat-menu-item>Item</button>
+      </mat-menu>
 
-      <button [md-menu-trigger-for]="combined" id="combined-t">
+      <button [mat-menu-trigger-for]="combined" id="combined-t">
         BOTH
       </button>
-      <md-menu x-position="before" y-position="above" class="combined" #combined="mdMenu">
-        <button md-menu-item>Item</button>
-      </md-menu>
+      <mat-menu x-position="before" y-position="above" class="combined" #combined="matMenu">
+        <button mat-menu-item>Item</button>
+      </mat-menu>
 
     </div>
   </div>

--- a/src/e2e-app/tabs/tabs-e2e.html
+++ b/src/e2e-app/tabs/tabs-e2e.html
@@ -1,16 +1,16 @@
 <section>
-  <md-tab-group>
-    <md-tab>
-      <template md-tab-label>One</template>
-      <template md-tab-content>First tab's content</template>
-    </md-tab>
-    <md-tab>
-      <template md-tab-label>Two</template>
-      <template md-tab-content>Second tab's content</template>
-    </md-tab>
-    <md-tab>
-      <template md-tab-label>Three</template>
-      <template md-tab-content>Third tab's content</template>
-    </md-tab>
-  </md-tab-group>
+  <mat-tab-group>
+    <mat-tab>
+      <template mat-tab-label>One</template>
+      <template mat-tab-content>First tab's content</template>
+    </mat-tab>
+    <mat-tab>
+      <template mat-tab-label>Two</template>
+      <template mat-tab-content>Second tab's content</template>
+    </mat-tab>
+    <mat-tab>
+      <template mat-tab-label>Three</template>
+      <template mat-tab-content>Third tab's content</template>
+    </mat-tab>
+  </mat-tab-group>
 </section>

--- a/src/lib/all/all.ts
+++ b/src/lib/all/all.ts
@@ -1,88 +1,76 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {MdButtonToggleModule} from '@angular2-material/button-toggle';
-import {MdButtonModule} from '@angular2-material/button';
-import {MdCheckboxModule} from '@angular2-material/checkbox';
-import {MdRadioModule} from '@angular2-material/radio';
-import {MdSlideToggleModule} from '@angular2-material/slide-toggle';
-import {MdSliderModule} from '@angular2-material/slider';
-import {MdSidenavModule} from '@angular2-material/sidenav';
-import {MdListModule} from '@angular2-material/list';
-import {MdGridListModule} from '@angular2-material/grid-list';
-import {MdCardModule} from '@angular2-material/card';
-import {MdIconModule} from '@angular2-material/icon';
-import {MdProgressCircleModule} from '@angular2-material/progress-circle';
-import {MdProgressBarModule} from '@angular2-material/progress-bar';
-import {MdInputModule} from '@angular2-material/input';
-import {MdTabsModule} from '@angular2-material/tabs';
-import {MdToolbarModule} from '@angular2-material/toolbar';
-import {MdTooltipModule} from '@angular2-material/tooltip';
-import {
-  MdLiveAnnouncer,
-  MdRippleModule,
-  RtlModule,
-  PortalModule,
-  OverlayModule
-} from '@angular2-material/core';
-import {MdMenuModule} from '@angular2-material/menu';
-import {MdDialogModule} from '@angular2-material/dialog';
+import {MatButtonToggleModule} from '@angular2-material/button-toggle';
+import {MatButtonModule} from '@angular2-material/button';
+import {MatCheckboxModule} from '@angular2-material/checkbox';
+import {MatRadioModule} from '@angular2-material/radio';
+import {MatSlideToggleModule} from '@angular2-material/slide-toggle';
+import {MatSliderModule} from '@angular2-material/slider';
+import {MatSidenavModule} from '@angular2-material/sidenav';
+import {MatListModule} from '@angular2-material/list';
+import {MatGridListModule} from '@angular2-material/grid-list';
+import {MatCardModule} from '@angular2-material/card';
+import {MatIconModule} from '@angular2-material/icon';
+import {MatProgressCircleModule} from '@angular2-material/progress-circle';
+import {MatProgressBarModule} from '@angular2-material/progress-bar';
+import {MatInputModule} from '@angular2-material/input';
+import {MatTabsModule} from '@angular2-material/tabs';
+import {MatToolbarModule} from '@angular2-material/toolbar';
+import {MatTooltipModule} from '@angular2-material/tooltip';
+import {MatCoreModule} from '@angular2-material/core';
+import {MatMenuModule} from '@angular2-material/menu';
+import {MatDialogModule} from '@angular2-material/dialog';
 
 
 const MATERIAL_MODULES = [
-  MdButtonModule,
-  MdButtonToggleModule,
-  MdCardModule,
-  MdCheckboxModule,
-  MdDialogModule,
-  MdGridListModule,
-  MdIconModule,
-  MdInputModule,
-  MdListModule,
-  MdMenuModule,
-  MdProgressBarModule,
-  MdProgressCircleModule,
-  MdRadioModule,
-  MdRippleModule,
-  MdSidenavModule,
-  MdSliderModule,
-  MdSlideToggleModule,
-  MdTabsModule,
-  MdToolbarModule,
-  MdTooltipModule,
-  OverlayModule,
-  PortalModule,
-  RtlModule,
+  MatButtonModule,
+  MatButtonToggleModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatCoreModule,
+  MatDialogModule,
+  MatGridListModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule,
+  MatMenuModule,
+  MatProgressBarModule,
+  MatProgressCircleModule,
+  MatRadioModule,
+  MatSidenavModule,
+  MatSliderModule,
+  MatSlideToggleModule,
+  MatTabsModule,
+  MatToolbarModule,
+  MatTooltipModule,
 ];
 
 @NgModule({
   imports: [
-    MdButtonModule.forRoot(),
-    MdCardModule.forRoot(),
-    MdCheckboxModule.forRoot(),
-    MdGridListModule.forRoot(),
-    MdInputModule.forRoot(),
-    MdListModule.forRoot(),
-    MdProgressBarModule.forRoot(),
-    MdProgressCircleModule.forRoot(),
-    MdRippleModule.forRoot(),
-    MdSidenavModule.forRoot(),
-    MdTabsModule.forRoot(),
-    MdToolbarModule.forRoot(),
-    PortalModule.forRoot(),
-    RtlModule.forRoot(),
+    MatButtonModule.forRoot(),
+    MatCardModule.forRoot(),
+    MatCheckboxModule.forRoot(),
+    MatCoreModule.forRoot(),
+    MatGridListModule.forRoot(),
+    MatInputModule.forRoot(),
+    MatListModule.forRoot(),
+    MatProgressBarModule.forRoot(),
+    MatProgressCircleModule.forRoot(),
+    MatSidenavModule.forRoot(),
+    MatTabsModule.forRoot(),
+    MatToolbarModule.forRoot(),
 
     // These modules include providers.
-    MdButtonToggleModule.forRoot(),
-    MdDialogModule.forRoot(),
-    MdIconModule.forRoot(),
-    MdMenuModule.forRoot(),
-    MdRadioModule.forRoot(),
-    MdSliderModule.forRoot(),
-    MdSlideToggleModule.forRoot(),
-    MdTooltipModule.forRoot(),
-    OverlayModule.forRoot(),
+    MatButtonToggleModule.forRoot(),
+    MatDialogModule.forRoot(),
+    MatIconModule.forRoot(),
+    MatMenuModule.forRoot(),
+    MatRadioModule.forRoot(),
+    MatSliderModule.forRoot(),
+    MatSlideToggleModule.forRoot(),
+    MatTooltipModule.forRoot(),
   ],
   exports: MATERIAL_MODULES,
-  providers: [MdLiveAnnouncer]
+  providers: []
 })
 export class MaterialRootModule { }
 

--- a/src/lib/button-toggle/button-toggle.html
+++ b/src/lib/button-toggle/button-toggle.html
@@ -1,5 +1,5 @@
-<label [attr.for]="inputId" class="md-button-toggle-label">
-  <input #input class="md-button-toggle-input"
+<label [attr.for]="inputId" class="mat-button-toggle-label">
+  <input #input class="mat-button-toggle-input"
          [type]="_type"
          [id]="inputId"
          [checked]="checked"
@@ -8,7 +8,7 @@
          (change)="_onInputChange($event)"
          (click)="_onInputClick($event)">
 
-  <div class="md-button-toggle-label-content">
+  <div class="mat-button-toggle-label-content">
     <ng-content></ng-content>
   </div>
 </label>

--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -3,44 +3,44 @@
 @import 'palette';
 @import 'mixins';
 
-$md-button-toggle-padding: 0 16px !default;
-$md-button-toggle-line-height: 36px !default;
-$md-button-toggle-border-radius: 3px !default;
+$mat-button-toggle-padding: 0 16px !default;
+$mat-button-toggle-line-height: 36px !default;
+$mat-button-toggle-border-radius: 3px !default;
 
-md-button-toggle-group {
-  @include md-elevation(2);
+mat-button-toggle-group {
+  @include mat-elevation(2);
   position: relative;
   display: inline-flex;
-  border-radius: $md-button-toggle-border-radius;
+  border-radius: $mat-button-toggle-border-radius;
   cursor: pointer;
   white-space: nowrap;
 }
 
 
-.md-button-toggle-checked .md-button-toggle-label-content {
-  background-color: md-color($md-grey, 300);
+.mat-button-toggle-checked .mat-button-toggle-label-content {
+  background-color: mat-color($mat-grey, 300);
 }
 
-.md-button-toggle-disabled .md-button-toggle-label-content {
-  background-color: md-color($md-foreground, disabled);
+.mat-button-toggle-disabled .mat-button-toggle-label-content {
+  background-color: mat-color($mat-foreground, disabled);
   cursor: not-allowed;
 }
 
-md-button-toggle {
+mat-button-toggle {
   white-space: nowrap;
 }
 
-.md-button-toggle-input {
-  @include md-visually-hidden;
+.mat-button-toggle-input {
+  @include mat-visually-hidden;
 }
 
-.md-button-toggle-label-content {
+.mat-button-toggle-label-content {
   display: inline-block;
-  line-height: $md-button-toggle-line-height;
-  padding: $md-button-toggle-padding;
+  line-height: $mat-button-toggle-line-height;
+  padding: $mat-button-toggle-padding;
   cursor: pointer;
 }
 
-.md-button-toggle-label-content > * {
+.mat-button-toggle-label-content > * {
   vertical-align: middle;
 }

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -9,18 +9,18 @@ import {NgControl, FormsModule} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
-    MdButtonToggleGroup,
-    MdButtonToggle,
-    MdButtonToggleGroupMultiple,
-    MdButtonToggleChange, MdButtonToggleModule,
+    MatButtonToggleGroup,
+    MatButtonToggle,
+    MatButtonToggleGroupMultiple,
+    MatButtonToggleChange, MatButtonToggleModule,
 } from './button-toggle';
 
 
-describe('MdButtonToggle', () => {
+describe('MatButtonToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdButtonToggleModule.forRoot(), FormsModule],
+      imports: [MatButtonToggleModule.forRoot(), FormsModule],
       declarations: [
         ButtonTogglesInsideButtonToggleGroup,
         ButtonToggleGroupWithNgModel,
@@ -42,8 +42,8 @@ describe('MdButtonToggle', () => {
     let buttonToggleDebugElements: DebugElement[];
     let buttonToggleNativeElements: HTMLElement[];
     let buttonToggleLabelElements: HTMLLabelElement[];
-    let groupInstance: MdButtonToggleGroup;
-    let buttonToggleInstances: MdButtonToggle[];
+    let groupInstance: MatButtonToggleGroup;
+    let buttonToggleInstances: MatButtonToggle[];
     let testComponent: ButtonTogglesInsideButtonToggleGroup;
 
     beforeEach(async(() => {
@@ -52,11 +52,11 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroup);
+      groupInstance = groupDebugElement.injector.get(MatButtonToggleGroup);
 
-      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MdButtonToggle));
+      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
 
       buttonToggleNativeElements = buttonToggleDebugElements
         .map(debugEl => debugEl.nativeElement);
@@ -201,8 +201,8 @@ describe('MdButtonToggle', () => {
     let groupNativeElement: HTMLElement;
     let buttonToggleDebugElements: DebugElement[];
     let buttonToggleNativeElements: HTMLElement[];
-    let groupInstance: MdButtonToggleGroup;
-    let buttonToggleInstances: MdButtonToggle[];
+    let groupInstance: MatButtonToggleGroup;
+    let buttonToggleInstances: MatButtonToggle[];
     let testComponent: ButtonToggleGroupWithNgModel;
     let groupNgControl: NgControl;
 
@@ -212,12 +212,12 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroup);
+      groupInstance = groupDebugElement.injector.get(MatButtonToggleGroup);
       groupNgControl = groupDebugElement.injector.get(NgControl);
 
-      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MdButtonToggle));
+      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
       buttonToggleNativeElements =
           buttonToggleDebugElements.map(debugEl => debugEl.nativeElement);
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
@@ -287,8 +287,8 @@ describe('MdButtonToggle', () => {
     let groupNativeElement: HTMLElement;
     let buttonToggleDebugElements: DebugElement[];
     let buttonToggleNativeElements: HTMLElement[];
-    let groupInstance: MdButtonToggleGroup;
-    let buttonToggleInstances: MdButtonToggle[];
+    let groupInstance: MatButtonToggleGroup;
+    let buttonToggleInstances: MatButtonToggle[];
     let testComponent: ButtonToggleGroupWithNgModel;
     let groupNgControl: NgControl;
 
@@ -297,12 +297,12 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroup);
+      groupInstance = groupDebugElement.injector.get(MatButtonToggleGroup);
       groupNgControl = groupDebugElement.injector.get(NgControl);
 
-      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MdButtonToggle));
+      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
       buttonToggleNativeElements =
           buttonToggleDebugElements.map(debugEl => debugEl.nativeElement);
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
@@ -329,8 +329,9 @@ describe('MdButtonToggle', () => {
     it('should not fire an initial change event', async(() => {
       let fixture = TestBed.createComponent(ButtonToggleGroupWithInitialValue);
       let testComponent = fixture.debugElement.componentInstance;
-      let groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
-      let groupInstance: MdButtonToggleGroup = groupDebugElement.injector.get(MdButtonToggleGroup);
+      let groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      let groupInstance: MatButtonToggleGroup = groupDebugElement.injector
+        .get(MatButtonToggleGroup);
 
       fixture.detectChanges();
 
@@ -353,8 +354,8 @@ describe('MdButtonToggle', () => {
     let buttonToggleDebugElements: DebugElement[];
     let buttonToggleNativeElements: HTMLElement[];
     let buttonToggleLabelElements: HTMLLabelElement[];
-    let groupInstance: MdButtonToggleGroupMultiple;
-    let buttonToggleInstances: MdButtonToggle[];
+    let groupInstance: MatButtonToggleGroupMultiple;
+    let buttonToggleInstances: MatButtonToggle[];
     let testComponent: ButtonTogglesInsideButtonToggleGroupMultiple;
 
     beforeEach(async(() => {
@@ -363,11 +364,11 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroupMultiple));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroupMultiple));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroupMultiple);
+      groupInstance = groupDebugElement.injector.get(MatButtonToggleGroupMultiple);
 
-      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MdButtonToggle));
+      buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
       buttonToggleNativeElements = buttonToggleDebugElements
         .map(debugEl => debugEl.nativeElement);
       buttonToggleLabelElements = fixture.debugElement.queryAll(By.css('label'))
@@ -451,7 +452,7 @@ describe('MdButtonToggle', () => {
     let buttonToggleDebugElement: DebugElement;
     let buttonToggleNativeElement: HTMLElement;
     let buttonToggleLabelElement: HTMLLabelElement;
-    let buttonToggleInstance: MdButtonToggle;
+    let buttonToggleInstance: MatButtonToggle;
     let testComponent: StandaloneButtonToggle;
 
     beforeEach(async(() => {
@@ -460,7 +461,7 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      buttonToggleDebugElement = fixture.debugElement.query(By.directive(MdButtonToggle));
+      buttonToggleDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
       buttonToggleNativeElement = buttonToggleDebugElement.nativeElement;
       buttonToggleLabelElement = fixture.debugElement.query(By.css('label')).nativeElement;
       buttonToggleInstance = buttonToggleDebugElement.componentInstance;
@@ -506,11 +507,11 @@ describe('MdButtonToggle', () => {
 
 @Component({
   template: `
-  <md-button-toggle-group [disabled]="isGroupDisabled" [value]="groupValue">
-    <md-button-toggle value="test1">Test1</md-button-toggle>
-    <md-button-toggle value="test2">Test2</md-button-toggle>
-    <md-button-toggle value="test3">Test3</md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group [disabled]="isGroupDisabled" [value]="groupValue">
+    <mat-button-toggle value="test1">Test1</mat-button-toggle>
+    <mat-button-toggle value="test2">Test2</mat-button-toggle>
+    <mat-button-toggle value="test3">Test3</mat-button-toggle>
+  </mat-button-toggle-group>
   `
 })
 class ButtonTogglesInsideButtonToggleGroup {
@@ -520,11 +521,11 @@ class ButtonTogglesInsideButtonToggleGroup {
 
 @Component({
   template: `
-  <md-button-toggle-group [(ngModel)]="modelValue" (change)="lastEvent = $event">
-    <md-button-toggle *ngFor="let option of options" [value]="option.value">
+  <mat-button-toggle-group [(ngModel)]="modelValue" (change)="lastEvent = $event">
+    <mat-button-toggle *ngFor="let option of options" [value]="option.value">
       {{option.label}}
-    </md-button-toggle>
-  </md-button-toggle-group>
+    </mat-button-toggle>
+  </mat-button-toggle-group>
   `
 })
 class ButtonToggleGroupWithNgModel {
@@ -534,16 +535,16 @@ class ButtonToggleGroupWithNgModel {
     {label: 'Green', value: 'green'},
     {label: 'Blue', value: 'blue'},
   ];
-  lastEvent: MdButtonToggleChange;
+  lastEvent: MatButtonToggleChange;
 }
 
 @Component({
   template: `
-  <md-button-toggle-group [disabled]="isGroupDisabled" multiple>
-    <md-button-toggle value="eggs">Eggs</md-button-toggle>
-    <md-button-toggle value="flour">Flour</md-button-toggle>
-    <md-button-toggle value="sugar">Sugar</md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group [disabled]="isGroupDisabled" multiple>
+    <mat-button-toggle value="eggs">Eggs</mat-button-toggle>
+    <mat-button-toggle value="flour">Flour</mat-button-toggle>
+    <mat-button-toggle value="sugar">Sugar</mat-button-toggle>
+  </mat-button-toggle-group>
   `
 })
 class ButtonTogglesInsideButtonToggleGroupMultiple {
@@ -552,19 +553,19 @@ class ButtonTogglesInsideButtonToggleGroupMultiple {
 
 @Component({
   template: `
-  <md-button-toggle>Yes</md-button-toggle>
+  <mat-button-toggle>Yes</mat-button-toggle>
   `
 })
 class StandaloneButtonToggle { }
 
 @Component({
   template: `
-  <md-button-toggle-group (change)="lastEvent = $event" value="red">
-    <md-button-toggle value="red">Value Red</md-button-toggle>
-    <md-button-toggle value="green">Value Green</md-button-toggle>
-  </md-button-toggle-group>
+  <mat-button-toggle-group (change)="lastEvent = $event" value="red">
+    <mat-button-toggle value="red">Value Red</mat-button-toggle>
+    <mat-button-toggle value="green">Value Green</mat-button-toggle>
+  </mat-button-toggle-group>
   `
 })
 class ButtonToggleGroupWithInitialValue {
-  lastEvent: MdButtonToggleChange;
+  lastEvent: MatButtonToggleChange;
 }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -21,50 +21,50 @@ import {
     FormsModule,
 } from '@angular/forms';
 import {Observable} from 'rxjs/Observable';
-import {BooleanFieldValue, MdUniqueSelectionDispatcher} from '@angular2-material/core';
+import {BooleanFieldValue, MatUniqueSelectionDispatcher} from '@angular2-material/core';
 
 export type ToggleType = 'checkbox' | 'radio';
 
 
 
 /**
- * Provider Expression that allows md-button-toggle-group to register as a ControlValueAccessor.
+ * Provider Expression that allows mat-button-toggle-group to register as a ControlValueAccessor.
  * This allows it to support [(ngModel)].
  */
-export const MD_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
+export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdButtonToggleGroup),
+  useExisting: forwardRef(() => MatButtonToggleGroup),
   multi: true
 };
 
 var _uniqueIdCounter = 0;
 
-/** A simple change event emitted by either MdButtonToggle or MdButtonToggleGroup. */
-export class MdButtonToggleChange {
-  source: MdButtonToggle;
+/** A simple change event emitted by either MatButtonToggle or MatButtonToggleGroup. */
+export class MatButtonToggleChange {
+  source: MatButtonToggle;
   value: any;
 }
 
 /** Exclusive selection button toggle group that behaves like a radio-button group. */
 @Directive({
-  selector: 'md-button-toggle-group:not([multiple])',
-  providers: [MD_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR],
+  selector: 'mat-button-toggle-group:not([multiple])',
+  providers: [MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR],
   host: {
     'role': 'radiogroup',
   },
 })
-export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor {
+export class MatButtonToggleGroup implements AfterViewInit, ControlValueAccessor {
   /** The value for the button toggle group. Should match currently selected button toggle. */
   private _value: any = null;
 
   /** The HTML name attribute applied to toggles in this group. */
-  private _name: string = `md-radio-group-${_uniqueIdCounter++}`;
+  private _name: string = `mat-radio-group-${_uniqueIdCounter++}`;
 
   /** Disables all toggles in the group. */
   private _disabled: boolean = null;
 
   /** The currently selected button toggle, should match the value. */
-  private _selected: MdButtonToggle = null;
+  private _selected: MatButtonToggle = null;
 
   /** Whether the button toggle group is initialized or not. */
   private _isInitialized: boolean = false;
@@ -76,14 +76,14 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   onTouched: () => any = () => {};
 
   /** Event emitted when the group's value changes. */
-  private _change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
-  @Output() get change(): Observable<MdButtonToggleChange> {
+  private _change: EventEmitter<MatButtonToggleChange> = new EventEmitter<MatButtonToggleChange>();
+  @Output() get change(): Observable<MatButtonToggleChange> {
     return this._change.asObservable();
   }
 
   /** Child button toggle buttons. */
-  @ContentChildren(forwardRef(() => MdButtonToggle))
-  _buttonToggles: QueryList<MdButtonToggle> = null;
+  @ContentChildren(forwardRef(() => MatButtonToggle))
+  _buttonToggles: QueryList<MatButtonToggle> = null;
 
   /** TODO: internal */
   ngAfterViewInit() {
@@ -134,7 +134,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     return this._selected;
   }
 
-  set selected(selected: MdButtonToggle) {
+  set selected(selected: MatButtonToggle) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
 
@@ -172,7 +172,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
 
   /** Dispatch change event with current selection and group value. */
   private _emitChangeEvent(): void {
-    let event = new MdButtonToggleChange();
+    let event = new MatButtonToggleChange();
     event.source = this._selected;
     event.value = this._value;
     this._controlValueAccessorChangeFn(event.value);
@@ -206,9 +206,9 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
 
 /** Multiple selection button-toggle group. */
 @Directive({
-  selector: 'md-button-toggle-group[multiple]',
+  selector: 'mat-button-toggle-group[multiple]',
 })
-export class MdButtonToggleGroupMultiple {
+export class MatButtonToggleGroupMultiple {
   /** Disables all toggles in the group. */
   private _disabled: boolean = null;
 
@@ -224,12 +224,12 @@ export class MdButtonToggleGroupMultiple {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-button-toggle',
+  selector: 'mat-button-toggle',
   templateUrl: 'button-toggle.html',
   styleUrls: ['button-toggle.css'],
   encapsulation: ViewEncapsulation.None,
 })
-export class MdButtonToggle implements OnInit {
+export class MatButtonToggle implements OnInit {
   /** Whether or not this button toggle is checked. */
   private _checked: boolean = false;
 
@@ -255,20 +255,20 @@ export class MdButtonToggle implements OnInit {
   private _isSingleSelector: boolean = null;
 
   /** The parent button toggle group (exclusive selection). Optional. */
-  buttonToggleGroup: MdButtonToggleGroup;
+  buttonToggleGroup: MatButtonToggleGroup;
 
   /** The parent button toggle group (multiple selection). Optional. */
-  buttonToggleGroupMultiple: MdButtonToggleGroupMultiple;
+  buttonToggleGroupMultiple: MatButtonToggleGroupMultiple;
 
   /** Event emitted when the group value changes. */
-  private _change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
-  @Output() get change(): Observable<MdButtonToggleChange> {
+  private _change: EventEmitter<MatButtonToggleChange> = new EventEmitter<MatButtonToggleChange>();
+  @Output() get change(): Observable<MatButtonToggleChange> {
     return this._change.asObservable();
   }
 
-  constructor(@Optional() toggleGroup: MdButtonToggleGroup,
-              @Optional() toggleGroupMultiple: MdButtonToggleGroupMultiple,
-              public buttonToggleDispatcher: MdUniqueSelectionDispatcher) {
+  constructor(@Optional() toggleGroup: MatButtonToggleGroup,
+              @Optional() toggleGroupMultiple: MatButtonToggleGroupMultiple,
+              public buttonToggleDispatcher: MatUniqueSelectionDispatcher) {
     this.buttonToggleGroup = toggleGroup;
 
     this.buttonToggleGroupMultiple = toggleGroupMultiple;
@@ -293,7 +293,7 @@ export class MdButtonToggle implements OnInit {
 
   ngOnInit() {
     if (this.id == null) {
-      this.id = `md-button-toggle-${_uniqueIdCounter++}`;
+      this.id = `mat-button-toggle-${_uniqueIdCounter++}`;
     }
 
     if (this.buttonToggleGroup && this._value == this.buttonToggleGroup.value) {
@@ -305,7 +305,7 @@ export class MdButtonToggle implements OnInit {
     return `${this.id}-input`;
   }
 
-  @HostBinding('class.md-button-toggle-checked')
+  @HostBinding('class.mat-button-toggle-checked')
   @Input()
   get checked(): boolean {
     return this._checked;
@@ -326,7 +326,7 @@ export class MdButtonToggle implements OnInit {
     }
   }
 
-  /** MdButtonToggleGroup reads this to assign its own value. */
+  /** MatButtonToggleGroup reads this to assign its own value. */
   @Input()
   get value(): any {
     return this._value;
@@ -343,13 +343,13 @@ export class MdButtonToggle implements OnInit {
 
   /** Dispatch change event with current value. */
   private _emitChangeEvent(): void {
-    let event = new MdButtonToggleChange();
+    let event = new MatButtonToggleChange();
     event.source = this;
     event.value = this._value;
     this._change.emit(event);
   }
 
-  @HostBinding('class.md-button-toggle-disabled')
+  @HostBinding('class.mat-button-toggle-disabled')
   @Input()
   get disabled(): boolean {
     return this._disabled || (this.buttonToggleGroup != null && this.buttonToggleGroup.disabled) ||
@@ -400,14 +400,14 @@ export class MdButtonToggle implements OnInit {
 
 @NgModule({
   imports: [FormsModule],
-  exports: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
-  declarations: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
+  exports: [MatButtonToggleGroup, MatButtonToggleGroupMultiple, MatButtonToggle],
+  declarations: [MatButtonToggleGroup, MatButtonToggleGroupMultiple, MatButtonToggle],
 })
-export class MdButtonToggleModule {
+export class MatButtonToggleModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdButtonToggleModule,
-      providers: [MdUniqueSelectionDispatcher]
+      ngModule: MatButtonToggleModule,
+      providers: [MatUniqueSelectionDispatcher]
     };
   }
 }

--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -8,34 +8,34 @@
 @import 'button-theme';
 
 // Flat and raised button standards
-$md-button-padding: 0 16px !default;
-$md-button-min-width: 88px !default;
-$md-button-margin: 0 !default;
-$md-button-line-height: 36px !default;
-$md-button-border-radius: 3px !default;
+$mat-button-padding: 0 16px !default;
+$mat-button-min-width: 88px !default;
+$mat-button-margin: 0 !default;
+$mat-button-line-height: 36px !default;
+$mat-button-border-radius: 3px !default;
 
 // Icon Button standards
-$md-icon-button-size: 40px !default;
-$md-icon-button-border-radius: 50% !default;
-$md-icon-button-line-height: 24px !default;
+$mat-icon-button-size: 40px !default;
+$mat-icon-button-border-radius: 50% !default;
+$mat-icon-button-line-height: 24px !default;
 
 // Fab standards
-$md-fab-border-radius: 50% !default;
-$md-fab-size: 56px !default;
-$md-fab-padding: 16px !default;
+$mat-fab-border-radius: 50% !default;
+$mat-fab-size: 56px !default;
+$mat-fab-padding: 16px !default;
 
-$md-mini-fab-size: 40px !default;
-$md-mini-fab-padding: 8px !default;
+$mat-mini-fab-size: 40px !default;
+$mat-mini-fab-padding: 8px !default;
 
 // Applies base styles to all button types.
-%md-button-base {
-  @include md-button-theme('color');
+%mat-button-base {
+  @include mat-button-theme('color');
 
   box-sizing: border-box;
   position: relative;
 
   // Reset browser <button> styles.
-  @include md-button-reset();
+  @include mat-button-reset();
 
   // Make anchors render like buttons.
   display: inline-block;
@@ -44,46 +44,46 @@ $md-mini-fab-padding: 8px !default;
   vertical-align: baseline;
 
   // Typography.
-  font-size: $md-body-font-size-base;
-  font-family: $md-font-family;
+  font-size: $mat-body-font-size-base;
+  font-family: $mat-font-family;
   font-weight: 500;
   color: currentColor;
   text-align: center;
 
   // Sizing.
-  margin: $md-button-margin;
-  min-width: $md-button-min-width;
-  line-height: $md-button-line-height;
-  padding: $md-button-padding;
-  border-radius: $md-button-border-radius;
+  margin: $mat-button-margin;
+  min-width: $mat-button-min-width;
+  line-height: $mat-button-line-height;
+  padding: $mat-button-padding;
+  border-radius: $mat-button-border-radius;
 
   &[disabled] {
     cursor: default;
   }
 
-  &.md-button-focus {
-    @include md-button-focus();
+  &.mat-button-focus {
+    @include mat-button-focus();
   }
 }
 
 // Applies styles to buttons with backgrounds: raised, fab, and mini-fab
-%md-raised-button {
-  @extend %md-button-base;
+%mat-raised-button {
+  @extend %mat-button-base;
 
-  @include md-elevation(2);
-  @include md-button-theme('color', default-contrast);
-  @include md-button-theme('background-color');
+  @include mat-elevation(2);
+  @include mat-button-theme('color', default-contrast);
+  @include mat-button-theme('background-color');
 
-  background-color: md-color($md-background, background);
+  background-color: mat-color($mat-background, background);
   // Force hardware acceleration.
   transform: translate3d(0, 0, 0);
 
   // Animation.
   transition: background $swift-ease-out-duration $swift-ease-out-timing-function,
-              md-elevation-transition-property-value();
+              mat-elevation-transition-property-value();
 
   &:active {
-    @include md-elevation(8);
+    @include mat-elevation(8);
   }
 
   &[disabled] {
@@ -92,18 +92,18 @@ $md-mini-fab-padding: 8px !default;
 }
 
 // Applies styles to fab and mini-fab button types only
-@mixin md-fab($size, $padding) {
-  @extend %md-raised-button;
+@mixin mat-fab($size, $padding) {
+  @extend %mat-raised-button;
 
   min-width: 0;
-  border-radius: $md-fab-border-radius;
-  background-color: md-color($md-accent);
-  color: md-color($md-accent, default-contrast);
+  border-radius: $mat-fab-border-radius;
+  background-color: mat-color($mat-accent);
+  color: mat-color($mat-accent, default-contrast);
   width: $size;
   height: $size;
   padding: 0;
 
-  i, md-icon {
+  i, mat-icon {
     padding: $padding 0;
   }
 }

--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -1,25 +1,25 @@
-/** Applies a property to an md-button element for each of the supported palettes. */
-@mixin md-button-theme($property, $color: 'default', $opacity: 1) {
-  &.md-primary {
-    #{$property}: md-color($md-primary, $color, $opacity);
+/** Applies a property to an mat-button element for each of the supported palettes. */
+@mixin mat-button-theme($property, $color: 'default', $opacity: 1) {
+  &.mat-primary {
+    #{$property}: mat-color($mat-primary, $color, $opacity);
   }
-  &.md-accent {
-    #{$property}: md-color($md-accent, $color, $opacity);
+  &.mat-accent {
+    #{$property}: mat-color($mat-accent, $color, $opacity);
   }
-  &.md-warn {
-    #{$property}: md-color($md-warn, $color, $opacity);
+  &.mat-warn {
+    #{$property}: mat-color($mat-warn, $color, $opacity);
   }
 
-  &.md-primary, &.md-accent, &.md-warn, &[disabled] {
+  &.mat-primary, &.mat-accent, &.mat-warn, &[disabled] {
     &[disabled] {
-      $palette: if($property == 'color', $md-foreground, $md-background);
-      #{$property}: md-color($palette, disabled-button);
+      $palette: if($property == 'color', $mat-foreground, $mat-background);
+      #{$property}: mat-color($palette, disabled-button);
     }
   }
 }
 
-/** Applies a focus style to an md-button element for each of the supported palettes. */
-@mixin md-button-focus {
+/** Applies a focus style to an mat-button element for each of the supported palettes. */
+@mixin mat-button-focus {
   &::after {
     // The button spec calls for focus on raised buttons (and FABs) to be indicated with a
     // black, 12% opacity shade over the normal color (for both light and dark themes).
@@ -35,15 +35,15 @@
     pointer-events: none;
   }
 
-  &.md-primary::after {
-    background-color: md-color($md-primary, 0.12);
+  &.mat-primary::after {
+    background-color: mat-color($mat-primary, 0.12);
   }
 
-  &.md-accent::after {
-    background-color: md-color($md-accent, 0.12);
+  &.mat-accent::after {
+    background-color: mat-color($mat-accent, 0.12);
   }
 
-  &.md-warn::after {
-    background-color: md-color($md-warn, 0.12);
+  &.mat-warn::after {
+    background-color: mat-color($mat-warn, 0.12);
   }
 }

--- a/src/lib/button/button.html
+++ b/src/lib/button/button.html
@@ -1,1 +1,1 @@
-<span class="md-button-wrapper"><ng-content></ng-content></span>
+<span class="mat-button-wrapper"><ng-content></ng-content></span>

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -4,53 +4,53 @@
 @import 'button-base';
 
 // TODO(kara): Replace attribute selectors with class selectors when possible
-[md-button], [md-icon-button] {
-  @extend %md-button-base;
+[mat-button], [mat-icon-button] {
+  @extend %mat-button-base;
 
   // Only flat buttons and icon buttons (not raised or fabs) have a hover style.
   &:hover {
     // Use the same visual treatment for hover as for focus.
-    @include md-button-focus();
+    @include mat-button-focus();
   }
 
   &[disabled]:hover {
-    &.md-primary, &.md-accent, &.md-warn, &::after {
+    &.mat-primary, &.mat-accent, &.mat-warn, &::after {
       background-color: transparent;
     }
   }
 }
 
-[md-raised-button] {
-  @extend %md-raised-button;
+[mat-raised-button] {
+  @extend %mat-raised-button;
 }
 
-[md-fab] {
-  @include md-fab($md-fab-size, $md-fab-padding);
+[mat-fab] {
+  @include mat-fab($mat-fab-size, $mat-fab-padding);
 }
 
-[md-mini-fab] {
-  @include md-fab($md-mini-fab-size, $md-mini-fab-padding);
+[mat-mini-fab] {
+  @include mat-fab($mat-mini-fab-size, $mat-mini-fab-padding);
 }
 
-[md-icon-button] {
-  @extend %md-button-base;
+[mat-icon-button] {
+  @extend %mat-button-base;
 
   min-width: 0;
   padding: 0;
 
-  width: $md-icon-button-size;
-  height: $md-icon-button-size;
+  width: $mat-icon-button-size;
+  height: $mat-icon-button-size;
 
-  line-height: $md-icon-button-line-height;
-  border-radius: $md-icon-button-border-radius;
+  line-height: $mat-icon-button-line-height;
+  border-radius: $mat-icon-button-border-radius;
 
-  .md-button-wrapper > * {
+  .mat-button-wrapper > * {
     vertical-align: middle;
   }
 }
 
 // The ripple container should match the bounds of the entire button.
-.md-button-ripple {
+.mat-button-ripple {
   position: absolute;
   top: 0;
   left: 0;
@@ -59,7 +59,7 @@
 }
 
 // For round buttons, the ripple container should clip child ripples to a circle.
-.md-button-ripple-round {
+.mat-button-ripple-round {
   border-radius: 50%;
   // z-index needed to make clipping to border-radius work correctly.
   // http://stackoverflow.com/questions/20001515/chrome-bug-border-radius-not-clipping-contents-when-combined-with-css-transiti
@@ -68,7 +68,7 @@
 
 // Applies a clearer border for high-contrast mode (a11y)
 @media screen and (-ms-high-contrast: active) {
-  .md-raised-button, .md-fab, .md-mini-fab {
+  .mat-raised-button, .mat-fab, .mat-mini-fab {
     border: 1px solid #fff;
   }
 }

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -4,14 +4,14 @@ import {
 } from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdButtonModule} from './button';
+import {MatButtonModule} from './button';
 
 
-describe('MdButton', () => {
+describe('MatButton', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdButtonModule.forRoot()],
+      imports: [MatButtonModule.forRoot()],
       declarations: [TestApp],
     });
 
@@ -28,13 +28,13 @@ describe('MdButton', () => {
 
     testComponent.buttonColor = 'primary';
     fixture.detectChanges();
-    expect(buttonDebugElement.nativeElement.classList.contains('md-primary')).toBe(true);
-    expect(aDebugElement.nativeElement.classList.contains('md-primary')).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-primary')).toBe(true);
+    expect(aDebugElement.nativeElement.classList.contains('mat-primary')).toBe(true);
 
     testComponent.buttonColor = 'accent';
     fixture.detectChanges();
-    expect(buttonDebugElement.nativeElement.classList.contains('md-accent')).toBe(true);
-    expect(aDebugElement.nativeElement.classList.contains('md-accent')).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-accent')).toBe(true);
+    expect(aDebugElement.nativeElement.classList.contains('mat-accent')).toBe(true);
   });
 
   it('should should not clear previous defined classes', () => {
@@ -47,20 +47,20 @@ describe('MdButton', () => {
     testComponent.buttonColor = 'primary';
     fixture.detectChanges();
 
-    expect(buttonDebugElement.nativeElement.classList.contains('md-primary')).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-primary')).toBe(true);
     expect(buttonDebugElement.nativeElement.classList.contains('custom-class')).toBe(true);
 
     testComponent.buttonColor = 'accent';
     fixture.detectChanges();
 
-    expect(buttonDebugElement.nativeElement.classList.contains('md-primary')).toBe(false);
-    expect(buttonDebugElement.nativeElement.classList.contains('md-accent')).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-primary')).toBe(false);
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-accent')).toBe(true);
     expect(buttonDebugElement.nativeElement.classList.contains('custom-class')).toBe(true);
 
   });
 
   // Regular button tests
-  describe('button[md-button]', () => {
+  describe('button[mat-button]', () => {
     it('should handle a click on the button', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
@@ -86,7 +86,7 @@ describe('MdButton', () => {
   });
 
   // Anchor button tests
-  describe('a[md-button]', () => {
+  describe('a[mat-button]', () => {
     it('should not redirect if disabled', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
@@ -124,15 +124,17 @@ describe('MdButton', () => {
   });
 });
 
-/** Test component that contains an MdButton. */
+/** Test component that contains an MatButton. */
 @Component({
   selector: 'test-app',
   template: `
-    <button md-button type="button" (click)="increment()"
+    <button mat-button type="button" (click)="increment()"
       [disabled]="isDisabled" [color]="buttonColor" [disableRipple]="rippleDisabled">
       Go
     </button>
-    <a href="http://www.google.com" md-button [disabled]="isDisabled" [color]="buttonColor">Link</a>
+    <a href="http://www.google.com" mat-button [disabled]="isDisabled" [color]="buttonColor">
+      Link
+    </a>
   `
 })
 class TestApp {

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BooleanFieldValue} from '@angular2-material/core';
-import {MdRippleModule} from '@angular2-material/core';
+import {MatRippleModule} from '@angular2-material/core';
 
 // TODO(jelbourn): Make the `isMouseDown` stuff done with one global listener.
 // TODO(kara): Convert attribute selectors to classes when attr maps become available
@@ -19,11 +19,11 @@ import {MdRippleModule} from '@angular2-material/core';
 
 @Component({
   moduleId: module.id,
-  selector: 'button[md-button], button[md-raised-button], button[md-icon-button], ' +
-            'button[md-fab], button[md-mini-fab]',
+  selector: 'button[mat-button], button[mat-raised-button], button[mat-icon-button], ' +
+            'button[mat-fab], button[mat-mini-fab]',
   inputs: ['color'],
   host: {
-    '[class.md-button-focus]': '_isKeyboardFocused',
+    '[class.mat-button-focus]': '_isKeyboardFocused',
     '(mousedown)': '_setMousedown()',
     '(focus)': '_setKeyboardFocus()',
     '(blur)': '_removeKeyboardFocus()',
@@ -33,7 +33,7 @@ import {MdRippleModule} from '@angular2-material/core';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdButton {
+export class MatButton {
   private _color: string;
 
   /** Whether the button has focus from the keyboard (not the mouse). Used for class binding. */
@@ -72,7 +72,7 @@ export class MdButton {
 
   _setElementColor(color: string, isAdd: boolean) {
     if (color != null && color != '') {
-      this._renderer.setElementClass(this._elementRef.nativeElement, `md-${color}`, isAdd);
+      this._renderer.setElementClass(this._elementRef.nativeElement, `mat-${color}`, isAdd);
     }
   }
 
@@ -95,9 +95,9 @@ export class MdButton {
 
   isRoundButton() {
     const el = this._elementRef.nativeElement;
-    return el.hasAttribute('md-icon-button') ||
-        el.hasAttribute('md-fab') ||
-        el.hasAttribute('md-mini-fab');
+    return el.hasAttribute('mat-icon-button') ||
+        el.hasAttribute('mat-fab') ||
+        el.hasAttribute('mat-mini-fab');
   }
 
   isRippleEnabled() {
@@ -107,10 +107,10 @@ export class MdButton {
 
 @Component({
   moduleId: module.id,
-  selector: 'a[md-button], a[md-raised-button], a[md-icon-button], a[md-fab], a[md-mini-fab]',
+  selector: 'a[mat-button], a[mat-raised-button], a[mat-icon-button], a[mat-fab], a[mat-mini-fab]',
   inputs: ['color'],
   host: {
-    '[class.md-button-focus]': '_isKeyboardFocused',
+    '[class.mat-button-focus]': '_isKeyboardFocused',
     '(mousedown)': '_setMousedown()',
     '(focus)': '_setKeyboardFocus()',
     '(blur)': '_removeKeyboardFocus()',
@@ -120,7 +120,7 @@ export class MdButton {
   styleUrls: ['button.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class MdAnchor extends MdButton {
+export class MatAnchor extends MatButton {
   _disabled: boolean = null;
 
   constructor(elementRef: ElementRef, renderer: Renderer) {
@@ -158,14 +158,14 @@ export class MdAnchor extends MdButton {
 
 
 @NgModule({
-  imports: [CommonModule, MdRippleModule],
-  exports: [MdButton, MdAnchor],
-  declarations: [MdButton, MdAnchor],
+  imports: [CommonModule, MatRippleModule],
+  exports: [MatButton, MatAnchor],
+  declarations: [MatButton, MatAnchor],
 })
-export class MdButtonModule {
+export class MatButtonModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdButtonModule,
+      ngModule: MatButtonModule,
       providers: []
     };
   }

--- a/src/lib/card/card-header.html
+++ b/src/lib/card/card-header.html
@@ -1,5 +1,5 @@
-<ng-content select="[md-card-avatar]"></ng-content>
-<div class="md-card-header-text">
-  <ng-content select="md-card-title, md-card-subtitle"></ng-content>
+<ng-content select="[mat-card-avatar]"></ng-content>
+<div class="mat-card-header-text">
+  <ng-content select="mat-card-title, mat-card-subtitle"></ng-content>
 </div>
 <ng-content></ng-content>

--- a/src/lib/card/card-title-group.html
+++ b/src/lib/card/card-title-group.html
@@ -1,5 +1,5 @@
 <div>
-  <ng-content select="md-card-title, md-card-subtitle"></ng-content>
+  <ng-content select="mat-card-title, mat-card-subtitle"></ng-content>
 </div>
 <ng-content select="img"></ng-content>
 <ng-content></ng-content>

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -128,7 +128,7 @@ mat-card-title-group {
   height: 80px;
 }
 
-[mat-card-mat-image] {
+[mat-card-md-image] {
   @extend %mat-card-title-img;
   width: 112px;
   height: 112px;

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -3,56 +3,56 @@
 @import 'elevation';
 @import 'default-theme';   // TODO: Remove this
 
-$md-card-default-padding: 24px !default;
-$md-card-mobile-padding: 24px 16px !default;
-$md-card-border-radius: 2px !default;
-$md-card-header-size: 40px !default;
+$mat-card-default-padding: 24px !default;
+$mat-card-mobile-padding: 24px 16px !default;
+$mat-card-border-radius: 2px !default;
+$mat-card-header-size: 40px !default;
 
-md-card {
-  @include md-elevation(1);
-  @include md-elevation-transition;
+mat-card {
+  @include mat-elevation(1);
+  @include mat-elevation-transition;
   display: block;
   position: relative;
-  padding: $md-card-default-padding;
-  border-radius: $md-card-border-radius;
-  font-family: $md-font-family;
-  background: md-color($md-background, card);
-  color: md-color($md-foreground, base);
+  padding: $mat-card-default-padding;
+  border-radius: $mat-card-border-radius;
+  font-family: $mat-font-family;
+  background: mat-color($mat-background, card);
+  color: mat-color($mat-foreground, base);
 }
 
-md-card:hover {
-  @include md-elevation(2);
+mat-card:hover {
+  @include mat-elevation(2);
 }
 
-.md-card-flat {
+.mat-card-flat {
   box-shadow: none;
 }
 
-// base styles for each card section preset (md-card-content, etc)
-%md-card-section-base {
+// base styles for each card section preset (mat-card-content, etc)
+%mat-card-section-base {
   display: block;
   margin-bottom: 16px;
 }
 
-md-card-title {
-  @extend %md-card-section-base;
+mat-card-title {
+  @extend %mat-card-section-base;
   font-size: 24px;
   font-weight: 400;
 }
 
-md-card-subtitle {
-  @extend %md-card-section-base;
-  font-size: $md-body-font-size-base;
-  color: md-color($md-foreground, secondary-text);
+mat-card-subtitle {
+  @extend %mat-card-section-base;
+  font-size: $mat-body-font-size-base;
+  color: mat-color($mat-foreground, secondary-text);
 }
 
-md-card-content {
-  @extend %md-card-section-base;
-  font-size: $md-body-font-size-base;
+mat-card-content {
+  @extend %mat-card-section-base;
+  font-size: $mat-body-font-size-base;
 }
 
-md-card-actions {
-  @extend %md-card-section-base;
+mat-card-actions {
+  @extend %mat-card-section-base;
   margin-left: -16px;
   margin-right: -16px;
   padding: 8px 0;
@@ -63,105 +63,105 @@ md-card-actions {
   }
 }
 
-[md-card-image] {
+[mat-card-image] {
   width: calc(100% + 48px);
   margin: 0 -24px 16px -24px;
 }
 
-[md-card-xl-image] {
+[mat-card-xl-image] {
   width: 240px;
   height: 240px;
   margin: -8px;
 }
 
-md-card-footer {
+mat-card-footer {
   position: absolute;
   bottom: 0;
 }
 
-md-card-actions {
-  [md-button], [md-raised-button] {
+mat-card-actions {
+  [mat-button], [mat-raised-button] {
     margin: 0 4px;
   }
 }
 
 /* HEADER STYLES */
 
-md-card-header {
+mat-card-header {
   display: flex;
   flex-direction: row;
-  height: $md-card-header-size;
+  height: $mat-card-header-size;
   margin: -8px 0 16px 0;
 }
 
-.md-card-header-text {
-  height: $md-card-header-size;
+.mat-card-header-text {
+  height: $mat-card-header-size;
   margin: 0 8px;
 }
 
-[md-card-avatar] {
-  height: $md-card-header-size;
-  width: $md-card-header-size;
+[mat-card-avatar] {
+  height: $mat-card-header-size;
+  width: $mat-card-header-size;
   border-radius: 50%;
 }
 
-md-card-header md-card-title {
-  font-size: $md-body-font-size-base;
+mat-card-header mat-card-title {
+  font-size: $mat-body-font-size-base;
 }
 
 /* TITLE-GROUP STYLES */
 
 // images grouped with title in title-group layout
-%md-card-title-img {
+%mat-card-title-img {
   margin: -8px 0;
 }
 
-md-card-title-group {
+mat-card-title-group {
   display: flex;
   justify-content: space-between;
   margin: 0 -8px;
 }
 
-[md-card-sm-image] {
-  @extend %md-card-title-img;
+[mat-card-sm-image] {
+  @extend %mat-card-title-img;
   width: 80px;
   height: 80px;
 }
 
-[md-card-md-image] {
-  @extend %md-card-title-img;
+[mat-card-mat-image] {
+  @extend %mat-card-title-img;
   width: 112px;
   height: 112px;
 }
 
-[md-card-lg-image] {
-  @extend %md-card-title-img;
+[mat-card-lg-image] {
+  @extend %mat-card-title-img;
   width: 152px;
   height: 152px;
 }
 
 /* MEDIA QUERIES */
 
-@media ($md-xsmall) {
-  md-card {
-    padding: $md-card-mobile-padding;
+@media ($mat-xsmall) {
+  mat-card {
+    padding: $mat-card-mobile-padding;
   }
 
-  [md-card-image] {
+  [mat-card-image] {
     width: calc(100% + 32px);
     margin: 16px -16px;
   }
 
-  md-card-title-group {
+  mat-card-title-group {
     margin: 0;
   }
 
-  [md-card-xl-image] {
+  [mat-card-xl-image] {
     margin-left: 0;
     margin-right: 0;
   }
 
-  md-card-header {
+  mat-card-header {
     margin: -8px 0 0 0;
   }
 
@@ -169,59 +169,59 @@ md-card-title-group {
 
 /* FIRST/LAST CHILD ADJUSTMENTS */
 
-// top els in md-card-content and md-card can't have their default margin-tops (e.g. <p> tags)
+// top els in mat-card-content and mat-card can't have their default margin-tops (e.g. <p> tags)
 // or they'll incorrectly add to card's top padding
-md-card > :first-child, md-card-content > :first-child {
+mat-card > :first-child, mat-card-content > :first-child {
   margin-top: 0;
 }
 
-// last els in md-card-content and md-card can't have their default margin-bottoms (e.g. <p> tags)
+// last els in mat-card-content and mat-card can't have their default margin-bottoms (e.g. <p> tags)
 // or they'll incorrectly add to card's bottom padding
-md-card > :last-child, md-card-content > :last-child {
+mat-card > :last-child, mat-card-content > :last-child {
   margin-bottom: 0;
 }
 
 // if main image is on top, need to place it flush against top
 // (by stripping card's default 24px padding)
-[md-card-image]:first-child {
+[mat-card-image]:first-child {
   margin-top: -24px;
 }
 
 // actions panel on bottom should be 8px from bottom of card
 // so must strip 16px from default card padding of 24px
-md-card > md-card-actions:last-child {
+mat-card > mat-card-actions:last-child {
   margin-bottom: -16px;
   padding-bottom: 0;
 }
 
 // actions panel should always be 8px from sides,
 // so the first button in the actions panel can't add its own margins
-md-card-actions [md-button]:first-child,
-md-card-actions [md-raised-button]:first-child {
+mat-card-actions [mat-button]:first-child,
+mat-card-actions [mat-raised-button]:first-child {
   margin-left: 0;
   margin-right: 0;
 }
 
 // should be 12px space between titles and subtitles generally
 // default margin-bottom is 16px, so need to move lower title up 4px
-md-card-title:not(:first-child), md-card-subtitle:not(:first-child) {
+mat-card-title:not(:first-child), mat-card-subtitle:not(:first-child) {
   margin-top: -4px;
 }
 
 // should be 8px space between titles and subtitles in header
 // default margin-bottom is 16px, so need to move subtitle in header up 4px
-md-card-header md-card-subtitle:not(:first-child) {
+mat-card-header mat-card-subtitle:not(:first-child) {
   margin-top: -8px;
 }
 
 // xl image should always have 16px on top.
 // when it's the first el, it'll need to remove 8px from default card padding of 24px
-md-card > [md-card-xl-image]:first-child {
+mat-card > [mat-card-xl-image]:first-child {
   margin-top: -8px;
 }
 
 // xl image should always have 16px on bottom
 // when it's the last el, it'll need to remove 8px from default card padding of 24px
-md-card > [md-card-xl-image]:last-child {
+mat-card > [mat-card-xl-image]:last-child {
   margin-bottom: -8px;
 }

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -12,46 +12,46 @@ import {
  * Content of a card, needed as it's used as a selector in the API.
  */
 @Directive({
-  selector: 'md-card-content'
+  selector: 'mat-card-content'
 })
-export class MdCardContent {}
+export class MatCardContent {}
 
 /**
  * Title of a card, needed as it's used as a selector in the API.
  */
 @Directive({
-  selector: 'md-card-title'
+  selector: 'mat-card-title'
 })
-export class MdCardTitle {}
+export class MatCardTitle {}
 
 /**
  * Sub-title of a card, needed as it's used as a selector in the API.
  */
 @Directive({
-  selector: 'md-card-subtitle'
+  selector: 'mat-card-subtitle'
 })
-export class MdCardSubtitle {}
+export class MatCardSubtitle {}
 
 /**
  * Action section of a card, needed as it's used as a selector in the API.
  */
 @Directive({
-  selector: 'md-card-actions'
+  selector: 'mat-card-actions'
 })
-export class MdCardActions {}
+export class MatCardActions {}
 
 
 /*
 
-<md-card> is a basic content container component that adds the styles of a material design card.
+<mat-card> is a basic content container component that adds the styles of a material design card.
 
 While you can use this component alone,
 it also provides a number of preset styles for common card sections, including:
- - md-card-title
- - md-card-subtitle
- - md-card-content
- - md-card-actions
- - md-card-footer
+ - mat-card-title
+ - mat-card-subtitle
+ - mat-card-content
+ - mat-card-actions
+ - mat-card-footer
 
  You can see some examples of cards here:
  http://embed.plnkr.co/s5O4YcyvbLhIApSrIhtj/
@@ -62,21 +62,21 @@ it also provides a number of preset styles for common card sections, including:
 
 @Component({
   moduleId: module.id,
-  selector: 'md-card',
+  selector: 'mat-card',
   templateUrl: 'card.html',
   styleUrls: ['card.css'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdCard {}
+export class MatCard {}
 
 
 /*  The following components don't have any behavior.
  They simply use content projection to wrap user content
- for flex layout purposes in <md-card> (and thus allow a cleaner, boilerplate-free API).
+ for flex layout purposes in <mat-card> (and thus allow a cleaner, boilerplate-free API).
 
 
-<md-card-header> is a component intended to be used within the <md-card> component.
+<mat-card-header> is a component intended to be used within the <mat-card> component.
 It adds styles for a preset header section (i.e. a title, subtitle, and avatar layout).
 
 You can see an example of a card with a header here:
@@ -87,16 +87,16 @@ TODO(kara): update link to demo site when it exists
 
 @Component({
   moduleId: module.id,
-  selector: 'md-card-header',
+  selector: 'mat-card-header',
   templateUrl: 'card-header.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdCardHeader {}
+export class MatCardHeader {}
 
 /*
 
-<md-card-title-group> is a component intended to be used within the <md-card> component.
+<mat-card-title-group> is a component intended to be used within the <mat-card> component.
 It adds styles for a preset layout that groups an image with a title section.
 
 You can see an example of a card with a title-group section here:
@@ -107,28 +107,28 @@ TODO(kara): update link to demo site when it exists
 
 @Component({
   moduleId: module.id,
-  selector: 'md-card-title-group',
+  selector: 'mat-card-title-group',
   templateUrl: 'card-title-group.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdCardTitleGroup {}
+export class MatCardTitleGroup {}
 
 
 @NgModule({
   exports: [
-    MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
-    MdCardActions
+    MatCard, MatCardHeader, MatCardTitleGroup, MatCardContent, MatCardTitle, MatCardSubtitle,
+    MatCardActions
   ],
   declarations: [
-    MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
-    MdCardActions
+    MatCard, MatCardHeader, MatCardTitleGroup, MatCardContent, MatCardTitle, MatCardSubtitle,
+    MatCardActions
   ],
 })
-export class MdCardModule {
+export class MatCardModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdCardModule,
+      ngModule: MatCardModule,
       providers: []
     };
   }

--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -1,6 +1,6 @@
-<label class="md-checkbox-layout">
-  <div class="md-checkbox-inner-container">
-    <input class="md-checkbox-input" type="checkbox"
+<label class="mat-checkbox-layout">
+  <div class="mat-checkbox-inner-container">
+    <input class="mat-checkbox-input" type="checkbox"
            [id]="inputId"
            [checked]="checked"
            [disabled]="disabled"
@@ -13,24 +13,24 @@
            (blur)="_onInputBlur()"
            (change)="_onInteractionEvent($event)"
            (click)="_onInputClick($event)">
-    <div class="md-ink-ripple"></div>
-    <div class="md-checkbox-frame"></div>
-    <div class="md-checkbox-background">
+    <div class="mat-ink-ripple"></div>
+    <div class="mat-checkbox-frame"></div>
+    <div class="mat-checkbox-background">
       <svg version="1.1"
-           class="md-checkbox-checkmark"
+           class="mat-checkbox-checkmark"
            xmlns="http://www.w3.org/2000/svg"
            viewBox="0 0 24 24"
            xml:space="preserve">
-        <path class="md-checkbox-checkmark-path"
+        <path class="mat-checkbox-checkmark-path"
               fill="none"
               stroke="white"
               d="M4.1,12.7 9,17.6 20.3,6.3"/>
       </svg>
       <!-- Element for rendering the indeterminate state checkbox. -->
-      <div class="md-checkbox-mixedmark"></div>
+      <div class="mat-checkbox-mixedmark"></div>
     </div>
   </div>
-  <span class="md-checkbox-label">
+  <span class="mat-checkbox-label">
     <ng-content></ng-content>
   </span>
 </label>

--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -4,30 +4,30 @@
 @import 'mixins';
 
 /** The width/height of the checkbox element. */
-$md-checkbox-size: $md-toggle-size !default;
+$mat-checkbox-size: $mat-toggle-size !default;
 /** The width of the line used to draw the checkmark / mixedmark. */
-$md-checkbox-mark-stroke-size: 2/15 * $md-checkbox-size !default;
+$mat-checkbox-mark-stroke-size: 2/15 * $mat-checkbox-size !default;
 /** The width of the checkbox border shown when the checkbox is unchecked. */
-$md-checkbox-border-width: 2px;
+$mat-checkbox-border-width: 2px;
 /** The color of the checkbox border. */
-$md-checkbox-border-color: if($md-is-dark-theme, rgba(white, 0.7), rgba(black, 0.54)) !default;
+$mat-checkbox-border-color: if($mat-is-dark-theme, rgba(white, 0.7), rgba(black, 0.54)) !default;
 /** The color of the checkbox's checkmark / mixedmark. */
-$md-checkbox-mark-color: md-color($md-background, background);
+$mat-checkbox-mark-color: mat-color($mat-background, background);
 /** The color that is used as the checkbox background when it is checked. */
-$md-checkbox-background-color: md-color($md-accent, 500);
+$mat-checkbox-background-color: mat-color($mat-accent, 500);
 /** The base duration used for the majority of transitions for the checkbox. */
-$md-checkbox-transition-duration: 90ms;
+$mat-checkbox-transition-duration: 90ms;
 /** The amount of spacing between the checkbox and its label. */
-$md-checkbox-item-spacing: $md-toggle-padding;
+$mat-checkbox-item-spacing: $mat-toggle-padding;
 
 // Manual calculation done on SVG
-$_md-checkbox-mark-path-length: 22.910259;
-$_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1);
+$_mat-checkbox-mark-path-length: 22.910259;
+$_mat-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1);
 
 /**
  * Fades in the background of the checkbox when it goes from unchecked -> {checked,indeterminate}.
  */
-@keyframes md-checkbox-fade-in-background {
+@keyframes mat-checkbox-fade-in-background {
   0% {
     opacity: 0;
   }
@@ -40,7 +40,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 /**
  * Fades out the background of the checkbox when it goes from {checked,indeterminate} -> unchecked.
  */
-@keyframes md-checkbox-fade-out-background {
+@keyframes mat-checkbox-fade-out-background {
   0%, 50% {
     opacity: 1;
   }
@@ -53,13 +53,13 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 /**
  * "Draws" in the checkmark when the checkbox goes from unchecked -> checked.
  */
-@keyframes md-checkbox-unchecked-checked-checkmark-path {
+@keyframes mat-checkbox-unchecked-checked-checkmark-path {
   0%, 50% {
-    stroke-dashoffset: $_md-checkbox-mark-path-length;
+    stroke-dashoffset: $_mat-checkbox-mark-path-length;
   }
 
   50% {
-    animation-timing-function: $md-linear-out-slow-in-timing-function;
+    animation-timing-function: $mat-linear-out-slow-in-timing-function;
   }
 
   100% {
@@ -70,7 +70,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 /**
  * Horizontally expands the mixedmark when the checkbox goes from unchecked -> indeterminate.
  */
-@keyframes md-checkbox-unchecked-indeterminate-mixedmark {
+@keyframes mat-checkbox-unchecked-indeterminate-mixedmark {
   0%, 68.2% {
     transform: scaleX(0);
   }
@@ -87,14 +87,14 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 /**
  * "Erases" the checkmark when the checkbox goes from checked -> unchecked.
  */
-@keyframes md-checkbox-checked-unchecked-checkmark-path {
+@keyframes mat-checkbox-checked-unchecked-checkmark-path {
   from {
-    animation-timing-function: $md-fast-out-linear-in-timing-function;
+    animation-timing-function: $mat-fast-out-linear-in-timing-function;
     stroke-dashoffset: 0;
   }
 
   to {
-    stroke-dashoffset: $_md-checkbox-mark-path-length * -1;
+    stroke-dashoffset: $_mat-checkbox-mark-path-length * -1;
   }
 }
 
@@ -102,9 +102,9 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  * Rotates and fades out the checkmark when the checkbox goes from checked -> indeterminate. This
  * animation helps provide the illusion of the checkmark "morphing" into the mixedmark.
  */
-@keyframes md-checkbox-checked-indeterminate-checkmark {
+@keyframes mat-checkbox-checked-indeterminate-checkmark {
   from {
-    animation-timing-function: $md-linear-out-slow-in-timing-function;
+    animation-timing-function: $mat-linear-out-slow-in-timing-function;
     opacity: 1;
     transform: rotate(0deg);
   }
@@ -120,9 +120,9 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  * checked. This animation helps provide the illusion that the mixedmark is "morphing" into the
  * checkmark.
  */
-@keyframes md-checkbox-indeterminate-checked-checkmark {
+@keyframes mat-checkbox-indeterminate-checked-checkmark {
   from {
-    animation-timing-function: $_md-checkbox-indeterminate-checked-easing-function;
+    animation-timing-function: $_mat-checkbox-indeterminate-checked-easing-function;
     opacity: 0;
     transform: rotate(45deg);
   }
@@ -135,12 +135,12 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 
 /**
  * Rotates and fades in the mixedmark when the checkbox goes from checked -> indeterminate. This
- * animation, similar to md-checkbox-checked-indeterminate-checkmark, helps provide an illusion
+ * animation, similar to mat-checkbox-checked-indeterminate-checkmark, helps provide an illusion
  * of "morphing" from checkmark -> mixedmark.
  */
-@keyframes md-checkbox-checked-indeterminate-mixedmark {
+@keyframes mat-checkbox-checked-indeterminate-mixedmark {
   from {
-    animation-timing-function: $md-linear-out-slow-in-timing-function;
+    animation-timing-function: $mat-linear-out-slow-in-timing-function;
     opacity: 0;
     transform: rotate(-45deg);
   }
@@ -153,12 +153,12 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 
 /**
  * Rotates and fades out the mixedmark when the checkbox goes from indeterminate -> checked. This
- * animation, similar to md-checkbox-indeterminate-checked-checkmark, helps provide an illusion
+ * animation, similar to mat-checkbox-indeterminate-checked-checkmark, helps provide an illusion
  * of "morphing" from mixedmark -> checkmark.
  */
-@keyframes md-checkbox-indeterminate-checked-mixedmark {
+@keyframes mat-checkbox-indeterminate-checked-mixedmark {
   from {
-    animation-timing-function: $_md-checkbox-indeterminate-checked-easing-function;
+    animation-timing-function: $_mat-checkbox-indeterminate-checked-easing-function;
     opacity: 1;
     transform: rotate(0deg);
   }
@@ -173,7 +173,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  * Horizontally collapses and fades out the mixedmark when the checkbox goes from indeterminate ->
  * unchecked.
  */
-@keyframes md-checkbox-indeterminate-unchecked-mixedmark {
+@keyframes mat-checkbox-indeterminate-unchecked-mixedmark {
   0% {
     animation-timing-function: linear;
     opacity: 1;
@@ -189,7 +189,7 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
 /**
  * Applied to elements that cover the checkbox's entire inner container.
  */
-%md-checkbox-cover-element {
+%mat-checkbox-cover-element {
   bottom: 0;
   left: 0;
   position: absolute;
@@ -201,8 +201,8 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  * Applied to elements that are considered "marks" within the checkbox, e.g. the checkmark and
  * the mixedmark.
  */
-%md-checkbox-mark {
-  $width-padding-inset: 2 * $md-checkbox-border-width;
+%mat-checkbox-mark {
+  $width-padding-inset: 2 * $mat-checkbox-border-width;
   width: calc(100% - #{$width-padding-inset});
 }
 
@@ -210,266 +210,266 @@ $_md-checkbox-indeterminate-checked-easing-function: cubic-bezier(0.14, 0, 0, 1)
  * Applied to elements that appear to make up the outer box of the checkmark, such as the frame
  * that contains the border and the actual background element that contains the marks.
  */
-%md-checkbox-outer-box {
-  @extend %md-checkbox-cover-element;
+%mat-checkbox-outer-box {
+  @extend %mat-checkbox-cover-element;
   border-radius: 2px;
   box-sizing: border-box;
   pointer-events: none;
 }
 
-md-checkbox {
+mat-checkbox {
   cursor: pointer;
 }
 
-.md-checkbox-layout {
-  // `cursor: inherit` ensures that the wrapper element gets the same cursor as the md-checkbox
+.mat-checkbox-layout {
+  // `cursor: inherit` ensures that the wrapper element gets the same cursor as the mat-checkbox
   // (e.g. pointer by default, regular when disabled), instead of the browser default.
   cursor: inherit;
   align-items: baseline;
   display: inline-flex;
 }
 
-.md-checkbox-inner-container {
+.mat-checkbox-inner-container {
   display: inline-block;
-  height: $md-checkbox-size;
+  height: $mat-checkbox-size;
   line-height: 0;
   margin: auto;
-  margin-right: $md-checkbox-item-spacing;
+  margin-right: $mat-checkbox-item-spacing;
   order: 0;
   position: relative;
   vertical-align: middle;
   white-space: nowrap;
-  width: $md-checkbox-size;
+  width: $mat-checkbox-size;
 
   [dir='rtl'] & {
     margin: {
-      left: $md-checkbox-item-spacing;
+      left: $mat-checkbox-item-spacing;
       right: auto;
     }
   }
 }
 
 // TODO(kara): Remove this style when fixing vertical baseline
-.md-checkbox-layout .md-checkbox-label {
+.mat-checkbox-layout .mat-checkbox-label {
   line-height: 24px;
 }
 
-.md-checkbox-frame {
-  @extend %md-checkbox-outer-box;
+.mat-checkbox-frame {
+  @extend %mat-checkbox-outer-box;
 
   background-color: transparent;
-  border: $md-checkbox-border-width solid $md-checkbox-border-color;
-  transition: border-color $md-checkbox-transition-duration $md-linear-out-slow-in-timing-function;
+  border: $mat-checkbox-border-width solid $mat-checkbox-border-color;
+  transition: border-color $mat-checkbox-transition-duration $mat-linear-out-slow-in-timing-function;
   will-change: border-color;
 }
 
-.md-checkbox-background {
-  @extend %md-checkbox-outer-box;
+.mat-checkbox-background {
+  @extend %mat-checkbox-outer-box;
 
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  transition: background-color $md-checkbox-transition-duration
-                  $md-linear-out-slow-in-timing-function,
-              opacity $md-checkbox-transition-duration $md-linear-out-slow-in-timing-function;
+  transition: background-color $mat-checkbox-transition-duration
+                  $mat-linear-out-slow-in-timing-function,
+              opacity $mat-checkbox-transition-duration $mat-linear-out-slow-in-timing-function;
   will-change: background-color, opacity;
 }
 
-.md-checkbox-checkmark {
-  @extend %md-checkbox-cover-element;
-  @extend %md-checkbox-mark;
+.mat-checkbox-checkmark {
+  @extend %mat-checkbox-cover-element;
+  @extend %mat-checkbox-mark;
 
-  fill: $md-checkbox-mark-color;
+  fill: $mat-checkbox-mark-color;
   width: 100%;
 }
 
-.md-checkbox-checkmark-path {
+.mat-checkbox-checkmark-path {
   // !important is needed here because a stroke must be set as an attribute on the SVG in order
   // for line animation to work properly.
-  stroke: $md-checkbox-mark-color !important;
+  stroke: $mat-checkbox-mark-color !important;
   stroke: {
-    dashoffset: $_md-checkbox-mark-path-length;
-    dasharray: $_md-checkbox-mark-path-length;
-    width: $md-checkbox-mark-stroke-size;
+    dashoffset: $_mat-checkbox-mark-path-length;
+    dasharray: $_mat-checkbox-mark-path-length;
+    width: $mat-checkbox-mark-stroke-size;
   }
 }
 
-.md-checkbox-mixedmark {
-  @extend %md-checkbox-mark;
+.mat-checkbox-mixedmark {
+  @extend %mat-checkbox-mark;
 
-  background-color: $md-checkbox-mark-color;
-  height: floor($md-checkbox-mark-stroke-size);
+  background-color: $mat-checkbox-mark-color;
+  height: floor($mat-checkbox-mark-stroke-size);
   opacity: 0;
   transform: scaleX(0) rotate(0deg);
 }
 
-.md-checkbox-align-end {
-  .md-checkbox-inner-container {
+.mat-checkbox-align-end {
+  .mat-checkbox-inner-container {
     order: 1;
     margin: {
-      left: $md-checkbox-item-spacing;
+      left: $mat-checkbox-item-spacing;
       right: auto;
     }
 
     [dir='rtl'] & {
       margin: {
         left: auto;
-        right: $md-checkbox-item-spacing;
+        right: $mat-checkbox-item-spacing;
       }
     }
   }
 }
 
-.md-checkbox-checked {
-  .md-checkbox-checkmark {
+.mat-checkbox-checked {
+  .mat-checkbox-checkmark {
     opacity: 1;
   }
 
-  .md-checkbox-checkmark-path {
+  .mat-checkbox-checkmark-path {
     stroke-dashoffset: 0;
   }
 
-  .md-checkbox-mixedmark {
+  .mat-checkbox-mixedmark {
     transform: scaleX(1) rotate(-45deg);
   }
 
-  .md-checkbox-background {
-    background-color: $md-checkbox-background-color;
+  .mat-checkbox-background {
+    background-color: $mat-checkbox-background-color;
   }
 }
 
-.md-checkbox-indeterminate {
-  .md-checkbox-background {
-    background-color: $md-checkbox-background-color;
+.mat-checkbox-indeterminate {
+  .mat-checkbox-background {
+    background-color: $mat-checkbox-background-color;
   }
 
-  .md-checkbox-checkmark {
+  .mat-checkbox-checkmark {
     opacity: 0;
     transform: rotate(45deg);
   }
 
-  .md-checkbox-checkmark-path {
+  .mat-checkbox-checkmark-path {
     stroke-dashoffset: 0;
   }
 
-  .md-checkbox-mixedmark {
+  .mat-checkbox-mixedmark {
     opacity: 1;
     transform: scaleX(1) rotate(0deg);
   }
 }
 
 
-.md-checkbox-unchecked {
-  .md-checkbox-background {
+.mat-checkbox-unchecked {
+  .mat-checkbox-background {
     background-color: transparent;
   }
 }
 
-.md-checkbox-disabled {
+.mat-checkbox-disabled {
   // NOTE(traviskaufman): While the spec calls for translucent blacks/whites for disabled colors,
   // this does not work well with elements layered on top of one another. To get around this we
   // blend the colors together based on the base color and the theme background.
   $white-30pct-opacity-on-dark-theme: #686868;
   $black-26pct-opacity-on-light-theme: #b0b0b0;
   $disabled-color: if(
-      $md-is-dark-theme, $white-30pct-opacity-on-dark-theme, $black-26pct-opacity-on-light-theme);
+      $mat-is-dark-theme, $white-30pct-opacity-on-dark-theme, $black-26pct-opacity-on-light-theme);
 
   cursor: default;
 
-  &.md-checkbox-checked,
-  &.md-checkbox-indeterminate {
-    .md-checkbox-background {
+  &.mat-checkbox-checked,
+  &.mat-checkbox-indeterminate {
+    .mat-checkbox-background {
       background-color: $disabled-color;
     }
   }
 
-  &:not(.md-checkbox-checked) {
-    .md-checkbox-frame {
+  &:not(.mat-checkbox-checked) {
+    .mat-checkbox-frame {
       border-color: $disabled-color;
     }
   }
 }
 
-.md-checkbox-anim {
+.mat-checkbox-anim {
   $indeterminate-change-duration: 500ms;
 
   &-unchecked-checked {
-    .md-checkbox-background {
-      animation: $md-checkbox-transition-duration * 2 linear 0ms md-checkbox-fade-in-background;
+    .mat-checkbox-background {
+      animation: $mat-checkbox-transition-duration * 2 linear 0ms mat-checkbox-fade-in-background;
     }
 
-    .md-checkbox-checkmark-path {
+    .mat-checkbox-checkmark-path {
       // Instead of delaying the animation, we simply multiply its length by 2 and begin the
       // animation at 50% in order to prevent a flash of styles applied to a checked checkmark
       // as the background is fading in before the animation begins.
       animation:
-        $md-checkbox-transition-duration * 2 linear 0ms md-checkbox-unchecked-checked-checkmark-path;
+        $mat-checkbox-transition-duration * 2 linear 0ms mat-checkbox-unchecked-checked-checkmark-path;
     }
   }
 
   &-unchecked-indeterminate {
-    .md-checkbox-background {
-      animation: $md-checkbox-transition-duration * 2 linear 0ms md-checkbox-fade-in-background;
+    .mat-checkbox-background {
+      animation: $mat-checkbox-transition-duration * 2 linear 0ms mat-checkbox-fade-in-background;
     }
 
-    .md-checkbox-mixedmark {
+    .mat-checkbox-mixedmark {
       animation:
-        $md-checkbox-transition-duration linear 0ms md-checkbox-unchecked-indeterminate-mixedmark;
+        $mat-checkbox-transition-duration linear 0ms mat-checkbox-unchecked-indeterminate-mixedmark;
     }
   }
 
   &-checked-unchecked {
-    .md-checkbox-background {
-      animation: $md-checkbox-transition-duration * 2 linear 0ms md-checkbox-fade-out-background;
+    .mat-checkbox-background {
+      animation: $mat-checkbox-transition-duration * 2 linear 0ms mat-checkbox-fade-out-background;
     }
 
-    .md-checkbox-checkmark-path {
+    .mat-checkbox-checkmark-path {
       animation:
-        $md-checkbox-transition-duration linear 0ms md-checkbox-checked-unchecked-checkmark-path;
+        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-unchecked-checkmark-path;
     }
   }
 
   &-checked-indeterminate {
-    .md-checkbox-checkmark {
+    .mat-checkbox-checkmark {
       animation:
-        $md-checkbox-transition-duration linear 0ms md-checkbox-checked-indeterminate-checkmark;
+        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-indeterminate-checkmark;
     }
 
-    .md-checkbox-mixedmark {
+    .mat-checkbox-mixedmark {
       animation:
-        $md-checkbox-transition-duration linear 0ms md-checkbox-checked-indeterminate-mixedmark;
+        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-indeterminate-mixedmark;
     }
   }
 
   &-indeterminate-checked {
-    .md-checkbox-checkmark {
+    .mat-checkbox-checkmark {
       animation:
-        $indeterminate-change-duration linear 0ms md-checkbox-indeterminate-checked-checkmark;
+        $indeterminate-change-duration linear 0ms mat-checkbox-indeterminate-checked-checkmark;
     }
 
-    .md-checkbox-mixedmark {
+    .mat-checkbox-mixedmark {
       animation:
-        $indeterminate-change-duration linear 0ms md-checkbox-indeterminate-checked-mixedmark;
+        $indeterminate-change-duration linear 0ms mat-checkbox-indeterminate-checked-mixedmark;
     }
   }
 
   &-indeterminate-unchecked {
-    .md-checkbox-background {
-      animation: $md-checkbox-transition-duration * 2 linear 0ms md-checkbox-fade-out-background;
+    .mat-checkbox-background {
+      animation: $mat-checkbox-transition-duration * 2 linear 0ms mat-checkbox-fade-out-background;
     }
 
-    .md-checkbox-mixedmark {
+    .mat-checkbox-mixedmark {
       animation:
         $indeterminate-change-duration * 0.6 linear 0ms
-        md-checkbox-indeterminate-unchecked-mixedmark;
+        mat-checkbox-indeterminate-unchecked-mixedmark;
     }
   }
 }
 
 // Underlying native input element.
 // Visually hidden but still able to respond to focus.
-.md-checkbox-input {
-  @include md-visually-hidden;
+.mat-checkbox-input {
+  @include mat-visually-hidden;
 }
 
-@include md-temporary-ink-ripple(checkbox);
+@include mat-temporary-ink-ripple(checkbox);

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -11,17 +11,17 @@ import {
 } from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdCheckbox, MdCheckboxChange, MdCheckboxModule} from './checkbox';
+import {MatCheckbox, MatCheckboxChange, MatCheckboxModule} from './checkbox';
 
 
 // TODO: Implement E2E tests for spacebar/click behavior for checking/unchecking
 
-describe('MdCheckbox', () => {
+describe('MatCheckbox', () => {
   let fixture: ComponentFixture<any>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdCheckboxModule.forRoot(), FormsModule],
+      imports: [MatCheckboxModule.forRoot(), FormsModule],
       declarations: [
         SingleCheckbox,
         CheckboxWithFormDirectives,
@@ -40,7 +40,7 @@ describe('MdCheckbox', () => {
   describe('basic behaviors', () => {
     let checkboxDebugElement: DebugElement;
     let checkboxNativeElement: HTMLElement;
-    let checkboxInstance: MdCheckbox;
+    let checkboxInstance: MatCheckbox;
     let testComponent: SingleCheckbox;
     let inputElement: HTMLInputElement;
     let labelElement: HTMLLabelElement;
@@ -49,7 +49,7 @@ describe('MdCheckbox', () => {
       fixture = TestBed.createComponent(SingleCheckbox);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -59,40 +59,40 @@ describe('MdCheckbox', () => {
 
     it('should add and remove the checked state', () => {
       expect(checkboxInstance.checked).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
       expect(inputElement.checked).toBe(false);
 
       testComponent.isChecked = true;
       fixture.detectChanges();
 
       expect(checkboxInstance.checked).toBe(true);
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-checked');
       expect(inputElement.checked).toBe(true);
 
       testComponent.isChecked = false;
       fixture.detectChanges();
 
       expect(checkboxInstance.checked).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
       expect(inputElement.checked).toBe(false);
     });
 
     it('should add and remove indeterminate state', () => {
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
       expect(inputElement.checked).toBe(false);
       expect(inputElement.indeterminate).toBe(false);
 
       testComponent.isIndeterminate = true;
       fixture.detectChanges();
 
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-indeterminate');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-indeterminate');
       expect(inputElement.checked).toBe(false);
       expect(inputElement.indeterminate).toBe(true);
 
       testComponent.isIndeterminate = false;
       fixture.detectChanges();
 
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-indeterminate');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-indeterminate');
       expect(inputElement.checked).toBe(false);
       expect(inputElement.indeterminate).toBe(false);
     });
@@ -133,7 +133,7 @@ describe('MdCheckbox', () => {
 
     it('should add and remove disabled state', () => {
       expect(checkboxInstance.disabled).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-disabled');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-disabled');
       expect(inputElement.tabIndex).toBe(0);
       expect(inputElement.disabled).toBe(false);
 
@@ -141,14 +141,14 @@ describe('MdCheckbox', () => {
       fixture.detectChanges();
 
       expect(checkboxInstance.disabled).toBe(true);
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-disabled');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-disabled');
       expect(inputElement.disabled).toBe(true);
 
       testComponent.isDisabled = false;
       fixture.detectChanges();
 
       expect(checkboxInstance.disabled).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-disabled');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-disabled');
       expect(inputElement.tabIndex).toBe(0);
       expect(inputElement.disabled).toBe(false);
     });
@@ -177,7 +177,7 @@ describe('MdCheckbox', () => {
     });
 
     it('should project the checkbox content into the label element', () => {
-      let label = <HTMLLabelElement>checkboxNativeElement.querySelector('.md-checkbox-label');
+      let label = <HTMLLabelElement>checkboxNativeElement.querySelector('.mat-checkbox-label');
       expect(label.textContent.trim()).toBe('Simple checkbox');
     });
 
@@ -189,7 +189,7 @@ describe('MdCheckbox', () => {
       testComponent.alignment = 'end';
       fixture.detectChanges();
 
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-align-end');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-align-end');
     });
 
     it('should not trigger the click event multiple times', () => {
@@ -201,12 +201,12 @@ describe('MdCheckbox', () => {
       spyOn(testComponent, 'onCheckboxClick');
 
       expect(inputElement.checked).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
 
       labelElement.click();
       fixture.detectChanges();
 
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-checked');
       expect(inputElement.checked).toBe(true);
 
       expect(testComponent.onCheckboxClick).toHaveBeenCalledTimes(1);
@@ -216,13 +216,13 @@ describe('MdCheckbox', () => {
       spyOn(testComponent, 'onCheckboxChange');
 
       expect(inputElement.checked).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
 
       labelElement.click();
       fixture.detectChanges();
 
       expect(inputElement.checked).toBe(true);
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-checked');
 
       // Wait for the fixture to become stable, because the EventEmitter for the change event,
       // will only fire after the zone async change detection has finished.
@@ -237,13 +237,13 @@ describe('MdCheckbox', () => {
       spyOn(testComponent, 'onCheckboxChange');
 
       expect(inputElement.checked).toBe(false);
-      expect(checkboxNativeElement.classList).not.toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).not.toContain('mat-checkbox-checked');
 
       testComponent.isChecked = true;
       fixture.detectChanges();
 
       expect(inputElement.checked).toBe(true);
-      expect(checkboxNativeElement.classList).toContain('md-checkbox-checked');
+      expect(checkboxNativeElement.classList).toContain('mat-checkbox-checked');
 
       // Wait for the fixture to become stable, because the EventEmitter for the change event,
       // will only fire after the zone async change detection has finished.
@@ -259,12 +259,13 @@ describe('MdCheckbox', () => {
       it('should transition unchecked -> checked -> unchecked', () => {
         testComponent.isChecked = true;
         fixture.detectChanges();
-        expect(checkboxNativeElement.classList).toContain('md-checkbox-anim-unchecked-checked');
+        expect(checkboxNativeElement.classList).toContain('mat-checkbox-anim-unchecked-checked');
 
         testComponent.isChecked = false;
         fixture.detectChanges();
-        expect(checkboxNativeElement.classList).not.toContain('md-checkbox-anim-unchecked-checked');
-        expect(checkboxNativeElement.classList).toContain('md-checkbox-anim-checked-unchecked');
+        expect(checkboxNativeElement.classList)
+          .not.toContain('mat-checkbox-anim-unchecked-checked');
+        expect(checkboxNativeElement.classList).toContain('mat-checkbox-anim-checked-unchecked');
       });
 
       it('should transition unchecked -> indeterminate -> unchecked', () => {
@@ -272,15 +273,15 @@ describe('MdCheckbox', () => {
         fixture.detectChanges();
 
         expect(checkboxNativeElement.classList)
-            .toContain('md-checkbox-anim-unchecked-indeterminate');
+            .toContain('mat-checkbox-anim-unchecked-indeterminate');
 
         testComponent.isIndeterminate = false;
         fixture.detectChanges();
 
         expect(checkboxNativeElement.classList)
-            .not.toContain('md-checkbox-anim-unchecked-indeterminate');
+            .not.toContain('mat-checkbox-anim-unchecked-indeterminate');
         expect(checkboxNativeElement.classList)
-            .toContain('md-checkbox-anim-indeterminate-unchecked');
+            .toContain('mat-checkbox-anim-indeterminate-unchecked');
       });
 
       it('should transition indeterminate -> checked', () => {
@@ -290,22 +291,23 @@ describe('MdCheckbox', () => {
         testComponent.isChecked = true;
         fixture.detectChanges();
 
-        expect(checkboxNativeElement.classList).not.toContain(
-            'md-checkbox-anim-unchecked-indeterminate');
-        expect(checkboxNativeElement.classList).toContain('md-checkbox-anim-indeterminate-checked');
+        expect(checkboxNativeElement.classList)
+          .not.toContain('mat-checkbox-anim-unchecked-indeterminate');
+        expect(checkboxNativeElement.classList)
+          .toContain('mat-checkbox-anim-indeterminate-checked');
       });
 
       it('should not apply transition classes when there is no state change', () => {
         testComponent.isChecked = checkboxInstance.checked;
         fixture.detectChanges();
-        expect(checkboxNativeElement).not.toMatch(/^md\-checkbox\-anim/g);
+        expect(checkboxNativeElement).not.toMatch(/^mat\-checkbox\-anim/g);
 
         testComponent.isIndeterminate = checkboxInstance.indeterminate;
-        expect(checkboxNativeElement).not.toMatch(/^md\-checkbox\-anim/g);
+        expect(checkboxNativeElement).not.toMatch(/^mat\-checkbox\-anim/g);
       });
 
       it('should not initially have any transition classes', () => {
-        expect(checkboxNativeElement).not.toMatch(/^md\-checkbox\-anim/g);
+        expect(checkboxNativeElement).not.toMatch(/^mat\-checkbox\-anim/g);
       });
     });
   });
@@ -313,7 +315,7 @@ describe('MdCheckbox', () => {
   describe('with change event and no initial value', () => {
     let checkboxDebugElement: DebugElement;
     let checkboxNativeElement: HTMLElement;
-    let checkboxInstance: MdCheckbox;
+    let checkboxInstance: MatCheckbox;
     let testComponent: CheckboxWithChangeEvent;
     let inputElement: HTMLInputElement;
     let labelElement: HTMLLabelElement;
@@ -322,7 +324,7 @@ describe('MdCheckbox', () => {
       fixture = TestBed.createComponent(CheckboxWithChangeEvent);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -372,7 +374,7 @@ describe('MdCheckbox', () => {
 
     it('should use the provided aria-label', async(() => {
       fixture = TestBed.createComponent(CheckboxWithAriaLabel);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -388,7 +390,7 @@ describe('MdCheckbox', () => {
 
     it('should use the provided aria-labelledby', async(() => {
       fixture = TestBed.createComponent(CheckboxWithAriaLabelledby);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -398,7 +400,7 @@ describe('MdCheckbox', () => {
 
     it('should not assign aria-labelledby if none is provided', async(() => {
       fixture = TestBed.createComponent(SingleCheckbox);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -419,7 +421,7 @@ describe('MdCheckbox', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
       labelElement = <HTMLLabelElement>checkboxNativeElement.querySelector('label');
@@ -451,7 +453,7 @@ describe('MdCheckbox', () => {
 
     it('should assign a unique id to each checkbox', () => {
       let [firstId, secondId] =
-          fixture.debugElement.queryAll(By.directive(MdCheckbox))
+          fixture.debugElement.queryAll(By.directive(MatCheckbox))
           .map(debugElement => debugElement.nativeElement.querySelector('input').id);
 
       expect(firstId).toBeTruthy();
@@ -469,7 +471,7 @@ describe('MdCheckbox', () => {
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
       flushMicrotasks();
 
-      let checkboxElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox));
       let ngControl = <NgControl> checkboxElement.injector.get(NgControl);
 
       expect(ngControl.valid).toBe(true);
@@ -488,7 +490,7 @@ describe('MdCheckbox', () => {
     }));
 
     it('should forward name value to input element', fakeAsync(() => {
-      let checkboxElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox));
       let inputElement = <HTMLInputElement> checkboxElement.nativeElement.querySelector('input');
 
       expect(inputElement.getAttribute('name')).toBe('test-name');
@@ -500,7 +502,7 @@ describe('MdCheckbox', () => {
 @Component({
   template: `
   <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">    
-    <md-checkbox 
+    <mat-checkbox 
         id="simple-check"
         [align]="alignment"
         [checked]="isChecked" 
@@ -510,7 +512,7 @@ describe('MdCheckbox', () => {
         (click)="onCheckboxClick($event)"
         (change)="onCheckboxChange($event)">
       Simple checkbox
-    </md-checkbox>
+    </mat-checkbox>
   </div>`
 })
 class SingleCheckbox {
@@ -524,14 +526,14 @@ class SingleCheckbox {
   changeCount: number = 0;
 
   onCheckboxClick(event: Event) {}
-  onCheckboxChange(event: MdCheckboxChange) {}
+  onCheckboxChange(event: MatCheckboxChange) {}
 }
 
-/** Simple component for testing an MdCheckbox with ngModel. */
+/** Simple component for testing an MatCheckbox with ngModel. */
 @Component({
   template: `
     <form>
-      <md-checkbox name="cb" [(ngModel)]="isGood">Be good</md-checkbox>
+      <mat-checkbox name="cb" [(ngModel)]="isGood">Be good</mat-checkbox>
     </form>
   `,
 })
@@ -542,8 +544,8 @@ class CheckboxWithFormDirectives {
 /** Simple test component with multiple checkboxes. */
 @Component(({
   template: `
-    <md-checkbox>Option 1</md-checkbox>
-    <md-checkbox>Option 2</md-checkbox>
+    <mat-checkbox>Option 1</mat-checkbox>
+    <mat-checkbox>Option 2</mat-checkbox>
   `
 }))
 class MultipleCheckboxes { }
@@ -552,8 +554,8 @@ class MultipleCheckboxes { }
 /** Simple test component with tabIndex */
 @Component({
   template: `
-    <md-checkbox [tabindex]="customTabIndex" [disabled]="isDisabled">
-    </md-checkbox>`,
+    <mat-checkbox [tabindex]="customTabIndex" [disabled]="isDisabled">
+    </mat-checkbox>`,
 })
 class CheckboxWithTabIndex {
   customTabIndex: number = 7;
@@ -562,26 +564,26 @@ class CheckboxWithTabIndex {
 
 /** Simple test component with an aria-label set. */
 @Component({
-  template: `<md-checkbox aria-label="Super effective"></md-checkbox>`
+  template: `<mat-checkbox aria-label="Super effective"></mat-checkbox>`
 })
 class CheckboxWithAriaLabel { }
 
 /** Simple test component with an aria-label set. */
 @Component({
-  template: `<md-checkbox aria-labelledby="some-id"></md-checkbox>`
+  template: `<mat-checkbox aria-labelledby="some-id"></mat-checkbox>`
 })
 class CheckboxWithAriaLabelledby {}
 
 /** Simple test component with name attribute */
 @Component({
-  template: `<md-checkbox name="test-name"></md-checkbox>`
+  template: `<mat-checkbox name="test-name"></mat-checkbox>`
 })
 class CheckboxWithNameAttribute {}
 
 /** Simple test component with change event */
 @Component({
-  template: `<md-checkbox (change)="lastEvent = $event"></md-checkbox>`
+  template: `<mat-checkbox (change)="lastEvent = $event"></mat-checkbox>`
 })
 class CheckboxWithChangeEvent {
-  lastEvent: MdCheckboxChange;
+  lastEvent: MatCheckboxChange;
 }

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -19,12 +19,12 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 let nextId = 0;
 
 /**
- * Provider Expression that allows md-checkbox to register as a ControlValueAccessor. This allows it
- * to support [(ngModel)].
+ * Provider Expression that allows mat-checkbox to register as a ControlValueAccessor. This allows
+ * it to support [(ngModel)].
  */
-export const MD_CHECKBOX_CONTROL_VALUE_ACCESSOR: any = {
+export const MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdCheckbox),
+  useExisting: forwardRef(() => MatCheckbox),
   multi: true
 };
 
@@ -42,15 +42,15 @@ export enum TransitionCheckState {
   Indeterminate
 }
 
-// A simple change event emitted by the MdCheckbox component.
-export class MdCheckboxChange {
-  source: MdCheckbox;
+// A simple change event emitted by the MatCheckbox component.
+export class MatCheckboxChange {
+  source: MatCheckbox;
   checked: boolean;
 }
 
 /**
  * A material design checkbox component. Supports all of the functionality of an HTML5 checkbox,
- * and exposes a similar API. An MdCheckbox can be either checked, unchecked, indeterminate, or
+ * and exposes a similar API. An MatCheckbox can be either checked, unchecked, indeterminate, or
  * disabled. Note that all additional accessibility attributes are taken care of by the component,
  * so there is no need to provide them yourself. However, if you want to omit a label and still
  * have the checkbox be accessible, you may supply an [aria-label] input.
@@ -58,21 +58,21 @@ export class MdCheckboxChange {
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-checkbox',
+  selector: 'mat-checkbox',
   templateUrl: 'checkbox.html',
   styleUrls: ['checkbox.css'],
   host: {
-    '[class.md-checkbox-indeterminate]': 'indeterminate',
-    '[class.md-checkbox-checked]': 'checked',
-    '[class.md-checkbox-disabled]': 'disabled',
-    '[class.md-checkbox-align-end]': 'align == "end"',
-    '[class.md-checkbox-focused]': 'hasFocus',
+    '[class.mat-checkbox-indeterminate]': 'indeterminate',
+    '[class.mat-checkbox-checked]': 'checked',
+    '[class.mat-checkbox-disabled]': 'disabled',
+    '[class.mat-checkbox-align-end]': 'align == "end"',
+    '[class.mat-checkbox-focused]': 'hasFocus',
   },
-  providers: [MD_CHECKBOX_CONTROL_VALUE_ACCESSOR],
+  providers: [MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MdCheckbox implements ControlValueAccessor {
+export class MatCheckbox implements ControlValueAccessor {
   /**
    * Attached to the aria-label attribute of the host element. In most cases, arial-labelledby will
    * take precedence so this may be omitted.
@@ -85,7 +85,7 @@ export class MdCheckbox implements ControlValueAccessor {
   @Input('aria-labelledby') ariaLabelledby: string = null;
 
   /** A unique id for the checkbox. If one is not supplied, it is auto-generated. */
-  @Input() id: string = `md-checkbox-${++nextId}`;
+  @Input() id: string = `mat-checkbox-${++nextId}`;
 
   /** ID to be applied to the `input` element */
   get inputId(): string {
@@ -111,7 +111,7 @@ export class MdCheckbox implements ControlValueAccessor {
   @Input() name: string = null;
 
   /** Event emitted when the checkbox's `checked` value changes. */
-  @Output() change: EventEmitter<MdCheckboxChange> = new EventEmitter<MdCheckboxChange>();
+  @Output() change: EventEmitter<MatCheckboxChange> = new EventEmitter<MatCheckboxChange>();
 
   /** Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor. */
   onTouched: () => any = () => {};
@@ -216,7 +216,7 @@ export class MdCheckbox implements ControlValueAccessor {
   }
 
   private _emitChangeEvent() {
-    let event = new MdCheckboxChange();
+    let event = new MatCheckboxChange();
     event.source = this;
     event.checked = this.checked;
 
@@ -301,19 +301,19 @@ export class MdCheckbox implements ControlValueAccessor {
           'indeterminate-checked' : 'indeterminate-unchecked';
     }
 
-    return `md-checkbox-anim-${animSuffix}`;
+    return `mat-checkbox-anim-${animSuffix}`;
   }
 }
 
 
 @NgModule({
-  exports: [MdCheckbox],
-  declarations: [MdCheckbox],
+  exports: [MatCheckbox],
+  declarations: [MatCheckbox],
 })
-export class MdCheckboxModule {
+export class MatCheckboxModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdCheckboxModule,
+      ngModule: MatCheckboxModule,
       providers: []
     };
   }

--- a/src/lib/core/a11y/live-announcer.scss
+++ b/src/lib/core/a11y/live-announcer.scss
@@ -1,5 +1,5 @@
 @import 'mixins';
 
-.md-live-announcer {
-  @include md-visually-hidden();
+.mat-live-announcer {
+  @include mat-visually-hidden();
 }

--- a/src/lib/core/a11y/live-announcer.spec.ts
+++ b/src/lib/core/a11y/live-announcer.spec.ts
@@ -1,21 +1,21 @@
 import {inject, fakeAsync, tick, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdLiveAnnouncer, LIVE_ANNOUNCER_ELEMENT_TOKEN} from './live-announcer';
+import {MatLiveAnnouncer, LIVE_ANNOUNCER_ELEMENT_TOKEN} from './live-announcer';
 
 
-describe('MdLiveAnnouncer', () => {
-  let announcer: MdLiveAnnouncer;
+describe('MatLiveAnnouncer', () => {
+  let announcer: MatLiveAnnouncer;
   let ariaLiveElement: Element;
   let fixture: ComponentFixture<TestApp>;
 
   describe('with default element', () => {
     beforeEach(() => TestBed.configureTestingModule({
       declarations: [TestApp],
-      providers: [MdLiveAnnouncer]
+      providers: [MatLiveAnnouncer]
     }));
 
-    beforeEach(fakeAsync(inject([MdLiveAnnouncer], (la: MdLiveAnnouncer) => {
+    beforeEach(fakeAsync(inject([MatLiveAnnouncer], (la: MatLiveAnnouncer) => {
       announcer = la;
       ariaLiveElement = getLiveElement();
       fixture = TestBed.createComponent(TestApp);
@@ -68,12 +68,12 @@ describe('MdLiveAnnouncer', () => {
         declarations: [TestApp],
         providers: [
           {provide: LIVE_ANNOUNCER_ELEMENT_TOKEN, useValue: customLiveElement},
-          MdLiveAnnouncer,
+          MatLiveAnnouncer,
         ],
       });
     });
 
-    beforeEach(inject([MdLiveAnnouncer], (la: MdLiveAnnouncer) => {
+    beforeEach(inject([MatLiveAnnouncer], (la: MatLiveAnnouncer) => {
         announcer = la;
         ariaLiveElement = getLiveElement();
       }));
@@ -92,12 +92,12 @@ describe('MdLiveAnnouncer', () => {
 
 
 function getLiveElement(): Element {
-  return document.body.querySelector('.md-live-announcer');
+  return document.body.querySelector('.mat-live-announcer');
 }
 
 @Component({template: `<button (click)="announceText('Test')">Announce</button>`})
 class TestApp {
-  constructor(public live: MdLiveAnnouncer) { };
+  constructor(public live: MatLiveAnnouncer) { };
 
   announceText(message: string) {
     this.live.announce(message);

--- a/src/lib/core/a11y/live-announcer.ts
+++ b/src/lib/core/a11y/live-announcer.ts
@@ -5,12 +5,12 @@ import {
   Inject
 } from '@angular/core';
 
-export const LIVE_ANNOUNCER_ELEMENT_TOKEN  = new OpaqueToken('mdLiveAnnouncerElement');
+export const LIVE_ANNOUNCER_ELEMENT_TOKEN  = new OpaqueToken('matLiveAnnouncerElement');
 
 export type AriaLivePoliteness = 'off' | 'polite' | 'assertive';
 
 @Injectable()
-export class MdLiveAnnouncer {
+export class MatLiveAnnouncer {
 
   private _liveElement: Element;
 
@@ -43,7 +43,7 @@ export class MdLiveAnnouncer {
   private _createLiveElement(): Element {
     let liveEl = document.createElement('div');
 
-    liveEl.classList.add('md-live-announcer');
+    liveEl.classList.add('mat-live-announcer');
     liveEl.setAttribute('aria-atomic', 'true');
     liveEl.setAttribute('aria-live', 'polite');
 

--- a/src/lib/core/annotations/field-value.ts
+++ b/src/lib/core/annotations/field-value.ts
@@ -15,7 +15,7 @@
 function booleanFieldValueFactory() {
   return function booleanFieldValueMetadata(target: any, key: string): void {
     const defaultValue = target[key];
-    const localKey = `__md_private_symbol_${key}`;
+    const localKey = `__mat_private_symbol_${key}`;
     target[localKey] = defaultValue;
 
     Object.defineProperty(target, key, {

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 
 
 // Users of the Dispatcher never need to see this type, but TypeScript requires it to be exported.
-export type MdUniqueSelectionDispatcherListener = (id: string, name: string) => void;
+export type MatUniqueSelectionDispatcherListener = (id: string, name: string) => void;
 
 /**
  * Class to coordinate unique selection based on name.
@@ -14,8 +14,8 @@ export type MdUniqueSelectionDispatcherListener = (id: string, name: string) => 
  * less error-prone if they are simply passed through when the events occur.
  */
 @Injectable()
-export class MdUniqueSelectionDispatcher {
-  private _listeners: MdUniqueSelectionDispatcherListener[] = [];
+export class MatUniqueSelectionDispatcher {
+  private _listeners: MatUniqueSelectionDispatcherListener[] = [];
 
   /** Notify other items that selection for the given name has been set. */
   notify(id: string, name: string) {
@@ -25,7 +25,7 @@ export class MdUniqueSelectionDispatcher {
   }
 
   /** Listen for future changes to item selection. */
-  listen(listener: MdUniqueSelectionDispatcherListener) {
+  listen(listener: MatUniqueSelectionDispatcherListener) {
     this._listeners.push(listener);
   }
 }

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -1,10 +1,10 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {MdLineModule} from './line/line';
+import {MatLineModule} from './line/line';
 import {RtlModule} from './rtl/dir';
-import {MdRippleModule} from './ripple/ripple';
+import {MatRippleModule} from './ripple/ripple';
 import {PortalModule} from './portal/portal-directives';
 import {OverlayModule} from './overlay/overlay-directives';
-import {MdLiveAnnouncer} from './a11y/live-announcer';
+import {MatLiveAnnouncer} from './a11y/live-announcer';
 
 // RTL
 export {Dir, LayoutDirection, RtlModule} from './rtl/dir';
@@ -38,30 +38,30 @@ export * from './overlay/position/connected-position-strategy';
 export * from './overlay/position/connected-position';
 
 // Gestures
-export {MdGestureConfig} from './gestures/MdGestureConfig';
+export {MatGestureConfig} from './gestures/gesture-config';
 
 // Ripple
-export {MdRipple, MdRippleModule} from './ripple/ripple';
+export {MatRipple, MatRippleModule} from './ripple/ripple';
 
 // a11y
 export {
   AriaLivePoliteness,
-  MdLiveAnnouncer,
+  MatLiveAnnouncer,
   LIVE_ANNOUNCER_ELEMENT_TOKEN,
 } from './a11y/live-announcer';
 
 export {
-  MdUniqueSelectionDispatcher,
-  MdUniqueSelectionDispatcherListener
+  MatUniqueSelectionDispatcher,
+  MatUniqueSelectionDispatcherListener
 } from './coordination/unique-selection-dispatcher';
 
-export {MdLineModule, MdLine, MdLineSetter} from './line/line';
+export {MatLineModule, MatLine, MatLineSetter} from './line/line';
 
 // Style
 export {applyCssTransform} from './style/apply-transform';
 
 // Error
-export {MdError} from './errors/error';
+export {MatError} from './errors/error';
 
 // Annotations.
 export {BooleanFieldValue} from './annotations/field-value';
@@ -74,14 +74,14 @@ export * from './keyboard/keycodes';
 
 
 @NgModule({
-  imports: [MdLineModule, RtlModule, MdRippleModule, PortalModule, OverlayModule],
-  exports: [MdLineModule, RtlModule, MdRippleModule, PortalModule, OverlayModule],
+  imports: [MatLineModule, RtlModule, MatRippleModule, PortalModule, OverlayModule],
+  exports: [MatLineModule, RtlModule, MatRippleModule, PortalModule, OverlayModule],
 })
-export class MdCoreModule {
+export class MatCoreModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdCoreModule,
-      providers: [MdLiveAnnouncer]
+      ngModule: MatCoreModule,
+      providers: [MatLiveAnnouncer]
     };
   }
 }

--- a/src/lib/core/errors/error.ts
+++ b/src/lib/core/errors/error.ts
@@ -3,7 +3,7 @@
 /**
  * Wrapper around Error that sets the error message.
  */
-export class MdError extends Error {
+export class MatError extends Error {
   constructor(value: string) {
     super();
     this.message = value;

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -3,7 +3,7 @@ import {HammerGestureConfig} from '@angular/platform-browser';
 
 /* Adjusts configuration of our gesture library, Hammer. */
 @Injectable()
-export class MdGestureConfig extends HammerGestureConfig {
+export class MatGestureConfig extends HammerGestureConfig {
 
   /* List of new event names to add to the gesture support list */
   events: string[] = [

--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -8,15 +8,15 @@ import {
 
 /**
  * Shared directive to count lines inside a text area, such as a list item.
- * Line elements can be extracted with a @ContentChildren(MdLine) query, then
+ * Line elements can be extracted with a @ContentChildren(MatLine) query, then
  * counted by checking the query list's length.
  */
-@Directive({ selector: '[md-line]' })
-export class MdLine {}
+@Directive({ selector: '[mat-line]' })
+export class MatLine {}
 
 /* Helper that takes a query list of lines and sets the correct class on the host */
-export class MdLineSetter {
-  constructor(private _lines: QueryList<MdLine>, private _renderer: Renderer,
+export class MatLineSetter {
+  constructor(private _lines: QueryList<MatLine>, private _renderer: Renderer,
               private _element: ElementRef) {
     this._setLineClass(this._lines.length);
 
@@ -29,13 +29,13 @@ export class MdLineSetter {
   private _setLineClass(count: number): void {
     this._resetClasses();
     if (count === 2 || count === 3) {
-      this._setClass(`md-${count}-line`, true);
+      this._setClass(`mat-${count}-line`, true);
     }
   }
 
   private _resetClasses(): void {
-    this._setClass('md-2-line', false);
-    this._setClass('md-3-line', false);
+    this._setClass('mat-2-line', false);
+    this._setClass('mat-3-line', false);
   }
 
   private _setClass(className: string, bool: boolean): void {
@@ -45,7 +45,7 @@ export class MdLineSetter {
 }
 
 @NgModule({
-  exports: [MdLine],
-  declarations: [MdLine],
+  exports: [MatLine],
+  declarations: [MatLine],
 })
-export class MdLineModule { }
+export class MatLineModule { }

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -18,11 +18,11 @@ export class OverlayContainer {
 
   /**
    * Create the overlay container element, which is simply a div
-   * with the 'md-overlay-container' class on the document body.
+   * with the 'mat-overlay-container' class on the document body.
    */
   private _createContainer(): void {
     let container = document.createElement('div');
-    container.classList.add('md-overlay-container');
+    container.classList.add('mat-overlay-container');
     document.body.appendChild(container);
     this._containerElement = container;
   }

--- a/src/lib/core/overlay/overlay.scss
+++ b/src/lib/core/overlay/overlay.scss
@@ -1,9 +1,9 @@
-// TODO(jelbourn): change from the `md` prefix to something else for everything in the toolkit.
+// TODO(jelbourn): change from the `mat` prefix to something else for everything in the toolkit.
 
 @import 'variables';
 
 /** The overlay-container is an invisible element which contains all individual overlays. */
-.md-overlay-container {
+.mat-overlay-container {
   position: absolute;
 
   // Disable events from being captured on the overlay container.
@@ -17,7 +17,7 @@
 }
 
 /** A single overlay pane. */
-.md-overlay-pane {
+.mat-overlay-pane {
   position: absolute;
   pointer-events: auto;
   box-sizing: border-box;

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -54,8 +54,8 @@ export class Overlay {
    */
   private _createPaneElement(): HTMLElement {
     var pane = document.createElement('div');
-    pane.id = `md-overlay-${nextUniqueId++}`;
-    pane.classList.add('md-overlay-pane');
+    pane.id = `mat-overlay-${nextUniqueId++}`;
+    pane.classList.add('mat-overlay-pane');
 
     this._overlayContainer.getContainerElement().appendChild(pane);
 

--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -1,6 +1,6 @@
 import {ComponentFactoryResolver, ComponentRef, EmbeddedViewRef} from '@angular/core';
 import {BasePortalHost, ComponentPortal, TemplatePortal} from './portal';
-import {MdComponentPortalAttachedToDomWithoutOriginError} from './portal-errors';
+import {MatComponentPortalAttachedToDomWithoutOriginError} from './portal-errors';
 
 
 /**
@@ -19,7 +19,7 @@ export class DomPortalHost extends BasePortalHost {
   /** Attach the given ComponentPortal to DOM element using the ComponentFactoryResolver. */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     if (portal.viewContainerRef == null) {
-      throw new MdComponentPortalAttachedToDomWithoutOriginError();
+      throw new MatComponentPortalAttachedToDomWithoutOriginError();
     }
 
     let componentFactory = this._componentFactoryResolver.resolveComponentFactory(portal.component);

--- a/src/lib/core/portal/portal-errors.ts
+++ b/src/lib/core/portal/portal-errors.ts
@@ -1,7 +1,7 @@
-import {MdError} from '../errors/error';
+import {MatError} from '../errors/error';
 
 /** Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin. */
-export class MdComponentPortalAttachedToDomWithoutOriginError extends MdError {
+export class MatComponentPortalAttachedToDomWithoutOriginError extends MatError {
   constructor() {
       super(
           'A ComponentPortal must have an origin set when attached to a DomPortalHost ' +
@@ -10,28 +10,28 @@ export class MdComponentPortalAttachedToDomWithoutOriginError extends MdError {
 }
 
 /** Exception thrown when attempting to attach a null portal to a host. */
-export class MdNullPortalError extends MdError {
+export class MatNullPortalError extends MatError {
   constructor() {
       super('Must provide a portal to attach');
   }
 }
 
 /** Exception thrown when attempting to attach a portal to a host that is already attached. */
-export class MdPortalAlreadyAttachedError extends MdError {
+export class MatPortalAlreadyAttachedError extends MatError {
   constructor() {
       super('Host already has a portal attached');
   }
 }
 
 /** Exception thrown when attempting to attach a portal to an already-disposed host. */
-export class MdPortalHostAlreadyDisposedError extends MdError {
+export class MatPortalHostAlreadyDisposedError extends MatError {
   constructor() {
       super('This PortalHost has already been disposed');
   }
 }
 
 /** Exception thrown when attempting to attach an unknown portal type. */
-export class MdUnknownPortalTypeError extends MdError {
+export class MatUnknownPortalTypeError extends MatError {
   constructor() {
       super(
         'Attempting to attach an unknown Portal type. ' +
@@ -40,14 +40,14 @@ export class MdUnknownPortalTypeError extends MdError {
 }
 
 /** Exception thrown when attempting to attach a portal to a null host. */
-export class MdNullPortalHostError extends MdError {
+export class MatNullPortalHostError extends MatError {
   constructor() {
       super('Attempting to attach a portal to a null PortalHost');
   }
 }
 
 /** Exception thrown when attempting to detach a portal that is not attached. */
-export class MdNoPortalAttachedError extends MdError {
+export class MatNoPortalAttachedError extends MatError {
   constructor() {
       super('Attempting to detach a portal that is not attached to a host');
   }

--- a/src/lib/core/portal/portal.ts
+++ b/src/lib/core/portal/portal.ts
@@ -6,12 +6,12 @@ import {
     Injector
 } from '@angular/core';
 import {
-    MdNullPortalHostError,
-    MdPortalAlreadyAttachedError,
-    MdNoPortalAttachedError,
-    MdNullPortalError,
-    MdPortalHostAlreadyDisposedError,
-    MdUnknownPortalTypeError
+    MatNullPortalHostError,
+    MatPortalAlreadyAttachedError,
+    MatNoPortalAttachedError,
+    MatNullPortalError,
+    MatPortalHostAlreadyDisposedError,
+    MatUnknownPortalTypeError
 } from './portal-errors';
 import {ComponentType} from '../overlay/generic-component-type';
 
@@ -27,11 +27,11 @@ export abstract class Portal<T> {
   /** Attach this portal to a host. */
   attach(host: PortalHost): T {
     if (host == null) {
-      throw new MdNullPortalHostError();
+      throw new MatNullPortalHostError();
     }
 
     if (host.hasAttached()) {
-      throw new MdPortalAlreadyAttachedError();
+      throw new MatPortalAlreadyAttachedError();
     }
 
     this._attachedHost = host;
@@ -42,7 +42,7 @@ export abstract class Portal<T> {
   detach(): void {
     let host = this._attachedHost;
     if (host == null) {
-      throw new MdNoPortalAttachedError();
+      throw new MatNoPortalAttachedError();
     }
 
     this._attachedHost = null;
@@ -168,15 +168,15 @@ export abstract class BasePortalHost implements PortalHost {
 
   attach(portal: Portal<any>): any {
     if (portal == null) {
-      throw new MdNullPortalError();
+      throw new MatNullPortalError();
     }
 
     if (this.hasAttached()) {
-      throw new MdPortalAlreadyAttachedError();
+      throw new MatPortalAlreadyAttachedError();
     }
 
     if (this._isDisposed) {
-      throw new MdPortalHostAlreadyDisposedError();
+      throw new MatPortalHostAlreadyDisposedError();
     }
 
     if (portal instanceof ComponentPortal) {
@@ -187,7 +187,7 @@ export abstract class BasePortalHost implements PortalHost {
       return this.attachTemplatePortal(portal);
     }
 
-    throw new MdUnknownPortalTypeError();
+    throw new MatUnknownPortalTypeError();
   }
 
   abstract attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -48,7 +48,7 @@ export class RippleRenderer {
     // It might be nice to delay creating the background until it's needed, but doing this in
     // fadeInRippleBackground causes the first click event to not be handled reliably.
     this._backgroundDiv = document.createElement('div');
-    this._backgroundDiv.classList.add('md-ripple-background');
+    this._backgroundDiv.classList.add('mat-ripple-background');
     this._rippleElement.appendChild(this._backgroundDiv);
   }
 
@@ -73,7 +73,7 @@ export class RippleRenderer {
   }
 
   /**
-   * Installs event handlers on the host element of the md-ripple directive.
+   * Installs event handlers on the host element of the mat-ripple directive.
    */
   setTriggerElementToHost() {
     this.setTriggerElement(this._rippleElement);
@@ -88,7 +88,7 @@ export class RippleRenderer {
 
   /**
    * Creates a foreground ripple and sets its animation to expand and fade in from the position
-   * given by rippleOriginLeft and rippleOriginTop (or from the center of the <md-ripple>
+   * given by rippleOriginLeft and rippleOriginTop (or from the center of the <mat-ripple>
    * bounding rect if centered is true).
    */
   createForegroundRipple(
@@ -112,7 +112,7 @@ export class RippleRenderer {
 
     const rippleDiv = document.createElement('div');
     this._rippleElement.appendChild(rippleDiv);
-    rippleDiv.classList.add('md-ripple-foreground');
+    rippleDiv.classList.add('mat-ripple-foreground');
     rippleDiv.style.left = `${offsetX - maxRadius}px`;
     rippleDiv.style.top = `${offsetY - maxRadius}px`;
     rippleDiv.style.width = `${2 * maxRadius}px`;
@@ -130,7 +130,7 @@ export class RippleRenderer {
     // https://timtaubert.de/blog/2012/09/css-transitions-for-dynamically-created-dom-elements/
     window.getComputedStyle(rippleDiv).opacity;
 
-    rippleDiv.classList.add('md-ripple-fade-in');
+    rippleDiv.classList.add('mat-ripple-fade-in');
     // Clearing the transform property causes the ripple to animate to its full size.
     rippleDiv.style.transform = '';
     const ripple = new ForegroundRipple(rippleDiv);
@@ -144,8 +144,8 @@ export class RippleRenderer {
    * Fades out a foreground ripple after it has fully expanded and faded in.
    */
   fadeOutForegroundRipple(ripple: Element) {
-    ripple.classList.remove('md-ripple-fade-in');
-    ripple.classList.add('md-ripple-fade-out');
+    ripple.classList.remove('mat-ripple-fade-in');
+    ripple.classList.add('mat-ripple-fade-out');
   }
 
   /**
@@ -159,7 +159,7 @@ export class RippleRenderer {
    * Fades in the ripple background.
    */
   fadeInRippleBackground(color: string) {
-    this._backgroundDiv.classList.add('md-ripple-active');
+    this._backgroundDiv.classList.add('mat-ripple-active');
     // If color is not set, this will default to the background color defined in CSS.
     this._backgroundDiv.style.backgroundColor = color;
   }
@@ -169,7 +169,7 @@ export class RippleRenderer {
    */
   fadeOutRippleBackground() {
     if (this._backgroundDiv) {
-      this._backgroundDiv.classList.remove('md-ripple-active');
+      this._backgroundDiv.classList.remove('mat-ripple-active');
     }
   }
 }

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -1,6 +1,6 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
-import {MdRipple, MdRippleModule} from './ripple';
+import {MatRipple, MatRippleModule} from './ripple';
 
 
 /** Creates a DOM event to indicate that a CSS transition for the given property ended. */
@@ -55,7 +55,7 @@ const pxStringToFloat = (s: string) => {
   return parseFloat(s.replace('px', ''));
 };
 
-describe('MdRipple', () => {
+describe('MatRipple', () => {
   let fixture: ComponentFixture<any>;
   let rippleElement: HTMLElement;
   let rippleBackground: Element;
@@ -63,7 +63,7 @@ describe('MdRipple', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MdRippleModule.forRoot()],
+      imports: [MatRippleModule.forRoot()],
       declarations: [BasicRippleContainer, RippleContainerWithInputBindings],
     });
   });
@@ -83,61 +83,61 @@ describe('MdRipple', () => {
       fixture = TestBed.createComponent(BasicRippleContainer);
       fixture.detectChanges();
 
-      rippleElement = fixture.debugElement.nativeElement.querySelector('[md-ripple]');
-      rippleBackground = rippleElement.querySelector('.md-ripple-background');
+      rippleElement = fixture.debugElement.nativeElement.querySelector('[mat-ripple]');
+      rippleBackground = rippleElement.querySelector('.mat-ripple-background');
       expect(rippleBackground).toBeTruthy();
     });
 
     it('shows background when parent receives mousedown event', () => {
-      expect(rippleBackground.classList).not.toContain('md-ripple-active');
+      expect(rippleBackground.classList).not.toContain('mat-ripple-active');
       const mouseDown = createMouseEvent('mousedown');
       // mousedown on the ripple element activates the background ripple.
       rippleElement.dispatchEvent(mouseDown);
-      expect(rippleBackground.classList).toContain('md-ripple-active');
+      expect(rippleBackground.classList).toContain('mat-ripple-active');
       // mouseleave on the container removes the background ripple.
       const mouseLeave = createMouseEvent('mouseleave');
       rippleElement.dispatchEvent(mouseLeave);
-      expect(rippleBackground.classList).not.toContain('md-ripple-active');
+      expect(rippleBackground.classList).not.toContain('mat-ripple-active');
     });
 
     it('creates foreground ripples on click', () => {
       rippleElement.click();
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(1);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(1);
       // Second click should create another ripple.
       rippleElement.click();
-      const ripples = rippleElement.querySelectorAll('.md-ripple-foreground');
+      const ripples = rippleElement.querySelectorAll('.mat-ripple-foreground');
       expect(ripples.length).toBe(2);
-      expect(ripples[0].classList).toContain('md-ripple-fade-in');
-      expect(ripples[1].classList).toContain('md-ripple-fade-in');
+      expect(ripples[0].classList).toContain('mat-ripple-fade-in');
+      expect(ripples[1].classList).toContain('mat-ripple-fade-in');
       // Signal the end of the first ripple's expansion. The second ripple should be unaffected.
       const opacityTransitionEnd = createTransitionEndEvent('opacity');
       ripples[0].dispatchEvent(opacityTransitionEnd);
-      expect(ripples[0].classList).not.toContain('md-ripple-fade-in');
-      expect(ripples[0].classList).toContain('md-ripple-fade-out');
-      expect(ripples[1].classList).toContain('md-ripple-fade-in');
-      expect(ripples[1].classList).not.toContain('md-ripple-fade-out');
+      expect(ripples[0].classList).not.toContain('mat-ripple-fade-in');
+      expect(ripples[0].classList).toContain('mat-ripple-fade-out');
+      expect(ripples[1].classList).toContain('mat-ripple-fade-in');
+      expect(ripples[1].classList).not.toContain('mat-ripple-fade-out');
       // Signal the end of the first ripple's fade out. The ripple should be removed from the DOM.
       ripples[0].dispatchEvent(opacityTransitionEnd);
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(1);
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground')[0]).toBe(ripples[1]);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(1);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground')[0]).toBe(ripples[1]);
       // Finish the second ripple.
       ripples[1].dispatchEvent(opacityTransitionEnd);
-      expect(ripples[1].classList).not.toContain('md-ripple-fade-in');
-      expect(ripples[1].classList).toContain('md-ripple-fade-out');
+      expect(ripples[1].classList).not.toContain('mat-ripple-fade-in');
+      expect(ripples[1].classList).toContain('mat-ripple-fade-out');
       ripples[1].dispatchEvent(opacityTransitionEnd);
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(0);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(0);
     });
 
     it('creates ripples when manually triggered', () => {
       const rippleComponent = fixture.debugElement.componentInstance.ripple;
       // start() should show the background, but no foreground ripple yet.
       rippleComponent.start();
-      expect(rippleBackground.classList).toContain('md-ripple-active');
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(0);
+      expect(rippleBackground.classList).toContain('mat-ripple-active');
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(0);
       // end() should deactivate the background and show the foreground ripple.
       rippleComponent.end(0, 0);
-      expect(rippleBackground.classList).not.toContain('md-ripple-active');
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(1);
+      expect(rippleBackground.classList).not.toContain('mat-ripple-active');
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(1);
     });
 
     it('sizes ripple to cover element', () => {
@@ -152,7 +152,7 @@ describe('MdRipple', () => {
       const expectedRadius = Math.sqrt(250 * 250 + 125 * 125);
       const expectedLeft = elementRect.left + 50 - expectedRadius;
       const expectedTop = elementRect.top + 75 - expectedRadius;
-      const ripple = <HTMLElement>rippleElement.querySelector('.md-ripple-foreground');
+      const ripple = <HTMLElement>rippleElement.querySelector('.mat-ripple-foreground');
       // Note: getBoundingClientRect won't work because there's a transform applied to make the
       // ripple start out tiny.
       expect(pxStringToFloat(ripple.style.left)).toBeCloseTo(expectedLeft, 1);
@@ -174,7 +174,7 @@ describe('MdRipple', () => {
       const expectedTop = elementRect.top + (elementRect.height / 2) - expectedRadius;
       // Note: getBoundingClientRect won't work because there's a transform applied to make the
       // ripple start out tiny.
-      const ripple = <HTMLElement>rippleElement.querySelector('.md-ripple-foreground');
+      const ripple = <HTMLElement>rippleElement.querySelector('.mat-ripple-foreground');
       expect(pxStringToFloat(ripple.style.left)).toBeCloseTo(expectedLeft, 1);
       expect(pxStringToFloat(ripple.style.top)).toBeCloseTo(expectedTop, 1);
       expect(pxStringToFloat(ripple.style.width)).toBeCloseTo(2 * expectedRadius, 1);
@@ -184,7 +184,7 @@ describe('MdRipple', () => {
 
   describe('configuring behavior', () => {
     let controller: RippleContainerWithInputBindings;
-    let rippleComponent: MdRipple;
+    let rippleComponent: MatRipple;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(RippleContainerWithInputBindings);
@@ -192,8 +192,8 @@ describe('MdRipple', () => {
 
       controller = fixture.debugElement.componentInstance;
       rippleComponent = controller.ripple;
-      rippleElement = fixture.debugElement.nativeElement.querySelector('[md-ripple]');
-      rippleBackground = rippleElement.querySelector('.md-ripple-background');
+      rippleElement = fixture.debugElement.nativeElement.querySelector('[mat-ripple]');
+      rippleBackground = rippleElement.querySelector('.mat-ripple-background');
       expect(rippleBackground).toBeTruthy();
     });
 
@@ -212,7 +212,7 @@ describe('MdRipple', () => {
       controller.color = color;
       fixture.detectChanges();
       rippleElement.click();
-      const ripple = rippleElement.querySelector('.md-ripple-foreground');
+      const ripple = rippleElement.querySelector('.mat-ripple-foreground');
       expect(window.getComputedStyle(ripple).backgroundColor).toBe(color);
     });
 
@@ -223,14 +223,14 @@ describe('MdRipple', () => {
       // The background ripple should not respond to mouseDown, and no foreground ripple should be
       // created on a click.
       rippleElement.dispatchEvent(mouseDown);
-      expect(rippleBackground.classList).not.toContain('md-ripple-active');
+      expect(rippleBackground.classList).not.toContain('mat-ripple-active');
       rippleElement.click();
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(0);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(0);
       // Calling start() and end() should still create a ripple.
       rippleComponent.start();
-      expect(rippleBackground.classList).toContain('md-ripple-active');
+      expect(rippleBackground.classList).toContain('mat-ripple-active');
       rippleComponent.end(0, 0);
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(1);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(1);
     });
 
     it('allows specifying custom trigger element', () => {
@@ -239,17 +239,17 @@ describe('MdRipple', () => {
           <HTMLElement>fixture.debugElement.nativeElement.querySelector('.alternateTrigger');
       const mouseDown = createMouseEvent('mousedown');
       alternateTrigger.dispatchEvent(mouseDown);
-      expect(rippleBackground.classList).not.toContain('md-ripple-active');
+      expect(rippleBackground.classList).not.toContain('mat-ripple-active');
       alternateTrigger.click();
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(0);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(0);
 
       // Reassign the trigger element, and now events should create ripples.
       controller.trigger = alternateTrigger;
       fixture.detectChanges();
       alternateTrigger.dispatchEvent(mouseDown);
-      expect(rippleBackground.classList).toContain('md-ripple-active');
+      expect(rippleBackground.classList).toContain('mat-ripple-active');
       alternateTrigger.click();
-      expect(rippleElement.querySelectorAll('.md-ripple-foreground').length).toBe(1);
+      expect(rippleElement.querySelectorAll('.mat-ripple-foreground').length).toBe(1);
     });
 
     it('expands ripple from center if centered input is set', () => {
@@ -267,7 +267,7 @@ describe('MdRipple', () => {
       const expectedLeft = elementRect.left + (elementRect.width / 2) - expectedRadius;
       const expectedTop = elementRect.top + (elementRect.height / 2) - expectedRadius;
 
-      const ripple = <HTMLElement>rippleElement.querySelector('.md-ripple-foreground');
+      const ripple = <HTMLElement>rippleElement.querySelector('.mat-ripple-foreground');
       expect(pxStringToFloat(ripple.style.left)).toBeCloseTo(expectedLeft, 1);
       expect(pxStringToFloat(ripple.style.top)).toBeCloseTo(expectedTop, 1);
       expect(pxStringToFloat(ripple.style.width)).toBeCloseTo(2 * expectedRadius, 1);
@@ -286,7 +286,7 @@ describe('MdRipple', () => {
       const expectedLeft = elementRect.left + 50 - customRadius;
       const expectedTop = elementRect.top + 75 - customRadius;
 
-      const ripple = <HTMLElement>rippleElement.querySelector('.md-ripple-foreground');
+      const ripple = <HTMLElement>rippleElement.querySelector('.mat-ripple-foreground');
       expect(pxStringToFloat(ripple.style.left)).toBeCloseTo(expectedLeft, 1);
       expect(pxStringToFloat(ripple.style.top)).toBeCloseTo(expectedTop, 1);
       expect(pxStringToFloat(ripple.style.width)).toBeCloseTo(2 * customRadius, 1);
@@ -297,24 +297,24 @@ describe('MdRipple', () => {
 
 @Component({
   template: `
-    <div id="container" md-ripple style="position: relative; width:300px; height:200px;">
+    <div id="container" mat-ripple style="position: relative; width:300px; height:200px;">
     </div>
   `,
 })
 class BasicRippleContainer {
-  @ViewChild(MdRipple) ripple: MdRipple;
+  @ViewChild(MatRipple) ripple: MatRipple;
 }
 
 @Component({
   template: `
     <div id="container" style="position: relative; width:300px; height:200px;"
-      md-ripple
-      [md-ripple-trigger]="trigger"
-      [md-ripple-centered]="centered"
-      [md-ripple-max-radius]="maxRadius"
-      [md-ripple-disabled]="disabled"
-      [md-ripple-color]="color"
-      [md-ripple-background-color]="backgroundColor">
+      mat-ripple
+      [mat-ripple-trigger]="trigger"
+      [mat-ripple-centered]="centered"
+      [mat-ripple-max-radius]="maxRadius"
+      [mat-ripple-disabled]="disabled"
+      [mat-ripple-color]="color"
+      [mat-ripple-background-color]="backgroundColor">
     </div>
     <div class="alternateTrigger"></div>
   `,
@@ -326,5 +326,5 @@ class RippleContainerWithInputBindings {
   maxRadius = 0;
   color = '';
   backgroundColor = '';
-  @ViewChild(MdRipple) ripple: MdRipple;
+  @ViewChild(MatRipple) ripple: MatRipple;
 }

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -18,46 +18,46 @@ import {
 
 
 @Directive({
-  selector: '[md-ripple]',
+  selector: '[mat-ripple]',
 })
-export class MdRipple implements OnInit, OnDestroy, OnChanges {
+export class MatRipple implements OnInit, OnDestroy, OnChanges {
   /**
    * The element that triggers the ripple when click events are received. Defaults to the
    * directive's host element.
    */
   // Prevent TS metadata emit from referencing HTMLElement in ripple.js
   // That breaks tests running in node that load material components.
-  @Input('md-ripple-trigger') trigger: HTMLElement|HTMLElement;
+  @Input('mat-ripple-trigger') trigger: HTMLElement|HTMLElement;
   /**
    * Whether the ripple always originates from the center of the host element's bounds, rather
    * than originating from the location of the click event.
    */
-  @Input('md-ripple-centered') centered: boolean;
+  @Input('mat-ripple-centered') centered: boolean;
   /**
    * Whether click events will not trigger the ripple. It can still be triggered by manually
    * calling start() and end().
    */
-  @Input('md-ripple-disabled') disabled: boolean;
+  @Input('mat-ripple-disabled') disabled: boolean;
   /**
    * If set, the radius in pixels of foreground ripples when fully expanded. If unset, the radius
    * will be the distance from the center of the ripple to the furthest corner of the host element's
    * bounding rectangle.
    */
-  @Input('md-ripple-max-radius') maxRadius: number = 0;
+  @Input('mat-ripple-max-radius') maxRadius: number = 0;
   /**
    * If set, the normal duration of ripple animations is divided by this value. For example,
    * setting it to 0.5 will cause the animations to take twice as long.
    */
-  @Input('md-ripple-speed-factor') speedFactor: number = 1;
+  @Input('mat-ripple-speed-factor') speedFactor: number = 1;
   /** Custom color for ripples. */
-  @Input('md-ripple-color') color: string;
+  @Input('mat-ripple-color') color: string;
   /** Custom color for the ripple background. */
-  @Input('md-ripple-background-color') backgroundColor: string;
+  @Input('mat-ripple-background-color') backgroundColor: string;
 
   /** Whether the ripple background will be highlighted to indicated a focused state. */
-  @HostBinding('class.md-ripple-focused') @Input('md-ripple-focused') focused: boolean;
+  @HostBinding('class.mat-ripple-focused') @Input('mat-ripple-focused') focused: boolean;
   /** Whether foreground ripples should be visible outside the component's bounds. */
-  @HostBinding('class.md-ripple-unbounded') @Input('md-ripple-unbounded') unbounded: boolean;
+  @HostBinding('class.mat-ripple-unbounded') @Input('mat-ripple-unbounded') unbounded: boolean;
 
   private _rippleRenderer: RippleRenderer;
 
@@ -171,13 +171,13 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
 
 
 @NgModule({
-  exports: [MdRipple],
-  declarations: [MdRipple],
+  exports: [MatRipple],
+  declarations: [MatRipple],
 })
-export class MdRippleModule {
+export class MatRippleModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdRippleModule,
+      ngModule: MatRippleModule,
       providers: []
     };
   }

--- a/src/lib/core/style/_button-mixins.scss
+++ b/src/lib/core/style/_button-mixins.scss
@@ -2,7 +2,7 @@
  * This mixin overrides default button styles like the gray background,
  * the border, and the outline.
  */
-@mixin md-button-reset {
+@mixin mat-button-reset {
   background: transparent;
   cursor: pointer;
   user-select: none;

--- a/src/lib/core/style/_default-theme.scss
+++ b/src/lib/core/style/_default-theme.scss
@@ -3,11 +3,11 @@
 
 
 // Person creating a theme writes variables like this:
-$md-is-dark-theme: false;
+$mat-is-dark-theme: false;
 
 
-$md-primary: md-palette($md-teal, 500, 100, 700, $md-contrast-palettes);
-$md-accent: md-palette($md-purple, 500, 300, 800, $md-contrast-palettes);
-$md-warn: md-palette($md-red, 500, 300, 900, $md-contrast-palettes);
-$md-foreground: if($md-is-dark-theme, $md-dark-theme-foreground, $md-light-theme-foreground);
-$md-background: if($md-is-dark-theme, $md-dark-theme-background, $md-light-theme-background);
+$mat-primary: mat-palette($mat-teal, 500, 100, 700, $mat-contrast-palettes);
+$mat-accent: mat-palette($mat-purple, 500, 300, 800, $mat-contrast-palettes);
+$mat-warn: mat-palette($mat-red, 500, 300, 900, $mat-contrast-palettes);
+$mat-foreground: if($mat-is-dark-theme, $mat-dark-theme-foreground, $mat-light-theme-foreground);
+$mat-background: if($mat-is-dark-theme, $mat-dark-theme-background, $mat-light-theme-background);

--- a/src/lib/core/style/_elevation.scss
+++ b/src/lib/core/style/_elevation.scss
@@ -7,15 +7,15 @@
  * Examples:
  *
  *
- * .md-foo {
- *   @include $md-elevation(2);
+ * .mat-foo {
+ *   @include $mat-elevation(2);
  *
  *   &:active {
- *     @include $md-elevation(8);
+ *     @include $mat-elevation(8);
  *   }
  * }
  *
- * <div id="external-card" class="md-elevation-z2"><p>Some content</p></div>
+ * <div id="external-card" class="mat-elevation-z2"><p>Some content</p></div>
  *
  * For an explanation of the design behind how elevation is implemented, see the design doc at
  * https://goo.gl/Kq0k9Z.
@@ -125,19 +125,19 @@ $_ambient-elevation-map: (
  * as a variable for abstraction / easy use when needing to reference the property directly, for
  * example in a will-change rule.
  */
-$md-elevation-property: box-shadow !default;
+$mat-elevation-property: box-shadow !default;
 
 /** The default duration value for elevation transitions. */
-$md-elevation-transition-duration: 280ms !default;
+$mat-elevation-transition-duration: 280ms !default;
 
 /** The default easing value for elevation transitions. */
-$md-elevation-transition-timing-function: $md-fast-out-slow-in-timing-function;
+$mat-elevation-transition-timing-function: $mat-fast-out-slow-in-timing-function;
 
 /**
  * Applies the correct css rules to an element to give it the elevation specified by $zValue.
  * The $zValue must be between 0 and 24.
  */
-@mixin md-elevation($zValue) {
+@mixin mat-elevation($zValue) {
   @if type-of($zValue) != number or not unitless($zValue) {
     @error '$zValue must be a unitless number';
   }
@@ -145,7 +145,7 @@ $md-elevation-transition-timing-function: $md-fast-out-slow-in-timing-function;
     @error '$zValue must be between 0 and 24';
   }
 
-  #{$md-elevation-property}: #{map-get($_umbra-elevation-map, $zValue)},
+  #{$mat-elevation-property}: #{map-get($_umbra-elevation-map, $zValue)},
                              #{map-get($_penumbra-elevation-map, $zValue)},
                              #{map-get($_ambient-elevation-map, $zValue)};
 }
@@ -156,14 +156,14 @@ $md-elevation-transition-timing-function: $md-fast-out-slow-in-timing-function;
  * more than one property.
  *
  * .foo {
- *   transition: md-elevation-transition-property-value(), opacity 100ms ease;
- *   will-change: $md-elevation-property, opacity;
+ *   transition: mat-elevation-transition-property-value(), opacity 100ms ease;
+ *   will-change: $mat-elevation-property, opacity;
  * }
  */
-@function md-elevation-transition-property-value(
-    $duration: $md-elevation-transition-duration,
-    $easing: $md-elevation-transition-timing-function) {
-  @return #{$md-elevation-property} #{$duration} #{$easing};
+@function mat-elevation-transition-property-value(
+    $duration: $mat-elevation-transition-duration,
+    $easing: $mat-elevation-transition-timing-function) {
+  @return #{$mat-elevation-property} #{$duration} #{$easing};
 }
 
 /**
@@ -173,9 +173,9 @@ $md-elevation-transition-timing-function: $md-fast-out-slow-in-timing-function;
  */
 // NOTE(traviskaufman): Both this mixin and the above function use default parameters so they can
 // be used in the same way by clients.
-@mixin md-elevation-transition(
-    $duration: $md-elevation-transition-duration,
-    $easing: $md-elevation-transition-timing-function) {
-  transition: md-elevation-transition-property-value($duration, $easing);
-  will-change: $md-elevation-property;
+@mixin mat-elevation-transition(
+    $duration: $mat-elevation-transition-duration,
+    $easing: $mat-elevation-transition-timing-function) {
+  transition: mat-elevation-transition-property-value($duration, $easing);
+  will-change: $mat-elevation-property;
 }

--- a/src/lib/core/style/_list-shared.scss
+++ b/src/lib/core/style/_list-shared.scss
@@ -2,19 +2,19 @@
  * This mixin will ensure that lines that overflow the container will
  * hide the overflow and truncate neatly with an ellipsis.
  */
-@mixin md-truncate-line() {
+@mixin mat-truncate-line() {
   white-space: nowrap;
   overflow-x: hidden;
   text-overflow: ellipsis;
 }
 
 /**
- * This mixin provides all md-line styles, changing secondary font size
+ * This mixin provides all mat-line styles, changing secondary font size
  * based on whether the list is in dense mode.
  */
-@mixin md-line-base($secondary-font-size) {
-  [md-line] {
-    @include md-truncate-line();
+@mixin mat-line-base($secondary-font-size) {
+  [mat-line] {
+    @include mat-truncate-line();
     display: block;
     box-sizing: border-box;
 
@@ -26,11 +26,11 @@
 }
 
 /**
- * This mixin provides base styles for the wrapper around md-line
+ * This mixin provides base styles for the wrapper around mat-line
  * elements in a list.
  */
-@mixin md-line-wrapper-base() {
-  @include md-normalize-text();
+@mixin mat-line-wrapper-base() {
+  @include mat-normalize-text();
 
   display: flex;
   flex-direction: column;
@@ -48,7 +48,7 @@
 /**
  * This mixin normalizes default element styles, e.g. font weight for heading text.
  */
-@mixin md-normalize-text() {
+@mixin mat-normalize-text() {
   & > * {
     margin: 0;
     padding: 0;

--- a/src/lib/core/style/_mixins.scss
+++ b/src/lib/core/style/_mixins.scss
@@ -3,7 +3,7 @@
  * Mixin that creates a new stacking context.
  * see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
  */
-@mixin md-stacking-context() {
+@mixin mat-stacking-context() {
   position: relative;
 
   // Use a transform to create a new stacking context.
@@ -14,7 +14,7 @@
  * This mixin hides an element visually.
  * That means it's still accessible for screen-readers but not visible in view.
  */
-@mixin md-visually-hidden {
+@mixin mat-visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -30,7 +30,7 @@
  * Forces an element to grow to fit floated contents; used as as an alternative to
  * `overflow: hidden;` because it doesn't cut off contents.
  */
-@mixin md-clearfix {
+@mixin mat-clearfix {
   &::before, &::after {
     content: '';
     clear: both;
@@ -45,10 +45,10 @@
  * It is also possible to specify the color palette of the temporary ripple. By default it uses the
  * accent palette for its background.
  */
-@mixin md-temporary-ink-ripple($component, $bindToParent: false, $palette: $md-accent) {
+@mixin mat-temporary-ink-ripple($component, $bindToParent: false, $palette: $mat-accent) {
   // TODO(mtlin): Replace when ink ripple component is implemented.
   // A placeholder ink ripple, shown when keyboard focused.
-  .md-ink-ripple {
+  .mat-ink-ripple {
     border-radius: 50%;
     opacity: 0;
     height: 48px;
@@ -63,14 +63,14 @@
   }
 
   // Fade in when radio focused.
-  #{if($bindToParent, '&', '')}.md-#{$component}-focused .md-ink-ripple {
+  #{if($bindToParent, '&', '')}.mat-#{$component}-focused .mat-ink-ripple {
     opacity: 1;
-    background-color: md-color($palette, 0.26);
+    background-color: mat-color($palette, 0.26);
   }
 
   // TODO(mtlin): This corresponds to disabled focus state, but it's unclear how to enter into
   // this state.
-  #{if($bindToParent, '&', '')}.md-#{$component}-disabled .md-ink-ripple {
+  #{if($bindToParent, '&', '')}.mat-#{$component}-disabled .mat-ink-ripple {
     background-color: #000;
   }
 }

--- a/src/lib/core/style/_palette.scss
+++ b/src/lib/core/style/_palette.scss
@@ -1,7 +1,7 @@
 // Color palettes from the Material Design spec.
 // See https://www.google.com/design/spec/style/color.html
 
-$md-red: (
+$mat-red: (
   50: #ffebee,
   100: #ffcdd2,
   200: #ef9a9a,
@@ -18,7 +18,7 @@ $md-red: (
   A700: #d50000,
 );
 
-$md-pink: (
+$mat-pink: (
   50: #fce4ec,
   100: #f8bbd0,
   200: #f48fb1,
@@ -35,7 +35,7 @@ $md-pink: (
   A700: #c51162,
 );
 
-$md-purple: (
+$mat-purple: (
   50: #f3e5f5,
   100: #e1bee7,
   200: #ce93d8,
@@ -52,7 +52,7 @@ $md-purple: (
   A700: #aa00ff,
 );
 
-$md-deep-purple: (
+$mat-deep-purple: (
   50: #ede7f6,
   100: #d1c4e9,
   200: #b39ddb,
@@ -69,7 +69,7 @@ $md-deep-purple: (
   A700: #6200ea,
 );
 
-$md-indigo: (
+$mat-indigo: (
   50: #e8eaf6,
   100: #c5cae9,
   200: #9fa8da,
@@ -86,7 +86,7 @@ $md-indigo: (
   A700: #304ffe,
 );
 
-$md-blue: (
+$mat-blue: (
   50: #e3f2fd,
   100: #bbdefb,
   200: #90caf9,
@@ -103,7 +103,7 @@ $md-blue: (
   A700: #2962ff,
 );
 
-$md-light-blue: (
+$mat-light-blue: (
   50: #e1f5fe,
   100: #b3e5fc,
   200: #81d4fa,
@@ -120,7 +120,7 @@ $md-light-blue: (
   A700: #0091ea,
 );
 
-$md-cyan: (
+$mat-cyan: (
   50: #e0f7fa,
   100: #b2ebf2,
   200: #80deea,
@@ -137,7 +137,7 @@ $md-cyan: (
   A700: #00b8d4,
 );
 
-$md-teal: (
+$mat-teal: (
   50: #e0f2f1,
   100: #b2dfdb,
   200: #80cbc4,
@@ -154,7 +154,7 @@ $md-teal: (
   A700: #00bfa5,
 );
 
-$md-green: (
+$mat-green: (
   50: #e8f5e9,
   100: #c8e6c9,
   200: #a5d6a7,
@@ -171,7 +171,7 @@ $md-green: (
   A700: #00c853,
 );
 
-$md-light-green: (
+$mat-light-green: (
   50: #f1f8e9,
   100: #dcedc8,
   200: #c5e1a5,
@@ -188,7 +188,7 @@ $md-light-green: (
   A700: #64dd17,
 );
 
-$md-lime: (
+$mat-lime: (
   50: #f9fbe7,
   100: #f0f4c3,
   200: #e6ee9c,
@@ -205,7 +205,7 @@ $md-lime: (
   A700: #aeea00,
 );
 
-$md-yellow: (
+$mat-yellow: (
   50: #fffde7,
   100: #fff9c4,
   200: #fff59d,
@@ -222,7 +222,7 @@ $md-yellow: (
   A700: #ffd600,
 );
 
-$md-amber: (
+$mat-amber: (
   50: #fff8e1,
   100: #ffecb3,
   200: #ffe082,
@@ -239,7 +239,7 @@ $md-amber: (
   A700: #ffab00,
 );
 
-$md-orange: (
+$mat-orange: (
   50: #fff3e0,
   100: #ffe0b2,
   200: #ffcc80,
@@ -256,7 +256,7 @@ $md-orange: (
   A700: #ff6d00,
 );
 
-$md-deep-orange: (
+$mat-deep-orange: (
   50: #fbe9e7,
   100: #ffccbc,
   200: #ffab91,
@@ -273,7 +273,7 @@ $md-deep-orange: (
   A700: #dd2c00,
 );
 
-$md-brown: (
+$mat-brown: (
   50: #efebe9,
   100: #d7ccc8,
   200: #bcaaa4,
@@ -290,7 +290,7 @@ $md-brown: (
   A700: #5d4037,
 );
 
-$md-grey: (
+$mat-grey: (
   0: #ffffff,
   50: #fafafa,
   100: #f5f5f5,
@@ -309,7 +309,7 @@ $md-grey: (
   A700: #616161,
 );
 
-$md-blue-grey: (
+$mat-blue-grey: (
   50: #eceff1,
   100: #cfd8dc,
   200: #b0bec5,
@@ -328,10 +328,10 @@ $md-blue-grey: (
 
 
 // Background palette for light themes.
-$md-light-theme-background: (
-  status-bar: map_get($md-grey, 300),
-  app-bar:    map_get($md-grey, 100),
-  background: map_get($md-grey, 50),
+$mat-light-theme-background: (
+  status-bar: map_get($mat-grey, 300),
+  app-bar:    map_get($mat-grey, 100),
+  background: map_get($mat-grey, 50),
   hover:      rgba(black, 0.04), // TODO(kara): check style with Material Design UX
   card:       white,
   dialog:     white,
@@ -339,18 +339,18 @@ $md-light-theme-background: (
 );
 
 // Background palette for dark themes.
-$md-dark-theme-background: (
+$mat-dark-theme-background: (
   status-bar: black,
-  app-bar:    map_get($md-grey, 900),
+  app-bar:    map_get($mat-grey, 900),
   background: #303030,
   hover:      rgba(white, 0.04), // TODO(kara): check style with Material Design UX
-  card:       map_get($md-grey, 800),
-  dialog:     map_get($md-grey, 800),
+  card:       map_get($mat-grey, 800),
+  dialog:     map_get($mat-grey, 800),
   disabled-button: rgba(white, 0.12)
 );
 
 // Foreground palette for light themes.
-$md-light-theme-foreground: (
+$mat-light-theme-foreground: (
   base:            black,
   divider:         rgba(black, 0.12),
   dividers:        rgba(black, 0.12),
@@ -365,7 +365,7 @@ $md-light-theme-foreground: (
 );
 
 // Foreground palette for dark themes.
-$md-dark-theme-foreground: (
+$mat-dark-theme-foreground: (
   base:            white,
   divider:         rgba(white, 0.12),
   dividers:        rgba(white, 0.12),
@@ -390,8 +390,8 @@ $md-dark-theme-foreground: (
 $black-87-opacity: rgba(black, 0.870588);
 $white-87-opacity: rgba(white, 0.870588);
 
-$md-contrast-palettes: (
-  $md-red: (
+$mat-contrast-palettes: (
+  $mat-red: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -407,7 +407,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: white,
   ),
-  $md-pink: (
+  $mat-pink: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -423,7 +423,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: white,
   ),
-  $md-purple: (
+  $mat-purple: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -439,7 +439,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: white,
   ),
-  $md-deep-purple: (
+  $mat-deep-purple: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -455,7 +455,7 @@ $md-contrast-palettes: (
     A400: $white-87-opacity,
     A700: $white-87-opacity,
   ),
-  $md-indigo: (
+  $mat-indigo: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -471,7 +471,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: $white-87-opacity,
   ),
-  $md-blue: (
+  $mat-blue: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -487,7 +487,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: white,
   ),
-  $md-light-blue: (
+  $mat-light-blue: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -503,7 +503,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: white,
   ),
-  $md-cyan: (
+  $mat-cyan: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -519,7 +519,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-teal: (
+  $mat-teal: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -535,7 +535,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-green: (
+  $mat-green: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -551,7 +551,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-light-green: (
+  $mat-light-green: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -567,7 +567,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-lime: (
+  $mat-lime: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -583,7 +583,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-yellow: (
+  $mat-yellow: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -599,7 +599,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-amber: (
+  $mat-amber: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -615,7 +615,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $black-87-opacity,
   ),
-  $md-orange: (
+  $mat-orange: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -631,7 +631,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: black,
   ),
-  $md-deep-orange: (
+  $mat-deep-orange: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -647,7 +647,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: white,
   ),
-  $md-brown: (
+  $mat-brown: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,
@@ -663,7 +663,7 @@ $md-contrast-palettes: (
     A400: white,
     A700: $white-87-opacity,
   ),
-  $md-grey: (
+  $mat-grey: (
     0: $black-87-opacity,
     50: $black-87-opacity,
     100: $black-87-opacity,
@@ -681,7 +681,7 @@ $md-contrast-palettes: (
     A400: $black-87-opacity,
     A700: $white-87-opacity,
   ),
-  $md-blue-grey: (
+  $mat-blue-grey: (
     50: $black-87-opacity,
     100: $black-87-opacity,
     200: $black-87-opacity,

--- a/src/lib/core/style/_ripple.scss
+++ b/src/lib/core/style/_ripple.scss
@@ -1,28 +1,28 @@
 @import 'default-theme';
 @import 'theme-functions';
 
-$md-ripple-focused-opacity: 0.1;
-$md-ripple-background-fade-duration: 300ms;
-$md-ripple-background-default-color: rgba(0, 0, 0, 0.0588);
-$md-ripple-foreground-initial-opacity: 0.25;
-$md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
+$mat-ripple-focused-opacity: 0.1;
+$mat-ripple-background-fade-duration: 300ms;
+$mat-ripple-background-default-color: rgba(0, 0, 0, 0.0588);
+$mat-ripple-foreground-initial-opacity: 0.25;
+$mat-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
 
 /**
- * The host element of an md-ripple directive should always have a position of "absolute" or
+ * The host element of an mat-ripple directive should always have a position of "absolute" or
  * "relative" so that the ripple divs it creates inside itself are correctly positioned.
  */
-[md-ripple] {
+[mat-ripple] {
   overflow: hidden;
 }
 
-[md-ripple].md-ripple-unbounded {
+[mat-ripple].mat-ripple-unbounded {
   overflow: visible;
 }
 
-.md-ripple-background {
-  background-color: $md-ripple-background-default-color;
+.mat-ripple-background {
+  background-color: $mat-ripple-background-default-color;
   opacity: 0;
-  transition: opacity $md-ripple-background-fade-duration linear;
+  transition: opacity $mat-ripple-background-fade-duration linear;
   position: absolute;
   left: 0;
   top: 0;
@@ -30,33 +30,33 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
   bottom: 0;
 }
 
-.md-ripple-unbounded .md-ripple-background {
+.mat-ripple-unbounded .mat-ripple-background {
   display: none;
 }
 
-.md-ripple-background.md-ripple-active {
+.mat-ripple-background.mat-ripple-active {
   opacity: 1;
 }
 
-.md-ripple-focused .md-ripple-background {
-  background-color: md-color($md-accent, $md-ripple-focused-opacity);
+.mat-ripple-focused .mat-ripple-background {
+  background-color: mat-color($mat-accent, $mat-ripple-focused-opacity);
   opacity: 1;
 }
 
-.md-ripple-foreground {
-  background-color: $md-ripple-foreground-default-color;
+.mat-ripple-foreground {
+  background-color: $mat-ripple-foreground-default-color;
   border-radius: 50%;
   pointer-events: none;
-  opacity: $md-ripple-foreground-initial-opacity;
+  opacity: $mat-ripple-foreground-initial-opacity;
   position: absolute;
   // The transition duration is manually set based on the ripple size.
   transition: 'opacity, transform' 0ms cubic-bezier(0, 0, 0.2, 1);
 }
 
-.md-ripple-foreground.md-ripple-fade-in {
+.mat-ripple-foreground.mat-ripple-fade-in {
   opacity: 1;
 }
 
-.md-ripple-foreground.md-ripple-fade-out {
+.mat-ripple-foreground.mat-ripple-fade-out {
   opacity: 0;
 }

--- a/src/lib/core/style/_sidenav-mixins.scss
+++ b/src/lib/core/style/_sidenav-mixins.scss
@@ -1,5 +1,5 @@
 /* This mixin ensures an element spans the whole viewport.*/
-@mixin md-fullscreen {
+@mixin mat-fullscreen {
   position: fixed;
   top: 0;
   left: 0;

--- a/src/lib/core/style/_theme-functions.scss
+++ b/src/lib/core/style/_theme-functions.scss
@@ -1,6 +1,6 @@
 // ** Two main functions for users **
-// md-palette: used for defining your theme in terms of Material hues.
-// md-color: apply colors to components from the palette. Consumes the output of md-palette
+// mat-palette: used for defining your theme in terms of Material hues.
+// mat-color: apply colors to components from the palette. Consumes the output of mat-palette
 
 // Implement the rem unit with SCSS so we don't have to actually set a font-size on
 // the user's body element.
@@ -10,7 +10,7 @@
 }
 
 // For a given hue in a palette, return the contrast color from the map of contrast palettes.
-@function md-contrast($color-map, $hue, $contrast-color-map) {
+@function mat-contrast($color-map, $hue, $contrast-color-map) {
   @return map-get(map-get($contrast-color-map, $color-map), $hue);
 }
 
@@ -20,21 +20,21 @@
 // $primary
 // $lighter
 // $darker
-@function md-palette($color-map, $primary, $lighter, $darker, $contrast-color-map) {
+@function mat-palette($color-map, $primary, $lighter, $darker, $contrast-color-map) {
   $result: map_merge($color-map, (
     default: map-get($color-map, $primary),
     lighter: map-get($color-map, $lighter),
     darker: map-get($color-map, $darker),
 
-    default-contrast: md-contrast($color-map, $primary, $contrast-color-map),
-    lighter-contrast: md-contrast($color-map, $lighter, $contrast-color-map),
-    darker-contrast: md-contrast($color-map, $darker, $contrast-color-map)
+    default-contrast: mat-contrast($color-map, $primary, $contrast-color-map),
+    lighter-contrast: mat-contrast($color-map, $lighter, $contrast-color-map),
+    darker-contrast: mat-contrast($color-map, $darker, $contrast-color-map)
   ));
 
   // For each hue in the palette, add a "-contrast" color to the map.
   @each $hue, $color in $color-map {
     $result: map_merge($result, (
-      '#{$hue}-contrast': md-contrast($color-map, $hue, $contrast-color-map)
+      '#{$hue}-contrast': mat-contrast($color-map, $hue, $contrast-color-map)
     ));
   }
 
@@ -46,11 +46,11 @@
 // $hue-key: key used to lookup the color in $colorMap. Defaults to 'default'
 //     If $hue-key is a number between 0 and 1, it will be treated as $opacity.
 // $opacity: the opacity to apply to the color.
-@function md-color($color-map, $hue-key: default, $opacity: 1) {
+@function mat-color($color-map, $hue-key: default, $opacity: 1) {
   // If hueKey is a number between zero and one, then it actually contains an
   // opacity value, so recall this function with the default hue and that given opacity.
   @if type-of($hue-key) == number and $hue-key >= 0 and $hue-key <= 1 {
-    @return md-color($color-map, default, $hue-key);
+    @return mat-color($color-map, default, $hue-key);
   }
 
   $color: map-get($color-map, $hue-key);

--- a/src/lib/core/style/_variables.scss
+++ b/src/lib/core/style/_variables.scss
@@ -2,11 +2,11 @@
 
 
 // Typography
-$md-body-font-size-base: rem(1.4) !default;
-$md-font-family: Roboto, 'Helvetica Neue', sans-serif !default;
+$mat-body-font-size-base: rem(1.4) !default;
+$mat-font-family: Roboto, 'Helvetica Neue', sans-serif !default;
 
 // Media queries
-$md-xsmall: 'max-width: 600px';
+$mat-xsmall: 'max-width: 600px';
 
 // TODO: Revisit all z-indices before beta
 // z-index master list
@@ -18,17 +18,17 @@ $z-index-overlay: 1000 !default;
 $pi: 3.14159265;
 
 // Padding between input toggles and their labels
-$md-toggle-padding: 8px !default;
+$mat-toggle-padding: 8px !default;
 // Width and height of input toggles
-$md-toggle-size: 20px !default;
+$mat-toggle-size: 20px !default;
 
 // Easing Curves
 // TODO(jelbourn): all of these need to be revisited
 
 // The default animation curves used by material design.
-$md-linear-out-slow-in-timing-function: cubic-bezier(0, 0, 0.2, 0.1) !default;
-$md-fast-out-slow-in-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;
-$md-fast-out-linear-in-timing-function: cubic-bezier(0.4, 0, 1, 1) !default;
+$mat-linear-out-slow-in-timing-function: cubic-bezier(0, 0, 0.2, 0.1) !default;
+$mat-fast-out-slow-in-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;
+$mat-fast-out-linear-in-timing-function: cubic-bezier(0.4, 0, 1, 1) !default;
 
 $ease-in-out-curve-function: cubic-bezier(0.35, 0, 0.25, 1) !default;
 

--- a/src/lib/core/style/core.scss
+++ b/src/lib/core/style/core.scss
@@ -5,10 +5,10 @@
 @import 'ripple';
 
 // Provides external CSS classes for each elevation value. Each CSS class is formatted as
-// `md-elevation-z$zValue` where `$zValue` corresponds to the z-space to which the element is
+// `mat-elevation-z$zValue` where `$zValue` corresponds to the z-space to which the element is
 // elevated.
 @for $zValue from 0 through 24 {
-  .md-elevation-z#{$zValue} {
-    @include md-elevation($zValue);
+  .mat-elevation-z#{$zValue} {
+    @include mat-elevation($zValue);
   }
 }

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -6,9 +6,9 @@ export type DialogRole = 'dialog' | 'alertdialog'
 
 
 /**
- * Configuration for opening a modal dialog with the MdDialog service.
+ * Configuration for opening a modal dialog with the MatDialog service.
  */
-export class MdDialogConfig {
+export class MatDialogConfig {
   viewContainerRef: ViewContainerRef;
 
   /** The ARIA role of the dialog element. */

--- a/src/lib/dialog/dialog-container.scss
+++ b/src/lib/dialog/dialog-container.scss
@@ -1,14 +1,14 @@
 @import 'elevation';
 @import 'default-theme';
 
-$md-dialog-padding: 24px !default;
+$mat-dialog-padding: 24px !default;
 
 :host {
   display: block;
   overflow: hidden;
 
-  padding: $md-dialog-padding;
+  padding: $mat-dialog-padding;
 
-  background: md-color($md-background, dialog);
-  @include md-elevation(24);
+  background: mat-color($mat-background, dialog);
+  @include mat-elevation(24);
 }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -5,8 +5,8 @@ import {
   PortalHostDirective,
   TemplatePortal
 } from '@angular2-material/core';
-import {MdDialogConfig} from './dialog-config';
-import {MdDialogContentAlreadyAttachedError} from './dialog-errors';
+import {MatDialogConfig} from './dialog-config';
+import {MatDialogContentAlreadyAttachedError} from './dialog-errors';
 
 
 /**
@@ -14,25 +14,25 @@ import {MdDialogContentAlreadyAttachedError} from './dialog-errors';
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-dialog-container',
+  selector: 'mat-dialog-container',
   templateUrl: 'dialog-container.html',
   styleUrls: ['dialog-container.css'],
   host: {
-    'class': 'md-dialog-container',
+    'class': 'mat-dialog-container',
     '[attr.role]': 'dialogConfig?.role'
   }
 })
-export class MdDialogContainer extends BasePortalHost {
+export class MatDialogContainer extends BasePortalHost {
   /** The portal host inside of this container into which the dialog content will be loaded. */
   @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
 
   /** The dialog configuration. */
-  dialogConfig: MdDialogConfig;
+  dialogConfig: MatDialogConfig;
 
   /** Attach a portal as content to this dialog container. */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     if (this._portalHost.hasAttached()) {
-      throw new MdDialogContentAlreadyAttachedError();
+      throw new MatDialogContentAlreadyAttachedError();
     }
 
     return this._portalHost.attachComponentPortal(portal);

--- a/src/lib/dialog/dialog-errors.ts
+++ b/src/lib/dialog/dialog-errors.ts
@@ -1,7 +1,7 @@
-import {MdError} from '@angular2-material/core';
+import {MatError} from '@angular2-material/core';
 
 /** Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin. */
-export class MdDialogContentAlreadyAttachedError extends MdError {
+export class MatDialogContentAlreadyAttachedError extends MatError {
   constructor() {
       super('Attempting to attach dialog content after content is already attached');
   }

--- a/src/lib/dialog/dialog-injector.ts
+++ b/src/lib/dialog/dialog-injector.ts
@@ -1,13 +1,13 @@
 import {Injector} from '@angular/core';
-import {MdDialogRef} from './dialog-ref';
+import {MatDialogRef} from './dialog-ref';
 
 
 /** Custom injector type specifically for instantiating components with a dialog. */
 export class DialogInjector implements Injector {
-  constructor(private _dialogRef: MdDialogRef<any>, private _parentInjector: Injector) { }
+  constructor(private _dialogRef: MatDialogRef<any>, private _parentInjector: Injector) { }
 
   get(token: any, notFoundValue?: any): any {
-    if (token === MdDialogRef) {
+    if (token === MatDialogRef) {
       return this._dialogRef;
     }
 

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -8,9 +8,9 @@ import {Subject} from 'rxjs/Subject';
 
 
 /**
- * Reference to a dialog opened via the MdDialog service.
+ * Reference to a dialog opened via the MatDialog service.
  */
-export class MdDialogRef<T> {
+export class MatDialogRef<T> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;
 

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -1,13 +1,13 @@
 import {inject, async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {NgModule, Component, Directive, ViewChild, ViewContainerRef} from '@angular/core';
-import {MdDialog, MdDialogModule} from './dialog';
+import {MatDialog, MatDialogModule} from './dialog';
 import {OverlayContainer} from '@angular2-material/core';
-import {MdDialogConfig} from './dialog-config';
-import {MdDialogRef} from './dialog-ref';
+import {MatDialogConfig} from './dialog-config';
+import {MatDialogRef} from './dialog-ref';
 
 
-describe('MdDialog', () => {
-  let dialog: MdDialog;
+describe('MatDialog', () => {
+  let dialog: MatDialog;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -15,7 +15,7 @@ describe('MdDialog', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdDialogModule.forRoot(), DialogTestModule],
+      imports: [MatDialogModule.forRoot(), DialogTestModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
@@ -27,7 +27,7 @@ describe('MdDialog', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(inject([MdDialog], (d: MdDialog) => {
+  beforeEach(inject([MatDialog], (d: MatDialog) => {
     dialog = d;
   }));
 
@@ -39,7 +39,7 @@ describe('MdDialog', () => {
   });
 
   it('should open a dialog with a component', () => {
-    let config = new MdDialogConfig();
+    let config = new MatDialogConfig();
     config.viewContainerRef = testViewContainerRef;
 
     let dialogRef = dialog.open(PizzaMsg, config);
@@ -51,12 +51,12 @@ describe('MdDialog', () => {
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();
-    let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
+    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container');
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
   });
 
   it('should apply the configured role to the dialog element', () => {
-    let config = new MdDialogConfig();
+    let config = new MatDialogConfig();
     config.viewContainerRef = testViewContainerRef;
     config.role = 'alertdialog';
 
@@ -64,12 +64,12 @@ describe('MdDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
+    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container');
     expect(dialogContainerElement.getAttribute('role')).toBe('alertdialog');
   });
 
   it('should close a dialog and get back a result', () => {
-    let config = new MdDialogConfig();
+    let config = new MatDialogConfig();
     config.viewContainerRef = testViewContainerRef;
 
     let dialogRef = dialog.open(PizzaMsg, config);
@@ -86,7 +86,7 @@ describe('MdDialog', () => {
     dialogRef.close('Charmander');
 
     expect(afterCloseResult).toBe('Charmander');
-    expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   });
 });
 
@@ -111,14 +111,14 @@ class ComponentWithChildViewContainer {
 /** Simple component for testing ComponentPortal. */
 @Component({template: '<p>Pizza</p>'})
 class PizzaMsg {
-  constructor(public dialogRef: MdDialogRef<PizzaMsg>) { }
+  constructor(public dialogRef: MatDialogRef<PizzaMsg>) { }
 }
 
 // Create a real (non-test) NgModule as a workaround for
 // https://github.com/angular/angular/issues/10760
 const TEST_DIRECTIVES = [ComponentWithChildViewContainer, PizzaMsg, DirectiveWithViewContainer];
 @NgModule({
-  imports: [MdDialogModule],
+  imports: [MatDialogModule],
   exports: TEST_DIRECTIVES,
   declarations: TEST_DIRECTIVES,
   entryComponents: [ComponentWithChildViewContainer, PizzaMsg],

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -9,13 +9,13 @@ import {
   OVERLAY_PROVIDERS,
 } from '@angular2-material/core';
 import {ComponentType} from '@angular2-material/core';
-import {MdDialogConfig} from './dialog-config';
-import {MdDialogRef} from './dialog-ref';
+import {MatDialogConfig} from './dialog-config';
+import {MatDialogRef} from './dialog-ref';
 import {DialogInjector} from './dialog-injector';
-import {MdDialogContainer} from './dialog-container';
+import {MatDialogContainer} from './dialog-container';
 
-export {MdDialogConfig} from './dialog-config';
-export {MdDialogRef} from './dialog-ref';
+export {MatDialogConfig} from './dialog-config';
+export {MatDialogRef} from './dialog-ref';
 
 
 // TODO(jelbourn): add shortcuts for `alert` and `confirm`.
@@ -32,7 +32,7 @@ export {MdDialogRef} from './dialog-ref';
  * Service to open Material Design modal dialogs.
  */
 @Injectable()
-export class MdDialog {
+export class MatDialog {
   constructor(private _overlay: Overlay, private _injector: Injector) { }
 
   /**
@@ -40,7 +40,7 @@ export class MdDialog {
    * @param component Type of the component to load into the load.
    * @param config
    */
-  open<T>(component: ComponentType<T>, config: MdDialogConfig): MdDialogRef<T> {
+  open<T>(component: ComponentType<T>, config: MatDialogConfig): MatDialogRef<T> {
     let overlayRef = this._createOverlay(config);
     let dialogContainer = this._attachDialogContainer(overlayRef, config);
 
@@ -52,43 +52,43 @@ export class MdDialog {
    * @param dialogConfig The dialog configuration.
    * @returns A promise resolving to the OverlayRef for the created overlay.
    */
-  private _createOverlay(dialogConfig: MdDialogConfig): OverlayRef {
+  private _createOverlay(dialogConfig: MatDialogConfig): OverlayRef {
     let overlayState = this._getOverlayState(dialogConfig);
     return this._overlay.create(overlayState);
   }
 
   /**
-   * Attaches an MdDialogContainer to a dialog's already-created overlay.
+   * Attaches an MatDialogContainer to a dialog's already-created overlay.
    * @param overlay Reference to the dialog's underlying overlay.
    * @param config The dialog configuration.
    * @returns A promise resolving to a ComponentRef for the attached container.
    */
-  private _attachDialogContainer(overlay: OverlayRef, config: MdDialogConfig): MdDialogContainer {
-    let containerPortal = new ComponentPortal(MdDialogContainer, config.viewContainerRef);
+  private _attachDialogContainer(overlay: OverlayRef, config: MatDialogConfig): MatDialogContainer {
+    let containerPortal = new ComponentPortal(MatDialogContainer, config.viewContainerRef);
 
-    let containerRef: ComponentRef<MdDialogContainer> = overlay.attach(containerPortal);
+    let containerRef: ComponentRef<MatDialogContainer> = overlay.attach(containerPortal);
     containerRef.instance.dialogConfig = config;
 
     return containerRef.instance;
   }
 
   /**
-   * Attaches the user-provided component to the already-created MdDialogContainer.
+   * Attaches the user-provided component to the already-created MatDialogContainer.
    * @param component The type of component being loaded into the dialog.
-   * @param dialogContainer Reference to the wrapping MdDialogContainer.
+   * @param dialogContainer Reference to the wrapping MatDialogContainer.
    * @param overlayRef Reference to the overlay in which the dialog resides.
-   * @returns A promise resolving to the MdDialogRef that should be returned to the user.
+   * @returns A promise resolving to the MatDialogRef that should be returned to the user.
    */
   private _attachDialogContent<T>(
       component: ComponentType<T>,
-      dialogContainer: MdDialogContainer,
-      overlayRef: OverlayRef): MdDialogRef<T> {
+      dialogContainer: MatDialogContainer,
+      overlayRef: OverlayRef): MatDialogRef<T> {
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
-    let dialogRef = <MdDialogRef<T>> new MdDialogRef(overlayRef);
+    let dialogRef = <MatDialogRef<T>> new MatDialogRef(overlayRef);
 
     // We create an injector specifically for the component we're instantiating so that it can
-    // inject the MdDialogRef. This allows a component loaded inside of a dialog to close itself
+    // inject the MatDialogRef. This allows a component loaded inside of a dialog to close itself
     // and, optionally, to return a value.
     let dialogInjector = new DialogInjector(dialogRef, this._injector);
 
@@ -105,7 +105,7 @@ export class MdDialog {
    * @param dialogConfig The dialog configuration.
    * @returns The overlay configuration.
    */
-  private _getOverlayState(dialogConfig: MdDialogConfig): OverlayState {
+  private _getOverlayState(dialogConfig: MatDialogConfig): OverlayState {
     let state = new OverlayState();
 
     state.positionStrategy = this._overlay.position()
@@ -120,15 +120,15 @@ export class MdDialog {
 
 @NgModule({
   imports: [OverlayModule, PortalModule],
-  exports: [MdDialogContainer],
-  declarations: [MdDialogContainer],
-  entryComponents: [MdDialogContainer],
+  exports: [MatDialogContainer],
+  declarations: [MatDialogContainer],
+  entryComponents: [MatDialogContainer],
 })
-export class MdDialogModule {
+export class MatDialogModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdDialogModule,
-      providers: [MdDialog, OVERLAY_PROVIDERS],
+      ngModule: MatDialogModule,
+      providers: [MatDialog, OVERLAY_PROVIDERS],
     };
   }
 }

--- a/src/lib/grid-list/grid-list-errors.ts
+++ b/src/lib/grid-list/grid-list-errors.ts
@@ -1,28 +1,28 @@
-import {MdError} from '@angular2-material/core';
+import {MatError} from '@angular2-material/core';
 
 /**
  * Exception thrown when cols property is missing from grid-list
  */
-export class MdGridListColsError extends MdError {
+export class MatGridListColsError extends MatError {
   constructor() {
-    super(`md-grid-list: must pass in number of columns. Example: <md-grid-list cols="3">`);
+    super(`mat-grid-list: must pass in number of columns. Example: <mat-grid-list cols="3">`);
   }
 }
 
 /**
  * Exception thrown when a tile's colspan is longer than the number of cols in list
  */
-export class MdGridTileTooWideError extends MdError {
+export class MatGridTileTooWideError extends MatError {
   constructor(cols: number, listLength: number) {
-    super(`md-grid-list: tile with colspan ${cols} is wider than grid with cols="${listLength}".`);
+    super(`mat-grid-list: tile with colspan ${cols} is wider than grid with cols="${listLength}".`);
   }
 }
 
 /**
  * Exception thrown when an invalid ratio is passed in as a rowHeight
  */
-export class MdGridListBadRatioError extends MdError {
+export class MatGridListBadRatioError extends MatError {
   constructor(value: string) {
-    super(`md-grid-list: invalid ratio given for row-height: "${value}"`);
+    super(`mat-grid-list: invalid ratio given for row-height: "${value}"`);
   }
 }

--- a/src/lib/grid-list/grid-list.html
+++ b/src/lib/grid-list/grid-list.html
@@ -1,3 +1,3 @@
-<div class="md-grid-list">
+<div class="mat-grid-list">
   <ng-content></ng-content>
 </div>

--- a/src/lib/grid-list/grid-list.scss
+++ b/src/lib/grid-list/grid-list.scss
@@ -1,22 +1,22 @@
 @import 'list-shared';
 
 /* height of tile header or footer if it has one line */
-$md-grid-list-one-line-height: 48px;
+$mat-grid-list-one-line-height: 48px;
 /* height of tile header or footer if it has two lines */
-$md-grid-list-two-line-height: 68px;
+$mat-grid-list-two-line-height: 68px;
 /* side padding for text in tile headers and footers */
-$md-grid-list-text-padding: 16px;
+$mat-grid-list-text-padding: 16px;
 
 /* font styles for text in tile headers and footers */
-$md-grid-list-font-size: 16px;
-$md-grid-list-secondary-font: 12px;
+$mat-grid-list-font-size: 16px;
+$mat-grid-list-secondary-font: 12px;
 
-md-grid-list {
+mat-grid-list {
   display: block;
   position: relative;
 }
 
-md-grid-tile {
+mat-grid-tile {
   display: block;
   position: absolute;
 
@@ -38,48 +38,48 @@ md-grid-tile {
   }
 
   // Headers & footers
-  md-grid-tile-header,
-  md-grid-tile-footer {
-    @include md-line-base($md-grid-list-secondary-font);
-    @include md-normalize-text();
+  mat-grid-tile-header,
+  mat-grid-tile-footer {
+    @include mat-line-base($mat-grid-list-secondary-font);
+    @include mat-normalize-text();
 
     display: flex;
     align-items: center;
-    height: $md-grid-list-one-line-height;
+    height: $mat-grid-list-one-line-height;
     color: #fff;
     background: rgba(0, 0, 0, 0.18);
     overflow: hidden;
-    padding: 0 $md-grid-list-text-padding;
-    font-size: $md-grid-list-font-size;
+    padding: 0 $mat-grid-list-text-padding;
+    font-size: $mat-grid-list-font-size;
 
     // Positioning
     position: absolute;
     left: 0;
     right: 0;
 
-    &.md-2-line {
-      height: $md-grid-list-two-line-height;
+    &.mat-2-line {
+      height: $mat-grid-list-two-line-height;
     }
   }
 
-  .md-grid-list-text {
-    @include md-line-wrapper-base();
+  .mat-grid-list-text {
+    @include mat-line-wrapper-base();
   }
 
-  md-grid-tile-header {
+  mat-grid-tile-header {
     top: 0;
   }
 
-  md-grid-tile-footer {
+  mat-grid-tile-footer {
     bottom: 0;
   }
 
-  [md-grid-avatar] {
-    padding-right: $md-grid-list-text-padding;
+  [mat-grid-avatar] {
+    padding-right: $mat-grid-list-text-padding;
 
     [dir='rtl'] & {
       padding-right: 0;
-      padding-left: $md-grid-list-text-padding;
+      padding-left: $mat-grid-list-text-padding;
     }
 
     &:empty {

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -1,14 +1,14 @@
 import {async, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdGridList, MdGridListModule} from './grid-list';
-import {MdGridTile, MdGridTileText} from './grid-tile';
+import {MatGridList, MatGridListModule} from './grid-list';
+import {MatGridTile, MatGridTileText} from './grid-tile';
 
 
-describe('MdGridList', () => {
+describe('MatGridList', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdGridListModule.forRoot()],
+      imports: [MatGridListModule.forRoot()],
       declarations: [
         GridListWithoutCols,
         GridListWithInvalidRowHeightRatio,
@@ -55,7 +55,7 @@ describe('MdGridList', () => {
   it('should default to 1:1 row height if undefined ', () => {
     let fixture = TestBed.createComponent(GridListWithUnspecifiedRowHeight);
     fixture.detectChanges();
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
 
     // In ratio mode, heights are set using the padding-top property.
     expect(getStyle(tile, 'padding-top')).toBe('200px');
@@ -67,7 +67,7 @@ describe('MdGridList', () => {
     fixture.componentInstance.heightRatio = '4:1';
     fixture.detectChanges();
 
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
     expect(getStyle(tile, 'padding-top')).toBe('100px');
 
     fixture.componentInstance.heightRatio = '2:1';
@@ -81,7 +81,7 @@ describe('MdGridList', () => {
 
     fixture.componentInstance.totalHeight = '300px';
     fixture.detectChanges();
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
 
     // 149.5 * 2 = 299px + 1px gutter = 300px
     expect(getStyle(tile, 'height')).toBe('149.5px');
@@ -99,7 +99,7 @@ describe('MdGridList', () => {
     fixture.componentInstance.rowHeight = '100px';
     fixture.detectChanges();
 
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
     expect(getStyle(tile, 'height')).toBe('100px');
 
     fixture.componentInstance.rowHeight = '200px';
@@ -112,7 +112,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithUnitlessFixedRowHeight);
     fixture.detectChanges();
 
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
     expect(getStyle(tile, 'height')).toBe('100px');
   });
 
@@ -120,7 +120,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithUnspecifiedGutterSize);
     fixture.detectChanges();
 
-    let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+    let tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
     expect(getStyle(tiles[0], 'width')).toBe('99.5px');
@@ -135,7 +135,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithGutterSize);
     fixture.detectChanges();
 
-    let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+    let tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
     expect(getStyle(tiles[0], 'width')).toBe('99px');
@@ -150,7 +150,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithUnitlessGutterSize);
     fixture.detectChanges();
 
-    let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+    let tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
     expect(getStyle(tiles[0], 'width')).toBe('99px');
@@ -165,7 +165,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithRatioHeightAndMulipleRows);
     fixture.detectChanges();
 
-    let list = fixture.debugElement.query(By.directive(MdGridList));
+    let list = fixture.debugElement.query(By.directive(MatGridList));
     expect(getStyle(list, 'padding-bottom')).toBe('201px');
   });
 
@@ -173,7 +173,7 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithFixRowHeightAndMultipleRows);
     fixture.detectChanges();
 
-    let list = fixture.debugElement.query(By.directive(MdGridList));
+    let list = fixture.debugElement.query(By.directive(MatGridList));
     expect(getStyle(list, 'height')).toBe('201px');
   });
 
@@ -182,7 +182,7 @@ describe('MdGridList', () => {
       fixture.componentInstance.colspan = 2;
       fixture.detectChanges();
 
-      let tile = fixture.debugElement.query(By.directive(MdGridTile));
+      let tile = fixture.debugElement.query(By.directive(MatGridTile));
       expect(getStyle(tile, 'width')).toBe('199.5px');
 
       fixture.componentInstance.colspan = 3;
@@ -196,7 +196,7 @@ describe('MdGridList', () => {
     fixture.componentInstance.rowspan = 2;
     fixture.detectChanges();
 
-    let tile = fixture.debugElement.query(By.directive(MdGridTile));
+    let tile = fixture.debugElement.query(By.directive(MatGridTile));
     expect(getStyle(tile, 'height')).toBe('201px');
 
     fixture.componentInstance.rowspan = 3;
@@ -215,7 +215,7 @@ describe('MdGridList', () => {
       ];
 
       fixture.detectChanges();
-      let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+      let tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
       expect(getStyle(tiles[0], 'width')).toBe('299.75px');
       expect(getStyle(tiles[0], 'height')).toBe('100px');
@@ -242,16 +242,16 @@ describe('MdGridList', () => {
     let fixture = TestBed.createComponent(GridListWithFootersWithoutLines);
     fixture.detectChanges();
 
-    let footer = fixture.debugElement.query(By.directive(MdGridTileText));
-    expect(footer.nativeElement.classList.contains('md-2-line')).toBe(false);
+    let footer = fixture.debugElement.query(By.directive(MatGridTileText));
+    expect(footer.nativeElement.classList.contains('mat-2-line')).toBe(false);
   });
 
   it('should add class to footers with two lines', () => {
     let fixture = TestBed.createComponent(GridListWithFooterContainingTwoLines);
     fixture.detectChanges();
 
-    let footer = fixture.debugElement.query(By.directive(MdGridTileText));
-    expect(footer.nativeElement.classList.contains('md-2-line')).toBe(true);
+    let footer = fixture.debugElement.query(By.directive(MatGridTileText));
+    expect(footer.nativeElement.classList.contains('mat-2-line')).toBe(true);
   });
 });
 
@@ -274,153 +274,153 @@ function getComputedLeft(element: DebugElement): number {
 
 
 
-@Component({template: '<md-grid-list></md-grid-list>'})
+@Component({template: '<mat-grid-list></mat-grid-list>'})
 class GridListWithoutCols { }
 
-@Component({template: '<md-grid-list cols="4" rowHeight="4:3:2"></md-grid-list>'})
+@Component({template: '<mat-grid-list cols="4" rowHeight="4:3:2"></mat-grid-list>'})
 class GridListWithInvalidRowHeightRatio { }
 
 @Component({template:
-    '<md-grid-list cols="4"><md-grid-tile colspan="5"></md-grid-tile></md-grid-list>'})
+    '<mat-grid-list cols="4"><mat-grid-tile colspan="5"></mat-grid-tile></mat-grid-list>'})
 class GridListWithTooWideColspan { }
 
 @Component({template: `
     <div style="width:200px">
-      <md-grid-list cols="1">
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="1">
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithUnspecifiedRowHeight { }
 
 @Component({template: `
     <div style="width:400px">
-      <md-grid-list cols="1" [rowHeight]="heightRatio">
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="1" [rowHeight]="heightRatio">
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GirdListWithRowHeightRatio {
   heightRatio: string;
 }
 
 @Component({template: `
-    <md-grid-list cols="1" rowHeight="fit" [style.height]="totalHeight">
-      <md-grid-tile></md-grid-tile>
-      <md-grid-tile></md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="1" rowHeight="fit" [style.height]="totalHeight">
+      <mat-grid-tile></mat-grid-tile>
+      <mat-grid-tile></mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithFitRowHeightMode {
   totalHeight: string;
 }
 
 @Component({template: `
-    <md-grid-list cols="4" [rowHeight]="rowHeight">
-      <md-grid-tile></md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="4" [rowHeight]="rowHeight">
+      <mat-grid-tile></mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithFixedRowHeightMode {
   rowHeight: string;
 }
 
 @Component({template: `
-    <md-grid-list cols="4" rowHeight="100">
-      <md-grid-tile></md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="4" rowHeight="100">
+      <mat-grid-tile></mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithUnitlessFixedRowHeight {
   rowHeight: string;
 }
 
 @Component({template: `
     <div style="width:200px">
-      <md-grid-list cols="2" rowHeight="100px">
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="2" rowHeight="100px">
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithUnspecifiedGutterSize { }
 
 @Component({template: `
     <div style="width:200px">
-      <md-grid-list cols="2" gutterSize="2px" rowHeight="100px">
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="2" gutterSize="2px" rowHeight="100px">
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithGutterSize { }
 
 @Component({template: `
     <div style="width:200px">
-      <md-grid-list cols="2" gutterSize="2" rowHeight="100px">
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="2" gutterSize="2" rowHeight="100px">
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithUnitlessGutterSize { }
 
 @Component({template: `
     <div style="width:400px">
-      <md-grid-list cols="1" rowHeight="4:1">
-        <md-grid-tile></md-grid-tile>
-        <md-grid-tile></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="1" rowHeight="4:1">
+        <mat-grid-tile></mat-grid-tile>
+        <mat-grid-tile></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithRatioHeightAndMulipleRows { }
 
 @Component({template: `
-    <md-grid-list cols="1" rowHeight="100px">
-      <md-grid-tile></md-grid-tile>
-      <md-grid-tile></md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="1" rowHeight="100px">
+      <mat-grid-tile></mat-grid-tile>
+      <mat-grid-tile></mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithFixRowHeightAndMultipleRows { }
 
 @Component({template: `
     <div style="width:400px">
-      <md-grid-list cols="4">
-        <md-grid-tile [colspan]="colspan"></md-grid-tile>
-      </md-grid-list>
+      <mat-grid-list cols="4">
+        <mat-grid-tile [colspan]="colspan"></mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithColspanBinding {
   colspan: number;
 }
 
 @Component({template: `
-    <md-grid-list cols="1" rowHeight="100px">
-      <md-grid-tile [rowspan]="rowspan"></md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="1" rowHeight="100px">
+      <mat-grid-tile [rowspan]="rowspan"></mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithRowspanBinding {
   rowspan: number;
 }
 
 @Component({template: `
     <div style="width:400px">
-      <md-grid-list cols="4" rowHeight="100px">
-        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
+      <mat-grid-list cols="4" rowHeight="100px">
+        <mat-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
                       [style.background]="tile.color">
           {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
+        </mat-grid-tile>
+      </mat-grid-list>
     </div>`})
 class GridListWithComplexLayout {
   tiles: any[];
 }
 
 @Component({template: `
-    <md-grid-list cols="1">
-      <md-grid-tile>
-        <md-grid-tile-footer>
+    <mat-grid-list cols="1">
+      <mat-grid-tile>
+        <mat-grid-tile-footer>
           I'm a footer!
-        </md-grid-tile-footer>
-      </md-grid-tile>
-    </md-grid-list>`})
+        </mat-grid-tile-footer>
+      </mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithFootersWithoutLines { }
 
 @Component({template: `
-    <md-grid-list cols="1">
-      <md-grid-tile>
-        <md-grid-tile-footer>
-          <h3 md-line>First line</h3>
-          <span md-line>Second line</span>
-        </md-grid-tile-footer>
-      </md-grid-tile>
-    </md-grid-list>`})
+    <mat-grid-list cols="1">
+      <mat-grid-tile>
+        <mat-grid-tile-footer>
+          <h3 mat-line>First line</h3>
+          <span mat-line>Second line</span>
+        </mat-grid-tile-footer>
+      </mat-grid-tile>
+    </mat-grid-list>`})
 class GridListWithFooterContainingTwoLines { }

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -12,7 +12,7 @@ import {
   ElementRef,
   Optional
 } from '@angular/core';
-import {MdGridTile, MdGridTileText} from './grid-tile';
+import {MatGridTile, MatGridTileText} from './grid-tile';
 import {TileCoordinator} from './tile-coordinator';
 import {
     TileStyler,
@@ -20,24 +20,24 @@ import {
     RatioTileStyler,
     FixedTileStyler
 } from './tile-styler';
-import {MdGridListColsError} from './grid-list-errors';
-import {Dir, MdLineModule} from '@angular2-material/core';
+import {MatGridListColsError} from './grid-list-errors';
+import {Dir, MatLineModule} from '@angular2-material/core';
 import {coerceToString, coerceToNumber} from './grid-list-measure';
 
 // TODO(kara): Conditional (responsive) column count / row size.
 // TODO(kara): Re-layout on window resize / media change (debounced).
 // TODO(kara): gridTileHeader and gridTileFooter.
 
-const MD_FIT_MODE = 'fit';
+const MAT_FIT_MODE = 'fit';
 
 @Component({
   moduleId: module.id,
-  selector: 'md-grid-list',
+  selector: 'mat-grid-list',
   templateUrl: 'grid-list.html',
   styleUrls: ['grid-list.css'],
   encapsulation: ViewEncapsulation.None,
 })
-export class MdGridList implements OnInit, AfterContentChecked {
+export class MatGridList implements OnInit, AfterContentChecked {
   /** Number of columns being rendered. */
   private _cols: number;
 
@@ -56,7 +56,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   private _tileStyler: TileStyler;
 
   /** Query list of tiles that are being rendered. */
-  @ContentChildren(MdGridTile) _tiles: QueryList<MdGridTile>;
+  @ContentChildren(MatGridTile) _tiles: QueryList<MatGridTile>;
 
   constructor(
       private _renderer: Renderer,
@@ -106,7 +106,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   /** Throw a friendly error if cols property is missing */
   private _checkCols() {
     if (!this.cols) {
-      throw new MdGridListColsError();
+      throw new MatGridListColsError();
     }
   }
 
@@ -119,7 +119,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
 
   /** Creates correct Tile Styler subtype based on rowHeight passed in by user */
   private _setTileStyler(): void {
-    if (this._rowHeight === MD_FIT_MODE) {
+    if (this._rowHeight === MAT_FIT_MODE) {
       this._tileStyler = new FitTileStyler();
     } else if (this._rowHeight && this._rowHeight.match(/:/g)) {
       this._tileStyler = new RatioTileStyler(this._rowHeight);
@@ -153,14 +153,14 @@ export class MdGridList implements OnInit, AfterContentChecked {
 
 
 @NgModule({
-  imports: [MdLineModule],
-  exports: [MdGridList, MdGridTile, MdGridTileText, MdLineModule],
-  declarations: [MdGridList, MdGridTile, MdGridTileText],
+  imports: [MatLineModule],
+  exports: [MatGridList, MatGridTile, MatGridTileText, MatLineModule],
+  declarations: [MatGridList, MatGridTile, MatGridTileText],
 })
-export class MdGridListModule {
+export class MatGridListModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdGridListModule,
+      ngModule: MatGridListModule,
       providers: []
     };
   }

--- a/src/lib/grid-list/grid-tile-text.html
+++ b/src/lib/grid-list/grid-tile-text.html
@@ -1,3 +1,3 @@
-<ng-content select="[md-grid-avatar]"></ng-content>
-<div class="md-grid-list-text"><ng-content select="[md-line]"></ng-content></div>
+<ng-content select="[mat-grid-avatar]"></ng-content>
+<div class="mat-grid-list-text"><ng-content select="[mat-line]"></ng-content></div>
 <ng-content></ng-content>

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -8,18 +8,18 @@ import {
   QueryList,
   AfterContentInit
 } from '@angular/core';
-import { MdLine, MdLineSetter } from '@angular2-material/core';
+import { MatLine, MatLineSetter } from '@angular2-material/core';
 import {coerceToNumber} from './grid-list-measure';
 
 @Component({
   moduleId: module.id,
-  selector: 'md-grid-tile',
+  selector: 'mat-grid-tile',
   host: { 'role': 'listitem' },
   templateUrl: 'grid-tile.html',
   styleUrls: ['grid-list.css'],
   encapsulation: ViewEncapsulation.None,
 })
-export class MdGridTile {
+export class MatGridTile {
   _rowspan: number = 1;
   _colspan: number = 1;
 
@@ -55,21 +55,21 @@ export class MdGridTile {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-grid-tile-header, md-grid-tile-footer',
+  selector: 'mat-grid-tile-header, mat-grid-tile-footer',
   templateUrl: 'grid-tile-text.html'
 })
-export class MdGridTileText implements AfterContentInit {
+export class MatGridTileText implements AfterContentInit {
   /**
    *  Helper that watches the number of lines in a text area and sets
    * a class on the host element that matches the line count.
    */
-  _lineSetter: MdLineSetter;
-  @ContentChildren(MdLine) _lines: QueryList<MdLine>;
+  _lineSetter: MatLineSetter;
+  @ContentChildren(MatLine) _lines: QueryList<MatLine>;
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
   ngAfterContentInit() {
-    this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
+    this._lineSetter = new MatLineSetter(this._lines, this._renderer, this._element);
   }
 }
 

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -1,5 +1,5 @@
-import {MdGridTile} from './grid-tile';
-import {MdGridTileTooWideError} from './grid-list-errors';
+import {MatGridTile} from './grid-tile';
+import {MatGridTileTooWideError} from './grid-list-errors';
 
 /**
  * Class for determining, from a list of tiles, the (row, col) position of each of those tiles
@@ -41,7 +41,7 @@ export class TileCoordinator {
   /** The computed (row, col) position of each tile (the output). */
   positions: TilePosition[];
 
-  constructor(numColumns: number, tiles: MdGridTile[]) {
+  constructor(numColumns: number, tiles: MatGridTile[]) {
     this.tracker = new Array(numColumns);
     this.tracker.fill(0, 0, this.tracker.length);
 
@@ -49,7 +49,7 @@ export class TileCoordinator {
   }
 
   /** Calculates the row and col position of a tile. */
-  private _trackTile(tile: MdGridTile): TilePosition {
+  private _trackTile(tile: MatGridTile): TilePosition {
     // Find a gap large enough for this tile.
     let gapStartIndex = this._findMatchingGap(tile.colspan);
 
@@ -66,7 +66,7 @@ export class TileCoordinator {
   /** Finds the next available space large enough to fit the tile. */
   private _findMatchingGap(tileCols: number): number {
     if (tileCols > this.tracker.length) {
-      throw new MdGridTileTooWideError(tileCols, this.tracker.length);
+      throw new MatGridTileTooWideError(tileCols, this.tracker.length);
     }
 
     // Start index is inclusive, end index is exclusive.
@@ -127,7 +127,7 @@ export class TileCoordinator {
   }
 
   /** Update the tile tracker to account for the given tile in the given space. */
-  private _markTilePosition(start: number, tile: MdGridTile): void {
+  private _markTilePosition(start: number, tile: MatGridTile): void {
     for (let i = 0; i < tile.colspan; i++) {
       this.tracker[start + i] = tile.rowspan;
     }

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -1,6 +1,6 @@
-import {MdGridTile} from './grid-tile';
+import {MatGridTile} from './grid-tile';
 import {TileCoordinator} from './tile-coordinator';
-import {MdGridListBadRatioError} from './grid-list-errors';
+import {MatGridListBadRatioError} from './grid-list-errors';
 
 /**
  * Sets the style properties for an individual tile, given the position calculated by the
@@ -68,7 +68,7 @@ export class TileStyler {
 
 
   /** Gets the style properties to be applied to a tile for the given row and column index. */
-  setStyle(tile: MdGridTile, rowIndex: number, colIndex: number): void {
+  setStyle(tile: MatGridTile, rowIndex: number, colIndex: number): void {
     // Percent of the available horizontal space that one column takes up.
     let percentWidthPerTile = 100 / this._cols;
 
@@ -81,7 +81,7 @@ export class TileStyler {
   }
 
   /** Sets the horizontal placement of the tile in the list. */
-  setColStyles(tile: MdGridTile, colIndex: number, percentWidth: number,
+  setColStyles(tile: MatGridTile, colIndex: number, percentWidth: number,
                gutterWidth: number) {
     // Base horizontal size of a column.
     let baseTileWidth = this.getBaseTileSize(percentWidth, gutterWidth);
@@ -107,7 +107,7 @@ export class TileStyler {
    * Sets the vertical placement of the tile in the list.
    * This method will be implemented by each type of TileStyler.
    */
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number, gutterWidth: number) {}
+  setRowStyles(tile: MatGridTile, rowIndex: number, percentWidth: number, gutterWidth: number) {}
 
   /**
    * Calculates the computed height and returns the correct style property to set.
@@ -119,7 +119,7 @@ export class TileStyler {
 
 /**
  * This type of styler is instantiated when the user passes in a fixed row height.
- * Example <md-grid-list cols="3" rowHeight="100px">
+ * Example <mat-grid-list cols="3" rowHeight="100px">
  * TODO: internal
  */
 export class FixedTileStyler extends TileStyler {
@@ -131,7 +131,7 @@ export class FixedTileStyler extends TileStyler {
     this.fixedRowHeight = normalizeUnits(this.fixedRowHeight);
   }
 
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
+  setRowStyles(tile: MatGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     tile._setStyle('top', this.getTilePosition(this.fixedRowHeight, rowIndex));
     tile._setStyle('height', calc(this.getTileSize(this.fixedRowHeight, tile.rowspan)));
@@ -147,7 +147,7 @@ export class FixedTileStyler extends TileStyler {
 
 /**
  * This type of styler is instantiated when the user passes in a width:height ratio
- * for the row height.  Example <md-grid-list cols="3" rowHeight="3:1">
+ * for the row height.  Example <mat-grid-list cols="3" rowHeight="3:1">
  * TODO: internal
  */
 export class RatioTileStyler extends TileStyler {
@@ -161,7 +161,7 @@ export class RatioTileStyler extends TileStyler {
     this._parseRatio(value);
   }
 
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
+  setRowStyles(tile: MatGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     let percentHeightPerTile = percentWidth / this.rowHeightRatio;
     this.baseTileHeight = this.getBaseTileSize(percentHeightPerTile, gutterWidth);
@@ -183,7 +183,7 @@ export class RatioTileStyler extends TileStyler {
     let ratioParts = value.split(':');
 
     if (ratioParts.length !== 2) {
-      throw new MdGridListBadRatioError(value);
+      throw new MatGridListBadRatioError(value);
     }
 
     this.rowHeightRatio = parseFloat(ratioParts[0]) / parseFloat(ratioParts[1]);
@@ -192,10 +192,10 @@ export class RatioTileStyler extends TileStyler {
 
 /*  This type of styler is instantiated when the user selects a "fit" row height mode.
  *  In other words, the row height will reflect the total height of the container divided
- *  by the number of rows.  Example <md-grid-list cols="3" rowHeight="fit"> */
+ *  by the number of rows.  Example <mat-grid-list cols="3" rowHeight="fit"> */
 export class FitTileStyler extends TileStyler {
 
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
+  setRowStyles(tile: MatGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     // Percent of the available vertical space that one row takes up.
     let percentHeightPerTile = 100 / this._rowspan;

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Http} from '@angular/http';
-import {MdError} from '@angular2-material/core';
+import {MatError} from '@angular2-material/core';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/of';
@@ -13,7 +13,7 @@ import 'rxjs/add/operator/catch';
 
 
 /** Exception thrown when attempting to load an icon with a name that cannot be found. */
-export class MdIconNameNotFoundError extends MdError {
+export class MatIconNameNotFoundError extends MatError {
   constructor(iconName: string) {
       super(`Unable to find icon with the name "${iconName}"`);
   }
@@ -23,7 +23,7 @@ export class MdIconNameNotFoundError extends MdError {
  * Exception thrown when attempting to load SVG content that does not contain the expected
  * <svg> tag.
  */
-export class MdIconSvgTagNotFoundError extends MdError {
+export class MatIconSvgTagNotFoundError extends MatError {
   constructor() {
       super('<svg> tag not found');
   }
@@ -39,14 +39,14 @@ class SvgIconConfig {
 const iconKey = (namespace: string, name: string) => namespace + ':' + name;
 
 /**
- * Service to register and display icons used by the <md-icon> component.
+ * Service to register and display icons used by the <mat-icon> component.
  * - Registers icon URLs by namespace and name.
  * - Registers icon set URLs by namespace.
  * - Registers aliases for CSS classes, for use with icon fonts.
  * - Loads icons from URLs and extracts individual icons from icon sets.
  */
 @Injectable()
-export class MdIconRegistry {
+export class MatIconRegistry {
   /**
    * URLs and cached SVG elements for individual icons. Keys are of the format "[namespace]:[icon]".
    */
@@ -68,7 +68,7 @@ export class MdIconRegistry {
   private _fontCssClassesByAlias = new Map<string, string>();
 
   /**
-   * The CSS class to apply when an <md-icon> component has no icon name, url, or font specified.
+   * The CSS class to apply when an <mat-icon> component has no icon name, url, or font specified.
    * The default 'material-icons' value assumes that the material icon font has been loaded as
    * described at http://google.github.io/material-design-icons/#icon-font-for-the-web
    */
@@ -105,9 +105,9 @@ export class MdIconRegistry {
   }
 
   /**
-   * Defines an alias for a CSS class name to be used for icon fonts. Creating an mdIcon
+   * Defines an alias for a CSS class name to be used for icon fonts. Creating an matIcon
    * component with the alias as the fontSet input will cause the class name to be applied
-   * to the <md-icon> element.
+   * to the <mat-icon> element.
    */
   registerFontClassAlias(alias: string, className = alias): this {
     this._fontCssClassesByAlias.set(alias, className);
@@ -123,7 +123,7 @@ export class MdIconRegistry {
   }
 
   /**
-   * Sets the CSS class name to be used for icon fonts when an <md-icon> component does not
+   * Sets the CSS class name to be used for icon fonts when an <mat-icon> component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
    */
   setDefaultFontSetClass(className: string): this {
@@ -132,7 +132,7 @@ export class MdIconRegistry {
   }
 
   /**
-   * Returns the CSS class name to be used for icon fonts when an <md-icon> component does not
+   * Returns the CSS class name to be used for icon fonts when an <mat-icon> component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
    */
   getDefaultFontSetClass(): string {
@@ -157,7 +157,7 @@ export class MdIconRegistry {
   /**
    * Returns an Observable that produces the icon (as an <svg> DOM element) with the given name
    * and namespace. The icon must have been previously registered with addIcon or addIconSet;
-   * if not, the Observable will throw an MdIconNameNotFoundError.
+   * if not, the Observable will throw an MatIconNameNotFoundError.
    */
   getNamedSvgIcon(name: string, namespace = ''): Observable<SVGElement> {
     // Return (copy of) cached icon if possible.
@@ -170,7 +170,7 @@ export class MdIconRegistry {
     if (iconSetConfigs) {
       return this._getSvgFromIconSetConfigs(name, iconSetConfigs);
     }
-    return Observable.throw(new MdIconNameNotFoundError(key));
+    return Observable.throw(new MatIconNameNotFoundError(key));
   }
 
   /**
@@ -194,7 +194,7 @@ export class MdIconRegistry {
    * if found copies the element to a new <svg> element. If not found, fetches all icon sets
    * that have not been cached, and searches again after all fetches are completed.
    * The returned Observable produces the SVG element if possible, and throws
-   * MdIconNameNotFoundError if no icon with the specified name can be found.
+   * MatIconNameNotFoundError if no icon with the specified name can be found.
    */
   private _getSvgFromIconSetConfigs(name: string, iconSetConfigs: SvgIconConfig[]):
       Observable<SVGElement> {
@@ -231,7 +231,7 @@ export class MdIconRegistry {
         .map((ignoredResults: any) => {
           const foundIcon = this._extractIconWithNameFromAnySet(name, iconSetConfigs);
           if (!foundIcon) {
-            throw new MdIconNameNotFoundError(name);
+            throw new MatIconNameNotFoundError(name);
           }
           return foundIcon;
         });
@@ -322,7 +322,7 @@ export class MdIconRegistry {
     div.innerHTML = str;
     const svg = <SVGElement>div.querySelector('svg');
     if (!svg) {
-      throw new MdIconSvgTagNotFoundError();
+      throw new MatIconSvgTagNotFoundError();
     }
     return svg;
   }

--- a/src/lib/icon/icon.scss
+++ b/src/lib/icon/icon.scss
@@ -2,16 +2,16 @@
 @import 'default-theme';
 
 /** The width/height of the icon element. */
-$md-icon-size: 24px !default;
+$mat-icon-size: 24px !default;
 
 /**
 This works because we're using ViewEncapsulation.None. If we used the default
 encapsulation, the selector would need to be ":host".
 */
-md-icon {
+mat-icon {
   background-repeat: no-repeat;
   display: inline-block;
   fill: currentColor;
-  height: $md-icon-size;
-  width: $md-icon-size;
+  height: $mat-icon-size;
+  width: $mat-icon-size;
 }

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -6,8 +6,8 @@ import {
 import {XHRBackend} from '@angular/http';
 import {MockBackend} from '@angular/http/testing';
 import {Component} from '@angular/core';
-import {MdIconModule} from './icon';
-import {MdIconRegistry} from './icon-registry';
+import {MatIconModule} from './icon';
+import {MatIconRegistry} from './icon-registry';
 import {getFakeSvgHttpResponse} from './fake-svgs';
 
 
@@ -35,17 +35,17 @@ const verifyPathChildElement = (element: Element, attributeValue: string) => {
   expect(pathElement.getAttribute('id')).toBe(attributeValue);
 };
 
-describe('MdIcon', () => {
+describe('MatIcon', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdIconModule.forRoot()],
+      imports: [MatIconModule.forRoot()],
       declarations: [
-        MdIconLigatureTestApp,
-        MdIconLigatureWithAriaBindingTestApp,
-        MdIconCustomFontCssTestApp,
-        MdIconFromSvgUrlTestApp,
-        MdIconFromSvgNameTestApp,
+        MatIconLigatureTestApp,
+        MatIconLigatureWithAriaBindingTestApp,
+        MatIconCustomFontCssTestApp,
+        MatIconFromSvgUrlTestApp,
+        MatIconFromSvgNameTestApp,
       ],
       providers: [
         MockBackend,
@@ -56,12 +56,12 @@ describe('MdIcon', () => {
     TestBed.compileComponents();
   }));
 
-  let mdIconRegistry: MdIconRegistry;
+  let matIconRegistry: MatIconRegistry;
   let httpRequestUrls: string[];
 
-  let deps = [MdIconRegistry, MockBackend];
-  beforeEach(inject(deps, (mir: MdIconRegistry, mockBackend: MockBackend) => {
-    mdIconRegistry = mir;
+  let deps = [MatIconRegistry, MockBackend];
+  beforeEach(inject(deps, (mir: MatIconRegistry, mockBackend: MockBackend) => {
+    matIconRegistry = mir;
     // Keep track of requests so we can verify caching behavior.
     // Return responses for the SVGs defined in fake-svgs.ts.
     httpRequestUrls = [];
@@ -74,40 +74,40 @@ describe('MdIcon', () => {
 
   describe('Ligature icons', () => {
     it('should add material-icons class by default', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+      let fixture = TestBed.createComponent(MatIconLigatureTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       fixture.detectChanges();
-      expect(sortedClassNames(mdIconElement)).toEqual(['material-icons']);
+      expect(sortedClassNames(matIconElement)).toEqual(['material-icons']);
     });
 
     it('should use alternate icon font if set', () => {
-      mdIconRegistry.setDefaultFontSetClass('myfont');
+      matIconRegistry.setDefaultFontSetClass('myfont');
 
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+      let fixture = TestBed.createComponent(MatIconLigatureTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       fixture.detectChanges();
-      expect(sortedClassNames(mdIconElement)).toEqual(['myfont']);
+      expect(sortedClassNames(matIconElement)).toEqual(['myfont']);
     });
   });
 
   describe('Icons from URLs', () => {
     it('should fetch SVG icon from URL and inline the content', () => {
-      let fixture = TestBed.createComponent(MdIconFromSvgUrlTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgUrlTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
 
       testComponent.iconUrl = 'cat.svg';
       fixture.detectChanges();
-      // An <svg> element should have been added as a child of <md-icon>.
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      // An <svg> element should have been added as a child of <mat-icon>.
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       // Default attributes should be set.
       expect(svgElement.getAttribute('height')).toBe('100%');
       expect(svgElement.getAttribute('height')).toBe('100%');
@@ -117,65 +117,65 @@ describe('MdIcon', () => {
       // Change the icon, and the SVG element should be replaced.
       testComponent.iconUrl = 'dog.svg';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'woof');
 
       expect(httpRequestUrls).toEqual(['cat.svg', 'dog.svg']);
       // Using an icon from a previously loaded URL should not cause another HTTP request.
       testComponent.iconUrl = 'cat.svg';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'meow');
       expect(httpRequestUrls).toEqual(['cat.svg', 'dog.svg']);
     });
 
     it('should register icon URLs by name', () => {
-      mdIconRegistry.addSvgIcon('fluffy', 'cat.svg');
-      mdIconRegistry.addSvgIcon('fido', 'dog.svg');
+      matIconRegistry.addSvgIcon('fluffy', 'cat.svg');
+      matIconRegistry.addSvgIcon('fido', 'dog.svg');
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgNameTestApp);
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: SVGElement;
 
       testComponent.iconName = 'fido';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'woof');
       // The aria label should be taken from the icon name.
-      expect(mdIconElement.getAttribute('aria-label')).toBe('fido');
+      expect(matIconElement.getAttribute('aria-label')).toBe('fido');
 
       // Change the icon, and the SVG element should be replaced.
       testComponent.iconName = 'fluffy';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'meow');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('fluffy');
+      expect(matIconElement.getAttribute('aria-label')).toBe('fluffy');
 
       expect(httpRequestUrls).toEqual(['dog.svg', 'cat.svg']);
       // Using an icon from a previously loaded URL should not cause another HTTP request.
       testComponent.iconName = 'fido';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'woof');
       expect(httpRequestUrls).toEqual(['dog.svg', 'cat.svg']);
     });
 
     it('should extract icon from SVG icon set', () => {
-      mdIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-1.svg');
+      matIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-1.svg');
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgNameTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
       fixture.detectChanges();
 
-      expect(mdIconElement.childNodes.length).toBe(1);
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      expect(matIconElement.childNodes.length).toBe(1);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       expect(svgElement.childNodes.length).toBe(1);
       svgChild = svgElement.childNodes[0];
       // The first <svg> child should be the <g id="pig"> element.
@@ -183,35 +183,35 @@ describe('MdIcon', () => {
       expect(svgChild.getAttribute('id')).toBe('pig');
       verifyPathChildElement(svgChild, 'oink');
       // The aria label should be taken from the icon name (without the icon set portion).
-      expect(mdIconElement.getAttribute('aria-label')).toBe('pig');
+      expect(matIconElement.getAttribute('aria-label')).toBe('pig');
 
       // Change the icon, and the SVG element should be replaced.
       testComponent.iconName = 'farm:cow';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       svgChild = svgElement.childNodes[0];
       // The first <svg> child should be the <g id="cow"> element.
       expect(svgChild.tagName.toLowerCase()).toBe('g');
       expect(svgChild.getAttribute('id')).toBe('cow');
       verifyPathChildElement(svgChild, 'moo');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('cow');
+      expect(matIconElement.getAttribute('aria-label')).toBe('cow');
     });
 
     it('should allow multiple icon sets in a namespace', () => {
-      mdIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-1.svg');
-      mdIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-2.svg');
-      mdIconRegistry.addSvgIconSetInNamespace('arrows', 'arrow-set.svg');
+      matIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-1.svg');
+      matIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-2.svg');
+      matIconRegistry.addSvgIconSetInNamespace('arrows', 'arrow-set.svg');
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgNameTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       expect(svgElement.childNodes.length).toBe(1);
       svgChild = svgElement.childNodes[0];
       // The <svg> child should be the <g id="pig"> element.
@@ -220,7 +220,7 @@ describe('MdIcon', () => {
       expect(svgChild.childNodes.length).toBe(1);
       verifyPathChildElement(svgChild, 'oink');
       // The aria label should be taken from the icon name (without the namespace).
-      expect(mdIconElement.getAttribute('aria-label')).toBe('pig');
+      expect(matIconElement.getAttribute('aria-label')).toBe('pig');
 
       // Both icon sets registered in the 'farm' namespace should have been fetched.
       expect(httpRequestUrls.sort()).toEqual(['farm-set-1.svg', 'farm-set-2.svg']);
@@ -230,45 +230,45 @@ describe('MdIcon', () => {
       // and no additional HTTP request should be made.
       testComponent.iconName = 'farm:cow';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       svgChild = svgElement.childNodes[0];
       // The first <svg> child should be the <g id="cow"> element.
       expect(svgChild.tagName.toLowerCase()).toBe('g');
       expect(svgChild.getAttribute('id')).toBe('cow');
       expect(svgChild.childNodes.length).toBe(1);
       verifyPathChildElement(svgChild, 'moo moo');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('cow');
+      expect(matIconElement.getAttribute('aria-label')).toBe('cow');
       expect(httpRequestUrls.sort()).toEqual(['farm-set-1.svg', 'farm-set-2.svg']);
     });
 
     it('should not wrap <svg> elements in icon sets in another svg tag', () => {
-      mdIconRegistry.addSvgIconSet('arrow-set.svg');
+      matIconRegistry.addSvgIconSet('arrow-set.svg');
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgNameTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
       // arrow-set.svg stores its icons as nested <svg> elements, so they should be used
       // directly and not wrapped in an outer <svg> tag like the <g> elements in other sets.
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'left');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('left-arrow');
+      expect(matIconElement.getAttribute('aria-label')).toBe('left-arrow');
     });
 
     it('should return unmodified copies of icons from URLs', () => {
-      let fixture = TestBed.createComponent(MdIconFromSvgUrlTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgUrlTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
 
       testComponent.iconUrl = 'cat.svg';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'meow');
       // Modify the SVG element by setting a viewBox attribute.
       svgElement.setAttribute('viewBox', '0 0 100 100');
@@ -276,29 +276,29 @@ describe('MdIcon', () => {
       // Switch to a different icon.
       testComponent.iconUrl = 'dog.svg';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'woof');
 
       // Switch back to the first icon. The viewBox attribute should not be present.
       testComponent.iconUrl = 'cat.svg';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'meow');
       expect(svgElement.getAttribute('viewBox')).toBeFalsy();
     });
 
     it('should return unmodified copies of icons from icon sets', () => {
-      mdIconRegistry.addSvgIconSet('arrow-set.svg');
+      matIconRegistry.addSvgIconSet('arrow-set.svg');
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(MatIconFromSvgNameTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       let svgElement: any;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'left');
       // Modify the SVG element by setting a viewBox attribute.
       svgElement.setAttribute('viewBox', '0 0 100 100');
@@ -306,13 +306,13 @@ describe('MdIcon', () => {
       // Switch to a different icon.
       testComponent.iconName = 'right-arrow';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'right');
 
       // Switch back to the first icon. The viewBox attribute should not be present.
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
-      svgElement = verifyAndGetSingleSvgChild(mdIconElement);
+      svgElement = verifyAndGetSingleSvgChild(matIconElement);
       verifyPathChildElement(svgElement, 'left');
       expect(svgElement.getAttribute('viewBox')).toBeFalsy();
     });
@@ -320,104 +320,104 @@ describe('MdIcon', () => {
 
   describe('custom fonts', () => {
     it('should apply CSS classes for custom font and icon', () => {
-      mdIconRegistry.registerFontClassAlias('f1', 'font1');
-      mdIconRegistry.registerFontClassAlias('f2');
+      matIconRegistry.registerFontClassAlias('f1', 'font1');
+      matIconRegistry.registerFontClassAlias('f2');
 
-      let fixture = TestBed.createComponent(MdIconCustomFontCssTestApp);
+      let fixture = TestBed.createComponent(MatIconCustomFontCssTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.fontSet = 'f1';
       testComponent.fontIcon = 'house';
       fixture.detectChanges();
-      expect(sortedClassNames(mdIconElement)).toEqual(['font1', 'house']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
+      expect(sortedClassNames(matIconElement)).toEqual(['font1', 'house']);
+      expect(matIconElement.getAttribute('aria-label')).toBe('house');
 
       testComponent.fontSet = 'f2';
       testComponent.fontIcon = 'igloo';
       fixture.detectChanges();
-      expect(sortedClassNames(mdIconElement)).toEqual(['f2', 'igloo']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('igloo');
+      expect(sortedClassNames(matIconElement)).toEqual(['f2', 'igloo']);
+      expect(matIconElement.getAttribute('aria-label')).toBe('igloo');
 
       testComponent.fontSet = 'f3';
       testComponent.fontIcon = 'tent';
       fixture.detectChanges();
-      expect(sortedClassNames(mdIconElement)).toEqual(['f3', 'tent']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('tent');
+      expect(sortedClassNames(matIconElement)).toEqual(['f3', 'tent']);
+      expect(matIconElement.getAttribute('aria-label')).toBe('tent');
     });
   });
 
   describe('aria label', () => {
     it('should set aria label from text content if not specified', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+      let fixture = TestBed.createComponent(MatIconLigatureTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
 
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
+      expect(matIconElement.getAttribute('aria-label')).toBe('home');
 
       testComponent.iconName = 'hand';
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('hand');
+      expect(matIconElement.getAttribute('aria-label')).toBe('hand');
     });
 
     it('should use alt tag if aria label is not specified', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureWithAriaBindingTestApp);
+      let fixture = TestBed.createComponent(MatIconLigatureWithAriaBindingTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       testComponent.altText = 'castle';
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('castle');
+      expect(matIconElement.getAttribute('aria-label')).toBe('castle');
 
       testComponent.ariaLabel = 'house';
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
+      expect(matIconElement.getAttribute('aria-label')).toBe('house');
     });
 
     it('should use provided aria label rather than icon name', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureWithAriaBindingTestApp);
+      let fixture = TestBed.createComponent(MatIconLigatureWithAriaBindingTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       testComponent.ariaLabel = 'house';
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
+      expect(matIconElement.getAttribute('aria-label')).toBe('house');
     });
 
     it('should use provided aria label rather than font icon', () => {
-      let fixture = TestBed.createComponent(MdIconCustomFontCssTestApp);
+      let fixture = TestBed.createComponent(MatIconCustomFontCssTestApp);
 
       const testComponent = fixture.debugElement.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.fontSet = 'f1';
       testComponent.fontIcon = 'house';
       testComponent.ariaLabel = 'home';
       fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
+      expect(matIconElement.getAttribute('aria-label')).toBe('home');
     });
   });
 });
 
-/** Test components that contain an MdIcon. */
+/** Test components that contain an MatIcon. */
 @Component({
   selector: 'test-app',
-  template: `<md-icon>{{iconName}}</md-icon>`,
+  template: `<mat-icon>{{iconName}}</mat-icon>`,
 })
-class MdIconLigatureTestApp {
+class MatIconLigatureTestApp {
   ariaLabel: string = null;
   iconName = '';
 }
 
 @Component({
   selector: 'test-app',
-  template: `<md-icon [aria-label]="ariaLabel" [alt]="altText">{{iconName}}</md-icon>`,
+  template: `<mat-icon [aria-label]="ariaLabel" [alt]="altText">{{iconName}}</mat-icon>`,
 })
-class MdIconLigatureWithAriaBindingTestApp {
+class MatIconLigatureWithAriaBindingTestApp {
   ariaLabel: string = null;
   iconName = '';
 }
@@ -425,10 +425,10 @@ class MdIconLigatureWithAriaBindingTestApp {
 @Component({
   selector: 'test-app',
   template: `
-      <md-icon [fontSet]="fontSet" [fontIcon]="fontIcon" [aria-label]="ariaLabel"></md-icon>
+      <mat-icon [fontSet]="fontSet" [fontIcon]="fontIcon" [aria-label]="ariaLabel"></mat-icon>
   `,
 })
-class MdIconCustomFontCssTestApp {
+class MatIconCustomFontCssTestApp {
   ariaLabel: string = null;
   fontSet = '';
   fontIcon = '';
@@ -436,18 +436,18 @@ class MdIconCustomFontCssTestApp {
 
 @Component({
   selector: 'test-app',
-  template: `<md-icon [svgSrc]="iconUrl" [aria-label]="ariaLabel"></md-icon>`,
+  template: `<mat-icon [svgSrc]="iconUrl" [aria-label]="ariaLabel"></mat-icon>`,
 })
-class MdIconFromSvgUrlTestApp {
+class MatIconFromSvgUrlTestApp {
   ariaLabel: string = null;
   iconUrl = '';
 }
 
 @Component({
   selector: 'test-app',
-  template: `<md-icon [svgIcon]="iconName" [aria-label]="ariaLabel"></md-icon>`,
+  template: `<mat-icon [svgIcon]="iconName" [aria-label]="ariaLabel"></mat-icon>`,
 })
-class MdIconFromSvgNameTestApp {
+class MatIconFromSvgNameTestApp {
   ariaLabel: string = null;
   iconName = '';
 }

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -13,13 +13,13 @@ import {
     AfterViewChecked
 } from '@angular/core';
 import {HttpModule} from '@angular/http';
-import {MdError} from '@angular2-material/core';
-import {MdIconRegistry} from './icon-registry';
-export {MdIconRegistry} from './icon-registry';
+import {MatError} from '@angular2-material/core';
+import {MatIconRegistry} from './icon-registry';
+export {MatIconRegistry} from './icon-registry';
 
 
-/** Exception thrown when an invalid icon name is passed to an md-icon component. */
-export class MdIconInvalidNameError extends MdError {
+/** Exception thrown when an invalid icon name is passed to an mat-icon component. */
+export class MatIconInvalidNameError extends MatError {
   constructor(iconName: string) {
       super(`Invalid icon name: "${iconName}"`);
   }
@@ -28,40 +28,40 @@ export class MdIconInvalidNameError extends MdError {
 /**
  * Component to display an icon. It can be used in the following ways:
  * - Specify the svgSrc input to load an SVG icon from a URL. The SVG content is directly inlined
- *   as a child of the <md-icon> component, so that CSS styles can easily be applied to it.
+ *   as a child of the <mat-icon> component, so that CSS styles can easily be applied to it.
  *   The URL is loaded via an XMLHttpRequest, so it must be on the same domain as the page or its
  *   server must be configured to allow cross-domain requests.
  *   Example:
- *     <md-icon svgSrc="assets/arrow.svg"></md-icon>
+ *     <mat-icon svgSrc="assets/arrow.svg"></mat-icon>
  *
  * - Specify the svgIcon input to load an SVG icon from a URL previously registered with the
  *   addSvgIcon, addSvgIconInNamespace, addSvgIconSet, or addSvgIconSetInNamespace methods of
- *   MdIconRegistry. If the svgIcon value contains a colon it is assumed to be in the format
+ *   MatIconRegistry. If the svgIcon value contains a colon it is assumed to be in the format
  *   "[namespace]:[name]", if not the value will be the name of an icon in the default namespace.
  *   Examples:
- *     <md-icon svgIcon="left-arrow"></md-icon>
- *     <md-icon svgIcon="animals:cat"></md-icon>
+ *     <mat-icon svgIcon="left-arrow"></mat-icon>
+ *     <mat-icon svgIcon="animals:cat"></mat-icon>
  *
- * - Use a font ligature as an icon by putting the ligature text in the content of the <md-icon>
+ * - Use a font ligature as an icon by putting the ligature text in the content of the <mat-icon>
  *   component. By default the Material icons font is used as described at
  *   http://google.github.io/material-design-icons/#icon-font-for-the-web. You can specify an
  *   alternate font by setting the fontSet input to either the CSS class to apply to use the
- *   desired font, or to an alias previously registered with MdIconRegistry.registerFontClassAlias.
+ *   desired font, or to an alias previously registered with MatIconRegistry.registerFontClassAlias.
  *   Examples:
- *     <md-icon>home</md-icon>
- *     <md-icon fontSet="myfont">sun</md-icon>
+ *     <mat-icon>home</mat-icon>
+ *     <mat-icon fontSet="myfont">sun</mat-icon>
  *
  * - Specify a font glyph to be included via CSS rules by setting the fontSet input to specify the
  *   font, and the fontIcon input to specify the icon. Typically the fontIcon will specify a
  *   CSS class which causes the glyph to be displayed via a :before selector, as in
  *   https://fortawesome.github.io/Font-Awesome/examples/
  *   Example:
- *     <md-icon fontSet="fa" fontIcon="alarm"></md-icon>
+ *     <mat-icon fontSet="fa" fontIcon="alarm"></mat-icon>
  */
 @Component({
   moduleId: module.id,
   template: '<ng-content></ng-content>',
-  selector: 'md-icon',
+  selector: 'mat-icon',
   styleUrls: ['icon.css'],
   host: {
     'role': 'img',
@@ -69,7 +69,7 @@ export class MdIconInvalidNameError extends MdError {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
+export class MatIcon implements OnChanges, OnInit, AfterViewChecked {
   @Input() svgSrc: string;
   @Input() svgIcon: string;
   @Input() fontSet: string;
@@ -84,7 +84,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
   constructor(
       private _element: ElementRef,
       private _renderer: Renderer,
-      private _mdIconRegistry: MdIconRegistry) { }
+      private _matIconRegistry: MatIconRegistry) { }
 
   /**
    * Splits an svgIcon binding value into its icon set and icon name components.
@@ -92,12 +92,12 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
    * The separator for the two fields is ':'. If there is no separator, an empty
    * string is returned for the icon set and the entire value is returned for
    * the icon name. If the argument is falsy, returns an array of two empty strings.
-   * Throws a MdIconInvalidNameError if the name contains two or more ':' separators.
+   * Throws a MatIconInvalidNameError if the name contains two or more ':' separators.
    * Examples:
    *   'social:cake' -> ['social', 'cake']
    *   'penguin' -> ['', 'penguin']
    *   null -> ['', '']
-   *   'a:b:c' -> (throws MdIconInvalidNameError)
+   *   'a:b:c' -> (throws MatIconInvalidNameError)
    */
   private _splitIconName(iconName: string): [string, string] {
     if (!iconName) {
@@ -111,7 +111,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
       case 2:
         return <[string, string]>parts;
       default:
-        throw new MdIconInvalidNameError(iconName);
+        throw new MatIconInvalidNameError(iconName);
     }
   }
 
@@ -122,11 +122,11 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     if (changedInputs.indexOf('svgIcon') != -1 || changedInputs.indexOf('svgSrc') != -1) {
       if (this.svgIcon) {
         const [namespace, iconName] = this._splitIconName(this.svgIcon);
-        this._mdIconRegistry.getNamedSvgIcon(iconName, namespace).subscribe(
+        this._matIconRegistry.getNamedSvgIcon(iconName, namespace).subscribe(
             svg => this._setSvgElement(svg),
             (err: any) => console.log(`Error retrieving icon: ${err}`));
       } else if (this.svgSrc) {
-        this._mdIconRegistry.getSvgIconFromUrl(this.svgSrc).subscribe(
+        this._matIconRegistry.getSvgIconFromUrl(this.svgSrc).subscribe(
             svg => this._setSvgElement(svg),
             (err: any) => console.log(`Error retrieving icon: ${err}`));
       }
@@ -140,7 +140,8 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
   /** TODO: internal */
   ngOnInit() {
     // Update font classes because ngOnChanges won't be called if none of the inputs are present,
-    // e.g. <md-icon>arrow</md-icon>. In this case we need to add a CSS class for the default font.
+    // e.g. <mat-icon>arrow</mat-icon>. In this case we need to add a CSS class for the default
+    // font.
     if (this._usingFontIcon()) {
       this._updateFontIconClasses();
     }
@@ -149,7 +150,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
   /** TODO: internal */
   ngAfterViewChecked() {
     // Update aria label here because it may depend on the projected text content.
-    // (e.g. <md-icon>home</md-icon> should use 'home').
+    // (e.g. <mat-icon>home</mat-icon> should use 'home').
     this._updateAriaLabel();
   }
 
@@ -202,8 +203,8 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
     const elem = this._element.nativeElement;
     const fontSetClass = this.fontSet ?
-        this._mdIconRegistry.classNameForFontAlias(this.fontSet) :
-        this._mdIconRegistry.getDefaultFontSetClass();
+        this._matIconRegistry.classNameForFontAlias(this.fontSet) :
+        this._matIconRegistry.getDefaultFontSetClass();
     if (fontSetClass != this._previousFontSetClass) {
       if (this._previousFontSetClass) {
         this._renderer.setElementClass(elem, this._previousFontSetClass, false);
@@ -229,14 +230,14 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
 
 @NgModule({
   imports: [HttpModule],
-  exports: [MdIcon],
-  declarations: [MdIcon],
+  exports: [MatIcon],
+  declarations: [MatIcon],
 })
-export class MdIconModule {
+export class MatIconModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdIconModule,
-      providers: [MdIconRegistry],
+      ngModule: MatIconModule,
+      providers: [MatIconRegistry],
     };
   }
 }

--- a/src/lib/input/input.html
+++ b/src/lib/input/input.html
@@ -1,12 +1,12 @@
-<div class="md-input-wrapper">
-  <div class="md-input-table">
-    <div class="md-input-prefix"><ng-content select="[md-prefix]"></ng-content></div>
+<div class="mat-input-wrapper">
+  <div class="mat-input-table">
+    <div class="mat-input-prefix"><ng-content select="[mat-prefix]"></ng-content></div>
 
-    <div class="md-input-infix">
+    <div class="mat-input-infix">
       <input #input
              aria-target
-             class="md-input-element"
-             [class.md-end]="align == 'end'"
+             class="mat-input-element"
+             [class.mat-end]="align == 'end'"
              [attr.aria-label]="ariaLabel"
              [attr.aria-labelledby]="ariaLabelledBy"
              [attr.aria-disabled]="ariaDisabled"
@@ -35,31 +35,31 @@
              [(ngModel)]="value"
              (change)="_handleChange($event)">
 
-      <label class="md-input-placeholder"
+      <label class="mat-input-placeholder"
              [attr.for]="inputId"
-             [class.md-empty]="empty"
-             [class.md-focused]="focused"
-             [class.md-float]="floatingPlaceholder"
-             [class.md-accent]="dividerColor == 'accent'"
-             [class.md-warn]="dividerColor == 'warn'"
+             [class.mat-empty]="empty"
+             [class.mat-focused]="focused"
+             [class.mat-float]="floatingPlaceholder"
+             [class.mat-accent]="dividerColor == 'accent'"
+             [class.mat-warn]="dividerColor == 'warn'"
              *ngIf="_hasPlaceholder()">
-        <ng-content select="md-placeholder"></ng-content>
+        <ng-content select="mat-placeholder"></ng-content>
         {{placeholder}}
-        <span class="md-placeholder-required" *ngIf="required">*</span>
+        <span class="mat-placeholder-required" *ngIf="required">*</span>
       </label>
     </div>
 
-    <div class="md-input-suffix"><ng-content select="[md-suffix]"></ng-content></div>
+    <div class="mat-input-suffix"><ng-content select="[mat-suffix]"></ng-content></div>
   </div>
 
-  <div class="md-input-underline"
-       [class.md-disabled]="disabled">
-    <span class="md-input-ripple"
-          [class.md-focused]="focused"
-          [class.md-accent]="dividerColor == 'accent'"
-          [class.md-warn]="dividerColor == 'warn'"></span>
+  <div class="mat-input-underline"
+       [class.mat-disabled]="disabled">
+    <span class="mat-input-ripple"
+          [class.mat-focused]="focused"
+          [class.mat-accent]="dividerColor == 'accent'"
+          [class.mat-warn]="dividerColor == 'warn'"></span>
   </div>
 
-  <div *ngIf="hintLabel != ''" class="md-hint">{{hintLabel}}</div>
-  <ng-content select="md-hint"></ng-content>
+  <div *ngIf="hintLabel != ''" class="mat-hint">{{hintLabel}}</div>
+  <ng-content select="mat-hint"></ng-content>
 </div>

--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -2,22 +2,22 @@
 @import 'mixins';
 @import 'variables';
 
-$md-input-floating-placeholder-scale-factor: 0.75 !default;
+$mat-input-floating-placeholder-scale-factor: 0.75 !default;
 
 // Placeholder colors. Required is used for the `*` star shown in the placeholder.
-$md-input-placeholder-color: md-color($md-foreground, hint-text);
-$md-input-floating-placeholder-color: md-color($md-primary);
-$md-input-required-placeholder-color: md-color($md-accent);
+$mat-input-placeholder-color: mat-color($mat-foreground, hint-text);
+$mat-input-floating-placeholder-color: mat-color($mat-primary);
+$mat-input-required-placeholder-color: mat-color($mat-accent);
 
 // Underline colors.
-$md-input-underline-color: md-color($md-foreground, hint-text);
-$md-input-underline-color-accent: md-color($md-accent);
-$md-input-underline-color-warn: md-color($md-warn);
-$md-input-underline-disabled-color: md-color($md-foreground, hint-text);
-$md-input-underline-focused-color: md-color($md-primary);
+$mat-input-underline-color: mat-color($mat-foreground, hint-text);
+$mat-input-underline-color-accent: mat-color($mat-accent);
+$mat-input-underline-color-warn: mat-color($mat-warn);
+$mat-input-underline-disabled-color: mat-color($mat-foreground, hint-text);
+$mat-input-underline-focused-color: mat-color($mat-primary);
 
 // Gradient for showing the dashed line when the input is disabled.
-$md-input-underline-disabled-background-image: linear-gradient(to right,
+$mat-input-underline-disabled-background-image: linear-gradient(to right,
         rgba(0, 0, 0, 0.26) 0%, rgba(0, 0, 0, 0.26) 33%, transparent 0%);
 
 /**
@@ -31,28 +31,28 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 /**
  * Applies a floating placeholder above the input itself.
  */
-@mixin md-input-placeholder-floating {
+@mixin mat-input-placeholder-floating {
   display: block;
   padding-bottom: 5px;
-  transform: translateY(-100%) scale($md-input-floating-placeholder-scale-factor);
-  width: 100% / $md-input-floating-placeholder-scale-factor;
+  transform: translateY(-100%) scale($mat-input-floating-placeholder-scale-factor);
+  width: 100% / $mat-input-floating-placeholder-scale-factor;
 
-  .md-placeholder-required {
-    color: $md-input-required-placeholder-color;
+  .mat-placeholder-required {
+    color: $mat-input-required-placeholder-color;
   }
 }
 
 :host {
   display: inline-block;
   position: relative;
-  font-family: $md-font-family;
+  font-family: $mat-font-family;
 
   // To avoid problems with text-align.
   text-align: left;
 
   // Global wrapper. We need to apply margin to the element for spacing, but
   // cannot apply it to the host element directly.
-  .md-input-wrapper {
+  .mat-input-wrapper {
     margin: 16px 0;
   }
 
@@ -61,7 +61,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   // this table.
   // Flex does not respect the baseline. What we really want is akin to a table
   // as want an inline-block where elements don't wrap.
-  .md-input-table {
+  .mat-input-table {
     display: inline-table;
     flex-flow: column;
     vertical-align: bottom;
@@ -73,7 +73,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   }
 
   // The Input element proper.
-  .md-input-element {
+  .mat-input-element {
     // Font needs to be inherited, because by default <input> has a system font.
     font: inherit;
 
@@ -86,19 +86,19 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
     padding: 0;
     width: 100%;
 
-    &.md-end {
+    &.mat-end {
       text-align: right;
     }
   }
 
-  .md-input-infix {
+  .mat-input-infix {
     position: relative;
   }
 
   // The placeholder label. This is invisible unless it is. The logic to show it is
   // basically `empty || (float && (!empty || focused))`. Float is dependent on the
   // `floatingPlaceholder` input.
-  .md-input-placeholder {
+  .mat-input-placeholder {
     // The placeholder is after the <input>, but needs to be aligned top-left of the
     // infix <div>.
     position: absolute;
@@ -107,7 +107,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 
     font-size: 100%;
     pointer-events: none;  // We shouldn't catch mouse events (let them through).
-    color: $md-input-placeholder-color;
+    color: $mat-input-placeholder-color;
     z-index: 1;
 
     // Put ellipsis text overflow.
@@ -124,26 +124,26 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
                 color $swift-ease-out-duration $swift-ease-out-timing-function,
                 width $swift-ease-out-duration $swift-ease-out-timing-function;
 
-    &.md-empty {
+    &.mat-empty {
       display: block;
       cursor: text;
     }
 
     // Show the placeholder above the input when it's not empty, or focused.
-    &.md-float:not(.md-empty), &.md-float.md-focused {
-      @include md-input-placeholder-floating;
+    &.mat-float:not(.mat-empty), &.mat-float.mat-focused {
+      @include mat-input-placeholder-floating;
     }
 
-    // :focus is applied to the input, but we apply md-focused to the other elements
+    // :focus is applied to the input, but we apply mat-focused to the other elements
     // that need to listen to it.
-    &.md-focused {
-      color: $md-input-floating-placeholder-color;
+    &.mat-focused {
+      color: $mat-input-floating-placeholder-color;
 
-      &.md-accent {
-        color: $md-input-underline-color-accent;
+      &.mat-accent {
+        color: $mat-input-underline-color-accent;
       }
-      &.md-warn {
-        color: $md-input-underline-color-warn;
+      &.mat-warn {
+        color: $mat-input-underline-color-warn;
       }
     }
   }
@@ -151,34 +151,34 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   // Pseudo-class for Chrome and Safari auto-fill to move the placeholder to
   // the floating position. This is necessary because these browsers do not actually
   // fire any events when a form auto-fill is occurring.
-  // Once the autofill is committed, a change event happen and the regular md-input
+  // Once the autofill is committed, a change event happen and the regular mat-input
   // classes take over to fulfill this behaviour.
-  input:-webkit-autofill + .md-input-placeholder {
-    @include md-input-placeholder-floating;
+  input:-webkit-autofill + .mat-input-placeholder {
+    @include mat-input-placeholder-floating;
   }
 
   // The underline is what's shown under the input, its prefix and its suffix.
   // The ripple is the blue animation coming on top of it.
-  .md-input-underline {
+  .mat-input-underline {
     position: absolute;
     height: 1px;
     width: 100%;
     margin-top: 4px;
-    border-top: 1px solid $md-input-underline-color;
+    border-top: 1px solid $mat-input-underline-color;
 
-    &.md-disabled {
+    &.mat-disabled {
       border-top: 0;
-      background-image: $md-input-underline-disabled-background-image;
+      background-image: $mat-input-underline-disabled-background-image;
       background-position: 0;
       background-size: 4px 1px;
       background-repeat: repeat-x;
     }
 
-    .md-input-ripple {
+    .mat-input-ripple {
       position: absolute;
       height: 2px;
       z-index: 1;
-      background-color: $md-input-underline-focused-color;
+      background-color: $mat-input-underline-focused-color;
       top: -1px;
       width: 100%;
       transform-origin: top;
@@ -187,14 +187,14 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
       transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
                   opacity $swift-ease-out-duration $swift-ease-out-timing-function;
 
-      &.md-accent {
-        background-color: $md-input-underline-color-accent;
+      &.mat-accent {
+        background-color: $mat-input-underline-color-accent;
       }
-      &.md-warn {
-        background-color: $md-input-underline-color-warn;
+      &.mat-warn {
+        background-color: $mat-input-underline-color-warn;
       }
 
-      &.md-focused {
+      &.mat-focused {
         opacity: 1;
         transform: scaleY(1);
       }
@@ -203,12 +203,12 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 
   // The hint is shown below the underline. There can be more than one; one at the start
   // and one at the end.
-  .md-hint {
+  .mat-hint {
     position: absolute;
     font-size: 75%;
     bottom: -0.5em;
 
-    &.md-right {
+    &.mat-right {
       right: 0;
     }
   }
@@ -219,19 +219,19 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 :host-context([dir='rtl']) {
   text-align: right;
 
-  .md-input-placeholder {
+  .mat-input-placeholder {
     transform-origin: bottom right;
   }
 
-  .md-input-element.md-end {
+  .mat-input-element.mat-end {
     text-align: left;
   }
 
-  .md-hint {
+  .mat-hint {
     right: 0;
     left: auto;
 
-    &.md-right {
+    &.mat-right {
       right: auto;
       left: 0;
     }

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -5,58 +5,58 @@ import {
 import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {MdInput, MdInputModule} from './input';
+import {MatInput, MatInputModule} from './input';
 
 function isInternetExplorer11() {
     return 'ActiveXObject' in window;
 }
 
-describe('MdInput', function () {
+describe('MatInput', function () {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdInputModule.forRoot(), FormsModule],
+      imports: [MatInputModule.forRoot(), FormsModule],
       declarations: [
-        MdInputNumberTypeConservedTestComponent,
-        MdInputPlaceholderRequiredTestComponent,
-        MdInputPlaceholderElementTestComponent,
-        MdInputPlaceholderAttrTestComponent,
-        MdInputHintLabel2TestController,
-        MdInputHintLabelTestController,
-        MdInputInvalidTypeTestController,
-        MdInputInvalidPlaceholderTestController,
-        MdInputInvalidHint2TestController,
-        MdInputInvalidHintTestController,
-        MdInputBaseTestController,
-        MdInputAriaTestController,
-        MdInputWithBlurAndFocusEvents,
-        MdInputWithNameTestController,
-        MdInputWithId,
-        MdInputWithAutocomplete,
-        MdInputWithUnboundAutocomplete,
-        MdInputWithUnboundAutocompleteWithValue,
-        MdInputWithAutocorrect,
-        MdInputWithUnboundAutocorrect,
-        MdInputWithAutocapitalize,
-        MdInputWithUnboundAutocapitalize,
-        MdInputWithAutofocus,
-        MdInputWithUnboundAutofocus,
-        MdInputWithReadonly,
-        MdInputWithUnboundReadonly,
-        MdInputWithSpellcheck,
-        MdInputWithUnboundSpellcheck,
-        MdInputWithDisabled,
-        MdInputWithUnboundDisabled,
-        MdInputWithRequired,
-        MdInputWithUnboundRequired,
-        MdInputWithList,
-        MdInputWithMax,
-        MdInputWithMin,
-        MdInputWithStep,
-        MdInputWithTabindex,
-        MdInputDateTestController,
-        MdInputTextTestController,
-        MdInputPasswordTestController,
-        MdInputNumberTestController,
+        MatInputNumberTypeConservedTestComponent,
+        MatInputPlaceholderRequiredTestComponent,
+        MatInputPlaceholderElementTestComponent,
+        MatInputPlaceholderAttrTestComponent,
+        MatInputHintLabel2TestController,
+        MatInputHintLabelTestController,
+        MatInputInvalidTypeTestController,
+        MatInputInvalidPlaceholderTestController,
+        MatInputInvalidHint2TestController,
+        MatInputInvalidHintTestController,
+        MatInputBaseTestController,
+        MatInputAriaTestController,
+        MatInputWithBlurAndFocusEvents,
+        MatInputWithNameTestController,
+        MatInputWithId,
+        MatInputWithAutocomplete,
+        MatInputWithUnboundAutocomplete,
+        MatInputWithUnboundAutocompleteWithValue,
+        MatInputWithAutocorrect,
+        MatInputWithUnboundAutocorrect,
+        MatInputWithAutocapitalize,
+        MatInputWithUnboundAutocapitalize,
+        MatInputWithAutofocus,
+        MatInputWithUnboundAutofocus,
+        MatInputWithReadonly,
+        MatInputWithUnboundReadonly,
+        MatInputWithSpellcheck,
+        MatInputWithUnboundSpellcheck,
+        MatInputWithDisabled,
+        MatInputWithUnboundDisabled,
+        MatInputWithRequired,
+        MatInputWithUnboundRequired,
+        MatInputWithList,
+        MatInputWithMax,
+        MatInputWithMin,
+        MatInputWithStep,
+        MatInputWithTabindex,
+        MatInputDateTestController,
+        MatInputTextTestController,
+        MatInputPasswordTestController,
+        MatInputNumberTestController,
       ],
     });
 
@@ -64,7 +64,7 @@ describe('MdInput', function () {
   }));
 
   it('creates a native <input> element', () => {
-    let fixture = TestBed.createComponent(MdInputBaseTestController);
+    let fixture = TestBed.createComponent(MatInputBaseTestController);
     fixture.detectChanges();
 
     expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
@@ -74,57 +74,57 @@ describe('MdInput', function () {
     if (isInternetExplorer11()) {
       return;
     }
-    let fixture = TestBed.createComponent(MdInputDateTestController);
+    let fixture = TestBed.createComponent(MatInputDateTestController);
     fixture.componentInstance.placeholder = 'Placeholder';
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label')).nativeElement;
     expect(el).not.toBeNull();
-    expect(el.className.includes('md-empty')).toBe(false);
+    expect(el.className.includes('mat-empty')).toBe(false);
   }));
 
   it('should treat text input type as empty at init', async(() => {
     if (isInternetExplorer11()) {
       return;
     }
-    let fixture = TestBed.createComponent(MdInputTextTestController);
+    let fixture = TestBed.createComponent(MatInputTextTestController);
     fixture.componentInstance.placeholder = 'Placeholder';
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label')).nativeElement;
     expect(el).not.toBeNull();
-    expect(el.className.includes('md-empty')).toBe(true);
+    expect(el.className.includes('mat-empty')).toBe(true);
   }));
 
   it('should treat password input type as empty at init', async(() => {
     if (isInternetExplorer11()) {
       return;
     }
-    let fixture = TestBed.createComponent(MdInputPasswordTestController);
+    let fixture = TestBed.createComponent(MatInputPasswordTestController);
     fixture.componentInstance.placeholder = 'Placeholder';
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label')).nativeElement;
     expect(el).not.toBeNull();
-    expect(el.className.includes('md-empty')).toBe(true);
+    expect(el.className.includes('mat-empty')).toBe(true);
   }));
 
   it('should treat number input type as empty at init', async(() => {
     if (isInternetExplorer11()) {
       return;
     }
-    let fixture = TestBed.createComponent(MdInputNumberTestController);
+    let fixture = TestBed.createComponent(MatInputNumberTestController);
     fixture.componentInstance.placeholder = 'Placeholder';
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label')).nativeElement;
     expect(el).not.toBeNull();
-    expect(el.className.includes('md-empty')).toBe(true);
+    expect(el.className.includes('mat-empty')).toBe(true);
   }));
 
   // TODO(kara): update when core/testing adds fix
   it('support ngModel', async(() => {
-    let fixture = TestBed.createComponent(MdInputBaseTestController);
+    let fixture = TestBed.createComponent(MatInputBaseTestController);
 
     fixture.detectChanges();
     let instance = fixture.componentInstance;
@@ -142,11 +142,11 @@ describe('MdInput', function () {
   }));
 
   it('should have a different ID for outer element and internal input', () => {
-    let fixture = TestBed.createComponent(MdInputWithId);
+    let fixture = TestBed.createComponent(MatInputWithId);
     fixture.detectChanges();
 
     const componentElement: HTMLElement =
-        fixture.debugElement.query(By.directive(MdInput)).nativeElement;
+        fixture.debugElement.query(By.directive(MatInput)).nativeElement;
     const inputElement: HTMLInputElement =
         fixture.debugElement.query(By.css('input')).nativeElement;
 
@@ -156,10 +156,10 @@ describe('MdInput', function () {
   });
 
   it('counts characters', async(() => {
-    let fixture = TestBed.createComponent(MdInputBaseTestController);
+    let fixture = TestBed.createComponent(MatInputBaseTestController);
     let instance = fixture.componentInstance;
     fixture.detectChanges();
-    let inputInstance = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let inputInstance = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     expect(inputInstance.characterCount).toEqual(0);
 
     instance.model = 'hello';
@@ -170,7 +170,7 @@ describe('MdInput', function () {
   }));
 
   it('copies aria attributes to the inner input', () => {
-    let fixture = TestBed.createComponent(MdInputAriaTestController);
+    let fixture = TestBed.createComponent(MatInputAriaTestController);
     let instance = fixture.componentInstance;
     fixture.detectChanges();
 
@@ -184,67 +184,67 @@ describe('MdInput', function () {
   });
 
   it(`validates there's only one hint label per side`, () => {
-    let fixture = TestBed.createComponent(MdInputInvalidHintTestController);
+    let fixture = TestBed.createComponent(MatInputInvalidHintTestController);
 
     expect(() => fixture.detectChanges()).toThrow();
-    // TODO(jelbourn): .toThrow(new MdInputDuplicatedHintError('start'));
+    // TODO(jelbourn): .toThrow(new MatInputDuplicatedHintError('start'));
     // See https://github.com/angular/angular/issues/8348
   });
 
   it(`validates there's only one hint label per side (attribute)`, () => {
-    let fixture = TestBed.createComponent(MdInputInvalidHint2TestController);
+    let fixture = TestBed.createComponent(MatInputInvalidHint2TestController);
 
     expect(() => fixture.detectChanges()).toThrow();
-    // TODO(jelbourn): .toThrow(new MdInputDuplicatedHintError('start'));
+    // TODO(jelbourn): .toThrow(new MatInputDuplicatedHintError('start'));
     // See https://github.com/angular/angular/issues/8348
   });
 
   it('validates there\'s only one placeholder', () => {
-    let fixture = TestBed.createComponent(MdInputInvalidPlaceholderTestController);
+    let fixture = TestBed.createComponent(MatInputInvalidPlaceholderTestController);
 
     expect(() => fixture.detectChanges()).toThrow();
-    // TODO(jelbourn): .toThrow(new MdInputPlaceholderConflictError());
+    // TODO(jelbourn): .toThrow(new MatInputPlaceholderConflictError());
     // See https://github.com/angular/angular/issues/8348
   });
 
   it('validates the type', () => {
-    let fixture = TestBed.createComponent(MdInputInvalidTypeTestController);
+    let fixture = TestBed.createComponent(MatInputInvalidTypeTestController);
 
     // Technically this throws during the OnChanges detection phase,
     // so the error is really a ChangeDetectionError and it becomes
     // hard to build a full exception to compare with.
     // We just check for any exception in this case.
-    expect(() => fixture.detectChanges()).toThrow(/* new MdInputUnsupportedTypeError('file') */);
+    expect(() => fixture.detectChanges()).toThrow(/* new MatInputUnsupportedTypeError('file') */);
   });
 
   it('supports hint labels attribute', () => {
-    let fixture = TestBed.createComponent(MdInputHintLabelTestController);
+    let fixture = TestBed.createComponent(MatInputHintLabelTestController);
     fixture.detectChanges();
 
     // If the hint label is empty, expect no label.
-    expect(fixture.debugElement.query(By.css('.md-hint'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.mat-hint'))).toBeNull();
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('.md-hint'))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css('.mat-hint'))).not.toBeNull();
   });
 
   it('supports hint labels elements', () => {
-    let fixture = TestBed.createComponent(MdInputHintLabel2TestController);
+    let fixture = TestBed.createComponent(MatInputHintLabel2TestController);
     fixture.detectChanges();
 
-    // In this case, we should have an empty <md-hint>.
-    let el = fixture.debugElement.query(By.css('md-hint')).nativeElement;
+    // In this case, we should have an empty <mat-hint>.
+    let el = fixture.debugElement.query(By.css('mat-hint')).nativeElement;
     expect(el.textContent).toBeFalsy();
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
-    el = fixture.debugElement.query(By.css('md-hint')).nativeElement;
+    el = fixture.debugElement.query(By.css('mat-hint')).nativeElement;
     expect(el.textContent).toBe('label');
   });
 
   it('supports placeholder attribute', () => {
-    let fixture = TestBed.createComponent(MdInputPlaceholderAttrTestComponent);
+    let fixture = TestBed.createComponent(MatInputPlaceholderAttrTestComponent);
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label'));
@@ -259,7 +259,7 @@ describe('MdInput', function () {
   });
 
   it('supports placeholder element', () => {
-    let fixture = TestBed.createComponent(MdInputPlaceholderElementTestComponent);
+    let fixture = TestBed.createComponent(MatInputPlaceholderElementTestComponent);
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label'));
@@ -275,7 +275,7 @@ describe('MdInput', function () {
   });
 
   it('supports placeholder required star', () => {
-    let fixture = TestBed.createComponent(MdInputPlaceholderRequiredTestComponent);
+    let fixture = TestBed.createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
     let el = fixture.debugElement.query(By.css('label'));
@@ -284,10 +284,10 @@ describe('MdInput', function () {
   });
 
   it('supports number types and conserved its value type from Angular', () => {
-    let fixture = TestBed.createComponent(MdInputNumberTypeConservedTestComponent);
+    let fixture = TestBed.createComponent(MatInputNumberTypeConservedTestComponent);
     fixture.detectChanges();
 
-    const input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    const input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     // Fake a `change` event being triggered.
@@ -300,9 +300,9 @@ describe('MdInput', function () {
   });
 
   it('supports blur and focus events', () => {
-    let fixture = TestBed.createComponent(MdInputWithBlurAndFocusEvents);
+    let fixture = TestBed.createComponent(MatInputWithBlurAndFocusEvents);
     const testComponent = fixture.componentInstance;
-    const inputComponent = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    const inputComponent = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     const fakeEvent = <FocusEvent>{};
 
     spyOn(testComponent, 'onFocus');
@@ -319,10 +319,10 @@ describe('MdInput', function () {
   });
 
   it('supports the autoComplete attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithAutocomplete);
+    let fixture = TestBed.createComponent(MatInputWithAutocomplete);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -334,10 +334,10 @@ describe('MdInput', function () {
   });
 
   it('supports the autoCorrect attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithAutocorrect);
+    let fixture = TestBed.createComponent(MatInputWithAutocorrect);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -349,10 +349,10 @@ describe('MdInput', function () {
   });
 
   it('supports the autoCapitalize attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithAutocapitalize);
+    let fixture = TestBed.createComponent(MatInputWithAutocapitalize);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -364,7 +364,7 @@ describe('MdInput', function () {
   });
 
   it('supports the autoComplete attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundAutocomplete);
+    let fixture = TestBed.createComponent(MatInputWithUnboundAutocomplete);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -374,7 +374,7 @@ describe('MdInput', function () {
   });
 
   it('supports the autoComplete attribute as an unbound value attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundAutocompleteWithValue);
+    let fixture = TestBed.createComponent(MatInputWithUnboundAutocompleteWithValue);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -384,10 +384,10 @@ describe('MdInput', function () {
   });
 
   it('supports the autoFocus attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithAutofocus);
+    let fixture = TestBed.createComponent(MatInputWithAutofocus);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -399,7 +399,7 @@ describe('MdInput', function () {
   });
 
   it('supports the autoFocus attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundAutofocus);
+    let fixture = TestBed.createComponent(MatInputWithUnboundAutofocus);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -409,8 +409,8 @@ describe('MdInput', function () {
   });
 
   it('supports the disabled attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithDisabled);
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let fixture = TestBed.createComponent(MatInputWithDisabled);
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     input.disabled = false;
     fixture.detectChanges();
 
@@ -428,7 +428,7 @@ describe('MdInput', function () {
   });
 
   it('supports the disabled attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundDisabled);
+    let fixture = TestBed.createComponent(MatInputWithUnboundDisabled);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -440,8 +440,8 @@ describe('MdInput', function () {
   });
 
   it('supports the list attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithList);
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let fixture = TestBed.createComponent(MatInputWithList);
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     input.disabled = false;
     fixture.detectChanges();
 
@@ -455,8 +455,8 @@ describe('MdInput', function () {
   });
 
   it('supports the max attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithMax);
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let fixture = TestBed.createComponent(MatInputWithMax);
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     input.disabled = false;
     fixture.detectChanges();
 
@@ -476,8 +476,8 @@ describe('MdInput', function () {
   });
 
   it('supports the min attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithMin);
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let fixture = TestBed.createComponent(MatInputWithMin);
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     input.disabled = false;
     fixture.detectChanges();
 
@@ -496,11 +496,11 @@ describe('MdInput', function () {
   });
 
   it('supports the readOnly attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithReadonly);
+    let fixture = TestBed.createComponent(MatInputWithReadonly);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
 
     expect(el).not.toBeNull();
     expect(el.getAttribute('readonly')).toBeNull();
@@ -511,7 +511,7 @@ describe('MdInput', function () {
   });
 
   it('supports the readOnly attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundReadonly);
+    let fixture = TestBed.createComponent(MatInputWithUnboundReadonly);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -521,10 +521,10 @@ describe('MdInput', function () {
   });
 
   it('supports the required attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithRequired);
+    let fixture = TestBed.createComponent(MatInputWithRequired);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -536,7 +536,7 @@ describe('MdInput', function () {
   });
 
   it('supports the required attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundRequired);
+    let fixture = TestBed.createComponent(MatInputWithUnboundRequired);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -546,10 +546,10 @@ describe('MdInput', function () {
   });
 
   it('supports the spellCheck attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithSpellcheck);
+    let fixture = TestBed.createComponent(MatInputWithSpellcheck);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -561,7 +561,7 @@ describe('MdInput', function () {
   });
 
   it('supports the spellCheck attribute as an unbound attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithUnboundSpellcheck);
+    let fixture = TestBed.createComponent(MatInputWithUnboundSpellcheck);
     fixture.detectChanges();
 
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -571,10 +571,10 @@ describe('MdInput', function () {
   });
 
   it('supports the step attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithStep);
+    let fixture = TestBed.createComponent(MatInputWithStep);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -586,10 +586,10 @@ describe('MdInput', function () {
   });
 
   it('supports the tabIndex attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithTabindex);
+    let fixture = TestBed.createComponent(MatInputWithTabindex);
     fixture.detectChanges();
 
-    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let input: MatInput = fixture.debugElement.query(By.directive(MatInput)).componentInstance;
     let el: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(el).not.toBeNull();
@@ -601,7 +601,7 @@ describe('MdInput', function () {
   });
 
   it('supports a name attribute', () => {
-    let fixture = TestBed.createComponent(MdInputWithNameTestController);
+    let fixture = TestBed.createComponent(MatInputWithNameTestController);
     const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input'))
         .nativeElement;
     fixture.detectChanges();
@@ -610,173 +610,175 @@ describe('MdInput', function () {
   });
 });
 
-@Component({template: `<md-input id="test-id"></md-input>`})
-class MdInputWithId {
+@Component({template: `<mat-input id="test-id"></mat-input>`})
+class MatInputWithId {
   value: number = 0;
 }
 
-@Component({template: `<md-input type="number" [(ngModel)]="value"></md-input>`})
-class MdInputNumberTypeConservedTestComponent {
+@Component({template: `<mat-input type="number" [(ngModel)]="value"></mat-input>`})
+class MatInputNumberTypeConservedTestComponent {
   value: number = 0;
 }
 
-@Component({template: `<md-input required placeholder="hello"></md-input>`})
-class MdInputPlaceholderRequiredTestComponent {
+@Component({template: `<mat-input required placeholder="hello"></mat-input>`})
+class MatInputPlaceholderRequiredTestComponent {
 }
 
-@Component({template: `<md-input> <md-placeholder>{{placeholder}}</md-placeholder> </md-input>`})
-class MdInputPlaceholderElementTestComponent {
+@Component({template: `
+  <mat-input> <mat-placeholder>{{placeholder}}</mat-placeholder> </mat-input>
+`})
+class MatInputPlaceholderElementTestComponent {
   placeholder: string = 'Default Placeholder';
 }
 
-@Component({template: `<md-input [placeholder]="placeholder"></md-input>`})
-class MdInputPlaceholderAttrTestComponent {
+@Component({template: `<mat-input [placeholder]="placeholder"></mat-input>`})
+class MatInputPlaceholderAttrTestComponent {
   placeholder: string = '';
 }
 
-@Component({template: `<md-input> <md-hint>{{label}}</md-hint> </md-input>`})
-class MdInputHintLabel2TestController {
+@Component({template: `<mat-input> <mat-hint>{{label}}</mat-hint> </mat-input>`})
+class MatInputHintLabel2TestController {
   label: string = '';
 }
 
-@Component({template: `<md-input [hintLabel]="label"></md-input>`})
-class MdInputHintLabelTestController {
+@Component({template: `<mat-input [hintLabel]="label"></mat-input>`})
+class MatInputHintLabelTestController {
   label: string = '';
 }
 
-@Component({template: `<md-input type="file"></md-input>`})
-class MdInputInvalidTypeTestController { }
+@Component({template: `<mat-input type="file"></mat-input>`})
+class MatInputInvalidTypeTestController { }
 
 @Component({
   template: `
-    <md-input placeholder="Hello">
-      <md-placeholder>World</md-placeholder>
-    </md-input>`
+    <mat-input placeholder="Hello">
+      <mat-placeholder>World</mat-placeholder>
+    </mat-input>`
 })
-class MdInputInvalidPlaceholderTestController { }
+class MatInputInvalidPlaceholderTestController { }
 
 @Component({
   template: `
-    <md-input hintLabel="Hello">
-      <md-hint>World</md-hint>
-    </md-input>`
+    <mat-input hintLabel="Hello">
+      <mat-hint>World</mat-hint>
+    </mat-input>`
 })
-class MdInputInvalidHint2TestController { }
+class MatInputInvalidHint2TestController { }
 
 @Component({
   template: `
-    <md-input>
-      <md-hint>Hello</md-hint>
-      <md-hint>World</md-hint>
-    </md-input>`
+    <mat-input>
+      <mat-hint>Hello</mat-hint>
+      <mat-hint>World</mat-hint>
+    </mat-input>`
 })
-class MdInputInvalidHintTestController { }
+class MatInputInvalidHintTestController { }
 
-@Component({template: `<md-input [(ngModel)]="model"></md-input>`})
-class MdInputBaseTestController {
+@Component({template: `<mat-input [(ngModel)]="model"></mat-input>`})
+class MatInputBaseTestController {
   model: any = '';
 }
 
 @Component({template:
-    `<md-input [aria-label]="ariaLabel" [aria-disabled]="ariaDisabled"></md-input>`})
-class MdInputAriaTestController {
+    `<mat-input [aria-label]="ariaLabel" [aria-disabled]="ariaDisabled"></mat-input>`})
+class MatInputAriaTestController {
   ariaLabel: string = 'label';
   ariaDisabled: boolean = true;
 }
 
-@Component({template: `<md-input (focus)="onFocus($event)" (blur)="onBlur($event)"></md-input>`})
-class MdInputWithBlurAndFocusEvents {
+@Component({template: `<mat-input (focus)="onFocus($event)" (blur)="onBlur($event)"></mat-input>`})
+class MatInputWithBlurAndFocusEvents {
   onBlur(event: FocusEvent) {}
   onFocus(event: FocusEvent) {}
 }
 
-@Component({template: `<md-input name="some-name"></md-input>`})
-class MdInputWithNameTestController { }
+@Component({template: `<mat-input name="some-name"></mat-input>`})
+class MatInputWithNameTestController { }
 
-@Component({template: `<md-input [autocomplete]="autoComplete"></md-input>`})
-class MdInputWithAutocomplete { }
+@Component({template: `<mat-input [autocomplete]="autoComplete"></mat-input>`})
+class MatInputWithAutocomplete { }
 
-@Component({template: `<md-input autocomplete></md-input>`})
-class MdInputWithUnboundAutocomplete { }
+@Component({template: `<mat-input autocomplete></mat-input>`})
+class MatInputWithUnboundAutocomplete { }
 
-@Component({template: `<md-input autocomplete="name"></md-input>`})
-class MdInputWithUnboundAutocompleteWithValue { }
+@Component({template: `<mat-input autocomplete="name"></mat-input>`})
+class MatInputWithUnboundAutocompleteWithValue { }
 
-@Component({template: `<md-input [autocorrect]="autoCorrect"></md-input>`})
-class MdInputWithAutocorrect { }
+@Component({template: `<mat-input [autocorrect]="autoCorrect"></mat-input>`})
+class MatInputWithAutocorrect { }
 
-@Component({template: `<md-input autocorrect></md-input>`})
-class MdInputWithUnboundAutocorrect { }
+@Component({template: `<mat-input autocorrect></mat-input>`})
+class MatInputWithUnboundAutocorrect { }
 
-@Component({template: `<md-input [autocapitalize]="autoCapitalize"></md-input>`})
-class MdInputWithAutocapitalize { }
+@Component({template: `<mat-input [autocapitalize]="autoCapitalize"></mat-input>`})
+class MatInputWithAutocapitalize { }
 
-@Component({template: `<md-input autocapitalize></md-input>`})
-class MdInputWithUnboundAutocapitalize { }
+@Component({template: `<mat-input autocapitalize></mat-input>`})
+class MatInputWithUnboundAutocapitalize { }
 
-@Component({template: `<md-input [autofocus]="autoFocus"></md-input>`})
-class MdInputWithAutofocus { }
+@Component({template: `<mat-input [autofocus]="autoFocus"></mat-input>`})
+class MatInputWithAutofocus { }
 
-@Component({template: `<md-input autofocus></md-input>`})
-class MdInputWithUnboundAutofocus { }
+@Component({template: `<mat-input autofocus></mat-input>`})
+class MatInputWithUnboundAutofocus { }
 
-@Component({template: `<md-input [readonly]="readOnly"></md-input>`})
-class MdInputWithReadonly { }
+@Component({template: `<mat-input [readonly]="readOnly"></mat-input>`})
+class MatInputWithReadonly { }
 
-@Component({template: `<md-input readonly></md-input>`})
-class MdInputWithUnboundReadonly { }
+@Component({template: `<mat-input readonly></mat-input>`})
+class MatInputWithUnboundReadonly { }
 
-@Component({template: `<md-input [spellcheck]="spellcheck"></md-input>`})
-class MdInputWithSpellcheck { }
+@Component({template: `<mat-input [spellcheck]="spellcheck"></mat-input>`})
+class MatInputWithSpellcheck { }
 
-@Component({template: `<md-input spellcheck></md-input>`})
-class MdInputWithUnboundSpellcheck { }
+@Component({template: `<mat-input spellcheck></mat-input>`})
+class MatInputWithUnboundSpellcheck { }
 
-@Component({template: `<md-input [disabled]="disabled"></md-input>`})
-class MdInputWithDisabled {
+@Component({template: `<mat-input [disabled]="disabled"></mat-input>`})
+class MatInputWithDisabled {
   disabled: boolean;
 }
 
-@Component({template: `<md-input disabled></md-input>`})
-class MdInputWithUnboundDisabled { }
+@Component({template: `<mat-input disabled></mat-input>`})
+class MatInputWithUnboundDisabled { }
 
-@Component({template: `<md-input [required]="required"></md-input>`})
-class MdInputWithRequired { }
+@Component({template: `<mat-input [required]="required"></mat-input>`})
+class MatInputWithRequired { }
 
-@Component({template: `<md-input required></md-input>`})
-class MdInputWithUnboundRequired { }
+@Component({template: `<mat-input required></mat-input>`})
+class MatInputWithUnboundRequired { }
 
-@Component({template: `<md-input [list]="list"></md-input>`})
-class MdInputWithList { }
+@Component({template: `<mat-input [list]="list"></mat-input>`})
+class MatInputWithList { }
 
-@Component({template: `<md-input [max]="max"></md-input>`})
-class MdInputWithMax { }
+@Component({template: `<mat-input [max]="max"></mat-input>`})
+class MatInputWithMax { }
 
-@Component({template: `<md-input [min]="min"></md-input>`})
-class MdInputWithMin { }
+@Component({template: `<mat-input [min]="min"></mat-input>`})
+class MatInputWithMin { }
 
-@Component({template: `<md-input [step]="step"></md-input>`})
-class MdInputWithStep { }
+@Component({template: `<mat-input [step]="step"></mat-input>`})
+class MatInputWithStep { }
 
-@Component({template: `<md-input [tabindex]="tabIndex"></md-input>`})
-class MdInputWithTabindex { }
+@Component({template: `<mat-input [tabindex]="tabIndex"></mat-input>`})
+class MatInputWithTabindex { }
 
-@Component({template: `<md-input type="date" [placeholder]="placeholder"></md-input>`})
-class MdInputDateTestController {
+@Component({template: `<mat-input type="date" [placeholder]="placeholder"></mat-input>`})
+class MatInputDateTestController {
   placeholder: string = '';
 }
 
-@Component({template: `<md-input type="text" [placeholder]="placeholder"></md-input>`})
-class MdInputTextTestController {
+@Component({template: `<mat-input type="text" [placeholder]="placeholder"></mat-input>`})
+class MatInputTextTestController {
   placeholder: string = '';
 }
 
-@Component({template: `<md-input type="password" [placeholder]="placeholder"></md-input>`})
-class MdInputPasswordTestController {
+@Component({template: `<mat-input type="password" [placeholder]="placeholder"></mat-input>`})
+class MatInputPasswordTestController {
   placeholder: string = '';
 }
 
-@Component({template: `<md-input type="number" [placeholder]="placeholder"></md-input>`})
-class MdInputNumberTestController {
+@Component({template: `<mat-input type="number" [placeholder]="placeholder"></mat-input>`})
+class MatInputNumberTestController {
   placeholder: string = '';
 }

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -23,20 +23,20 @@ import {
   FormsModule,
 } from '@angular/forms';
 import {CommonModule} from '@angular/common';
-import {BooleanFieldValue, MdError} from '@angular2-material/core';
+import {BooleanFieldValue, MatError} from '@angular2-material/core';
 import {Observable} from 'rxjs/Observable';
 
 
 const noop = () => {};
 
-export const MD_INPUT_CONTROL_VALUE_ACCESSOR: any = {
+export const MAT_INPUT_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdInput),
+  useExisting: forwardRef(() => MatInput),
   multi: true
 };
 
-// Invalid input type. Using one of these will throw an MdInputUnsupportedTypeError.
-const MD_INPUT_INVALID_INPUT_TYPE = [
+// Invalid input type. Using one of these will throw an MatInputUnsupportedTypeError.
+const MAT_INPUT_INVALID_INPUT_TYPE = [
   'file',
   'radio',
   'checkbox',
@@ -46,19 +46,19 @@ const MD_INPUT_INVALID_INPUT_TYPE = [
 let nextUniqueId = 0;
 
 
-export class MdInputPlaceholderConflictError extends MdError {
+export class MatInputPlaceholderConflictError extends MatError {
   constructor() {
     super('Placeholder attribute and child element were both specified.');
   }
 }
 
-export class MdInputUnsupportedTypeError extends MdError {
+export class MatInputUnsupportedTypeError extends MatError {
   constructor(type: string) {
-    super(`Input type "${type}" isn't supported by md-input.`);
+    super(`Input type "${type}" isn't supported by mat-input.`);
   }
 }
 
-export class MdInputDuplicatedHintError extends MdError {
+export class MatInputDuplicatedHintError extends MatError {
   constructor(align: string) {
     super(`A hint was already declared for 'align="${align}"'.`);
   }
@@ -71,20 +71,20 @@ export class MdInputDuplicatedHintError extends MdError {
  * complex placeholders.
  */
 @Directive({
-  selector: 'md-placeholder'
+  selector: 'mat-placeholder'
 })
-export class MdPlaceholder {}
+export class MatPlaceholder {}
 
 
 /** The hint directive, used to tag content as hint labels (going under the input). */
 @Directive({
-  selector: 'md-hint',
+  selector: 'mat-hint',
   host: {
-    '[class.md-right]': 'align == "end"',
-    '[class.md-hint]': 'true'
+    '[class.mat-right]': 'align == "end"',
+    '[class.mat-hint]': 'true'
   }
 })
-export class MdHint {
+export class MatHint {
   // Whether to align the hint label at the start or end of the line.
   @Input() align: 'start' | 'end' = 'start';
 }
@@ -96,13 +96,13 @@ export class MdHint {
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-input',
+  selector: 'mat-input',
   templateUrl: 'input.html',
   styleUrls: ['input.css'],
-  providers: [MD_INPUT_CONTROL_VALUE_ACCESSOR],
+  providers: [MAT_INPUT_CONTROL_VALUE_ACCESSOR],
   host: {'(click)' : 'focus()'}
 })
-export class MdInput implements ControlValueAccessor, AfterContentInit, OnChanges {
+export class MatInput implements ControlValueAccessor, AfterContentInit, OnChanges {
   private _focused: boolean = false;
   private _value: any = '';
 
@@ -123,8 +123,8 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   /**
    * Content directives.
    */
-  @ContentChild(MdPlaceholder) _placeholderChild: MdPlaceholder;
-  @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
+  @ContentChild(MatPlaceholder) _placeholderChild: MatPlaceholder;
+  @ContentChildren(MatHint) _hintChildren: QueryList<MatHint>;
 
   /** Readonly properties. */
   get focused() { return this._focused; }
@@ -147,7 +147,7 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   @Input() autocapitalize: string;
   @Input() @BooleanFieldValue() autofocus: boolean = false;
   @Input() @BooleanFieldValue() disabled: boolean = false;
-  @Input() id: string = `md-input-${nextUniqueId++}`;
+  @Input() id: string = `mat-input-${nextUniqueId++}`;
   @Input() list: string = null;
   @Input() max: string | number = null;
   @Input() maxlength: number = null;
@@ -184,7 +184,7 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     }
   }
 
-  // This is to remove the `align` property of the `md-input` itself. Otherwise HTML5
+  // This is to remove the `align` property of the `mat-input` itself. Otherwise HTML5
   // might place it as RTL when we don't want to. We still want to use `align` as an
   // Input though, so we use HostBinding.
   @HostBinding('attr.align') get _align(): any { return null; }
@@ -257,7 +257,7 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   }
 
   /**
-   * Convert the value passed in to a value that is expected from the type of the md-input.
+   * Convert the value passed in to a value that is expected from the type of the mat-input.
    * This is normally performed by the *_VALUE_ACCESSOR in forms, but since the type is bound
    * on our internal input it won't work locally.
    * @private
@@ -272,33 +272,33 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   /**
    * Ensure that all constraints defined by the API are validated, or throw errors otherwise.
    * Constraints for now:
-   *   - placeholder attribute and <md-placeholder> are mutually exclusive.
+   *   - placeholder attribute and <mat-placeholder> are mutually exclusive.
    *   - type attribute is not one of the forbidden types (see constant at the top).
-   *   - Maximum one of each `<md-hint>` alignment specified, with the attribute being
+   *   - Maximum one of each `<mat-hint>` alignment specified, with the attribute being
    *     considered as align="start".
    * @private
    */
   private _validateConstraints() {
     if (this.placeholder != '' && this.placeholder != null && this._placeholderChild != null) {
-      throw new MdInputPlaceholderConflictError();
+      throw new MatInputPlaceholderConflictError();
     }
-    if (MD_INPUT_INVALID_INPUT_TYPE.indexOf(this.type) != -1) {
-      throw new MdInputUnsupportedTypeError(this.type);
+    if (MAT_INPUT_INVALID_INPUT_TYPE.indexOf(this.type) != -1) {
+      throw new MatInputUnsupportedTypeError(this.type);
     }
 
     if (this._hintChildren) {
       // Validate the hint labels.
-      let startHint: MdHint = null;
-      let endHint: MdHint = null;
-      this._hintChildren.forEach((hint: MdHint) => {
+      let startHint: MatHint = null;
+      let endHint: MatHint = null;
+      this._hintChildren.forEach((hint: MatHint) => {
         if (hint.align == 'start') {
           if (startHint || this.hintLabel) {
-            throw new MdInputDuplicatedHintError('start');
+            throw new MatInputDuplicatedHintError('start');
           }
           startHint = hint;
         } else if (hint.align == 'end') {
           if (endHint) {
-            throw new MdInputDuplicatedHintError('end');
+            throw new MatInputDuplicatedHintError('end');
           }
           endHint = hint;
         }
@@ -309,14 +309,14 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
 
 
 @NgModule({
-  declarations: [MdPlaceholder, MdInput, MdHint],
+  declarations: [MatPlaceholder, MatInput, MatHint],
   imports: [CommonModule, FormsModule],
-  exports: [MdPlaceholder, MdInput, MdHint],
+  exports: [MatPlaceholder, MatInput, MatHint],
 })
-export class MdInputModule {
+export class MatInputModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdInputModule,
+      ngModule: MatInputModule,
       providers: []
     };
   }

--- a/src/lib/list/list-item.html
+++ b/src/lib/list/list-item.html
@@ -1,5 +1,5 @@
-<div class="md-list-item" [class.md-list-item-focus]="_hasFocus">
-  <ng-content select="[md-list-avatar],[md-list-icon]"></ng-content>
-  <div class="md-list-text"><ng-content select="[md-line]"></ng-content></div>
+<div class="mat-list-item" [class.mat-list-item-focus]="_hasFocus">
+  <ng-content select="[mat-list-avatar],[mat-list-icon]"></ng-content>
+  <div class="mat-list-text"><ng-content select="[mat-line]"></ng-content></div>
   <ng-content></ng-content>
 </div>

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -2,79 +2,79 @@
 @import 'default-theme';
 @import 'list-shared';
 
-$md-list-side-padding: 16px;
-$md-list-avatar-size: 40px;
-$md-list-icon-size: 24px;
+$mat-list-side-padding: 16px;
+$mat-list-avatar-size: 40px;
+$mat-list-icon-size: 24px;
 
 /*  Normal list variables */
-$md-list-top-padding: 8px;
-$md-list-font-size: 16px;
-$md-list-secondary-font: 14px;
+$mat-list-top-padding: 8px;
+$mat-list-font-size: 16px;
+$mat-list-secondary-font: 14px;
 // height for single-line lists
-$md-list-base-height: 48px;
+$mat-list-base-height: 48px;
 // height for single-line lists with avatars
-$md-list-avatar-height: 56px;
+$mat-list-avatar-height: 56px;
 // spec requires two- and three-line lists be taller
-$md-list-two-line-height: 72px;
-$md-list-three-line-height: 88px;
+$mat-list-two-line-height: 72px;
+$mat-list-three-line-height: 88px;
 
 /* Dense list variables */
-$md-dense-top-padding: 4px;
-$md-dense-font-size: 13px;
-$md-dense-base-height: 40px;
-$md-dense-avatar-height: 48px;
-$md-dense-two-line-height: 60px;
-$md-dense-three-line-height: 76px;
+$mat-dense-top-padding: 4px;
+$mat-dense-font-size: 13px;
+$mat-dense-base-height: 40px;
+$mat-dense-avatar-height: 48px;
+$mat-dense-two-line-height: 60px;
+$mat-dense-three-line-height: 76px;
 
 /*
 This mixin provides all list-item styles, changing font size and height
 based on whether the list is in dense mode.
 */
-@mixin md-list-item-base($font-size, $base-height, $avatar-height,
+@mixin mat-list-item-base($font-size, $base-height, $avatar-height,
   $two-line-height, $three-line-height) {
 
-  .md-list-item {
+  .mat-list-item {
     display: flex;
     flex-direction: row;
     align-items: center;
-    font-family: $md-font-family;
+    font-family: $mat-font-family;
     box-sizing: border-box;
     font-size: $font-size;
     height: $base-height;
-    padding: 0 $md-list-side-padding;
-    color: md-color($md-foreground, base);
+    padding: 0 $mat-list-side-padding;
+    color: mat-color($mat-foreground, base);
   }
 
-  &.md-list-avatar .md-list-item {
+  &.mat-list-avatar .mat-list-item {
     height: $avatar-height;
   }
 
-  &.md-2-line .md-list-item {
+  &.mat-2-line .mat-list-item {
     height: $two-line-height;
   }
 
-  &.md-3-line .md-list-item {
+  &.mat-3-line .mat-list-item {
     height: $three-line-height;
   }
 
-  .md-list-text {
-    @include md-line-wrapper-base();
-    padding: 0 $md-list-side-padding;
+  .mat-list-text {
+    @include mat-line-wrapper-base();
+    padding: 0 $mat-list-side-padding;
 
     &:first-child {
       padding: 0;
     }
   }
 
-  [md-list-avatar] {
-    width: $md-list-avatar-size;
-    height: $md-list-avatar-size;
+  [mat-list-avatar] {
+    width: $mat-list-avatar-size;
+    height: $mat-list-avatar-size;
     border-radius: 50%;
   }
 
-  [md-list-icon] {
-    width: $md-list-icon-size;
-    height: $md-list-icon-size;
+  [mat-list-icon] {
+    width: $mat-list-icon-size;
+    height: $mat-list-icon-size;
     border-radius: 50%;
     padding: 4px;
   }
@@ -84,93 +84,93 @@ based on whether the list is in dense mode.
 This mixin provides all subheader styles, adjusting heights and padding
 based on whether the list is in dense mode.
 */
-@mixin md-subheader-base($top-padding, $secondary-size, $base-height) {
+@mixin mat-subheader-base($top-padding, $secondary-size, $base-height) {
   display: block;
   box-sizing: border-box;
   height: $base-height;
-  padding: $md-list-side-padding;
+  padding: $mat-list-side-padding;
   margin: 0;
 
   font-size: $secondary-size;
   font-weight: 500;
-  color: md-color($md-foreground, secondary-text);
+  color: mat-color($mat-foreground, secondary-text);
 
   &:first-child {
     margin-top: -$top-padding;
   }
 }
 
-md-list, md-nav-list {
-  padding-top: $md-list-top-padding;
+mat-list, mat-nav-list {
+  padding-top: $mat-list-top-padding;
   display: block;
 
-  [md-subheader] {
-    @include md-subheader-base(
-      $md-list-top-padding,
-      $md-list-secondary-font,
-      $md-list-base-height
+  [mat-subheader] {
+    @include mat-subheader-base(
+      $mat-list-top-padding,
+      $mat-list-secondary-font,
+      $mat-list-base-height
     );
   }
 
 
-  md-list-item, a[md-list-item] {
-    @include md-list-item-base(
-      $md-list-font-size,
-      $md-list-base-height,
-      $md-list-avatar-height,
-      $md-list-two-line-height,
-      $md-list-three-line-height
+  mat-list-item, a[mat-list-item] {
+    @include mat-list-item-base(
+      $mat-list-font-size,
+      $mat-list-base-height,
+      $mat-list-avatar-height,
+      $mat-list-two-line-height,
+      $mat-list-three-line-height
     );
 
-    @include md-line-base($md-list-secondary-font);
+    @include mat-line-base($mat-list-secondary-font);
   }
 }
 
 
-md-list[dense], md-nav-list[dense] {
-  padding-top: $md-dense-top-padding;
+mat-list[dense], mat-nav-list[dense] {
+  padding-top: $mat-dense-top-padding;
   display: block;
 
-  [md-subheader] {
-    @include md-subheader-base(
-      $md-dense-top-padding,
-      $md-dense-font-size,
-      $md-dense-base-height
+  [mat-subheader] {
+    @include mat-subheader-base(
+      $mat-dense-top-padding,
+      $mat-dense-font-size,
+      $mat-dense-base-height
     );
   }
 
-  md-list-item, a[md-list-item] {
-    @include md-list-item-base(
-      $md-dense-font-size,
-      $md-dense-base-height,
-      $md-dense-avatar-height,
-      $md-dense-two-line-height,
-      $md-dense-three-line-height
+  mat-list-item, a[mat-list-item] {
+    @include mat-list-item-base(
+      $mat-dense-font-size,
+      $mat-dense-base-height,
+      $mat-dense-avatar-height,
+      $mat-dense-two-line-height,
+      $mat-dense-three-line-height
     );
 
-    @include md-line-base($md-dense-font-size);
+    @include mat-line-base($mat-dense-font-size);
   }
 
 }
 
-md-divider {
+mat-divider {
   display: block;
-  border-top: 1px solid md-color($md-foreground, divider);
+  border-top: 1px solid mat-color($mat-foreground, divider);
   margin: 0;
 }
 
-md-nav-list {
+mat-nav-list {
   a {
     text-decoration: none;
     color: inherit;
   }
 
-  .md-list-item {
+  .mat-list-item {
     cursor: pointer;
 
-    &:hover, &.md-list-item-focus {
+    &:hover, &.mat-list-item-focus {
       outline: none;
-      background: md-color($md-background, 'hover');
+      background: mat-color($mat-background, 'hover');
     }
   }
 }

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -1,14 +1,14 @@
 import {async, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdListItem, MdListModule} from './list';
+import {MatListItem, MatListModule} from './list';
 
 
-describe('MdList', () => {
+describe('MatList', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdListModule.forRoot()],
+      imports: [MatListModule.forRoot()],
       declarations: [
         ListWithOneAnchorItem,
         ListWithOneItem,
@@ -26,51 +26,51 @@ describe('MdList', () => {
 
   it('should add and remove focus class on focus/blur', () => {
     let fixture = TestBed.createComponent(ListWithOneAnchorItem);
-    let listItem = fixture.debugElement.query(By.directive(MdListItem));
-    let listItemDiv = fixture.debugElement.query(By.css('.md-list-item'));
+    let listItem = fixture.debugElement.query(By.directive(MatListItem));
+    let listItemDiv = fixture.debugElement.query(By.css('.mat-list-item'));
     fixture.detectChanges();
-    expect(listItemDiv.nativeElement.classList).not.toContain('md-list-item-focus');
+    expect(listItemDiv.nativeElement.classList).not.toContain('mat-list-item-focus');
 
     listItem.componentInstance._handleFocus();
     fixture.detectChanges();
-    expect(listItemDiv.nativeElement.classList).toContain('md-list-item-focus');
+    expect(listItemDiv.nativeElement.classList).toContain('mat-list-item-focus');
 
     listItem.componentInstance._handleBlur();
     fixture.detectChanges();
-    expect(listItemDiv.nativeElement.classList).not.toContain('md-list-item-focus');
+    expect(listItemDiv.nativeElement.classList).not.toContain('mat-list-item-focus');
   });
 
   it('should not apply any class to a list without lines', () => {
     let fixture = TestBed.createComponent(ListWithOneItem);
-    let listItem = fixture.debugElement.query(By.css('md-list-item'));
+    let listItem = fixture.debugElement.query(By.css('mat-list-item'));
     fixture.detectChanges();
     expect(listItem.nativeElement.className).toBe('');
   });
 
-  it('should apply md-2-line class to lists with two lines', () => {
+  it('should apply mat-2-line class to lists with two lines', () => {
     let fixture = TestBed.createComponent(ListWithTwoLineItem);
     fixture.detectChanges();
 
-    let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
-    expect(listItems[0].nativeElement.className).toBe('md-2-line');
-    expect(listItems[1].nativeElement.className).toBe('md-2-line');
+    let listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toBe('mat-2-line');
+    expect(listItems[1].nativeElement.className).toBe('mat-2-line');
   });
 
-  it('should apply md-3-line class to lists with three lines', () => {
+  it('should apply mat-3-line class to lists with three lines', () => {
     let fixture = TestBed.createComponent(ListWithThreeLineItem);
     fixture.detectChanges();
 
-    let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
-    expect(listItems[0].nativeElement.className).toBe('md-3-line');
-    expect(listItems[1].nativeElement.className).toBe('md-3-line');
+    let listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toBe('mat-3-line');
+    expect(listItems[1].nativeElement.className).toBe('mat-3-line');
   });
 
-  it('should apply md-list-avatar class to list items with avatars', () => {
+  it('should apply mat-list-avatar class to list items with avatars', () => {
     let fixture = TestBed.createComponent(ListWithAvatar);
     fixture.detectChanges();
 
-    let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
-    expect(listItems[0].nativeElement.className).toBe('md-list-avatar');
+    let listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toBe('mat-list-avatar');
     expect(listItems[1].nativeElement.className).toBe('');
   });
 
@@ -78,7 +78,7 @@ describe('MdList', () => {
     let fixture = TestBed.createComponent(ListWithItemWithCssClass);
     fixture.detectChanges();
 
-    let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
+    let listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
     expect(listItems[0].nativeElement.classList.contains('test-class')).toBe(true);
   });
 
@@ -87,12 +87,12 @@ describe('MdList', () => {
     fixture.debugElement.componentInstance.showThirdLine = false;
     fixture.detectChanges();
 
-    let listItem = fixture.debugElement.children[0].query(By.css('md-list-item'));
-    expect(listItem.nativeElement.className).toBe('md-2-line');
+    let listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'));
+    expect(listItem.nativeElement.className).toBe('mat-2-line');
 
     fixture.debugElement.componentInstance.showThirdLine = true;
     fixture.detectChanges();
-    expect(listItem.nativeElement.className).toBe('md-3-line');
+    expect(listItem.nativeElement.className).toBe('mat-3-line');
   });
 
   it('should add aria roles properly', () => {
@@ -100,7 +100,7 @@ describe('MdList', () => {
     fixture.detectChanges();
 
     let list = fixture.debugElement.children[0];
-    let listItem = fixture.debugElement.children[0].query(By.css('md-list-item'));
+    let listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'));
     expect(list.nativeElement.getAttribute('role')).toBe('list');
     expect(listItem.nativeElement.getAttribute('role')).toBe('listitem');
   });
@@ -117,76 +117,76 @@ class BaseTestList {
 }
 
 @Component({template: `
-  <md-list>
-    <a md-list-item>
+  <mat-list>
+    <a mat-list-item>
       Paprika
     </a>
-  </md-list>`})
+  </mat-list>`})
 class ListWithOneAnchorItem extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item>
+  <mat-list>
+    <mat-list-item>
       Paprika
-    </md-list-item>
-  </md-list>`})
+    </mat-list-item>
+  </mat-list>`})
 class ListWithOneItem extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item *ngFor="let item of items">
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
       <img src="">
-      <h3 md-line>{{item.name}}</h3>
-      <p md-line>{{item.description}}</p>
-    </md-list-item>
-  </md-list>`})
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+    </mat-list-item>
+  </mat-list>`})
 class ListWithTwoLineItem extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item *ngFor="let item of items">
-      <h3 md-line>{{item.name}}</h3>
-      <p md-line>{{item.description}}</p>
-      <p md-line>Some other text</p>
-    </md-list-item>
-  </md-list>`})
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+      <p mat-line>Some other text</p>
+    </mat-list-item>
+  </mat-list>`})
 class ListWithThreeLineItem extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item>
-      <img src="" md-list-avatar>
+  <mat-list>
+    <mat-list-item>
+      <img src="" mat-list-avatar>
       Paprika
-    </md-list-item>
-    <md-list-item>
+    </mat-list-item>
+    <mat-list-item>
       Pepper
-    </md-list-item>
-  </md-list>`})
+    </mat-list-item>
+  </mat-list>`})
 class ListWithAvatar extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item class="test-class" *ngFor="let item of items">
-      <h3 md-line>{{item.name}}</h3>
-      <p md-line>{{item.description}}</p>
-    </md-list-item>
-  </md-list>`})
+  <mat-list>
+    <mat-list-item class="test-class" *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+    </mat-list-item>
+  </mat-list>`})
 class ListWithItemWithCssClass extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item *ngFor="let item of items">
-      <h3 md-line>{{item.name}}</h3>
-      <p md-line>{{item.description}}</p>
-      <p md-line *ngIf="showThirdLine">Some other text</p>
-    </md-list-item>
-  </md-list>`})
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+      <p mat-line *ngIf="showThirdLine">Some other text</p>
+    </mat-list-item>
+  </mat-list>`})
 class ListWithDynamicNumberOfLines extends BaseTestList { }
 
 @Component({template: `
-  <md-list>
-    <md-list-item *ngFor="let item of items">
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
       {{item.name}}
-    </md-list-item>
-  </md-list>`})
+    </mat-list-item>
+  </mat-list>`})
 class ListWithMultipleItems extends BaseTestList { }

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -11,30 +11,30 @@ import {
     NgModule,
     ModuleWithProviders,
 } from '@angular/core';
-import {MdLine, MdLineSetter, MdLineModule} from '@angular2-material/core';
+import {MatLine, MatLineSetter, MatLineModule} from '@angular2-material/core';
 
 @Directive({
-  selector: 'md-divider'
+  selector: 'mat-divider'
 })
-export class MdListDivider {}
+export class MatListDivider {}
 
 @Component({
   moduleId: module.id,
-  selector: 'md-list, md-nav-list',
+  selector: 'mat-list, mat-nav-list',
   host: {'role': 'list'},
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class MdList {}
+export class MatList {}
 
 /* Need directive for a ContentChild query in list-item */
-@Directive({ selector: '[md-list-avatar]' })
-export class MdListAvatar {}
+@Directive({ selector: '[mat-list-avatar]' })
+export class MatListAvatar {}
 
 @Component({
   moduleId: module.id,
-  selector: 'md-list-item, a[md-list-item]',
+  selector: 'mat-list-item, a[mat-list-item]',
   host: {
     'role': 'listitem',
     '(focus)': '_handleFocus()',
@@ -43,23 +43,23 @@ export class MdListAvatar {}
   templateUrl: 'list-item.html',
   encapsulation: ViewEncapsulation.None
 })
-export class MdListItem implements AfterContentInit {
+export class MatListItem implements AfterContentInit {
   _hasFocus: boolean = false;
 
-  private _lineSetter: MdLineSetter;
+  private _lineSetter: MatLineSetter;
 
-  @ContentChildren(MdLine) _lines: QueryList<MdLine>;
+  @ContentChildren(MatLine) _lines: QueryList<MatLine>;
 
-  @ContentChild(MdListAvatar)
-  set _hasAvatar(avatar: MdListAvatar) {
-    this._renderer.setElementClass(this._element.nativeElement, 'md-list-avatar', avatar != null);
+  @ContentChild(MatListAvatar)
+  set _hasAvatar(avatar: MatListAvatar) {
+    this._renderer.setElementClass(this._element.nativeElement, 'mat-list-avatar', avatar != null);
   }
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
   /** TODO: internal */
   ngAfterContentInit() {
-    this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
+    this._lineSetter = new MatLineSetter(this._lines, this._renderer, this._element);
   }
 
   _handleFocus() {
@@ -73,14 +73,14 @@ export class MdListItem implements AfterContentInit {
 
 
 @NgModule({
-  imports: [MdLineModule],
-  exports: [MdList, MdListItem, MdListDivider, MdListAvatar, MdLineModule],
-  declarations: [MdList, MdListItem, MdListDivider, MdListAvatar],
+  imports: [MatLineModule],
+  exports: [MatList, MatListItem, MatListDivider, MatListAvatar, MatLineModule],
+  declarations: [MatList, MatListItem, MatListDivider, MatListAvatar],
 })
-export class MdListModule {
+export class MatListModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdListModule,
+      ngModule: MatListModule,
       providers: []
     };
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -13,20 +13,20 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
-import {MdMenuInvalidPositionX, MdMenuInvalidPositionY} from './menu-errors';
-import {MdMenuItem} from './menu-item';
+import {MatMenuInvalidPositionX, MatMenuInvalidPositionY} from './menu-errors';
+import {MatMenuItem} from './menu-item';
 import {UP_ARROW, DOWN_ARROW, TAB} from '@angular2-material/core';
 
 @Component({
   moduleId: module.id,
-  selector: 'md-menu',
+  selector: 'mat-menu',
   host: {'role': 'menu'},
   templateUrl: 'menu.html',
   styleUrls: ['menu.css'],
   encapsulation: ViewEncapsulation.None,
-  exportAs: 'mdMenu'
+  exportAs: 'matMenu'
 })
-export class MdMenu {
+export class MatMenu {
   _showClickCatcher: boolean = false;
   private _focusedItemIndex: number = 0;
 
@@ -37,7 +37,7 @@ export class MdMenu {
   positionY: MenuPositionY = 'below';
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
-  @ContentChildren(MdMenuItem) items: QueryList<MdMenuItem>;
+  @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 
   constructor(@Attribute('x-position') posX: MenuPositionX,
               @Attribute('y-position') posY: MenuPositionY) {
@@ -46,7 +46,7 @@ export class MdMenu {
   }
 
   /**
-   * This method takes classes set on the host md-menu element and applies them on the
+   * This method takes classes set on the host mat-menu element and applies them on the
    * menu template that displays in the overlay container.  Otherwise, it's difficult
    * to style the containing menu from outside the component.
    * @param classes list of class names
@@ -120,7 +120,7 @@ export class MdMenu {
    * @param menuItems the menu items that should be focused
    * @private
      */
-  private _updateFocusedItemIndex(delta: number, menuItems: MdMenuItem[] = this.items.toArray()) {
+  private _updateFocusedItemIndex(delta: number, menuItems: MatMenuItem[] = this.items.toArray()) {
     // when focus would leave menu, wrap to beginning or end
     this._focusedItemIndex = (this._focusedItemIndex + delta + this.items.length)
                               % this.items.length;
@@ -134,14 +134,14 @@ export class MdMenu {
 
   private _setPositionX(pos: MenuPositionX): void {
     if ( pos !== 'before' && pos !== 'after') {
-      throw new MdMenuInvalidPositionX();
+      throw new MatMenuInvalidPositionX();
     }
     this.positionX = pos;
   }
 
   private _setPositionY(pos: MenuPositionY): void {
     if ( pos !== 'above' && pos !== 'below') {
-      throw new MdMenuInvalidPositionY();
+      throw new MatMenuInvalidPositionY();
     }
     this.positionY = pos;
   }

--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -1,15 +1,15 @@
-import {MdError} from '@angular2-material/core';
+import {MatError} from '@angular2-material/core';
 
 /**
- * Exception thrown when menu trigger doesn't have a valid md-menu instance
+ * Exception thrown when menu trigger doesn't have a valid mat-menu instance
  */
-export class MdMenuMissingError extends MdError {
+export class MatMenuMissingError extends MatError {
   constructor() {
-    super(`md-menu-trigger: must pass in an md-menu instance.
+    super(`mat-menu-trigger: must pass in an mat-menu instance.
 
     Example:
-      <md-menu #menu="mdMenu"></md-menu>
-      <button [md-menu-trigger-for]="menu"></button>
+      <mat-menu #menu="matMenu"></mat-menu>
+      <button [mat-menu-trigger-for]="menu"></button>
     `);
   }
 }
@@ -18,10 +18,10 @@ export class MdMenuMissingError extends MdError {
  * Exception thrown when menu's x-position value isn't valid.
  * In other words, it doesn't match 'before' or 'after'.
  */
-export class MdMenuInvalidPositionX extends MdError {
+export class MatMenuInvalidPositionX extends MatError {
   constructor() {
     super(`x-position value must be either 'before' or after'.
-      Example: <md-menu x-position="before" #menu="mdMenu"></md-menu>
+      Example: <mat-menu x-position="before" #menu="matMenu"></mat-menu>
     `);
   }
 }
@@ -30,10 +30,10 @@ export class MdMenuInvalidPositionX extends MdError {
  * Exception thrown when menu's y-position value isn't valid.
  * In other words, it doesn't match 'above' or 'below'.
  */
-export class MdMenuInvalidPositionY extends MdError {
+export class MatMenuInvalidPositionY extends MatError {
   constructor() {
     super(`y-position value must be either 'above' or below'.
-      Example: <md-menu y-position="above" #menu="mdMenu"></md-menu>
+      Example: <mat-menu y-position="above" #menu="matMenu"></mat-menu>
     `);
   }
 }

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -1,19 +1,19 @@
 import {Directive, ElementRef, Input, HostBinding, Renderer} from '@angular/core';
 
 /**
- * This directive is intended to be used inside an md-menu tag.
+ * This directive is intended to be used inside an mat-menu tag.
  * It exists mostly to set the role attribute.
  */
 @Directive({
-  selector: '[md-menu-item]',
+  selector: '[mat-menu-item]',
   host: {
     'role': 'menuitem',
     '(click)': '_checkDisabled($event)',
     'tabindex': '-1'
   },
-  exportAs: 'mdMenuItem'
+  exportAs: 'matMenuItem'
 })
-export class MdMenuItem {
+export class MatMenuItem {
   _disabled: boolean;
 
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -10,8 +10,8 @@ import {
     OnDestroy,
     Renderer
 } from '@angular/core';
-import {MdMenu} from './menu-directive';
-import {MdMenuMissingError} from './menu-errors';
+import {MatMenu} from './menu-directive';
+import {MatMenuMissingError} from './menu-errors';
 import {
     ENTER,
     Overlay,
@@ -24,18 +24,18 @@ import {
 } from '@angular2-material/core';
 
 /**
- * This directive is intended to be used in conjunction with an md-menu tag.  It is
+ * This directive is intended to be used in conjunction with an mat-menu tag.  It is
  * responsible for toggling the display of the provided menu instance.
  */
 @Directive({
-  selector: '[md-menu-trigger-for]',
+  selector: '[mat-menu-trigger-for]',
   host: {
     'aria-haspopup': 'true',
     '(keydown)': '_handleKeydown($event)'
   },
-  exportAs: 'mdMenuTrigger'
+  exportAs: 'matMenuTrigger'
 })
-export class MdMenuTrigger implements AfterViewInit, OnDestroy {
+export class MatMenuTrigger implements AfterViewInit, OnDestroy {
   private _portal: TemplatePortal;
   private _overlayRef: OverlayRef;
   private _menuOpen: boolean = false;
@@ -44,7 +44,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   // the first item of the list when the menu is opened via the keyboard
   private _openedFromKeyboard: boolean = false;
 
-  @Input('md-menu-trigger-for') menu: MdMenu;
+  @Input('mat-menu-trigger-for') menu: MatMenu;
   @Output() onMenuOpen = new EventEmitter();
   @Output() onMenuClose = new EventEmitter();
 
@@ -122,12 +122,12 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   }
 
   /**
-   *  This method checks that a valid instance of MdMenu has been passed into
-   *  md-menu-trigger-for.  If not, an exception is thrown.
+   *  This method checks that a valid instance of MatMenu has been passed into
+   *  mat-menu-trigger-for.  If not, an exception is thrown.
    */
   private _checkMenu() {
-    if (!this.menu || !(this.menu instanceof MdMenu)) {
-      throw new MdMenuMissingError();
+    if (!this.menu || !(this.menu instanceof MatMenu)) {
+      throw new MatMenuMissingError();
     }
   }
 

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -1,6 +1,6 @@
 <template>
-  <div class="md-menu" [ngClass]="_classList" (click)="_emitCloseEvent()" (keydown)="_handleKeydown($event)">
+  <div class="mat-menu" [ngClass]="_classList" (click)="_emitCloseEvent()" (keydown)="_handleKeydown($event)">
     <ng-content></ng-content>
   </div>
 </template>
-<div class="md-menu-click-catcher" *ngIf="_showClickCatcher" (click)="_emitCloseEvent()"></div>
+<div class="mat-menu-click-catcher" *ngIf="_showClickCatcher" (click)="_emitCloseEvent()"></div>

--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -8,59 +8,59 @@
 @import 'list-shared';
 
 // menu width must be a multiple of 56px
-$md-menu-overlay-min-width: 112px !default;   // 56 * 2
-$md-menu-overlay-max-width: 280px !default;   // 56 * 5
+$mat-menu-overlay-min-width: 112px !default;   // 56 * 2
+$mat-menu-overlay-max-width: 280px !default;   // 56 * 5
 
-$md-menu-item-height: 48px !default;
-$md-menu-font-size: 16px !default;
-$md-menu-side-padding: 16px !default;
-$md-menu-vertical-padding: 8px !default;
+$mat-menu-item-height: 48px !default;
+$mat-menu-font-size: 16px !default;
+$mat-menu-side-padding: 16px !default;
+$mat-menu-vertical-padding: 8px !default;
 
-.md-menu {
-  @include md-elevation(2);
-  min-width: $md-menu-overlay-min-width;
-  max-width: $md-menu-overlay-max-width;
+.mat-menu {
+  @include mat-elevation(2);
+  min-width: $mat-menu-overlay-min-width;
+  max-width: $mat-menu-overlay-max-width;
 
   // max height must be 100% of the viewport height + one row height
   max-height: calc(100vh + 48px);
   overflow: auto;
   -webkit-overflow-scrolling: touch;   // for momentum scroll on mobile
 
-  background: md-color($md-background, 'card');
-  padding-top: $md-menu-vertical-padding;
-  padding-bottom: $md-menu-vertical-padding;
+  background: mat-color($mat-background, 'card');
+  padding-top: $mat-menu-vertical-padding;
+  padding-bottom: $mat-menu-vertical-padding;
 }
 
-[md-menu-item] {
-  @include md-button-reset();
-  @include md-truncate-line();
+[mat-menu-item] {
+  @include mat-button-reset();
+  @include mat-truncate-line();
 
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: $md-menu-item-height;
-  padding: 0 $md-menu-side-padding;
+  height: $mat-menu-item-height;
+  padding: 0 $mat-menu-side-padding;
 
-  font-size: $md-menu-font-size;
-  font-family: $md-font-family;
+  font-size: $mat-menu-font-size;
+  font-family: $mat-font-family;
   text-align: start;
   text-decoration: none;   // necessary to reset anchor tags
-  color: md-color($md-foreground, 'text');
+  color: mat-color($mat-foreground, 'text');
 
   &[disabled] {
-    color: md-color($md-foreground, 'disabled');
+    color: mat-color($mat-foreground, 'disabled');
     cursor: default;
   }
 
   &:hover:not([disabled]), &:focus:not([disabled]) {
-    background: md-color($md-background, 'hover');
+    background: mat-color($mat-background, 'hover');
   }
 }
 
-button[md-menu-item] {
+button[mat-menu-item] {
   width: 100%;
 }
 
-.md-menu-click-catcher {
-  @include md-fullscreen();
+.mat-menu-click-catcher {
+  @include mat-fullscreen();
 }

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1,13 +1,13 @@
 import {TestBed, async} from '@angular/core/testing';
 import {Component} from '@angular/core';
-import {MdMenuModule} from './menu';
+import {MatMenuModule} from './menu';
 
 
-describe('MdMenu', () => {
+describe('MatMenu', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdMenuModule.forRoot()],
+      imports: [MatMenuModule.forRoot()],
       declarations: [TestMenu],
     });
 

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,23 +1,23 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {OverlayModule, OVERLAY_PROVIDERS} from '@angular2-material/core';
-import {MdMenu} from './menu-directive';
-import {MdMenuItem} from './menu-item';
-import {MdMenuTrigger} from './menu-trigger';
-export {MdMenu} from './menu-directive';
-export {MdMenuItem} from './menu-item';
-export {MdMenuTrigger} from './menu-trigger';
+import {MatMenu} from './menu-directive';
+import {MatMenuItem} from './menu-item';
+import {MatMenuTrigger} from './menu-trigger';
+export {MatMenu} from './menu-directive';
+export {MatMenuItem} from './menu-item';
+export {MatMenuTrigger} from './menu-trigger';
 
 
 @NgModule({
   imports: [OverlayModule, CommonModule],
-  exports: [MdMenu, MdMenuItem, MdMenuTrigger],
-  declarations: [MdMenu, MdMenuItem, MdMenuTrigger],
+  exports: [MatMenu, MatMenuItem, MatMenuTrigger],
+  declarations: [MatMenu, MatMenuItem, MatMenuTrigger],
 })
-export class MdMenuModule {
+export class MatMenuModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdMenuModule,
+      ngModule: MatMenuModule,
       providers: OVERLAY_PROVIDERS,
     };
   }

--- a/src/lib/progress-bar/progress-bar.html
+++ b/src/lib/progress-bar/progress-bar.html
@@ -1,5 +1,5 @@
 <!-- The background div is named as such because it appears below the other divs and is not sized based on values. -->
-<div class="md-progress-bar-background"></div>
-<div class="md-progress-bar-buffer" [ngStyle]="_bufferTransform()"></div>
-<div class="md-progress-bar-primary md-progress-bar-fill" [ngStyle]="_primaryTransform()"></div>
-<div class="md-progress-bar-secondary md-progress-bar-fill"></div>
+<div class="mat-progress-bar-background"></div>
+<div class="mat-progress-bar-buffer" [ngStyle]="_bufferTransform()"></div>
+<div class="mat-progress-bar-primary mat-progress-bar-fill" [ngStyle]="_primaryTransform()"></div>
+<div class="mat-progress-bar-secondary mat-progress-bar-fill"></div>

--- a/src/lib/progress-bar/progress-bar.scss
+++ b/src/lib/progress-bar/progress-bar.scss
@@ -1,9 +1,9 @@
 @import 'variables';
 @import 'default-theme';
 
-$md-progress-bar-height: 5px !default;
-$md-progress-bar-full-animation-duration: 2000ms !default;
-$md-progress-bar-piece-animation-duration: 250ms !default;
+$mat-progress-bar-height: 5px !default;
+$mat-progress-bar-full-animation-duration: 2000ms !default;
+$mat-progress-bar-piece-animation-duration: 250ms !default;
 
 // TODO(josephperrott): Find better way to inline svgs.
 /** In buffer mode a repeated SVG object is used as a background.  Each of the following defines the SVG object for each
@@ -18,39 +18,39 @@ $md-progress-bar-piece-animation-duration: 250ms !default;
     </svg>
 
     */
-$md-buffer-bubbles-primary-url: url(
+$mat-buffer-bubbles-primary-url: url(
   'data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%271.1%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27' +
   '%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%27%20x%3D%270px%27%20y%3D%270px%27%20enable-backgroun' +
   'd%3D%27new%200%200%205%202%27%20xml%3Aspace%3D%27preserve%27%20viewBox%3D%270%200%205%202%27%20preserveAspectRatio' +
   '%3D%27none%20slice%27%3E%3Ccircle%20cx%3D%271%27%20cy%3D%271%27%20r%3D%271%27%20fill%3D%27' +
-  md-color($md-primary, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
-$md-buffer-bubbles-accent-url: url(
+  mat-color($mat-primary, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
+$mat-buffer-bubbles-accent-url: url(
   'data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%271.1%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27' +
   '%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%27%20x%3D%270px%27%20y%3D%270px%27%20enable-backgroun' +
   'd%3D%27new%200%200%205%202%27%20xml%3Aspace%3D%27preserve%27%20viewBox%3D%270%200%205%202%27%20preserveAspectRatio' +
   '%3D%27none%20slice%27%3E%3Ccircle%20cx%3D%271%27%20cy%3D%271%27%20r%3D%271%27%20fill%3D%27' +
-  md-color($md-accent, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
-$md-buffer-bubbles-warn-url: url(
+  mat-color($mat-accent, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
+$mat-buffer-bubbles-warn-url: url(
   'data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%271.1%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27' +
   '%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%27%20x%3D%270px%27%20y%3D%270px%27%20enable-backgroun' +
   'd%3D%27new%200%200%205%202%27%20xml%3Aspace%3D%27preserve%27%20viewBox%3D%270%200%205%202%27%20preserveAspectRatio' +
   '%3D%27none%20slice%27%3E%3Ccircle%20cx%3D%271%27%20cy%3D%271%27%20r%3D%271%27%20fill%3D%27' +
-  md-color($md-warn, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
+  mat-color($mat-warn, 100) + '%27%2F%3E%3C%2Fsvg%3E') !default;
 
 :host {
   display: block;
-  // Height is provided for md-progress-bar to act as a default.
-  height: $md-progress-bar-height;
+  // Height is provided for mat-progress-bar to act as a default.
+  height: $mat-progress-bar-height;
   overflow: hidden;
   position: relative;
-  // translateZ is added to force the md-progress-bar into its own GPU layer.
+  // translateZ is added to force the mat-progress-bar into its own GPU layer.
   transform: translateZ(0);
-  transition: opacity $md-progress-bar-piece-animation-duration linear;
+  transition: opacity $mat-progress-bar-piece-animation-duration linear;
   width: 100%;
 
   // The progress bar background is used to show the bubble animation scrolling behind a buffering progress bar.
-  .md-progress-bar-background {
-    background: $md-buffer-bubbles-primary-url;
+  .mat-progress-bar-background {
+    background: $mat-buffer-bubbles-primary-url;
     background-repeat: repeat-x;
     background-size: 10px 4px;
     height: 100%;
@@ -63,40 +63,40 @@ $md-buffer-bubbles-warn-url: url(
    * The progress bar buffer is the bar indicator showing the buffer value and is only visible beyond the current value
    * of the primary progress bar.
    */
-  .md-progress-bar-buffer {
-    background-color: md-color($md-primary, 100);
+  .mat-progress-bar-buffer {
+    background-color: mat-color($mat-primary, 100);
     height: 100%;
     position: absolute;
     transform-origin: top left;
-    transition: transform $md-progress-bar-piece-animation-duration ease;
+    transition: transform $mat-progress-bar-piece-animation-duration ease;
     width: 100%;
   }
 
   /**
    * The secondary progress bar is only used in the indeterminate animation, because of this it is hidden in other uses.
    */
-  .md-progress-bar-secondary {
+  .mat-progress-bar-secondary {
     visibility: hidden;
   }
 
   /**
   * The progress bar fill fills the progress bar with the indicator color.
   */
-  .md-progress-bar-fill {
+  .mat-progress-bar-fill {
     animation: none;
     height: 100%;
     position: absolute;
     transform-origin: top left;
-    transition: transform $md-progress-bar-piece-animation-duration ease;
+    transition: transform $mat-progress-bar-piece-animation-duration ease;
     width: 100%;
   }
 
   /**
   * A pseudo element is created for each progress bar bar that fills with the indicator color.
   */
-  .md-progress-bar-fill::after {
+  .mat-progress-bar-fill::after {
     animation: none;
-    background-color: md-color($md-primary, 600);
+    background-color: mat-color($mat-primary, 600);
     content: '';
     display: inline-block;
     height: 100%;
@@ -105,30 +105,30 @@ $md-buffer-bubbles-warn-url: url(
   }
 
   &[color='accent'] {
-    .md-progress-bar-background {
-      background: $md-buffer-bubbles-accent-url;
+    .mat-progress-bar-background {
+      background: $mat-buffer-bubbles-accent-url;
       background-repeat: repeat-x;
       background-size: 10px 4px;
     }
-    .md-progress-bar-buffer {
-      background-color: md-color($md-accent, 100);
+    .mat-progress-bar-buffer {
+      background-color: mat-color($mat-accent, 100);
     }
-    .md-progress-bar-fill::after {
-      background-color: md-color($md-accent, 600);
+    .mat-progress-bar-fill::after {
+      background-color: mat-color($mat-accent, 600);
     }
   }
 
   &[color='warn'] {
-    .md-progress-bar-background {
-      background: $md-buffer-bubbles-warn-url;
+    .mat-progress-bar-background {
+      background: $mat-buffer-bubbles-warn-url;
       background-repeat: repeat-x;
       background-size: 10px 4px;
     }
-    .md-progress-bar-buffer {
-      background-color: md-color($md-warn, 100);
+    .mat-progress-bar-buffer {
+      background-color: mat-color($mat-warn, 100);
     }
-    .md-progress-bar-fill::after {
-      background-color: md-color($md-warn, 600);
+    .mat-progress-bar-fill::after {
+      background-color: mat-color($mat-warn, 600);
     }
   }
 
@@ -138,29 +138,29 @@ $md-buffer-bubbles-warn-url: url(
 
   &[mode='indeterminate'],
   &[mode='query'] {
-    .md-progress-bar-fill {
+    .mat-progress-bar-fill {
       transition: none;
     }
-    .md-progress-bar-primary {
-      animation: md-progress-bar-primary-indeterminate-translate $md-progress-bar-full-animation-duration infinite linear;
+    .mat-progress-bar-primary {
+      animation: mat-progress-bar-primary-indeterminate-translate $mat-progress-bar-full-animation-duration infinite linear;
       left: -145.166611%;
     }
-    .md-progress-bar-primary.md-progress-bar-fill::after {
-      animation: md-progress-bar-primary-indeterminate-scale $md-progress-bar-full-animation-duration infinite linear;
+    .mat-progress-bar-primary.mat-progress-bar-fill::after {
+      animation: mat-progress-bar-primary-indeterminate-scale $mat-progress-bar-full-animation-duration infinite linear;
     }
-    .md-progress-bar-secondary {
-      animation: md-progress-bar-secondary-indeterminate-translate $md-progress-bar-full-animation-duration infinite linear;
+    .mat-progress-bar-secondary {
+      animation: mat-progress-bar-secondary-indeterminate-translate $mat-progress-bar-full-animation-duration infinite linear;
       left: -54.888891%;
       visibility: visible;
     }
-    .md-progress-bar-secondary.md-progress-bar-fill::after {
-      animation: md-progress-bar-secondary-indeterminate-scale $md-progress-bar-full-animation-duration infinite linear;
+    .mat-progress-bar-secondary.mat-progress-bar-fill::after {
+      animation: mat-progress-bar-secondary-indeterminate-scale $mat-progress-bar-full-animation-duration infinite linear;
     }
   }
 
   &[mode='buffer'] {
-    .md-progress-bar-background {
-      animation: md-progress-bar-background-scroll $md-progress-bar-piece-animation-duration infinite linear;
+    .mat-progress-bar-background {
+      animation: mat-progress-bar-background-scroll $mat-progress-bar-piece-animation-duration infinite linear;
       visibility: visible;
     }
   }
@@ -173,7 +173,7 @@ $md-buffer-bubbles-warn-url: url(
 }
 
 
-/** The values used for animations in md-progress-bar, both timing and transformation, can be considered magic values.
+/** The values used for animations in mat-progress-bar, both timing and transformation, can be considered magic values.
     They are sourced from the Material Design example spec and duplicate the values of the original designers
     definitions.
 
@@ -195,38 +195,38 @@ $md-buffer-bubbles-warn-url: url(
 */
 
 // Progress Bar Timing functions:
-// $md-progress-bar-primary-indeterminate-translate-step-1 has no timing function.
-$md-progress-bar-primary-indeterminate-translate-step-2: cubic-bezier(0.5, 0, 0.701732, 0.495819) !default;
-$md-progress-bar-primary-indeterminate-translate-step-3: cubic-bezier(0.302435, 0.381352, 0.55, 0.956352) !default;
-// $md-progress-bar-primary-indeterminate-translate-step-4 has no timing function.
+// $mat-progress-bar-primary-indeterminate-translate-step-1 has no timing function.
+$mat-progress-bar-primary-indeterminate-translate-step-2: cubic-bezier(0.5, 0, 0.701732, 0.495819) !default;
+$mat-progress-bar-primary-indeterminate-translate-step-3: cubic-bezier(0.302435, 0.381352, 0.55, 0.956352) !default;
+// $mat-progress-bar-primary-indeterminate-translate-step-4 has no timing function.
 
-// $md-progress-bar-primary-indeterminate-scale-step-1 has no timing function
-$md-progress-bar-primary-indeterminate-scale-step-2: cubic-bezier(0.334731, 0.12482, 0.785844, 1) !default;
-$md-progress-bar-primary-indeterminate-scale-step-3: cubic-bezier(0.06, 0.11, 0.6, 1) !default;
-// $md-progress-bar-primary-indeterminate-scale-step-4 has no timing function
+// $mat-progress-bar-primary-indeterminate-scale-step-1 has no timing function
+$mat-progress-bar-primary-indeterminate-scale-step-2: cubic-bezier(0.334731, 0.12482, 0.785844, 1) !default;
+$mat-progress-bar-primary-indeterminate-scale-step-3: cubic-bezier(0.06, 0.11, 0.6, 1) !default;
+// $mat-progress-bar-primary-indeterminate-scale-step-4 has no timing function
 
-$md-progress-bar-secondary-indeterminate-translate-step-1: cubic-bezier(0.15, 0, 0.515058, 0.409685) !default;
-$md-progress-bar-secondary-indeterminate-translate-step-2: cubic-bezier(0.31033, 0.284058, 0.8, 0.733712) !default;
-$md-progress-bar-secondary-indeterminate-translate-step-3: cubic-bezier(0.4, 0.627035, 0.6, 0.902026) !default;
-// $md-progress-bar-secondary-indeterminate-translate-step-4 has no timing function
+$mat-progress-bar-secondary-indeterminate-translate-step-1: cubic-bezier(0.15, 0, 0.515058, 0.409685) !default;
+$mat-progress-bar-secondary-indeterminate-translate-step-2: cubic-bezier(0.31033, 0.284058, 0.8, 0.733712) !default;
+$mat-progress-bar-secondary-indeterminate-translate-step-3: cubic-bezier(0.4, 0.627035, 0.6, 0.902026) !default;
+// $mat-progress-bar-secondary-indeterminate-translate-step-4 has no timing function
 
-$md-progress-bar-secondary-indeterminate-scale-step-1: cubic-bezier(0.15, 0, 0.515058, 0.409685) !default;
-$md-progress-bar-secondary-indeterminate-scale-step-2: cubic-bezier(0.31033, 0.284058, 0.8, 0.733712) !default;
-$md-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.627035, 0.6, 0.902026) !default;
-// $md-progress-bar-secondary-indeterminate-scale-step-4 has no timing function
+$mat-progress-bar-secondary-indeterminate-scale-step-1: cubic-bezier(0.15, 0, 0.515058, 0.409685) !default;
+$mat-progress-bar-secondary-indeterminate-scale-step-2: cubic-bezier(0.31033, 0.284058, 0.8, 0.733712) !default;
+$mat-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.627035, 0.6, 0.902026) !default;
+// $mat-progress-bar-secondary-indeterminate-scale-step-4 has no timing function
 
 /** Animations for indeterminate and query mode. */
 // Primary indicator.
-@keyframes md-progress-bar-primary-indeterminate-translate {
+@keyframes mat-progress-bar-primary-indeterminate-translate {
   0% {
     transform: translateX(0);
   }
   20% {
-    animation-timing-function: $md-progress-bar-primary-indeterminate-translate-step-2;
+    animation-timing-function: $mat-progress-bar-primary-indeterminate-translate-step-2;
     transform: translateX(0);
   }
   59.15% {
-    animation-timing-function: $md-progress-bar-primary-indeterminate-translate-step-3;
+    animation-timing-function: $mat-progress-bar-primary-indeterminate-translate-step-3;
     transform: translateX(83.67142%);
   }
   100% {
@@ -234,16 +234,16 @@ $md-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.62703
   }
 }
 
-@keyframes md-progress-bar-primary-indeterminate-scale {
+@keyframes mat-progress-bar-primary-indeterminate-scale {
   0% {
     transform: scaleX(0.08);
   }
   36.65% {
-    animation-timing-function: $md-progress-bar-primary-indeterminate-scale-step-2;
+    animation-timing-function: $mat-progress-bar-primary-indeterminate-scale-step-2;
     transform: scaleX(0.08);
   }
   69.15% {
-    animation-timing-function: $md-progress-bar-primary-indeterminate-scale-step-3;
+    animation-timing-function: $mat-progress-bar-primary-indeterminate-scale-step-3;
     transform: scaleX(0.661479);
   }
   100% {
@@ -252,18 +252,18 @@ $md-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.62703
 }
 
 // Secondary indicator.
-@keyframes md-progress-bar-secondary-indeterminate-translate {
+@keyframes mat-progress-bar-secondary-indeterminate-translate {
   0% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-translate-step-1;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-translate-step-1;
     transform: translateX(0);
   }
   25% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-translate-step-2;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-translate-step-2;
 
     transform: translateX(37.651913%);
   }
   48.35% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-translate-step-3;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-translate-step-3;
     transform: translateX(84.386165%);
   }
   100% {
@@ -271,17 +271,17 @@ $md-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.62703
   }
 }
 
-@keyframes md-progress-bar-secondary-indeterminate-scale {
+@keyframes mat-progress-bar-secondary-indeterminate-scale {
   0% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-scale-step-1;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-scale-step-1;
     transform: scaleX(0.08);
   }
   19.15% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-scale-step-2;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-scale-step-2;
     transform: scaleX(0.457104);
   }
   44.15% {
-    animation-timing-function: $md-progress-bar-secondary-indeterminate-scale-step-3;
+    animation-timing-function: $mat-progress-bar-secondary-indeterminate-scale-step-3;
     transform: scaleX(0.72796);
   }
   100% {
@@ -290,7 +290,7 @@ $md-progress-bar-secondary-indeterminate-scale-step-3: cubic-bezier(0.4, 0.62703
 }
 
 /** Animation for buffer mode. */
-@keyframes md-progress-bar-background-scroll {
+@keyframes mat-progress-bar-background-scroll {
   to {
     transform: translateX(-10px);
   }

--- a/src/lib/progress-bar/progress-bar.spec.ts
+++ b/src/lib/progress-bar/progress-bar.spec.ts
@@ -1,14 +1,14 @@
 import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdProgressBarModule} from './progress-bar';
+import {MatProgressBarModule} from './progress-bar';
 
 
-describe('MdProgressBar', () => {
+describe('MatProgressBar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdProgressBarModule.forRoot()],
+      imports: [MatProgressBarModule.forRoot()],
       declarations: [
         BasicProgressBar,
         BufferProgressBar,
@@ -28,18 +28,18 @@ describe('MdProgressBar', () => {
     });
 
     it('should apply a mode of "determinate" if no mode is provided.', () => {
-      let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
       expect(progressElement.componentInstance.mode).toBe('determinate');
     });
 
     it('should define default values for value and bufferValue attributes', () => {
-      let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
       expect(progressElement.componentInstance.value).toBe(0);
       expect(progressElement.componentInstance.bufferValue).toBe(0);
     });
 
     it('should clamp value and bufferValue between 0 and 100', () => {
-      let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
       let progressComponent = progressElement.componentInstance;
 
       progressComponent.value = 50;
@@ -62,7 +62,7 @@ describe('MdProgressBar', () => {
     });
 
     it('should return the transform attribute for bufferValue and mode', () => {
-      let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
       let progressComponent = progressElement.componentInstance;
 
       expect(progressComponent._primaryTransform()).toEqual({transform: 'scaleX(0)'});
@@ -98,15 +98,15 @@ describe('MdProgressBar', () => {
     });
 
     it('should not modify the mode if a valid mode is provided.', () => {
-      let progressElement = fixture.debugElement.query(By.css('md-progress-bar'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
       expect(progressElement.componentInstance.mode).toBe('buffer');
     });
   });
 });
 
 
-@Component({template: '<md-progress-bar></md-progress-bar>'})
+@Component({template: '<mat-progress-bar></mat-progress-bar>'})
 class BasicProgressBar { }
 
-@Component({template: '<md-progress-bar mode="buffer"></md-progress-bar>'})
+@Component({template: '<mat-progress-bar mode="buffer"></mat-progress-bar>'})
 class BufferProgressBar { }

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -13,11 +13,11 @@ import {CommonModule} from '@angular/common';
 
 
 /**
- * <md-progress-bar> component.
+ * <mat-progress-bar> component.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-progress-bar',
+  selector: 'mat-progress-bar',
   host: {
     'role': 'progressbar',
     'aria-valuemin': '0',
@@ -27,7 +27,7 @@ import {CommonModule} from '@angular/common';
   styleUrls: ['progress-bar.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdProgressBar {
+export class MatProgressBar {
   /** Value of the progressbar. Defaults to zero. Mirrored to aria-valuenow. */
   private _value: number = 0;
 
@@ -90,13 +90,13 @@ function clamp(v: number, min = 0, max = 100) {
 
 @NgModule({
   imports: [CommonModule],
-  exports: [MdProgressBar],
-  declarations: [MdProgressBar],
+  exports: [MatProgressBar],
+  declarations: [MatProgressBar],
 })
-export class MdProgressBarModule {
+export class MatProgressBarModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdProgressBarModule,
+      ngModule: MatProgressBarModule,
       providers: []
     };
   }

--- a/src/lib/progress-circle/progress-circle.html
+++ b/src/lib/progress-circle/progress-circle.html
@@ -1,6 +1,6 @@
 <!--
   preserveAspectRatio of xMidYMid meet as the center of the viewport is the circle's
-  center.  The center of the circle with remain at the center of the md-progress-circle
+  center.  The center of the circle with remain at the center of the mat-progress-circle
   element containing the SVG.
 -->
 <svg viewBox="0 0 100 100"

--- a/src/lib/progress-circle/progress-circle.scss
+++ b/src/lib/progress-circle/progress-circle.scss
@@ -3,22 +3,22 @@
 @import 'default-theme';
 
 /* Animation Durations */
-$md-progress-circle-duration: 5250ms !default;
-$md-progress-circle-constant-rotate-duration: $md-progress-circle-duration * 0.55 !default;
-$md-progress-circle-sporadic-rotate-duration: $md-progress-circle-duration !default;
+$mat-progress-circle-duration: 5250ms !default;
+$mat-progress-circle-constant-rotate-duration: $mat-progress-circle-duration * 0.55 !default;
+$mat-progress-circle-sporadic-rotate-duration: $mat-progress-circle-duration !default;
 
 /** Component sizing */
-$md-progress-circle-stroke-width: 10px !default;
-// Height and weight of the viewport for md-progress-circle.
-$md-progress-circle-viewport-size: 100px !default;
+$mat-progress-circle-stroke-width: 10px !default;
+// Height and weight of the viewport for mat-progress-circle.
+$mat-progress-circle-viewport-size: 100px !default;
 
 
 :host {
   display: block;
-  /** Height and width are provided for md-progress-circle to act as a default.
+  /** Height and width are provided for mat-progress-circle to act as a default.
       The height and width are expected to be overwritten by application css. */
-  height: $md-progress-circle-viewport-size;
-  width: $md-progress-circle-viewport-size;
+  height: $mat-progress-circle-viewport-size;
+  width: $mat-progress-circle-viewport-size;
 
   /** SVG's viewBox is defined as 0 0 100 100, this means that all SVG children will placed
       based on a 100px by 100px box.  Additionally all SVG sizes and locations are in reference to
@@ -33,26 +33,26 @@ $md-progress-circle-viewport-size: 100px !default;
 
   path {
     fill: transparent;
-    stroke: md-color($md-primary, 600);
+    stroke: mat-color($mat-primary, 600);
     /** Stroke width of 10px defines stroke as 10% of the viewBox */
-    stroke-width: $md-progress-circle-stroke-width;
+    stroke-width: $mat-progress-circle-stroke-width;
   }
 
   &[color='accent'] path {
-    stroke: md-color($md-accent, 600);
+    stroke: mat-color($mat-accent, 600);
   }
 
 
   &[color='warn'] path {
-    stroke: md-color($md-warn, 600);
+    stroke: mat-color($mat-warn, 600);
   }
 
 
   &[mode='indeterminate'] {
-    animation-duration: $md-progress-circle-sporadic-rotate-duration,
-                        $md-progress-circle-constant-rotate-duration;
-    animation-name: md-progress-circle-sporadic-rotate,
-                    md-progress-circle-linear-rotate;
+    animation-duration: $mat-progress-circle-sporadic-rotate-duration,
+                        $mat-progress-circle-constant-rotate-duration;
+    animation-name: mat-progress-circle-sporadic-rotate,
+                    mat-progress-circle-linear-rotate;
     animation-timing-function: $ease-in-out-curve-function,
                                linear;
     animation-iteration-count: infinite;
@@ -62,11 +62,11 @@ $md-progress-circle-viewport-size: 100px !default;
 
 
 /** Animations for indeterminate mode */
-@keyframes md-progress-circle-linear-rotate {
+@keyframes mat-progress-circle-linear-rotate {
   0%       { transform: rotate(0deg); }
   100%     { transform: rotate(360deg); }
 }
-@keyframes md-progress-circle-sporadic-rotate {
+@keyframes mat-progress-circle-sporadic-rotate {
   12.5%    { transform: rotate( 135deg); }
   25%      { transform: rotate( 270deg); }
   37.5%    { transform: rotate( 405deg); }

--- a/src/lib/progress-circle/progress-circle.spec.ts
+++ b/src/lib/progress-circle/progress-circle.spec.ts
@@ -1,14 +1,14 @@
 import {TestBed, async} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdProgressCircleModule} from './progress-circle';
+import {MatProgressCircleModule} from './progress-circle';
 
 
-describe('MdProgressCircular', () => {
+describe('MatProgressCircular', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdProgressCircleModule.forRoot()],
+      imports: [MatProgressCircleModule.forRoot()],
       declarations: [
         BasicProgressSpinner,
         IndeterminateProgressSpinner,
@@ -24,7 +24,7 @@ describe('MdProgressCircular', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
       fixture.detectChanges();
 
-      let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+      let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
       expect(progressElement.componentInstance.mode).toBe('determinate');
   });
 
@@ -32,7 +32,7 @@ describe('MdProgressCircular', () => {
     let fixture = TestBed.createComponent(IndeterminateProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
     expect(progressElement.componentInstance.mode).toBe('indeterminate');
   });
 
@@ -40,13 +40,13 @@ describe('MdProgressCircular', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
     expect(progressElement.componentInstance.value).toBeUndefined();
   });
 
   it('should set the value to undefined when the mode is set to indeterminate', () => {
     let fixture = TestBed.createComponent(ProgressSpinnerWithValueAndBoundMode);
-    let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
     fixture.debugElement.componentInstance.mode = 'determinate';
     fixture.detectChanges();
 
@@ -60,7 +60,7 @@ describe('MdProgressCircular', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
     let progressComponent = progressElement.componentInstance;
 
     progressComponent.value = 50;
@@ -77,7 +77,7 @@ describe('MdProgressCircular', () => {
     let fixture = TestBed.createComponent(IndeterminateProgressSpinnerWithNgIf);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('md-progress-circle'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-circle'));
     expect(progressElement.componentInstance.interdeterminateInterval).toBeTruthy();
 
     fixture.debugElement.componentInstance.isHidden = true;
@@ -87,15 +87,15 @@ describe('MdProgressCircular', () => {
 });
 
 
-@Component({template: '<md-progress-circle></md-progress-circle>'})
+@Component({template: '<mat-progress-circle></mat-progress-circle>'})
 class BasicProgressSpinner { }
 
-@Component({template: '<md-progress-circle mode="indeterminate"></md-progress-circle>'})
+@Component({template: '<mat-progress-circle mode="indeterminate"></mat-progress-circle>'})
 class IndeterminateProgressSpinner { }
 
-@Component({template: '<md-progress-circle value="50" [mode]="mode"></md-progress-circle>'})
+@Component({template: '<mat-progress-circle value="50" [mode]="mode"></mat-progress-circle>'})
 class ProgressSpinnerWithValueAndBoundMode { }
 
 @Component({template: `
-    <md-progress-circle mode="indeterminate" *ngIf="!isHidden"></md-progress-circle>`})
+    <mat-progress-circle mode="indeterminate" *ngIf="!isHidden"></mat-progress-circle>`})
 class IndeterminateProgressSpinnerWithNgIf { }

--- a/src/lib/progress-circle/progress-circle.ts
+++ b/src/lib/progress-circle/progress-circle.ts
@@ -30,11 +30,11 @@ type EasingFn = (currentTime: number, startValue: number,
 
 
 /**
- * <md-progress-circle> component.
+ * <mat-progress-circle> component.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-progress-circle',
+  selector: 'mat-progress-circle',
   host: {
     'role': 'progressbar',
     '[attr.aria-valuemin]': '_ariaValueMin',
@@ -44,7 +44,7 @@ type EasingFn = (currentTime: number, startValue: number,
   styleUrls: ['progress-circle.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdProgressCircle implements OnDestroy {
+export class MatProgressCircle implements OnDestroy {
   /** The id of the last requested animation. */
   private _lastAnimationId: number = 0;
 
@@ -214,14 +214,14 @@ export class MdProgressCircle implements OnDestroy {
 
 
 /**
- * <md-spinner> component.
+ * <mat-spinner> component.
  *
  * This is a component definition to be used as a convenience reference to create an
- * indeterminate <md-progress-circle> instance.
+ * indeterminate <mat-progress-circle> instance.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-spinner',
+  selector: 'mat-spinner',
   host: {
     'role': 'progressbar',
     'mode': 'indeterminate',
@@ -229,7 +229,7 @@ export class MdProgressCircle implements OnDestroy {
   templateUrl: 'progress-circle.html',
   styleUrls: ['progress-circle.css'],
 })
-export class MdSpinner extends MdProgressCircle {
+export class MatSpinner extends MatProgressCircle {
   constructor(changeDetectorRef: ChangeDetectorRef) {
     super(changeDetectorRef);
     this.mode = 'indeterminate';
@@ -316,13 +316,13 @@ function getSvgArc(currentValue: number, rotation: number) {
 
 
 @NgModule({
-  exports: [MdProgressCircle, MdSpinner],
-  declarations: [MdProgressCircle, MdSpinner],
+  exports: [MatProgressCircle, MatSpinner],
+  declarations: [MatProgressCircle, MatSpinner],
 })
-export class MdProgressCircleModule {
+export class MatProgressCircleModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdProgressCircleModule,
+      ngModule: MatProgressCircleModule,
       providers: []
     };
   }

--- a/src/lib/radio/radio.html
+++ b/src/lib/radio/radio.html
@@ -1,14 +1,14 @@
 <!-- TODO(jelbourn): render the radio on either side of the content -->
 <!-- TODO(mtlin): Evaluate trade-offs of using native radio vs. cost of additional bindings. -->
-<label [attr.for]="inputId" class="md-radio-label">
+<label [attr.for]="inputId" class="mat-radio-label">
   <!-- The actual 'radio' part of the control. -->
-  <div class="md-radio-container">
-    <div class="md-radio-outer-circle"></div>
-    <div class="md-radio-inner-circle"></div>
-    <div class="md-ink-ripple"></div>
+  <div class="mat-radio-container">
+    <div class="mat-radio-outer-circle"></div>
+    <div class="mat-radio-inner-circle"></div>
+    <div class="mat-ink-ripple"></div>
   </div>
 
-  <input #input class="md-radio-input" type="radio"
+  <input #input class="mat-radio-input" type="radio"
           [id]="inputId"
           [checked]="checked"
           [disabled]="disabled"
@@ -21,7 +21,7 @@
           (click)="_onInputClick($event)">
 
   <!-- The label content for radio control. -->
-  <div class="md-radio-label-content" [class.md-radio-align-end]="align == 'end'">
+  <div class="mat-radio-label-content" [class.mat-radio-align-end]="align == 'end'">
     <ng-content></ng-content>
   </div>
 </label>

--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -2,16 +2,16 @@
 @import 'variables';
 @import 'mixins';
 
-$md-radio-size: $md-toggle-size !default;
+$mat-radio-size: $mat-toggle-size !default;
 
 // Top-level host container.
-md-radio-button {
+mat-radio-button {
   display: inline-block;
 }
 
 // Inner label container, wrapping entire element.
 // Enables focus by click.
-.md-radio-label {
+.mat-radio-label {
   cursor: pointer;
   display: inline-flex;
   align-items: baseline;
@@ -19,94 +19,94 @@ md-radio-button {
 }
 
 // Container for radio circles and ripple.
-.md-radio-container {
+.mat-radio-container {
   box-sizing: border-box;
   display: inline-block;
-  height: $md-radio-size;
+  height: $mat-radio-size;
   position: relative;
-  width: $md-radio-size;
+  width: $mat-radio-size;
   top: 2px;
 }
 
 // The outer circle for the radio, always present.
-.md-radio-outer-circle {
-  border-color: md-color($md-foreground, secondary-text);
+.mat-radio-outer-circle {
+  border-color: mat-color($mat-foreground, secondary-text);
   border: solid 2px;
   border-radius: 50%;
   box-sizing: border-box;
-  height: $md-radio-size;
+  height: $mat-radio-size;
   left: 0;
   position: absolute;
   top: 0;
   transition: border-color ease 280ms;
-  width: $md-radio-size;
+  width: $mat-radio-size;
 
-  .md-radio-checked & {
-    border-color: md-color($md-accent);
+  .mat-radio-checked & {
+    border-color: mat-color($mat-accent);
   }
 
-  .md-radio-disabled & {
-    border-color: md-color($md-foreground, disabled);
+  .mat-radio-disabled & {
+    border-color: mat-color($mat-foreground, disabled);
   }
 }
 
 // The inner circle for the radio, shown when checked.
-.md-radio-inner-circle {
-  background-color: md-color($md-accent);
+.mat-radio-inner-circle {
+  background-color: mat-color($mat-accent);
   border-radius: 50%;
   box-sizing: border-box;
-  height: $md-radio-size;
+  height: $mat-radio-size;
   left: 0;
   position: absolute;
   top: 0;
   transition: transform ease 280ms, background-color ease 280ms;
   transform: scale(0);
-  width: $md-radio-size;
+  width: $mat-radio-size;
 
-  .md-radio-checked & {
+  .mat-radio-checked & {
     transform: scale(0.5);
   }
 
-  .md-radio-disabled & {
-    background-color: md-color($md-foreground, disabled);
+  .mat-radio-disabled & {
+    background-color: mat-color($mat-foreground, disabled);
   }
 }
 
 // Text label next to radio.
-.md-radio-label-content {
+.mat-radio-label-content {
   display: inline-block;
   order: 0;
   line-height: inherit;
-  padding-left: $md-toggle-padding;
+  padding-left: $mat-toggle-padding;
   padding-right: 0;
 
   [dir='rtl'] & {
-    padding-right: $md-toggle-padding;
+    padding-right: $mat-toggle-padding;
     padding-left: 0;
   }
 }
 
 // Alignment.
-.md-radio-label-content.md-radio-align-end {
+.mat-radio-label-content.mat-radio-align-end {
   order: -1;
   padding-left: 0;
-  padding-right: $md-toggle-padding;
+  padding-right: $mat-toggle-padding;
 
   [dir='rtl'] & {
     padding-right: 0;
-    padding-left: $md-toggle-padding;
+    padding-left: $mat-toggle-padding;
   }
 }
 
 // Underlying native input element.
 // Visually hidden but still able to respond to focus.
-.md-radio-input {
-  @include md-visually-hidden;
+.mat-radio-input {
+  @include mat-visually-hidden;
 }
 
 // Basic disabled state.
-.md-radio-disabled, .md-radio-disabled .md-radio-label {
+.mat-radio-disabled, .mat-radio-disabled .mat-radio-label {
   cursor: default;
 }
 
-@include md-temporary-ink-ripple(radio);
+@include mat-temporary-ink-ripple(radio);

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -2,14 +2,14 @@ import {async, fakeAsync, ComponentFixture, TestBed} from '@angular/core/testing
 import {NgControl, FormsModule} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdRadioGroup, MdRadioButton, MdRadioChange, MdRadioModule} from './radio';
+import {MatRadioGroup, MatRadioButton, MatRadioChange, MatRadioModule} from './radio';
 
 
-describe('MdRadio', () => {
+describe('MatRadio', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdRadioModule.forRoot(), FormsModule],
+      imports: [MatRadioModule.forRoot(), FormsModule],
       declarations: [
         RadiosInsideRadioGroup,
         RadioGroupWithNgModel,
@@ -27,8 +27,8 @@ describe('MdRadio', () => {
     let radioDebugElements: DebugElement[];
     let radioNativeElements: HTMLElement[];
     let radioLabelElements: HTMLLabelElement[];
-    let groupInstance: MdRadioGroup;
-    let radioInstances: MdRadioButton[];
+    let groupInstance: MatRadioGroup;
+    let radioInstances: MatRadioButton[];
     let testComponent: RadiosInsideRadioGroup;
 
     beforeEach(async(() => {
@@ -37,11 +37,11 @@ describe('MdRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdRadioGroup);
+      groupInstance = groupDebugElement.injector.get(MatRadioGroup);
 
-      radioDebugElements = fixture.debugElement.queryAll(By.directive(MdRadioButton));
+      radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
       radioNativeElements = radioDebugElements.map(debugEl => debugEl.nativeElement);
       radioInstances = radioDebugElements.map(debugEl => debugEl.componentInstance);
 
@@ -174,17 +174,17 @@ describe('MdRadio', () => {
     it('should focus individual radio buttons', () => {
       let nativeRadioInput = <HTMLElement> radioNativeElements[0].querySelector('input');
 
-      expect(nativeRadioInput.classList).not.toContain('md-radio-focused');
+      expect(nativeRadioInput.classList).not.toContain('mat-radio-focused');
 
       dispatchFocusChangeEvent('focus', nativeRadioInput);
       fixture.detectChanges();
 
-      expect(radioNativeElements[0].classList).toContain('md-radio-focused');
+      expect(radioNativeElements[0].classList).toContain('mat-radio-focused');
 
       dispatchFocusChangeEvent('blur', nativeRadioInput);
       fixture.detectChanges();
 
-      expect(radioNativeElements[0].classList).not.toContain('md-radio-focused');
+      expect(radioNativeElements[0].classList).not.toContain('mat-radio-focused');
     });
 
     it('should update the group and radios when updating the group value', () => {
@@ -225,8 +225,8 @@ describe('MdRadio', () => {
     let radioDebugElements: DebugElement[];
     let radioNativeElements: HTMLElement[];
     let radioLabelElements: HTMLLabelElement[];
-    let groupInstance: MdRadioGroup;
-    let radioInstances: MdRadioButton[];
+    let groupInstance: MatRadioGroup;
+    let radioInstances: MatRadioButton[];
     let testComponent: RadioGroupWithNgModel;
     let groupNgControl: NgControl;
 
@@ -236,12 +236,12 @@ describe('MdRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdRadioGroup);
+      groupInstance = groupDebugElement.injector.get(MatRadioGroup);
       groupNgControl = groupDebugElement.injector.get(NgControl);
 
-      radioDebugElements = fixture.debugElement.queryAll(By.directive(MdRadioButton));
+      radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
       radioNativeElements = radioDebugElements.map(debugEl => debugEl.nativeElement);
       radioInstances = radioDebugElements.map(debugEl => debugEl.componentInstance);
 
@@ -327,9 +327,9 @@ describe('MdRadio', () => {
   describe('as standalone', () => {
     let fixture: ComponentFixture<StandaloneRadioButtons>;
     let radioDebugElements: DebugElement[];
-    let seasonRadioInstances: MdRadioButton[];
-    let weatherRadioInstances: MdRadioButton[];
-    let fruitRadioInstances: MdRadioButton[];
+    let seasonRadioInstances: MatRadioButton[];
+    let weatherRadioInstances: MatRadioButton[];
+    let fruitRadioInstances: MatRadioButton[];
     let fruitRadioNativeInputs: HTMLElement[];
     let testComponent: StandaloneRadioButtons;
 
@@ -339,7 +339,7 @@ describe('MdRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      radioDebugElements = fixture.debugElement.queryAll(By.directive(MdRadioButton));
+      radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
       seasonRadioInstances = radioDebugElements
           .filter(debugEl => debugEl.componentInstance.name == 'season')
           .map(debugEl => debugEl.componentInstance);
@@ -429,14 +429,14 @@ describe('MdRadio', () => {
 
 @Component({
   template: `
-  <md-radio-group [disabled]="isGroupDisabled"
+  <mat-radio-group [disabled]="isGroupDisabled"
                   [align]="alignment"
                   [value]="groupValue"
                   name="test-name">
-    <md-radio-button value="fire">Charmander</md-radio-button>
-    <md-radio-button value="water">Squirtle</md-radio-button>
-    <md-radio-button value="leaf">Bulbasaur</md-radio-button>
-  </md-radio-group>
+    <mat-radio-button value="fire">Charmander</mat-radio-button>
+    <mat-radio-button value="water">Squirtle</mat-radio-button>
+    <mat-radio-button value="leaf">Bulbasaur</mat-radio-button>
+  </mat-radio-group>
   `
 })
 class RadiosInsideRadioGroup {
@@ -448,18 +448,18 @@ class RadiosInsideRadioGroup {
 
 @Component({
   template: `
-    <md-radio-button name="season" value="spring">Spring</md-radio-button>
-    <md-radio-button name="season" value="summer">Summer</md-radio-button>
-    <md-radio-button name="season" value="autum">Autumn</md-radio-button>
+    <mat-radio-button name="season" value="spring">Spring</mat-radio-button>
+    <mat-radio-button name="season" value="summer">Summer</mat-radio-button>
+    <mat-radio-button name="season" value="autum">Autumn</mat-radio-button>
     
-    <md-radio-button name="weather" value="warm">Spring</md-radio-button>
-    <md-radio-button name="weather" value="hot">Summer</md-radio-button>
-    <md-radio-button name="weather" value="cool">Autumn</md-radio-button>
+    <mat-radio-button name="weather" value="warm">Spring</mat-radio-button>
+    <mat-radio-button name="weather" value="hot">Summer</mat-radio-button>
+    <mat-radio-button name="weather" value="cool">Autumn</mat-radio-button>
     
     <span id="xyz">Baby Banana</span>
-    <md-radio-button name="fruit" value="banana" aria-label="Banana" aria-labelledby="xyz">
-    </md-radio-button>
-    <md-radio-button name="fruit" value="raspberry">Raspberry</md-radio-button>
+    <mat-radio-button name="fruit" value="banana" aria-label="Banana" aria-labelledby="xyz">
+    </mat-radio-button>
+    <mat-radio-button name="fruit" value="raspberry">Raspberry</mat-radio-button>
   `
 })
 class StandaloneRadioButtons { }
@@ -467,11 +467,11 @@ class StandaloneRadioButtons { }
 
 @Component({
   template: `
-  <md-radio-group [(ngModel)]="modelValue" (change)="lastEvent = $event">
-    <md-radio-button *ngFor="let option of options" [value]="option.value">
+  <mat-radio-group [(ngModel)]="modelValue" (change)="lastEvent = $event">
+    <mat-radio-button *ngFor="let option of options" [value]="option.value">
       {{option.label}}
-    </md-radio-button>
-  </md-radio-group>
+    </mat-radio-button>
+  </mat-radio-group>
   `
 })
 class RadioGroupWithNgModel {
@@ -481,7 +481,7 @@ class RadioGroupWithNgModel {
     {label: 'Chocolate', value: 'chocolate'},
     {label: 'Strawberry', value: 'strawberry'},
   ];
-  lastEvent: MdRadioChange;
+  lastEvent: MatRadioChange;
 }
 
 // TODO(jelbourn): remove eveything below when Angular supports faking events.

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -19,21 +19,21 @@ import {
   NG_VALUE_ACCESSOR,
   ControlValueAccessor
 } from '@angular/forms';
-import {MdUniqueSelectionDispatcher} from '@angular2-material/core';
+import {MatUniqueSelectionDispatcher} from '@angular2-material/core';
 
 
 // Re-exports.
-export {MdUniqueSelectionDispatcher} from '@angular2-material/core';
+export {MatUniqueSelectionDispatcher} from '@angular2-material/core';
 
 
 
 /**
- * Provider Expression that allows md-radio-group to register as a ControlValueAccessor. This
+ * Provider Expression that allows mat-radio-group to register as a ControlValueAccessor. This
  * allows it to support [(ngModel)] and ngControl.
  */
-export const MD_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
+export const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdRadioGroup),
+  useExisting: forwardRef(() => MatRadioGroup),
   multi: true
 };
 
@@ -47,20 +47,20 @@ export const MD_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
 
 var _uniqueIdCounter = 0;
 
-/** A simple change event emitted by either MdRadioButton or MdRadioGroup. */
-export class MdRadioChange {
-  source: MdRadioButton;
+/** A simple change event emitted by either MatRadioButton or MatRadioGroup. */
+export class MatRadioChange {
+  source: MatRadioButton;
   value: any;
 }
 
 @Directive({
-  selector: 'md-radio-group',
-  providers: [MD_RADIO_GROUP_CONTROL_VALUE_ACCESSOR],
+  selector: 'mat-radio-group',
+  providers: [MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR],
   host: {
     'role': 'radiogroup',
   },
 })
-export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
+export class MatRadioGroup implements AfterContentInit, ControlValueAccessor {
   /**
    * Selected value for group. Should equal the value of the selected radio button if there *is*
    * a corresponding radio button with a matching value. If there is *not* such a corresponding
@@ -70,13 +70,13 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   private _value: any = null;
 
   /** The HTML name attribute applied to radio buttons in this group. */
-  private _name: string = `md-radio-group-${_uniqueIdCounter++}`;
+  private _name: string = `mat-radio-group-${_uniqueIdCounter++}`;
 
   /** Disables all individual radio buttons assigned to this group. */
   private _disabled: boolean = false;
 
   /** The currently selected radio button. Should match value. */
-  private _selected: MdRadioButton = null;
+  private _selected: MatRadioButton = null;
 
   /** Whether the `value` has been set to its initial value. */
   private _isInitialized: boolean = false;
@@ -89,11 +89,11 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Event emitted when the group value changes. */
   @Output()
-  change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
+  change: EventEmitter<MatRadioChange> = new EventEmitter<MatRadioChange>();
 
   /** Child radio buttons. */
-  @ContentChildren(forwardRef(() => MdRadioButton))
-  _radios: QueryList<MdRadioButton> = null;
+  @ContentChildren(forwardRef(() => MatRadioButton))
+  _radios: QueryList<MatRadioButton> = null;
 
   @Input()
   get name(): string {
@@ -141,7 +141,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
     return this._selected;
   }
 
-  set selected(selected: MdRadioButton) {
+  set selected(selected: MatRadioButton) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
 
@@ -157,8 +157,8 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
    */
   ngAfterContentInit() {
     // Mark this component as initialized in AfterContentInit because the initial value can
-    // possibly be set by NgModel on MdRadioGroup, and it is possible that the OnInit of the
-    // NgModel occurs *after* the OnInit of the MdRadioGroup.
+    // possibly be set by NgModel on MatRadioGroup, and it is possible that the OnInit of the
+    // NgModel occurs *after* the OnInit of the MatRadioGroup.
     this._isInitialized = true;
   }
 
@@ -199,7 +199,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Dispatch change event with current selection and group value. */
   private _emitChangeEvent(): void {
-    let event = new MdRadioChange();
+    let event = new MatRadioChange();
     event.source = this._selected;
     event.value = this._value;
     this._controlValueAccessorChangeFn(event.value);
@@ -234,14 +234,14 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-radio-button',
+  selector: 'mat-radio-button',
   templateUrl: 'radio.html',
   styleUrls: ['radio.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class MdRadioButton implements OnInit {
+export class MatRadioButton implements OnInit {
 
-  @HostBinding('class.md-radio-focused')
+  @HostBinding('class.mat-radio-focused')
   _isFocused: boolean;
 
   /** Whether this radio is checked. */
@@ -250,7 +250,7 @@ export class MdRadioButton implements OnInit {
   /** The unique ID for the radio button. */
   @HostBinding('id')
   @Input()
-  id: string = `md-radio-${_uniqueIdCounter++}`;
+  id: string = `mat-radio-${_uniqueIdCounter++}`;
 
   /** Analog to HTML 'name' attribute used to group radios for unique selection. */
   @Input()
@@ -269,14 +269,14 @@ export class MdRadioButton implements OnInit {
   private _value: any = null;
 
   /** The parent radio group. May or may not be present. */
-  radioGroup: MdRadioGroup;
+  radioGroup: MatRadioGroup;
 
   /** Event emitted when the group value changes. */
   @Output()
-  change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
+  change: EventEmitter<MatRadioChange> = new EventEmitter<MatRadioChange>();
 
-  constructor(@Optional() radioGroup: MdRadioGroup,
-              public radioDispatcher: MdUniqueSelectionDispatcher) {
+  constructor(@Optional() radioGroup: MatRadioGroup,
+              public radioDispatcher: MatUniqueSelectionDispatcher) {
     // Assertions. Ideally these should be stripped out by the compiler.
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.
 
@@ -293,7 +293,7 @@ export class MdRadioButton implements OnInit {
     return `${this.id}-input`;
   }
 
-  @HostBinding('class.md-radio-checked')
+  @HostBinding('class.mat-radio-checked')
   @Input()
   get checked(): boolean {
     return this._checked;
@@ -312,7 +312,7 @@ export class MdRadioButton implements OnInit {
     }
   }
 
-  /** MdRadioGroup reads this to assign its own value. */
+  /** MatRadioGroup reads this to assign its own value. */
   @Input()
   get value(): any {
     return this._value;
@@ -338,7 +338,7 @@ export class MdRadioButton implements OnInit {
     this._align = value;
   }
 
-  @HostBinding('class.md-radio-disabled')
+  @HostBinding('class.mat-radio-disabled')
   @Input()
   get disabled(): boolean {
     return this._disabled || (this.radioGroup != null && this.radioGroup.disabled);
@@ -361,7 +361,7 @@ export class MdRadioButton implements OnInit {
 
   /** Dispatch change event with current value. */
   private _emitChangeEvent(): void {
-    let event = new MdRadioChange();
+    let event = new MatRadioChange();
     event.source = this;
     event.value = this._value;
     this.change.emit(event);
@@ -419,14 +419,14 @@ export class MdRadioButton implements OnInit {
 
 
 @NgModule({
-  exports: [MdRadioGroup, MdRadioButton],
-  declarations: [MdRadioGroup, MdRadioButton],
+  exports: [MatRadioGroup, MatRadioButton],
+  declarations: [MatRadioGroup, MatRadioButton],
 })
-export class MdRadioModule {
+export class MatRadioModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdRadioModule,
-      providers: [MdUniqueSelectionDispatcher],
+      ngModule: MatRadioModule,
+      providers: [MatUniqueSelectionDispatcher],
     };
   }
 }

--- a/src/lib/sidenav/sidenav-transitions.scss
+++ b/src/lib/sidenav/sidenav-transitions.scss
@@ -3,14 +3,14 @@
  */
 @import 'variables';
 
-md-sidenav {
+mat-sidenav {
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 }
 
-.md-sidenav-content {
+.mat-sidenav-content {
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 }
 
-.md-sidenav-backdrop.md-sidenav-shown {
+.mat-sidenav-backdrop.mat-sidenav-shown {
   transition: background-color $swift-ease-out-duration $swift-ease-out-timing-function;
 }

--- a/src/lib/sidenav/sidenav.html
+++ b/src/lib/sidenav/sidenav.html
@@ -1,8 +1,8 @@
-<div class="md-sidenav-backdrop" (click)="_closeModalSidenav()"
-     [class.md-sidenav-shown]="_isShowingBackdrop()"></div>
+<div class="mat-sidenav-backdrop" (click)="_closeModalSidenav()"
+     [class.mat-sidenav-shown]="_isShowingBackdrop()"></div>
 
-<ng-content select="md-sidenav"></ng-content>
+<ng-content select="mat-sidenav"></ng-content>
 
-<div class="md-sidenav-content" [ngStyle]="_getStyles()">
+<div class="mat-sidenav-content" [ngStyle]="_getStyles()">
   <ng-content></ng-content>
 </div>

--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -6,9 +6,9 @@
 
 // We use invert() here to have the darken the background color expected to be used. If the
 // background is light, we use a dark backdrop. If the background is dark, we use a light backdrop.
-$md-sidenav-backdrop-color: invert(md-color($md-background, card, 0.6)) !default;
-$md-sidenav-background-color: md-color($md-background, dialog) !default;
-$md-sidenav-push-background-color: md-color($md-background, dialog) !default;
+$mat-sidenav-backdrop-color: invert(mat-color($mat-background, card, 0.6)) !default;
+$mat-sidenav-background-color: mat-color($mat-background, dialog) !default;
+$mat-sidenav-push-background-color: mat-color($mat-background, dialog) !default;
 
 
 /**
@@ -16,38 +16,38 @@ $md-sidenav-push-background-color: md-color($md-background, dialog) !default;
  * @param $open The translation value when the sidenav is opened.
  * @param $close The translation value when the sidenav is closed.
  */
-@mixin md-sidenav-transition($open, $close) {
+@mixin mat-sidenav-transition($open, $close) {
   transform: translate3d($close, 0, 0);
 
-  &.md-sidenav-closed {
+  &.mat-sidenav-closed {
     // We use 'visibility: hidden | visible' because 'display: none' will not animate any
     // transitions, while visibility will interpolate transitions properly.
     // see https://developer.mozilla.org/en-US/docs/Web/CSS/visibility, the Interpolation
     // section.
     visibility: hidden;
   }
-  &.md-sidenav-closing {
+  &.mat-sidenav-closing {
     transform: translate3d($close, 0, 0);
     will-change: transform;
   }
-  &.md-sidenav-opening {
-    @include md-elevation(1);
+  &.mat-sidenav-opening {
+    @include mat-elevation(1);
     visibility: visible;
     transform: translate3d($open, 0, 0);
     will-change: transform;
   }
-  &.md-sidenav-opened {
-    @include md-elevation(1);
+  &.mat-sidenav-opened {
+    @include mat-elevation(1);
     transform: translate3d($open, 0, 0);
   }
 }
 
-md-sidenav-layout {
+mat-sidenav-layout {
   // We need a stacking context here so that the backdrop and drawers are clipped to the
-  // MdSidenavLayout. This creates a new z-index stack so we use low numbered z-indices.
-  // We create another stacking context in the '.md-sidenav-content' and in each sidenav so that
+  // MatSidenavLayout. This creates a new z-index stack so we use low numbered z-indices.
+  // We create another stacking context in the '.mat-sidenav-content' and in each sidenav so that
   // the application content does not get messed up with our own CSS.
-  @include md-stacking-context();
+  @include mat-stacking-context();
 
   box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
@@ -60,16 +60,16 @@ md-sidenav-layout {
 
   // TODO(hansl): Update this with a more robust solution.
   &[fullscreen] {
-    @include md-fullscreen();
+    @include mat-fullscreen();
 
-    &.md-sidenav-opened {
+    &.mat-sidenav-opened {
       overflow: hidden;
     }
   }
 }
 
-.md-sidenav-backdrop {
-  @include md-fullscreen();
+.mat-sidenav-backdrop {
+  @include mat-fullscreen();
 
   display: block;
 
@@ -83,22 +83,22 @@ md-sidenav-layout {
   // section.
   visibility: hidden;
 
-  &.md-sidenav-shown {
+  &.mat-sidenav-shown {
     visibility: visible;
-    background-color: $md-sidenav-backdrop-color;
+    background-color: $mat-sidenav-backdrop-color;
   }
 }
 
-.md-sidenav-content {
-  @include md-stacking-context();
+.mat-sidenav-content {
+  @include mat-stacking-context();
 
   display: block;
   height: 100%;
   overflow: auto;
 }
 
-md-sidenav {
-  @include md-stacking-context();
+mat-sidenav {
+  @include mat-stacking-context();
 
   display: block;
   position: absolute;
@@ -110,32 +110,32 @@ md-sidenav {
   // TODO(kara): revisit scrolling behavior for sidenavs
   overflow-y: auto;
 
-  background-color: $md-sidenav-background-color;
+  background-color: $mat-sidenav-background-color;
 
-  @include md-sidenav-transition(0, -100%);
+  @include mat-sidenav-transition(0, -100%);
 
-  &.md-sidenav-push {
-    background-color: $md-sidenav-push-background-color;
+  &.mat-sidenav-push {
+    background-color: $mat-sidenav-push-background-color;
   }
 
-  &.md-sidenav-side {
+  &.mat-sidenav-side {
     z-index: 1;
   }
 
-  &.md-sidenav-end {
+  &.mat-sidenav-end {
     right: 0;
 
-    @include md-sidenav-transition(0, 100%);
+    @include mat-sidenav-transition(0, 100%);
   }
 
   [dir='rtl'] & {
-    @include md-sidenav-transition(0, 100%);
+    @include mat-sidenav-transition(0, 100%);
 
-    &.md-sidenav-end {
+    &.mat-sidenav-end {
       left: 0;
       right: auto;
 
-      @include md-sidenav-transition(0, -100%);
+      @include mat-sidenav-transition(0, -100%);
     }
   }
 }

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -1,11 +1,11 @@
 import {fakeAsync, async, tick, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdSidenav, MdSidenavModule} from './sidenav';
+import {MatSidenav, MatSidenavModule} from './sidenav';
 
 
 function endSidenavTransition(fixture: ComponentFixture<any>) {
-  let sidenav: any = fixture.debugElement.query(By.directive(MdSidenav)).componentInstance;
+  let sidenav: any = fixture.debugElement.query(By.directive(MatSidenav)).componentInstance;
   sidenav._onTransitionEnd(<any> {
     target: (<any>sidenav)._elementRef.nativeElement,
     propertyName: 'transform'
@@ -14,11 +14,11 @@ function endSidenavTransition(fixture: ComponentFixture<any>) {
 }
 
 
-describe('MdSidenav', () => {
+describe('MatSidenav', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSidenavModule.forRoot()],
+      imports: [MatSidenavModule.forRoot()],
       declarations: [
         BasicTestApp,
         SidenavLayoutTwoSidenavTestApp,
@@ -52,8 +52,8 @@ describe('MdSidenav', () => {
       expect(testComponent.closeStartCount).toBe(0);
       expect(testComponent.closeCount).toBe(0);
 
-      let sidenavElement = fixture.debugElement.query(By.css('md-sidenav'));
-      let sidenavBackdropElement = fixture.debugElement.query(By.css('.md-sidenav-backdrop'));
+      let sidenavElement = fixture.debugElement.query(By.css('mat-sidenav'));
+      let sidenavBackdropElement = fixture.debugElement.query(By.css('.mat-sidenav-backdrop'));
       expect(getComputedStyle(sidenavElement.nativeElement).visibility).toEqual('visible');
       expect(getComputedStyle(sidenavBackdropElement.nativeElement).visibility)
         .toEqual('visible');
@@ -83,8 +83,8 @@ describe('MdSidenav', () => {
 
     it('open/close() return a promise that resolves after animation end', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
-      let sidenav: MdSidenav = fixture.debugElement
-        .query(By.directive(MdSidenav)).componentInstance;
+      let sidenav: MatSidenav = fixture.debugElement
+        .query(By.directive(MatSidenav)).componentInstance;
       let called = false;
 
       sidenav.open().then(() => {
@@ -110,8 +110,8 @@ describe('MdSidenav', () => {
 
     it('open/close() twice returns the same promise', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
-      let sidenav: MdSidenav = fixture.debugElement
-        .query(By.directive(MdSidenav)).componentInstance;
+      let sidenav: MatSidenav = fixture.debugElement
+        .query(By.directive(MatSidenav)).componentInstance;
 
       let promise = sidenav.open();
       expect(sidenav.open()).toBe(promise);
@@ -125,8 +125,8 @@ describe('MdSidenav', () => {
 
     it('open() then close() cancel animations when called too fast', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
-      let sidenav: MdSidenav = fixture.debugElement
-        .query(By.directive(MdSidenav)).componentInstance;
+      let sidenav: MatSidenav = fixture.debugElement
+        .query(By.directive(MatSidenav)).componentInstance;
 
       let openCalled = false;
       let openCancelled = false;
@@ -154,8 +154,8 @@ describe('MdSidenav', () => {
 
     it('close() then open() cancel animations when called too fast', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
-      let sidenav: MdSidenav = fixture.debugElement
-        .query(By.directive(MdSidenav)).componentInstance;
+      let sidenav: MatSidenav = fixture.debugElement
+        .query(By.directive(MatSidenav)).componentInstance;
 
       let closeCalled = false;
       let closeCancelled = false;
@@ -209,20 +209,20 @@ describe('MdSidenav', () => {
       let fixture = TestBed.createComponent(SidenavSetToOpenedFalse);
       fixture.detectChanges();
 
-      let sidenavEl = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
+      let sidenavEl = fixture.debugElement.query(By.css('mat-sidenav')).nativeElement;
 
-      expect(sidenavEl.classList).toContain('md-sidenav-closed');
-      expect(sidenavEl.classList).not.toContain('md-sidenav-opened');
+      expect(sidenavEl.classList).toContain('mat-sidenav-closed');
+      expect(sidenavEl.classList).not.toContain('mat-sidenav-opened');
     });
 
     it('should correctly parse opened="true"', () => {
       let fixture = TestBed.createComponent(SidenavSetToOpenedTrue);
       fixture.detectChanges();
 
-      let sidenavEl = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
+      let sidenavEl = fixture.debugElement.query(By.css('mat-sidenav')).nativeElement;
 
-      expect(sidenavEl.classList).not.toContain('md-sidenav-closed');
-      expect(sidenavEl.classList).toContain('md-sidenav-opened');
+      expect(sidenavEl.classList).not.toContain('mat-sidenav-closed');
+      expect(sidenavEl.classList).toContain('mat-sidenav-opened');
     });
 
   });
@@ -230,34 +230,34 @@ describe('MdSidenav', () => {
 });
 
 
-/** Test component that contains an MdSidenavLayout but no MdSidenav. */
-@Component({template: `<md-sidenav-layout></md-sidenav-layout>`})
+/** Test component that contains an MatSidenavLayout but no MatSidenav. */
+@Component({template: `<mat-sidenav-layout></mat-sidenav-layout>`})
 class SidenavLayoutNoSidenavTestApp { }
 
-/** Test component that contains an MdSidenavLayout and 2 MdSidenav on the same side. */
+/** Test component that contains an MatSidenavLayout and 2 MatSidenav on the same side. */
 @Component({
   template: `
-    <md-sidenav-layout>
-      <md-sidenav> </md-sidenav>
-      <md-sidenav> </md-sidenav>
-    </md-sidenav-layout>`,
+    <mat-sidenav-layout>
+      <mat-sidenav> </mat-sidenav>
+      <mat-sidenav> </mat-sidenav>
+    </mat-sidenav-layout>`,
 })
 class SidenavLayoutTwoSidenavTestApp { }
 
-/** Test component that contains an MdSidenavLayout and one MdSidenav. */
+/** Test component that contains an MatSidenavLayout and one MatSidenav. */
 @Component({
   template: `
-    <md-sidenav-layout>
-      <md-sidenav #sidenav align="start"
+    <mat-sidenav-layout>
+      <mat-sidenav #sidenav align="start"
                   (open-start)="openStart()"
                   (open)="open()"
                   (close-start)="closeStart()"
                   (close)="close()">
         Content.
-      </md-sidenav>
+      </mat-sidenav>
       <button (click)="sidenav.open()" class="open"></button>
       <button (click)="sidenav.close()" class="close"></button>
-    </md-sidenav-layout>`,
+    </mat-sidenav-layout>`,
 })
 class BasicTestApp {
   openStartCount: number = 0;
@@ -284,20 +284,20 @@ class BasicTestApp {
 
 @Component({
   template: `
-    <md-sidenav-layout>
-      <md-sidenav #sidenav mode="side" opened="false">
+    <mat-sidenav-layout>
+      <mat-sidenav #sidenav mode="side" opened="false">
         Closed Sidenav.
-      </md-sidenav>
-    </md-sidenav-layout>`,
+      </mat-sidenav>
+    </mat-sidenav-layout>`,
 })
 class SidenavSetToOpenedFalse { }
 
 @Component({
   template: `
-    <md-sidenav-layout>
-      <md-sidenav #sidenav mode="side" opened="true">
+    <mat-sidenav-layout>
+      <mat-sidenav #sidenav mode="side" opened="true">
         Closed Sidenav.
-      </md-sidenav>
-    </md-sidenav-layout>`,
+      </mat-sidenav>
+    </mat-sidenav-layout>`,
 })
 class SidenavSetToOpenedTrue { }

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -16,25 +16,25 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {Dir, MdError, BooleanFieldValue} from '@angular2-material/core';
+import {Dir, MatError, BooleanFieldValue} from '@angular2-material/core';
 
-/** Exception thrown when two MdSidenav are matching the same side. */
-export class MdDuplicatedSidenavError extends MdError {
+/** Exception thrown when two MatSidenav are matching the same side. */
+export class MatDuplicatedSidenavError extends MatError {
   constructor(align: string) {
     super(`A sidenav was already declared for 'align="${align}"'`);
   }
 }
 
 /**
- * <md-sidenav> component.
+ * <mat-sidenav> component.
  *
  * This component corresponds to the drawer of the sidenav.
  *
- * Please refer to README.md for examples on how to use it.
+ * Please refer to README.mat for examples on how to use it.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-sidenav',
+  selector: 'mat-sidenav',
   template: '<ng-content></ng-content>',
   host: {
     '(transitionend)': '_onTransitionEnd($event)',
@@ -42,7 +42,7 @@ export class MdDuplicatedSidenavError extends MdError {
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MdSidenav {
+export class MatSidenav {
   /** Alignment of the sidenav (direction neutral); whether 'start' or 'end'. */
   @Input() align: 'start' | 'end' = 'start';
 
@@ -174,32 +174,32 @@ export class MdSidenav {
     }
   }
 
-  @HostBinding('class.md-sidenav-closing') get _isClosing() {
+  @HostBinding('class.mat-sidenav-closing') get _isClosing() {
     return !this._opened && this._transition;
   }
-  @HostBinding('class.md-sidenav-opening') get _isOpening() {
+  @HostBinding('class.mat-sidenav-opening') get _isOpening() {
     return this._opened && this._transition;
   }
-  @HostBinding('class.md-sidenav-closed') get _isClosed() {
+  @HostBinding('class.mat-sidenav-closed') get _isClosed() {
     return !this._opened && !this._transition;
   }
-  @HostBinding('class.md-sidenav-opened') get _isOpened() {
+  @HostBinding('class.mat-sidenav-opened') get _isOpened() {
     return this._opened && !this._transition;
   }
-  @HostBinding('class.md-sidenav-end') get _isEnd() {
+  @HostBinding('class.mat-sidenav-end') get _isEnd() {
     return this.align == 'end';
   }
-  @HostBinding('class.md-sidenav-side') get _modeSide() {
+  @HostBinding('class.mat-sidenav-side') get _modeSide() {
     return this.mode == 'side';
   }
-  @HostBinding('class.md-sidenav-over') get _modeOver() {
+  @HostBinding('class.mat-sidenav-over') get _modeOver() {
     return this.mode == 'over';
   }
-  @HostBinding('class.md-sidenav-push') get _modePush() {
+  @HostBinding('class.mat-sidenav-push') get _modePush() {
     return this.mode == 'push';
   }
 
-  /** TODO: internal (needed by MdSidenavLayout). */
+  /** TODO: internal (needed by MatSidenavLayout). */
   get _width() {
     if (this._elementRef.nativeElement) {
       return this._elementRef.nativeElement.offsetWidth;
@@ -217,17 +217,17 @@ export class MdSidenav {
 }
 
 /**
- * <md-sidenav-layout> component.
+ * <mat-sidenav-layout> component.
  *
- * This is the parent component to one or two <md-sidenav>s that validates the state internally
+ * This is the parent component to one or two <mat-sidenav>s that validates the state internally
  * and coordinate the backdrop and content styling.
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-sidenav-layout',
+  selector: 'mat-sidenav-layout',
   // Do not use ChangeDetectionStrategy.OnPush. It does not work for this component because
-  // technically it is a sibling of MdSidenav (on the content tree) and isn't updated when MdSidenav
-  // changes its state.
+  // technically it is a sibling of MatSidenav (on the content tree) and isn't updated when
+  // MatSidenav changes its state.
   templateUrl: 'sidenav.html',
   styleUrls: [
     'sidenav.css',
@@ -235,15 +235,15 @@ export class MdSidenav {
   ],
   encapsulation: ViewEncapsulation.None,
 })
-export class MdSidenavLayout implements AfterContentInit {
-  @ContentChildren(MdSidenav) _sidenavs: QueryList<MdSidenav>;
+export class MatSidenavLayout implements AfterContentInit {
+  @ContentChildren(MatSidenav) _sidenavs: QueryList<MatSidenav>;
 
   get start() { return this._start; }
   get end() { return this._end; }
 
   /** The sidenav at the start/end alignment, independent of direction. */
-  private _start: MdSidenav;
-  private _end: MdSidenav;
+  private _start: MatSidenav;
+  private _end: MatSidenav;
 
   /**
    * The sidenav at the left/right. When direction changes, these will change as well.
@@ -251,8 +251,8 @@ export class MdSidenavLayout implements AfterContentInit {
    * In LTR, _left == _start and _right == _end.
    * In RTL, _left == _end and _right == _start.
    */
-  private _left: MdSidenav;
-  private _right: MdSidenav;
+  private _left: MatSidenav;
+  private _right: MatSidenav;
 
   constructor(@Optional() private _dir: Dir, private _element: ElementRef,
               private _renderer: Renderer) {
@@ -267,7 +267,7 @@ export class MdSidenavLayout implements AfterContentInit {
   ngAfterContentInit() {
     // On changes, assert on consistency.
     this._sidenavs.changes.subscribe(() => this._validateDrawers());
-    this._sidenavs.forEach((sidenav: MdSidenav) => this._watchSidenavToggle(sidenav));
+    this._sidenavs.forEach((sidenav: MatSidenav) => this._watchSidenavToggle(sidenav));
     this._validateDrawers();
   }
 
@@ -276,15 +276,15 @@ export class MdSidenavLayout implements AfterContentInit {
   * is open and the backdrop is visible. This ensures any overflow on the layout element is properly
   * hidden.
   */
-  private _watchSidenavToggle(sidenav: MdSidenav): void {
+  private _watchSidenavToggle(sidenav: MatSidenav): void {
     if (!sidenav || sidenav.mode === 'side') { return; }
     sidenav.onOpen.subscribe(() => this._setLayoutClass(sidenav, true));
     sidenav.onClose.subscribe(() => this._setLayoutClass(sidenav, false));
   }
 
-  /* Toggles the 'md-sidenav-opened' class on the main 'md-sidenav-layout' element. */
-  private _setLayoutClass(sidenav: MdSidenav, bool: boolean): void {
-    this._renderer.setElementClass(this._element.nativeElement, 'md-sidenav-opened', bool);
+  /* Toggles the 'mat-sidenav-opened' class on the main 'mat-sidenav-layout' element. */
+  private _setLayoutClass(sidenav: MatSidenav, bool: boolean): void {
+    this._renderer.setElementClass(this._element.nativeElement, 'mat-sidenav-opened', bool);
   }
 
   /** Validate the state of the sidenav children components. */
@@ -295,12 +295,12 @@ export class MdSidenavLayout implements AfterContentInit {
     this._sidenavs.forEach(sidenav => {
       if (sidenav.align == 'end') {
         if (this._end != null) {
-          throw new MdDuplicatedSidenavError('end');
+          throw new MatDuplicatedSidenavError('end');
         }
         this._end = sidenav;
       } else {
         if (this._start != null) {
-          throw new MdDuplicatedSidenavError('start');
+          throw new MatDuplicatedSidenavError('start');
         }
         this._start = sidenav;
       }
@@ -332,7 +332,7 @@ export class MdSidenavLayout implements AfterContentInit {
         || (this._isSidenavOpen(this._end) && this._end.mode != 'side');
   }
 
-  private _isSidenavOpen(side: MdSidenav): boolean {
+  private _isSidenavOpen(side: MatSidenav): boolean {
     return side != null && side.opened;
   }
 
@@ -342,7 +342,7 @@ export class MdSidenavLayout implements AfterContentInit {
    * @param sidenav
    * @param mode
    */
-  private _getSidenavEffectiveWidth(sidenav: MdSidenav, mode: string): number {
+  private _getSidenavEffectiveWidth(sidenav: MatSidenav, mode: string): number {
     return (this._isSidenavOpen(sidenav) && sidenav.mode == mode) ? sidenav._width : 0;
   }
 
@@ -387,13 +387,13 @@ export class MdSidenavLayout implements AfterContentInit {
 
 @NgModule({
   imports: [CommonModule],
-  exports: [MdSidenavLayout, MdSidenav],
-  declarations: [MdSidenavLayout, MdSidenav],
+  exports: [MatSidenavLayout, MatSidenav],
+  declarations: [MatSidenavLayout, MatSidenav],
 })
-export class MdSidenavModule {
+export class MatSidenavModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdSidenavModule,
+      ngModule: MatSidenavModule,
       providers: []
     };
   }

--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -1,19 +1,19 @@
-<label class="md-slide-toggle-label">
+<label class="mat-slide-toggle-label">
 
-  <div class="md-slide-toggle-container">
-    <div class="md-slide-toggle-bar"></div>
+  <div class="mat-slide-toggle-container">
+    <div class="mat-slide-toggle-bar"></div>
 
-    <div class="md-slide-toggle-thumb-container"
+    <div class="mat-slide-toggle-thumb-container"
          (slidestart)="_onDragStart()"
          (slide)="_onDrag($event)"
          (slideend)="_onDragEnd()">
 
-      <div class="md-slide-toggle-thumb">
-        <div class="md-ink-ripple"></div>
+      <div class="mat-slide-toggle-thumb">
+        <div class="mat-ink-ripple"></div>
       </div>
     </div>
 
-    <input #input class="md-slide-toggle-checkbox" type="checkbox"
+    <input #input class="mat-slide-toggle-checkbox" type="checkbox"
            [id]="getInputId()"
            [tabIndex]="tabIndex"
            [checked]="checked"
@@ -26,7 +26,7 @@
            (change)="_onChangeEvent($event)"
            (click)="_onInputClick($event)">
   </div>
-  <span class="md-slide-toggle-content">
+  <span class="mat-slide-toggle-content">
     <ng-content></ng-content>
   </span>
 </label>

--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -5,98 +5,98 @@
 //TODO(): remove the default theme.
 @import 'default-theme';
 
-$md-slide-toggle-width: 36px !default;
-$md-slide-toggle-height: 24px !default;
-$md-slide-toggle-bar-height: 14px !default;
-$md-slide-toggle-thumb-size: 20px !default;
-$md-slide-toggle-margin: 16px !default;
+$mat-slide-toggle-width: 36px !default;
+$mat-slide-toggle-height: 24px !default;
+$mat-slide-toggle-bar-height: 14px !default;
+$mat-slide-toggle-thumb-size: 20px !default;
+$mat-slide-toggle-margin: 16px !default;
 
-@mixin md-switch-checked($palette) {
-  &.md-checked {
-    .md-slide-toggle-thumb {
-      background-color: md-color($palette);
+@mixin mat-switch-checked($palette) {
+  &.mat-checked {
+    .mat-slide-toggle-thumb {
+      background-color: mat-color($palette);
     }
 
-    .md-slide-toggle-bar {
-      background-color: md-color($palette, 0.5);
+    .mat-slide-toggle-bar {
+      background-color: mat-color($palette, 0.5);
     }
   }
 }
 
-@mixin md-switch-ripple($palette) {
+@mixin mat-switch-ripple($palette) {
   // Temporary ripple effect for the thumb of the slide-toggle.
   // Bind to the parent selector and specify the current palette.
-  @include md-temporary-ink-ripple(slide-toggle, true, $palette);
+  @include mat-temporary-ink-ripple(slide-toggle, true, $palette);
 
-  &.md-slide-toggle-focused {
-    &:not(.md-checked) .md-ink-ripple {
+  &.mat-slide-toggle-focused {
+    &:not(.mat-checked) .mat-ink-ripple {
       // When the slide-toggle is not checked and it shows its focus indicator, it should use a 12% opacity
       // of black in light themes and 12% of white in dark themes.
-      background-color: md-color($md-foreground, divider);
+      background-color: mat-color($mat-foreground, divider);
     }
   }
 }
 
 :host {
   display: flex;
-  height: $md-slide-toggle-height;
+  height: $mat-slide-toggle-height;
 
-  margin: $md-slide-toggle-margin 0;
-  line-height: $md-slide-toggle-height;
+  margin: $mat-slide-toggle-margin 0;
+  line-height: $mat-slide-toggle-height;
 
   white-space: nowrap;
   user-select: none;
 
   outline: none;
 
-  &.md-checked {
-    .md-slide-toggle-thumb-container {
+  &.mat-checked {
+    .mat-slide-toggle-thumb-container {
       transform: translate3d(100%, 0, 0);
     }
   }
 
-  @include md-switch-checked($md-accent);
-  @include md-switch-ripple($md-accent);
+  @include mat-switch-checked($mat-accent);
+  @include mat-switch-ripple($mat-accent);
 
-  &.md-primary {
-    @include md-switch-checked($md-primary);
-    @include md-switch-ripple($md-primary);
+  &.mat-primary {
+    @include mat-switch-checked($mat-primary);
+    @include mat-switch-ripple($mat-primary);
   }
 
-  &.md-warn {
-    @include md-switch-checked($md-warn);
-    @include md-switch-ripple($md-warn);
+  &.mat-warn {
+    @include mat-switch-checked($mat-warn);
+    @include mat-switch-ripple($mat-warn);
   }
 
-  &.md-disabled {
+  &.mat-disabled {
 
-    .md-slide-toggle-label, .md-slide-toggle-container {
+    .mat-slide-toggle-label, .mat-slide-toggle-container {
       cursor: default;
     }
 
-    .md-slide-toggle-thumb {
+    .mat-slide-toggle-thumb {
       // The thumb of the slide-toggle always uses the hue 400 of the grey palette in dark or light themes.
       // Since this is very specific to the slide-toggle component, we're not providing
       // it in the background palette.
-      background-color: md-color($md-grey, 400);
+      background-color: mat-color($mat-grey, 400);
     }
-    .md-slide-toggle-bar {
-      background-color: md-color($md-foreground, divider);
+    .mat-slide-toggle-bar {
+      background-color: mat-color($mat-foreground, divider);
     }
   }
 }
 
 // The content element is responsible for the users content.
 // It will apply the given typography styles and align at the end of the slide-toggle.
-.md-slide-toggle-content {
-  font-size: $md-body-font-size-base;
-  font-family: $md-font-family;
+.mat-slide-toggle-content {
+  font-size: $mat-body-font-size-base;
+  font-family: $mat-font-family;
   font-weight: 500;
 }
 
 // The label element is our root container for the slide-toggle / switch indicator and label text.
 // It has to be a label, to support accessibility for the visual hidden input.
-.md-slide-toggle-label {
+.mat-slide-toggle-label {
   display: flex;
   flex: 1;
 
@@ -104,10 +104,10 @@ $md-slide-toggle-margin: 16px !default;
 }
 
 // Container for the composition of the slide-toggle / switch indicator.
-.md-slide-toggle-container {
+.mat-slide-toggle-container {
   cursor: grab;
-  width: $md-slide-toggle-width;
-  height: $md-slide-toggle-height;
+  width: $mat-slide-toggle-width;
+  height: $mat-slide-toggle-height;
 
   position: relative;
   user-select: none;
@@ -117,13 +117,13 @@ $md-slide-toggle-margin: 16px !default;
 
 // The thumb container is responsible for the dragging functionality.
 // It moves around and holds the actual circle as a thumb.
-.md-slide-toggle-thumb-container {
+.mat-slide-toggle-thumb-container {
   position: absolute;
-  top: $md-slide-toggle-height / 2 - $md-slide-toggle-thumb-size / 2;
+  top: $mat-slide-toggle-height / 2 - $mat-slide-toggle-thumb-size / 2;
   left: 0;
   z-index: 1;
 
-  width: $md-slide-toggle-width - $md-slide-toggle-thumb-size;
+  width: $mat-slide-toggle-width - $mat-slide-toggle-thumb-size;
 
   transform: translate3d(0, 0, 0);
 
@@ -132,41 +132,41 @@ $md-slide-toggle-margin: 16px !default;
 
   // Once the thumb container is being dragged around, we remove the transition duration to
   // make the drag feeling fast and not delayed.
-  &.md-dragging {
+  &.mat-dragging {
     transition-duration: 0ms;
   }
 }
 
 // The thumb will be elevated from the slide-toggle bar.
 // Also the thumb is bound to its parent thumb-container, which manages the movement of the thumb.
-.md-slide-toggle-thumb {
+.mat-slide-toggle-thumb {
   position: absolute;
   margin: 0;
   left: 0;
   top: 0;
 
-  height: $md-slide-toggle-thumb-size;
-  width: $md-slide-toggle-thumb-size;
+  height: $mat-slide-toggle-thumb-size;
+  width: $mat-slide-toggle-thumb-size;
   border-radius: 50%;
 
-  background-color: md-color($md-background, background);
-  @include md-elevation(1);
+  background-color: mat-color($mat-background, background);
+  @include mat-elevation(1);
 }
 
 // Horizontal bar for the slide-toggle.
 // The slide-toggle bar is shown behind the thumb container.
-.md-slide-toggle-bar {
+.mat-slide-toggle-bar {
   position: absolute;
   left: 1px;
-  top: $md-slide-toggle-height / 2 - $md-slide-toggle-bar-height / 2;
+  top: $mat-slide-toggle-height / 2 - $mat-slide-toggle-bar-height / 2;
 
-  width: $md-slide-toggle-width - 2px;
-  height: $md-slide-toggle-bar-height;
+  width: $mat-slide-toggle-width - 2px;
+  height: $mat-slide-toggle-bar-height;
 
   // The bar of the slide-toggle always uses the hue 500 of the grey palette in dark or light themes.
   // Since this is very specific to the slide-toggle component, we're not providing
   // it in the background palette.
-  background-color: md-color($md-grey, 500);
+  background-color: mat-color($mat-grey, 500);
 
   border-radius: 8px;
 }
@@ -174,12 +174,12 @@ $md-slide-toggle-margin: 16px !default;
 // The slide toggle shows a visually hidden checkbox inside of the component.
 // This checkbox allows us to take advantage of the browsers support.
 // Like accessibility and keyboard interaction.
-.md-slide-toggle-checkbox {
-  @include md-visually-hidden();
+.mat-slide-toggle-checkbox {
+  @include mat-visually-hidden();
 }
 
-.md-slide-toggle-bar,
-.md-slide-toggle-thumb {
+.mat-slide-toggle-bar,
+.mat-slide-toggle-thumb {
   transition: $swift-linear;
   transition-property: background-color;
   transition-delay: 50ms;

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -1,14 +1,14 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
-import {MdSlideToggle, MdSlideToggleChange, MdSlideToggleModule} from './slide-toggle';
+import {MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule} from './slide-toggle';
 import {FormsModule, NgControl} from '@angular/forms';
 
-describe('MdSlideToggle', () => {
+describe('MatSlideToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSlideToggleModule.forRoot(), FormsModule],
+      imports: [MatSlideToggleModule.forRoot(), FormsModule],
       declarations: [SlideToggleTestApp],
     });
 
@@ -19,7 +19,7 @@ describe('MdSlideToggle', () => {
     let fixture: ComponentFixture<any>;
 
     let testComponent: SlideToggleTestApp;
-    let slideToggle: MdSlideToggle;
+    let slideToggle: MatSlideToggle;
     let slideToggleElement: HTMLElement;
     let slideToggleControl: NgControl;
     let labelElement: HTMLLabelElement;
@@ -39,7 +39,7 @@ describe('MdSlideToggle', () => {
       // Initialize the slide-toggle component, by triggering the first change detection cycle.
       fixture.detectChanges();
 
-      let slideToggleDebug = fixture.debugElement.query(By.css('md-slide-toggle'));
+      let slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
 
       slideToggle = slideToggleDebug.componentInstance;
       slideToggleElement = slideToggleDebug.nativeElement;
@@ -50,13 +50,13 @@ describe('MdSlideToggle', () => {
 
     // TODO(kara); update when core/testing adds fix
     it('should update the model correctly', async(() => {
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       testComponent.slideModel = true;
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
-        expect(slideToggleElement.classList).toContain('md-checked');
+        expect(slideToggleElement.classList).toContain('mat-checked');
       });
 
     }));
@@ -65,12 +65,12 @@ describe('MdSlideToggle', () => {
       testComponent.slideColor = 'primary';
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList).toContain('md-primary');
+      expect(slideToggleElement.classList).toContain('mat-primary');
 
       testComponent.slideColor = 'accent';
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList).toContain('md-accent');
+      expect(slideToggleElement.classList).toContain('mat-accent');
     });
 
     it('should correctly update the disabled property', () => {
@@ -93,12 +93,12 @@ describe('MdSlideToggle', () => {
 
     it('should set the toggle to checked on click', () => {
       expect(slideToggle.checked).toBe(false);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       labelElement.click();
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
       expect(slideToggle.checked).toBe(true);
     });
 
@@ -109,12 +109,12 @@ describe('MdSlideToggle', () => {
       // to an issue, where the click events on the slide-toggle are getting executed twice.
 
       expect(slideToggle.checked).toBe(false);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       labelElement.click();
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
       expect(slideToggle.checked).toBe(true);
 
       expect(testComponent.onSlideClick).toHaveBeenCalledTimes(1);
@@ -122,13 +122,13 @@ describe('MdSlideToggle', () => {
 
     it('should trigger the change event properly', async(() => {
       expect(inputElement.checked).toBe(false);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       labelElement.click();
       fixture.detectChanges();
 
       expect(inputElement.checked).toBe(true);
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
 
       // Wait for the fixture to become stable, because the EventEmitter for the change event,
       // will only fire after the zone async change detection has finished.
@@ -142,13 +142,13 @@ describe('MdSlideToggle', () => {
 
     it('should not trigger the change event by changing the native value', async(() => {
       expect(inputElement.checked).toBe(false);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       testComponent.slideChecked = true;
       fixture.detectChanges();
 
       expect(inputElement.checked).toBe(true);
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
 
       // Wait for the fixture to become stable, because the EventEmitter for the change event,
       // will only fire after the zone async change detection has finished.
@@ -162,13 +162,13 @@ describe('MdSlideToggle', () => {
 
     it('should not trigger the change event on initialization', async(() => {
       expect(inputElement.checked).toBe(false);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
 
       testComponent.slideChecked = true;
       fixture.detectChanges();
 
       expect(inputElement.checked).toBe(true);
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
 
       // Wait for the fixture to become stable, because the EventEmitter for the change event,
       // will only fire after the zone async change detection has finished.
@@ -194,7 +194,7 @@ describe('MdSlideToggle', () => {
       fixture.detectChanges();
 
       // Once the id input is falsy, we use a default prefix with a incrementing unique number.
-      expect(inputElement.id).toMatch(/md-slide-toggle-[0-9]+-input/g);
+      expect(inputElement.id).toMatch(/mat-slide-toggle-[0-9]+-input/g);
     });
 
     it('should forward the specified name to the input', () => {
@@ -256,7 +256,7 @@ describe('MdSlideToggle', () => {
     }));
 
     it('should support subscription on the change observable', () => {
-      slideToggle.change.subscribe((event: MdSlideToggleChange) => {
+      slideToggle.change.subscribe((event: MatSlideToggleChange) => {
         expect(event.checked).toBe(true);
       });
 
@@ -297,7 +297,7 @@ describe('MdSlideToggle', () => {
       fixture.detectChanges();
 
       expect(slideToggleControl.touched).toBe(false);
-      expect(slideToggleElement.classList).toContain('md-checked');
+      expect(slideToggleElement.classList).toContain('mat-checked');
 
       // After a user interaction occurs (such as a click), the control should remain dirty and
       // now also be touched.
@@ -305,7 +305,7 @@ describe('MdSlideToggle', () => {
       fixture.detectChanges();
 
       expect(slideToggleControl.touched).toBe(true);
-      expect(slideToggleElement.classList).not.toContain('md-checked');
+      expect(slideToggleElement.classList).not.toContain('mat-checked');
     });
 
     // TODO(kara): update when core/testing adds fix
@@ -319,17 +319,17 @@ describe('MdSlideToggle', () => {
         fixture.detectChanges();
         expect(slideToggleControl.touched).toBe(false);
         expect(slideToggle.checked).toBe(true);
-        expect(slideToggleElement.classList).toContain('md-checked');
+        expect(slideToggleElement.classList).toContain('mat-checked');
       });
     }));
 
     it('should correctly set the slide-toggle to checked on focus', () => {
-      expect(slideToggleElement.classList).not.toContain('md-slide-toggle-focused');
+      expect(slideToggleElement.classList).not.toContain('mat-slide-toggle-focused');
 
       dispatchFocusChangeEvent('focus', inputElement);
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList).toContain('md-slide-toggle-focused');
+      expect(slideToggleElement.classList).toContain('mat-slide-toggle-focused');
     });
 
   });
@@ -361,13 +361,13 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
 @Component({
   selector: 'slide-toggle-test-app',
   template: `
-    <md-slide-toggle [(ngModel)]="slideModel" [disabled]="isDisabled" [color]="slideColor" 
+    <mat-slide-toggle [(ngModel)]="slideModel" [disabled]="isDisabled" [color]="slideColor" 
                      [id]="slideId" [checked]="slideChecked" [name]="slideName" 
                      [ariaLabel]="slideLabel" [ariaLabelledby]="slideLabelledBy" 
                      (change)="onSlideChange($event)"
                      (click)="onSlideClick($event)">
       <span>Test Slide Toggle</span>
-    </md-slide-toggle>`,
+    </mat-slide-toggle>`,
 })
 class SlideToggleTestApp {
   isDisabled: boolean = false;
@@ -378,10 +378,10 @@ class SlideToggleTestApp {
   slideName: string;
   slideLabel: string;
   slideLabelledBy: string;
-  lastEvent: MdSlideToggleChange;
+  lastEvent: MatSlideToggleChange;
 
   onSlideClick(event: Event) {}
-  onSlideChange(event: MdSlideToggleChange) {
+  onSlideChange(event: MatSlideToggleChange) {
     this.lastEvent = event;
   }
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -19,18 +19,18 @@ import {
 } from '@angular/forms';
 import {BooleanFieldValue, applyCssTransform} from '@angular2-material/core';
 import {Observable} from 'rxjs/Observable';
-import {MdGestureConfig} from '@angular2-material/core';
+import {MatGestureConfig} from '@angular2-material/core';
 
 
-export const MD_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
+export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdSlideToggle),
+  useExisting: forwardRef(() => MatSlideToggle),
   multi: true
 };
 
-// A simple change event emitted by the MdSlideToggle component.
-export class MdSlideToggleChange {
-  source: MdSlideToggle;
+// A simple change event emitted by the MatSlideToggle component.
+export class MatSlideToggleChange {
+  source: MatSlideToggle;
   checked: boolean;
 }
 
@@ -39,26 +39,26 @@ let nextId = 0;
 
 @Component({
   moduleId: module.id,
-  selector: 'md-slide-toggle',
+  selector: 'mat-slide-toggle',
   host: {
-    '[class.md-checked]': 'checked',
-    '[class.md-disabled]': 'disabled',
-    // This md-slide-toggle prefix will change, once the temporary ripple is removed.
-    '[class.md-slide-toggle-focused]': '_hasFocus',
+    '[class.mat-checked]': 'checked',
+    '[class.mat-disabled]': 'disabled',
+    // This mat-slide-toggle prefix will change, once the temporary ripple is removed.
+    '[class.mat-slide-toggle-focused]': '_hasFocus',
     '(mousedown)': '_setMousedown()'
   },
   templateUrl: 'slide-toggle.html',
   styleUrls: ['slide-toggle.css'],
-  providers: [MD_SLIDE_TOGGLE_VALUE_ACCESSOR],
+  providers: [MAT_SLIDE_TOGGLE_VALUE_ACCESSOR],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
+export class MatSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   private onChange = (_: any) => {};
   private onTouched = () => {};
 
   // A unique id for the slide-toggle. By default the id is auto-generated.
-  private _uniqueId = `md-slide-toggle-${++nextId}`;
+  private _uniqueId = `mat-slide-toggle-${++nextId}`;
   private _checked: boolean = false;
   private _color: string;
   _hasFocus: boolean = false;
@@ -72,8 +72,8 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   @Input() ariaLabel: string = null;
   @Input() ariaLabelledby: string = null;
 
-  private _change: EventEmitter<MdSlideToggleChange> = new EventEmitter<MdSlideToggleChange>();
-  @Output() change: Observable<MdSlideToggleChange> = this._change.asObservable();
+  private _change: EventEmitter<MatSlideToggleChange> = new EventEmitter<MatSlideToggleChange>();
+  @Output() change: Observable<MatSlideToggleChange> = this._change.asObservable();
 
   // Returns the unique id for the visual hidden input.
   getInputId = () => `${this.id || this._uniqueId}-input`;
@@ -199,13 +199,13 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   private _setElementColor(color: string, isAdd: boolean) {
     if (color != null && color != '') {
-      this._renderer.setElementClass(this._elementRef.nativeElement, `md-${color}`, isAdd);
+      this._renderer.setElementClass(this._elementRef.nativeElement, `mat-${color}`, isAdd);
     }
   }
 
   /** Emits the change event to the `change` output EventEmitter */
   private _emitChangeEvent() {
-    let event = new MdSlideToggleChange();
+    let event = new MatSlideToggleChange();
     event.source = this;
     event.checked = this.checked;
     this._change.emit(event);
@@ -245,8 +245,8 @@ class SlideToggleRenderer {
   private _percentage: number;
 
   constructor(private _elementRef: ElementRef) {
-    this._thumbEl = _elementRef.nativeElement.querySelector('.md-slide-toggle-thumb-container');
-    this._thumbBarEl = _elementRef.nativeElement.querySelector('.md-slide-toggle-bar');
+    this._thumbEl = _elementRef.nativeElement.querySelector('.mat-slide-toggle-thumb-container');
+    this._thumbBarEl = _elementRef.nativeElement.querySelector('.mat-slide-toggle-bar');
   }
 
   /** Whether the slide-toggle is currently dragging. */
@@ -260,7 +260,7 @@ class SlideToggleRenderer {
     if (!this._thumbBarWidth) {
       this._thumbBarWidth = this._thumbBarEl.clientWidth - this._thumbEl.clientWidth;
       this._checked = checked;
-      this._thumbEl.classList.add('md-dragging');
+      this._thumbEl.classList.add('mat-dragging');
     }
   }
 
@@ -268,7 +268,7 @@ class SlideToggleRenderer {
   stopThumbDrag(): boolean {
     if (this._thumbBarWidth) {
       this._thumbBarWidth = null;
-      this._thumbEl.classList.remove('md-dragging');
+      this._thumbEl.classList.remove('mat-dragging');
 
       applyCssTransform(this._thumbEl, '');
 
@@ -301,14 +301,14 @@ class SlideToggleRenderer {
 
 @NgModule({
   imports: [FormsModule],
-  exports: [MdSlideToggle],
-  declarations: [MdSlideToggle],
+  exports: [MatSlideToggle],
+  declarations: [MatSlideToggle],
 })
-export class MdSlideToggleModule {
+export class MatSlideToggleModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdSlideToggleModule,
-      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig}]
+      ngModule: MatSlideToggleModule,
+      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MatGestureConfig}]
     };
   }
 }

--- a/src/lib/slider/slider.html
+++ b/src/lib/slider/slider.html
@@ -1,19 +1,19 @@
-<div class="md-slider-wrapper">
-  <div class="md-slider-container"
-       [class.md-slider-sliding]="isSliding"
-       [class.md-slider-active]="isActive"
-       [class.md-slider-thumb-label-showing]="thumbLabel">
-    <div class="md-slider-track-container">
-      <div class="md-slider-track"></div>
-      <div class="md-slider-track md-slider-track-fill"></div>
-      <div class="md-slider-tick-container"></div>
-      <div class="md-slider-last-tick-container"></div>
+<div class="mat-slider-wrapper">
+  <div class="mat-slider-container"
+       [class.mat-slider-sliding]="isSliding"
+       [class.mat-slider-active]="isActive"
+       [class.mat-slider-thumb-label-showing]="thumbLabel">
+    <div class="mat-slider-track-container">
+      <div class="mat-slider-track"></div>
+      <div class="mat-slider-track mat-slider-track-fill"></div>
+      <div class="mat-slider-tick-container"></div>
+      <div class="mat-slider-last-tick-container"></div>
     </div>
-    <div class="md-slider-thumb-container">
-      <div class="md-slider-thumb-position">
-        <div class="md-slider-thumb"></div>
-        <div class="md-slider-thumb-label">
-          <span class="md-slider-thumb-label-text">{{value}}</span>
+    <div class="mat-slider-thumb-container">
+      <div class="mat-slider-thumb-position">
+        <div class="mat-slider-thumb"></div>
+        <div class="mat-slider-thumb-label">
+          <span class="mat-slider-thumb-label-text">{{value}}</span>
         </div>
       </div>
     </div>

--- a/src/lib/slider/slider.scss
+++ b/src/lib/slider/slider.scss
@@ -3,30 +3,30 @@
 
 // This refers to the thickness of the slider. On a horizontal slider this is the height, on a
 // vertical slider this is the width.
-$md-slider-thickness: 48px !default;
-$md-slider-min-size: 128px !default;
-$md-slider-padding: 8px !default;
+$mat-slider-thickness: 48px !default;
+$mat-slider-min-size: 128px !default;
+$mat-slider-padding: 8px !default;
 
-$md-slider-track-height: 2px !default;
-$md-slider-thumb-size: 20px !default;
+$mat-slider-track-height: 2px !default;
+$mat-slider-thumb-size: 20px !default;
 
-$md-slider-thumb-default-scale: 0.7 !default;
-$md-slider-thumb-focus-scale: 1 !default;
+$mat-slider-thumb-default-scale: 0.7 !default;
+$mat-slider-thumb-focus-scale: 1 !default;
 
 // TODO(iveysaur): Find an implementation to hide the track under a disabled thumb.
-$md-slider-off-color: rgba(black, 0.26);
-$md-slider-focused-color: rgba(black, 0.38);
-$md-slider-disabled-color: rgba(black, 0.26);
+$mat-slider-off-color: rgba(black, 0.26);
+$mat-slider-focused-color: rgba(black, 0.38);
+$mat-slider-disabled-color: rgba(black, 0.26);
 
-$md-slider-thumb-arrow-height: 16px !default;
-$md-slider-thumb-arrow-width: 28px !default;
+$mat-slider-thumb-arrow-height: 16px !default;
+$mat-slider-thumb-arrow-width: 28px !default;
 
-$md-slider-thumb-label-size: 28px !default;
+$mat-slider-thumb-label-size: 28px !default;
 // The thumb has to be moved down so that it appears right over the slider track when visible and
 // on the slider track when not.
-$md-slider-thumb-label-top: ($md-slider-thickness / 2) -
-    ($md-slider-thumb-default-scale * $md-slider-thumb-size / 2) - $md-slider-thumb-label-size -
-    $md-slider-thumb-arrow-height + 10px !default;
+$mat-slider-thumb-label-top: ($mat-slider-thickness / 2) -
+    ($mat-slider-thumb-default-scale * $mat-slider-thumb-size / 2) - $mat-slider-thumb-label-size -
+    $mat-slider-thumb-arrow-height + 10px !default;
 
 /**
  * Uses a container height and an item height to center an item vertically within the container.
@@ -38,9 +38,9 @@ $md-slider-thumb-label-top: ($md-slider-thickness / 2) -
 /**
  * Positions the thumb based on its width and height.
  */
-@mixin slider-thumb-position($width: $md-slider-thumb-size, $height: $md-slider-thumb-size) {
+@mixin slider-thumb-position($width: $mat-slider-thumb-size, $height: $mat-slider-thumb-size) {
   position: absolute;
-  top: center-vertically($md-slider-thickness, $height);
+  top: center-vertically($mat-slider-thickness, $height);
   // This makes it so that the center of the thumb aligns with where the click was.
   // This is not affected by the movement of the thumb.
   left: (-$width / 2);
@@ -49,9 +49,9 @@ $md-slider-thumb-label-top: ($md-slider-thickness / 2) -
   border-radius: max($width, $height);
 }
 
-md-slider {
-  height: $md-slider-thickness;
-  min-width: $md-slider-min-size;
+mat-slider {
+  height: $mat-slider-thickness;
+  min-width: $mat-slider-min-size;
   position: relative;
   padding: 0;
   display: inline-block;
@@ -59,60 +59,60 @@ md-slider {
   vertical-align: middle;
 }
 
-md-slider *,
-md-slider *::after {
+mat-slider *,
+mat-slider *::after {
   box-sizing: border-box;
 }
 
 /**
  * Exists in order to pad the slider and keep everything positioned correctly.
- * Cannot be merged with the .md-slider-container.
+ * Cannot be merged with the .mat-slider-container.
  */
-.md-slider-wrapper {
+.mat-slider-wrapper {
   width: 100%;
   height: 100%;
-  padding-left: $md-slider-padding;
-  padding-right: $md-slider-padding;
+  padding-left: $mat-slider-padding;
+  padding-right: $mat-slider-padding;
 }
 
 /**
  * Holds the isActive and isSliding classes as well as helps with positioning the children.
- * Cannot be merged with .md-slider-wrapper.
+ * Cannot be merged with .mat-slider-wrapper.
  */
-.md-slider-container {
+.mat-slider-container {
   position: relative;
 }
 
-.md-slider-track-container {
+.mat-slider-track-container {
   width: 100%;
   position: absolute;
-  top: center-vertically($md-slider-thickness, $md-slider-track-height);
-  height: $md-slider-track-height;
+  top: center-vertically($mat-slider-thickness, $mat-slider-track-height);
+  height: $mat-slider-track-height;
 }
 
-.md-slider-track {
+.mat-slider-track {
   position: absolute;
   left: 0;
   right: 0;
   height: 100%;
-  background-color: $md-slider-off-color;
+  background-color: $mat-slider-off-color;
 }
 
-.md-slider-track-fill {
+.mat-slider-track-fill {
   transition-duration: $swift-ease-out-duration;
   transition-timing-function: $swift-ease-out-timing-function;
   transition-property: width, height;
-  background-color: md-color($md-accent);
+  background-color: mat-color($mat-accent);
 }
 
-.md-slider-tick-container, .md-slider-last-tick-container {
+.mat-slider-tick-container, .mat-slider-last-tick-container {
   position: absolute;
   left: 0;
   right: 0;
   height: 100%;
 }
 
-.md-slider-thumb-container {
+.mat-slider-thumb-container {
   position: absolute;
   left: 0;
   top: 50%;
@@ -122,51 +122,51 @@ md-slider *::after {
   transition-property: left, bottom;
 }
 
-.md-slider-thumb-position {
+.mat-slider-thumb-position {
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 }
 
-.md-slider-thumb {
+.mat-slider-thumb {
   z-index: 1;
 
-  @include slider-thumb-position($md-slider-thumb-size, $md-slider-thumb-size);
-  transform: scale($md-slider-thumb-default-scale);
+  @include slider-thumb-position($mat-slider-thumb-size, $mat-slider-thumb-size);
+  transform: scale($mat-slider-thumb-default-scale);
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 }
 
-.md-slider-thumb::after {
+.mat-slider-thumb::after {
   content: '';
   position: absolute;
-  width: $md-slider-thumb-size;
-  height: $md-slider-thumb-size;
-  border-radius: max($md-slider-thumb-size, $md-slider-thumb-size);
+  width: $mat-slider-thumb-size;
+  height: $mat-slider-thumb-size;
+  border-radius: max($mat-slider-thumb-size, $mat-slider-thumb-size);
   border-width: 3px;
   border-style: solid;
   transition: inherit;
-  background-color: md-color($md-accent);
-  border-color: md-color($md-accent);
+  background-color: mat-color($mat-accent);
+  border-color: mat-color($mat-accent);
 }
 
-.md-slider-thumb-label {
+.mat-slider-thumb-label {
   display: flex;
   align-items: center;
   justify-content: center;
 
   position: absolute;
-  left: -($md-slider-thumb-label-size / 2);
-  top: $md-slider-thumb-label-top;
-  width: $md-slider-thumb-label-size;
-  height: $md-slider-thumb-label-size;
+  left: -($mat-slider-thumb-label-size / 2);
+  top: $mat-slider-thumb-label-top;
+  width: $mat-slider-thumb-label-size;
+  height: $mat-slider-thumb-label-size;
   border-radius: 50%;
 
-  transform: scale(0.4) translate3d(0, (-$md-slider-thumb-label-top + 10) / 0.4, 0) rotate(45deg);
+  transform: scale(0.4) translate3d(0, (-$mat-slider-thumb-label-top + 10) / 0.4, 0) rotate(45deg);
   transition: 300ms $swift-ease-in-out-timing-function;
   transition-property: transform, border-radius;
 
-  background-color: md-color($md-accent);
+  background-color: mat-color($mat-accent);
 }
 
-.md-slider-thumb-label-text {
+.mat-slider-thumb-label-text {
   z-index: 1;
   font-size: 12px;
   font-weight: bold;
@@ -176,29 +176,29 @@ md-slider *::after {
   color: white;
 }
 
-.md-slider-container:not(.md-slider-thumb-label-showing) .md-slider-thumb-label {
+.mat-slider-container:not(.mat-slider-thumb-label-showing) .mat-slider-thumb-label {
   display: none;
 }
 
-.md-slider-active.md-slider-thumb-label-showing .md-slider-thumb {
+.mat-slider-active.mat-slider-thumb-label-showing .mat-slider-thumb {
   transform: scale(0);
 }
 
-.md-slider-sliding .md-slider-thumb-position,
-.md-slider-sliding .md-slider-track-fill {
+.mat-slider-sliding .mat-slider-thumb-position,
+.mat-slider-sliding .mat-slider-track-fill {
   transition: none;
   cursor: default;
 }
 
-.md-slider-active .md-slider-thumb {
-  transform: scale($md-slider-thumb-focus-scale);
+.mat-slider-active .mat-slider-thumb {
+  transform: scale($mat-slider-thumb-focus-scale);
 }
 
-.md-slider-active .md-slider-thumb-label {
+.mat-slider-active .mat-slider-thumb-label {
   border-radius: 50% 50% 0;
   transform: rotate(45deg);
 }
 
-.md-slider-active .md-slider-thumb-label-text {
+.mat-slider-active .mat-slider-thumb-label-text {
   opacity: 1;
 }

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -2,17 +2,17 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule, FormControl} from '@angular/forms';
 import {Component, DebugElement, ViewEncapsulation} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdSlider, MdSliderModule} from './slider';
+import {MatSlider, MatSliderModule} from './slider';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {TestGestureConfig} from './test-gesture-config';
 
 
-describe('MdSlider', () => {
+describe('MatSlider', () => {
   let gestureConfig: TestGestureConfig;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSliderModule.forRoot(), ReactiveFormsModule],
+      imports: [MatSliderModule.forRoot(), ReactiveFormsModule],
       declarations: [
         StandardSlider,
         DisabledSlider,
@@ -39,7 +39,7 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<StandardSlider>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let trackFillElement: HTMLElement;
     let trackFillDimensions: ClientRect;
     let sliderTrackElement: HTMLElement;
@@ -51,16 +51,16 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(StandardSlider);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
 
-      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track-fill');
+      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
       trackFillDimensions = trackFillElement.getBoundingClientRect();
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
       sliderDimensions = sliderTrackElement.getBoundingClientRect();
 
-      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-thumb-position');
+      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-thumb-position');
       thumbDimensions = thumbElement.getBoundingClientRect();
     });
 
@@ -146,44 +146,44 @@ describe('MdSlider', () => {
       expect(thumbDimensions.left).toBe(sliderDimensions.width * 0.5 + sliderDimensions.left);
     });
 
-    it('should add the md-slider-active class on click', () => {
-      let containerElement = sliderNativeElement.querySelector('.md-slider-container');
-      expect(containerElement.classList).not.toContain('md-slider-active');
+    it('should add the mat-slider-active class on click', () => {
+      let containerElement = sliderNativeElement.querySelector('.mat-slider-container');
+      expect(containerElement.classList).not.toContain('mat-slider-active');
 
       dispatchClickEvent(sliderNativeElement, 0.23);
       fixture.detectChanges();
 
-      expect(containerElement.classList).toContain('md-slider-active');
+      expect(containerElement.classList).toContain('mat-slider-active');
     });
 
-    it('should remove the md-slider-active class on blur', () => {
-      let containerElement = sliderNativeElement.querySelector('.md-slider-container');
+    it('should remove the mat-slider-active class on blur', () => {
+      let containerElement = sliderNativeElement.querySelector('.mat-slider-container');
 
       dispatchClickEvent(sliderNativeElement, 0.95);
       fixture.detectChanges();
 
-      expect(containerElement.classList).toContain('md-slider-active');
+      expect(containerElement.classList).toContain('mat-slider-active');
 
       // Call the `onBlur` handler directly because we cannot simulate a focus event in unit tests.
       sliderInstance.onBlur();
       fixture.detectChanges();
 
-      expect(containerElement.classList).not.toContain('md-slider-active');
+      expect(containerElement.classList).not.toContain('mat-slider-active');
     });
 
-    it('should add and remove the md-slider-sliding class when sliding', () => {
-      let containerElement = sliderNativeElement.querySelector('.md-slider-container');
-      expect(containerElement.classList).not.toContain('md-slider-sliding');
+    it('should add and remove the mat-slider-sliding class when sliding', () => {
+      let containerElement = sliderNativeElement.querySelector('.mat-slider-container');
+      expect(containerElement.classList).not.toContain('mat-slider-sliding');
 
       dispatchSlideStartEvent(sliderNativeElement, 0, gestureConfig);
       fixture.detectChanges();
 
-      expect(containerElement.classList).toContain('md-slider-sliding');
+      expect(containerElement.classList).toContain('mat-slider-sliding');
 
       dispatchSlideEndEvent(sliderNativeElement, 0.34, gestureConfig);
       fixture.detectChanges();
 
-      expect(containerElement.classList).not.toContain('md-slider-sliding');
+      expect(containerElement.classList).not.toContain('mat-slider-sliding');
     });
   });
 
@@ -191,13 +191,13 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<StandardSlider>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(DisabledSlider);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
     });
@@ -218,24 +218,24 @@ describe('MdSlider', () => {
       expect(sliderInstance.value).toBe(0);
     });
 
-    it('should not add the md-slider-active class on click when disabled', () => {
-      let containerElement = sliderNativeElement.querySelector('.md-slider-container');
-      expect(containerElement.classList).not.toContain('md-slider-active');
+    it('should not add the mat-slider-active class on click when disabled', () => {
+      let containerElement = sliderNativeElement.querySelector('.mat-slider-container');
+      expect(containerElement.classList).not.toContain('mat-slider-active');
 
       dispatchClickEvent(sliderNativeElement, 0.43);
       fixture.detectChanges();
 
-      expect(containerElement.classList).not.toContain('md-slider-active');
+      expect(containerElement.classList).not.toContain('mat-slider-active');
     });
 
-    it('should not add the md-slider-sliding class on slide when disabled', () => {
-      let containerElement = sliderNativeElement.querySelector('.md-slider-container');
-      expect(containerElement.classList).not.toContain('md-slider-sliding');
+    it('should not add the mat-slider-sliding class on slide when disabled', () => {
+      let containerElement = sliderNativeElement.querySelector('.mat-slider-container');
+      expect(containerElement.classList).not.toContain('mat-slider-sliding');
 
       dispatchSlideStartEvent(sliderNativeElement, 0.46, gestureConfig);
       fixture.detectChanges();
 
-      expect(containerElement.classList).not.toContain('md-slider-sliding');
+      expect(containerElement.classList).not.toContain('mat-slider-sliding');
     });
   });
 
@@ -243,7 +243,7 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<SliderWithMinAndMax>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let sliderTrackElement: HTMLElement;
     let sliderDimensions: ClientRect;
     let trackFillElement: HTMLElement;
@@ -253,13 +253,13 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(SliderWithMinAndMax);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderInstance = sliderDebugElement.injector.get(MdSlider);
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
+      sliderInstance = sliderDebugElement.injector.get(MatSlider);
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
       sliderDimensions = sliderTrackElement.getBoundingClientRect();
-      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track-fill');
-      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-thumb-position');
+      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
+      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-thumb-position');
     });
 
     it('should set the default values from the attributes', () => {
@@ -319,17 +319,17 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<SliderWithValue>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let sliderTrackElement: HTMLElement;
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SliderWithValue);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderInstance = sliderDebugElement.injector.get(MdSlider);
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
+      sliderInstance = sliderDebugElement.injector.get(MatSlider);
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
     }));
 
     it('should set the default value from the attribute', () => {
@@ -353,7 +353,7 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<SliderWithStep>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let sliderTrackElement: HTMLElement;
     let sliderDimensions: ClientRect;
     let trackFillElement: HTMLElement;
@@ -363,13 +363,13 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(SliderWithStep);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderInstance = sliderDebugElement.injector.get(MdSlider);
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
+      sliderInstance = sliderDebugElement.injector.get(MatSlider);
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
       sliderDimensions = sliderTrackElement.getBoundingClientRect();
-      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track-fill');
-      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-thumb-position');
+      trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
+      thumbElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-thumb-position');
     });
 
     it('should set the correct step value on click', () => {
@@ -429,11 +429,11 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(SliderWithAutoTickInterval);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      tickContainer = <HTMLElement>sliderNativeElement.querySelector('.md-slider-tick-container');
+      tickContainer = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-tick-container');
       lastTickContainer =
-          <HTMLElement>sliderNativeElement.querySelector('.md-slider-last-tick-container');
+          <HTMLElement>sliderNativeElement.querySelector('.mat-slider-last-tick-container');
     }));
 
     it('should set the correct tick separation', () => {
@@ -473,11 +473,11 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(SliderWithSetTickInterval);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      tickContainer = <HTMLElement>sliderNativeElement.querySelector('.md-slider-tick-container');
+      tickContainer = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-tick-container');
       lastTickContainer =
-          <HTMLElement>sliderNativeElement.querySelector('.md-slider-last-tick-container');
+          <HTMLElement>sliderNativeElement.querySelector('.mat-slider-last-tick-container');
     });
 
     it('should set the correct tick separation', () => {
@@ -498,7 +498,7 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<SliderWithThumbLabel>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let sliderTrackElement: HTMLElement;
     let sliderContainerElement: Element;
     let thumbLabelTextElement: Element;
@@ -507,16 +507,16 @@ describe('MdSlider', () => {
       fixture = TestBed.createComponent(SliderWithThumbLabel);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
-      sliderContainerElement = sliderNativeElement.querySelector('.md-slider-container');
-      thumbLabelTextElement = sliderNativeElement.querySelector('.md-slider-thumb-label-text');
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
+      sliderContainerElement = sliderNativeElement.querySelector('.mat-slider-container');
+      thumbLabelTextElement = sliderNativeElement.querySelector('.mat-slider-thumb-label-text');
     });
 
     it('should add the thumb label class to the slider container', () => {
-      expect(sliderContainerElement.classList).toContain('md-slider-thumb-label-showing');
+      expect(sliderContainerElement.classList).toContain('mat-slider-thumb-label-showing');
     });
 
     it('should update the thumb label text on click', () => {
@@ -540,26 +540,26 @@ describe('MdSlider', () => {
     });
 
     it('should show the thumb label on click', () => {
-      expect(sliderContainerElement.classList).not.toContain('md-slider-active');
-      expect(sliderContainerElement.classList).toContain('md-slider-thumb-label-showing');
+      expect(sliderContainerElement.classList).not.toContain('mat-slider-active');
+      expect(sliderContainerElement.classList).toContain('mat-slider-thumb-label-showing');
 
       dispatchClickEvent(sliderNativeElement, 0.49);
       fixture.detectChanges();
 
-      // The thumb label appears when the slider is active and the 'md-slider-thumb-label-showing'
+      // The thumb label appears when the slider is active and the 'mat-slider-thumb-label-showing'
       // class is applied.
-      expect(sliderContainerElement.classList).toContain('md-slider-thumb-label-showing');
-      expect(sliderContainerElement.classList).toContain('md-slider-active');
+      expect(sliderContainerElement.classList).toContain('mat-slider-thumb-label-showing');
+      expect(sliderContainerElement.classList).toContain('mat-slider-active');
     });
 
     it('should show the thumb label on slide', () => {
-      expect(sliderContainerElement.classList).not.toContain('md-slider-active');
+      expect(sliderContainerElement.classList).not.toContain('mat-slider-active');
 
       dispatchSlideEvent(sliderTrackElement, sliderNativeElement, 0, 0.91, gestureConfig);
       fixture.detectChanges();
 
-      expect(sliderContainerElement.classList).toContain('md-slider-thumb-label-showing');
-      expect(sliderContainerElement.classList).toContain('md-slider-active');
+      expect(sliderContainerElement.classList).toContain('mat-slider-thumb-label-showing');
+      expect(sliderContainerElement.classList).toContain('mat-slider-active');
     });
   });
 
@@ -567,7 +567,7 @@ describe('MdSlider', () => {
     let fixture: ComponentFixture<SliderWithTwoWayBinding>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MdSlider;
+    let sliderInstance: MatSlider;
     let sliderTrackElement: HTMLElement;
     let testComponent: SliderWithTwoWayBinding;
 
@@ -577,10 +577,10 @@ describe('MdSlider', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MdSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderInstance = sliderDebugElement.injector.get(MdSlider);
-      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.md-slider-track');
+      sliderInstance = sliderDebugElement.injector.get(MatSlider);
+      sliderTrackElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track');
     });
 
     it('should update the control when the value is updated', () => {
@@ -625,54 +625,54 @@ describe('MdSlider', () => {
 
 // The transition has to be removed in order to test the updated positions without setTimeout.
 const noTransitionStyle =
-    '.md-slider-track-fill, .md-slider-thumb-position { transition: none !important; }';
+    '.mat-slider-track-fill, .mat-slider-thumb-position { transition: none !important; }';
 
 @Component({
-  template: `<md-slider></md-slider>`,
+  template: `<mat-slider></mat-slider>`,
   styles: [noTransitionStyle],
   encapsulation: ViewEncapsulation.None
 })
 class StandardSlider { }
 
 @Component({
-  template: `<md-slider disabled></md-slider>`
+  template: `<mat-slider disabled></mat-slider>`
 })
 class DisabledSlider { }
 
 @Component({
-  template: `<md-slider min="4" max="6"></md-slider>`,
+  template: `<mat-slider min="4" max="6"></mat-slider>`,
   styles: [noTransitionStyle],
   encapsulation: ViewEncapsulation.None
 })
 class SliderWithMinAndMax { }
 
 @Component({
-  template: `<md-slider value="26"></md-slider>`
+  template: `<mat-slider value="26"></mat-slider>`
 })
 class SliderWithValue { }
 
 @Component({
-  template: `<md-slider step="25"></md-slider>`,
+  template: `<mat-slider step="25"></mat-slider>`,
   styles: [noTransitionStyle],
   encapsulation: ViewEncapsulation.None
 })
 class SliderWithStep { }
 
-@Component({template: `<md-slider step="5" tick-interval="auto"></md-slider>`})
+@Component({template: `<mat-slider step="5" tick-interval="auto"></mat-slider>`})
 class SliderWithAutoTickInterval { }
 
-@Component({template: `<md-slider step="3" tick-interval="6"></md-slider>`})
+@Component({template: `<mat-slider step="3" tick-interval="6"></mat-slider>`})
 class SliderWithSetTickInterval { }
 
 @Component({
-  template: `<md-slider thumb-label></md-slider>`,
+  template: `<mat-slider thumb-label></mat-slider>`,
   styles: [noTransitionStyle],
   encapsulation: ViewEncapsulation.None
 })
 class SliderWithThumbLabel { }
 
 @Component({
-  template: `<md-slider [formControl]="control"></md-slider>`
+  template: `<mat-slider [formControl]="control"></mat-slider>`
 })
 class SliderWithTwoWayBinding {
   control = new FormControl('');

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -15,7 +15,7 @@ import {
   FormsModule,
 } from '@angular/forms';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {BooleanFieldValue, MdGestureConfig, applyCssTransform} from '@angular2-material/core';
+import {BooleanFieldValue, MatGestureConfig, applyCssTransform} from '@angular2-material/core';
 import {Input as HammerInput} from 'hammerjs';
 
 /**
@@ -25,19 +25,19 @@ import {Input as HammerInput} from 'hammerjs';
 const MIN_AUTO_TICK_SEPARATION = 30;
 
 /**
- * Provider Expression that allows md-slider to register as a ControlValueAccessor.
+ * Provider Expression that allows mat-slider to register as a ControlValueAccessor.
  * This allows it to support [(ngModel)] and [formControl].
  */
-export const MD_SLIDER_VALUE_ACCESSOR: any = {
+export const MAT_SLIDER_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => MdSlider),
+  useExisting: forwardRef(() => MatSlider),
   multi: true
 };
 
 @Component({
   moduleId: module.id,
-  selector: 'md-slider',
-  providers: [MD_SLIDER_VALUE_ACCESSOR],
+  selector: 'mat-slider',
+  providers: [MAT_SLIDER_VALUE_ACCESSOR],
   host: {
     'tabindex': '0',
     '(click)': 'onClick($event)',
@@ -51,7 +51,7 @@ export const MD_SLIDER_VALUE_ACCESSOR: any = {
   styleUrls: ['slider.css'],
   encapsulation: ViewEncapsulation.None,
 })
-export class MdSlider implements AfterContentInit, ControlValueAccessor {
+export class MatSlider implements AfterContentInit, ControlValueAccessor {
   /** A renderer to handle updating the slider's thumb and fill track. */
   private _renderer: SliderRenderer = null;
 
@@ -60,7 +60,7 @@ export class MdSlider implements AfterContentInit, ControlValueAccessor {
 
   @Input()
   @BooleanFieldValue()
-  @HostBinding('class.md-slider-disabled')
+  @HostBinding('class.mat-slider-disabled')
   @HostBinding('attr.aria-disabled')
   disabled: boolean = false;
 
@@ -394,7 +394,7 @@ export class SliderRenderer {
    * take up.
    */
   getSliderDimensions() {
-    let trackElement = this._sliderElement.querySelector('.md-slider-track');
+    let trackElement = this._sliderElement.querySelector('.mat-slider-track');
     return trackElement.getBoundingClientRect();
   }
 
@@ -404,8 +404,8 @@ export class SliderRenderer {
   updateThumbAndFillPosition(percent: number, width: number) {
     // A container element that is used to avoid overwriting the transform on the thumb itself.
     let thumbPositionElement =
-        <HTMLElement>this._sliderElement.querySelector('.md-slider-thumb-position');
-    let fillTrackElement = <HTMLElement>this._sliderElement.querySelector('.md-slider-track-fill');
+        <HTMLElement>this._sliderElement.querySelector('.mat-slider-thumb-position');
+    let fillTrackElement = <HTMLElement>this._sliderElement.querySelector('.mat-slider-track-fill');
 
     let position = Math.round(percent * width);
 
@@ -425,13 +425,14 @@ export class SliderRenderer {
    * Draws ticks onto the tick container.
    */
   drawTicks(tickSeparation: number) {
-    let tickContainer = <HTMLElement>this._sliderElement.querySelector('.md-slider-tick-container');
+    let tickContainer = <HTMLElement>this._sliderElement
+      .querySelector('.mat-slider-tick-container');
     let tickContainerWidth = tickContainer.getBoundingClientRect().width;
     // An extra element for the last tick is needed because the linear gradient cannot be told to
     // always draw a tick at the end of the gradient. To get around this, there is a second
     // container for ticks that has a single tick mark on the very right edge.
     let lastTickContainer =
-        <HTMLElement>this._sliderElement.querySelector('.md-slider-last-tick-container');
+        <HTMLElement>this._sliderElement.querySelector('.mat-slider-last-tick-container');
     // Subtract 1 from the tick separation to center the tick.
     // TODO: Evaluate the rendering performance of using repeating background gradients.
     tickContainer.style.background = `repeating-linear-gradient(to right, black, black 2px, ` +
@@ -451,17 +452,17 @@ export class SliderRenderer {
 
 @NgModule({
   imports: [FormsModule],
-  exports: [MdSlider],
-  declarations: [MdSlider],
+  exports: [MatSlider],
+  declarations: [MatSlider],
   providers: [
-    {provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig},
+    {provide: HAMMER_GESTURE_CONFIG, useClass: MatGestureConfig},
   ],
 })
-export class MdSliderModule {
+export class MatSliderModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdSliderModule,
-      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MdGestureConfig}]
+      ngModule: MatSliderModule,
+      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: MatGestureConfig}]
     };
   }
 }

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -1,12 +1,12 @@
 import {Injectable} from '@angular/core';
-import {MdGestureConfig} from '@angular2-material/core';
+import {MatGestureConfig} from '@angular2-material/core';
 
 /**
- * An extension of MdGestureConfig that exposes the underlying HammerManager instances.
+ * An extension of MatGestureConfig that exposes the underlying HammerManager instances.
  * Tests can use these instances to emit fake gesture events.
  */
 @Injectable()
-export class TestGestureConfig extends MdGestureConfig {
+export class TestGestureConfig extends MatGestureConfig {
   /**
    * A map of Hammer instances to element.
    * Used to emit events over instances for an element.

--- a/src/lib/tabs/ink-bar.ts
+++ b/src/lib/tabs/ink-bar.ts
@@ -3,9 +3,9 @@ import {Directive, Renderer, ElementRef} from '@angular/core';
 
 /** The ink-bar is used to display and animate the line underneath the current active tab label. */
 @Directive({
-  selector: 'md-ink-bar',
+  selector: 'mat-ink-bar',
 })
-export class MdInkBar {
+export class MatInkBar {
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
   /**

--- a/src/lib/tabs/tab-content.ts
+++ b/src/lib/tabs/tab-content.ts
@@ -3,9 +3,9 @@ import {TemplatePortalDirective} from '@angular2-material/core';
 
 /** Used to flag tab contents for use with the portal directive */
 @Directive({
-  selector: '[md-tab-content]'
+  selector: '[mat-tab-content]'
 })
-export class MdTabContent extends TemplatePortalDirective {
+export class MatTabContent extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
     super(templateRef, viewContainerRef);
   }

--- a/src/lib/tabs/tab-group.html
+++ b/src/lib/tabs/tab-group.html
@@ -1,24 +1,24 @@
-<div class="md-tab-header" role="tablist"
+<div class="mat-tab-header" role="tablist"
      (keydown)="handleKeydown($event)">
-  <div class="md-tab-label" role="tab" md-tab-label-wrapper
+  <div class="mat-tab-label" role="tab" mat-tab-label-wrapper
        *ngFor="let tab of _tabs; let i = index"
        [id]="_getTabLabelId(i)"
        [tabIndex]="selectedIndex == i ? 0 : -1"
        [attr.aria-controls]="_getTabContentId(i)"
        [attr.aria-selected]="selectedIndex == i"
-       [class.md-tab-active]="selectedIndex == i"
-       [class.md-tab-disabled]="tab.disabled"
+       [class.mat-tab-active]="selectedIndex == i"
+       [class.mat-tab-disabled]="tab.disabled"
        (click)="focusIndex = selectedIndex = i">
     <template [portalHost]="tab.label"></template>
   </div>
-  <md-ink-bar></md-ink-bar>
+  <mat-ink-bar></mat-ink-bar>
 </div>
-<div class="md-tab-body-wrapper">
-  <div class="md-tab-body"
+<div class="mat-tab-body-wrapper">
+  <div class="mat-tab-body"
        role="tabpanel"
        *ngFor="let tab of _tabs; let i = index"
        [id]="_getTabContentId(i)"
-       [class.md-tab-active]="selectedIndex == i"
+       [class.mat-tab-active]="selectedIndex == i"
        [attr.aria-labelledby]="_getTabLabelId(i)">
     <template [ngIf]="selectedIndex == i">
       <template [portalHost]="tab.content"></template>

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -1,31 +1,31 @@
 @import 'variables';
 @import 'default-theme';
 
-$md-tab-bar-height: 48px !default;
+$mat-tab-bar-height: 48px !default;
 
 :host {
   display: flex;
   flex-direction: column;
-  font-family: $md-font-family;
+  font-family: $mat-font-family;
 }
 
 /** The top section of the view; contains the tab labels */
-.md-tab-header {
+.mat-tab-header {
   overflow: hidden;
   position: relative;
   display: flex;
   flex-direction: row;
-  border-bottom: 1px solid md-color($md-background, status-bar);
+  border-bottom: 1px solid mat-color($mat-background, status-bar);
   flex-shrink: 0;
 }
 
 /** Wraps each tab label */
-.md-tab-label {
-  line-height: $md-tab-bar-height;
-  height: $md-tab-bar-height;
+.mat-tab-label {
+  line-height: $mat-tab-bar-height;
+  height: $mat-tab-bar-height;
   padding: 0 12px;
-  font-size: $md-body-font-size-base;
-  font-family: $md-font-family;
+  font-size: $mat-body-font-size-base;
+  font-family: $mat-font-family;
   font-weight: 500;
   cursor: pointer;
   box-sizing: border-box;
@@ -36,17 +36,17 @@ $md-tab-bar-height: 48px !default;
   &:focus {
     outline: none;
     opacity: 1;
-    background-color: md-color($md-primary, 100, 0.3);
+    background-color: mat-color($mat-primary, 100, 0.3);
   }
 }
 
-.md-tab-disabled {
+.mat-tab-disabled {
   cursor: default;
   pointer-events: none;
 }
 
 /** The bottom section of the view; contains the tab bodies */
-.md-tab-body-wrapper {
+.mat-tab-body-wrapper {
   position: relative;
   overflow: hidden;
   flex-grow: 1;
@@ -54,22 +54,22 @@ $md-tab-bar-height: 48px !default;
 }
 
 /** Wraps each tab body */
-.md-tab-body {
+.mat-tab-body {
   display: none;
   overflow: auto;
   box-sizing: border-box;
   flex-grow: 1;
   flex-shrink: 1;
-  &.md-tab-active {
+  &.mat-tab-active {
     display: block;
   }
 }
 
 /** The colored bar that underlines the active tab */
-md-ink-bar {
+mat-ink-bar {
   position: absolute;
   bottom: 0;
   height: 2px;
-  background-color: md-color($md-primary, 500);
+  background-color: mat-color($mat-primary, 500);
   transition: 350ms ease-out;
 }

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -1,15 +1,15 @@
 import {async, fakeAsync, tick, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MdTabGroup, MdTabsModule} from './tabs';
+import {MatTabGroup, MatTabsModule} from './tabs';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {Observable} from 'rxjs/Observable';
 
 
-describe('MdTabGroup', () => {
+describe('MatTabGroup', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTabsModule.forRoot()],
+      imports: [MatTabsModule.forRoot()],
       declarations: [
         SimpleTabsTestApp,
         AsyncTabsTestApp,
@@ -37,12 +37,12 @@ describe('MdTabGroup', () => {
       checkSelectedIndex(0, fixture);
 
       // select the second tab
-      let tabLabel = fixture.debugElement.queryAll(By.css('.md-tab-label'))[1];
+      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
       tabLabel.nativeElement.click();
       checkSelectedIndex(1, fixture);
 
       // select the third tab
-      tabLabel = fixture.debugElement.queryAll(By.css('.md-tab-label'))[2];
+      tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[2];
       tabLabel.nativeElement.click();
       checkSelectedIndex(2, fixture);
     }));
@@ -53,7 +53,7 @@ describe('MdTabGroup', () => {
 
       fixture.detectChanges();
 
-      let tabLabel = fixture.debugElement.queryAll(By.css('.md-tab-label'))[1];
+      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
       tabLabel.nativeElement.click();
 
       fixture.detectChanges();
@@ -64,7 +64,7 @@ describe('MdTabGroup', () => {
 
     it('should cycle tab focus with focusNextTab/focusPreviousTab functions', fakeAsync(() => {
       let testComponent = fixture.componentInstance;
-      let tabComponent = fixture.debugElement.query(By.css('md-tab-group')).componentInstance;
+      let tabComponent = fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
 
       spyOn(testComponent, 'handleFocus').and.callThrough();
       fixture.detectChanges();
@@ -121,7 +121,7 @@ describe('MdTabGroup', () => {
 
     it('should change tabs based on selectedIndex', fakeAsync(() => {
       let component = fixture.componentInstance;
-      let tabComponent = fixture.debugElement.query(By.css('md-tab-group')).componentInstance;
+      let tabComponent = fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
 
       spyOn(component, 'handleSelection').and.callThrough();
 
@@ -146,13 +146,13 @@ describe('MdTabGroup', () => {
     }));
 
     it('should disable the second tab', () => {
-      let labels = fixture.debugElement.queryAll(By.css('.md-tab-label'));
+      let labels = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
 
-      expect(labels[1].nativeElement.classList.contains('md-tab-disabled')).toBeTruthy();
+      expect(labels[1].nativeElement.classList.contains('mat-tab-disabled')).toBeTruthy();
     });
 
     it('should skip over disabled tabs when navigating by keyboard', () => {
-      let component: MdTabGroup = fixture.debugElement.query(By.css('md-tab-group'))
+      let component: MatTabGroup = fixture.debugElement.query(By.css('mat-tab-group'))
           .componentInstance;
 
       component.focusIndex = 0;
@@ -171,7 +171,7 @@ describe('MdTabGroup', () => {
     });
 
     it('should ignore attempts to select a disabled tab', () => {
-      let component: MdTabGroup = fixture.debugElement.query(By.css('md-tab-group'))
+      let component: MatTabGroup = fixture.debugElement.query(By.css('mat-tab-group'))
           .componentInstance;
 
       component.selectedIndex = 0;
@@ -182,7 +182,7 @@ describe('MdTabGroup', () => {
     });
 
     it('should ignore attempts to focus a disabled tab', () => {
-      let component: MdTabGroup = fixture.debugElement.query(By.css('md-tab-group'))
+      let component: MatTabGroup = fixture.debugElement.query(By.css('mat-tab-group'))
           .componentInstance;
 
       component.focusIndex = 0;
@@ -193,7 +193,7 @@ describe('MdTabGroup', () => {
     });
 
     it('should ignore attempts to set invalid selectedIndex', () => {
-      let component: MdTabGroup = fixture.debugElement.query(By.css('md-tab-group'))
+      let component: MatTabGroup = fixture.debugElement.query(By.css('mat-tab-group'))
           .componentInstance;
 
       component.selectedIndex = 0;
@@ -207,7 +207,7 @@ describe('MdTabGroup', () => {
     });
 
     it('should ignore attempts to set invalid focusIndex', () => {
-      let component: MdTabGroup = fixture.debugElement.query(By.css('md-tab-group'))
+      let component: MatTabGroup = fixture.debugElement.query(By.css('mat-tab-group'))
           .componentInstance;
 
       component.focusIndex = 0;
@@ -227,7 +227,7 @@ describe('MdTabGroup', () => {
     it('should show tabs when they are available', async(() => {
       fixture = TestBed.createComponent(AsyncTabsTestApp);
 
-      let labels = fixture.debugElement.queryAll(By.css('.md-tab-label'));
+      let labels = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
 
       expect(labels.length).toBe(0);
 
@@ -235,7 +235,7 @@ describe('MdTabGroup', () => {
 
       fixture.whenStable().then(() => {
         fixture.detectChanges();
-        labels = fixture.debugElement.queryAll(By.css('.md-tab-label'));
+        labels = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
         expect(labels.length).toBe(2);
       });
     }));
@@ -243,45 +243,45 @@ describe('MdTabGroup', () => {
 
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have the
-   * `md-tab-active` class
+   * `mat-tab-active` class
    */
   function checkSelectedIndex(index: number, fixture: ComponentFixture<any>) {
     fixture.detectChanges();
 
-    let tabComponent: MdTabGroup = fixture.debugElement
-        .query(By.css('md-tab-group')).componentInstance;
+    let tabComponent: MatTabGroup = fixture.debugElement
+        .query(By.css('mat-tab-group')).componentInstance;
     expect(tabComponent.selectedIndex).toBe(index);
 
     let tabLabelElement = fixture.debugElement
-        .query(By.css(`.md-tab-label:nth-of-type(${index + 1})`)).nativeElement;
-    expect(tabLabelElement.classList.contains('md-tab-active')).toBe(true);
+        .query(By.css(`.mat-tab-label:nth-of-type(${index + 1})`)).nativeElement;
+    expect(tabLabelElement.classList.contains('mat-tab-active')).toBe(true);
 
     let tabContentElement = fixture.debugElement
         .query(By.css(`#${tabLabelElement.id}`)).nativeElement;
-    expect(tabContentElement.classList.contains('md-tab-active')).toBe(true);
+    expect(tabContentElement.classList.contains('mat-tab-active')).toBe(true);
   }
 });
 
 @Component({
   selector: 'test-app',
   template: `
-    <md-tab-group class="tab-group"
+    <mat-tab-group class="tab-group"
         [(selectedIndex)]="selectedIndex"
         (focusChange)="handleFocus($event)"
         (selectChange)="handleSelection($event)">
-      <md-tab>
-        <template md-tab-label>Tab One</template>
-        <template md-tab-content>Tab one content</template>
-      </md-tab>
-      <md-tab>
-        <template md-tab-label>Tab Two</template>
-        <template md-tab-content>Tab two content</template>
-      </md-tab>
-      <md-tab>
-        <template md-tab-label>Tab Three</template>
-        <template md-tab-content>Tab three content</template>
-      </md-tab>
-    </md-tab-group>
+      <mat-tab>
+        <template mat-tab-label>Tab One</template>
+        <template mat-tab-content>Tab one content</template>
+      </mat-tab>
+      <mat-tab>
+        <template mat-tab-label>Tab Two</template>
+        <template mat-tab-content>Tab two content</template>
+      </mat-tab>
+      <mat-tab>
+        <template mat-tab-label>Tab Three</template>
+        <template mat-tab-content>Tab three content</template>
+      </mat-tab>
+    </mat-tab-group>
   `
 })
 class SimpleTabsTestApp {
@@ -299,20 +299,20 @@ class SimpleTabsTestApp {
 @Component({
   selector: 'test-app',
   template: `
-    <md-tab-group class="tab-group">
-      <md-tab>
-        <template md-tab-label>Tab One</template>
-        <template md-tab-content>Tab one content</template>
-      </md-tab>
-      <md-tab disabled>
-        <template md-tab-label>Tab Two</template>
-        <template md-tab-content>Tab two content</template>
-      </md-tab>
-      <md-tab>
-        <template md-tab-label>Tab Three</template>
-        <template md-tab-content>Tab three content</template>
-      </md-tab>
-    </md-tab-group>
+    <mat-tab-group class="tab-group">
+      <mat-tab>
+        <template mat-tab-label>Tab One</template>
+        <template mat-tab-content>Tab one content</template>
+      </mat-tab>
+      <mat-tab disabled>
+        <template mat-tab-label>Tab Two</template>
+        <template mat-tab-content>Tab two content</template>
+      </mat-tab>
+      <mat-tab>
+        <template mat-tab-label>Tab Three</template>
+        <template mat-tab-content>Tab three content</template>
+      </mat-tab>
+    </mat-tab-group>
   `,
 })
 class DisabledTabsTestApp {}
@@ -320,12 +320,12 @@ class DisabledTabsTestApp {}
 @Component({
   selector: 'test-app',
   template: `
-    <md-tab-group class="tab-group">
-      <md-tab *ngFor="let tab of tabs | async">
-        <template md-tab-label>{{ tab.label }}</template>
-        <template md-tab-content>{{ tab.content }}</template>
-      </md-tab>
-   </md-tab-group>
+    <mat-tab-group class="tab-group">
+      <mat-tab *ngFor="let tab of tabs | async">
+        <template mat-tab-label>{{ tab.label }}</template>
+        <template mat-tab-content>{{ tab.content }}</template>
+      </mat-tab>
+   </mat-tab-group>
   `
 })
 class AsyncTabsTestApp {

--- a/src/lib/tabs/tab-label-wrapper.ts
+++ b/src/lib/tabs/tab-label-wrapper.ts
@@ -1,11 +1,11 @@
 import {Directive, ElementRef} from '@angular/core';
 
 
-/** Used in the `md-tab-group` view to display tab labels */
+/** Used in the `mat-tab-group` view to display tab labels */
 @Directive({
-  selector: '[md-tab-label-wrapper]'
+  selector: '[mat-tab-label-wrapper]'
 })
-export class MdTabLabelWrapper {
+export class MatTabLabelWrapper {
   constructor(public elementRef: ElementRef) {}
 
   /**

--- a/src/lib/tabs/tab-label.ts
+++ b/src/lib/tabs/tab-label.ts
@@ -3,9 +3,9 @@ import {TemplatePortalDirective} from '@angular2-material/core';
 
 /** Used to flag tab labels for use with the portal directive */
 @Directive({
-  selector: '[md-tab-label]',
+  selector: '[mat-tab-label]',
 })
-export class MdTabLabel extends TemplatePortalDirective {
+export class MatTabLabel extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
     super(templateRef, viewContainerRef);
   }

--- a/src/lib/tabs/tabs.ts
+++ b/src/lib/tabs/tabs.ts
@@ -14,10 +14,10 @@ import {
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {PortalModule} from '@angular2-material/core';
-import {MdTabLabel} from './tab-label';
-import {MdTabContent} from './tab-content';
-import {MdTabLabelWrapper} from './tab-label-wrapper';
-import {MdInkBar} from './ink-bar';
+import {MatTabLabel} from './tab-label';
+import {MatTabContent} from './tab-content';
+import {MatTabLabelWrapper} from './tab-label-wrapper';
+import {MatInkBar} from './ink-bar';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import {RIGHT_ARROW, LEFT_ARROW, ENTER} from '@angular2-material/core';
@@ -26,17 +26,17 @@ import {RIGHT_ARROW, LEFT_ARROW, ENTER} from '@angular2-material/core';
 let nextId = 0;
 
 /** A simple change event emitted on focus or selection changes. */
-export class MdTabChangeEvent {
+export class MatTabChangeEvent {
   index: number;
-  tab: MdTab;
+  tab: MatTab;
 }
 
 @Directive({
-  selector: 'md-tab'
+  selector: 'mat-tab'
 })
-export class MdTab {
-  @ContentChild(MdTabLabel) label: MdTabLabel;
-  @ContentChild(MdTabContent) content: MdTabContent;
+export class MatTab {
+  @ContentChild(MatTabLabel) label: MatTabLabel;
+  @ContentChild(MatTabContent) content: MatTabContent;
 
   // TODO: Replace this when BooleanFieldValue is removed.
   private _disabled = false;
@@ -56,15 +56,15 @@ export class MdTab {
  */
 @Component({
   moduleId: module.id,
-  selector: 'md-tab-group',
+  selector: 'mat-tab-group',
   templateUrl: 'tab-group.html',
   styleUrls: ['tab-group.css'],
 })
-export class MdTabGroup {
-  @ContentChildren(MdTab) _tabs: QueryList<MdTab>;
+export class MatTabGroup {
+  @ContentChildren(MatTab) _tabs: QueryList<MatTab>;
 
-  @ViewChildren(MdTabLabelWrapper) _labelWrappers: QueryList<MdTabLabelWrapper>;
-  @ViewChildren(MdInkBar) _inkBar: QueryList<MdInkBar>;
+  @ViewChildren(MatTabLabelWrapper) _labelWrappers: QueryList<MatTabLabelWrapper>;
+  @ViewChildren(MatInkBar) _inkBar: QueryList<MatInkBar>;
 
   private _isInitialized: boolean = false;
 
@@ -101,13 +101,13 @@ export class MdTabGroup {
     return this.selectChange.map(event => event.index);
   }
 
-  private _onFocusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
-  @Output('focusChange') get focusChange(): Observable<MdTabChangeEvent> {
+  private _onFocusChange: EventEmitter<MatTabChangeEvent> = new EventEmitter<MatTabChangeEvent>();
+  @Output('focusChange') get focusChange(): Observable<MatTabChangeEvent> {
     return this._onFocusChange.asObservable();
   }
 
-  private _onSelectChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
-  @Output('selectChange') get selectChange(): Observable<MdTabChangeEvent> {
+  private _onSelectChange: EventEmitter<MatTabChangeEvent> = new EventEmitter<MatTabChangeEvent>();
+  @Output('selectChange') get selectChange(): Observable<MatTabChangeEvent> {
     return this._onSelectChange.asObservable();
   }
 
@@ -167,8 +167,8 @@ export class MdTabGroup {
     }
   }
 
-  private _createChangeEvent(index: number): MdTabChangeEvent {
-    const event = new MdTabChangeEvent;
+  private _createChangeEvent(index: number): MatTabChangeEvent {
+    const event = new MatTabChangeEvent;
     event.index = index;
     if (this._tabs && this._tabs.length) {
       event.tab = this._tabs.toArray()[index];
@@ -178,12 +178,12 @@ export class MdTabGroup {
 
   /** Returns a unique id for each tab label element */
   _getTabLabelId(i: number): string {
-    return `md-tab-label-${this._groupId}-${i}`;
+    return `mat-tab-label-${this._groupId}-${i}`;
   }
 
   /** Returns a unique id for each tab content element */
   _getTabContentId(i: number): string {
-    return `md-tab-content-${this._groupId}-${i}`;
+    return `mat-tab-content-${this._groupId}-${i}`;
   }
 
   handleKeydown(event: KeyboardEvent) {
@@ -205,7 +205,7 @@ export class MdTabGroup {
    */
   moveFocus(offset: number) {
     if (this._labelWrappers) {
-      const tabs: MdTab[] = this._tabs.toArray();
+      const tabs: MatTab[] = this._tabs.toArray();
       for (let i = this.focusIndex + offset; i < tabs.length && i >= 0; i += offset) {
         if (this.isValidIndex(i)) {
           this.focusIndex = i;
@@ -229,14 +229,14 @@ export class MdTabGroup {
 
 @NgModule({
   imports: [CommonModule, PortalModule],
-  // Don't export MdInkBar or MdTabLabelWrapper, as they are internal implementatino details.
-  exports: [MdTabGroup, MdTabLabel, MdTabContent, MdTab],
-  declarations: [MdTabGroup, MdTabLabel, MdTabContent, MdTab, MdInkBar, MdTabLabelWrapper],
+  // Don't export MatInkBar or MatTabLabelWrapper, as they are internal implementatino details.
+  exports: [MatTabGroup, MatTabLabel, MatTabContent, MatTab],
+  declarations: [MatTabGroup, MatTabLabel, MatTabContent, MatTab, MatInkBar, MatTabLabelWrapper],
 })
-export class MdTabsModule {
+export class MatTabsModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdTabsModule,
+      ngModule: MatTabsModule,
       providers: []
     };
   }

--- a/src/lib/toolbar/toolbar.html
+++ b/src/lib/toolbar/toolbar.html
@@ -1,6 +1,6 @@
-<div class="md-toolbar-layout">
-  <md-toolbar-row>
+<div class="mat-toolbar-layout">
+  <mat-toolbar-row>
     <ng-content></ng-content>
-  </md-toolbar-row>
-  <ng-content select="md-toolbar-row"></ng-content>
+  </mat-toolbar-row>
+  <ng-content select="mat-toolbar-row"></ng-content>
 </div>

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -2,52 +2,52 @@
 @import 'mixins';
 @import 'default-theme'; //TODO: remove that soon.
 
-$md-toolbar-min-height: 64px !default;
-$md-toolbar-font-size: 20px !default;
-$md-toolbar-padding: 16px !default;
+$mat-toolbar-min-height: 64px !default;
+$mat-toolbar-font-size: 20px !default;
+$mat-toolbar-padding: 16px !default;
 
 @mixin toolbar-theme($palette) {
-  background: md-color($palette);
-  color: md-color($palette, default-contrast);
+  background: mat-color($palette);
+  color: mat-color($palette, default-contrast);
 }
 
-md-toolbar {
+mat-toolbar {
   display: flex;
   box-sizing: border-box;
 
   width: 100%;
-  min-height: $md-toolbar-min-height;
+  min-height: $mat-toolbar-min-height;
 
   // Font Styling
-  font-size: $md-toolbar-font-size;
+  font-size: $mat-toolbar-font-size;
   font-weight: 400;
-  font-family: $md-font-family;
+  font-family: $mat-font-family;
 
-  padding: 0 $md-toolbar-padding;
+  padding: 0 $mat-toolbar-padding;
 
   flex-direction: column;
 
-  background: md-color($md-background, app-bar);
-  color: md-color($md-foreground, text);
+  background: mat-color($mat-background, app-bar);
+  color: mat-color($mat-foreground, text);
 
-  &.md-primary {
-    @include toolbar-theme($md-primary);
+  &.mat-primary {
+    @include toolbar-theme($mat-primary);
   }
 
-  &.md-accent {
-    @include toolbar-theme($md-accent);
+  &.mat-accent {
+    @include toolbar-theme($mat-accent);
   }
 
-  &.md-warn {
-    @include toolbar-theme($md-warn);
+  &.mat-warn {
+    @include toolbar-theme($mat-warn);
   }
 
-  md-toolbar-row {
+  mat-toolbar-row {
     display: flex;
     box-sizing: border-box;
 
     width: 100%;
-    height: $md-toolbar-min-height;
+    height: $mat-toolbar-min-height;
 
     // Flexbox Vertical Alignment
     flex-direction: row;

--- a/src/lib/toolbar/toolbar.spec.ts
+++ b/src/lib/toolbar/toolbar.spec.ts
@@ -1,14 +1,14 @@
 import {Component} from '@angular/core';
 import {TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {MdToolbarModule} from './toolbar';
+import {MatToolbarModule} from './toolbar';
 
 
-describe('MdToolbar', () => {
+describe('MatToolbar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdToolbarModule.forRoot()],
+      imports: [MatToolbarModule.forRoot()],
       declarations: [TestApp],
     });
 
@@ -18,29 +18,29 @@ describe('MdToolbar', () => {
   it('should apply class based on color attribute', () => {
     let fixture = TestBed.createComponent(TestApp);
     let testComponent = fixture.debugElement.componentInstance;
-    let toolbarElement = fixture.debugElement.query(By.css('md-toolbar')).nativeElement;
+    let toolbarElement = fixture.debugElement.query(By.css('mat-toolbar')).nativeElement;
 
     testComponent.toolbarColor = 'primary';
     fixture.detectChanges();
 
-    expect(toolbarElement.classList.contains('md-primary')).toBe(true);
+    expect(toolbarElement.classList.contains('mat-primary')).toBe(true);
 
     testComponent.toolbarColor = 'accent';
     fixture.detectChanges();
 
-    expect(toolbarElement.classList.contains('md-primary')).toBe(false);
-    expect(toolbarElement.classList.contains('md-accent')).toBe(true);
+    expect(toolbarElement.classList.contains('mat-primary')).toBe(false);
+    expect(toolbarElement.classList.contains('mat-accent')).toBe(true);
 
     testComponent.toolbarColor = 'warn';
     fixture.detectChanges();
 
-    expect(toolbarElement.classList.contains('md-accent')).toBe(false);
-    expect(toolbarElement.classList.contains('md-warn')).toBe(true);
+    expect(toolbarElement.classList.contains('mat-accent')).toBe(false);
+    expect(toolbarElement.classList.contains('mat-warn')).toBe(true);
   });
 });
 
 
-@Component({template: `<md-toolbar [color]="toolbarColor">Test Toolbar</md-toolbar>`})
+@Component({template: `<mat-toolbar [color]="toolbarColor">Test Toolbar</mat-toolbar>`})
 class TestApp {
   toolbarColor: string;
 }

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -11,19 +11,19 @@ import {Renderer} from '@angular/core';
 import {ElementRef} from '@angular/core';
 
 @Directive({
-  selector: 'md-toolbar-row'
+  selector: 'mat-toolbar-row'
 })
-export class MdToolbarRow {}
+export class MatToolbarRow {}
 
 @Component({
   moduleId: module.id,
-  selector: 'md-toolbar',
+  selector: 'mat-toolbar',
   templateUrl: 'toolbar.html',
   styleUrls: ['toolbar.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class MdToolbar {
+export class MatToolbar {
 
   private _color: string;
 
@@ -46,7 +46,7 @@ export class MdToolbar {
 
   private _setElementColor(color: string, isAdd: boolean) {
     if (color != null && color != '') {
-      this.renderer.setElementClass(this.elementRef.nativeElement, `md-${color}`, isAdd);
+      this.renderer.setElementClass(this.elementRef.nativeElement, `mat-${color}`, isAdd);
     }
   }
 
@@ -54,13 +54,13 @@ export class MdToolbar {
 
 
 @NgModule({
-  exports: [MdToolbar, MdToolbarRow],
-  declarations: [MdToolbar, MdToolbarRow],
+  exports: [MatToolbar, MatToolbarRow],
+  declarations: [MatToolbar, MatToolbarRow],
 })
-export class MdToolbarModule {
+export class MatToolbarModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdToolbarModule,
+      ngModule: MatToolbarModule,
       providers: []
     };
   }

--- a/src/lib/tooltip/tooltip.scss
+++ b/src/lib/tooltip/tooltip.scss
@@ -2,21 +2,21 @@
 @import 'theme-functions';
 @import 'palette';
 
-$md-tooltip-height: 22px;
-$md-tooltip-margin: 14px;
-$md-tooltip-padding: 8px;
+$mat-tooltip-height: 22px;
+$mat-tooltip-margin: 14px;
+$mat-tooltip-padding: 8px;
 
 :host {
   pointer-events: none;
 }
-.md-tooltip {
-  background: md-color($md-grey, 700, 0.9);
+.mat-tooltip {
+  background: mat-color($mat-grey, 700, 0.9);
   color: white;
-  padding: 0 $md-tooltip-padding;
+  padding: 0 $mat-tooltip-padding;
   border-radius: 2px;
-  font-family: $md-font-family;
+  font-family: $mat-font-family;
   font-size: 10px;
-  margin: $md-tooltip-margin;
-  height: $md-tooltip-height;
-  line-height: $md-tooltip-height;
+  margin: $mat-tooltip-margin;
+  height: $mat-tooltip-height;
+  line-height: $mat-tooltip-height;
 }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -1,17 +1,17 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {TooltipPosition, MdTooltip} from '@angular2-material/tooltip';
+import {TooltipPosition, MatTooltip} from '@angular2-material/tooltip';
 import {OverlayContainer} from '@angular2-material/core';
-import {MdTooltipModule} from './tooltip';
+import {MatTooltipModule} from './tooltip';
 
 
-describe('MdTooltip', () => {
+describe('MatTooltip', () => {
   let overlayContainerElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTooltipModule.forRoot()],
+      imports: [MatTooltipModule.forRoot()],
       declarations: [BasicTooltipDemo],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -28,14 +28,14 @@ describe('MdTooltip', () => {
     let fixture: ComponentFixture<BasicTooltipDemo>;
     let buttonDebugElement: DebugElement;
     let buttonElement: HTMLButtonElement;
-    let tooltipDirective: MdTooltip;
+    let tooltipDirective: MatTooltip;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       buttonDebugElement = fixture.debugElement.query(By.css('button'));
       buttonElement = <HTMLButtonElement> buttonDebugElement.nativeElement;
-      tooltipDirective = buttonDebugElement.injector.get(MdTooltip);
+      tooltipDirective = buttonDebugElement.injector.get(MatTooltip);
     });
 
     it('should show/hide on mouse enter/leave', () => {
@@ -55,7 +55,7 @@ describe('MdTooltip', () => {
 
 @Component({
   selector: 'app',
-  template: `<button md-tooltip="some message" [tooltip-position]="position">Button</button>`
+  template: `<button mat-tooltip="some message" [tooltip-position]="position">Button</button>`
 })
 class BasicTooltipDemo {
   position: TooltipPosition = 'below';

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -22,13 +22,13 @@ import {
 export type TooltipPosition = 'before' | 'after' | 'above' | 'below';
 
 @Directive({
-  selector: '[md-tooltip]',
+  selector: '[mat-tooltip]',
   host: {
     '(mouseenter)': '_handleMouseEnter($event)',
     '(mouseleave)': '_handleMouseLeave($event)',
   }
 })
-export class MdTooltip {
+export class MatTooltip {
   visible: boolean = false;
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
@@ -46,7 +46,7 @@ export class MdTooltip {
 
   /** The message to be displayed in the tooltip */
   private _message: string;
-  @Input('md-tooltip') get message() {
+  @Input('mat-tooltip') get message() {
     return this._message;
   }
   set message(value: string) {
@@ -182,8 +182,8 @@ export class MdTooltip {
 
 @Component({
   moduleId: module.id,
-  selector: 'md-tooltip-component',
-  template: `<div class="md-tooltip">{{message}}</div>`,
+  selector: 'mat-tooltip-component',
+  template: `<div class="mat-tooltip">{{message}}</div>`,
   styleUrls: ['tooltip.css'],
 })
 export class TooltipComponent {
@@ -193,14 +193,14 @@ export class TooltipComponent {
 
 @NgModule({
   imports: [OverlayModule],
-  exports: [MdTooltip, TooltipComponent],
-  declarations: [MdTooltip, TooltipComponent],
+  exports: [MatTooltip, TooltipComponent],
+  declarations: [MatTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
 })
-export class MdTooltipModule {
+export class MatTooltipModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MdTooltipModule,
+      ngModule: MatTooltipModule,
       providers: OVERLAY_PROVIDERS,
     };
   }

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -60,7 +60,7 @@ task(':build:components:rollup', [':build:components:ts'], () => {
     'rxjs/Observable': 'Rx'
   };
   components.forEach(name => {
-    globals[`@angular2-material/${name}`] = `md.${camelCase(name)}`
+    globals[`@angular2-material/${name}`] = `mat.${camelCase(name)}`
   });
 
   // Build all of them asynchronously.
@@ -78,7 +78,7 @@ task(':build:components:rollup', [':build:components:ts'], () => {
       })
       .then((bundle: any) => {
         const result = bundle.generate({
-          moduleName: `md.${camelCase(name)}`,
+          moduleName: `mat.${camelCase(name)}`,
           format: 'umd',
           globals
         });


### PR DESCRIPTION
A bit of explanation:

Because Material 1 already uses `md` as their prefix, and also because we want people to be able to use Material 1 and 2 in their apps (in an ng-upgrade kind of situation), we needed to change our prefix to something else.

After a long list of prefixes was considered (including the much loved but probably trademarked `mc`), `mat` was decided as being the best.


This is the renaming PR which moved all prefixes to use Mat. We also understand that this will break your apps. Considering this is alpha, we decided it was better to just rip the bandaid as soon as possible so people would have to change now instead of when we move to beta.

@kara @jelbourn Please prioritize this PR as it will likely conflict with everything if I need to rebase it.