### PR TITLE
Fix: Input/Radio should be disabled when disabling the formcontrol

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -194,6 +194,14 @@ export class MdCheckbox implements ControlValueAccessor {
     this.onTouched = fn;
   }
 
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
   private _transitionCheckState(newState: TransitionCheckState) {
     let oldState = this._currentCheckState;
     let renderer = this._renderer;

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -259,6 +259,14 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   }
 
   /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  /**
    * Convert the value passed in to a value that is expected from the type of the md-input.
    * This is normally performed by the *_VALUE_ACCESSOR in forms, but since the type is bound
    * on our internal input it won't work locally.

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -439,40 +439,32 @@ describe('MdRadio', () => {
     let radioInputs: Array<MdRadioButton> = [];
     let nativeRadioInputs: Array<HTMLInputElement> = [];
 
-    beforeEach(async(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(RadioGroupWithReactiveForms);
       fixture.detectChanges();
 
-      fixture.whenStable().then(() => {
-        let inputs = fixture.debugElement.queryAll(By.directive(MdRadioButton));
+      let inputs = fixture.debugElement.queryAll(By.directive(MdRadioButton));
 
-        for (let element of inputs) {
-          radioInputs.push(element.componentInstance);
-          nativeRadioInputs.push(<HTMLInputElement> element.nativeElement.querySelector('input'));
-        }
+      for (let element of inputs) {
+        radioInputs.push(element.componentInstance);
+        nativeRadioInputs.push(<HTMLInputElement> element.nativeElement.querySelector('input'));
+      }
 
-        formControl = <FormControl> fixture.componentInstance.form.controls['radio'];
-      });
-    }));
+      formControl = <FormControl> fixture.componentInstance.form.controls['radio'];
+    });
 
-    it('should be disabled when the form-control is set disabled', async(() => {
+    it('should be disabled when the form-control is set disabled', () => {
       radioInputs.forEach(input => expect(input.disabled).toBeFalsy());
       nativeRadioInputs.forEach(input => expect(input.disabled).toBeFalsy());
 
       formControl.disable();
       fixture.detectChanges();
 
-      fixture.whenStable().then(() => {
-        // Temporary workaround, see https://github.com/angular/angular/issues/10148
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          radioInputs.forEach(input =>
-              expect(input.disabled).toBeTruthy(input.value + ' should be disabled'));
-          nativeRadioInputs.forEach(input =>
-              expect(input.disabled).toBeTruthy('Native ' + input.id + ' should be disabled'));
-        });
-      });
-    }));
+      radioInputs.forEach(input =>
+          expect(input.disabled).toBeTruthy(`${input.value} should be disabled`));
+      nativeRadioInputs.forEach(input =>
+          expect(input.disabled).toBeTruthy(`Native ${input.id} should be disabled`));
+    });
   });
 });
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -229,6 +229,14 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
 }
 
 


### PR DESCRIPTION
Fixes #1171 for Input-Elements and Radio

@jelbourn @kara I've tried to repair the checkbox too, but i couldn't test it properly.
My test for the checkbox only worked, when i deleted the ChangeDetectionStrategy.OnPush from the Component, but thats not the solution i wanted to push.
