### PR TITLE
fix(sidenav): move @Input to getter/setter instead of private field

### DIFF
--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -50,7 +50,7 @@ export class MdSidenav {
   @Input() mode: 'over' | 'push' | 'side' = 'over';
 
   /** Whether the sidenav is opened. */
-  @Input('opened') @BooleanFieldValue() private _opened: boolean = false;
+  private _opened: boolean = false;
 
   /** Event emitted when the sidenav is being opened. Use this to synchronize animations. */
   @Output('open-start') onOpenStart = new EventEmitter<void>();
@@ -75,6 +75,7 @@ export class MdSidenav {
    * Whether the sidenav is opened. We overload this because we trigger an event when it
    * starts or end.
    */
+  @Input() @BooleanFieldValue()
   get opened(): boolean { return this._opened; }
   set opened(v: boolean) {
     this.toggle(v);


### PR DESCRIPTION
This breaks AOT compile since the generated factory tries to set the private field.

I'm unsure of the ramifications of change detection setting `opened` via the setter, which will call `toggle()` where it didn't before - someone who understands the code should look at that.