### PR TITLE
fix(theming): fix top-level `&` in input theme

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -40,7 +40,7 @@
 
   // See md-input-placeholder-floating mixin in input.scss
   md-input input:-webkit-autofill + .md-input-placeholder,
-  .md-input-placeholder.md-float:not(.md-empty), &.md-float.md-focused {
+  .md-input-placeholder.md-float:not(.md-empty), .md-input-placeholder.md-float.md-focused {
 
     .md-placeholder-required {
       color: $input-required-placeholder-color;


### PR DESCRIPTION
This was fine in sassc, but ruby sass errors on it.