### PR TITLE
fix(theming): set default color to currentColor in input theme (#1260)

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -62,6 +62,9 @@ md-input {
   // The Material input should match whatever background it is above.
   background: transparent;
 
+  // If background matches current background then so should the color for proper contrast
+  color: currentColor;
+
   // By default, <input> has a padding, border, outline and a default width.
   border: none;
   outline: none;


### PR DESCRIPTION
Currently input color does not update when switching between dark and light theme. Since the background of ```md-input-element``` is transparent it is currently possible to have black text on a dark background making it hard to read. This PR sets the color for ```.md-input-element``` to ```currentColor```. 

You can see the current behavior in @jelbourn 's https://github.com/jelbourn/material2-app (just toggle the dark theme).