### PR TITLE
fix(slide-toggle): disabled theme not working and dragging works if disabled

### DIFF
--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -3,7 +3,9 @@
 
 
 @mixin _md-slide-toggle-checked($palette) {
-  &.md-checked {
+  // Do not apply the checked colors if the toggle is disabled, because the specificity would be to high for
+  // the disabled styles.
+  &.md-checked:not(.md-disabled) {
     .md-slide-toggle-thumb {
       background-color: md-color($palette);
     }

--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -24,6 +24,12 @@ $md-slide-toggle-margin: 16px !default;
   line-height: $md-slide-toggle-height;
 
   white-space: nowrap;
+
+  // Disable user selection to ensure that dragging is smooth without grabbing some elements
+  // accidentally. Manually prefixing here, because the un-prefixed property is not supported yet.
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 
   outline: none;
@@ -68,7 +74,6 @@ $md-slide-toggle-margin: 16px !default;
   height: $md-slide-toggle-height;
 
   position: relative;
-  user-select: none;
 
   margin-right: 8px;
 }

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -408,18 +408,11 @@ describe('MdSlideToggle', () => {
     let slideToggleControl: NgControl;
     let slideThumbContainer: HTMLElement;
 
-    // This initialization is async() because it needs to wait for ngModel to set the initial value.
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SlideToggleTestApp);
 
       testComponent = fixture.debugElement.componentInstance;
 
-      // Enable jasmine spies on event functions, which may trigger at initialization
-      // of the slide-toggle component.
-      spyOn(fixture.debugElement.componentInstance, 'onSlideChange').and.callThrough();
-      spyOn(fixture.debugElement.componentInstance, 'onSlideClick').and.callThrough();
-
-      // Initialize the slide-toggle component, by triggering the first change detection cycle.
       fixture.detectChanges();
 
       let slideToggleDebug = fixture.debugElement.query(By.css('md-slide-toggle'));
@@ -507,7 +500,6 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
   event.initEvent(eventName, true, true);
   element.dispatchEvent(event);
 }
-
 
 @Component({
   selector: 'slide-toggle-test-app',

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -432,7 +432,7 @@ describe('MdSlideToggle', () => {
       expect(slideThumbContainer.classList).toContain('md-dragging');
 
       gestureConfig.emitEventForElement('slide', slideThumbContainer, {
-        deltaX: 200 // Use a random number which will be clamped.
+        deltaX: 200 // Arbitrary, large delta that will be clamped to the end of the slide-toggle.
       });
 
       gestureConfig.emitEventForElement('slideend', slideThumbContainer);
@@ -452,7 +452,7 @@ describe('MdSlideToggle', () => {
       expect(slideThumbContainer.classList).toContain('md-dragging');
 
       gestureConfig.emitEventForElement('slide', slideThumbContainer, {
-        deltaX: -200 // Use a random negative number which will be clamped.
+        deltaX: -200 // Arbitrary, large delta that will be clamped to the end of the slide-toggle.
       });
 
       gestureConfig.emitEventForElement('slideend', slideThumbContainer);
@@ -474,7 +474,7 @@ describe('MdSlideToggle', () => {
       expect(slideThumbContainer.classList).not.toContain('md-dragging');
 
       gestureConfig.emitEventForElement('slide', slideThumbContainer, {
-        deltaX: 200 // Use a random number which will be clamped.
+        deltaX: 200 // Arbitrary, large delta that will be clamped to the end of the slide-toggle.
       });
 
       gestureConfig.emitEventForElement('slideend', slideThumbContainer);

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -215,16 +215,24 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   /** TODO: internal */
   _onDragStart() {
-    this._slideRenderer.startThumbDrag(this.checked);
+    if (!this.disabled) {
+      this._slideRenderer.startThumbDrag(this.checked);
+    }
   }
 
   /** TODO: internal */
   _onDrag(event: HammerInput) {
-    this._slideRenderer.updateThumbPosition(event.deltaX);
+    if (this._slideRenderer.isDragging()) {
+      this._slideRenderer.updateThumbPosition(event.deltaX);
+    }
   }
 
   /** TODO: internal */
   _onDragEnd() {
+    if (!this._slideRenderer.isDragging()) {
+      return;
+    }
+
     // Notice that we have to stop outside of the current event handler,
     // because otherwise the click event will be fired and will reset the new checked variable.
     setTimeout(() => {
@@ -258,7 +266,7 @@ class SlideToggleRenderer {
 
   /** Initializes the drag of the slide-toggle. */
   startThumbDrag(checked: boolean) {
-    if (!this._thumbBarWidth) {
+    if (!this.isDragging()) {
       this._thumbBarWidth = this._thumbBarEl.clientWidth - this._thumbEl.clientWidth;
       this._checked = checked;
       this._thumbEl.classList.add('md-dragging');
@@ -267,7 +275,7 @@ class SlideToggleRenderer {
 
   /** Stops the current drag and returns the new checked value. */
   stopThumbDrag(): boolean {
-    if (this._thumbBarWidth) {
+    if (this.isDragging()) {
       this._thumbBarWidth = null;
       this._thumbEl.classList.remove('md-dragging');
 
@@ -279,10 +287,8 @@ class SlideToggleRenderer {
 
   /** Updates the thumb containers position from the specified distance. */
   updateThumbPosition(distance: number) {
-    if (this._thumbBarWidth) {
-      this._percentage = this._getThumbPercentage(distance);
-      applyCssTransform(this._thumbEl, `translate3d(${this._percentage}%, 0, 0)`);
-    }
+    this._percentage = this._getThumbPercentage(distance);
+    applyCssTransform(this._thumbEl, `translate3d(${this._percentage}%, 0, 0)`);
   }
 
   /** Retrieves the percentage of thumb from the moved distance. */

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -32,7 +32,7 @@ export class TestGestureConfig extends MdGestureConfig {
    * The Angular event plugin for Hammer creates a new HammerManager instance for each listener,
    * so we need to apply our event on all instances to hit the correct listener.
    */
-  emitEventForElement(eventType: string, element: HTMLElement, eventData: Object) {
+  emitEventForElement(eventType: string, element: HTMLElement, eventData = {}) {
     let instances = this.hammerInstances.get(element);
     instances.forEach(instance => instance.emit(eventType, eventData));
   }


### PR DESCRIPTION
| Quick Summary |
| ------ |
| If checked and disabled theme is now invalid |
| Dragging while disabled |
| Improved dragging for UX | 

<details>
> * It seems like as per the new theming feature, view encapsulation turned off and now the checked theming overwrites the disabled theme (too high specificity)
> * If a slide-toggle is disabled, users are still able to drag the thumb (which is invalid)
> * Fix invalid `user-select` property, and now dragging works without clamps.
</details>

---
> Notice: We are two times extra checking for `isDragging`, that's because we want to keep the renderer as abstract as possible

FYI: I'm trying to get some good HammerJS tests into the slide-toggle in the future.