### PR TITLE
chore: fix warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "0.6.0",
+    "@angular/platform-server": "^2.0.0",
     "@types/glob": "^5.0.29",
     "@types/gulp": "^3.8.29",
     "@types/hammerjs": "^2.0.30",
@@ -82,7 +83,7 @@
     "symlink-or-copy": "^1.0.1",
     "ts-node": "^0.7.3",
     "tslint": "^3.13.0",
-    "typescript": "^2.0.0",
+    "typescript": "^2.0.2",
     "typings": "^1.3.1",
     "which": "^1.2.4"
   }


### PR DESCRIPTION
Fixes the following console warnings:
```console
npm WARN @angular/compiler-cli@0.6.0 requires a peer of typescript@^2.0.2 but none was installed.
npm WARN @angular/compiler-cli@0.6.0 requires a peer of @angular/platform-server@^2.0.0-rc.6 but none was installed.
npm WARN @angular/tsc-wrapped@0.3.0 requires a peer of typescript@^2.0.2 but none was installed.
```