### PR TITLE
build: do not inline resources for normal builds

### DIFF
--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -147,14 +147,18 @@ export function cleanTask(glob: string) {
 
 
 /** Build an task that depends on all application build tasks. */
-export function buildAppTask(appName: string) {
+export function buildAppTask(appName: string, inlineResources = false) {
   const buildTasks = ['vendor', 'ts', 'scss', 'assets']
     .map(taskName => `:build:${appName}:${taskName}`);
+
+  const baseTasks = [
+    inlineResources ? ':build:components:inline' : 'build:components'
+  ];
 
   return (done: () => void) => {
     gulpRunSequence(
       'clean',
-      ['build:components', ...buildTasks],
+      [...baseTasks, ...buildTasks],
       done
     );
   };

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -97,11 +97,15 @@ task(':build:components:rollup', [':build:components:ts'], () => {
 task('build:components', sequenceTask(
   ':build:components:rollup',
   ':build:components:assets',
-  ':build:components:scss',
-  ':inline-resources',
+  ':build:components:scss'
 ));
 
-task(':build:components:ngc', ['build:components'], execNodeTask(
+task(':build:components:inline', sequenceTask(
+  'build:components',
+  ':inline-resources'
+));
+
+task(':build:components:ngc', [':build:components:inline'], execNodeTask(
   '@angular/compiler-cli', 'ngc', ['-p', path.relative(PROJECT_ROOT, path.join(componentsDir, 'tsconfig.json'))]
 ));
 


### PR DESCRIPTION
Inlining the resources for normal builds does not refresh the view.

> For example if I change a HTML file, it will be properly copied over (per assets gulp task), but it's still inlined wrong and does not update the view.

<details>
> By default all build tasks should not inline the resources, and only the build tasks (like with the ng compiler) should inline the resources.
</details>

I can imagine that it is intentionally to **always** inline the resources, there were the following approaches
- Always re-inline the resources (not cool for a dev app IMO)
- Only inline the resources if explicitly requested (release, ngc)

I'm up for some other approaches or requested changes.