### PR TITLE
fix(sidenav): align text at start

### DIFF
--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -226,6 +226,15 @@ describe('MdSidenav', () => {
       expect(sidenavEl.classList).toContain('md-sidenav-opened');
     });
 
+    it('should remove align attr from DOM', () => {
+      const fixture = TestBed.createComponent(BasicTestApp);
+      fixture.detectChanges();
+
+      const sidenavEl = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
+      expect(sidenavEl.hasAttribute('align'))
+          .toBe(false, 'Expected sidenav not to have a native align attribute.');
+    });
+
   });
 
 });

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -38,6 +38,8 @@ export class MdDuplicatedSidenavError extends MdError {
   template: '<ng-content></ng-content>',
   host: {
     '(transitionend)': '_onTransitionEnd($event)',
+    // must prevent the browser from aligning text based on value
+    '[attr.align]': 'null'
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
End sidenavs were aligning text at "end" because the `align="end"` attribute was still on the DOM. This PR removes the attribute so it won't confuse browsers.