### PR TITLE
Remove some text from the ripple demo

### DIFF
--- a/src/demo-app/ripple/ripple-demo.html
+++ b/src/demo-app/ripple/ripple-demo.html
@@ -49,5 +49,4 @@
       Click me
     </div>
   </section>
-  {{centered}} {{rounded}}
 </div>


### PR DESCRIPTION
It shows up as "false false" in the app with no indication to the user of what that means