### PR TITLE
fix(gestures): add hammer types by default

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -23,5 +23,8 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/common": "^2.0.0"
+  },
+  "dependencies": {
+    "@types/hammerjs": "^2.0.30"
   }
 }


### PR DESCRIPTION
This PR adds Hammer typings as a dep of the project so people don't have to manually add typings and reference paths for it.

Closes #797 