### PR TITLE
style(card): add default outer-margin on mobile

### DIFF
--- a/src/demo-app/card/card-demo.scss
+++ b/src/demo-app/card/card-demo.scss
@@ -2,9 +2,11 @@
   display: flex;
   flex-flow: column nowrap;
 
-  md-card {
-    margin: 0 16px 16px 0;
-    width: 350px;
+  @media ('min-width: 600px') {
+    md-card {
+      margin: 0 16px 16px 0;
+      width: 350px;
+    }
   }
 
   img {

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -4,6 +4,7 @@
 
 $md-card-default-padding: 24px !default;
 $md-card-mobile-padding: 24px 16px !default;
+$md-card-mobile-margin: 8px 8px 0 !default;  // avoid doubling margins between cards by setting bottom-margin to 0
 $md-card-border-radius: 2px !default;
 $md-card-header-size: 40px !default;
 
@@ -144,6 +145,7 @@ md-card-title-group {
 @media ($md-xsmall) {
   md-card {
     padding: $md-card-mobile-padding;
+    margin: $md-card-mobile-margin;
   }
 
   [md-card-image] {


### PR DESCRIPTION
 Previously cards did not have the outer margin, that is specified in the Material Design spec.
 Now cards have a 8px outer margin on top, the sides and in between of them.
 The outer margin does not apply to the bottom of the cards.

 Closes #1325