### PR TITLE
feat(input): add md-focused class on wrapper

### DIFF
--- a/src/lib/input/input.html
+++ b/src/lib/input/input.html
@@ -1,4 +1,4 @@
-<div class="md-input-wrapper">
+<div class="md-input-wrapper" [class.md-focused]="focused">
   <div class="md-input-table">
     <div class="md-input-prefix"><ng-content select="[md-prefix]"></ng-content></div>
 


### PR DESCRIPTION
Add `.md-focused` to the `md-input-wrapper`

Fix #1135
