### PR TITLE
style(tabs): set correct min-width on mobile devices

### DIFF
--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -38,6 +38,12 @@ $md-tab-bar-height: 48px !default;
   }
 }
 
+@media ($md-xsmall) {
+  .md-tab-label {
+    min-width: 72px;
+  }
+}
+
 .md-tab-disabled {
   cursor: default;
   pointer-events: none;


### PR DESCRIPTION
Tabs on mobile devices have a min-width of 72px.

Closes #1350