### PR TITLE
fix(aot): add constant for a11y providers, use in core module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "deploy": "firebase deploy",
     "webdriver-manager": "webdriver-manager"
   },
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.9-2",
   "license": "MIT",
   "engines": {
     "node": ">= 4.2.1 < 5"

--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -7,6 +7,7 @@ export {FocusTrap} from './focus-trap';
 export {MdLiveAnnouncer} from './live-announcer';
 export {InteractivityChecker} from './interactivity-checker';
 
+export const A11Y_PROVIDERS = [MdLiveAnnouncer, InteractivityChecker];
 
 @NgModule({
   declarations: [FocusTrap],
@@ -16,7 +17,7 @@ export class A11yModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: A11yModule,
-      providers: [MdLiveAnnouncer, InteractivityChecker],
+      providers: A11Y_PROVIDERS,
     };
   }
 }

--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -1,3 +1,5 @@
+import {Injectable} from '@angular/core';
+
 /**
  * Utility for checking the interactivity of an element, such as whether is is focusable or
  * tabbable.
@@ -11,6 +13,7 @@
  * TODO(jelbourn): explore using ally.js directly for its significantly more robust
  * checks (need to evaluate payload size, performance, and compatibility with tree-shaking).
  */
+@Injectable()
 export class InteractivityChecker {
 
   /** Gets whether an element is disabled. */

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -4,9 +4,9 @@ import {RtlModule} from './rtl/dir';
 import {MdRippleModule} from './ripple/ripple';
 import {PortalModule} from './portal/portal-directives';
 import {OverlayModule} from './overlay/overlay-directives';
-import {A11yModule} from './a11y/index';
-import {MdLiveAnnouncer} from './a11y/live-announcer';
-import {InteractivityChecker} from './a11y/interactivity-checker';
+import {A11yModule, A11Y_PROVIDERS, MdLiveAnnouncer, InteractivityChecker} from './a11y/index';
+import {OVERLAY_PROVIDERS} from './overlay/overlay';
+import {MdUniqueSelectionDispatcher} from './coordination/unique-selection-dispatcher';
 
 
 // RTL
@@ -89,7 +89,7 @@ export class MdCoreModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: MdCoreModule,
-      providers: [MdLiveAnnouncer, InteractivityChecker],
+      providers: [A11Y_PROVIDERS, OVERLAY_PROVIDERS],
     };
   }
 }

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -4,9 +4,8 @@ import {RtlModule} from './rtl/dir';
 import {MdRippleModule} from './ripple/ripple';
 import {PortalModule} from './portal/portal-directives';
 import {OverlayModule} from './overlay/overlay-directives';
-import {A11yModule, A11Y_PROVIDERS, MdLiveAnnouncer, InteractivityChecker} from './a11y/index';
+import {A11yModule, A11Y_PROVIDERS} from './a11y/index';
 import {OVERLAY_PROVIDERS} from './overlay/overlay';
-import {MdUniqueSelectionDispatcher} from './coordination/unique-selection-dispatcher';
 
 
 // RTL

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -1,11 +1,11 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {
-  MdLiveAnnouncer,
   MdRippleModule,
   RtlModule,
   PortalModule,
-  OverlayModule
+  OverlayModule,
+  A11yModule,
 } from './core/index';
 
 import {MdButtonToggleModule} from './button-toggle/index';
@@ -29,7 +29,6 @@ import {MdToolbarModule} from './toolbar/index';
 import {MdTooltipModule} from './tooltip/index';
 import {MdMenuModule} from './menu/index';
 import {MdDialogModule} from './dialog/index';
-import {A11yModule} from './core/a11y/index';
 
 
 const MATERIAL_MODULES = [
@@ -93,7 +92,6 @@ const MATERIAL_MODULES = [
     OverlayModule.forRoot(),
   ],
   exports: MATERIAL_MODULES,
-  providers: [MdLiveAnnouncer]
 })
 export class MaterialRootModule { }
 

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/material",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.9-2",
   "description": "Angular 2 Material",
   "main": "./material.umd.js",
   "module": "./index.js",


### PR DESCRIPTION
With these changes I have AoT working on my material2-app: https://material2-app.firebaseapp.com/

Also bumps the version so I can publish the fix.

See #1342 