### PR TITLE
docs: update component docs for new packaging

### DIFF
--- a/src/lib/core/README.md
+++ b/src/lib/core/README.md
@@ -1,2 +1,1 @@
-Core library code for other `@angular2-material` components.
-This should be added as a dependency for any project using the components.
+Core library code for other `@angular/material` components.

--- a/src/lib/grid-list/README.md
+++ b/src/lib/grid-list/README.md
@@ -7,19 +7,6 @@ See Material Design spec [here](https://www.google.com/design/spec/components/gr
 
 ### Simple grid list
 
-To use `md-grid-list`, import the MdGridList module into your application's NgModule:
-
-*my-app-module.ts*
-```ts
-import {MdGridListModule} from '@angular2-material/grid-list';
-
-@NgModule({
-  imports: [MdGridListModule.forRoot()],
-  ...
-})
-export class MyAppModule {}
-```
-
 In your template, create an `md-grid-list` element and specify the number of columns you want for
 your grid using the `cols` property (this is the only mandatory attribute). 
 

--- a/src/lib/list/README.md
+++ b/src/lib/list/README.md
@@ -7,19 +7,6 @@
 
 ### Simple list
 
-To use `md-list`, import the MdList module into your application's NgModule:
-
-*my-app-module.ts*
-```ts
-import {MdListModule} from '@angular2-material/list';
-
-@NgModule({
-  imports: [MdListModule.forRoot()],
-  ...
-})
-export class MyAppModule {}
-```
-
 In your template, create an `md-list` element and wrap each of your items in an `md-list-item` tag.
 
 ```html

--- a/src/lib/menu/README.md
+++ b/src/lib/menu/README.md
@@ -12,24 +12,10 @@
 ## Usage
 
 ### Setup
-
-Import the MdMenu module.
-
-*my-app-module.ts*
-```ts
-import {MdMenuModule} from '@angular2-material/menu';
-
-@NgModule({
-  imports: [MdMenuModule.forRoot()],
-  ...
-})
-export class MyAppModule {}
-```
-
 For alpha.7, you need to include the overlay styles in your app via a `link` element. This will
 look something like
 ```html
-<link href="vendor/@angular2-material/core/overlay/overlay.css" rel="stylesheet">
+<link href="vendor/@angular/material/core/overlay/overlay.css" rel="stylesheet">
 ```
 
 ### Simple menu

--- a/src/lib/radio/README.md
+++ b/src/lib/radio/README.md
@@ -3,21 +3,6 @@ Radio buttons allow the user to select one option from a set. Use radio buttons 
 
 ![Preview](https://material.angularjs.org/material2_assets/radio/radios.png)
 
-### Setup
-Importing the symbols:
-```ts
-import { MdRadioModule } from '@angular2-material/radio';
-```
-
-Adding providers and directives:
-```ts
-@NgModule({
-  imports: [MdRadioModule.forRoot()],
-  ...
-})
-export class MyAppModule { }
-```
-
 ### Examples
 A basic radio group would have the following markup.
 ```html

--- a/src/lib/tooltip/README.md
+++ b/src/lib/tooltip/README.md
@@ -5,7 +5,7 @@ Tooltip allows the user to specify text to be displayed when the mouse hover ove
 For alpha.7, you need to include the overlay styles in your app via a `link` element. This will
 look something like
 ```html
-<link href="vendor/@angular2-material/core/overlay/overlay.css" rel="stylesheet">
+<link href="vendor/@angular/material/core/overlay/overlay.css" rel="stylesheet">
 ```
 
 


### PR DESCRIPTION
Updates the documentation for components so that they no longer reference the old `@angular2-material` package.