### PR TITLE
Fixes MdSidenav issue when closing a sidenav with [opened]="true"

### DIFF
--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -83,6 +83,9 @@ export class MdSidenav {
     // TODO(jelbourn): this coercion goes away when BooleanFieldValue is removed.
     let booleanValue = v != null && `${v}` !== 'false';
     this.toggle(booleanValue);
+
+    this._openPromise = null;
+    this._closePromise = null;
   }
 
 


### PR DESCRIPTION
Fixes MdSidenav issue with sidenav opened as default.
Setting the attribute on the html component creates `_openPromise` via `toggle()`, which is never resolved, like it's usually done with with `_onTransitionEnd` (issue #1382).

The reason is when MdSidenav component is initialized:

```
@Input()
  get opened(): boolean { return this._opened; }
  set opened(v: boolean) {
    // TODO(jelbourn): this coercion goes away when BooleanFieldValue is removed.
    let booleanValue = v != null && `${v}` !== 'false';
    this.toggle(booleanValue);
  } 
```

`toggle()` method creates `_openPromiseReject` and `_openPromiseReject`:

```
    if (isOpen) {
      if (this._openPromise == null) {
        this._openPromise = new Promise<void>((resolve, reject) => {
          this._openPromiseResolve = resolve;
          this._openPromiseReject = reject;
        });
      }
      return this._openPromise;
    } else {
      if (this._closePromise == null) {
        this._closePromise = new Promise<void>((resolve, reject) => {
          this._closePromiseResolve = resolve;
          this._closePromiseReject = reject;
        });
      }
      return this._closePromise;
    }
```

They are usually resolved at `_onTransitionEnd`, but since no transition occurs on application start, this method never gets called. When we click the close button, it rejects the open promise.

```
  _onTransitionEnd(transitionEvent: TransitionEvent) {
    if (transitionEvent.target == this._elementRef.nativeElement
        // Simpler version to check for prefixes.
        && transitionEvent.propertyName.endsWith('transform')) {
      this._transition = false;
      if (this._opened) {
        if (this._openPromise != null) {
          this._openPromiseResolve();
        }
        if (this._closePromise != null) {
          this._closePromiseReject();
        }

        this.onOpen.emit(null);
      } else {
        if (this._closePromise != null) {
          this._closePromiseResolve();
        }
        if (this._openPromise != null) {
          this._openPromiseReject();
        }

        this.onClose.emit(null);
      }

      this._openPromise = null;
      this._closePromise = null;
    }
  }
```

My current solution is to clear the promises when setting the propery:

```
  @Input()
  get opened(): boolean { return this._opened; }
  set opened(v: boolean) {
    // TODO(jelbourn): this coercion goes away when BooleanFieldValue is removed.
    let booleanValue = v != null && `${v}` !== 'false';
    this.toggle(booleanValue);

    this._openPromise = null;
    this._closePromise = null;
  }
```
