### PR TITLE
﻿fix(input): asterisk color when not focused

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -39,8 +39,7 @@
   }
 
   // See md-input-placeholder-floating mixin in input.scss
-  md-input input:-webkit-autofill + .md-input-placeholder,
-  .md-input-placeholder.md-float:not(.md-empty), .md-input-placeholder.md-float.md-focused {
+  md-input input:-webkit-autofill + .md-input-placeholder, .md-input-placeholder.md-float.md-focused {
 
     .md-placeholder-required {
       color: $input-required-placeholder-color;


### PR DESCRIPTION
* Currently the asterisk is still using the warn color when the input is not focused anymore.

* Per Material Specs the asterisk should be only red when the input is focused ([Specs Video](https://material-design.storage.googleapis.com/publish/material_v_9/0B7WCemMG6e0VcHFla0dwOE5pVVE/forms-supportive-content-v3_xhdpi.webm))

| Focused | Blurred |
| ------- | ---------- |
| ![](https://i.gyazo.com/d6b6e4b316a35bb7d9f54d87989b5d15.png) | ![](https://i.gyazo.com/59e858b90f15f4e617afe7454c9db81d.png) |
 

Fixes #1395.