### PR TITLE
fix(slide-toggle): emit change event after drag end 

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -494,7 +494,7 @@ describe('MdSlideToggle', () => {
       expect(slideThumbContainer.classList).toContain('md-dragging');
 
       gestureConfig.emitEventForElement('slide', slideThumbContainer, {
-        deltaX: 200 // Use a random number which will be clamped.
+        deltaX: 200 // Arbitrary, large delta that will be clamped to the end of the slide-toggle.
       });
 
       gestureConfig.emitEventForElement('slideend', slideThumbContainer);

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -486,6 +486,27 @@ describe('MdSlideToggle', () => {
       expect(slideThumbContainer.classList).not.toContain('md-dragging');
     }));
 
+    it('should should emit a change event after drag', fakeAsync(() => {
+      expect(slideToggle.checked).toBe(false);
+
+      gestureConfig.emitEventForElement('slidestart', slideThumbContainer);
+
+      expect(slideThumbContainer.classList).toContain('md-dragging');
+
+      gestureConfig.emitEventForElement('slide', slideThumbContainer, {
+        deltaX: 200 // Use a random number which will be clamped.
+      });
+
+      gestureConfig.emitEventForElement('slideend', slideThumbContainer);
+
+      // Flush the timeout for the slide ending.
+      tick();
+
+      expect(slideToggle.checked).toBe(true);
+      expect(slideThumbContainer.classList).not.toContain('md-dragging');
+      expect(testComponent.lastEvent.checked).toBe(true);
+    }));
+
   });
 
 });

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -237,6 +237,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     // because otherwise the click event will be fired and will reset the new checked variable.
     setTimeout(() => {
       this.checked = this._slideRenderer.stopThumbDrag();
+      this._emitChangeEvent();
     }, 0);
   }
 


### PR DESCRIPTION
* Emits a change event after the drag completed.

Fixes #1390.

**FYI**: Rebased on top of #1268 (should be merged before)