### PR TITLE
fix(snack-bar): add explicit box-sizing

### DIFF
--- a/src/lib/snack-bar/snack-bar-container.scss
+++ b/src/lib/snack-bar/snack-bar-container.scss
@@ -16,4 +16,5 @@ $md-snack-bar-max-width: 568px !default;
   min-width: $md-snack-bar-min-width;
   overflow: hidden;
   padding: $md-snack-bar-padding;
+  box-sizing: content-box;
 }


### PR DESCRIPTION
Fixes the snack bar not being readable in the cases where `box-sizing: border-box` is applied globally.

Fixes #1412.

**Note:** this can also be fixed by removing the explicit height, however I wasn't sure whether it wasn't there on purpose (e.g. to prevent line wraps).