### PR TITLE
feat(overlay): add ability to set custom class on panes

### DIFF
--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -1,3 +1,10 @@
 .demo-dialog {
   color: rebeccapurple;
 }
+
+// apply custom z-index
+/deep/ .md-overlay-pane {
+  &.jazz-dialog {
+    z-index: 9999;
+  }
+}

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,11 +1,11 @@
-import {Component, ViewContainerRef} from '@angular/core';
+import {Component, ViewContainerRef,ViewEncapsulation} from '@angular/core';
 import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular/material';
 
 @Component({
   moduleId: module.id,
   selector: 'dialog-demo',
   templateUrl: 'dialog-demo.html',
-  styleUrls: ['dialog-demo.css'],
+  styleUrls: ['dialog-demo.css']
 })
 export class DialogDemo {
   dialogRef: MdDialogRef<JazzDialog>;
@@ -18,6 +18,7 @@ export class DialogDemo {
   open() {
     let config = new MdDialogConfig();
     config.viewContainerRef = this.viewContainerRef;
+    config.paneClassName = 'jazz-dialog';
 
     this.dialogRef = this.dialog.open(JazzDialog, config);
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,4 +1,4 @@
-import {Component, ViewContainerRef,ViewEncapsulation} from '@angular/core';
+import {Component, ViewContainerRef} from '@angular/core';
 import {MdDialog, MdDialogConfig, MdDialogRef} from '@angular/material';
 
 @Component({

--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -60,4 +60,20 @@
       </button>
     </md-menu>
   </div>
+  <div class="menu-section">
+    <p>Custom classes on menu' overlay pane</p>
+
+    <md-toolbar>
+      <button md-icon-button [md-menu-trigger-for]="menuCustomClassName">
+        <md-icon>more_vert</md-icon>
+      </button>
+    </md-toolbar>
+
+    <md-menu #menuCustomClassName="mdMenu" [paneClassName]="['foo', 'bar']">
+
+      <button md-menu-item *ngFor="let item of items" (click)="select(item.text)" [disabled]="item.disabled">
+        {{ item.text }}
+      </button>
+    </md-menu>
+  </div>
 </div>

--- a/src/lib/core/overlay/overlay-state.ts
+++ b/src/lib/core/overlay/overlay-state.ts
@@ -7,7 +7,7 @@ import {PositionStrategy} from './position/position-strategy';
  */
 export class OverlayState {
   /** Strategy with which to position the overlay. */
-  positionStrategy: PositionStrategy
+  positionStrategy: PositionStrategy;
 
   /** Whether the overlay has a backdrop. */
   hasBackdrop: boolean = false;

--- a/src/lib/core/overlay/overlay-state.ts
+++ b/src/lib/core/overlay/overlay-state.ts
@@ -7,10 +7,13 @@ import {PositionStrategy} from './position/position-strategy';
  */
 export class OverlayState {
   /** Strategy with which to position the overlay. */
-  positionStrategy: PositionStrategy;
+  positionStrategy: PositionStrategy
 
   /** Whether the overlay has a backdrop. */
   hasBackdrop: boolean = false;
+
+  /** Optional custom class to be added to the pane. */
+  paneClassName: string | Array<string>;
 
   // TODO(jelbourn): configuration still to add
   // - overlay size

--- a/src/lib/core/overlay/overlay.scss
+++ b/src/lib/core/overlay/overlay.scss
@@ -20,7 +20,6 @@
     left: 0;
     height: 100%;
     width: 100%;
-    z-index: $md-z-index-overlay-container;
   }
 
   // A single overlay pane.

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -37,7 +37,7 @@ export class Overlay {
    * @returns A reference to the created overlay.
    */
   create(state: OverlayState = defaultState): OverlayRef {
-    return this._createOverlayRef(this._createPaneElement(), state);
+    return this._createOverlayRef(this._createPaneElement(state), state);
   }
 
   /**
@@ -52,10 +52,21 @@ export class Overlay {
    * Creates the DOM element for an overlay and appends it to the overlay container.
    * @returns Promise resolving to the created element.
    */
-  private _createPaneElement(): HTMLElement {
+  private _createPaneElement(state: OverlayState): HTMLElement {
     var pane = document.createElement('div');
-    pane.id = `md-overlay-${nextUniqueId++}`;
+    const id = nextUniqueId++;
+    pane.id = `md-overlay-${id}`;
     pane.classList.add('md-overlay-pane');
+    pane.classList.add(`md-has-index-${id}`);
+
+    if (state.paneClassName) {
+      // check if custom class is an array of classes
+      if (state.paneClassName.constructor === Array) {
+        pane.classList.add(...<Array<string>>state.paneClassName);
+      } else {
+        pane.classList.add(<string>state.paneClassName);
+      }
+    }
 
     this._overlayContainer.getContainerElement().appendChild(pane);
 

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -14,6 +14,9 @@ export class MdDialogConfig {
   /** The ARIA role of the dialog element. */
   role: DialogRole = 'dialog';
 
+  /** Optional custom class to be added to dialog's overlay pane. */
+  paneClassName: string | Array<string>;
+
   // TODO(jelbourn): add configuration for size, clickOutsideToClose, lifecycle hooks,
   // ARIA labelling.
 }

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -120,6 +120,10 @@ export class MdDialog {
         .centerHorizontally()
         .centerVertically();
 
+    if (dialogConfig.paneClassName) {
+      state.paneClassName = dialogConfig.paneClassName;
+    }
+
     return state;
   }
 }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -59,6 +59,12 @@ export class MdMenu {
     }, {});
   }
 
+  /**
+   * Takes either a string or array of strins and applies them to the
+   * parent overlay pane, giving consumer control over z-indexes
+   */
+  @Input('paneClassName') paneClassName: string | Array<string>;
+
   @Output() close = new EventEmitter;
 
   /**

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -147,8 +147,14 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
    * @returns OverlayState
    */
   private _getOverlayConfig(): OverlayState {
-    const overlayState = new OverlayState();
+    let overlayState: OverlayState = new OverlayState();
     overlayState.positionStrategy = this._getPosition();
+
+    // check if custom paneClassName is set on menu and pass it to overlay config
+    if (this.menu.paneClassName) {
+      overlayState.paneClassName = this.menu.paneClassName;
+    }
+
     return overlayState;
   }
 


### PR DESCRIPTION
It's more of a proof-of-concept for https://github.com/angular/material2/issues/1432, since I feel like you'd rather control this by passing the config a z-index value, but I think this is more flexible(for example when you need to control this with css media queries).

What I've changed:

**Overlay** - You can pass `paneClassName`, which can be either a string or an array of string, to a config for `Overlay`s `create`, it then adds it to the created `md-overlay-pane`, I have also added a new helper class to it `md-has-index-${id}`(which can then be used along your custom class to differentiate between more panes inside one overlay)

**Dialog** - added `paneClassName` option to `MdDialogConfig`, which is then passes to `OverlayState` and create example in the dialog-demo

**Menu** - added a new `@Input` to `md-menu`, which takes either a string or array of string, and passes it down to `OverlayState` in `[md-menu-trigger-for]`

**Overlay** - removed z-index from `overlay.scss` as it was making z-indexes of panes useless