### PR TITLE
change overflow of placeholder in Input element

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -114,7 +114,7 @@ md-input {
   display: none;
   white-space: nowrap;
   text-overflow: ellipsis;
-  overflow-x: hidden;
+  overflow: hidden;
 
   transform: translateY(0);
   transform-origin: bottom left;


### PR DESCRIPTION
changed on line 117 "overflow-x : hidden" to "overflow : hidden" because of visible scroll of the placeholder element
