### PR TITLE
Compatability with drag&drop API

### DIFF
--- a/src/lib/core/gestures/MdGestureConfig.ts
+++ b/src/lib/core/gestures/MdGestureConfig.ts
@@ -8,8 +8,6 @@ export class MdGestureConfig extends HammerGestureConfig {
   /* List of new event names to add to the gesture support list */
   events: string[] = [
     'drag',
-    'dragstart',
-    'dragend',
     'dragright',
     'dragleft',
     'longpress',


### PR DESCRIPTION
Remove dragstart and dragend from Hammer.js config so they don't override native HTML5 drag&drop API.
drag event unused right now except for one demo. dragstart and dragend not used at all, should be removed. Eventually, their features can be accessed via drag event anyway.
This should fix issue #1457