### PR TITLE
fix(list): set flex-shrink for avatar

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -64,6 +64,7 @@ $md-dense-three-line-height: 76px;
   }
 
   [md-list-avatar] {
+    flex-shrink: 0;
     width: $md-list-avatar-size;
     height: $md-list-avatar-size;
     border-radius: 50%;


### PR DESCRIPTION
md-list-avatar aren't correctly displayed on the initial render
set flex-shrink to fix this behavior

Closes #1403