### PR TITLE
fix(list): ensure multi-line lists expand to fill space

### DIFF
--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -30,12 +30,15 @@ export class MdLineSetter {
     this._resetClasses();
     if (count === 2 || count === 3) {
       this._setClass(`md-${count}-line`, true);
+    } else if (count > 3) {
+      this._setClass(`md-multi-line`, true);
     }
   }
 
   private _resetClasses(): void {
     this._setClass('md-2-line', false);
     this._setClass('md-3-line', false);
+    this._setClass('md-multi-line', false);
   }
 
   private _setClass(className: string, bool: boolean): void {

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -50,8 +50,16 @@ $md-dense-three-line-height: 76px;
     height: $two-line-height;
   }
 
+
   &.md-3-line .md-list-item {
     height: $three-line-height;
+  }
+
+  // list items with more than 3 lines should expand to match
+  // the height of its contained text
+  &.md-multi-line .md-list-item {
+    height: 100%;
+    padding: 8px $md-list-side-padding;
   }
 
   .md-list-text {

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -18,6 +18,7 @@ describe('MdList', () => {
         ListWithItemWithCssClass,
         ListWithDynamicNumberOfLines,
         ListWithMultipleItems,
+        ListWithManyLines,
       ],
     });
 
@@ -63,6 +64,15 @@ describe('MdList', () => {
     let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
     expect(listItems[0].nativeElement.className).toBe('md-3-line');
     expect(listItems[1].nativeElement.className).toBe('md-3-line');
+  });
+
+  it('should apply md-multi-line class to lists with more than 3 lines', () => {
+    let fixture = TestBed.createComponent(ListWithManyLines);
+    fixture.detectChanges();
+
+    let listItems = fixture.debugElement.children[0].queryAll(By.css('md-list-item'));
+    expect(listItems[0].nativeElement.className).toBe('md-multi-line');
+    expect(listItems[1].nativeElement.className).toBe('md-multi-line');
   });
 
   it('should apply md-list-avatar class to list items with avatars', () => {
@@ -151,6 +161,17 @@ class ListWithTwoLineItem extends BaseTestList { }
     </md-list-item>
   </md-list>`})
 class ListWithThreeLineItem extends BaseTestList { }
+
+@Component({template: `
+  <md-list>
+    <md-list-item *ngFor="let item of items">
+      <h3 md-line>Line 1</h3>
+      <p md-line>Line 2</p>
+      <p md-line>Line 3</p>
+      <p md-line>Line 4</p>
+    </md-list-item>
+  </md-list>`})
+class ListWithManyLines extends BaseTestList { }
 
 @Component({template: `
   <md-list>


### PR DESCRIPTION
The Material Design spec only recommends a maximum of three lines in list items, so this is what we formally support. However, if you decide to go off-spec and add more than three lines to a list item, all the lines are currently squeezed into a shorter height (which looks awful). 

This PR allows list items with 4+ lines to expand to match the height of the contained text so they will look a bit saner.

r: @jelbourn

