### PR TITLE
feature(md-icon-button): set fixed line height for wrapped content

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -112,5 +112,6 @@ $md-mini-fab-padding: 8px !default;
 
   i, md-icon {
     padding: $padding 0;
+    line-height: $size - $padding * 2;
   }
 }

--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -112,6 +112,6 @@ $md-mini-fab-padding: 8px !default;
 
   i, md-icon {
     padding: $padding 0;
-    line-height: $size - $padding * 2;
+    line-height: $md-icon-button-line-height;
   }
 }

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -43,6 +43,7 @@
   border-radius: $md-icon-button-border-radius;
 
   .md-button-wrapper > * {
+    line-height: $md-icon-button-line-height;
     vertical-align: middle;
   }
 }


### PR DESCRIPTION
<md-icon></md-icon> should be centered inside <button md-icon-button></button> when it's size is reduced
in additional fix it for md-fab

Closes #1426
