### PR TITLE
fix(tooltip): remove tooltip component after it's parent destroyed

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -50,6 +50,14 @@ describe('MdTooltip', () => {
       tooltipDirective._handleMouseLeave(null);
       expect(overlayContainerElement.textContent).toBe('');
     });
+
+    it('should be removed after parent destroyed', () => {
+      tooltipDirective._handleMouseEnter(null);
+      expect(tooltipDirective.visible).toBeTruthy();
+      fixture.destroy();
+      expect(overlayContainerElement.childNodes.length).toBe(0);
+      expect(overlayContainerElement.textContent).toBe('');
+    });
   });
 });
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -69,6 +69,15 @@ export class MdTooltip {
   }
 
   /**
+   * Remove overlay after tooltip's parent has been destroyed
+   */
+  ngOnDestroy() {
+    this.visible = false;
+    this._overlayRef.dispose();
+    this._overlayRef = null;
+  }
+
+  /**
    * Create the overlay config and position strategy
    */
   private _createOverlay() {


### PR DESCRIPTION
fix #1111 
