### PR TITLE
fix(menu): make menu open idempotent

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -66,9 +66,11 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   }
 
   openMenu(): void {
-    this._createOverlay();
-    this._overlayRef.attach(this._portal);
-    this._initMenu();
+    if (!this._menuOpen) {
+      this._createOverlay();
+      this._overlayRef.attach(this._portal);
+      this._initMenu();
+    }
   }
 
   closeMenu(): void {

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1,6 +1,7 @@
 import {TestBed, async} from '@angular/core/testing';
-import {Component} from '@angular/core';
-import {MdMenuModule} from './menu';
+import {Component, ViewChild} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {MdMenuModule, MdMenuTrigger} from './menu';
 
 
 describe('MdMenu', () => {
@@ -8,17 +9,35 @@ describe('MdMenu', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MdMenuModule.forRoot()],
-      declarations: [TestMenu],
+      declarations: [SimpleMenu],
     });
 
     TestBed.compileComponents();
   }));
 
-  it('should add and remove focus class on focus/blur', () => {
-    let fixture = TestBed.createComponent(TestMenu);
-    expect(fixture).toBeTruthy();
+  it('should open the menu as an idempotent operation', () => {
+    let fixture = TestBed.createComponent(SimpleMenu);
+    fixture.detectChanges();
+    let menu = fixture.debugElement.query(By.css('.md-menu'));
+    expect(menu).toBe(null);
+    expect(() => {
+      fixture.componentInstance.trigger.openMenu();
+      fixture.componentInstance.trigger.openMenu();
+
+      menu = fixture.debugElement.query(By.css('.md-menu'));
+      expect(menu.nativeElement.innerHTML.trim()).toEqual('Content');
+    }).not.toThrowError();
   });
 });
 
-@Component({template: ``})
-class TestMenu {}
+@Component({
+  template: `
+    <button [md-menu-trigger-for]="menu">Toggle menu</button>
+    <md-menu #menu="mdMenu">
+      Content
+    </md-menu>
+  `
+})
+class SimpleMenu {
+  @ViewChild(MdMenuTrigger) trigger: MdMenuTrigger;
+}


### PR DESCRIPTION
Calling `openMenu()` multiple times shouldn't cause issues.

Closes https://github.com/angular/material2/issues/1104.