### PR TITLE
chore: use yarn instead of npm in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
   - env: "MODE=saucelabs_optional"
   - env: "MODE=browserstack_optional"
 
+# i will add yarn
+
 install:
   - npm install
 


### PR DESCRIPTION
This is an attempt at https://github.com/angular/material2/issues/1494

~~The method used is slightly different than the one referenced in the issue, yarn was installed from its repository rather than using npm.~~
~~We'll see what Travis does.~~