### PR TITLE
fix(menu): destroy click catcher when trigger is destroyed

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -84,6 +84,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
     if (this._overlayRef) {
       this._overlayRef.dispose();
       this._overlayRef = null;
+      this._resetMenu();
     }
   }
 


### PR DESCRIPTION
Eventually we should switch to using the overlay's backdrop as a click-catcher. Hot fix until then.

Closes https://github.com/angular/material2/issues/1506