### PR TITLE
chore(saucelabs): fix microsoft edge version

### DIFF
--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -150,7 +150,7 @@ export const customLaunchers: { [name: string]: BrowserLauncherInfo } = {
     base: 'SauceLabs',
     browserName: 'microsoftedge',
     platform: 'Windows 10',
-    version: '20.10240'
+    version: '14'
   },
   'SL_ANDROID4.1': {
     base: 'SauceLabs',


### PR DESCRIPTION
The last days the Saucelabs mode in the CI is failing with Microsoft Edge.

> As per error message, there seems to be an invalid browser configuration.

While looking at the Saucelabs API and comparing the "available" versions for `SL_EDGE`, it looks like they have changed the versions to match the `HTML` engine

<img src="https://i.gyazo.com/81ea13b6e0ead2df990f28b6b75f570b.png" height="70">

See https://gist.github.com/DevVersion/ffcd03143de80a22bc49aae52b612d16