### PR TITLE
fix(input): remove invalid aria-target attribute

### DIFF
--- a/src/lib/input/input.html
+++ b/src/lib/input/input.html
@@ -4,7 +4,6 @@
 
     <div class="md-input-infix">
       <input #input
-             aria-target
              class="md-input-element"
              [class.md-end]="align == 'end'"
              [attr.aria-label]="ariaLabel"


### PR DESCRIPTION
* The aria-target attribute is a non-existing attribute (also confirmed again by searching through the W3C docs)

Fixes #929