### PR TITLE
chore: rename tsconfigs for IDEs

### DIFF
--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
     "mapRoot": "",
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
@@ -15,18 +15,18 @@
     "target": "es5",
     "inlineSources": true,
     "stripInternal": true,
-    "baseUrl": "",
-    "paths": {
-    },
     "typeRoots": [
       "../../node_modules/@types"
     ],
     "types": [
-      "jasmine"
     ]
   },
+  "exclude": [
+    "**/*.spec.*",
+    "system-config-spec.ts"
+  ],
   "angularCompilerOptions": {
-    "genDir": "../../dist",
+    "genDir": "../../dist/@angular/material",
     "skipTemplateCodegen": true,
     "debug": true
   }

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
     "mapRoot": "",
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
@@ -15,18 +15,18 @@
     "target": "es5",
     "inlineSources": true,
     "stripInternal": true,
+    "baseUrl": "",
+    "paths": {
+    },
     "typeRoots": [
       "../../node_modules/@types"
     ],
     "types": [
+      "jasmine"
     ]
   },
-  "exclude": [
-    "**/*.spec.*",
-    "system-config-spec.ts"
-  ],
   "angularCompilerOptions": {
-    "genDir": "../../dist/@angular/material",
+    "genDir": "../../dist",
     "skipTemplateCodegen": true,
     "debug": true
   }

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -34,11 +34,11 @@ function _globify(maybeGlob: string, suffix = '**/*') {
 
 
 /** Create a TS Build Task, based on the options. */
-export function tsBuildTask(tsConfigPath: string) {
+export function tsBuildTask(tsConfigPath: string, tsConfigName = 'tsconfig.json') {
   let tsConfigDir = tsConfigPath;
-  if (fs.existsSync(path.join(tsConfigDir, 'tsconfig.json'))) {
+  if (fs.existsSync(path.join(tsConfigDir, tsConfigName))) {
     // Append tsconfig.json
-    tsConfigPath = path.join(tsConfigDir, 'tsconfig.json');
+    tsConfigPath = path.join(tsConfigDir, tsConfigName);
   } else {
     tsConfigDir = path.dirname(tsConfigDir);
   }

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -40,10 +40,10 @@ task(':watch:components:spec', () => {
 
 
 /** Builds component typescript only (ESM output). */
-task(':build:components:ts', tsBuildTask(componentsDir));
+task(':build:components:ts', tsBuildTask(componentsDir, 'tsconfig-srcs.json'));
 
 /** Builds components typescript for tests (CJS output). */
-task(':build:components:spec', tsBuildTask(path.join(componentsDir, 'tsconfig-spec.json')));
+task(':build:components:spec', tsBuildTask(componentsDir));
 
 /** Copies assets (html, markdown) to build output. */
 task(':build:components:assets', copyTask([


### PR DESCRIPTION
R: @kara 

Renames `tsconfig-spec.json` to just `tsconfig.json` and the previous `tsconfig.json` to `tsconfig-srcs.json`. This fixes IDEs that assume `tsconfig.json` is the right configuration for the entire directory (e.g. WebStorm). 