### PR TITLE
feat(overlay): add ability to set custom class on panes

### DIFF
--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -20,7 +20,6 @@
     left: 0;
     height: 100%;
     width: 100%;
-    z-index: $md-z-index-overlay-container;
   }
 
   // A single overlay pane.

--- a/src/lib/core/overlay/overlay-state.ts
+++ b/src/lib/core/overlay/overlay-state.ts
@@ -14,6 +14,9 @@ export class OverlayState {
 
   backdropClass: string = 'md-overlay-dark-backdrop';
 
+  /** Optional custom class to be added to dialog's overlay pane. */
+  overlayClass: string | string[];
+
   // TODO(jelbourn): configuration still to add
   // - overlay size
   // - focus trap

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -149,8 +149,8 @@ describe('Overlay', () => {
       overlayRef.attach(componentPortal);
       viewContainerFixture.detectChanges();
 
-      let backdrop = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
-      expect(backdrop.classList).toContain('some-custom-class');
+      let pane = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
+      expect(pane.classList).toContain('some-custom-class');
     });
 
     it('should apply a custom overlay pane classes', () => {
@@ -160,9 +160,9 @@ describe('Overlay', () => {
       overlayRef.attach(componentPortal);
       viewContainerFixture.detectChanges();
 
-      let backdrop = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
-      expect(backdrop.classList).toContain('first-custom-class');
-      expect(backdrop.classList).toContain('second-custom-class');
+      let pane = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
+      expect(pane.classList).toContain('first-custom-class');
+      expect(pane.classList).toContain('second-custom-class');
     });
 
   });

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -142,6 +142,29 @@ describe('Overlay', () => {
       expect(backdrop.classList).toContain('md-overlay-transparent-backdrop');
     });
 
+    it('should apply a custom overlay pane class', () => {
+      config.overlayClass = 'some-custom-class';
+
+      let overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      let backdrop = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
+      expect(backdrop.classList).toContain('some-custom-class');
+    });
+
+    it('should apply a custom overlay pane classes', () => {
+      config.overlayClass = ['first-custom-class', 'second-custom-class'];
+
+      let overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      let backdrop = <HTMLElement> overlayContainerElement.querySelector('.md-overlay-pane');
+      expect(backdrop.classList).toContain('first-custom-class');
+      expect(backdrop.classList).toContain('second-custom-class');
+    });
+
   });
 });
 

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -37,7 +37,7 @@ export class Overlay {
    * @returns A reference to the created overlay.
    */
   create(state: OverlayState = defaultState): OverlayRef {
-    return this._createOverlayRef(this._createPaneElement(), state);
+    return this._createOverlayRef(this._createPaneElement(state), state);
   }
 
   /**
@@ -52,10 +52,19 @@ export class Overlay {
    * Creates the DOM element for an overlay and appends it to the overlay container.
    * @returns Promise resolving to the created element.
    */
-  private _createPaneElement(): HTMLElement {
-    var pane = document.createElement('div');
-    pane.id = `md-overlay-${nextUniqueId++}`;
+  private _createPaneElement(state: OverlayState): HTMLElement {
+    let pane = document.createElement('div');
+    const id = nextUniqueId++;
+    pane.id = `md-overlay-${id}`;
     pane.classList.add('md-overlay-pane');
+
+    let overlayClass = state.overlayClass;
+    if (overlayClass) {
+      if (typeof overlayClass === 'string') {
+        overlayClass = [overlayClass];
+      }
+      pane.classList.add(...overlayClass);
+    }
 
     this._overlayContainer.getContainerElement().appendChild(pane);
 

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -14,6 +14,9 @@ export class MdDialogConfig {
   /** The ARIA role of the dialog element. */
   role: DialogRole = 'dialog';
 
+  /** Optional custom class to be added to dialog's overlay pane. */
+  overlayClass: string | string[];
+
   // TODO(jelbourn): add configuration for size, clickOutsideToClose, lifecycle hooks,
   // ARIA labelling.
 }

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -120,6 +120,10 @@ export class MdDialog {
         .centerHorizontally()
         .centerVertically();
 
+    if (dialogConfig.overlayClass) {
+      state.overlayClass = dialogConfig.overlayClass;
+    }
+
     return state;
   }
 }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -58,6 +58,12 @@ export class MdMenu {
     }, {});
   }
 
+  /**
+   * Takes either a string or array of strins and applies them to the
+   * parent overlay pane, giving consumer control over z-indexes
+   */
+  @Input('overlayClass') overlayClass: string | Array<string>;
+
   @Output() close = new EventEmitter;
 
   /**

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -169,10 +169,16 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
    * @returns OverlayState
    */
   private _getOverlayConfig(): OverlayState {
-    const overlayState = new OverlayState();
+    let overlayState = new OverlayState();
     overlayState.positionStrategy = this._getPosition();
     overlayState.hasBackdrop = true;
     overlayState.backdropClass = 'md-overlay-transparent-backdrop';
+
+    // check if custom `overlayClass` is set on menu and pass it to overlay config
+    if (this.menu.overlayClass) {
+      overlayState.overlayClass = this.menu.overlayClass;
+    }
+
     return overlayState;
   }
 


### PR DESCRIPTION
I re-did https://github.com/angular/material2/pull/1438 

It includes tests for overlay(I didn't see any similar tests for say backdrop class on menu or dialog, so I assumed it's not required since it should inherently work when overlay tests passes) and comments from the previous PR with the exception of https://github.com/angular/material2/pull/1438#discussion_r84730695 and https://github.com/angular/material2/pull/1438#discussion_r84734492 which didn't make sense to me.

@jelbourn 
