### PR TITLE
Log the port the demo app is running on

### DIFF
--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -188,15 +188,19 @@ export function vendorTask() {
 export function serverTask(liveReload: boolean = true,
                            streamCallback: (stream: NodeJS.ReadWriteStream) => void = null) {
   return () => {
+    const port = 4200;
+
     const stream = gulp.src('dist').pipe(gulpServer({
       livereload: liveReload,
       fallback: 'index.html',
-      port: 4200
+      port
     }));
 
     if (streamCallback) {
       streamCallback(stream);
     }
+
+    console.log(`Running app at http://localhost:${port}.`);
     return stream;
   }
 }


### PR DESCRIPTION
Hello Angular Material2,

I was running the demo app and had to dig in the source to find out what was going on. The demo app was running but it was not immediately obvious. This change logs a message to developers where the demo app is running.

Thanks!