### PR TITLE
feat(Slider): Allow controlling disabled state from form control

### DIFF
--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -619,6 +619,24 @@ describe('MdSlider', () => {
       expect(sliderInstance.value).toBe(7);
     });
 
+    it('should update the disabled state when control is disabled', () => {
+      expect(sliderInstance.disabled).toBe(false);
+
+      testComponent.control.disable();
+      fixture.detectChanges();
+
+      expect(sliderInstance.disabled).toBe(true);
+    });
+
+    it('should update the disabled state when the control is enabled', () => {
+      sliderInstance.disabled = true;
+
+      testComponent.control.enable();
+      fixture.detectChanges();
+
+      expect(sliderInstance.disabled).toBe(false);
+    });
+
     // TODO: Add tests for ng-pristine, ng-touched, ng-invalid.
   });
 });

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -376,6 +376,13 @@ export class MdSlider implements AfterContentInit, ControlValueAccessor {
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
+
+  /**
+  * Implemented as part of ControlValueAccessor
+  */
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
 }
 
 /**


### PR DESCRIPTION
This enables controlling the disabled state of a slider using a custom form control's
`enable()` and `disable()` methods.