### PR TITLE
fix(slide-toggle): match theme with specs

### DIFF
--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -2,22 +2,22 @@
 @import '../core/theming/theming';
 
 
-@mixin _md-slide-toggle-checked($palette, $thumb-on-hue) {
+@mixin _md-slide-toggle-checked($palette, $thumb-checked-hue) {
   // Do not apply the checked colors if the toggle is disabled, because the specificity would be to high for
   // the disabled styles.
   &.md-checked:not(.md-disabled) {
     .md-slide-toggle-thumb {
-      background-color: md-color($palette, $thumb-on-hue);
+      background-color: md-color($palette, $thumb-checked-hue);
     }
 
     .md-slide-toggle-bar {
-      background-color: md-color($palette, $thumb-on-hue, 0.5);
+      background-color: md-color($palette, $thumb-checked-hue, 0.5);
     }
   }
 }
 
 // TODO(jelbourn): remove this when the real ripple has been applied to slide-toggle.
-@mixin _md-slide-toggle-ripple($palette, $foreground, $thumb-on-hue) {
+@mixin _md-slide-toggle-ripple($palette, $foreground, $thumb-checked-hue) {
 
   &.md-slide-toggle-focused {
     &:not(.md-checked) .md-ink-ripple {
@@ -27,7 +27,7 @@
     }
 
     .md-ink-ripple {
-      background-color: md-color($palette, $thumb-on-hue, 0.26);
+      background-color: md-color($palette, $thumb-checked-hue, 0.26);
     }
   }
 
@@ -41,24 +41,28 @@
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
-  $thumb-on-hue: if($is-dark, 200, 500);
-  $thumb-off-hue: if($is-dark, 400, 50);
+  // Color hues based on the specs, which prescribe different hues for dark and light themes
+  // https://material.google.com/components/selection-controls.html#selection-controls-switch
+  $thumb-normal-hue: if($is-dark, 400, 50);
+  $thumb-checked-hue: if($is-dark, 200, 500);
   $thumb-disabled-hue: if($is-dark, 800, 400);
+
+  $bar-normal-color: md-color($foreground, disabled);
   $bar-disabled-color: if($is-dark, rgba(white, 0.12), rgba(black, 0.1));
 
   md-slide-toggle {
-    @include _md-slide-toggle-checked($accent, $thumb-on-hue);
-    @include _md-slide-toggle-ripple($accent, $foreground, $thumb-on-hue);
+    @include _md-slide-toggle-checked($accent, $thumb-checked-hue);
+    @include _md-slide-toggle-ripple($accent, $foreground, $thumb-checked-hue);
     
 
     &.md-primary {
-      @include _md-slide-toggle-checked($primary, $thumb-on-hue);
-      @include _md-slide-toggle-ripple($primary, $foreground, $thumb-on-hue);
+      @include _md-slide-toggle-checked($primary, $thumb-checked-hue);
+      @include _md-slide-toggle-ripple($primary, $foreground, $thumb-checked-hue);
     }
   
     &.md-warn {
-      @include _md-slide-toggle-checked($warn, $thumb-on-hue);
-      @include _md-slide-toggle-ripple($warn, $foreground, $thumb-on-hue);
+      @include _md-slide-toggle-checked($warn, $thumb-checked-hue);
+      @include _md-slide-toggle-ripple($warn, $foreground, $thumb-checked-hue);
     }
 
   }
@@ -76,10 +80,10 @@
   }
 
   .md-slide-toggle-thumb {
-    background-color: md-color($md-grey, $thumb-off-hue);
+    background-color: md-color($md-grey, $thumb-normal-hue);
   }
 
   .md-slide-toggle-bar {
-    background-color: md-color($foreground, disabled);
+    background-color: $bar-normal-color;
   }
 }

--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -2,55 +2,63 @@
 @import '../core/theming/theming';
 
 
-@mixin _md-slide-toggle-checked($palette) {
+@mixin _md-slide-toggle-checked($palette, $thumb-on-hue) {
   // Do not apply the checked colors if the toggle is disabled, because the specificity would be to high for
   // the disabled styles.
   &.md-checked:not(.md-disabled) {
     .md-slide-toggle-thumb {
-      background-color: md-color($palette);
+      background-color: md-color($palette, $thumb-on-hue);
     }
 
     .md-slide-toggle-bar {
-      background-color: md-color($palette, 0.5);
+      background-color: md-color($palette, $thumb-on-hue, 0.5);
     }
   }
 }
 
 // TODO(jelbourn): remove this when the real ripple has been applied to slide-toggle.
-@mixin _md-slide-toggle-ripple($palette, $foreground) {
+@mixin _md-slide-toggle-ripple($palette, $foreground, $thumb-on-hue) {
+
   &.md-slide-toggle-focused {
     &:not(.md-checked) .md-ink-ripple {
       // When the slide-toggle is not checked and it shows its focus indicator, it should use a 12% opacity
       // of black in light themes and 12% of white in dark themes.
       background-color: md-color($foreground, divider);
     }
+
+    .md-ink-ripple {
+      background-color: md-color($palette, $thumb-on-hue, 0.26);
+    }
   }
 
-  &.md-slide-toggle-focused .md-ink-ripple {
-    background-color: md-color($palette, 0.26);
-  }
 }
 
 @mixin md-slide-toggle-theme($theme) {
+  $is-dark: map_get($theme, is-dark);
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
   $warn: map-get($theme, warn);
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
+  $thumb-on-hue: if($is-dark, 200, 500);
+  $thumb-off-hue: if($is-dark, 400, 50);
+  $thumb-disabled-hue: if($is-dark, 800, 400);
+  $bar-disabled-color: if($is-dark, rgba(white, 0.12), rgba(black, 0.1));
+
   md-slide-toggle {
-    @include _md-slide-toggle-checked($accent);
-    @include _md-slide-toggle-ripple($accent, $foreground);
+    @include _md-slide-toggle-checked($accent, $thumb-on-hue);
+    @include _md-slide-toggle-ripple($accent, $foreground, $thumb-on-hue);
     
 
     &.md-primary {
-      @include _md-slide-toggle-checked($primary);
-      @include _md-slide-toggle-ripple($primary, $foreground);
+      @include _md-slide-toggle-checked($primary, $thumb-on-hue);
+      @include _md-slide-toggle-ripple($primary, $foreground, $thumb-on-hue);
     }
   
     &.md-warn {
-      @include _md-slide-toggle-checked($warn);
-      @include _md-slide-toggle-ripple($warn, $foreground);
+      @include _md-slide-toggle-checked($warn, $thumb-on-hue);
+      @include _md-slide-toggle-ripple($warn, $foreground, $thumb-on-hue);
     }
 
   }
@@ -60,20 +68,18 @@
       // The thumb of the slide-toggle always uses the hue 400 of the grey palette in dark or light themes.
       // Since this is very specific to the slide-toggle component, we're not providing
       // it in the background palette.
-      background-color: md-color($md-grey, 400);
+      background-color: md-color($md-grey, $thumb-disabled-hue);
     }
     .md-slide-toggle-bar {
-      background-color: md-color($foreground, divider);
+      background-color: $bar-disabled-color;
     }
   }
 
   .md-slide-toggle-thumb {
-    background-color: md-color($background, background);
+    background-color: md-color($md-grey, $thumb-off-hue);
   }
 
   .md-slide-toggle-bar {
-    // The slide-toggle bar always uses grey-500 for both dark and light themes.
-    // Since this is very specific to slide-toggle, it's not part of the common background palette.
-    background-color: md-color($md-grey, 500);
+    background-color: md-color($foreground, disabled);
   }
 }


### PR DESCRIPTION
* Currently the theme stylesheet for the slide-toggle was not following the specs.

* This commit ensures that the stylesheet follows the specs with all details (https://material.google.com/components/selection-controls.html#selection-controls-switch)
 

| --- | --- |
| --- | --- |
| <img src="https://i.gyazo.com/a03d23769d53cc639f589edc7ac3effa.png" height="40"> | <img src="https://i.gyazo.com/96ed307a01a33b8804e7524632194bce.png" height="40"> |
| <img src="https://i.gyazo.com/7eb0b9b97e93a99e434d7eddcd54098e.png" height="40">| <img src="https://i.gyazo.com/1fb6f4b0cb55d3a11923d3cab86f56a9.png" height="40">

@jelbourn

-  I assume the way the bar color currently is determined is not looking very good (but it's per specs and I don't wanted to add it to the foreground palette)
- Regarding passing `$thumb-on-hue` - we can't place mixins inside of mixins (so I'd rather make a follow up and discuss possible approaches)



Fixes #1568.