### PR TITLE
fix(overlay): raise z-index for overlay-container

### DIFF
--- a/src/lib/core/style/_variables.scss
+++ b/src/lib/core/style/_variables.scss
@@ -15,8 +15,12 @@ $z-index-fab: 20 !default;
 $z-index-drawer: 100 !default;
 
 // Overlay z indices.
+
+// We want overlays to always appear over user content, so set a baseline
+// very high z-index for the overlay container, which is where we create the new
+// stacking context for all overlays.
+$md-z-index-overlay-container: 1000;
 $md-z-index-overlay: 1000;
-$md-z-index-overlay-container: 1;
 $md-z-index-overlay-backdrop: 1;
 
 


### PR DESCRIPTION
R: @kara 
This will help prevent the overlay container from being covered up by other stacking contexts that are directly on the document body.

(of course there's always a _higher_ z-index...)