### PR TITLE
fix: correct EventEmitter generic type across lib

### DIFF
--- a/src/lib/core/a11y/list-key-manager.ts
+++ b/src/lib/core/a11y/list-key-manager.ts
@@ -21,7 +21,7 @@ export class ListKeyManager {
    * This event is emitted any time the TAB key is pressed, so components can react
    * when focus is shifted off of the list.
    */
-  @Output() tabOut: EventEmitter<null> = new EventEmitter();
+  @Output() tabOut = new EventEmitter<void>();
 
   constructor(private _items: QueryList<MdFocusable>) {}
 
@@ -35,7 +35,7 @@ export class ListKeyManager {
     } else if (event.keyCode === UP_ARROW) {
       this._focusPreviousItem();
     } else if (event.keyCode === TAB) {
-      this.tabOut.emit(null);
+      this.tabOut.emit();
     }
   }
 

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -98,7 +98,7 @@ export class ConnectedOverlayDirective implements OnDestroy {
   }
 
   /** Event emitted when the backdrop is clicked. */
-  @Output() backdropClick: EventEmitter<null> = new EventEmitter();
+  @Output() backdropClick = new EventEmitter<void>();
 
   // TODO(jelbourn): inputs for size, scroll behavior, animation, etc.
 
@@ -178,7 +178,7 @@ export class ConnectedOverlayDirective implements OnDestroy {
 
     if (this.hasBackdrop) {
       this._backdropSubscription = this._overlayRef.backdropClick().subscribe(() => {
-        this.backdropClick.emit(null);
+        this.backdropClick.emit();
       });
     }
   }

--- a/src/lib/core/rtl/dir.ts
+++ b/src/lib/core/rtl/dir.ts
@@ -34,7 +34,7 @@ export class Dir {
     let old = this._dir;
     this._dir = v;
     if (old != this._dir) {
-      this.dirChange.emit(null);
+      this.dirChange.emit();
     }
   }
 

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -63,7 +63,7 @@ export class MdMenu {
     }, {});
   }
 
-  @Output() close = new EventEmitter;
+  @Output() close = new EventEmitter<void>();
 
   /**
    * Focus the first item in the menu. This method is used by the menu trigger
@@ -80,7 +80,7 @@ export class MdMenu {
    * trigger will close the menu.
    */
   private _emitCloseEvent(): void {
-    this.close.emit(null);
+    this.close.emit();
   }
 
   private _setPositionX(pos: MenuPositionX): void {

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -48,8 +48,8 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   private _openedFromKeyboard: boolean = false;
 
   @Input('md-menu-trigger-for') menu: MdMenu;
-  @Output() onMenuOpen = new EventEmitter();
-  @Output() onMenuClose = new EventEmitter();
+  @Output() onMenuOpen = new EventEmitter<void>();
+  @Output() onMenuClose = new EventEmitter<void>();
 
   constructor(private _overlay: Overlay, private _element: ElementRef,
               private _viewContainerRef: ViewContainerRef, private _renderer: Renderer) {}
@@ -140,7 +140,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   // set state rather than toggle to support triggers sharing a menu
   private _setIsMenuOpen(isOpen: boolean): void {
     this._menuOpen = isOpen;
-    this._menuOpen ? this.onMenuOpen.emit(null) : this.onMenuClose.emit(null);
+    this._menuOpen ? this.onMenuOpen.emit() : this.onMenuClose.emit();
   }
 
   /**

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -117,9 +117,9 @@ export class MdSidenav {
     this._transition = true;
 
     if (isOpen) {
-      this.onOpenStart.emit(null);
+      this.onOpenStart.emit();
     } else {
-      this.onCloseStart.emit(null);
+      this.onCloseStart.emit();
     }
 
     if (isOpen) {
@@ -160,7 +160,7 @@ export class MdSidenav {
           this._closePromiseReject();
         }
 
-        this.onOpen.emit(null);
+        this.onOpen.emit();
       } else {
         if (this._closePromise != null) {
           this._closePromiseResolve();
@@ -169,7 +169,7 @@ export class MdSidenav {
           this._openPromiseReject();
         }
 
-        this.onClose.emit(null);
+        this.onClose.emit();
       }
 
       this._openPromise = null;


### PR DESCRIPTION
R: @tinayuangao 
CC: @kara 

The default generic type of `EventEmitter` is `{}`. If TS has `strictNullChecks` enabled, emitting `null` on such an emitter will cause a build error:
```
Type 'EventEmitter<{}>' is not assignable to type 'EventEmitter<null>'
```