### PR TITLE
fix(ripple): disable pointer events on ripple

### DIFF
--- a/src/lib/core/ripple/_ripple.scss
+++ b/src/lib/core/ripple/_ripple.scss
@@ -13,6 +13,7 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
   // "relative" so that the ripple divs it creates inside itself are correctly positioned.
   [md-ripple] {
     overflow: hidden;
+    pointer-events: none;
   }
 
   [md-ripple].md-ripple-unbounded {


### PR DESCRIPTION
R: @tinayuangao 

I noticed on the checkbox demo that you could sometimes click outside of the checkbox and on the ripple and it would toggle the checkbox. 