### PR TITLE
perf(progress-circle): improved rendering performance

### DIFF
--- a/src/lib/progress-circle/progress-circle.html
+++ b/src/lib/progress-circle/progress-circle.html
@@ -5,5 +5,5 @@
 -->
 <svg viewBox="0 0 100 100"
      preserveAspectRatio="xMidYMid meet">
-  <path [attr.d]="currentPath"></path>
+  <path></path>
 </svg>


### PR DESCRIPTION
Currently the progress circle hits ZoneJS on every animation frame, due to `requestAnimationFrame`. This change:
- Wraps the `requestAnimationFrame` calls in `runOutsideAngular` in order to avoid hitting the change detection on every frame.
- Switches from using an attribute binding to manipulating the `path` node directly.

Referencing #1570, #1511.

**Note:** I'm open to suggestions on better ways to fetch a reference to the `path` node. I've tried doing it in the constructor and in an `OnInit` method, but certain animations fire too early for the element to be rendered.
