### PR TITLE
fix(overlay): make overlay work in fullscreen mode

### DIFF
--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -25,6 +25,9 @@
       </button>
       <div class="demo-toolbar">
         <h1>Angular Material 2 Demos</h1>
+        <button md-button (click)="toggleFullscreen()" title="Toggle fullscreen">
+          Fullscreen
+        </button>
         <button md-button (click)="root.dir = (root.dir == 'rtl' ? 'ltr' : 'rtl')" title="Toggle between RTL and LTR">
           {{root.dir.toUpperCase()}}
         </button>

--- a/src/demo-app/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app/demo-app.scss
@@ -39,3 +39,9 @@ body {
     font-size: 20px;
   }
 }
+
+// stretch to screen size in fullscreen mode
+.demo-content {
+  width: 100%;
+  height: 100%;
+}

--- a/src/demo-app/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app/demo-app.scss
@@ -44,4 +44,5 @@ body {
 .demo-content {
   width: 100%;
   height: 100%;
+  background-color: white;
 }

--- a/src/demo-app/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app/demo-app.scss
@@ -23,6 +23,13 @@ body {
     padding: 32px;
   }
 
+  // stretch to screen size in fullscreen mode
+  .demo-content:fullscreen {
+    width: 100%;
+    height: 100%;
+    background-color: white;
+  }
+
   md-toolbar {
     md-icon {
       cursor: pointer;
@@ -38,11 +45,4 @@ body {
   h1 {
     font-size: 20px;
   }
-}
-
-// stretch to screen size in fullscreen mode
-.demo-content {
-  width: 100%;
-  height: 100%;
-  background-color: white;
 }

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -56,14 +56,11 @@ export class DemoApp {
     let elem = this._element.nativeElement.querySelector('.demo-content');
     if (elem.requestFullscreen) {
       elem.requestFullscreen();
-    }
-    else if (elem.webkitRequestFullScreen) {
+    } else if (elem.webkitRequestFullScreen) {
       elem.webkitRequestFullScreen();
-    }
-    else if (elem.mozRequestFullScreen) {
+    } else if (elem.mozRequestFullScreen) {
       elem.mozRequestFullScreen();
-    }
-    else if (elem.msRequestFullScreen) {
+    } else if (elem.msRequestFullScreen) {
       elem.msRequestFullScreen();
     }
   }

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -60,8 +60,8 @@ export class DemoApp {
       elem.webkitRequestFullScreen();
     } else if (elem.mozRequestFullScreen) {
       elem.mozRequestFullScreen();
-    } else if (elem.msRequestFullScreen) {
-      elem.msRequestFullScreen();
+    } else if (elem.msRequestFullscreen) {
+      elem.msRequestFullscreen();
     }
   }
 }

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -1,4 +1,4 @@
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component, ViewEncapsulation, ElementRef} from '@angular/core';
 
 
 @Component({
@@ -47,4 +47,24 @@ export class DemoApp {
     {name: 'Toolbar', route: 'toolbar'},
     {name: 'Tooltip', route: 'tooltip'}
   ];
+
+  constructor(private _element: ElementRef) {
+
+  }
+
+  public toggleFullscreen() {
+    let elem = this._element.nativeElement.querySelector('.demo-content');
+    if (elem.requestFullscreen) {
+      elem.requestFullscreen();
+    }
+    else if (elem.webkitRequestFullScreen) {
+      elem.webkitRequestFullScreen();
+    }
+    else if (elem.mozRequestFullScreen) {
+      elem.mozRequestFullScreen();
+    }
+    else if (elem.msRequestFullScreen) {
+      elem.msRequestFullScreen();
+    }
+  }
 }

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -22,31 +22,27 @@ export class OverlayContainer {
    */
   private _createContainer(): void {
     let container = document.createElement('div');
-    container.classList.add('md-overlay-container');    
-    document.addEventListener("fullscreenchange", () => this._adjustContainerParent());
-    document.addEventListener("webkitfullscreenchange", () => this._adjustContainerParent());
-    document.addEventListener("mozfullscreenchange", () => this._adjustContainerParent());
-    document.addEventListener("msfullscreenchange", () => this._adjustContainerParent());
+    container.classList.add('md-overlay-container');
+    document.addEventListener('fullscreenchange', () => this._adjustContainerParent());
+    document.addEventListener('webkitfullscreenchange', () => this._adjustContainerParent());
+    document.addEventListener('mozfullscreenchange', () => this._adjustContainerParent());
+    document.addEventListener('msfullscreenchange', () => this._adjustContainerParent());
     this._containerElement = container;
-    this._adjustContainerParent();    
+    this._adjustContainerParent();
   }
 
   private _adjustContainerParent() {
     // use any type because document type doesn't declare full screen variables
     let currentDocument: any = document;
-    if (currentDocument.fullscreenElement) {        
-        currentDocument.fullScreenElement.appendChild(this._containerElement);            
-    }
-    else if (currentDocument.mozFullscreenElement) {        
-        currentDocument.mozFullScreenElement.appendChild(this._containerElement);            
-    }
-    else if (currentDocument.webkitFullscreenElement) {        
-        currentDocument.webkitCurrentFullScreenElement.appendChild(this._containerElement);            
-    }
-    else if (currentDocument.msFullscreenElement) {        
-        currentDocument.msCurrentFullScreenElement.appendChild(this._containerElement);            
-    }
-    else {
+    if (currentDocument.fullscreenElement) {
+      currentDocument.fullScreenElement.appendChild(this._containerElement);
+    } else if (currentDocument.mozFullscreenElement) {
+      currentDocument.mozFullScreenElement.appendChild(this._containerElement);
+    } else if (currentDocument.webkitFullscreenElement) {
+      currentDocument.webkitCurrentFullScreenElement.appendChild(this._containerElement);
+    } else if (currentDocument.msFullscreenElement) {
+      currentDocument.msCurrentFullScreenElement.appendChild(this._containerElement);
+    } else {
       document.body.appendChild(this._containerElement);
     }
   }

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -36,7 +36,7 @@ export class OverlayContainer {
     let currentDocument: any = document;
     if (currentDocument.fullscreenElement) {
       currentDocument.fullScreenElement.appendChild(this._containerElement);
-    } else if (currentDocument.mozFullscreenElement) {
+    } else if (currentDocument.mozFullScreenElement) {
       currentDocument.mozFullScreenElement.appendChild(this._containerElement);
     } else if (currentDocument.webkitFullscreenElement) {
       currentDocument.webkitCurrentFullScreenElement.appendChild(this._containerElement);

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -22,8 +22,32 @@ export class OverlayContainer {
    */
   private _createContainer(): void {
     let container = document.createElement('div');
-    container.classList.add('md-overlay-container');
-    document.body.appendChild(container);
+    container.classList.add('md-overlay-container');    
+    document.addEventListener("fullscreenchange", () => this._adjustContainerParent());
+    document.addEventListener("webkitfullscreenchange", () => this._adjustContainerParent());
+    document.addEventListener("mozfullscreenchange", () => this._adjustContainerParent());
+    document.addEventListener("msfullscreenchange", () => this._adjustContainerParent());
     this._containerElement = container;
+    this._adjustContainerParent();    
+  }
+
+  private _adjustContainerParent() {
+    // use any type because document type doesn't declare full screen variables
+    let currentDocument: any = document;
+    if (currentDocument.fullscreenElement) {        
+        currentDocument.fullScreenElement.appendChild(this._containerElement);            
+    }
+    else if (currentDocument.mozFullscreenElement) {        
+        currentDocument.mozFullScreenElement.appendChild(this._containerElement);            
+    }
+    else if (currentDocument.webkitFullscreenElement) {        
+        currentDocument.webkitCurrentFullScreenElement.appendChild(this._containerElement);            
+    }
+    else if (currentDocument.msFullscreenElement) {        
+        currentDocument.msCurrentFullScreenElement.appendChild(this._containerElement);            
+    }
+    else {
+      document.body.appendChild(this._containerElement);
+    }
   }
 }

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -23,12 +23,20 @@ export class OverlayContainer {
   private _createContainer(): void {
     let container = document.createElement('div');
     container.classList.add('md-overlay-container');
-    document.addEventListener('fullscreenchange', () => this._adjustContainerParent());
-    document.addEventListener('webkitfullscreenchange', () => this._adjustContainerParent());
-    document.addEventListener('mozfullscreenchange', () => this._adjustContainerParent());
-    document.addEventListener('MSFullscreenChange', () => this._adjustContainerParent());
     this._containerElement = container;
     this._adjustContainerParent();
+    if (document.fullscreenEnabled) {
+      document.addEventListener('fullscreenchange', () => this._adjustContainerParent());
+    }
+    if (document.webkitFullscreenEnabled) {
+      document.addEventListener('webkitfullscreenchange', () => this._adjustContainerParent());
+    }
+    if ((<any>document).mozFullScreenEnabled) {
+      document.addEventListener('mozfullscreenchange', () => this._adjustContainerParent());
+    }
+    if ((<any>document).msFullscreenEnabled) {
+      document.addEventListener('MSFullscreenChange', () => this._adjustContainerParent());
+    }        
   }
 
   private _adjustContainerParent() {

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -36,7 +36,7 @@ export class OverlayContainer {
     }
     if ((<any>document).msFullscreenEnabled) {
       document.addEventListener('MSFullscreenChange', () => this._adjustContainerParent());
-    }        
+    }
   }
 
   private _adjustContainerParent() {

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -26,7 +26,7 @@ export class OverlayContainer {
     document.addEventListener('fullscreenchange', () => this._adjustContainerParent());
     document.addEventListener('webkitfullscreenchange', () => this._adjustContainerParent());
     document.addEventListener('mozfullscreenchange', () => this._adjustContainerParent());
-    document.addEventListener('msfullscreenchange', () => this._adjustContainerParent());
+    document.addEventListener('MSFullscreenChange', () => this._adjustContainerParent());
     this._containerElement = container;
     this._adjustContainerParent();
   }

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -41,7 +41,7 @@ export class OverlayContainer {
     } else if (currentDocument.webkitFullscreenElement) {
       currentDocument.webkitCurrentFullScreenElement.appendChild(this._containerElement);
     } else if (currentDocument.msFullscreenElement) {
-      currentDocument.msCurrentFullScreenElement.appendChild(this._containerElement);
+      currentDocument.msFullscreenElement.appendChild(this._containerElement);
     } else {
       document.body.appendChild(this._containerElement);
     }


### PR DESCRIPTION
This allows all overlay-based components like dialog, menu, tooltip etc work in full screen mode https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen

Implementation moves overlay container into fullscreen element and back to document.body as user navigates between fullscreen and non-fullscreen modes. Apps not using fullscreen mode are unaffected.

fixes https://github.com/angular/material2/issues/1628

PS: I added Fullscreen button near to RTL one to test fix across all components
PPS: I have no idea about tests for this fix, any advice?
