### PR TITLE
fix(slide-toggle): thumb spacing at end for rtl

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -8,6 +8,7 @@ $md-slide-toggle-height: 24px !default;
 $md-slide-toggle-bar-height: 14px !default;
 $md-slide-toggle-thumb-size: 20px !default;
 $md-slide-toggle-margin: 16px !default;
+$md-slide-toggle-spacing: 8px !default;
 
 
 @mixin md-switch-ripple() {
@@ -72,7 +73,12 @@ md-slide-toggle {
 
   position: relative;
 
-  margin-right: 8px;
+  margin-right: $md-slide-toggle-spacing;
+
+  [dir='rtl'] & {
+    margin-left: $md-slide-toggle-spacing;
+    margin-right: 0;
+  }
 }
 
 // The thumb container is responsible for the dragging functionality.


### PR DESCRIPTION
* Ensure that the `md-slide-toggle` always shows the spacing at the end of the `thumb` container.

| Before | After |
| ------- | ------ |
| ![](https://i.gyazo.com/f2fca7df79184484770d6d138a4e3864.png) | ![](https://i.gyazo.com/00fa8b4863ebb21bd6955c894007ad08.png) |

