### PR TITLE
fix(overlay): not taking up entire viewport if body is scrollable

### DIFF
--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -10,7 +10,7 @@
 
   // The overlay-container is an invisible element which contains all individual overlays.
   .md-overlay-container {
-    position: absolute;
+    position: fixed;
 
     // Disable events from being captured on the overlay container.
     pointer-events: none;
@@ -18,8 +18,8 @@
     // The container should be the size of the viewport.
     top: 0;
     left: 0;
-    height: 100vh;
-    width: 100vw;
+    height: 100%;
+    width: 100%;
     z-index: $md-z-index-overlay-container;
   }
 


### PR DESCRIPTION
Fixes the overlay not taking up the entire viewport if the `body` is scrollable.

Fixes #1633.