### PR TITLE
feat(dialog): add escapeToClose config option

### DIFF
--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -14,6 +14,9 @@ export class MdDialogConfig {
   /** The ARIA role of the dialog element. */
   role: DialogRole = 'dialog';
 
+  /** Whether the escape key should close the dialog. */
+  escapeToClose = true;
+
   // TODO(jelbourn): add configuration for size, clickOutsideToClose, lifecycle hooks,
   // ARIA labelling.
 }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -74,8 +74,9 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
 
   /** Handles the user pressing the Escape key. */
   handleEscapeKey() {
-    // TODO(jelbourn): add MdDialogConfig option to disable this behavior.
-    this.dialogRef.close();
+    if (this.dialogConfig.escapeToClose) {
+      this.dialogRef.close();
+    }
   }
 
   ngOnDestroy() {

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -97,22 +97,42 @@ describe('MdDialog', () => {
   });
 
 
-  it('should close a dialog via the escape key', () => {
-    let config = new MdDialogConfig();
-    config.viewContainerRef = testViewContainerRef;
+  describe('escape key functionality', () => {
+    it('should close a dialog via the escape key', () => {
+      let config = new MdDialogConfig();
+      config.viewContainerRef = testViewContainerRef;
 
-    dialog.open(PizzaMsg, config);
+      dialog.open(PizzaMsg, config);
 
-    viewContainerFixture.detectChanges();
+      viewContainerFixture.detectChanges();
 
-    let dialogContainer: MdDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(MdDialogContainer)).componentInstance;
+      let dialogContainer: MdDialogContainer = viewContainerFixture.debugElement.query(
+          By.directive(MdDialogContainer)).componentInstance;
 
-    // Fake the user pressing the escape key by calling the handler directly.
-    dialogContainer.handleEscapeKey();
+      // Fake the user pressing the escape key by calling the handler directly.
+      dialogContainer.handleEscapeKey();
 
-    expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
+      expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
+    });
+
+    it('should allow disabling the close via the escape key', () => {
+      let config = new MdDialogConfig();
+      config.viewContainerRef = testViewContainerRef;
+      config.escapeToClose = false;
+
+      dialog.open(PizzaMsg, config);
+
+      viewContainerFixture.detectChanges();
+
+      let dialogContainer: MdDialogContainer = viewContainerFixture.debugElement.query(
+          By.directive(MdDialogContainer)).componentInstance;
+
+      dialogContainer.handleEscapeKey();
+
+      expect(overlayContainerElement.querySelector('md-dialog-container')).toBeTruthy();
+    });
   });
+
 
   it('should close when clicking on the overlay backdrop', () => {
     let config = new MdDialogConfig();


### PR DESCRIPTION
Adds the ability to disable the pressing escape to close a dialog.