### PR TITLE
fix(ripple): allow pointer events on ripple; disable on checkbox ripple

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -425,4 +425,5 @@ md-checkbox {
   bottom: -$md-checkbox-ripple-size;
   border-radius: 50%;
   z-index: 1;
+  pointer-events: none;
 }

--- a/src/lib/core/ripple/_ripple.scss
+++ b/src/lib/core/ripple/_ripple.scss
@@ -13,7 +13,6 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
   // "relative" so that the ripple divs it creates inside itself are correctly positioned.
   [md-ripple] {
     overflow: hidden;
-    pointer-events: none;
   }
 
   [md-ripple].md-ripple-unbounded {

--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -98,4 +98,5 @@ md-radio-button {
   bottom: -$md-radio-ripple-size;
   border-radius: 50%;
   z-index: 1;
+  pointer-events: none;
 }


### PR DESCRIPTION
Followup on #1623 (checkbox ripple was clickable)