### PR TITLE
chore(a11y): duplicate imports

### DIFF
--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -3,10 +3,6 @@ import {FocusTrap} from './focus-trap';
 import {MdLiveAnnouncer} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
 
-export {FocusTrap} from './focus-trap';
-export {MdLiveAnnouncer} from './live-announcer';
-export {InteractivityChecker} from './interactivity-checker';
-
 export const A11Y_PROVIDERS = [MdLiveAnnouncer, InteractivityChecker];
 
 @NgModule({


### PR DESCRIPTION
Removes some duplicated imports in the a11y/index.ts file.