### PR TITLE
fix(ripple): color flickering

### DIFF
--- a/src/lib/checkbox/_checkbox-theme.scss
+++ b/src/lib/checkbox/_checkbox-theme.scss
@@ -68,7 +68,7 @@
     }
   }
 
-  .md-checkbox-focused {
+  .md-checkbox:not(.md-checkbox-disabled) {
     &.md-primary .md-checkbox-ripple .md-ripple-foreground {
       background-color: md-color($primary, 0.26);
     }

--- a/src/lib/radio/_radio-theme.scss
+++ b/src/lib/radio/_radio-theme.scss
@@ -29,7 +29,11 @@
     }
   }
 
-  .md-radio-focused .md-radio-ripple .md-ripple-foreground {
+  .md-radio-ripple .md-ripple-foreground {
     background-color: md-color($accent, 0.26);
+
+    .md-radio-disabled & {
+      background-color: md-color($foreground, disabled);
+    }
   }
 }


### PR DESCRIPTION
- fix style to generate dark ripples only on disabled radio/checkbox
(same fashion as in ng1 material)

Closes #1686 