### PR TITLE
fix(checkbox): fix the checkbox squishes problem

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -218,6 +218,7 @@ md-checkbox {
   vertical-align: middle;
   white-space: nowrap;
   width: $md-checkbox-size;
+  flex-shrink: 0;
 
   [dir='rtl'] & {
     margin: {


### PR DESCRIPTION
Add flex-shrink to checkbox so they do not squish if the parent wrapper has a fixed width and the label text is too long.
Continued from #1103

Closes #1097 

R: @jelbourn 