### PR TITLE
fix(progress-bar): bar being thrown off by parent's text-align

### DIFF
--- a/src/lib/progress-bar/progress-bar.scss
+++ b/src/lib/progress-bar/progress-bar.scss
@@ -62,6 +62,7 @@ $md-progress-bar-piece-animation-duration: 250ms !default;
     height: 100%;
     position: absolute;
     width: 100%;
+    left: 0;
   }
 
   &[mode='query'] {


### PR DESCRIPTION
Fixes the `md-progress-bar`'s bar being positioned weirdly, if it's parent has `text-align: right`.
Note that this doesn't require any special styling for RTL since we use a transform rotation to flip the styling.

Fixes #1165.