### PR TITLE
chore(ci): ensure browserstack binaries are latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/minimist": "^1.1.28",
     "@types/node": "^6.0.34",
     "@types/run-sequence": "0.0.27",
-    "browserstacktunnel-wrapper": "^1.4.2",
+    "browserstacktunnel-wrapper": "^2.0.0",
     "conventional-changelog": "^1.1.0",
     "express": "^4.14.0",
     "firebase-tools": "^2.2.1",

--- a/scripts/browserstack/start_tunnel.js
+++ b/scripts/browserstack/start_tunnel.js
@@ -34,7 +34,12 @@ var tunnel = new BrowserStackTunnel({
 });
 
 console.log('Starting tunnel on ports', PORTS.join(', '));
-tunnel.start(function(error) {
+
+// Emit a `newer_available` event to force an update of the Browserstack binaries (necessary due to Travis caching)
+// This also starts a new tunnel after the latest binaries are available.
+tunnel.emit('newer_available');
+
+tunnel.once('started', function(error) {
   if (error) {
     console.error('Can not establish the tunnel', error);
   } else {


### PR DESCRIPTION
* The Browserstack versions are always fetched from the cache, and never update them self. The `TunnelWrapper` package does not update the binaries if a newer version is available (that's not implemented yet [here](https://github.com/pghalliday/node-BrowserStackTunnel))

* It might be good to get rid of that `wrapper` in the future and do something similar to the saucelabs scripts

**Note**: Right now older versions can cause issues like 
- https://travis-ci.org/angular/material2/jobs/173114233
- https://travis-ci.org/angular/material2/jobs/173114074