### PR TITLE
fix(button-toggle): missing hover state

### DIFF
--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -5,9 +5,12 @@
 @mixin md-button-toggle-theme($theme) {
   $foreground: map-get($theme, foreground);
 
-  .md-button-toggle-checked .md-button-toggle-label-content {
-    background-color: md-color($md-grey, 300);
+  .md-button-toggle-checked, md-button-toggle:not(.md-button-toggle-disabled):hover {
+    .md-button-toggle-label-content {
+      background-color: md-color($md-grey, 300);
+    }
   }
+
   .md-button-toggle-disabled .md-button-toggle-label-content {
     background-color: md-color($foreground, disabled);
   }


### PR DESCRIPTION
Adds a hover effect to the button toggles.

Referencing #421.