### PR TITLE
fix(button): ensure icons are aligned vertically.

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -104,11 +104,15 @@ $md-mini-fab-padding: 8px !default;
 @mixin md-fab($size, $padding) {
   @extend %md-raised-button;
 
+  // Reset the min-width from the button base.
   min-width: 0;
+
   border-radius: $md-fab-border-radius;
   width: $size;
   height: $size;
   padding: 0;
+
+  flex-shrink: 0;
 
   i, md-icon {
     padding: $padding 0;

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -33,23 +33,26 @@
 }
 
 [md-icon-button] {
-  min-width: 0;
   padding: 0;
+
+  // Reset the min-width from the button base.
+  min-width: 0;
 
   width: $md-icon-button-size;
   height: $md-icon-button-size;
 
-  line-height: $md-icon-button-line-height;
+  flex-shrink: 0;
+
+  line-height: $md-icon-button-size;
   border-radius: $md-icon-button-border-radius;
 
-  .md-button-wrapper > * {
+  i, md-icon {
     line-height: $md-icon-button-line-height;
-    vertical-align: middle;
   }
 }
 
 // The text and icon should be vertical aligned inside a button
-[md-button], [md-raised-button] {
+[md-button], [md-raised-button], [md-icon-button] {
   .md-button-wrapper > * {
     vertical-align: middle;
   }


### PR DESCRIPTION
* The icon buttons are never a perfect cirlce, because they can shrink (depending on siblings).
  
   In Material 1 we solved this by adding `min-width/height`, but having flex-shrink is more elegant here (it allows developers to easily overwrite height and width)

* Sets the line-height for icons only to `i` and `md-icon` elements (as same as for fab buttons)

  > Can be made more generic in the future, with another mixin.

Fixes #1093.