### PR TITLE
chore: remove unused autoprefixer config file

### DIFF
--- a/build/autoprefixer-options.js
+++ b/build/autoprefixer-options.js
@@ -1,9 +1,0 @@
-// Options for autoprefixer. See https://github.com/postcss/autoprefixer#options
-module.exports = {
-  // To see the full list of supported browers, you can direcly use `browserslist`
-  browsers: [
-    'last 2 versions',
-    'not ie <= 10',
-    'not ie_mob <= 10',
-  ]
-};


### PR DESCRIPTION
* The autoprefixer config has been added to the `constants` in the gulp build process.

See SHA https://github.com/angular/material2/commit/bfee9c31eb669b8543bec0b8f97bb613b16abfa0