### PR TITLE
chore(build): fix karma not exiting properly

### DIFF
--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -59,6 +59,7 @@ export function config(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    autoWatchBatchDelay: 500,
 
     sauceLabs: {
       testName: 'material2',

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -2,7 +2,7 @@ import gulp = require('gulp');
 import path = require('path');
 import gulpMerge = require('merge2');
 
-import {PROJECT_ROOT, DIST_COMPONENTS_ROOT} from '../constants';
+import {PROJECT_ROOT} from '../constants';
 import {sequenceTask} from '../task_helpers';
 
 const karma = require('karma');
@@ -48,10 +48,10 @@ gulp.task(':test:deps:inline', sequenceTask(':test:deps', ':inline-resources'));
  *
  * This task should be used when running unit tests locally.
  */
-gulp.task('test', [':test:watch'], (done: () => void) => {
+gulp.task('test', [':test:watch'], () => {
   new karma.Server({
     configFile: path.join(PROJECT_ROOT, 'test/karma.conf.js')
-  }, done).start();
+  }).start();
 });
 
 /**
@@ -59,9 +59,9 @@ gulp.task('test', [':test:watch'], (done: () => void) => {
  *
  * This task should be used when running tests on the CI server.
  */
-gulp.task('test:single-run', [':test:deps:inline'], (done: () => void) => {
+gulp.task('test:single-run', [':test:deps:inline'], () => {
   new karma.Server({
     configFile: path.join(PROJECT_ROOT, 'test/karma.conf.js'),
     singleRun: true
-  }, done).start();
+  }).start();
 });


### PR DESCRIPTION
* Fixes the Karma tasks not exiting properly. This is an issue, because doing a keyboard interrupt doesn't stop the Gulp watchers that are going on in the background.
* Increase the time that Karma waits before starting to run tests. This should help mitigate the multiple reloads when running unit tests locally.

Related to #1681.