### PR TITLE
chore(saucelabs): interrupt if saucelabs tunnel does not start

### DIFF
--- a/scripts/browserstack/waitfor_tunnel.sh
+++ b/scripts/browserstack/waitfor_tunnel.sh
@@ -2,18 +2,17 @@
 
 
 # Wait for Connect to be ready before exiting
-# Time out if we wait for more than 2 minutes, so that we can print logs.
+# Time out if we wait for more than 2 minutes, so the process won't run forever.
 let "counter=0"
 
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
+
   if [ $counter -gt 240 ]; then
-    echo "Timed out after 2 minutes waiting for browser provider ready file"
-    # We must manually print logs here because travis will not run
-    # after_script commands if the failure occurs before the script
-    # phase.
-    ./scripts/ci/print-logs.sh
+    echo "Timed out after 2 minutes waiting for tunnel ready file"
     exit 5
   fi
+
+  printf "."
   sleep .5
 done

--- a/scripts/browserstack/waitfor_tunnel.sh
+++ b/scripts/browserstack/waitfor_tunnel.sh
@@ -9,6 +9,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
 
   if [ $counter -gt 240 ]; then
+    echo
     echo "Timed out after 2 minutes waiting for tunnel ready file"
     exit 5
   fi

--- a/scripts/sauce/sauce_connect_block.sh
+++ b/scripts/sauce/sauce_connect_block.sh
@@ -2,9 +2,23 @@
 
 # Wait for Connect to be ready before exiting
 echo "Connecting to Sauce Labs"
+
+
+# Wait for Saucelabs Connect to be ready before exiting
+# Time out if we wait for more than 2 minutes, so the process won't run forever.
+let "counter=0"
+
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
+  let "counter++"
+
+  if [ $counter -gt 240 ]; then
+    echo "Timed out after 2 minutes waiting for tunnel ready file"
+    exit 5
+  fi
+
   printf "."
   sleep .5
 done
+
 echo
 echo "Connected"

--- a/scripts/sauce/sauce_connect_block.sh
+++ b/scripts/sauce/sauce_connect_block.sh
@@ -12,6 +12,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
 
   if [ $counter -gt 240 ]; then
+    echo
     echo "Timed out after 2 minutes waiting for tunnel ready file"
     exit 5
   fi


### PR DESCRIPTION
* Adds a timeout to the Saucelabs wait script (as same as in the browserstack tunnel)
* Logs dots while waiting for the tunnel to be ready (same as in the saucelabs wait script)
* No longer calls `print-logs` file (File does not exist and also `browserstacktunnel-wrapper` prints necessary output to the console)

---
Fixes
> ![](https://i.gyazo.com/0dddd4ec5876e143cbd4f3680b40bb97.png)

and Travis builds like [this one](https://travis-ci.org/angular/material2/jobs/173114071), which can run about **2 hours**
