### PR TITLE
fix(checkbox, input, radio, slide-toggle): implement setDisabledState from ControlValueAccessor

### DIFF
--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -8,6 +8,8 @@ import {
 import {
     NgControl,
     FormsModule,
+    ReactiveFormsModule,
+    FormControl,
 } from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
@@ -21,7 +23,7 @@ describe('MdCheckbox', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdCheckboxModule.forRoot(), FormsModule],
+      imports: [MdCheckboxModule.forRoot(), FormsModule, ReactiveFormsModule],
       declarations: [
         SingleCheckbox,
         CheckboxWithFormDirectives,
@@ -31,6 +33,7 @@ describe('MdCheckbox', () => {
         CheckboxWithAriaLabelledby,
         CheckboxWithNameAttribute,
         CheckboxWithChangeEvent,
+        CheckboxWithFormControl,
       ],
     });
 
@@ -561,18 +564,48 @@ describe('MdCheckbox', () => {
       expect(inputElement.getAttribute('name')).toBe('test-name');
     });
   });
+
+
+  describe('with form control', () => {
+    let checkboxDebugElement: DebugElement;
+    let checkboxInstance: MdCheckbox;
+    let testComponent: CheckboxWithFormControl;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(CheckboxWithFormControl);
+      fixture.detectChanges();
+
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
+      checkboxInstance = checkboxDebugElement.componentInstance;
+      testComponent = fixture.debugElement.componentInstance;
+    });
+
+    it('should toggle the disabled state', () => {
+      expect(checkboxInstance.disabled).toBe(false);
+
+      testComponent.formControl.disable();
+      fixture.detectChanges();
+
+      expect(checkboxInstance.disabled).toBe(true);
+
+      testComponent.formControl.enable();
+      fixture.detectChanges();
+
+      expect(checkboxInstance.disabled).toBe(false);
+    });
+  });
 });
 
 /** Simple component for testing a single checkbox. */
 @Component({
   template: `
-  <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">    
-    <md-checkbox 
+  <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">
+    <md-checkbox
         id="simple-check"
         [required]="isRequired"
         [align]="alignment"
-        [checked]="isChecked" 
-        [indeterminate]="isIndeterminate" 
+        [checked]="isChecked"
+        [indeterminate]="isIndeterminate"
         [disabled]="isDisabled"
         [color]="checkboxColor"
         (change)="changeCount = changeCount + 1"
@@ -623,9 +656,9 @@ class MultipleCheckboxes { }
 /** Simple test component with tabIndex */
 @Component({
   template: `
-    <md-checkbox 
-        [tabindex]="customTabIndex" 
-        [disabled]="isDisabled" 
+    <md-checkbox
+        [tabindex]="customTabIndex"
+        [disabled]="isDisabled"
         [disableRipple]="disableRipple">
     </md-checkbox>`,
 })
@@ -659,4 +692,12 @@ class CheckboxWithNameAttribute {}
 })
 class CheckboxWithChangeEvent {
   lastEvent: MdCheckboxChange;
+}
+
+/** Test component with reactive forms */
+@Component({
+  template: `<md-checkbox [formControl]="formControl"></md-checkbox>`
+})
+class CheckboxWithFormControl {
+  formControl = new FormControl();
 }

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -112,7 +112,7 @@ export class MdCheckbox implements ControlValueAccessor {
   /** Whether or not the checkbox should come before or after the label. */
   @Input() align: 'start' | 'end' = 'start';
 
-  private _disabled: boolean;
+  private _disabled: boolean = false;
 
   /**
    * Whether the checkbox is disabled. When the checkbox is disabled it cannot be interacted with.
@@ -243,6 +243,13 @@ export class MdCheckbox implements ControlValueAccessor {
    */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
+  }
+
+  /**
+   * Implemented as a part of ControlValueAccessor.
+   */
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
   }
 
   private _transitionCheckState(newState: TransitionCheckState) {

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -3,7 +3,7 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {Component} from '@angular/core';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MdInput, MdInputModule} from './input';
 
@@ -14,7 +14,7 @@ function isInternetExplorer11() {
 describe('MdInput', function () {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdInputModule.forRoot(), FormsModule],
+      imports: [MdInputModule.forRoot(), FormsModule, ReactiveFormsModule],
       declarations: [
         MdInputNumberTypeConservedTestComponent,
         MdInputPlaceholderRequiredTestComponent,
@@ -58,6 +58,7 @@ describe('MdInput', function () {
         MdInputPasswordTestController,
         MdInputNumberTestController,
         MdTextareaWithBindings,
+        MdInputWithFormControl,
       ],
     });
 
@@ -621,6 +622,27 @@ describe('MdInput', function () {
     expect(inputElement.name).toBe('some-name');
   });
 
+  it('toggles the disabled state when used with a FormControl', () => {
+    let fixture = TestBed.createComponent(MdInputWithFormControl);
+
+    fixture.detectChanges();
+
+    let input: MdInput = fixture.debugElement.query(By.directive(MdInput)).componentInstance;
+    let testComponent: MdInputWithFormControl = fixture.debugElement.componentInstance;
+
+    expect(input.disabled).toBe(false);
+
+    testComponent.formControl.disable();
+    fixture.detectChanges();
+
+    expect(input.disabled).toBe(true);
+
+    testComponent.formControl.enable();
+    fixture.detectChanges();
+
+    expect(input.disabled).toBe(false);
+  });
+
   describe('md-textarea', () => {
     it('supports the rows, cols, and wrap attributes', () => {
       let fixture = TestBed.createComponent(MdTextareaWithBindings);
@@ -805,6 +827,11 @@ class MdInputPasswordTestController {
 @Component({template: `<md-input type="number" [placeholder]="placeholder"></md-input>`})
 class MdInputNumberTestController {
   placeholder: string = '';
+}
+
+@Component({template: `<md-input [formControl]="formControl"></md-input>`})
+class MdInputWithFormControl {
+  formControl = new FormControl();
 }
 
 @Component({template:

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -293,6 +293,13 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     this._onTouchedCallback = fn;
   }
 
+  /**
+   * Implemented as a part of ControlValueAccessor.
+   */
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
   /** TODO: internal */
   ngAfterContentInit() {
     this._validateConstraints();

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -1,5 +1,5 @@
 import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
-import {NgControl, FormsModule} from '@angular/forms';
+import {NgControl, FormsModule, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MdRadioGroup, MdRadioButton, MdRadioChange, MdRadioModule} from './radio';
@@ -9,10 +9,11 @@ describe('MdRadio', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdRadioModule.forRoot(), FormsModule],
+      imports: [MdRadioModule.forRoot(), FormsModule, ReactiveFormsModule],
       declarations: [
         RadiosInsideRadioGroup,
         RadioGroupWithNgModel,
+        RadioGroupWithFormControl,
         StandaloneRadioButtons,
       ],
     });
@@ -152,7 +153,7 @@ describe('MdRadio', () => {
       expect(spies[1]).toHaveBeenCalledTimes(1);
     });
 
-    it(`should not emit a change event from the radio group when change group value 
+    it(`should not emit a change event from the radio group when change group value
         programmatically`, () => {
       expect(groupInstance.value).toBeFalsy();
 
@@ -246,7 +247,7 @@ describe('MdRadio', () => {
       }
     }));
 
-    it(`should update the group's selected radio to null when unchecking that radio 
+    it(`should update the group's selected radio to null when unchecking that radio
         programmatically`, () => {
       let changeSpy = jasmine.createSpy('radio-group change listener');
       groupInstance.change.subscribe(changeSpy);
@@ -420,6 +421,36 @@ describe('MdRadio', () => {
     });
   });
 
+  describe('group with FormControl', () => {
+    let fixture: ComponentFixture<RadioGroupWithFormControl>;
+    let groupDebugElement: DebugElement;
+    let groupInstance: MdRadioGroup;
+    let testComponent: RadioGroupWithFormControl;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(RadioGroupWithFormControl);
+      fixture.detectChanges();
+
+      testComponent = fixture.debugElement.componentInstance;
+      groupDebugElement = fixture.debugElement.query(By.directive(MdRadioGroup));
+      groupInstance = groupDebugElement.injector.get(MdRadioGroup);
+    });
+
+    it('should toggle the disabled state', () => {
+      expect(groupInstance.disabled).toBeFalsy();
+
+      testComponent.formControl.disable();
+      fixture.detectChanges();
+
+      expect(groupInstance.disabled).toBeTruthy();
+
+      testComponent.formControl.enable();
+      fixture.detectChanges();
+
+      expect(groupInstance.disabled).toBeFalsy();
+    });
+  });
+
   describe('as standalone', () => {
     let fixture: ComponentFixture<StandaloneRadioButtons>;
     let radioDebugElements: DebugElement[];
@@ -548,11 +579,11 @@ class RadiosInsideRadioGroup {
     <md-radio-button name="season" value="spring">Spring</md-radio-button>
     <md-radio-button name="season" value="summer">Summer</md-radio-button>
     <md-radio-button name="season" value="autum">Autumn</md-radio-button>
-    
+
     <md-radio-button name="weather" value="warm">Spring</md-radio-button>
     <md-radio-button name="weather" value="hot">Summer</md-radio-button>
     <md-radio-button name="weather" value="cool">Autumn</md-radio-button>
-    
+
     <span id="xyz">Baby Banana</span>
     <md-radio-button name="fruit" value="banana" aria-label="Banana" aria-labelledby="xyz">
     </md-radio-button>
@@ -579,6 +610,17 @@ class RadioGroupWithNgModel {
     {label: 'Strawberry', value: 'strawberry'},
   ];
   lastEvent: MdRadioChange;
+}
+
+@Component({
+  template: `
+  <md-radio-group [formControl]="formControl">
+    <md-radio-button value="1">One</md-radio-button>
+  </md-radio-group>
+  `
+})
+class RadioGroupWithFormControl {
+  formControl = new FormControl();
 }
 
 // TODO(jelbourn): remove everything below when Angular supports faking events.

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -228,6 +228,13 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
+
+  /**
+   * Implemented as a part of ControlValueAccessor.
+   */
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
 }
 
 

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -2,7 +2,7 @@ import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/t
 import {By, HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 import {MdSlideToggle, MdSlideToggleChange, MdSlideToggleModule} from './slide-toggle';
-import {FormsModule, NgControl} from '@angular/forms';
+import {FormsModule, NgControl, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {TestGestureConfig} from '../slider/test-gesture-config';
 
 describe('MdSlideToggle', () => {
@@ -11,8 +11,8 @@ describe('MdSlideToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSlideToggleModule.forRoot(), FormsModule],
-      declarations: [SlideToggleTestApp, SlideToggleFormsTestApp],
+      imports: [MdSlideToggleModule.forRoot(), FormsModule, ReactiveFormsModule],
+      declarations: [SlideToggleTestApp, SlideToggleFormsTestApp, SlideToggleWithFormControl],
       providers: [
         {provide: HAMMER_GESTURE_CONFIG, useFactory: () => gestureConfig = new TestGestureConfig()}
       ]
@@ -509,6 +509,34 @@ describe('MdSlideToggle', () => {
 
   });
 
+  describe('with a FormControl', () => {
+    let fixture: ComponentFixture<SlideToggleWithFormControl>;
+
+    let testComponent: SlideToggleWithFormControl;
+    let slideToggle: MdSlideToggle;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SlideToggleWithFormControl);
+      fixture.detectChanges();
+
+      testComponent = fixture.debugElement.componentInstance;
+      slideToggle = fixture.debugElement.query(By.directive(MdSlideToggle)).componentInstance;
+    });
+
+    it('should toggle the disabled state', () => {
+      expect(slideToggle.disabled).toBe(false);
+
+      testComponent.formControl.disable();
+      fixture.detectChanges();
+
+      expect(slideToggle.disabled).toBe(true);
+
+      testComponent.formControl.enable();
+      fixture.detectChanges();
+
+      expect(slideToggle.disabled).toBe(false);
+    });
+  });
 });
 
 /**
@@ -525,20 +553,20 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
 @Component({
   selector: 'slide-toggle-test-app',
   template: `
-    <md-slide-toggle [(ngModel)]="slideModel" 
+    <md-slide-toggle [(ngModel)]="slideModel"
                      [required]="isRequired"
-                     [disabled]="isDisabled" 
-                     [color]="slideColor" 
-                     [id]="slideId" 
-                     [checked]="slideChecked" 
-                     [name]="slideName" 
+                     [disabled]="isDisabled"
+                     [color]="slideColor"
+                     [id]="slideId"
+                     [checked]="slideChecked"
+                     [name]="slideName"
                      [ariaLabel]="slideLabel"
-                     [ariaLabelledby]="slideLabelledBy" 
-                     (change)="onSlideChange($event)" 
+                     [ariaLabelledby]="slideLabelledBy"
+                     (change)="onSlideChange($event)"
                      (click)="onSlideClick($event)">
-                     
+
       <span>Test Slide Toggle</span>
-      
+
     </md-slide-toggle>`,
 })
 class SlideToggleTestApp {
@@ -571,4 +599,15 @@ class SlideToggleTestApp {
 class SlideToggleFormsTestApp {
   isSubmitted: boolean = false;
   isRequired: boolean = false;
+}
+
+
+@Component({
+  template: `
+    <md-slide-toggle [formControl]="formControl">
+      <span>Test Slide Toggle</span>
+    </md-slide-toggle>`,
+})
+class SlideToggleWithFormControl {
+  formControl = new FormControl();
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -174,6 +174,13 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     this.onTouched = fn;
   }
 
+  /**
+   * Implemented as a part of ControlValueAccessor.
+   */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
   @Input()
   get checked() {
     return !!this._checked;


### PR DESCRIPTION
Implements the `setDisabledState` method from the `ControlValueAccessor` interface in all of the input-related components, in order to support disabling via reactive forms. Note that the `select` component is missing the implementation, however there's a pending PR for it already (#1667).

Fixes #1171.