### PR TITLE
feat(focus-trap): add the ability to specify a focus target

### DIFF
--- a/src/lib/core/a11y/focus-trap.spec.ts
+++ b/src/lib/core/a11y/focus-trap.spec.ts
@@ -6,24 +6,21 @@ import {InteractivityChecker} from './interactivity-checker';
 
 
 describe('FocusTrap', () => {
-  let checker: InteractivityChecker;
-  let fixture: ComponentFixture<FocusTrapTestApp>;
-
   describe('with default element', () => {
+    let fixture: ComponentFixture<FocusTrapTestApp>;
+    let focusTrapInstance: FocusTrap;
+
     beforeEach(() => TestBed.configureTestingModule({
       declarations: [FocusTrap, FocusTrapTestApp],
       providers: [InteractivityChecker]
     }));
 
     beforeEach(inject([InteractivityChecker], (c: InteractivityChecker) => {
-      checker = c;
       fixture = TestBed.createComponent(FocusTrapTestApp);
+      focusTrapInstance = fixture.debugElement.query(By.directive(FocusTrap)).componentInstance;
     }));
 
     it('wrap focus from end to start', () => {
-      let focusTrap = fixture.debugElement.query(By.directive(FocusTrap));
-      let focusTrapInstance = focusTrap.componentInstance as FocusTrap;
-
       // Because we can't mimic a real tab press focus change in a unit test, just call the
       // focus event handler directly.
       focusTrapInstance.focusFirstTabbableElement();
@@ -33,15 +30,41 @@ describe('FocusTrap', () => {
     });
 
     it('should wrap focus from start to end', () => {
-      let focusTrap = fixture.debugElement.query(By.directive(FocusTrap));
-      let focusTrapInstance = focusTrap.componentInstance as FocusTrap;
-
       // Because we can't mimic a real tab press focus change in a unit test, just call the
       // focus event handler directly.
       focusTrapInstance.focusLastTabbableElement();
 
       expect(document.activeElement.nodeName.toLowerCase())
           .toBe('button', 'Expected button element to be focused');
+    });
+  });
+
+  describe('with focus targets', () => {
+    let fixture: ComponentFixture<FocusTrapTargetTestApp>;
+    let focusTrapInstance: FocusTrap;
+
+    beforeEach(() => TestBed.configureTestingModule({
+      declarations: [FocusTrap, FocusTrapTargetTestApp],
+      providers: [InteractivityChecker]
+    }));
+
+    beforeEach(inject([InteractivityChecker], (c: InteractivityChecker) => {
+      fixture = TestBed.createComponent(FocusTrapTargetTestApp);
+      focusTrapInstance = fixture.debugElement.query(By.directive(FocusTrap)).componentInstance;
+    }));
+
+    it('should be able to prioritize the first focus target', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusFirstTabbableElement();
+      expect(document.activeElement.id).toBe('first');
+    });
+
+    it('should be able to prioritize the last focus target', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusLastTabbableElement();
+      expect(document.activeElement.id).toBe('last');
     });
   });
 });
@@ -56,3 +79,16 @@ describe('FocusTrap', () => {
     `
 })
 class FocusTrapTestApp { }
+
+
+@Component({
+  template: `
+    <focus-trap>
+      <input>
+      <button id="last" md-focus-end></button>
+      <button id="first" md-focus-start>SAVE</button>
+      <input>
+    </focus-trap>
+    `
+})
+class FocusTrapTargetTestApp { }

--- a/src/lib/core/a11y/focus-trap.ts
+++ b/src/lib/core/a11y/focus-trap.ts
@@ -27,7 +27,10 @@ export class FocusTrap {
 
   /** Focuses the first tabbable element within the focus trap region. */
   focusFirstTabbableElement() {
-    let redirectToElement = this._getFirstTabbableElement(this.trappedContent.nativeElement);
+    let rootElement = this.trappedContent.nativeElement;
+    let redirectToElement = rootElement.querySelector('[md-focus-start]') as HTMLElement ||
+                            this._getFirstTabbableElement(rootElement);
+
     if (redirectToElement) {
       redirectToElement.focus();
     }
@@ -35,7 +38,16 @@ export class FocusTrap {
 
   /** Focuses the last tabbable element within the focus trap region. */
   focusLastTabbableElement() {
-    let redirectToElement = this._getLastTabbableElement(this.trappedContent.nativeElement);
+    let rootElement = this.trappedContent.nativeElement;
+    let focusTargets = rootElement.querySelectorAll('[md-focus-end]');
+    let redirectToElement: HTMLElement = null;
+
+    if (focusTargets.length) {
+      redirectToElement = focusTargets[focusTargets.length - 1] as HTMLElement;
+    } else {
+      redirectToElement = this._getLastTabbableElement(rootElement);
+    }
+
     if (redirectToElement) {
       redirectToElement.focus();
     }


### PR DESCRIPTION
Adds the ability to specify an element that should take precedence over other focusable elements inside of a focus trap.

Fixes #1468.

**Note:** @jelbourn we discussed that we should have separate `start` and `end` directives, which we'd query via `@ContentChild` or `@ViewChild`, however I wasn't able to get it working. I was testing with the dialog demo and I think that either the element being nested in multiple other components is breaking it, or the `portal` (which is used to inject the dialog content) isn't working properly. I've also tried injecting the focus trap into a focus target directive, but it didn't work either.