### PR TITLE
chore: revert "fix(button-toggle): missing hover state (#1733)"

### DIFF
--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -5,12 +5,9 @@
 @mixin md-button-toggle-theme($theme) {
   $foreground: map-get($theme, foreground);
 
-  .md-button-toggle-checked, md-button-toggle:not(.md-button-toggle-disabled):hover {
-    .md-button-toggle-label-content {
-      background-color: md-color($md-grey, 300);
-    }
+  .md-button-toggle-checked .md-button-toggle-label-content {
+    background-color: md-color($md-grey, 300);
   }
-
   .md-button-toggle-disabled .md-button-toggle-label-content {
     background-color: md-color($foreground, disabled);
   }


### PR DESCRIPTION
R: @kara 
CC: @crisbeto 
This reverts commit 15cd28bca351b1035ca749b411f3930084d2d73b.

I am reverting this because the focus state makes the toggle buttons appear broken- if you un-check, it looks like its still in the toggles state, which is very confusing. 