### PR TITLE
fix(overlay-ref): check if parent node still exists before removing c…

### DIFF
--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -104,7 +104,9 @@ export class OverlayRef implements PortalHost {
       backdropToDetach.classList.remove('md-overlay-backdrop-showing');
       backdropToDetach.classList.remove(this._state.backdropClass);
       backdropToDetach.addEventListener('transitionend', () => {
-        backdropToDetach.parentNode.removeChild(backdropToDetach);
+        if(backdropToDetach.parentNode){
+          backdropToDetach.parentNode.removeChild(backdropToDetach);
+        }
 
         // It is possible that a new portal has been attached to this overlay since we started
         // removing the backdrop. If that is the case, only clear the backdrop reference if it


### PR DESCRIPTION
…hild

Getting the following exception in some scenarios, eg. multiple dialogs of the same type are open and closing them fast

 TypeError: Cannot read property 'removeChild' of null
    at HTMLDivElement.<anonymous> (overlay-ref.js:70)
    at ZoneDelegate.invokeTask (zone.js:265)
    at Object.onInvokeTask (ng_zone.js:227)
    at ZoneDelegate.invokeTask (zone.js:264)
    at Zone.runTask (zone.js:154)
    at HTMLDivElement.ZoneTask.invoke (zone.js:335)