### PR TITLE
docs(dialog): add new option and update example

### DIFF
--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,4 +1,4 @@
-import {Component, ViewContainerRef} from '@angular/core';
+import {Component} from '@angular/core';
 import {MdDialog, MdDialogRef} from '@angular/material';
 
 @Component({
@@ -11,9 +11,7 @@ export class DialogDemo {
   dialogRef: MdDialogRef<JazzDialog>;
   lastCloseResult: string;
 
-  constructor(
-      public dialog: MdDialog,
-      public viewContainerRef: ViewContainerRef) { }
+  constructor(public dialog: MdDialog) { }
 
   open() {
     this.dialogRef = this.dialog.open(JazzDialog);

--- a/src/lib/dialog/README.md
+++ b/src/lib/dialog/README.md
@@ -1,6 +1,6 @@
 # MdDialog
 
-MdDialog is a service, which opens dialogs components in the view. 
+MdDialog is a service, which opens dialogs components in the view.
 
 ### Methods
 
@@ -12,8 +12,9 @@ MdDialog is a service, which opens dialogs components in the view.
 
 | Key |  Description |
 | --- | --- |
-| `viewContainerRef: ViewContainerRef` | The view container ref to attach the dialog to. |
 | `role: DialogRole = 'dialog'` | The ARIA role of the dialog element. Possible values are `dialog` and `alertdialog`. Defaults to `dialog`. |
+| `disableClose: boolean = false` | Whether to prevent the user from closing a dialog by clicking on the backdrop or pressing escape. Defaults to `false`. |
+| `viewContainerRef: ViewContainerRef` | The view container ref to attach the dialog to. Optional. |
 
 ## MdDialogRef
 
@@ -40,15 +41,12 @@ export class PizzaComponent {
 
   dialogRef: MdDialogRef<PizzaDialog>;
 
-  constructor(
-    public dialog: MdDialog,
-    public viewContainerRef: ViewContainerRef) { }
+  constructor(public dialog: MdDialog) { }
 
   openDialog() {
-    let config = new MdDialogConfig();
-    config.viewContainerRef = this.viewContainerRef;
-
-    this.dialogRef = this.dialog.open(PizzaDialog, config);
+    this.dialogRef = this.dialog.open(PizzaDialog, {
+      disableClose: false
+    });
 
     this.dialogRef.afterClosed().subscribe(result => {
       console.log('result: ' + result);


### PR DESCRIPTION
* Mentions the `disableClose` option in the readme.
* Updates the dialog readme and dialog demo not to use the `viewContainerRef` since it's not necessary anymore.