### PR TITLE
add gulp task to convert markdown to html

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gulp-autoprefixer": "^3.1.1",
     "gulp-clean": "^0.3.2",
     "gulp-cli": "^1.2.2",
+    "gulp-markdown": "^1.2.0",
     "gulp-sass": "^2.3.2",
     "gulp-server-livereload": "^1.8.2",
     "gulp-shell": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gulp-server-livereload": "^1.8.2",
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
+    "gulp-transform": "^1.1.0",
     "gulp-typescript": "^2.13.6",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.1",

--- a/src/lib/button/README.md
+++ b/src/lib/button/README.md
@@ -40,6 +40,8 @@ between the tags, as you would with a normal button.
 
 Example:
 
+<!-- example(my example) -->
+
  ```html
 <button md-button>FLAT</button>
 <button md-raised-button>RAISED</button>
@@ -66,6 +68,8 @@ Simply pass in the palette name.
 In flat buttons, the palette chosen will affect the text color, while in other buttons, it affects the background.
 
 Example:
+
+<!-- example(my other example) -->
 
  ```html
 <button md-raised-button color="primary">PRIMARY</button>

--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -3,6 +3,7 @@ import './tasks/clean';
 import './tasks/components';
 import './tasks/default';
 import './tasks/development';
+import './tasks/docs';
 import './tasks/e2e';
 import './tasks/lint';
 import './tasks/release';

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -3,6 +3,10 @@ const markdown = require('gulp-markdown');
 const transform = require('gulp-transform');
 
 
+// Our docs contain comments of the form `<!-- example(...) -->` which serve as placeholders where
+// example code should be inserted. We replace these comments with divs that have a
+// `material-docs-example` attribute which can be used to locate the divs and initialize the example
+// viewer.
 const EXAMPLE_PATTERN = /<!--\W*example\(([^)]+)\)\W*-->/g;
 
 
@@ -11,6 +15,6 @@ gulp.task('docs', () => {
       .pipe(markdown())
       .pipe(transform((content: string) =>
           content.toString().replace(EXAMPLE_PATTERN, (match: string, name: string) =>
-              `<div example="${name}"></div>`)))
+              `<div material-docs-example="${name}"></div>`)))
       .pipe(gulp.dest('dist/docs'));
 });

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -1,0 +1,7 @@
+import gulp = require('gulp');
+
+
+gulp.task('docs', [':docs:md-to-html']);
+gulp.task(':docs:md-to-html', () => {
+  return gulp.src(['*.md'])
+});

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -1,7 +1,16 @@
 import gulp = require('gulp');
+const markdown = require('gulp-markdown');
+const transform = require('gulp-transform');
 
 
-gulp.task('docs', [':docs:md-to-html']);
-gulp.task(':docs:md-to-html', () => {
-  return gulp.src(['*.md'])
+const EXAMPLE_PATTERN = /<!--\W*example\(([^)]+)\)\W*-->/g;
+
+
+gulp.task('docs', () => {
+  return gulp.src(['src/lib/**/*.md'])
+      .pipe(markdown())
+      .pipe(transform((content: string) =>
+          content.toString().replace(EXAMPLE_PATTERN, (match: string, name: string) =>
+              `<div example="${name}"></div>`)))
+      .pipe(gulp.dest('dist/docs'));
 });


### PR DESCRIPTION
additionally replaces comments in the outputted html of the form `<!-- example(label) -->` with `<div example="label">`