### PR TITLE
fix(md-spinner): animation not being cleaned up when used with AoT

### DIFF
--- a/src/lib/progress-circle/progress-circle.spec.ts
+++ b/src/lib/progress-circle/progress-circle.spec.ts
@@ -14,6 +14,7 @@ describe('MdProgressCircular', () => {
         IndeterminateProgressSpinner,
         ProgressSpinnerWithValueAndBoundMode,
         IndeterminateProgressSpinnerWithNgIf,
+        SpinnerWithNgIf,
       ],
     });
 
@@ -90,6 +91,20 @@ describe('MdProgressCircular', () => {
     fixture.detectChanges();
     expect(progressElement.componentInstance.interdeterminateInterval).toBeFalsy();
   });
+
+  it('should clean up the animation when a spinner is destroyed', () => {
+    let fixture = TestBed.createComponent(SpinnerWithNgIf);
+    fixture.detectChanges();
+
+    let progressElement = fixture.debugElement.query(By.css('md-spinner'));
+
+    expect(progressElement.componentInstance.interdeterminateInterval).toBeTruthy();
+
+    fixture.debugElement.componentInstance.isHidden = true;
+    fixture.detectChanges();
+
+    expect(progressElement.componentInstance.interdeterminateInterval).toBeFalsy();
+  });
 });
 
 
@@ -105,3 +120,6 @@ class ProgressSpinnerWithValueAndBoundMode { }
 @Component({template: `
     <md-progress-circle mode="indeterminate" *ngIf="!isHidden"></md-progress-circle>`})
 class IndeterminateProgressSpinnerWithNgIf { }
+
+@Component({template: `<md-spinner *ngIf="!isHidden"></md-spinner>`})
+class SpinnerWithNgIf { }

--- a/src/lib/progress-circle/progress-circle.ts
+++ b/src/lib/progress-circle/progress-circle.ts
@@ -244,10 +244,16 @@ export class MdProgressCircle implements OnDestroy {
   templateUrl: 'progress-circle.html',
   styleUrls: ['progress-circle.css'],
 })
-export class MdSpinner extends MdProgressCircle {
+export class MdSpinner extends MdProgressCircle implements OnDestroy {
   constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef, ngZone: NgZone) {
     super(changeDetectorRef, ngZone, elementRef);
     this.mode = 'indeterminate';
+  }
+
+  ngOnDestroy() {
+    // The `ngOnDestroy` from `MdProgressCircle` should be called explicitly, because
+    // in certain cases Angular won't call it (e.g. when using AoT and in unit tests).
+    super.ngOnDestroy();
   }
 }
 


### PR DESCRIPTION
Fixes the `md-spinner` animation interval not being cleaned up when the app has been compiled through the AoT.
This is due to the the fact that the `ngOnDestroy` handler is in the base `MdProgressCircle` class.

Fixes #1283.

**Note:** At some point it may be better to reorganize the component so we have the following setup:
* Base progress circle class - handles all of the rendering and animation logic.
* Progress circle class - a subclass that only handles the determinate mode.
* Progress spinner - a subclass that only handles the spinning animation.

This should avoid having to refer to the `super` class for things like cleaning up the animation.