### PR TITLE
chore(e2e): fix e2e tests for latest chrome versions

### DIFF
--- a/e2e/components/menu/menu.e2e.ts
+++ b/e2e/components/menu/menu.e2e.ts
@@ -75,7 +75,10 @@ describe('menu', () => {
     });
 
     it('should auto-focus the first item when opened with SPACE', () => {
-      page.pressKey(protractor.Key.SPACE);
+      // Due to chromebug https://bugs.chromium.org/p/chromedriver/issues/detail?id=1502,
+      // the space key is not properly working in the latest Chromedriver.
+      // TODO: Revert temporary change to use space key after Chromedriver 2.26 is available.
+      page.pressKey(protractor.Key.ENTER);
       page.expectFocusOn(page.items(0));
     });
 

--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -65,7 +65,7 @@ export const customLaunchers: { [name: string]: BrowserLauncherInfo } = {
   'SL_CHROME': {
     base: 'SauceLabs',
     browserName: 'chrome',
-    version: '46'
+    version: 'latest'
   },
   'SL_CHROMEBETA': {
     base: 'SauceLabs',
@@ -80,7 +80,7 @@ export const customLaunchers: { [name: string]: BrowserLauncherInfo } = {
   'SL_FIREFOX': {
     base: 'SauceLabs',
     browserName: 'firefox',
-    version: '42'
+    version: 'latest'
   },
   'SL_FIREFOXBETA': {
     base: 'SauceLabs',


### PR DESCRIPTION
* Temporary fixed a test, which fails in Chrome 53+ (due to [cr-bug/1502](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1502))
* Updates the Firefox and Chrome versions for Saucelabs.
* Another e2e test in the menu has been fixed with SHA accab2049626fe267a94b74d45c3dd7d6b5df865

**Note**: This is pretty important, because pretty much everyone who works on E2E tests uses one of latest Chrome versions-and the tests don't pass locally (makes working on e2e difficult)