### PR TITLE
chore: update iOS unit test configuration

### DIFF
--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -44,7 +44,7 @@ const configuration: { [name: string]: ConfigurationInfo } = {
   'Safari8':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari9':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'iOS7':         { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
-  'iOS8':         { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'iOS8':         { unitTest: {target: 'BS', required: true}, e2e: {target: null, required: true}},
   'iOS9':         { unitTest: {target: 'BS', required: true}, e2e: {target: null, required: true}},
   'WindowsPhone': { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}}
 };

--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -43,11 +43,9 @@ const configuration: { [name: string]: ConfigurationInfo } = {
   'Safari7':      { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
   'Safari8':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
   'Safari9':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
-  'iOS7':         { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
-  'iOS8':         { unitTest: {target: 'BS', required: true}, e2e: {target: null, required: true}},
-  // TODO(mlaval): iOS9 deactivated as not reliable, reactivate after
-  //               https://github.com/angular/angular/issues/5408
-  'iOS9':         { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'iOS7':         { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
+  'iOS8':         { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'iOS9':         { unitTest: {target: 'BS', required: true}, e2e: {target: null, required: true}},
   'WindowsPhone': { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}}
 };
 


### PR DESCRIPTION
* Since iOS9 now runs very stable, we could rather run this in required mode than the iOS8 version.
* iOS8 will still run on the CI, but now in optional mode.
* Disabling iOS7 since it breaks our optional mode and fixing it requires bandages to fix the pixel-deviations (See Material 1)

**Note**: iOS10 is not available in Browserstack yet. Running the two latest (*available*) devices (iOS9 and iOS8)
- https://gist.github.com/DevVersion/98be055b10003ac5515c9ada7a14688a