### PR TITLE
fix(input): error in IE on unsupported input types

### DIFF
--- a/src/lib/input/input.html
+++ b/src/lib/input/input.html
@@ -28,7 +28,7 @@
              [spellcheck]="spellcheck"
              [attr.step]="step"
              [attr.tabindex]="tabindex"
-             [type]="type"
+             [attr.type]="type"
              [attr.name]="name"
              (focus)="_handleFocus($event)"
              (blur)="_handleBlur($event)"


### PR DESCRIPTION
Fixes IE throwing a template error and stopping all rendering if an unsupported input type is set on an `md-input` instance.