### PR TITLE
fix(connected-position): fix position emitter

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -278,13 +278,23 @@ describe('ConnectedPositionStrategy', () => {
             {overlayX: 'end', overlayY: 'top'});
 
     const positionChangeHandler = jasmine.createSpy('positionChangeHandler');
-    strategy.onPositionChange.first().subscribe(positionChangeHandler);
+    const subscription = strategy.onPositionChange.subscribe(positionChangeHandler);
 
     strategy.apply(overlayElement);
     expect(positionChangeHandler).toHaveBeenCalled();
     expect(positionChangeHandler.calls.mostRecent().args[0])
         .toEqual(jasmine.any(ConnectedOverlayPositionChange),
             `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
+
+    originElement.style.top = '0';
+    originElement.style.left = '0';
+
+    // If the strategy is re-applied and the initial position would now fit,
+    // the position change event should be emitted again.
+    strategy.apply(overlayElement);
+    expect(positionChangeHandler).toHaveBeenCalledTimes(2);
+
+    subscription.unsubscribe();
   });
 
 

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -73,7 +73,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     // We use the viewport rect to determine whether a position would go off-screen.
     const viewportRect = this._viewportRuler.getViewportRect();
     let firstOverlayPoint: Point = null;
-    let isFirstPosition = true;
 
     // We want to place the overlay in the first of the preferred positions such that the
     // overlay fits on-screen.
@@ -87,12 +86,9 @@ export class ConnectedPositionStrategy implements PositionStrategy {
       // If the overlay in the calculated position fits on-screen, put it there and we're done.
       if (this._willOverlayFitWithinViewport(overlayPoint, overlayRect, viewportRect)) {
         this._setElementPosition(element, overlayPoint);
-        if (!isFirstPosition) {
-          this._onPositionChange.next(new ConnectedOverlayPositionChange(pos));
-        }
+        this._onPositionChange.next(new ConnectedOverlayPositionChange(pos));
         return Promise.resolve(null);
       }
-      isFirstPosition = false;
     }
 
     // TODO(jelbourn): fallback behavior for when none of the preferred positions fit on-screen.


### PR DESCRIPTION
Realized my first implementation made no sense because if you scroll back to a position where the default orientation will fit, it won't fire a position change event.  Now it will fire a change event whenever the position changes, including the first time.