### PR TITLE
fix(dialog): add border radius

### DIFF
--- a/src/lib/dialog/dialog-container.scss
+++ b/src/lib/dialog/dialog-container.scss
@@ -2,6 +2,7 @@
 
 
 $md-dialog-padding: 24px !default;
+$md-dialog-border-radius: 2px !default;
 
 md-dialog-container {
   @include md-elevation(24);
@@ -9,4 +10,5 @@ md-dialog-container {
   display: block;
   overflow: hidden;
   padding: $md-dialog-padding;
+  border-radius: $md-dialog-border-radius;
 }


### PR DESCRIPTION
Adds a border radius to the `md-dialog-container`.

Fixes #1868.