### PR TITLE
test(grid-list): add basic e2e tests

### DIFF
--- a/e2e/components/grid-list/grid-list.e2e.ts
+++ b/e2e/components/grid-list/grid-list.e2e.ts
@@ -1,0 +1,12 @@
+describe('grid-list', () => {
+  beforeEach(() => browser.get('/grid-list'));
+
+  it('should render a grid list container', () => {
+    expect(element(by.css('md-grid-list')).isPresent()).toBe(true);
+  });
+
+  it('should render list items inside the grid list container', () => {
+    let container = element(by.css('md-grid-list'));
+    expect(container.isElementPresent(by.css('md-grid-tile'))).toBe(true);
+  });
+});

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -9,6 +9,7 @@ import {MenuE2E} from './menu/menu-e2e';
 import {SimpleRadioButtons} from './radio/radio-e2e';
 import {BasicTabs} from './tabs/tabs-e2e';
 import {DialogE2E, TestDialog} from './dialog/dialog-e2e';
+import {GridListE2E} from './grid-list/grid-list-e2e';
 import {MaterialModule} from '@angular/material';
 import {E2E_APP_ROUTES} from './e2e-app/routes';
 
@@ -30,6 +31,7 @@ import {E2E_APP_ROUTES} from './e2e-app/routes';
     Home,
     DialogE2E,
     TestDialog,
+    GridListE2E,
   ],
   bootstrap: [E2EApp],
   providers: [

--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -1,6 +1,7 @@
 <a md-list-item [routerLink]="['button']">Button</a>
 <a md-list-item [routerLink]="['checkbox']">Checkbox</a>
 <a md-list-item [routerLink]="['dialog']">Dialog</a>
+<a md-list-item [routerLink]="['grid-list']">Grid list</a>
 <a md-list-item [routerLink]="['icon']">Icon</a>
 <a md-list-item [routerLink]="['menu']">Menu</a>
 <a md-list-item [routerLink]="['radio']">Radios</a>

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -7,6 +7,7 @@ import {MenuE2E} from '../menu/menu-e2e';
 import {SimpleRadioButtons} from '../radio/radio-e2e';
 import {SimpleCheckboxes} from '../checkbox/checkbox-e2e';
 import {DialogE2E} from '../dialog/dialog-e2e';
+import {GridListE2E} from '../grid-list/grid-list-e2e';
 
 export const E2E_APP_ROUTES: Routes = [
   {path: '', component: Home},
@@ -17,4 +18,5 @@ export const E2E_APP_ROUTES: Routes = [
   {path: 'radio', component: SimpleRadioButtons},
   {path: 'tabs', component: BasicTabs},
   {path: 'dialog', component: DialogE2E},
+  {path: 'grid-list', component: GridListE2E},
 ];

--- a/src/e2e-app/grid-list/grid-list-e2e.html
+++ b/src/e2e-app/grid-list/grid-list-e2e.html
@@ -1,0 +1,6 @@
+<md-grid-list cols="4" [rowHeight]="100">
+  <md-grid-tile>One</md-grid-tile>
+  <md-grid-tile>Two</md-grid-tile>
+  <md-grid-tile>Three</md-grid-tile>
+  <md-grid-tile>Four</md-grid-tile>
+</md-grid-list>

--- a/src/e2e-app/grid-list/grid-list-e2e.ts
+++ b/src/e2e-app/grid-list/grid-list-e2e.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'grid-list-e2e',
+  templateUrl: 'grid-list-e2e.html',
+})
+export class GridListE2E {}


### PR DESCRIPTION
Adds basic e2e tests for the `grid-list` component. As discussed, these tests are only basic sanity checks that everything renders without errors, all the other logic is better tested in the unit tests.

Fixes #547.