### PR TITLE
fix(tab-link): avoid potential memory leak

### DIFF
--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -64,7 +64,11 @@ describe('MdRipple', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MdRippleModule.forRoot()],
-      declarations: [BasicRippleContainer, RippleContainerWithInputBindings],
+      declarations: [
+        BasicRippleContainer,
+        RippleContainerWithInputBindings,
+        RippleContainerWithNgIf,
+      ],
     });
   });
 
@@ -179,6 +183,20 @@ describe('MdRipple', () => {
       expect(pxStringToFloat(ripple.style.top)).toBeCloseTo(expectedTop, 1);
       expect(pxStringToFloat(ripple.style.width)).toBeCloseTo(2 * expectedRadius, 1);
       expect(pxStringToFloat(ripple.style.height)).toBeCloseTo(2 * expectedRadius, 1);
+    });
+
+    it('cleans up the event handlers when the container gets destroyed', () => {
+      fixture = TestBed.createComponent(RippleContainerWithNgIf);
+      fixture.detectChanges();
+
+      rippleElement = fixture.debugElement.nativeElement.querySelector('[md-ripple]');
+      rippleBackground = rippleElement.querySelector('.md-ripple-background');
+
+      fixture.componentInstance.isDestroyed = true;
+      fixture.detectChanges();
+
+      rippleElement.dispatchEvent(createMouseEvent('mousedown'));
+      expect(rippleBackground.classList).not.toContain('md-ripple-active');
     });
   });
 
@@ -327,4 +345,10 @@ class RippleContainerWithInputBindings {
   color = '';
   backgroundColor = '';
   @ViewChild(MdRipple) ripple: MdRipple;
+}
+
+@Component({ template: `<div id="container" md-ripple *ngIf="!isDestroyed"></div>` })
+class RippleContainerWithNgIf {
+  @ViewChild(MdRipple) ripple: MdRipple;
+  isDestroyed = false;
 }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -10,7 +10,8 @@ describe('MdTabNavBar', () => {
     TestBed.configureTestingModule({
       imports: [MdTabsModule.forRoot()],
       declarations: [
-        SimpleTabNavBarTestApp
+        SimpleTabNavBarTestApp,
+        TabLinkWithNgIf,
       ],
     });
 
@@ -38,6 +39,25 @@ describe('MdTabNavBar', () => {
       expect(component.activeIndex).toBe(2);
     });
   });
+
+  it('should clean up the ripple event handlers on destroy', () => {
+    let fixture: ComponentFixture<TabLinkWithNgIf> = TestBed.createComponent(TabLinkWithNgIf);
+    fixture.detectChanges();
+
+    let link = fixture.debugElement.nativeElement.querySelector('[md-tab-link]');
+    let rippleBackground = link.querySelector('.md-ripple-background');
+    let mouseEvent = document.createEvent('MouseEvents');
+
+    fixture.componentInstance.isDestroyed = true;
+    fixture.detectChanges();
+
+    mouseEvent.initMouseEvent('mousedown', false, false, window, 0, 0, 0, 0, 0, false, false,
+        false, false, 0, null);
+
+    link.dispatchEvent(mouseEvent);
+
+    expect(rippleBackground.classList).not.toContain('md-ripple-active');
+  });
 });
 
 @Component({
@@ -52,4 +72,15 @@ describe('MdTabNavBar', () => {
 })
 class SimpleTabNavBarTestApp {
   activeIndex = 0;
+}
+
+@Component({
+  template: `
+    <nav md-tab-nav-bar>
+      <a md-tab-link *ngIf="!isDestroyed">Link</a>
+    </nav>
+  `
+})
+class TabLinkWithNgIf {
+  isDestroyed = false;
 }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -1,4 +1,13 @@
-import {Component, Input, ViewChild, ElementRef, ViewEncapsulation, Directive} from '@angular/core';
+import {
+  Component,
+  Input,
+  ViewChild,
+  ElementRef,
+  ViewEncapsulation,
+  Directive,
+  OnDestroy,
+} from '@angular/core';
+
 import {MdInkBar} from '../ink-bar';
 import {MdRipple} from '../../core/ripple/ripple';
 
@@ -50,8 +59,14 @@ export class MdTabLink {
 @Directive({
   selector: '[md-tab-link]',
 })
-export class MdTabLinkRipple extends MdRipple {
+export class MdTabLinkRipple extends MdRipple implements OnDestroy {
   constructor(private _element: ElementRef) {
     super(_element);
+  }
+
+  // In certain cases the parent destroy handler
+  // may not get called. See Angular issue #11606.
+  ngOnDestroy() {
+    super.ngOnDestroy();
   }
 }


### PR DESCRIPTION
* Similarly to #1838, the `tab-link` destroy handler may not be called in certain situations, because it is being inherited from the MdRipple class. This PR explicitly calls the destroy handler.
* Adds a unit test to make sure that the ripples are being cleaned up properly.