### PR TITLE
fix(interactivity-checker): improve robustness of isTabbable

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -34,6 +34,7 @@ import {PortalDemo, ScienceJoke} from './portal/portal-demo';
 import {MenuDemo} from './menu/menu-demo';
 import {TabsDemo, SunnyTabContent, RainyTabContent, FoggyTabContent} from './tabs/tabs-demo';
 import {ProjectionDemo, ProjectionTestComponent} from './projection/projection-demo';
+import {PlatformDemo} from './platform/platform-demo';
 
 @NgModule({
   imports: [
@@ -84,6 +85,7 @@ import {ProjectionDemo, ProjectionTestComponent} from './projection/projection-d
     SunnyTabContent,
     RainyTabContent,
     FoggyTabContent,
+    PlatformDemo
   ],
   entryComponents: [
     DemoApp,

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -46,6 +46,7 @@ export class DemoApp {
     {name: 'Snack Bar', route: 'snack-bar'},
     {name: 'Tabs', route: 'tabs'},
     {name: 'Toolbar', route: 'toolbar'},
-    {name: 'Tooltip', route: 'tooltip'}
+    {name: 'Tooltip', route: 'tooltip'},
+    {name: 'Platform', route: 'platform'}
   ];
 }

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -29,6 +29,7 @@ import {TooltipDemo} from '../tooltip/tooltip-demo';
 import {SnackBarDemo} from '../snack-bar/snack-bar-demo';
 import {ProjectionDemo} from '../projection/projection-demo';
 import {TABS_DEMO_ROUTES} from '../tabs/routes';
+import {PlatformDemo} from '../platform/platform-demo';
 
 export const DEMO_APP_ROUTES: Routes = [
   {path: '', component: Home},
@@ -60,4 +61,5 @@ export const DEMO_APP_ROUTES: Routes = [
   {path: 'dialog', component: DialogDemo},
   {path: 'tooltip', component: TooltipDemo},
   {path: 'snack-bar', component: SnackBarDemo},
+  {path: 'platform', component: PlatformDemo}
 ];

--- a/src/demo-app/platform/platform-demo.ts
+++ b/src/demo-app/platform/platform-demo.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+import {MdPlatform} from '@angular/material';
+
+@Component({
+  template: `
+    <p>Is Android: {{ platform.ANDROID }}</p>
+    <p>Is iOS: {{ platform.IOS }}</p>
+    <p>Is Firefox: {{ platform.FIREFOX }}</p>
+    <p>Is Blink: {{ platform.BLINK }}</p>
+    <p>Is Webkit: {{ platform.WEBKIT }}</p>
+    <p>Is Trident: {{ platform.TRIDENT }}</p>
+    <p>Is Edge: {{ platform.EDGE }}</p>
+
+  `
+})
+export class PlatformDemo {
+
+  constructor(public platform: MdPlatform) {}
+
+}

--- a/src/demo-app/platform/platform-demo.ts
+++ b/src/demo-app/platform/platform-demo.ts
@@ -10,7 +10,6 @@ import {MdPlatform} from '@angular/material';
     <p>Is Webkit: {{ platform.WEBKIT }}</p>
     <p>Is Trident: {{ platform.TRIDENT }}</p>
     <p>Is Edge: {{ platform.EDGE }}</p>
-
   `
 })
 export class PlatformDemo {

--- a/src/demo-app/platform/platform-demo.ts
+++ b/src/demo-app/platform/platform-demo.ts
@@ -14,7 +14,5 @@ import {MdPlatform} from '@angular/material';
   `
 })
 export class PlatformDemo {
-
   constructor(public platform: MdPlatform) {}
-
 }

--- a/src/lib/core/a11y/focus-trap.spec.ts
+++ b/src/lib/core/a11y/focus-trap.spec.ts
@@ -3,17 +3,21 @@ import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 import {FocusTrap} from './focus-trap';
 import {InteractivityChecker} from './interactivity-checker';
+import {MdPlatform} from '../platform/platform';
 
 
 describe('FocusTrap', () => {
+
   describe('with default element', () => {
+
     let fixture: ComponentFixture<FocusTrapTestApp>;
     let focusTrapInstance: FocusTrap;
+    let platform: MdPlatform = new MdPlatform();
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         declarations: [FocusTrap, FocusTrapTestApp],
-        providers: [InteractivityChecker]
+        providers: [InteractivityChecker, MdPlatform]
       });
 
       TestBed.compileComponents();
@@ -38,8 +42,11 @@ describe('FocusTrap', () => {
       // focus event handler directly.
       focusTrapInstance.focusLastTabbableElement();
 
+      // In iOS button elements are never tabbable, so the last element will be the input.
+      let lastElement = platform.IOS ? 'input' : 'button';
+
       expect(document.activeElement.nodeName.toLowerCase())
-          .toBe('button', 'Expected button element to be focused');
+          .toBe(lastElement, `Expected ${lastElement} element to be focused`);
     });
   });
 
@@ -50,7 +57,7 @@ describe('FocusTrap', () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         declarations: [FocusTrap, FocusTrapTargetTestApp],
-        providers: [InteractivityChecker]
+        providers: [InteractivityChecker, MdPlatform]
       });
 
       TestBed.compileComponents();

--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -2,10 +2,12 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {FocusTrap} from './focus-trap';
 import {MdLiveAnnouncer} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
+import {PlatformModule} from '../platform/platform';
 
 export const A11Y_PROVIDERS = [MdLiveAnnouncer, InteractivityChecker];
 
 @NgModule({
+  imports: [PlatformModule],
   declarations: [FocusTrap],
   exports: [FocusTrap],
 })

--- a/src/lib/core/a11y/interactivity-checker.spec.ts
+++ b/src/lib/core/a11y/interactivity-checker.spec.ts
@@ -1,14 +1,17 @@
 import {InteractivityChecker} from './interactivity-checker';
+import {MdPlatform} from '../platform/platform';
+import {async} from '@angular/core/testing';
 
 describe('InteractivityChecker', () => {
   let testContainerElement: HTMLElement;
   let checker: InteractivityChecker;
+  let platform: MdPlatform = new MdPlatform();
 
   beforeEach(() => {
     testContainerElement = document.createElement('div');
     document.body.appendChild(testContainerElement);
 
-    checker = new InteractivityChecker();
+    checker = new InteractivityChecker(platform);
   });
 
   afterEach(() => {
@@ -234,57 +237,259 @@ describe('InteractivityChecker', () => {
       });
     });
 
-    it('should return true for div and span with tabindex == 0', () => {
-      let elements = createElements('div', 'span');
 
-      elements.forEach(el => el.setAttribute('tabindex', '0'));
-      appendElements(elements);
-
-      elements.forEach(el => {
-        expect(checker.isFocusable(el))
-            .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be focusable`);
-      });
-    });
   });
 
   describe('isTabbable', () => {
-    it('should return true for native form controls and anchor without tabindex attribute', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button', 'a');
-      appendElements(elements);
 
-      elements.forEach(el => {
-        expect(checker.isTabbable(el)).toBe(true, `Expected <${el.nodeName}> to be tabbable`);
+    it('should respect the tabindex for video elements with controls',
+      // Do not run for Blink, Firefox and iOS because those treat video elements
+      // with controls different and are covered in other tests.
+      runIf(!platform.BLINK && !platform.FIREFOX && !platform.IOS, () => {
+
+        let video = createFromTemplate('<video controls>', true);
+
+        expect(checker.isTabbable(video)).toBe(true);
+
+        video.tabIndex = -1;
+
+        expect(checker.isTabbable(video)).toBe(false);
+      })
+    );
+
+    it('should always mark video elements with controls as tabbable (BLINK & FIREFOX)',
+      // Only run this spec for Blink and Firefox, because those always treat video
+      // elements with controls as tabbable.
+      runIf(platform.BLINK || platform.FIREFOX, () => {
+
+        let video = createFromTemplate('<video controls>', true);
+
+        expect(checker.isTabbable(video)).toBe(true);
+
+        video.tabIndex = -1;
+
+        expect(checker.isTabbable(video)).toBe(true);
+      })
+    );
+
+    // Some tests should not run inside of iOS browsers, because those only allow specific
+    // elements to be tabbable and cause the tests to always fail.
+    describe('for non-iOS browsers', runIf(!platform.IOS, () => {
+
+      it('should mark form controls and anchors without tabindex attribute as tabbable', () => {
+        let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+        appendElements(elements);
+
+        elements.forEach(el => {
+          expect(checker.isTabbable(el)).toBe(true, `Expected <${el.nodeName}> to be tabbable`);
+        });
       });
-    });
 
-    it('should return false for native form controls and anchor with tabindex == -1', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+      it('should return true for div and span with tabindex == 0', () => {
+        let elements = createElements('div', 'span');
 
-      elements.forEach(el => el.setAttribute('tabindex', '-1'));
-      appendElements(elements);
+        elements.forEach(el => el.setAttribute('tabindex', '0'));
+        appendElements(elements);
 
-      elements.forEach(el => {
-        expect(checker.isTabbable(el))
-            .toBe(false, `Expected <${el.nodeName} tabindex="-1"> not to be tabbable`);
+        elements.forEach(el => {
+          expect(checker.isFocusable(el))
+          .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be focusable`);
+        });
       });
-    });
 
-    it('should return true for div and span with tabindex == 0', () => {
-      let elements = createElements('div', 'span');
+      it('should return false for native form controls and anchor with tabindex == -1', () => {
+        let elements = createElements('input', 'textarea', 'select', 'button', 'a');
 
-      elements.forEach(el => el.setAttribute('tabindex', '0'));
-      appendElements(elements);
+        elements.forEach(el => el.setAttribute('tabindex', '-1'));
+        appendElements(elements);
 
-      elements.forEach(el => {
-        expect(checker.isTabbable(el))
-            .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be tabbable`);
+        elements.forEach(el => {
+          expect(checker.isTabbable(el))
+          .toBe(false, `Expected <${el.nodeName} tabindex="-1"> not to be tabbable`);
+        });
       });
-    });
+
+      it('should return true for div and span with tabindex == 0', () => {
+        let elements = createElements('div', 'span');
+
+        elements.forEach(el => el.setAttribute('tabindex', '0'));
+        appendElements(elements);
+
+        elements.forEach(el => {
+          expect(checker.isTabbable(el))
+          .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be tabbable`);
+        });
+      });
+
+      it('should respect the inherited tabindex inside of frame elements', () => {
+        let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+        appendElements([iframe]);
+
+        iframe.tabIndex = -1;
+        iframe.contentDocument.body.appendChild(button);
+
+        expect(checker.isTabbable(iframe)).toBe(false);
+        expect(checker.isTabbable(button)).toBe(false);
+
+        iframe.tabIndex = null;
+
+        expect(checker.isTabbable(iframe)).toBe(false);
+        expect(checker.isTabbable(button)).toBe(true);
+      });
+
+      it('should mark elements which are contentEditable as tabbable', async(() => {
+        let editableEl = createFromTemplate('<div contenteditable="true">', true);
+
+        // Wait one tick, because the browser takes some time to update the tabIndex
+        // according to the contentEditable attribute.
+        setTimeout(() => {
+
+          expect(checker.isTabbable(editableEl)).toBe(true);
+
+          editableEl.tabIndex = -1;
+
+          expect(checker.isTabbable(editableEl)).toBe(false);
+
+        }, 1);
+
+      }));
+
+      it('should never mark iframe elements as tabbable', () => {
+        let iframe = createFromTemplate('<iframe>', true);
+
+        // iFrame elements will be never marked as tabbable, because it depends on the content
+        // which is mostly not detectable due to CORS and also the checks will be not reliable.
+        expect(checker.isTabbable(iframe)).toBe(false);
+      });
+
+      it('should always mark audio elements without controls as not tabbable', () => {
+        let audio = createFromTemplate('<audio>', true);
+
+        expect(checker.isTabbable(audio)).toBe(false);
+      });
+
+    }));
+
+    describe('for Blink and Webkit browsers', runIf(platform.BLINK || platform.WEBKIT, () => {
+
+      it('should not mark elements inside of object frames as tabbable', () => {
+        let objectEl = createFromTemplate('<object>', true) as HTMLObjectElement;
+        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+        appendElements([objectEl]);
+
+        // This is a hack to create an empty contentDocument for the frame element.
+        objectEl.type = 'text/html';
+        objectEl.contentDocument.body.appendChild(button);
+
+        expect(checker.isTabbable(objectEl)).toBe(false);
+        expect(checker.isTabbable(button)).toBe(false);
+      });
+
+      it('should not mark elements inside of invisible frames as tabbable', () => {
+        let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+        appendElements([iframe]);
+
+        iframe.style.display = 'none';
+        iframe.contentDocument.body.appendChild(button);
+
+        expect(checker.isTabbable(iframe)).toBe(false);
+        expect(checker.isTabbable(button)).toBe(false);
+      });
+
+      it('should never mark object frame elements as tabbable', () => {
+        let objectEl = createFromTemplate('<object>', true);
+
+        expect(checker.isTabbable(objectEl)).toBe(false);
+      });
+
+    }));
+
+    describe('for Blink browsers', runIf(platform.BLINK, () => {
+
+      it('should always mark audio elements with controls as tabbable', () => {
+        let audio = createFromTemplate('<audio controls>', true);
+
+        expect(checker.isTabbable(audio)).toBe(true);
+
+        audio.tabIndex = -1;
+
+        // The audio element will be still tabbable because Blink always
+        // considers them as tabbable.
+        expect(checker.isTabbable(audio)).toBe(true);
+      });
+
+    }));
+
+    describe('for Internet Explorer', runIf(platform.TRIDENT, () => {
+
+      it('should never mark video elements without controls as tabbable', () => {
+        // In Internet Explorer video elements without controls are never tabbable.
+        let video = createFromTemplate('<video>', true);
+
+        expect(checker.isTabbable(video)).toBe(false);
+
+        video.tabIndex = 0;
+
+        expect(checker.isTabbable(video)).toBe(false);
+
+      });
+
+    }));
+
+    describe('for iOS browsers', runIf(platform.IOS && platform.WEBKIT, () => {
+
+      it('should never allow div elements to be tabbable', () => {
+        let divEl = createFromTemplate('<div tabindex="0">', true);
+
+        expect(checker.isTabbable(divEl)).toBe(false);
+      });
+
+      it('should never allow span elements to be tabbable', () => {
+        let spanEl = createFromTemplate('<span tabindex="0">Text</span>', true);
+
+        expect(checker.isTabbable(spanEl)).toBe(false);
+      });
+
+      it('should never allow button elements to be tabbable', () => {
+        let buttonEl = createFromTemplate('<button tabindex="0">', true);
+
+        expect(checker.isTabbable(buttonEl)).toBe(false);
+      });
+
+      it('should never allow anchor elements to be tabbable', () => {
+        let anchorEl = createFromTemplate('<a tabindex="0">Link</a>', true);
+
+        expect(checker.isTabbable(anchorEl)).toBe(false);
+      });
+
+    }));
+
+
   });
 
   /** Creates an array of elements with the given node names. */
   function createElements(...nodeNames: string[]) {
     return nodeNames.map(name => document.createElement(name));
+  }
+
+  function createFromTemplate(template: string, append = false) {
+    let tmpRoot = document.createElement('div');
+    tmpRoot.innerHTML = template;
+
+    let element = tmpRoot.firstElementChild;
+
+    tmpRoot.removeChild(element);
+
+    if (append) {
+      appendElements([element]);
+    }
+
+    return element as HTMLElement;
   }
 
   /** Appends elements to the testContainerElement. */
@@ -293,4 +498,13 @@ describe('InteractivityChecker', () => {
       testContainerElement.appendChild(e);
     }
   }
+
+  function runIf(condition: boolean, runFn: Function): () => void {
+    return function() {
+      if (condition) {
+        runFn.apply(this, arguments);
+      }
+    };
+  }
+
 });

--- a/src/lib/core/a11y/interactivity-checker.spec.ts
+++ b/src/lib/core/a11y/interactivity-checker.spec.ts
@@ -350,7 +350,7 @@ describe('InteractivityChecker', () => {
 
           expect(checker.isTabbable(editableEl)).toBe(false);
 
-        }, 1);
+        }, 0);
 
       }));
 

--- a/src/lib/core/a11y/interactivity-checker.spec.ts
+++ b/src/lib/core/a11y/interactivity-checker.spec.ts
@@ -246,7 +246,6 @@ describe('InteractivityChecker', () => {
       // Do not run for Blink, Firefox and iOS because those treat video elements
       // with controls different and are covered in other tests.
       runIf(!platform.BLINK && !platform.FIREFOX && !platform.IOS, () => {
-
         let video = createFromTemplate('<video controls>', true);
 
         expect(checker.isTabbable(video)).toBe(true);
@@ -261,7 +260,6 @@ describe('InteractivityChecker', () => {
       // Only run this spec for Blink and Firefox, because those always treat video
       // elements with controls as tabbable.
       runIf(platform.BLINK || platform.FIREFOX, () => {
-
         let video = createFromTemplate('<video controls>', true);
 
         expect(checker.isTabbable(video)).toBe(true);
@@ -293,7 +291,7 @@ describe('InteractivityChecker', () => {
 
         elements.forEach(el => {
           expect(checker.isFocusable(el))
-          .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be focusable`);
+            .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be focusable`);
         });
       });
 
@@ -305,7 +303,7 @@ describe('InteractivityChecker', () => {
 
         elements.forEach(el => {
           expect(checker.isTabbable(el))
-          .toBe(false, `Expected <${el.nodeName} tabindex="-1"> not to be tabbable`);
+            .toBe(false, `Expected <${el.nodeName} tabindex="-1"> not to be tabbable`);
         });
       });
 
@@ -317,7 +315,7 @@ describe('InteractivityChecker', () => {
 
         elements.forEach(el => {
           expect(checker.isTabbable(el))
-          .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be tabbable`);
+            .toBe(true, `Expected <${el.nodeName} tabindex="0"> to be tabbable`);
         });
       });
 
@@ -500,9 +498,9 @@ describe('InteractivityChecker', () => {
   }
 
   function runIf(condition: boolean, runFn: Function): () => void {
-    return function() {
+    return (...args: any[]) => {
       if (condition) {
-        runFn.apply(this, arguments);
+        runFn.apply(this, args);
       }
     };
   }

--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -38,12 +38,11 @@ export class InteractivityChecker {
    */
   isTabbable(element: HTMLElement) {
 
-    let nodeName = element.nodeName.toLowerCase();
     let frameElement = getWindow(element).frameElement as HTMLElement;
-    let frameType = frameElement && frameElement.nodeName.toLowerCase();
-    let tabIndexValue = getTabIndexValue(element);
 
     if (frameElement) {
+
+      let frameType = frameElement && frameElement.nodeName.toLowerCase();
 
       // Frame elements inherit their tabindex onto all child elements.
       if (getTabIndexValue(frameElement) === -1) {
@@ -61,6 +60,9 @@ export class InteractivityChecker {
       }
 
     }
+
+    let nodeName = element.nodeName.toLowerCase();
+    let tabIndexValue = getTabIndexValue(element);
 
     if (element.hasAttribute('contenteditable')) {
       return tabIndexValue !== -1;

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -29,6 +29,9 @@ export {DomPortalHost} from './portal/dom-portal-host';
 // Projection
 export * from './projection/projection';
 
+// Platform
+export * from './platform/platform';
+
 // Overlay
 export {Overlay, OVERLAY_PROVIDERS} from './overlay/overlay';
 export {OverlayContainer} from './overlay/overlay-container';

--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -1,12 +1,15 @@
 import {Injectable, NgModule, ModuleWithProviders} from '@angular/core';
 
-// Declare window with type of any.
 declare const window: any;
 
 // Whether the current platform supports the V8 Break Iterator. The V8 check
 // is necessary to detect all Blink based browsers.
 const hasV8BreakIterator = (window.Intl && (window.Intl as any).v8BreakIterator);
 
+/**
+ * Service to detect the current platform by comparing the userAgent strings and
+ * checking browser-specific global properties.
+ */
 @Injectable()
 export class MdPlatform {
 

--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -26,6 +26,11 @@ export class MdPlatform {
 
   /** Browsers and Platform Types */
   IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+  // It's difficult to detect the plain Gecko engine, because most of the browsers identify
+  // them self as Gecko-like browsers and modify the userAgent's according to that.
+  // Since we only cover one explicit Firefox case, we can simply check for Firefox
+  // instead of having an unstable check for Gecko.
   FIREFOX = /(firefox|minefield)/i.test(navigator.userAgent);
 
   // Trident on mobile adds the android platform to the userAgent to trick detections.

--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -1,0 +1,41 @@
+import {Injectable, NgModule, ModuleWithProviders} from '@angular/core';
+
+// Declare window with type of any.
+declare const window: any;
+
+// Whether the current platform supports the V8 Break Iterator. The V8 check
+// is necessary to detect all Blink based browsers.
+const hasV8BreakIterator = (window.Intl && (window.Intl as any).v8BreakIterator);
+
+@Injectable()
+export class MdPlatform {
+
+  /** Layout Engines */
+  EDGE = /(edge)/i.test(navigator.userAgent);
+  TRIDENT = /(msie|trident)/i.test(navigator.userAgent);
+
+  // EdgeHTML and Trident mock Blink specific things and need to excluded from this check.
+  BLINK = !!(window.chrome || hasV8BreakIterator) && !!CSS && !this.EDGE && !this.TRIDENT;
+
+  // Webkit is part of the userAgent in EdgeHTML Blink and Trident, so we need to
+  // ensure that Webkit runs standalone and is not use as another engines base.
+  WEBKIT = /AppleWebKit/i.test(navigator.userAgent) && !this.BLINK && !this.EDGE && !this.TRIDENT;
+
+  /** Browsers and Platform Types */
+  IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+  FIREFOX = /(firefox|minefield)/i.test(navigator.userAgent);
+
+  // Trident on mobile adds the android platform to the userAgent to trick detections.
+  ANDROID = /android/i.test(navigator.userAgent) && !this.TRIDENT;
+
+}
+
+@NgModule({})
+export class PlatformModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: PlatformModule,
+      providers: [MdPlatform],
+    };
+  }
+}

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -13,9 +13,8 @@ import {MdDialogConfig} from './dialog-config';
 import {MdDialogRef} from './dialog-ref';
 import {DialogInjector} from './dialog-injector';
 import {MdDialogContainer} from './dialog-container';
-import {A11yModule, InteractivityChecker} from '../core';
+import {A11yModule, InteractivityChecker, MdPlatform} from '../core';
 import {extendObject} from '../core/util/object-extend';
-
 export {MdDialogConfig} from './dialog-config';
 export {MdDialogRef} from './dialog-ref';
 
@@ -150,7 +149,7 @@ export class MdDialogModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: MdDialogModule,
-      providers: [MdDialog, OVERLAY_PROVIDERS, InteractivityChecker],
+      providers: [MdDialog, OVERLAY_PROVIDERS, InteractivityChecker, MdPlatform],
     };
   }
 }

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -31,6 +31,7 @@ import {MdToolbarModule} from './toolbar/index';
 import {MdTooltipModule} from './tooltip/index';
 import {MdMenuModule} from './menu/index';
 import {MdDialogModule} from './dialog/index';
+import {PlatformModule} from './core/platform/platform';
 
 
 const MATERIAL_MODULES = [
@@ -60,6 +61,7 @@ const MATERIAL_MODULES = [
   PortalModule,
   RtlModule,
   A11yModule,
+  PlatformModule,
   ProjectionModule,
   StyleCompatibilityModule,
 ];
@@ -94,6 +96,7 @@ const MATERIAL_MODULES = [
     MdSlideToggleModule.forRoot(),
     MdSnackBarModule.forRoot(),
     MdTooltipModule.forRoot(),
+    PlatformModule.forRoot(),
     OverlayModule.forRoot(),
     StyleCompatibilityModule.forRoot(),
   ],


### PR DESCRIPTION
A couple of notes: 

* It's intentional to *not* nest things like [that](https://github.com/DevVersion/material2/blob/c12ef840f39e678759f19b76cd059c0e75080e81/src/lib/core/a11y/interactivity-checker.ts#L71-L79), because such functions need to be clear.

* You may have noticed that there are no specs for the Platform. It's just hard to mock the `userAgent` and stuff like `v8BreakIterator` without polluting the other tests.

References #1625 