### PR TITLE
docs(CONTRIBUTING): fix link to the google javascript style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [github]: https://github.com/angular/material2
 [gitter]: https://gitter.im/angular/material2
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html
-[js-style-guide]: https://google.github.io/styleguide/javascriptguide.xml
+[js-style-guide]: https://google.github.io/styleguide/jsguide.html
 [codepen]: http://codepen.io/
 [jsbin]: http://jsbin.com/
 [jsfiddle]: http://jsfiddle.net/


### PR DESCRIPTION
Style Guide link changed, this commit simply points straight to new Style Guide, one less extra click to make :) 