### PR TITLE
fix(tooltip): throw a better error when an invalid position is passed

### DIFF
--- a/src/lib/tooltip/tooltip-errors.ts
+++ b/src/lib/tooltip/tooltip-errors.ts
@@ -1,0 +1,8 @@
+import {MdError} from '../core';
+
+/** Exception thrown when a tooltip has an invalid position. */
+export class MdTooltipInvalidPositionError extends MdError {
+  constructor(position: string) {
+    super(`Tooltip position "${position}" is invalid.`);
+  }
+}

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -253,6 +253,14 @@ describe('MdTooltip', () => {
       tooltipDirective.show();
       expect(tooltipDirective._tooltipInstance._transformOrigin).toBe('right');
     });
+
+    it('should throw when trying to assign an invalid position', () => {
+      expect(() => {
+        fixture.componentInstance.position = 'everywhere';
+        fixture.detectChanges();
+        tooltipDirective.show();
+      }).toThrowError('Tooltip position "everywhere" is invalid.');
+    });
   });
 });
 
@@ -260,13 +268,13 @@ describe('MdTooltip', () => {
   selector: 'app',
   template: `
     <button *ngIf="showButton"
-            [md-tooltip]="message" 
+            [md-tooltip]="message"
             [tooltip-position]="position">
       Button
     </button>`
 })
 class BasicTooltipDemo {
-  position: TooltipPosition = 'below';
+  position: string = 'below';
   message: string = initialTooltipMessage;
   showButton: boolean = true;
 }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -26,6 +26,7 @@ import {
   OVERLAY_PROVIDERS,
   DefaultStyleCompatibilityModeModule,
 } from '../core';
+import {MdTooltipInvalidPositionError} from './tooltip-errors';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {Dir} from '../core/rtl/dir';
@@ -178,6 +179,8 @@ export class MdTooltip {
         this.position == 'before' && !isDirectionLtr) {
       return {originX: 'end', originY: 'center'};
     }
+
+    throw new MdTooltipInvalidPositionError(this.position);
   }
 
   /** Returns the overlay position based on the user's preference */
@@ -202,6 +205,8 @@ export class MdTooltip {
         this.position == 'before' && !isLtr) {
       return {overlayX: 'start', overlayY: 'center'};
     }
+
+    throw new MdTooltipInvalidPositionError(this.position);
   }
 
   /** Updates the tooltip message and repositions the overlay according to the new message length */
@@ -302,6 +307,7 @@ export class TooltipComponent {
       case 'right':  this._transformOrigin = 'left'; break;
       case 'above':    this._transformOrigin = 'bottom'; break;
       case 'below': this._transformOrigin = 'top'; break;
+      default: throw new MdTooltipInvalidPositionError(value);
     }
   }
 


### PR DESCRIPTION
* Throws a more informative error message when an invalid position is passed to the tooltip. Previously it would throw something along the lines of `Cannot read property 'originX' of undefined`.
* Moves the various tooltip switch statements to use an enum for easier validation.

Referencing #1959.