### PR TITLE
refactor(icon): remove unused arguments

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -15,7 +15,7 @@ import 'rxjs/add/operator/catch';
 /** Exception thrown when attempting to load an icon with a name that cannot be found. */
 export class MdIconNameNotFoundError extends MdError {
   constructor(iconName: string) {
-      super(`Unable to find icon with the name "${iconName}"`);
+    super(`Unable to find icon with the name "${iconName}"`);
   }
 }
 
@@ -25,7 +25,7 @@ export class MdIconNameNotFoundError extends MdError {
  */
 export class MdIconSvgTagNotFoundError extends MdError {
   constructor() {
-      super('<svg> tag not found');
+    super('<svg> tag not found');
   }
 }
 
@@ -248,7 +248,7 @@ export class MdIconRegistry {
     for (let i = iconSetConfigs.length - 1; i >= 0; i--) {
       const config = iconSetConfigs[i];
       if (config.svgElement) {
-        const foundIcon = this._extractSvgIconFromSet(config.svgElement, iconName, config);
+        const foundIcon = this._extractSvgIconFromSet(config.svgElement, iconName);
         if (foundIcon) {
           return foundIcon;
         }
@@ -263,7 +263,7 @@ export class MdIconRegistry {
    */
   private _loadSvgIconFromConfig(config: SvgIconConfig): Observable<SVGElement> {
     return this._fetchUrl(config.url)
-        .map(svgText => this._createSvgElementForSingleIcon(svgText, config));
+        .map(svgText => this._createSvgElementForSingleIcon(svgText));
   }
 
   /**
@@ -273,15 +273,15 @@ export class MdIconRegistry {
   private _loadSvgIconSetFromConfig(config: SvgIconConfig): Observable<SVGElement> {
       // TODO: Document that icons should only be loaded from trusted sources.
     return this._fetchUrl(config.url)
-        .map((svgText) => this._svgElementFromString(svgText));
+        .map(svgText => this._svgElementFromString(svgText));
   }
 
   /**
    * Creates a DOM element from the given SVG string, and adds default attributes.
    */
-  private _createSvgElementForSingleIcon(responseText: string, config: SvgIconConfig): SVGElement {
+  private _createSvgElementForSingleIcon(responseText: string): SVGElement {
     const svg = this._svgElementFromString(responseText);
-    this._setSvgAttributes(svg, config);
+    this._setSvgAttributes(svg);
     return svg;
   }
 
@@ -290,8 +290,7 @@ export class MdIconRegistry {
    * tag matches the specified name. If found, copies the nested element to a new SVG element and
    * returns it. Returns null if no matching element is found.
    */
-  private _extractSvgIconFromSet(
-      iconSet: SVGElement, iconName: string, config: SvgIconConfig): SVGElement {
+  private _extractSvgIconFromSet(iconSet: SVGElement, iconName: string): SVGElement {
     const iconNode = iconSet.querySelector('#' + iconName);
     if (!iconNode) {
       return null;
@@ -299,7 +298,7 @@ export class MdIconRegistry {
     // If the icon node is itself an <svg> node, clone and return it directly. If not, set it as
     // the content of a new <svg> node.
     if (iconNode.tagName.toLowerCase() == 'svg') {
-      return this._setSvgAttributes(<SVGElement>iconNode.cloneNode(true), config);
+      return this._setSvgAttributes(iconNode.cloneNode(true) as SVGElement);
     }
     // createElement('SVG') doesn't work as expected; the DOM ends up with
     // the correct nodes, but the SVG content doesn't render. Instead we
@@ -309,7 +308,7 @@ export class MdIconRegistry {
     const svg = this._svgElementFromString('<svg></svg>');
     // Clone the node so we don't remove it from the parent icon set element.
     svg.appendChild(iconNode.cloneNode(true));
-    return this._setSvgAttributes(svg, config);
+    return this._setSvgAttributes(svg);
   }
 
   /**
@@ -320,7 +319,7 @@ export class MdIconRegistry {
     // creating an element from an HTML string.
     const div = document.createElement('DIV');
     div.innerHTML = str;
-    const svg = <SVGElement>div.querySelector('svg');
+    const svg = div.querySelector('svg') as SVGElement;
     if (!svg) {
       throw new MdIconSvgTagNotFoundError();
     }
@@ -330,7 +329,7 @@ export class MdIconRegistry {
   /**
    * Sets the default attributes for an SVG element to be used as an icon.
    */
-  private _setSvgAttributes(svg: SVGElement, config: SvgIconConfig): SVGElement {
+  private _setSvgAttributes(svg: SVGElement): SVGElement {
     if (!svg.getAttribute('xmlns')) {
       svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     }
@@ -369,6 +368,6 @@ export class MdIconRegistry {
 
 
 /** Clones an SVGElement while preserving type information. */
-function cloneSvg(svg: SVGElement) {
-  return <SVGElement> svg.cloneNode(true);
+function cloneSvg(svg: SVGElement): SVGElement {
+  return svg.cloneNode(true) as SVGElement;
 }


### PR DESCRIPTION
As per the discussion #1539, there are a few places in the icon registry where the config is being passed without actually being used. This change removes those instances and does some minor cleanup.

Fixes #1539.