### PR TITLE
feat(sidenav): close via escape key and restore focus to trigger element

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,3 +12,4 @@ require('ts-node').register({
 });
 
 require('./tools/gulp/gulpfile');
+//

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,4 +12,3 @@ require('ts-node').register({
 });
 
 require('./tools/gulp/gulpfile');
-//

--- a/src/lib/core/keyboard/keycodes.ts
+++ b/src/lib/core/keyboard/keycodes.ts
@@ -19,4 +19,4 @@ export const ENTER = 13;
 export const SPACE = 32;
 export const TAB = 9;
 
-export const ESCAPE = 27
+export const ESCAPE = 27;

--- a/src/lib/core/keyboard/keycodes.ts
+++ b/src/lib/core/keyboard/keycodes.ts
@@ -18,3 +18,5 @@ export const END = 35;
 export const ENTER = 13;
 export const SPACE = 32;
 export const TAB = 9;
+
+export const ESCAPE = 27

--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -107,6 +107,7 @@ md-sidenav {
   bottom: 0;
   z-index: 3;
   min-width: 5%;
+  outline: 0;
 
   // TODO(kara): revisit scrolling behavior for sidenavs
   overflow-y: auto;

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -4,6 +4,7 @@ import {By} from '@angular/platform-browser';
 import {MdSidenav, MdSidenavModule, MdSidenavToggleResult} from './sidenav';
 import {A11yModule} from '../core/a11y/index';
 import {PlatformModule} from '../core/platform/platform';
+import {ESCAPE} from '../core/keyboard/keycodes';
 
 
 function endSidenavTransition(fixture: ComponentFixture<any>) {
@@ -251,7 +252,7 @@ describe('MdSidenav', () => {
       expect(testComponent.closeCount).toBe(0);
 
       // Simulate pressing the escape key.
-      sidenav.handleEscapeKey();
+      sidenav.handleyKeydown({ keyCode: ESCAPE } as KeyboardEvent);
 
       fixture.detectChanges();
       endSidenavTransition(fixture);

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -252,7 +252,7 @@ describe('MdSidenav', () => {
       expect(testComponent.closeCount).toBe(0);
 
       // Simulate pressing the escape key.
-      sidenav.handleyKeydown({ keyCode: ESCAPE } as KeyboardEvent);
+      sidenav.handleKeydown({ keyCode: ESCAPE } as KeyboardEvent);
 
       fixture.detectChanges();
       endSidenavTransition(fixture);

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -278,9 +278,6 @@ describe('MdSidenav', () => {
       endSidenavTransition(fixture);
       tick();
 
-      expect(document.activeElement)
-          .not.toBe(trigger, 'Expected focus to change when the sidenav was opened.');
-
       sidenav.close();
 
       fixture.detectChanges();

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -252,7 +252,10 @@ describe('MdSidenav', () => {
       expect(testComponent.closeCount).toBe(0);
 
       // Simulate pressing the escape key.
-      sidenav.handleKeydown({ keyCode: ESCAPE } as KeyboardEvent);
+      sidenav.handleKeydown({
+        keyCode: ESCAPE,
+        stopPropagation: () => {}
+      } as KeyboardEvent);
 
       fixture.detectChanges();
       endSidenavTransition(fixture);

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -235,6 +235,59 @@ describe('MdSidenav', () => {
       expect(testComponent.backdropClickedCount).toBe(1);
     }));
 
+    it('should close when pressing escape', fakeAsync(() => {
+      let fixture = TestBed.createComponent(BasicTestApp);
+      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
+      let sidenav: MdSidenav = fixture.debugElement
+        .query(By.directive(MdSidenav)).componentInstance;
+
+      sidenav.open();
+
+      fixture.detectChanges();
+      endSidenavTransition(fixture);
+      tick();
+
+      expect(testComponent.openCount).toBe(1);
+      expect(testComponent.closeCount).toBe(0);
+
+      // Simulate pressing the escape key.
+      sidenav.handleEscapeKey();
+
+      fixture.detectChanges();
+      endSidenavTransition(fixture);
+      tick();
+
+      expect(testComponent.closeCount).toBe(1);
+    }));
+
+    it('should restore focus to the trigger element on close', fakeAsync(() => {
+      let fixture = TestBed.createComponent(BasicTestApp);
+      let sidenav: MdSidenav = fixture.debugElement
+        .query(By.directive(MdSidenav)).componentInstance;
+      let trigger = document.createElement('button');
+
+      document.body.appendChild(trigger);
+      trigger.focus();
+      sidenav.open();
+
+      fixture.detectChanges();
+      endSidenavTransition(fixture);
+      tick();
+
+      expect(document.activeElement)
+          .not.toBe(trigger, 'Expected focus to change when the sidenav was opened.');
+
+      sidenav.close();
+
+      fixture.detectChanges();
+      endSidenavTransition(fixture);
+      tick();
+
+      expect(document.activeElement)
+          .toBe(trigger, 'Expected focus to be restored to the trigger on close.');
+
+      trigger.parentNode.removeChild(trigger);
+    }));
   });
 
   describe('attributes', () => {

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -137,9 +137,13 @@ export class MdSidenav implements AfterContentInit {
     });
 
     this.onClose.subscribe(() => {
-      if (this._elementFocusedBeforeSidenavWasOpened) {
+      if (this._elementFocusedBeforeSidenavWasOpened instanceof HTMLElement) {
         this._elementFocusedBeforeSidenavWasOpened.focus();
+      } else {
+        this._elementRef.nativeElement.blur();
       }
+
+      this._elementFocusedBeforeSidenavWasOpened = null;
     });
   }
 

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -140,14 +140,9 @@ export class MdSidenav implements AfterContentInit {
    *     If not available we do not hook on transitions.
    */
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) {
-    this.onOpen.subscribe(() => {
-      this._elementFocusedBeforeSidenavWasOpened = document.activeElement as HTMLElement;
-      this._renderer.invokeElementMethod(this._elementRef.nativeElement, 'focus');
-    });
-
     this.onClose.subscribe(() => {
       if (this._elementFocusedBeforeSidenavWasOpened instanceof HTMLElement) {
-        this._elementFocusedBeforeSidenavWasOpened.focus();
+        this._renderer.invokeElementMethod(this._elementFocusedBeforeSidenavWasOpened, 'focus');
       } else {
         this._renderer.invokeElementMethod(this._elementRef.nativeElement, 'blur');
       }
@@ -215,6 +210,7 @@ export class MdSidenav implements AfterContentInit {
     }
 
     if (!this.isFocusTrapDisabled) {
+      this._elementFocusedBeforeSidenavWasOpened = document.activeElement as HTMLElement;
       this._focusTrap.focusFirstTabbableElementWhenReady();
     }
 

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -16,9 +16,18 @@ import {
   ViewChild
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {Dir, coerceBooleanProperty, DefaultStyleCompatibilityModeModule} from '../core';
+import {Dir, MdError, coerceBooleanProperty, DefaultStyleCompatibilityModeModule} from '../core';
 import {A11yModule, A11Y_PROVIDERS} from '../core/a11y/index';
 import {FocusTrap} from '../core/a11y/focus-trap';
+import {ESCAPE} from '../core/keyboard/keycodes';
+
+
+/** Exception thrown when two MdSidenav are matching the same side. */
+export class MdDuplicatedSidenavError extends MdError {
+  constructor(align: string) {
+    super(`A sidenav was already declared for 'align="${align}"'`);
+  }
+}
 
 
 /** Sidenav toggle promise result. */
@@ -40,7 +49,7 @@ export class MdSidenavToggleResult {
   template: '<focus-trap [disabled]="isFocusTrapDisabled"><ng-content></ng-content></focus-trap>',
   host: {
     '(transitionend)': '_onTransitionEnd($event)',
-    '(keydown.escape)': 'handleEscapeKey()',
+    '(keydown)': 'handleKeydown($event)',
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',
     '[class.md-sidenav-closed]': '_isClosed',
@@ -219,11 +228,13 @@ export class MdSidenav implements AfterContentInit {
     return this._toggleAnimationPromise;
   }
 
-  /** Handles the user pressing the escape key. */
-  handleEscapeKey() {
-    // TODO(crisbeto): this is in a separate method in order to
-    // allow for disabling the behavior later.
-    this.close();
+  /**
+   * Handles the keyboard events.
+   */
+  handleyKeydown(event: KeyboardEvent) {
+    if (event.keyCode === ESCAPE) {
+      this.close();
+    }
   }
 
   /**

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -139,17 +139,17 @@ export class MdSidenav implements AfterContentInit {
    * @param _elementRef The DOM element reference. Used for transition and width calculation.
    *     If not available we do not hook on transitions.
    */
-  constructor(private _elementRef: ElementRef) {
+  constructor(private _elementRef: ElementRef, private _renderer: Renderer) {
     this.onOpen.subscribe(() => {
       this._elementFocusedBeforeSidenavWasOpened = document.activeElement as HTMLElement;
-      this._elementRef.nativeElement.focus();
+      this._renderer.invokeElementMethod(this._elementRef.nativeElement, 'focus');
     });
 
     this.onClose.subscribe(() => {
       if (this._elementFocusedBeforeSidenavWasOpened instanceof HTMLElement) {
         this._elementFocusedBeforeSidenavWasOpened.focus();
       } else {
-        this._elementRef.nativeElement.blur();
+        this._renderer.invokeElementMethod(this._elementRef.nativeElement, 'blur');
       }
 
       this._elementFocusedBeforeSidenavWasOpened = null;
@@ -231,7 +231,7 @@ export class MdSidenav implements AfterContentInit {
   /**
    * Handles the keyboard events.
    */
-  handleyKeydown(event: KeyboardEvent) {
+  handleKeydown(event: KeyboardEvent) {
     if (event.keyCode === ESCAPE) {
       this.close();
     }

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -234,6 +234,7 @@ export class MdSidenav implements AfterContentInit {
   handleKeydown(event: KeyboardEvent) {
     if (event.keyCode === ESCAPE) {
       this.close();
+      event.stopPropagation();
     }
   }
 

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -140,6 +140,14 @@ export class MdSidenav implements AfterContentInit {
    *     If not available we do not hook on transitions.
    */
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) {
+    this.onOpen.subscribe(() => {
+      this._elementFocusedBeforeSidenavWasOpened = document.activeElement as HTMLElement;
+
+      if (!this.isFocusTrapDisabled) {
+        this._focusTrap.focusFirstTabbableElementWhenReady();
+      }
+    });
+
     this.onClose.subscribe(() => {
       if (this._elementFocusedBeforeSidenavWasOpened instanceof HTMLElement) {
         this._renderer.invokeElementMethod(this._elementFocusedBeforeSidenavWasOpened, 'focus');
@@ -207,11 +215,6 @@ export class MdSidenav implements AfterContentInit {
       this.onOpenStart.emit();
     } else {
       this.onCloseStart.emit();
-    }
-
-    if (!this.isFocusTrapDisabled) {
-      this._elementFocusedBeforeSidenavWasOpened = document.activeElement as HTMLElement;
-      this._focusTrap.focusFirstTabbableElementWhenReady();
     }
 
     if (this._toggleAnimationPromise) {

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -291,14 +291,6 @@ export class MdSidenav implements AfterContentInit {
     return 0;
   }
 
-
-  private _transition: boolean = false;
-  private _openPromise: Promise<void>;
-  private _openPromiseResolve: () => void;
-  private _openPromiseReject: () => void;
-  private _closePromise: Promise<void>;
-  private _closePromiseResolve: () => void;
-  private _closePromiseReject: () => void;
   private _elementFocusedBeforeSidenavWasOpened: HTMLElement = null;
 }
 


### PR DESCRIPTION
* Adds the ability to close a sidenav by pressing escape.
* Restores focus to the trigger element after a sidenav is closed.