### PR TITLE
test(slide-togle): add missing e2e tests for slide-toggle component

### DIFF
--- a/e2e/components/slide-toggle/slide-toggle.e2e.ts
+++ b/e2e/components/slide-toggle/slide-toggle.e2e.ts
@@ -1,0 +1,33 @@
+describe('slide-toggle', () => {
+    beforeEach(() => browser.get('/slide-toggle'));
+    
+    describe('check behavior', () => {
+        it('should be checked when clicked, and  be unchecked when clicked again', () => {
+            element(by.id('test-slide-toggle')).click();
+            element(by.css('input[id=test-slide-toggle-input]'))
+                .getAttribute('checked')
+                .then((value: string) => {
+                    expect(value).toBeTruthy('Expect slide toggle "checked" property to be true');
+                });
+
+            element(by.id('test-slide-toggle')).click();
+            element(by.css('input[id=test-slide-toggle-input]'))
+                .getAttribute('checked')
+                .then((value: string) => {
+                    expect(value).toBeFalsy('Expect slide toggle "check" property to be false');
+                });
+        });
+    });
+
+    describe('disable behavior', () => {
+        it('should prevent click handlers from executing when disabled', () => {
+            element(by.id('disable-toggle')).click();
+            element(by.id('test-slide-toggle')).click();
+            element(by.css('input[id=test-slide-toggle-input]'))
+                .getAttribute('checked')
+                .then((value: string) => {
+                    expect(value).toBeFalsy('Expect slide toggle "check" property to be false');
+                });
+        });
+    });
+});

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -11,6 +11,7 @@ import {BasicTabs} from './tabs/tabs-e2e';
 import {DialogE2E, TestDialog} from './dialog/dialog-e2e';
 import {GridListE2E} from './grid-list/grid-list-e2e';
 import {ListE2E} from './list/list-e2e';
+import {SlideToggleE2E} from './slide-toggle/slide-toggle-e2e';
 import {MaterialModule} from '@angular/material';
 import {E2E_APP_ROUTES} from './e2e-app/routes';
 
@@ -34,6 +35,7 @@ import {E2E_APP_ROUTES} from './e2e-app/routes';
     TestDialog,
     GridListE2E,
     ListE2E,
+    SlideToggleE2E,
   ],
   bootstrap: [E2EApp],
   providers: [

--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -7,5 +7,6 @@
 <a md-list-item [routerLink]="['menu']">Menu</a>
 <a md-list-item [routerLink]="['radio']">Radios</a>
 <a md-list-item [routerLink]="['tabs']">Tabs</a>
+<a md-list-item [routerLink]="['slide-toggle']">Slide Toggle</a>
 
 <router-outlet></router-outlet>

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -9,6 +9,7 @@ import {SimpleCheckboxes} from '../checkbox/checkbox-e2e';
 import {DialogE2E} from '../dialog/dialog-e2e';
 import {GridListE2E} from '../grid-list/grid-list-e2e';
 import {ListE2E} from '../list/list-e2e';
+import {SlideToggleE2E} from '../slide-toggle/slide-toggle-e2e';
 
 export const E2E_APP_ROUTES: Routes = [
   {path: '', component: Home},
@@ -21,4 +22,5 @@ export const E2E_APP_ROUTES: Routes = [
   {path: 'dialog', component: DialogE2E},
   {path: 'grid-list', component: GridListE2E},
   {path: 'list', component: ListE2E},
+  {path: 'slide-toggle', component: SlideToggleE2E}
 ];

--- a/src/e2e-app/slide-toggle/slide-toggle-e2e.html
+++ b/src/e2e-app/slide-toggle/slide-toggle-e2e.html
@@ -1,0 +1,5 @@
+<section>
+    <md-slide-toggle id="test-slide-toggle" [disabled]="isDisabled"></md-slide-toggle>
+    <p>isDisabled: {{isDisabled}}</p>
+    <button (click)="isDisabled=!isDisabled" id="disable-toggle">Toggle Disable</button>
+</section>

--- a/src/e2e-app/slide-toggle/slide-toggle-e2e.ts
+++ b/src/e2e-app/slide-toggle/slide-toggle-e2e.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+
+@Component({
+    moduleId: module.id,
+    selector: 'slide-toggle-e2e',
+    templateUrl: 'slide-toggle-e2e.html'
+})
+export class SlideToggleE2E {
+    isDisabled: boolean = false;
+}


### PR DESCRIPTION
Add e2e tests for slide-toggle component to verify click changes its checked state only when
the component is enabled.

Closes #1963 

@DevVersion 