### PR TITLE
Deselectable radio buttons

### DIFF
--- a/src/demo-app/radio/radio-demo.html
+++ b/src/demo-app/radio/radio-demo.html
@@ -1,7 +1,7 @@
 <h1>Basic Example</h1>
 <section class="demo-section">
   <md-radio-button name="group1">Option 1</md-radio-button>
-  <md-radio-button name="group1">Option 2</md-radio-button>
+  <md-radio-button name="group1" deselectable="true">Option 2 (deselectable)</md-radio-button>
   <md-radio-button name="group1" disabled="true">Option 3 (disabled)</md-radio-button>
 </section>
 <h1>Dynamic Example</h1>
@@ -13,9 +13,15 @@
     </button>
   </div>
   <div>
+    <span>deselectable: {{isDeselectable}}</span>
+    <button md-raised-button (click)="isDeselectable=!isDeselectable" class="demo-button">
+      Make deselectable
+    </button>
+  </div>
+  <div>
     <span><md-checkbox [(ngModel)]="isAlignEnd">Align end</md-checkbox></span>
   </div>
-  <md-radio-group name="my_options" [disabled]="isDisabled" [align]="isAlignEnd ? 'end' : 'start'">
+  <md-radio-group name="my_options" [deselectable]="isDeselectable" [disabled]="isDisabled" [align]="isAlignEnd ? 'end' : 'start'">
     <md-radio-button value="option_1">Option 1</md-radio-button>
     <md-radio-button value="option_2">Option 2</md-radio-button>
     <md-radio-button value="option_3">Option 3</md-radio-button>

--- a/src/demo-app/radio/radio-demo.ts
+++ b/src/demo-app/radio/radio-demo.ts
@@ -9,6 +9,7 @@ import {Component} from '@angular/core';
 })
 export class RadioDemo {
   isDisabled: boolean = false;
+  isDeselectable: boolean = false;
   isAlignEnd: boolean = false;
   favoriteSeason: string = 'Autumn';
   seasonOptions = [

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -74,6 +74,9 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /** Disables all individual radio buttons assigned to this group. */
   private _disabled: boolean = false;
 
+  /** Makes all individual radio buttons assigned to this group possible to deselect. */
+  private _deselectable: boolean = false;
+
   /** The currently selected radio button. Should match value. */
   private _selected: MdRadioButton = null;
 
@@ -114,6 +117,15 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   set disabled(value) {
     // The presence of *any* disabled value makes the component disabled, *except* for false.
     this._disabled = (value != null && value !== false) ? true : null;
+  }
+
+  @Input() get deselectable() {
+    return this._deselectable;
+  }
+
+  set deselectable(value: boolean) {
+    // The presence of *any* deselectable value makes the component deselectable, *except* for false.
+    this._deselectable = (value != null && value !== false) ? true : null;
   }
 
   @Input()
@@ -184,7 +196,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
     // If the value already matches the selected radio, do nothing.
     let isAlreadySelected = this._selected != null && this._selected.value == this._value;
 
-    if (this._radios != null && !isAlreadySelected) {
+    if (this._radios != null && (!isAlreadySelected || this.deselectable)) {
       this._selected = null;
       this._radios.forEach(radio => {
         radio.checked = this.value == radio.value;
@@ -263,6 +275,9 @@ export class MdRadioButton implements OnInit {
 
   /** Whether this radio is disabled. */
   private _disabled: boolean;
+
+  /** Whether this radio is deselectable. */
+  private _deselectable: boolean;
 
   /** Value assigned to this radio.*/
   private _value: any = null;
@@ -369,6 +384,17 @@ export class MdRadioButton implements OnInit {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
+  @HostBinding('class.md-radio-deselectable')
+  @Input()
+  get deselectable(): boolean {
+    return this._deselectable || (this.radioGroup != null && this.radioGroup.deselectable);
+  }
+
+  set deselectable(value: boolean) {
+    // The presence of *any* deselectable value makes the component deselectable, *except* for false.
+    this._deselectable = (value != null && value !== false) ? true : null;
+  }
+
   /** TODO: internal */
   ngOnInit() {
     if (this.radioGroup) {
@@ -418,6 +444,9 @@ export class MdRadioButton implements OnInit {
     // The real click event will bubble up, and the generated click event also tries to bubble up.
     // This will lead to multiple click events.
     // Preventing bubbling for the second event will solve that issue.
+    if(this.checked && (this.radioGroup && this.radioGroup.deselectable || this._deselectable)){
+      this._onInputChange(event);
+    }
     event.stopPropagation();
   }
 
@@ -432,12 +461,14 @@ export class MdRadioButton implements OnInit {
     // emit its event object to the `change` output.
     event.stopPropagation();
 
-    let groupValueChanged = this.radioGroup && this.value != this.radioGroup.value;
-    this.checked = true;
+    let groupValueChanged = this.radioGroup && (this.value != this.radioGroup.value || this.radioGroup.deselectable);
+
+    this.checked = (this.radioGroup && this.radioGroup.deselectable || this._deselectable) ? !this.checked : true;
+
     this._emitChangeEvent();
 
     if (this.radioGroup) {
-      this.radioGroup._controlValueAccessorChangeFn(this.value);
+      this.radioGroup._controlValueAccessorChangeFn(this.checked ? this.value : null);
       this.radioGroup._touch();
       if (groupValueChanged) {
         this.radioGroup._emitChangeEvent();

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -124,7 +124,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   }
 
   set deselectable(value: boolean) {
-    // The presence of *any* deselectable value makes the component deselectable, *except* for false.
+    // The presence of *any* value makes the component deselectable, *except* for false.
     this._deselectable = (value != null && value !== false) ? true : null;
   }
 
@@ -391,7 +391,7 @@ export class MdRadioButton implements OnInit {
   }
 
   set deselectable(value: boolean) {
-    // The presence of *any* deselectable value makes the component deselectable, *except* for false.
+    // The presence of *any* value makes the component deselectable, *except* for false.
     this._deselectable = (value != null && value !== false) ? true : null;
   }
 
@@ -444,7 +444,7 @@ export class MdRadioButton implements OnInit {
     // The real click event will bubble up, and the generated click event also tries to bubble up.
     // This will lead to multiple click events.
     // Preventing bubbling for the second event will solve that issue.
-    if(this.checked && (this.radioGroup && this.radioGroup.deselectable || this._deselectable)){
+    if (this.checked && (this.radioGroup && this.radioGroup.deselectable || this._deselectable)) {
       this._onInputChange(event);
     }
     event.stopPropagation();
@@ -461,9 +461,10 @@ export class MdRadioButton implements OnInit {
     // emit its event object to the `change` output.
     event.stopPropagation();
 
-    let groupValueChanged = this.radioGroup && (this.value != this.radioGroup.value || this.radioGroup.deselectable);
-
-    this.checked = (this.radioGroup && this.radioGroup.deselectable || this._deselectable) ? !this.checked : true;
+    let groupValueChanged =
+        this.radioGroup && (this.value != this.radioGroup.value || this.radioGroup.deselectable);
+    let deselectable = (this._deselectable || this.radioGroup && this.radioGroup.deselectable);
+    this.checked = deselectable ? !this.checked : true;
 
     this._emitChangeEvent();
 


### PR DESCRIPTION
I needed to be able to deselect md-radio buttons in a project and found kind of a hackish solution for this, so I thought I'd have a go on actually implement it in material2.

I've updated both the lib and the demo. My biggest concern is the lines 447-449 that feels kind of misplaced.

Deselectability of individual radio buttons and all members of groups is set the same way as when they are disabled.

If you agree that this feature should be implemented I'm happy to improve it based on feedback and add tests.