### PR TITLE
fix(input): label alignment in rtl

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -138,6 +138,8 @@ md-input, md-textarea {
 
   [dir='rtl'] & {
     transform-origin: bottom right;
+    left: auto;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
Fixes the focused label alignment being off in RTL.

Fixes #2034.