### PR TITLE
fix(select): only animate placeholder when no selection

### DIFF
--- a/src/lib/select/select-animations.ts
+++ b/src/lib/select/select-animations.ts
@@ -20,14 +20,15 @@ import {
  * depending on the text direction of the application.
  */
 export const transformPlaceholder: AnimationEntryMetadata = trigger('transformPlaceholder', [
-  state('normal', style({
-    transform: `translate3d(0, 0, 0) scale(1)`
-  })),
   state('floating-ltr', style({
-    transform: `translate3d(-2px, -22px, 0) scale(0.75)`
+    top: '-22px',
+    left: '-2px',
+    transform: `scale(0.75)`
   })),
   state('floating-rtl', style({
-    transform: `translate3d(2px, -22px, 0) scale(0.75)`
+    top: '-22px',
+    left: '2px',
+    transform: `scale(0.75)`
   })),
   transition('* => *', animate(`400ms cubic-bezier(0.25, 0.8, 0.25, 1)`))
 ]);

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -1,5 +1,6 @@
 <div class="md-select-trigger" overlay-origin (click)="toggle()" #origin="overlayOrigin" #trigger>
-  <span class="md-select-placeholder" [@transformPlaceholder]="_getPlaceholderState()"> {{ placeholder }} </span>
+  <span class="md-select-placeholder" [class.md-floating-placeholder]="this.selected"
+   [@transformPlaceholder]="_placeholderState"> {{ placeholder }} </span>
   <span class="md-select-value" *ngIf="selected"> {{ selected?.viewValue }} </span>
   <span class="md-select-arrow"></span>
 </div>

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -32,11 +32,26 @@ md-select {
 }
 
 .md-select-placeholder {
+  position: relative;
   padding: 0 2px;
   transform-origin: left top;
 
+  // These values are duplicated from animation code in order to
+  // allow placeholders to sometimes float without animating,
+  // for example when the value is set programmatically.
+  // TODO(kara): Change when animations API supports skipping animation.
+  &.md-floating-placeholder {
+    top: -22px;
+    left: -2px;
+    transform: scale(0.75);
+  }
+
   [dir='rtl'] & {
     transform-origin: right top;
+
+    &.md-floating-placeholder {
+      left: 2px;
+    }
   }
 
   // TODO: Double-check accessibility of this style

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -456,30 +456,35 @@ describe('MdSelect', () => {
       trigger = fixture.debugElement.query(By.css('.md-select-trigger')).nativeElement;
     });
 
-      it('should float the placeholder when the panel is open', () => {
-        expect(fixture.componentInstance.select._getPlaceholderState()).toEqual('normal');
+      it('should float the placeholder when the panel is open and unselected', () => {
+        expect(fixture.componentInstance.select._placeholderState)
+            .toEqual('', 'Expected placeholder to initially have a normal position.');
 
         trigger.click();
         fixture.detectChanges();
-        expect(fixture.componentInstance.select._getPlaceholderState()).toEqual('floating-ltr');
+        expect(fixture.componentInstance.select._placeholderState)
+            .toEqual('floating-ltr', 'Expected placeholder to animate up to floating position.');
 
         const backdrop =
           overlayContainerElement.querySelector('.md-overlay-backdrop') as HTMLElement;
         backdrop.click();
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.select._getPlaceholderState()).toEqual('normal');
+        expect(fixture.componentInstance.select._placeholderState)
+            .toEqual('', 'Expected placeholder to animate back down to normal position.');
       });
 
-      it('should float the placeholder when there is a selection', () => {
-        trigger.click();
+      it('should float the placeholder without animation when value is set', () => {
+        fixture.componentInstance.control.setValue('pizza-1');
         fixture.detectChanges();
 
-        const option = overlayContainerElement.querySelector('md-option') as HTMLElement;
-        option.click();
-        fixture.detectChanges();
+        const placeholderEl =
+            fixture.debugElement.query(By.css('.md-select-placeholder')).nativeElement;
 
-        expect(fixture.componentInstance.select._getPlaceholderState()).toEqual('floating-ltr');
+        expect(placeholderEl.classList)
+            .toContain('md-floating-placeholder', 'Expected placeholder to display as floating.');
+        expect(fixture.componentInstance.select._placeholderState)
+            .toEqual('', 'Expected animation state to be empty to avoid animation.');
       });
 
       it('should use the floating-rtl state when the dir is rtl', () => {
@@ -487,7 +492,7 @@ describe('MdSelect', () => {
 
         trigger.click();
         fixture.detectChanges();
-        expect(fixture.componentInstance.select._getPlaceholderState()).toEqual('floating-rtl');
+        expect(fixture.componentInstance.select._placeholderState).toEqual('floating-rtl');
       });
 
   });


### PR DESCRIPTION
Uses CSS to float the placeholder when the value is set programmatically so no animation plays.  Will only play animation if the panel is opening or closing without a selection.

r: @jelbourn 