### PR TITLE
chore: update sauce connect to latest version

### DIFF
--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -23,10 +23,10 @@ CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
 if [ `uname -s` = "Darwin" ]; then
   # If the user is running Mac, download the OSX version
   # https://en.wikipedia.org/wiki/Darwin_(operating_system)
-  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.1-osx.zip"
+  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.2-osx.zip"
 else
   # Otherwise, default to Linux for Travis-CI
-  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.1-linux.tar.gz"
+  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.2-linux.tar.gz"
 fi
 mkdir -p $CONNECT_DIR
 cd $CONNECT_DIR


### PR DESCRIPTION
- Updates the Saucelabs Connector to the latest version (might help reducing the flakiness for Sauce)

> https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect

@jelbourn Notice, that we still can't use the `latest` tag, because it still refers to an older version
