### PR TITLE
chore: properly exit e2e tasks

### DIFF
--- a/tools/gulp/tasks/ci.ts
+++ b/tools/gulp/tasks/ci.ts
@@ -10,5 +10,5 @@ task('ci:forbidden-identifiers', function() {
 
 // Travis sometimes does not exit the process and times out. This is to prevent that.
 task('ci:test', ['test:single-run'], () => process.exit(0));
-// Travis sometimes does not exit the process and times out. This is to prevent that.
-task('ci:e2e', ['e2e:single-run'], () => process.exit(0));
+
+task('ci:e2e', ['e2e:single-run']);


### PR DESCRIPTION
* Instead of manually exiting the process we should just ensure that everything is properly cleaned up and then gulp can take care of the exit codes.

* If we have the `e2e:done` task at the end of the sequence it will be never called when an error occurred before (will cause things like https://travis-ci.org/angular/material2/jobs/180782730)