### PR TITLE
fix(list): prevent list item wrapper elements from collapsing

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -31,6 +31,9 @@ $md-dense-three-line-height: 76px;
 @mixin md-list-item-base($font-size, $base-height, $avatar-height,
   $two-line-height, $three-line-height) {
 
+  // Prevents the wrapper `md-list-item` from collapsing due to it being `inline` by default.
+  display: block;
+
   .md-list-item {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Adds a `display: block` to the list items, in order to prevent them from collapsing. This allows users to set a custom background directly on the list item.

Fixes #2012.