### PR TITLE
docs(getting-started): include a section about adding hammerjs to the config types

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -60,6 +60,18 @@ Import HammerJS on your app's module.
 import 'hammerjs';
 ```
 
+Finally, you need to add `hammerjs` to the `types` section of your `tsconfig.json` file:
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "hammerjs"
+    ]
+  }
+}
+```
+
 ## Configuring SystemJS
 If your project is using SystemJS for module loading, you will need to add `@angular/material` 
 to the SystemJS configuration:


### PR DESCRIPTION
Adds a section to the docs, mentioning that the user needs to add `hammerjs` to the `tsconfig.json`, in order to avoid some compilation errors.

Fixes #1944.