### PR TITLE
chore: mark non-public APIs as @internal

### DIFF
--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "../../dist/",
     "sourceMap": true,
     "target": "es5",
-    "stripInternal": true,
+    "stripInternal": false,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types"

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "../../dist/",
     "sourceMap": true,
     "target": "es5",
-    "stripInternal": true,
+    "stripInternal": false,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types",

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -97,7 +97,6 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   @ContentChildren(forwardRef(() => MdButtonToggle))
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
-  /** TODO: internal */
   ngAfterViewInit() {
     this._isInitialized = true;
   }
@@ -199,26 +198,17 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     this._change.emit(event);
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
@@ -423,9 +413,7 @@ export class MdButtonToggle implements OnInit {
     this._emitChangeEvent();
   }
 
-  /** TODO: internal */
   _onInputClick(event: Event) {
-
     // We have to stop propagation for click events on the visual hidden input element.
     // By default, when a user clicks on a label element, a generated click event will be
     // dispatched on the associated input element. Since we are using a label element as our

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -231,33 +231,22 @@ export class MdCheckbox implements ControlValueAccessor {
     return this.disableRipple || this.disabled;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any) {
     this.checked = !!value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /**
-   * Implemented as a part of ControlValueAccessor.
-   */
+  /** Implemented as a part of ControlValueAccessor. */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }

--- a/src/lib/core/animation/animation.ts
+++ b/src/lib/core/animation/animation.ts
@@ -1,13 +1,15 @@
+/** @internal */
 export class AnimationCurves {
   static STANDARD_CURVE = 'cubic-bezier(0.4,0.0,0.2,1)';
   static DECELERATION_CURVE = 'cubic-bezier(0.0,0.0,0.2,1)';
   static ACCELERATION_CURVE = 'cubic-bezier(0.4,0.0,1,1)';
   static SHARP_CURVE = 'cubic-bezier(0.4,0.0,0.6,1)';
-};
+}
 
 
+/** @internal */
 export class AnimationDurations {
-   static COMPLEX = '375ms';
-   static ENTERING = '225ms';
-   static EXITING = '195ms';
- };
+  static COMPLEX = '375ms';
+  static ENTERING = '225ms';
+  static EXITING = '195ms';
+}

--- a/src/lib/core/animation/animation.ts
+++ b/src/lib/core/animation/animation.ts
@@ -1,4 +1,4 @@
-/** @internal */
+/** @docs-private */
 export class AnimationCurves {
   static STANDARD_CURVE = 'cubic-bezier(0.4,0.0,0.2,1)';
   static DECELERATION_CURVE = 'cubic-bezier(0.0,0.0,0.2,1)';
@@ -7,7 +7,7 @@ export class AnimationCurves {
 }
 
 
-/** @internal */
+/** @docs-private */
 export class AnimationDurations {
   static COMPLEX = '375ms';
   static ENTERING = '225ms';

--- a/src/lib/core/async/promise-completer.ts
+++ b/src/lib/core/async/promise-completer.ts
@@ -1,4 +1,4 @@
-/** @internal */
+/** @docs-private */
 export class PromiseCompleter<R> {
   promise: Promise<R>;
   resolve: (value?: R | PromiseLike<R>) => void;

--- a/src/lib/core/async/promise-completer.ts
+++ b/src/lib/core/async/promise-completer.ts
@@ -1,4 +1,4 @@
-
+/** @internal */
 export class PromiseCompleter<R> {
   promise: Promise<R>;
   resolve: (value?: R | PromiseLike<R>) => void;

--- a/src/lib/core/errors/error.ts
+++ b/src/lib/core/errors/error.ts
@@ -2,6 +2,7 @@
 
 /**
  * Wrapper around Error that sets the error message.
+ * @internal
  */
 export class MdError extends Error {
   constructor(value: string) {

--- a/src/lib/core/errors/error.ts
+++ b/src/lib/core/errors/error.ts
@@ -2,7 +2,7 @@
 
 /**
  * Wrapper around Error that sets the error message.
- * @internal
+ * @docs-private
  */
 export class MdError extends Error {
   constructor(value: string) {

--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -18,7 +18,7 @@ export class MdLine {}
 
 /**
  * Helper that takes a query list of lines and sets the correct class on the host.
- * @internal
+ * @docs-private
  */
 export class MdLineSetter {
   constructor(private _lines: QueryList<MdLine>, private _renderer: Renderer,

--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -16,7 +16,10 @@ import {DefaultStyleCompatibilityModeModule} from '../compatibility/default-mode
 @Directive({ selector: '[md-line], [mat-line]' })
 export class MdLine {}
 
-/* Helper that takes a query list of lines and sets the correct class on the host */
+/**
+ * Helper that takes a query list of lines and sets the correct class on the host.
+ * @internal
+ */
 export class MdLineSetter {
   constructor(private _lines: QueryList<MdLine>, private _renderer: Renderer,
               private _element: ElementRef) {

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -160,7 +160,6 @@ export class ConnectedOverlayDirective implements OnDestroy {
     return this._dir ? this._dir.value : 'ltr';
   }
 
-  /** TODO: internal */
   ngOnDestroy() {
     this._destroyOverlay();
   }

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -66,7 +66,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   /**
    * Updates the position of the overlay element, using whichever preferred position relative
    * to the origin fits on-screen.
-   * TODO: internal
+   * @internal
    */
   apply(element: HTMLElement): Promise<void> {
     // We need the bounding rects for the origin and the overlay to determine how to position

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -66,7 +66,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   /**
    * Updates the position of the overlay element, using whichever preferred position relative
    * to the origin fits on-screen.
-   * @internal
+   * @docs-private
    */
   apply(element: HTMLElement): Promise<void> {
     // We need the bounding rects for the origin and the overlay to determine how to position

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -101,7 +101,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
   /**
    * Apply the position to the element.
-   * TODO: internal
+   * @internal
    */
   apply(element: HTMLElement): Promise<void> {
     if (!this._wrapper) {

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -101,7 +101,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
   /**
    * Apply the position to the element.
-   * @internal
+   * @docs-private
    */
   apply(element: HTMLElement): Promise<void> {
     if (!this._wrapper) {

--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -4,7 +4,7 @@ import {Injectable} from '@angular/core';
 
 /**
  * Simple utility for getting the bounds of the browser viewport.
- * TODO: internal
+ * @internal
  */
 @Injectable()
 export class ViewportRuler {

--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -4,7 +4,7 @@ import {Injectable} from '@angular/core';
 
 /**
  * Simple utility for getting the bounds of the browser viewport.
- * @internal
+ * @docs-private
  */
 @Injectable()
 export class ViewportRuler {

--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -9,6 +9,7 @@ const hasV8BreakIterator = (window.Intl && (window.Intl as any).v8BreakIterator)
 /**
  * Service to detect the current platform by comparing the userAgent strings and
  * checking browser-specific global properties.
+ * @internal
  */
 @Injectable()
 export class MdPlatform {

--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -9,7 +9,7 @@ const hasV8BreakIterator = (window.Intl && (window.Intl as any).v8BreakIterator)
 /**
  * Service to detect the current platform by comparing the userAgent strings and
  * checking browser-specific global properties.
- * @internal
+ * @docs-private
  */
 @Injectable()
 export class MdPlatform {

--- a/src/lib/core/portal/portal-errors.ts
+++ b/src/lib/core/portal/portal-errors.ts
@@ -2,7 +2,7 @@ import {MdError} from '../errors/error';
 
 /**
  * Exception thrown when attempting to attach a null portal to a host.
- * @internal
+ * @docs-private
  */
 export class MdNullPortalError extends MdError {
   constructor() {
@@ -12,7 +12,7 @@ export class MdNullPortalError extends MdError {
 
 /**
  * Exception thrown when attempting to attach a portal to a host that is already attached.
- * @internal
+ * @docs-private
  */
 export class MdPortalAlreadyAttachedError extends MdError {
   constructor() {
@@ -22,7 +22,7 @@ export class MdPortalAlreadyAttachedError extends MdError {
 
 /**
  * Exception thrown when attempting to attach a portal to an already-disposed host.
- * @internal
+ * @docs-private
  */
 export class MdPortalHostAlreadyDisposedError extends MdError {
   constructor() {
@@ -32,7 +32,7 @@ export class MdPortalHostAlreadyDisposedError extends MdError {
 
 /**
  * Exception thrown when attempting to attach an unknown portal type.
- * @internal
+ * @docs-private
  */
 export class MdUnknownPortalTypeError extends MdError {
   constructor() {
@@ -44,7 +44,7 @@ export class MdUnknownPortalTypeError extends MdError {
 
 /**
  * Exception thrown when attempting to attach a portal to a null host.
- * @internal
+ * @docs-private
  */
 export class MdNullPortalHostError extends MdError {
   constructor() {
@@ -54,7 +54,7 @@ export class MdNullPortalHostError extends MdError {
 
 /**
  * Exception thrown when attempting to detach a portal that is not attached.
- * @internal
+ * @docs-private
  */
 export class MdNoPortalAttachedError extends MdError {
   constructor() {

--- a/src/lib/core/portal/portal-errors.ts
+++ b/src/lib/core/portal/portal-errors.ts
@@ -1,27 +1,39 @@
 import {MdError} from '../errors/error';
 
-/** Exception thrown when attempting to attach a null portal to a host. */
+/**
+ * Exception thrown when attempting to attach a null portal to a host.
+ * @internal
+ */
 export class MdNullPortalError extends MdError {
   constructor() {
       super('Must provide a portal to attach');
   }
 }
 
-/** Exception thrown when attempting to attach a portal to a host that is already attached. */
+/**
+ * Exception thrown when attempting to attach a portal to a host that is already attached.
+ * @internal
+ */
 export class MdPortalAlreadyAttachedError extends MdError {
   constructor() {
       super('Host already has a portal attached');
   }
 }
 
-/** Exception thrown when attempting to attach a portal to an already-disposed host. */
+/**
+ * Exception thrown when attempting to attach a portal to an already-disposed host.
+ * @internal
+ */
 export class MdPortalHostAlreadyDisposedError extends MdError {
   constructor() {
       super('This PortalHost has already been disposed');
   }
 }
 
-/** Exception thrown when attempting to attach an unknown portal type. */
+/**
+ * Exception thrown when attempting to attach an unknown portal type.
+ * @internal
+ */
 export class MdUnknownPortalTypeError extends MdError {
   constructor() {
       super(
@@ -30,14 +42,20 @@ export class MdUnknownPortalTypeError extends MdError {
   }
 }
 
-/** Exception thrown when attempting to attach a portal to a null host. */
+/**
+ * Exception thrown when attempting to attach a portal to a null host.
+ * @internal
+ */
 export class MdNullPortalHostError extends MdError {
   constructor() {
       super('Attempting to attach a portal to a null PortalHost');
   }
 }
 
-/** Exception thrown when attempting to detach a portal that is not attached. */
+/**
+ * Exception thrown when attempting to detach a portal that is not attached.
+ * @internal
+ */
 export class MdNoPortalAttachedError extends MdError {
   constructor() {
       super('Attempting to detach a portal that is not attached to a host');

--- a/src/lib/core/projection/projection.ts
+++ b/src/lib/core/projection/projection.ts
@@ -7,7 +7,7 @@ function _replaceWith(toReplaceEl: HTMLElement, otherEl: HTMLElement) {
   toReplaceEl.parentElement.replaceChild(otherEl, toReplaceEl);
 }
 
-/** @internal */
+/** @docs-private */
 @Directive({
   selector: 'dom-projection-host'
 })
@@ -16,7 +16,7 @@ export class DomProjectionHost {
 }
 
 
-/** @internal */
+/** @docs-private */
 @Injectable()
 export class DomProjection {
   /**
@@ -74,7 +74,7 @@ export class DomProjection {
 }
 
 
-/** @internal */
+/** @docs-private */
 @NgModule({
   exports: [DomProjectionHost],
   declarations: [DomProjectionHost],

--- a/src/lib/core/projection/projection.ts
+++ b/src/lib/core/projection/projection.ts
@@ -7,7 +7,7 @@ function _replaceWith(toReplaceEl: HTMLElement, otherEl: HTMLElement) {
   toReplaceEl.parentElement.replaceChild(otherEl, toReplaceEl);
 }
 
-
+/** @internal */
 @Directive({
   selector: 'dom-projection-host'
 })
@@ -16,6 +16,7 @@ export class DomProjectionHost {
 }
 
 
+/** @internal */
 @Injectable()
 export class DomProjection {
   /**
@@ -73,6 +74,7 @@ export class DomProjection {
 }
 
 
+/** @internal */
 @NgModule({
   exports: [DomProjectionHost],
   declarations: [DomProjectionHost],

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -3,7 +3,7 @@ import {
   NgZone,
 } from '@angular/core';
 
-/** @internal */
+/** @docs-private */
 export enum ForegroundRippleState {
   NEW,
   EXPANDING,
@@ -12,7 +12,7 @@ export enum ForegroundRippleState {
 
 /**
  * Wrapper for a foreground ripple DOM element and its animation state.
- * @internal
+ * @docs-private
  */
 export class ForegroundRipple {
   state = ForegroundRippleState.NEW;
@@ -37,7 +37,7 @@ const distanceToFurthestCorner = (x: number, y: number, rect: ClientRect) => {
  * The constructor takes a reference to the ripple directive's host element and a map of DOM
  * event handlers to be installed on the element that triggers ripple animations.
  * This will eventually become a custom renderer once Angular support exists.
- * @internal
+ * @docs-private
  */
 export class RippleRenderer {
   private _backgroundDiv: HTMLElement;

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -3,7 +3,7 @@ import {
   NgZone,
 } from '@angular/core';
 
-/** TODO: internal */
+/** @internal */
 export enum ForegroundRippleState {
   NEW,
   EXPANDING,
@@ -12,7 +12,7 @@ export enum ForegroundRippleState {
 
 /**
  * Wrapper for a foreground ripple DOM element and its animation state.
- * TODO: internal
+ * @internal
  */
 export class ForegroundRipple {
   state = ForegroundRippleState.NEW;
@@ -37,7 +37,7 @@ const distanceToFurthestCorner = (x: number, y: number, rect: ClientRect) => {
  * The constructor takes a reference to the ripple directive's host element and a map of DOM
  * event handlers to be installed on the element that triggers ripple animations.
  * This will eventually become a custom renderer once Angular support exists.
- * TODO: internal
+ * @internal
  */
 export class RippleRenderer {
   private _backgroundDiv: HTMLElement;

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -75,7 +75,6 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     this._ruler = _ruler;
   }
 
-  /** TODO: internal */
   ngOnInit() {
     // If no trigger element was explicity set, use the host element
     if (!this.trigger) {
@@ -86,13 +85,11 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  /** TODO: internal */
   ngOnDestroy() {
     // Remove event listeners on the trigger element.
     this._rippleRenderer.clearTriggerElement();
   }
 
-  /** TODO: internal */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     // If the trigger element changed (or is being initially set), add event listeners to it.
     const changedInputs = Object.keys(changes);

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -16,7 +16,7 @@ import 'rxjs/add/operator/first';
 
 /**
  * Internal component that wraps user-provided dialog content.
- * @internal
+ * @docs-private
  */
 @Component({
   moduleId: module.id,

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -16,6 +16,7 @@ import 'rxjs/add/operator/first';
 
 /**
  * Internal component that wraps user-provided dialog content.
+ * @internal
  */
 @Component({
   moduleId: module.id,

--- a/src/lib/grid-list/grid-list-errors.ts
+++ b/src/lib/grid-list/grid-list-errors.ts
@@ -2,6 +2,7 @@ import {MdError} from '../core';
 
 /**
  * Exception thrown when cols property is missing from grid-list
+ * @internal
  */
 export class MdGridListColsError extends MdError {
   constructor() {
@@ -11,6 +12,7 @@ export class MdGridListColsError extends MdError {
 
 /**
  * Exception thrown when a tile's colspan is longer than the number of cols in list
+ * @internal
  */
 export class MdGridTileTooWideError extends MdError {
   constructor(cols: number, listLength: number) {
@@ -20,6 +22,7 @@ export class MdGridTileTooWideError extends MdError {
 
 /**
  * Exception thrown when an invalid ratio is passed in as a rowHeight
+ * @internal
  */
 export class MdGridListBadRatioError extends MdError {
   constructor(value: string) {

--- a/src/lib/grid-list/grid-list-errors.ts
+++ b/src/lib/grid-list/grid-list-errors.ts
@@ -2,7 +2,7 @@ import {MdError} from '../core';
 
 /**
  * Exception thrown when cols property is missing from grid-list
- * @internal
+ * @docs-private
  */
 export class MdGridListColsError extends MdError {
   constructor() {
@@ -12,7 +12,7 @@ export class MdGridListColsError extends MdError {
 
 /**
  * Exception thrown when a tile's colspan is longer than the number of cols in list
- * @internal
+ * @docs-private
  */
 export class MdGridTileTooWideError extends MdError {
   constructor(cols: number, listLength: number) {
@@ -22,7 +22,7 @@ export class MdGridTileTooWideError extends MdError {
 
 /**
  * Exception thrown when an invalid ratio is passed in as a rowHeight
- * @internal
+ * @docs-private
  */
 export class MdGridListBadRatioError extends MdError {
   constructor(value: string) {

--- a/src/lib/grid-list/grid-list-measure.ts
+++ b/src/lib/grid-list/grid-list-measure.ts
@@ -1,7 +1,7 @@
 
 /**
  * Converts values into strings. Falsy values become empty strings.
- * TODO: internal
+ * @internal
  */
 export function coerceToString(value: string | number): string {
   return `${value || ''}`;
@@ -9,7 +9,7 @@ export function coerceToString(value: string | number): string {
 
 /**
  * Converts a value that might be a string into a number.
- * TODO: internal
+ * @internal
  */
 export function coerceToNumber(value: string | number): number {
   return typeof value === 'string' ? parseInt(value, 10) : value;

--- a/src/lib/grid-list/grid-list-measure.ts
+++ b/src/lib/grid-list/grid-list-measure.ts
@@ -1,7 +1,7 @@
 
 /**
  * Converts values into strings. Falsy values become empty strings.
- * @internal
+ * @docs-private
  */
 export function coerceToString(value: string | number): string {
   return `${value || ''}`;
@@ -9,7 +9,7 @@ export function coerceToString(value: string | number): string {
 
 /**
  * Converts a value that might be a string into a number.
- * @internal
+ * @docs-private
  */
 export function coerceToNumber(value: string | number): number {
   return typeof value === 'string' ? parseInt(value, 10) : value;

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -87,7 +87,6 @@ export class MdGridList implements OnInit, AfterContentChecked {
     this._setTileStyler();
   }
 
-  /** TODO: internal */
   ngOnInit() {
     this._checkCols();
     this._checkRowHeight();
@@ -96,7 +95,6 @@ export class MdGridList implements OnInit, AfterContentChecked {
   /**
    * The layout calculation is fairly cheap if nothing changes, so there's little cost
    * to run it frequently.
-   * TODO: internal
    */
   ngAfterContentChecked() {
     this._layoutTiles();

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -16,7 +16,7 @@ import {MdGridTileTooWideError} from './grid-list-errors';
  * decrements each value in the tracking array (indicating that the column is one cell closer to
  * being free).
  *
- * @internal
+ * @docs-private
  */
 export class TileCoordinator {
   /** Tracking array (see class description). */
@@ -138,7 +138,7 @@ export class TileCoordinator {
 
 /**
  * Simple data structure for tile position (row, col).
- * @internal
+ * @docs-private
  */
 export class TilePosition {
   constructor(public row: number, public col: number) {}

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -15,6 +15,8 @@ import {MdGridTileTooWideError} from './grid-list-errors';
  * column are already occupied; zero indicates an empty cell. Moving "down" to the next row
  * decrements each value in the tracking array (indicating that the column is one cell closer to
  * being free).
+ *
+ * @internal
  */
 export class TileCoordinator {
   /** Tracking array (see class description). */
@@ -134,7 +136,10 @@ export class TileCoordinator {
   }
 }
 
-/** Simple data structure for tile position (row, col). */
+/**
+ * Simple data structure for tile position (row, col).
+ * @internal
+ */
 export class TilePosition {
   constructor(public row: number, public col: number) {}
 }

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -5,7 +5,7 @@ import {MdGridListBadRatioError} from './grid-list-errors';
 /**
  * Sets the style properties for an individual tile, given the position calculated by the
  * Tile Coordinator.
- * TODO: internal
+ * @internal
  */
 export class TileStyler {
   _gutterSize: string;
@@ -120,7 +120,7 @@ export class TileStyler {
 /**
  * This type of styler is instantiated when the user passes in a fixed row height.
  * Example <md-grid-list cols="3" rowHeight="100px">
- * TODO: internal
+ * @internal
  */
 export class FixedTileStyler extends TileStyler {
 
@@ -148,7 +148,7 @@ export class FixedTileStyler extends TileStyler {
 /**
  * This type of styler is instantiated when the user passes in a width:height ratio
  * for the row height.  Example <md-grid-list cols="3" rowHeight="3:1">
- * TODO: internal
+ * @internal
  */
 export class RatioTileStyler extends TileStyler {
 
@@ -190,9 +190,13 @@ export class RatioTileStyler extends TileStyler {
   }
 }
 
-/*  This type of styler is instantiated when the user selects a "fit" row height mode.
- *  In other words, the row height will reflect the total height of the container divided
- *  by the number of rows.  Example <md-grid-list cols="3" rowHeight="fit"> */
+/**
+ * This type of styler is instantiated when the user selects a "fit" row height mode.
+ * In other words, the row height will reflect the total height of the container divided
+ * by the number of rows.  Example <md-grid-list cols="3" rowHeight="fit">
+ *
+ * @internal
+ */
 export class FitTileStyler extends TileStyler {
 
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -5,7 +5,7 @@ import {MdGridListBadRatioError} from './grid-list-errors';
 /**
  * Sets the style properties for an individual tile, given the position calculated by the
  * Tile Coordinator.
- * @internal
+ * @docs-private
  */
 export class TileStyler {
   _gutterSize: string;
@@ -120,7 +120,7 @@ export class TileStyler {
 /**
  * This type of styler is instantiated when the user passes in a fixed row height.
  * Example <md-grid-list cols="3" rowHeight="100px">
- * @internal
+ * @docs-private
  */
 export class FixedTileStyler extends TileStyler {
 
@@ -148,7 +148,7 @@ export class FixedTileStyler extends TileStyler {
 /**
  * This type of styler is instantiated when the user passes in a width:height ratio
  * for the row height.  Example <md-grid-list cols="3" rowHeight="3:1">
- * @internal
+ * @docs-private
  */
 export class RatioTileStyler extends TileStyler {
 
@@ -195,7 +195,7 @@ export class RatioTileStyler extends TileStyler {
  * In other words, the row height will reflect the total height of the container divided
  * by the number of rows.  Example <md-grid-list cols="3" rowHeight="fit">
  *
- * @internal
+ * @docs-private
  */
 export class FitTileStyler extends TileStyler {
 

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -14,7 +14,7 @@ import 'rxjs/add/operator/catch';
 
 /**
  * Exception thrown when attempting to load an icon with a name that cannot be found.
- * @internal
+ * @docs-private
  */
 export class MdIconNameNotFoundError extends MdError {
   constructor(iconName: string) {
@@ -25,7 +25,7 @@ export class MdIconNameNotFoundError extends MdError {
 /**
  * Exception thrown when attempting to load SVG content that does not contain the expected
  * <svg> tag.
- * @internal
+ * @docs-private
  */
 export class MdIconSvgTagNotFoundError extends MdError {
   constructor() {
@@ -35,7 +35,7 @@ export class MdIconSvgTagNotFoundError extends MdError {
 
 /**
  * Configuration for an icon, including the URL and possibly the cached SVG element.
- * @internal
+ * @docs-private
  */
 class SvgIconConfig {
   svgElement: SVGElement = null;

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -12,7 +12,10 @@ import 'rxjs/add/operator/finally';
 import 'rxjs/add/operator/catch';
 
 
-/** Exception thrown when attempting to load an icon with a name that cannot be found. */
+/**
+ * Exception thrown when attempting to load an icon with a name that cannot be found.
+ * @internal
+ */
 export class MdIconNameNotFoundError extends MdError {
   constructor(iconName: string) {
       super(`Unable to find icon with the name "${iconName}"`);
@@ -22,6 +25,7 @@ export class MdIconNameNotFoundError extends MdError {
 /**
  * Exception thrown when attempting to load SVG content that does not contain the expected
  * <svg> tag.
+ * @internal
  */
 export class MdIconSvgTagNotFoundError extends MdError {
   constructor() {
@@ -29,7 +33,10 @@ export class MdIconSvgTagNotFoundError extends MdError {
   }
 }
 
-/** Configuration for an icon, including the URL and possibly the cached SVG element. */
+/**
+ * Configuration for an icon, including the URL and possibly the cached SVG element.
+ * @internal
+ */
 class SvgIconConfig {
   svgElement: SVGElement = null;
   constructor(public url: string) { }

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -137,7 +137,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
-  /** TODO: internal */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     const changedInputs = Object.keys(changes);
     // Only update the inline SVG icon if the inputs changed, to avoid unnecessary DOM operations.
@@ -159,7 +158,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     this._updateAriaLabel();
   }
 
-  /** TODO: internal */
   ngOnInit() {
     // Update font classes because ngOnChanges won't be called if none of the inputs are present,
     // e.g. <md-icon>arrow</md-icon>. In this case we need to add a CSS class for the default font.
@@ -168,7 +166,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
-  /** TODO: internal */
   ngAfterViewChecked() {
     // Update aria label here because it may depend on the projected text content.
     // (e.g. <md-icon>home</md-icon> should use 'home').

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -247,38 +247,26 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     return !!this.placeholder || this._placeholderChild != null;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any) {
     this._value = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: any) {
     this._onChangeCallback = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any) {
     this._onTouchedCallback = fn;
   }
 
-  /**
-   * Implemented as a part of ControlValueAccessor.
-   */
+  /** Implemented as a part of ControlValueAccessor. */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
 
-  /** TODO: internal */
   ngAfterContentInit() {
     this._validateConstraints();
 
@@ -288,7 +276,6 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     });
   }
 
-  /** TODO: internal */
   ngOnChanges(changes: {[key: string]: SimpleChange}) {
     this._validateConstraints();
   }

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -57,7 +57,6 @@ export class MdListItem implements AfterContentInit {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
-  /** TODO: internal */
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -57,7 +57,6 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     this.setPositionClasses(this.positionX, this.positionY);
   }
 
-  // TODO: internal
   ngAfterContentInit() {
     this._keyManager = new ListKeyManager(this.items).withFocusWrap();
     this._tabSubscription = this._keyManager.tabOut.subscribe(() => {
@@ -65,7 +64,6 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     });
   }
 
-  // TODO: internal
   ngOnDestroy() {
     this._tabSubscription.unsubscribe();
   }
@@ -91,7 +89,6 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   /**
    * Focus the first item in the menu. This method is used by the menu trigger
    * to focus the first item when the menu is opened by the ENTER key.
-   * TODO: internal
    */
   focusFirstItem() {
     this._keyManager.focusFirstItem();

--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -2,6 +2,7 @@ import {MdError} from '../core';
 
 /**
  * Exception thrown when menu trigger doesn't have a valid md-menu instance
+ * @internal
  */
 export class MdMenuMissingError extends MdError {
   constructor() {
@@ -17,6 +18,7 @@ export class MdMenuMissingError extends MdError {
 /**
  * Exception thrown when menu's x-position value isn't valid.
  * In other words, it doesn't match 'before' or 'after'.
+ * @internal
  */
 export class MdMenuInvalidPositionX extends MdError {
   constructor() {
@@ -29,6 +31,7 @@ export class MdMenuInvalidPositionX extends MdError {
 /**
  * Exception thrown when menu's y-position value isn't valid.
  * In other words, it doesn't match 'above' or 'below'.
+ * @internal
  */
 export class MdMenuInvalidPositionY extends MdError {
   constructor() {

--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -2,7 +2,7 @@ import {MdError} from '../core';
 
 /**
  * Exception thrown when menu trigger doesn't have a valid md-menu instance
- * @internal
+ * @docs-private
  */
 export class MdMenuMissingError extends MdError {
   constructor() {
@@ -18,7 +18,7 @@ export class MdMenuMissingError extends MdError {
 /**
  * Exception thrown when menu's x-position value isn't valid.
  * In other words, it doesn't match 'before' or 'after'.
- * @internal
+ * @docs-private
  */
 export class MdMenuInvalidPositionX extends MdError {
   constructor() {
@@ -31,7 +31,7 @@ export class MdMenuInvalidPositionX extends MdError {
 /**
  * Exception thrown when menu's y-position value isn't valid.
  * In other words, it doesn't match 'above' or 'below'.
- * @internal
+ * @docs-private
  */
 export class MdMenuInvalidPositionY extends MdError {
   constructor() {

--- a/src/lib/progress-circle/progress-circle.ts
+++ b/src/lib/progress-circle/progress-circle.ts
@@ -72,11 +72,11 @@ export class MdProgressCircle implements OnDestroy {
     return this.mode == 'determinate' ? 100 : null;
   }
 
-  /** @internal */
+  /** @docs-private */
   get interdeterminateInterval() {
     return this._interdeterminateInterval;
   }
-  /** @internal */
+  /** @docs-private */
   set interdeterminateInterval(interval: number) {
     clearInterval(this._interdeterminateInterval);
     this._interdeterminateInterval = interval;

--- a/src/lib/progress-circle/progress-circle.ts
+++ b/src/lib/progress-circle/progress-circle.ts
@@ -72,11 +72,11 @@ export class MdProgressCircle implements OnDestroy {
     return this.mode == 'determinate' ? 100 : null;
   }
 
-  /** TODO: internal */
+  /** @internal */
   get interdeterminateInterval() {
     return this._interdeterminateInterval;
   }
-  /** TODO: internal */
+  /** @internal */
   set interdeterminateInterval(interval: number) {
     clearInterval(this._interdeterminateInterval);
     this._interdeterminateInterval = interval;

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -155,7 +155,6 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /**
    * Initialize properties once content children are available.
    * This allows us to propagate relevant attributes to associated buttons.
-   * TODO: internal
    */
   ngAfterContentInit() {
     // Mark this component as initialized in AfterContentInit because the initial value can
@@ -208,33 +207,22 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  /**
-    * Implemented as part of ControlValueAccessor.
-    * TODO: internal
-    */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /**
-   * Implemented as a part of ControlValueAccessor.
-   */
+  /** Implemented as a part of ControlValueAccessor. */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
@@ -383,7 +371,6 @@ export class MdRadioButton implements OnInit {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
-  /** TODO: internal */
   ngOnInit() {
     if (this.radioGroup) {
       // If the radio is inside a radio group, determine if it should be checked
@@ -419,7 +406,6 @@ export class MdRadioButton implements OnInit {
     this._onInputFocus();
   }
 
-  /** TODO: internal */
   _onInputBlur() {
     this._isFocused = false;
 
@@ -428,7 +414,6 @@ export class MdRadioButton implements OnInit {
     }
   }
 
-  /** TODO: internal */
   _onInputClick(event: Event) {
     // We have to stop propagation for click events on the visual hidden input element.
     // By default, when a user clicks on a label element, a generated click event will be
@@ -443,7 +428,6 @@ export class MdRadioButton implements OnInit {
   /**
    * Triggered when the radio button received a click or the input recognized any change.
    * Clicking on a label element, will trigger a change event on the associated input.
-   * TODO: internal
    */
   _onInputChange(event: Event) {
     // We always have to stop propagation on the change event.

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -96,7 +96,6 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) {}
 
-  /** TODO: internal */
   ngAfterContentInit() {
     this._slideRenderer = new SlideToggleRenderer(this._elementRef);
   }
@@ -158,33 +157,22 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     this.onTouched();
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any): void {
     this.checked = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: any): void {
     this.onChange = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   * TODO: internal
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any): void {
     this.onTouched = fn;
   }
 
-  /**
-   * Implemented as a part of ControlValueAccessor.
-   */
+  /** Implemented as a part of ControlValueAccessor. */
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
@@ -240,21 +228,18 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   }
 
 
-  /** TODO: internal */
   _onDragStart() {
     if (!this.disabled) {
       this._slideRenderer.startThumbDrag(this.checked);
     }
   }
 
-  /** TODO: internal */
   _onDrag(event: HammerInput) {
     if (this._slideRenderer.isDragging()) {
       this._slideRenderer.updateThumbPosition(event.deltaX);
     }
   }
 
-  /** TODO: internal */
   _onDragEnd() {
     if (!this._slideRenderer.isDragging()) {
       return;

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -490,7 +490,7 @@ export class MdSlider implements ControlValueAccessor {
 
 /**
  * Renderer class in order to keep all dom manipulation in one place and outside of the main class.
- * @internal
+ * @docs-private
  */
 export class SliderRenderer {
   private _sliderElement: HTMLElement;

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -399,9 +399,7 @@ export class MdSlider implements ControlValueAccessor {
     this.value = this._clamp(this.value + this.step * numSteps, this.min, this.max);
   }
 
-  /**
-   * Calculate the new value from the new physical location. The value will always be snapped.
-   */
+  /** Calculate the new value from the new physical location. The value will always be snapped. */
   private _updateValueFromPosition(pos: {x: number, y: number}) {
     if (!this._sliderDimensions) {
       return;
@@ -437,9 +435,7 @@ export class MdSlider implements ControlValueAccessor {
     }
   }
 
-  /**
-   * Updates the amount of space between ticks as a percentage of the width of the slider.
-   */
+  /** Updates the amount of space between ticks as a percentage of the width of the slider. */
   private _updateTickIntervalPercent() {
     if (!this.tickInterval) {
       return;
@@ -456,51 +452,37 @@ export class MdSlider implements ControlValueAccessor {
     }
   }
 
-  /**
-   * Calculates the percentage of the slider that a value is.
-   */
+  /** Calculates the percentage of the slider that a value is. */
   private _calculatePercentage(value: number) {
     return (value - this.min) / (this.max - this.min);
   }
 
-  /**
-   * Calculates the value a percentage of the slider corresponds to.
-   */
+  /** Calculates the value a percentage of the slider corresponds to. */
   private _calculateValue(percentage: number) {
     return this.min + percentage * (this.max - this.min);
   }
 
-  /**
-   * Return a number between two numbers.
-   */
+  /** Return a number between two numbers. */
   private _clamp(value: number, min = 0, max = 1) {
     return Math.max(min, Math.min(value, max));
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
+  /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
+  /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
+  /** Implemented as part of ControlValueAccessor. */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
@@ -508,6 +490,7 @@ export class MdSlider implements ControlValueAccessor {
 
 /**
  * Renderer class in order to keep all dom manipulation in one place and outside of the main class.
+ * @internal
  */
 export class SliderRenderer {
   private _sliderElement: HTMLElement;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -134,7 +134,6 @@ export class MdTabGroup {
   /**
    * Waits one frame for the view to update, then updates the ink bar
    * Note: This must be run outside of the zone or it will create an infinite change detection loop
-   * TODO: internal
    */
   ngAfterViewChecked(): void {
     this._isInitialized = true;

--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -14,7 +14,7 @@
     "sourceMap": true,
     "target": "es5",
     "inlineSources": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "typeRoots": [
       "../../node_modules/@types"
     ],

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -14,7 +14,7 @@
     "sourceMap": true,
     "target": "es5",
     "inlineSources": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "baseUrl": "",
     "paths": {
     },

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "target": "es5",
     "inlineSources": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types"


### PR DESCRIPTION
R: @mmalerba 

Disables the `stripInternal` TypeScript option (which omits `@internal` symbols from the `.d.ts` files) and uses the `@internal` JsDoc to mark classes as non-public. This will tell our docs generation that this isn't a public API that needs to be documented.

This is mainly for symbols where we don;t want to start them with an underscore (such as for class names) or for symbols that already have an underscored version (rare in our codebase).