### PR TITLE
fix(select): transparent background when overscrolling

### DIFF
--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -34,7 +34,7 @@
     }
   }
 
-  .md-select-panel {
+  .md-select-content, .md-select-panel-done-animating {
     background: md-color($background, card);
   }
 

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -34,7 +34,7 @@
     }
   }
 
-  .md-select-content {
+  .md-select-panel {
     background: md-color($background, card);
   }
 

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -10,7 +10,7 @@
   [offsetY]="_offsetY" [offsetX]="_offsetX" (attach)="_setScrollTop()">
   <div class="md-select-panel" [@transformPanel]="'showing'" (@transformPanel.done)="_onPanelDone()"
     (keydown)="_keyManager.onKeydown($event)" [style.transformOrigin]="_transformOrigin"
-      [ngClass]="_panelDoneAnimating ? 'md-select-panel-done-animating' : ''">
+      [class.md-select-panel-done-animating]="_panelDoneAnimating">
     <div class="md-select-content" [@fadeInContent]="'showing'">
       <ng-content></ng-content>
     </div>

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -5,11 +5,12 @@
   <span class="md-select-arrow"></span>
 </div>
 
-<template cdk-connected-overlay [origin]="origin"  [open]="panelOpen" hasBackdrop (backdropClick)="close()"
+<template cdk-connected-overlay [origin]="origin" [open]="panelOpen" hasBackdrop (backdropClick)="close()"
   backdropClass="cdk-overlay-transparent-backdrop" [positions]="_positions" [minWidth]="_triggerWidth"
   [offsetY]="_offsetY" [offsetX]="_offsetX" (attach)="_setScrollTop()">
   <div class="md-select-panel" [@transformPanel]="'showing'" (@transformPanel.done)="_onPanelDone()"
-    (keydown)="_keyManager.onKeydown($event)" [style.transformOrigin]="_transformOrigin">
+    (keydown)="_keyManager.onKeydown($event)" [style.transformOrigin]="_transformOrigin"
+      [ngClass]="_panelDoneAnimating ? 'md-select-panel-done-animating' : ''">
     <div class="md-select-content" [@fadeInContent]="'showing'">
       <ng-content></ng-content>
     </div>

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {TestBed, async, ComponentFixture, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Component, DebugElement, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {MdSelectModule} from './index';
@@ -542,6 +542,20 @@ describe('MdSelect', () => {
         expect(fixture.componentInstance.select._placeholderState).toEqual('floating-rtl');
       });
 
+
+      it('should add a class to the panel when the menu is done animating', fakeAsync(() => {
+        trigger.click();
+        fixture.detectChanges();
+
+        const panel = overlayContainerElement.querySelector('.md-select-panel');
+
+        expect(panel.classList).not.toContain('md-select-panel-done-animating');
+
+        tick(250);
+        fixture.detectChanges();
+
+        expect(panel.classList).toContain('md-select-panel-done-animating');
+      }));
   });
 
   describe('positioning', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -349,7 +349,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
       this.onClose.emit();
     }
 
-    this._panelDoneAnimating = true;
+    this._panelDoneAnimating = this.panelOpen;
   }
 
   /**

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -147,6 +147,9 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   /** The value of the select panel's transform-origin property. */
   _transformOrigin: string = 'top';
 
+  /** Whether the panel's animation is done. */
+  _panelDoneAnimating: boolean = false;
+
   /**
    * The x-offset of the overlay panel in relation to the trigger's top start corner.
    * This must be adjusted to align the selected option text over the trigger text when
@@ -345,6 +348,8 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     } else {
       this.onClose.emit();
     }
+
+    this._panelDoneAnimating = true;
   }
 
   /**


### PR DESCRIPTION
Fixes the select being transparent on browsers that allow overscrolling (mostly mobile).

Here's what it looks like before the fix:
![img_1189](https://cloud.githubusercontent.com/assets/4450522/21025876/771e42ca-bd8a-11e6-898a-84404345d82a.PNG)
