### PR TITLE
fix  characters remaining hint for textarea

### DIFF
--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -68,8 +68,8 @@
     <p>
       <md-textarea placeholder="Character count (100 max)" maxLength="100" class="demo-full-width"
                 value="Hello world. How are you?"
-                #characterCountHintExample>
-        <md-hint align="end">{{characterCountHintExample.characterCount}} / 100</md-hint>
+                #characterCountHintExampleTextarea>
+        <md-hint align="end">{{characterCountHintExampleTextarea.characterCount}} / 100</md-hint>
       </md-textarea>
     </p>
   </md-card-content>


### PR DESCRIPTION
fix (input): Change name of local variable on md-textarea to fix hint binding of md-input.

#characterCountHintExample is the name given to both the md-input and md-textarea.  This breaks the binding of the md-hint on the md-input.  As the user types in the md-input field, the hint is not updated to show the remaining characters.  However, when the user types in the md-textarea, the md-hint is updated on the textarea AND the input.  The fix is simply to give each control a different #name.

