### PR TITLE
fix: TSError: ? Unable to compile TypeScript when running 'gulp:build'

### DIFF
--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -34,7 +34,7 @@ task(':publish:whoami', execTask('npm', ['whoami'], {
 task(':publish:logout', execTask('npm', ['logout']));
 
 
-function _execNpmPublish(label: string): Promise<void> {
+function _execNpmPublish(label: string): Promise<{}> {
   const packageDir = DIST_COMPONENTS_ROOT;
   if (!statSync(packageDir).isDirectory()) {
     return;


### PR DESCRIPTION
fix (gulp task): change Promise<void> to Promise<{}>

When running 'gulp build' getting an error "TSError: ? Unable to compile TypeScript
tools\gulp\tasks\release.ts (52,10): Type 'Promise<{}>' is not assignable to type 'Promise<void>'"

