### PR TITLE
docs(radio): Delete example for two-way binding

### DIFF
--- a/src/lib/radio/README.md
+++ b/src/lib/radio/README.md
@@ -12,15 +12,6 @@ A basic radio group would have the following markup.
 </md-radio-group>
 ```
 
-A dynamic example, populated from a `data` variable:
-```html
-<md-radio-group [(value)]="groupValue">
-  <md-radio-button *ngFor="let d of data" [value]="d.value">
-    {{d.label}}
-  </md-radio-button>
-</md-radio-group>
-```
-
 A dynamic example for use inside a form showing support for `[(ngModel)]`:
 ```html
 <md-radio-group [(ngModel)]="chosenOption">


### PR DESCRIPTION
 - Delete the `[(value)]` example because we don't support it. There's another example for `[(ngModel)]`
Closes #1790 

R: @jelbourn 