### PR TITLE
chore: fix invalid check for travis pull request

### DIFF
--- a/scripts/ci/after-success.sh
+++ b/scripts/ci/after-success.sh
@@ -9,7 +9,7 @@ cd $(dirname $0)/../..
 npmBin=$(npm bin)
 ciResult=$($npmBin/travis-after-modes)
 
-if [ "$ciResult" = "PASSED" ] && [ -z "$TRAVIS_PULL_REQUEST" ]; then
+if [ "$ciResult" = "PASSED" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   echo "All travis modes passed. Publishing the build artifacts..."
   ./scripts/release/publish-build-artifacts.sh
 fi


### PR DESCRIPTION
* The recently added script for the per-commit publishing is not properly checking for the environment variable.
 
  This means that the per-commit packages can be not created yet.