### PR TITLE
perf(sidenav): avoid extra repaints while scrolling

### DIFF
--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -140,6 +140,9 @@ md-sidenav {
     box-sizing: border-box;
     height: 100%;
     overflow-y: auto; // TODO(kara): revisit scrolling behavior for sidenavs
+
+    // Prevents unnecessary repaints while scrolling.
+    transform: translateZ(0);
   }
 }
 


### PR DESCRIPTION
Avoids repaints while scrolling inside of a sidenav. This isn't an issue on desktop browsers, but can potentially be on mobile. This can be checked by going to the dev tools > console fold-out menu > Rendering > Scrolling Performance Issues.