### PR TITLE
update(toolbar): add responsive heights as per spec

### DIFF
--- a/src/lib/core/style/_variables.scss
+++ b/src/lib/core/style/_variables.scss
@@ -6,7 +6,10 @@ $md-body-font-size-base: rem(1.4) !default;
 $md-font-family: Roboto, 'Helvetica Neue', sans-serif !default;
 
 // Media queries
+// TODO: Find a way to respect media query ranges.
+// TODO: For example the xs-breakpoint should not interfere with the sm-breakpoint.
 $md-xsmall: 'max-width: 600px';
+$md-small: 'max-width: 960px';
 
 // TODO: Revisit all z-indices before beta
 // z-index master list

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -17,7 +17,6 @@ $md-toolbar-padding: 16px !default;
   }
 }
 
-
 md-toolbar {
   display: flex;
   box-sizing: border-box;

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -1,9 +1,21 @@
 @import '../core/style/variables';
 
+$md-toolbar-height-desktop: 64px !default;
+$md-toolbar-height-mobile-portrait: 56px !default;
+$md-toolbar-height-mobile-landscape: 48px !default;
 
-$md-toolbar-min-height: 64px !default;
 $md-toolbar-font-size: 20px !default;
 $md-toolbar-padding: 16px !default;
+
+
+@mixin md-toolbar-height($height) {
+  md-toolbar {
+    min-height: $height;
+  }
+  md-toolbar-row {
+    height: $height;
+  }
+}
 
 
 md-toolbar {
@@ -11,7 +23,6 @@ md-toolbar {
   box-sizing: border-box;
 
   width: 100%;
-  min-height: $md-toolbar-min-height;
 
   // Font Styling
   font-size: $md-toolbar-font-size;
@@ -27,10 +38,22 @@ md-toolbar {
     box-sizing: border-box;
 
     width: 100%;
-    height: $md-toolbar-min-height;
 
     // Flexbox Vertical Alignment
     flex-direction: row;
     align-items: center;
   }
+}
+
+// Set the default height for the toolbar.
+@include md-toolbar-height($md-toolbar-height-desktop);
+
+// Specific height for mobile devices in portrait mode.
+@media ($md-xsmall) and (orientation: portrait) {
+  @include md-toolbar-height($md-toolbar-height-mobile-portrait);
+}
+
+// Specific height for mobile devices in landscape mode.
+@media ($md-small) and (orientation: landscape) {
+  @include md-toolbar-height($md-toolbar-height-mobile-landscape);
 }


### PR DESCRIPTION
* Adds media queries to dynamically adjust the height of the toolbar according to the specifications.
  https://material.google.com/layout/structure.html#structure-app-bar

@jelbourn Notice that the `@media` query for the landscape modes intentionally uses the `$md-small` breakpoint. See https://material.google.com/layout/responsive-ui.html#responsive-ui-breakpoints

Closes #2085.