### PR TITLE
build: fix invalid sass paths being resolved

### DIFF
--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -67,13 +67,11 @@ export function tsBuildTask(tsConfigPath: string, tsConfigName = 'tsconfig.json'
 
 
 /** Create a SASS Build Task. */
-export function sassBuildTask(dest: string, root: string, includePaths: string[]) {
-  const sassOptions = { includePaths };
-
+export function sassBuildTask(dest: string, root: string) {
   return () => {
     return gulp.src(_globify(root, '**/*.scss'))
       .pipe(gulpSourcemaps.init())
-      .pipe(gulpSass(sassOptions).on('error', gulpSass.logError))
+      .pipe(gulpSass().on('error', gulpSass.logError))
       .pipe(gulpAutoprefixer(SASS_AUTOPREFIXER_OPTIONS))
       .pipe(gulpSourcemaps.write('.'))
       .pipe(gulp.dest(dest));

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -52,9 +52,7 @@ task(':build:components:assets', copyTask([
 ], DIST_COMPONENTS_ROOT));
 
 /** Builds scss into css. */
-task(':build:components:scss', sassBuildTask(
-  DIST_COMPONENTS_ROOT, componentsDir, [path.join(componentsDir, 'core/style')]
-));
+task(':build:components:scss', sassBuildTask(DIST_COMPONENTS_ROOT, componentsDir));
 
 /** Builds the UMD bundle for all of Angular Material. */
 task(':build:components:rollup', [':build:components:inline'], () => {

--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -25,7 +25,7 @@ task(':watch:devapp', () => {
 
 task(':build:devapp:vendor', vendorTask());
 task(':build:devapp:ts', [':build:components:rollup'], tsBuildTask(appDir));
-task(':build:devapp:scss', [':build:components:scss'], sassBuildTask(outDir, appDir, []));
+task(':build:devapp:scss', [':build:components:scss'], sassBuildTask(outDir, appDir));
 task(':build:devapp:assets', copyTask(appDir, outDir));
 task('build:devapp', buildAppTask('devapp'));
 

--- a/tools/gulp/tasks/e2e.ts
+++ b/tools/gulp/tasks/e2e.ts
@@ -28,7 +28,7 @@ task(':build:e2eapp:vendor', vendorTask());
 task(':build:e2eapp:ts', [':build:components:ts'], tsBuildTask(appDir));
 
 /** No-op (needed by buildAppTask). */
-task(':build:e2eapp:scss', [':build:components:scss'], sassBuildTask(outDir, appDir, []));
+task(':build:e2eapp:scss', [':build:components:scss'], sassBuildTask(outDir, appDir));
 
 /** Copies e2e app assets (html, css) to build output. */
 task(':build:e2eapp:assets', copyTask(appDir, outDir));


### PR DESCRIPTION
Prevents SASS from resolving certain paths, even though they're invalid. This should prevent issues like #2133 from happening again.

@jelbourn I'm not sure what the reasoning was for adding `core/styles` to the `includePaths` in Gulp, but this is what helped `@import '../a11y/_a11y';` to always be resolved. I re-ran all of the SASS-related Gulp tasks and they went through fine.