### PR TITLE
chore: remove typings manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 # compiled output
 /dist
 /tmp
-/typings
 /deploy
 
 # dependencies

--- a/firebase.json
+++ b/firebase.json
@@ -23,8 +23,7 @@
       "**/.*",
       "**/node_modules/**",
       "tmp",
-      "deploy",
-      "typings"
+      "deploy"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "tslint": "^3.13.0",
     "typedoc": "^0.5.1",
     "typescript": "^2.0.2",
-    "typings": "^1.3.1",
     "which": "^1.2.4"
   }
 }


### PR DESCRIPTION
* Removes the typings manager because the project uses `@types` now.