### PR TITLE
fix(snack-bar): clean up element when associated viewContainer is destroyed

### DIFF
--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -33,16 +33,13 @@ export class MdSnackBarRef<T> {
     this.containerInstance = containerInstance;
     // Dismiss snackbar on action.
     this.onAction().subscribe(() => this.dismiss());
+    containerInstance._onExit().subscribe(() => this._cleanup());
   }
 
   /** Dismisses the snack bar. */
   dismiss(): void {
     if (!this._afterClosed.closed) {
-      this.containerInstance.exit().subscribe(() => {
-        this._overlayRef.dispose();
-        this._afterClosed.next();
-        this._afterClosed.complete();
-      });
+      this.containerInstance.exit();
     }
   }
 
@@ -60,6 +57,13 @@ export class MdSnackBarRef<T> {
       this._afterOpened.next();
       this._afterOpened.complete();
     }
+  }
+
+  /** Cleans up the DOM after closing. */
+  private _cleanup(): void {
+    this._overlayRef.dispose();
+    this._afterClosed.next();
+    this._afterClosed.complete();
   }
 
   /** Gets an observable that is notified when the snack bar is finished closing. */

--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -33,7 +33,7 @@ export class MdSnackBarRef<T> {
     this.containerInstance = containerInstance;
     // Dismiss snackbar on action.
     this.onAction().subscribe(() => this.dismiss());
-    containerInstance._onExit().subscribe(() => this._cleanup());
+    containerInstance._onExit().subscribe(() => this._finishDismiss());
   }
 
   /** Dismisses the snack bar. */
@@ -60,7 +60,7 @@ export class MdSnackBarRef<T> {
   }
 
   /** Cleans up the DOM after closing. */
-  private _cleanup(): void {
+  private _finishDismiss(): void {
     this._overlayRef.dispose();
     this._afterClosed.next();
     this._afterClosed.complete();

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -8,6 +8,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import {NgModule, Component, Directive, ViewChild, ViewContainerRef} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {MdSnackBar, MdSnackBarModule} from './snack-bar';
 import {MdSnackBarConfig} from './snack-bar-config';
 import {OverlayContainer, MdLiveAnnouncer} from '../core';
@@ -148,6 +149,20 @@ describe('MdSnackBar', () => {
       expect(dismissObservableCompleted).toBeTruthy('Expected the snack bar to be dismissed');
       expect(overlayContainerElement.childElementCount)
           .toBe(0, 'Expected the overlay container element to have no child elements');
+    });
+  }));
+
+  it('should clean itself up when the view container gets destroyed', async(() => {
+    snackBar.open(simpleMessage, null, { viewContainerRef: testViewContainerRef });
+    viewContainerFixture.detectChanges();
+    expect(overlayContainerElement.childElementCount).toBeGreaterThan(0);
+
+    viewContainerFixture.componentInstance.childComponentExists = false;
+    viewContainerFixture.detectChanges();
+
+    viewContainerFixture.whenStable().then(() => {
+      expect(overlayContainerElement.childElementCount).toBe(
+          0, 'Expected snack bar to be removed after the view container was destroyed');
     });
   }));
 
@@ -314,10 +329,12 @@ class DirectiveWithViewContainer {
 
 @Component({
   selector: 'arbitrary-component',
-  template: `<dir-with-view-container></dir-with-view-container>`,
+  template: `<dir-with-view-container *ngIf="childComponentExists"></dir-with-view-container>`,
 })
 class ComponentWithChildViewContainer {
   @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+
+  childComponentExists: boolean = true;
 
   get childViewContainer() {
     return this.childWithViewContainer.viewContainerRef;
@@ -337,7 +354,7 @@ const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
                          BurritosNotification,
                          DirectiveWithViewContainer];
 @NgModule({
-  imports: [MdSnackBarModule],
+  imports: [CommonModule, MdSnackBarModule],
   exports: TEST_DIRECTIVES,
   declarations: TEST_DIRECTIVES,
   entryComponents: [ComponentWithChildViewContainer, BurritosNotification],

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -161,8 +161,8 @@ describe('MdSnackBar', () => {
     viewContainerFixture.detectChanges();
 
     viewContainerFixture.whenStable().then(() => {
-      expect(overlayContainerElement.childElementCount).toBe(
-          0, 'Expected snack bar to be removed after the view container was destroyed');
+      expect(overlayContainerElement.childElementCount)
+          .toBe(0, 'Expected snack bar to be removed after the view container was destroyed');
     });
   }));
 


### PR DESCRIPTION
Fixes the snack bar not being removed from the DOM when it's associated `viewContainerRef` gets destroyed.

Fixes #2190.