### PR TITLE
Remove assumption of `window' in MdPlatform

### DIFF
--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -4,7 +4,9 @@ declare const window: any;
 
 // Whether the current platform supports the V8 Break Iterator. The V8 check
 // is necessary to detect all Blink based browsers.
-const hasV8BreakIterator = (window.Intl && (window.Intl as any).v8BreakIterator);
+const hasV8BreakIterator = typeof(window) !== 'undefined' ?
+    (window.Intl && (window.Intl as any).v8BreakIterator) :
+    (typeof(Intl) !== 'undefined' && (Intl as any).v8BreakIterator);
 
 /**
  * Service to detect the current platform by comparing the userAgent strings and


### PR DESCRIPTION
Makes it work when loaded in node

See https://github.com/angular/material2/issues/2171
https://github.com/angular/material2/issues/308#issuecomment-267124520

If you would rather see this rewritten with proper node detection instead of this workaround to make it load, that would be fine with me as well.