### PR TITLE
fix(a11y): add all providers to forRoot

### DIFF
--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -16,7 +16,10 @@ export class A11yModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: A11yModule,
-      providers: PlatformModule.forRoot().providers.concat(A11Y_PROVIDERS),
+      providers: [
+        PlatformModule.forRoot().providers,
+        A11Y_PROVIDERS,
+      ],
     };
   }
 }

--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -16,7 +16,7 @@ export class A11yModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: A11yModule,
-      providers: A11Y_PROVIDERS,
+      providers: PlatformModule.forRoot().providers.concat(A11Y_PROVIDERS),
     };
   }
 }


### PR DESCRIPTION
Adds all of the necessary providers to the `A11yModule`.

Fixes #2189.