### PR TITLE
chore: bump to rxjs 5 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^3.2.0",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
-    "rxjs": "5.0.0-beta.12",
+    "rxjs": "5.0.1",
     "systemjs": "0.19.38",
     "zone.js": "^0.6.23"
   },


### PR DESCRIPTION
Bumps RxJS to 5.0.1 stable.

EDIT: This might have to wait for Angular to update.