### PR TITLE
fix(input): unable to focus input in IE 11

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -16,7 +16,10 @@ md-input-container {
 
 .md-input-element {
   &::placeholder {
-    visibility: hidden;
+    // Note that we can't use something like visibility: hidden or
+    // display: none, because IE ends up preventing the user from
+    // focusing the input altogether.
+    color: transparent;
   }
 
   .md-end & {


### PR DESCRIPTION
Fixes being unable to focus an input in IE 11 by clicking on the label. This was due to the style for hiding the placeholder which, for some reason, ended up disabling the input altogether if it didn't have a value.