### PR TITLE
fix(input): character count hint for input

### DIFF
--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -111,7 +111,9 @@
     </p>
     <p>
       <md-input placeholder="Show Hint Label With Character Count" style="width: 100%"
-                hintLabel="Hint label" characterCounter></md-input>
+                hintLabel="Hint label" #characterCountHintExampleInput>
+           <md-hint align="end">{{characterCountHintExampleInput.characterCount}}</md-hint>
+      </md-input>
     </p>
     <p>
       <md-checkbox [(ngModel)]="dividerColor">Check to change the divider color:</md-checkbox>


### PR DESCRIPTION
fix (input): Remove the property CharacterCounter on md-input. Add name
of local variable on md-input and add md-hint to fix counter binding of
md-input for the show hint lable with charater count example.

The property characterCounter does not exist on md-input and therefore
the character count was not being displayed for the show hint lable with
charater count example. Removing this and adding the name
#characterCountHintExampleInput along with the md-hint tag using the
name and the character count property fixes the issue.