### PR TITLE
chore: log messages while waiting for ci modes to finish

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "strip-ansi": "^3.0.0",
     "stylelint": "^7.5.0",
     "symlink-or-copy": "^1.0.1",
-    "travis-after-modes": "0.0.5",
+    "travis-after-modes": "0.0.6-2",
     "ts-node": "^0.7.3",
     "tslint": "^3.13.0",
     "typedoc": "^0.5.1",

--- a/scripts/ci/after-success.sh
+++ b/scripts/ci/after-success.sh
@@ -6,10 +6,8 @@
 # Go to the project root directory
 cd $(dirname $0)/../..
 
-npmBin=$(npm bin)
-ciResult=$($npmBin/travis-after-modes)
-
-if [ "$ciResult" = "PASSED" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+# If not running as a PR, wait for all other travis modes to finish.
+if [ "$TRAVIS_PULL_REQUEST" = "false" ] && $(npm bin)/travis-after-modes; then
   echo "All travis modes passed. Publishing the build artifacts..."
   ./scripts/release/publish-build-artifacts.sh
 fi


### PR DESCRIPTION
* Currently the Travis CI leader mode can timeout, because the `e2e modes` runs longer than 10 minutes and the leader mode then needs to wait the same time (just without any output).
  Travis stops the build automatically when there is no output for the last 10 minutes.

* The plugin `travis-after-modes` has been updated to log a message (like a progress-bar) each time the modes are checked again.

@jelbourn This should fix the timeout issues for the `lint` mode you mentioned on Slack.