### PR TITLE
refactor: convert dash-case inputs to camelCase

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -3,7 +3,7 @@
     <p>You clicked on: {{ selected }}</p>
 
     <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="menu" aria-label="Open basic menu">
+      <button md-icon-button [mdMenuTriggerFor]="menu" aria-label="Open basic menu">
         <md-icon>more_vert</md-icon>
       </button>
     </md-toolbar>
@@ -17,7 +17,7 @@
   <div class="menu-section">
     <p> Clicking these will navigate:</p>
     <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="anchorMenu" aria-label="Open anchor menu">
+      <button md-icon-button [mdMenuTriggerFor]="anchorMenu" aria-label="Open anchor menu">
         <md-icon>more_vert</md-icon>
       </button>
     </md-toolbar>
@@ -33,7 +33,7 @@
       Position x: before
     </p>
     <md-toolbar class="end-icon">
-      <button md-icon-button [md-menu-trigger-for]="posXMenu" aria-label="Open x-positioned menu">
+      <button md-icon-button [mdMenuTriggerFor]="posXMenu" aria-label="Open x-positioned menu">
         <md-icon>more_vert</md-icon>
       </button>
     </md-toolbar>
@@ -50,7 +50,7 @@
       Position y: above
     </p>
     <md-toolbar>
-      <button md-icon-button [md-menu-trigger-for]="posYMenu" aria-label="Open y-positioned menu">
+      <button md-icon-button [mdMenuTriggerFor]="posYMenu" aria-label="Open y-positioned menu">
         <md-icon>more_vert</md-icon>
       </button>
     </md-toolbar>

--- a/src/demo-app/ripple/ripple-demo.html
+++ b/src/demo-app/ripple/ripple-demo.html
@@ -48,13 +48,13 @@
         [class.demo-ripple-disabled]="disabled"
         [class.demo-ripple-rounded]="rounded"
         md-ripple
-        [md-ripple-centered]="centered"
-        [md-ripple-disabled]="disabled"
-        [md-ripple-unbounded]="unbounded"
-        [md-ripple-max-radius]="maxRadius"
-        [md-ripple-color]="rippleColor"
-        [md-ripple-background-color]="rippleBackgroundColor"
-        [md-ripple-speed-factor]="rippleSpeed">
+        [mdRippleCentered]="centered"
+        [mdRippleDisabled]="disabled"
+        [mdRippleUnbounded]="unbounded"
+        [mdRippleMaxRadius]="maxRadius"
+        [mdRippleColor]="rippleColor"
+        [mdRippleBackgroundColor]="rippleBackgroundColor"
+        [mdRippleSpeedFactor]="rippleSpeed">
       Click me
     </div>
   </section>

--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -4,7 +4,7 @@ Label <md-slider #slidey></md-slider>
 
 <h1>Slider with Min and Max</h1>
 <input [(ngModel)]="min">
-<md-slider [min]="min" [max]="max" tick-interval="5" #slider2></md-slider>
+<md-slider [min]="min" [max]="max" tickInterval="5" #slider2></md-slider>
 {{slider2.value}}
 <input [(ngModel)]="max">
 
@@ -20,11 +20,11 @@ Label <md-slider #slidey></md-slider>
 {{slider5.value}}
 
 <h1>Slider with set tick interval</h1>
-<md-slider tick-interval="auto"></md-slider>
-<md-slider tick-interval="9"></md-slider>
+<md-slider tickInterval="auto"></md-slider>
+<md-slider tickInterval="9"></md-slider>
 
 <h1>Slider with Thumb Label</h1>
-<md-slider thumb-label></md-slider>
+<md-slider thumbLabel></md-slider>
 
 <h1>Slider with one-way binding</h1>
 <md-slider [value]="val" step="40"></md-slider>
@@ -35,13 +35,13 @@ Label <md-slider #slidey></md-slider>
 <input [(ngModel)]="demo">
 
 <h1>Inverted slider</h1>
-<md-slider invert value="50" tick-interval="5"></md-slider>
+<md-slider invert value="50" tickInterval="5"></md-slider>
 
 <h1>Vertical slider</h1>
-<md-slider vertical thumb-label tick-interval="auto" value="50"></md-slider>
+<md-slider vertical thumbLabel tickInterval="auto" value="50"></md-slider>
 
 <h1>Inverted vertical slider</h1>
-<md-slider vertical invert thumb-label tick-interval="auto" value="50"></md-slider>
+<md-slider vertical invert thumbLabel tickInterval="auto" value="50"></md-slider>
 
 <md-tab-group>
   <md-tab label="One">

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -43,7 +43,7 @@
   </md-card>
 
   <md-tab-group class="demo-tab-group"
-                md-dynamic-height
+                mdDynamicHeight
                 [(selectedIndex)]="activeTabIndex">
     <md-tab *ngFor="let tab of dynamicTabs" [disabled]="tab.disabled">
       <template md-tab-label>{{tab.label}}</template>
@@ -92,7 +92,7 @@
 
 <h1>Tab Group Demo - Dynamic Height</h1>
 
-<md-tab-group class="demo-tab-group" md-dynamic-height>
+<md-tab-group class="demo-tab-group" mdDynamicHeight>
   <md-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
     <template md-tab-label>{{tab.label}}</template>
     {{tab.content}}

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -42,9 +42,7 @@
     </md-card-content>
   </md-card>
 
-  <md-tab-group class="demo-tab-group"
-                mdDynamicHeight
-                [(selectedIndex)]="activeTabIndex">
+  <md-tab-group class="demo-tab-group" dynamicHeight [(selectedIndex)]="activeTabIndex">
     <md-tab *ngFor="let tab of dynamicTabs" [disabled]="tab.disabled">
       <template md-tab-label>{{tab.label}}</template>
       {{tab.content}}
@@ -92,7 +90,7 @@
 
 <h1>Tab Group Demo - Dynamic Height</h1>
 
-<md-tab-group class="demo-tab-group" mdDynamicHeight>
+<md-tab-group class="demo-tab-group" dynamicHeight>
   <md-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
     <template md-tab-label>{{tab.label}}</template>
     {{tab.content}}

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -5,10 +5,10 @@
     <button #tooltip="mdTooltip"
         md-raised-button
         color="primary"
-        [md-tooltip]="message"
-        [tooltipPosition]="position"
-        [tooltipShowDelay]="showDelay"
-        [tooltipHideDelay]="hideDelay">
+        [mdTooltip]="message"
+        [mdTooltipPosition]="position"
+        [mdTooltipShowDelay]="showDelay"
+        [mdTooltipHideDelay]="hideDelay">
       Mouse over to see the tooltip
     </button>
   </p>

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -6,7 +6,7 @@
         md-raised-button
         color="primary"
         [md-tooltip]="message"
-        [tooltip-position]="position"
+        [tooltipPosition]="position"
         [tooltipShowDelay]="showDelay"
         [tooltipHideDelay]="hideDelay">
       Mouse over to see the tooltip

--- a/src/e2e-app/menu/menu-e2e.html
+++ b/src/e2e-app/menu/menu-e2e.html
@@ -2,8 +2,8 @@
   <div style="float:left">
     <div id="text">{{ selected }}</div>
     <button id="start">START</button>
-    <button [md-menu-trigger-for]="menu" id="trigger">TRIGGER</button>
-    <button [md-menu-trigger-for]="menu" id="trigger-two">TRIGGER 2</button>
+    <button [mdMenuTriggerFor]="menu" id="trigger">TRIGGER</button>
+    <button [mdMenuTriggerFor]="menu" id="trigger-two">TRIGGER 2</button>
 
     <md-menu #menu="mdMenu" y-position="below" class="custom">
       <button md-menu-item (click)="selected='one'">One</button>
@@ -12,7 +12,7 @@
       <button md-menu-item>Four</button>
     </md-menu>
 
-    <button [md-menu-trigger-for]="beforeMenu" id="before-t">
+    <button [mdMenuTriggerFor]="beforeMenu" id="before-t">
       BEFORE
     </button>
     <md-menu x-position="before" y-position="below" class="before" #beforeMenu="mdMenu">
@@ -20,12 +20,12 @@
     </md-menu>
 
     <div class="bottom-row">
-      <button [md-menu-trigger-for]="aboveMenu" id="above-t">ABOVE</button>
+      <button [mdMenuTriggerFor]="aboveMenu" id="above-t">ABOVE</button>
       <md-menu y-position="above" class="above" #aboveMenu="mdMenu">
         <button md-menu-item>Item</button>
       </md-menu>
 
-      <button [md-menu-trigger-for]="combined" id="combined-t">
+      <button [mdMenuTriggerFor]="combined" id="combined-t">
         BOTH
       </button>
       <md-menu x-position="before" y-position="above" class="combined" #combined="mdMenu">

--- a/src/lib/button/button.html
+++ b/src/lib/button/button.html
@@ -1,7 +1,7 @@
 <span class="md-button-wrapper"><ng-content></ng-content></span>
 <div md-ripple *ngIf="!_isRippleDisabled()" class="md-button-ripple"
     [class.md-button-ripple-round]="_isRoundButton()"
-    [mdRippleTrigger]="getHostElement()"
+    [mdRippleTrigger]="_getHostElement()"
     [mdRippleColor]="isRoundButton() ? 'rgba(255, 255, 255, 0.2)' : ''"
     mdRippleBackgroundColor="rgba(0, 0, 0, 0)"></div>
 <!-- the touchstart handler prevents the overlay from capturing the initial tap on touch devices -->

--- a/src/lib/button/button.html
+++ b/src/lib/button/button.html
@@ -1,8 +1,8 @@
 <span class="md-button-wrapper"><ng-content></ng-content></span>
 <div md-ripple *ngIf="!_isRippleDisabled()" class="md-button-ripple"
     [class.md-button-ripple-round]="_isRoundButton()"
-    [md-ripple-trigger]="_getHostElement()"
-    [md-ripple-color]="_isRoundButton() ? 'rgba(255, 255, 255, 0.2)' : ''"
-    md-ripple-background-color="rgba(0, 0, 0, 0)"></div>
+    [mdRippleTrigger]="getHostElement()"
+    [mdRippleColor]="isRoundButton() ? 'rgba(255, 255, 255, 0.2)' : ''"
+    mdRippleBackgroundColor="rgba(0, 0, 0, 0)"></div>
 <!-- the touchstart handler prevents the overlay from capturing the initial tap on touch devices -->
 <div class="md-button-focus-overlay" (touchstart)="$event.preventDefault()"></div>

--- a/src/lib/button/button.html
+++ b/src/lib/button/button.html
@@ -2,7 +2,7 @@
 <div md-ripple *ngIf="!_isRippleDisabled()" class="md-button-ripple"
     [class.md-button-ripple-round]="_isRoundButton()"
     [mdRippleTrigger]="_getHostElement()"
-    [mdRippleColor]="isRoundButton() ? 'rgba(255, 255, 255, 0.2)' : ''"
+    [mdRippleColor]="_isRoundButton() ? 'rgba(255, 255, 255, 0.2)' : ''"
     mdRippleBackgroundColor="rgba(0, 0, 0, 0)"></div>
 <!-- the touchstart handler prevents the overlay from capturing the initial tap on touch devices -->
 <div class="md-button-focus-overlay" (touchstart)="$event.preventDefault()"></div>

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -168,7 +168,7 @@ describe('MdButton', () => {
       anchorElement = fixture.nativeElement.querySelector('a[md-button]');
     });
 
-    it('should remove ripple if md-ripple-disabled input is set', () => {
+    it('should remove ripple if mdRippleDisabled input is set', () => {
       expect(buttonElement.querySelectorAll('[md-ripple]').length).toBe(1);
 
       testComponent.rippleDisabled = true;

--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -16,10 +16,10 @@
            (change)="_onInteractionEvent($event)"
            (click)="_onInputClick($event)">
     <div md-ripple *ngIf="!_isRippleDisabled()" class="md-checkbox-ripple"
-         [md-ripple-trigger]="_getHostElement()"
-         [md-ripple-centered]="true"
-         [md-ripple-speed-factor]="0.3"
-         md-ripple-background-color="rgba(0, 0, 0, 0)"></div>
+         [mdRippleTrigger]="_getHostElement()"
+         [mdRippleCentered]="true"
+         [mdRippleSpeedFactor]="0.3"
+         mdRippleBackgroundColor="rgba(0, 0, 0, 0)"></div>
     <div class="md-checkbox-frame"></div>
     <div class="md-checkbox-background">
       <svg version="1.1"

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -521,7 +521,7 @@ describe('MdCheckbox', () => {
       expect(inputElement.tabIndex).toBe(13);
     });
 
-    it('should remove ripple if md-ripple-disabled input is set', async(() => {
+    it('should remove ripple if mdRippleDisabled input is set', async(() => {
       testComponent.disableRipple = true;
       fixture.detectChanges();
 

--- a/src/lib/core/ripple/README.md
+++ b/src/lib/core/ripple/README.md
@@ -1,6 +1,6 @@
 # md-ripple
 
-`md-ripple` defines an area in which a ripple animates, usually in response to user action. It is used as an attribute directive, for example `<div md-ripple [md-ripple-color]="rippleColor">...</div>`.
+`md-ripple` defines an area in which a ripple animates, usually in response to user action. It is used as an attribute directive, for example `<div md-ripple [mdRippleColor]="rippleColor">...</div>`.
 
 By default, a ripple is activated when the host element of the `md-ripple` directive receives mouse or touch events. On a mousedown or touch start, the ripple background fades in. When the click event completes, a circular foreground ripple fades in and expands from the event location to cover the host element bounds.
 
@@ -17,11 +17,11 @@ Properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `md-ripple-trigger` | Element | The DOM element that triggers the ripple when clicked. Defaults to the parent of the `md-ripple`.
-| `md-ripple-color` | string | Custom color for foreground ripples
-| `md-ripple-background-color` | string | Custom color for the ripple background
-| `md-ripple-centered` | boolean | If true, the ripple animation originates from the center of the `md-ripple` bounds rather than from the location of the click event.
-| `md-ripple-max-radius` | number | Optional fixed radius of foreground ripples when fully expanded. Mainly used in conjunction with `unbounded` attribute. If not set, ripples will expand from their origin to the most distant corner of the component's bounding rectangle.
-| `md-ripple-unbounded` | boolean | If true, foreground ripples will be visible outside the component's bounds.
-| `md-ripple-focused` | boolean | If true, the background ripple is shown using the current theme's accent color to indicate focus.
-| `md-ripple-disabled` | boolean | If true, click events on the trigger element will not activate ripples. The `start` and `end` methods can still be called to programmatically create ripples.
+| `mdRippleTrigger` | Element | The DOM element that triggers the ripple when clicked. Defaults to the parent of the `md-ripple`.
+| `mdRippleColor` | string | Custom color for foreground ripples
+| `mdRippleBackgroundColor` | string | Custom color for the ripple background
+| `mdRippleCentered` | boolean | If true, the ripple animation originates from the center of the `md-ripple` bounds rather than from the location of the click event.
+| `mdRippleMaxRadius` | number | Optional fixed radius of foreground ripples when fully expanded. Mainly used in conjunction with `unbounded` attribute. If not set, ripples will expand from their origin to the most distant corner of the component's bounding rectangle.
+| `mdRippleUnbounded` | boolean | If true, foreground ripples will be visible outside the component's bounds.
+| `mdRippleFocused` | boolean | If true, the background ripple is shown using the current theme's accent color to indicate focus.
+| `mdRippleDisabled` | boolean | If true, click events on the trigger element will not activate ripples. The `start` and `end` methods can still be called to programmatically create ripples.

--- a/src/lib/core/ripple/_ripple.scss
+++ b/src/lib/core/ripple/_ripple.scss
@@ -1,7 +1,7 @@
 @import '../theming/theming';
 
 
-$md-ripple-focused-opacity: 0.1;
+$mdRippleFocused-opacity: 0.1;
 $md-ripple-background-fade-duration: 300ms;
 $md-ripple-background-default-color: rgba(0, 0, 0, 0.0588);
 $md-ripple-foreground-initial-opacity: 0.25;
@@ -15,7 +15,7 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
     overflow: hidden;
   }
 
-  [md-ripple].md-ripple-unbounded {
+  [md-ripple].mdRippleUnbounded {
     overflow: visible;
   }
 
@@ -30,7 +30,7 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
     bottom: 0;
   }
 
-  .md-ripple-unbounded .md-ripple-background {
+  .mdRippleUnbounded .md-ripple-background {
     display: none;
   }
 
@@ -38,7 +38,7 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
     opacity: 1;
   }
 
-  .md-ripple-focused .md-ripple-background {
+  .mdRippleFocused .md-ripple-background {
     opacity: 1;
   }
 
@@ -64,8 +64,8 @@ $md-ripple-foreground-default-color: rgba(0, 0, 0, 0.0588);
 @mixin md-ripple-theme($theme) {
   $accent: map-get($theme, accent);
 
-  .md-ripple-focused .md-ripple-background {
-    background-color: md-color($accent, $md-ripple-focused-opacity);
+  .mdRippleFocused .md-ripple-background {
+    background-color: md-color($accent, $mdRippleFocused-opacity);
   }
 }
 

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -438,12 +438,12 @@ class BasicRippleContainer {
   template: `
     <div id="container" style="position: relative; width:300px; height:200px;"
       md-ripple
-      [md-ripple-trigger]="trigger"
-      [md-ripple-centered]="centered"
-      [md-ripple-max-radius]="maxRadius"
-      [md-ripple-disabled]="disabled"
-      [md-ripple-color]="color"
-      [md-ripple-background-color]="backgroundColor">
+      [mdRippleTrigger]="trigger"
+      [mdRippleCentered]="centered"
+      [mdRippleMaxRadius]="maxRadius"
+      [mdRippleDisabled]="disabled"
+      [mdRippleColor]="color"
+      [mdRippleBackgroundColor]="backgroundColor">
     </div>
     <div class="alternateTrigger"></div>
   `,

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -30,37 +30,89 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
    */
   // Prevent TS metadata emit from referencing HTMLElement in ripple.js
   // That breaks tests running in node that load material components.
-  @Input('md-ripple-trigger') trigger: HTMLElement|HTMLElement;
+  @Input('mdRippleTrigger') trigger: HTMLElement|HTMLElement;
+
+  /** @deprecated */
+  @Input('md-ripple-trigger')
+  get _triggerDeprecated() { return this.trigger; }
+  set _triggerDeprecated(value: HTMLElement|HTMLElement) { this.trigger = value; };
+
   /**
    * Whether the ripple always originates from the center of the host element's bounds, rather
    * than originating from the location of the click event.
    */
-  @Input('md-ripple-centered') centered: boolean;
+  @Input('mdRippleCentered') centered: boolean;
+
+  /** @deprecated */
+  @Input('md-ripple-centered')
+  get _centeredDeprecated() { return this.centered; }
+  set _centeredDeprecated(value: boolean) { this.centered = value; };
+
   /**
    * Whether click events will not trigger the ripple. It can still be triggered by manually
    * calling start() and end().
    */
-  @Input('md-ripple-disabled') disabled: boolean;
+  @Input('mdRippleDisabled') disabled: boolean;
+
+  /** @deprecated */
+  @Input('md-ripple-disabled')
+  get _disabledDeprecated() { return this.disabled; }
+  set _disabledDeprecated(value: boolean) { this.disabled = value; };
+
   /**
    * If set, the radius in pixels of foreground ripples when fully expanded. If unset, the radius
    * will be the distance from the center of the ripple to the furthest corner of the host element's
    * bounding rectangle.
    */
-  @Input('md-ripple-max-radius') maxRadius: number = 0;
+  @Input('mdRippleMaxRadius') maxRadius: number = 0;
+
+  /** @deprecated */
+  @Input('md-ripple-max-radius')
+  get _maxRadiusDeprecated() { return this.maxRadius; }
+  set _maxRadiusDeprecated(value: number) { this.maxRadius = value; };
+
   /**
    * If set, the normal duration of ripple animations is divided by this value. For example,
    * setting it to 0.5 will cause the animations to take twice as long.
    */
-  @Input('md-ripple-speed-factor') speedFactor: number = 1;
+  @Input('mdRippleSpeedFactor') speedFactor: number = 1;
+
+  /** @deprecated */
+  @Input('md-ripple-speed-factor')
+  get _speedFactorDeprecated() { return this.speedFactor; }
+  set _speedFactorDeprecated(value: number) { this.speedFactor = value; };
+
   /** Custom color for ripples. */
-  @Input('md-ripple-color') color: string;
+  @Input('mdRippleColor') color: string;
+
+  /** @deprecated */
+  @Input('md-ripple-color')
+  get _colorDeprecated() { return this.color; }
+  set _colorDeprecated(value: string) { this.color = value; };
+
   /** Custom color for the ripple background. */
-  @Input('md-ripple-background-color') backgroundColor: string;
+  @Input('mdRippleBackgroundColor') backgroundColor: string;
+
+  /** @deprecated */
+  @Input('md-ripple-background-color')
+  get _backgroundColorDeprecated() { return this.backgroundColor; }
+  set _backgroundColorDeprecated(value: string) { this.backgroundColor = value; };
 
   /** Whether the ripple background will be highlighted to indicated a focused state. */
-  @HostBinding('class.md-ripple-focused') @Input('md-ripple-focused') focused: boolean;
+  @HostBinding('class.md-ripple-focused') @Input('mdRippleFocused') focused: boolean;
+
+  /** @deprecated */
+  @Input('md-ripple-focused')
+  get _focusedDeprecated(): boolean { return this.focused; }
+  set _focusedDeprecated(value: boolean) { this.focused = value; };
+
   /** Whether foreground ripples should be visible outside the component's bounds. */
-  @HostBinding('class.md-ripple-unbounded') @Input('md-ripple-unbounded') unbounded: boolean;
+  @HostBinding('class.md-ripple-unbounded') @Input('mdRippleUnbounded') unbounded: boolean;
+
+  /** @deprecated */
+  @Input('md-ripple-unbounded')
+  get _unboundedDeprecated(): boolean { return this.unbounded; }
+  set _unboundedDeprecated(value: boolean) { this.unbounded = value; };
 
   private _rippleRenderer: RippleRenderer;
   _ruler: ViewportRuler;

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -66,22 +66,12 @@ export class MdGridList implements OnInit, AfterContentChecked {
       @Optional() private _dir: Dir) {}
 
   @Input()
-  get cols() {
-    return this._cols;
-  }
+  get cols() { return this._cols; }
+  set cols(value: any) { this._cols = coerceToNumber(value); }
 
-  set cols(value: any) {
-    this._cols = coerceToNumber(value);
-  }
-
-  @Input('gutterSize')
-  get gutterSize() {
-    return this._gutter;
-  }
-
-  set gutterSize(value: any) {
-    this._gutter = coerceToString(value);
-  }
+  @Input()
+  get gutterSize() { return this._gutter; }
+  set gutterSize(value: any) { this._gutter = coerceToString(value); }
 
   /** Set internal representation of row height from the user-provided value. */
   @Input()

--- a/src/lib/menu/README.md
+++ b/src/lib/menu/README.md
@@ -1,6 +1,6 @@
 # md-menu
 
-`md-menu` is a list of options that displays when triggered.  You can read more about menus in the 
+`md-menu` is a list of options that displays when triggered.  You can read more about menus in the
 [Material Design spec](https://material.google.com/components/menus.html).
 
 ### Not yet implemented
@@ -13,8 +13,8 @@
 
 ### Simple menu
 
-In your template, create an `md-menu` element. You can use either `<button>` or `<anchor>` tags for 
-your menu items, as long as each is tagged with an `md-menu-item` attribute. Note that you can 
+In your template, create an `md-menu` element. You can use either `<button>` or `<anchor>` tags for
+your menu items, as long as each is tagged with an `md-menu-item` attribute. Note that you can
 disable items by adding the `disabled` boolean attribute or binding to it.
 
 *my-comp.html*
@@ -28,15 +28,15 @@ disable items by adding the `disabled` boolean attribute or binding to it.
 </md-menu>
 ```
 
-Menus are hidden by default, so you'll want to connect up a menu trigger that can open your menu.  
-You can do so by adding a button tag with an `md-menu-trigger-for` attribute and passing in the menu 
-instance.  You can create a local reference to your menu instance by adding `#menu="mdMenu"` to  
+Menus are hidden by default, so you'll want to connect up a menu trigger that can open your menu.
+You can do so by adding a button tag with an `mdMenuTriggerFor` attribute and passing in the menu
+instance.  You can create a local reference to your menu instance by adding `#menu="mdMenu"` to
 your menu element.
 
 *my-comp.html*
 ```html
 <!-- menu opens when trigger button is clicked -->
-<button md-icon-button [md-menu-trigger-for]="menu">
+<button md-icon-button [mdMenuTriggerFor]="menu">
    <md-icon>more_vert</md-icon>
 </button>
 
@@ -55,10 +55,10 @@ Output:
 
 ### Toggling the menu programmatically
 
-You can also use the menu's API to open or close the menu programmatically from your class. Please 
-note that in this case, an `md-menu-trigger-for` attribute is still necessary to connect 
+You can also use the menu's API to open or close the menu programmatically from your class. Please
+note that in this case, an `mdMenuTriggerFor` attribute is still necessary to connect
 the menu to its trigger element in the DOM.
-  
+
 *my-comp.component.ts*
 ```ts
 class MyComp {
@@ -72,7 +72,7 @@ class MyComp {
 
 *my-comp.html*
 ```html
-<button md-icon-button [md-menu-trigger-for]="menu">
+<button md-icon-button [mdMenuTriggerFor]="menu">
    <md-icon>more_vert</md-icon>
 </button>
 
@@ -91,15 +91,15 @@ Menus also support displaying `md-icon` elements before the menu item text.
 *my-comp.html*
 ```html
 <md-menu #menu="mdMenu">
-  <button md-menu-item> 
+  <button md-menu-item>
     <md-icon> dialpad </md-icon>
     <span> Redial </span>
   </button>
-  <button md-menu-item disabled> 
+  <button md-menu-item disabled>
     <md-icon> voicemail </md-icon>
     <span> Check voicemail </span>
   </button>
-  <button md-menu-item> 
+  <button md-menu-item>
     <md-icon> notifications_off </md-icon>
     <span> Disable alerts </span>
   </button>
@@ -114,8 +114,8 @@ Output:
 
 ### Customizing menu position
 
-By default, the menu will display after and below its trigger.  You can change this display position 
-using the `x-position` (`before | after`) and `y-position` (`above | below`) attributes.  
+By default, the menu will display after and below its trigger.  You can change this display position
+using the `x-position` (`before | after`) and `y-position` (`above | below`) attributes.
 
 *my-comp.html*
 ```html
@@ -134,7 +134,7 @@ Output:
 
 ### Accessibility
 
-The menu adds `role="menu"` to the main menu element and `role="menuitem"` to each menu item. It 
+The menu adds `role="menu"` to the main menu element and `role="menuitem"` to each menu item. It
 also adds `aria-hasPopup="true"` to the trigger element.
 
 #### Keyboard events:
@@ -146,18 +146,18 @@ also adds `aria-hasPopup="true"` to the trigger element.
 
 | Signature | Values | Description |
 | --- | --- | --- |
-| `x-position` | `before | after` | The horizontal position of the menu in relation to the trigger. Defaults to `after`. | 
+| `x-position` | `before | after` | The horizontal position of the menu in relation to the trigger. Defaults to `after`. |
 | `y-position` | `above | below` | The vertical position of the menu in relation to the trigger. Defaults to `below`. |
- 
+
 ### Trigger Programmatic API
 
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `menuOpen` | `Boolean` | Property that is true when the menu is open. It is not settable (use methods below). | 
-| `onMenuOpen` | `Observable<void>` | Observable that emits when the menu opens. | 
-| `onMenuClose` | `Observable<void>` | Observable that emits when the menu closes. | 
+| `menuOpen` | `Boolean` | Property that is true when the menu is open. It is not settable (use methods below). |
+| `onMenuOpen` | `Observable<void>` | Observable that emits when the menu opens. |
+| `onMenuClose` | `Observable<void>` | Observable that emits when the menu closes. |
 
 **Methods**
 
@@ -165,7 +165,7 @@ also adds `aria-hasPopup="true"` to the trigger element.
 | --- | --- | --- |
 | `openMenu()` | `Promise<void>` | Opens the menu. Returns a promise that will resolve when the menu has opened. |
 | `closeMenu()` | `Promise<void>` | Closes the menu. Returns a promise that will resolve when the menu has closed. |
-| `toggleMenu()` | `Promise<void>` | Toggles the menu. Returns a promise that will resolve when the menu has completed opening or closing. |  
-| `destroyMenu()` | `Promise<void>` | Destroys the menu overlay completely. 
-  
+| `toggleMenu()` | `Promise<void>` | Toggles the menu. Returns a promise that will resolve when the menu has completed opening or closing. |
+| `destroyMenu()` | `Promise<void>` | Destroys the menu overlay completely.
+
 

--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -10,7 +10,7 @@ export class MdMenuMissingError extends MdError {
 
     Example:
       <md-menu #menu="mdMenu"></md-menu>
-      <button [md-menu-trigger-for]="menu"></button>
+      <button [mdMenuTriggerFor]="menu"></button>
     `);
   }
 }

--- a/src/lib/menu/menu-item.html
+++ b/src/lib/menu/menu-item.html
@@ -1,4 +1,4 @@
 <ng-content></ng-content>
-<div class="md-menu-ripple" *ngIf="!disabled" md-ripple md-ripple-background-color="rgba(0,0,0,0)"
-     [md-ripple-trigger]="_getHostElement()">
+<div class="md-menu-ripple" *ngIf="!disabled" md-ripple mdRippleBackgroundColor="rgba(0,0,0,0)"
+     [mdRippleTrigger]="_getHostElement()">
 </div>

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -51,6 +51,11 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   // the first item of the list when the menu is opened via the keyboard
   private _openedByMouse: boolean = false;
 
+  /** @deprecated */
+  @Input('md-menu-trigger-for')
+  get _deprecatedMenuTriggerFor(): MdMenuPanel { return this.menu; }
+  set _deprecatedMenuTriggerFor(v: MdMenuPanel) { this.menu = v; }
+
   @Input('mdMenuTriggerFor') menu: MdMenuPanel;
   @Output() onMenuOpen = new EventEmitter<void>();
   @Output() onMenuClose = new EventEmitter<void>();

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -32,7 +32,7 @@ import {MenuPositionX, MenuPositionY} from './menu-positions';
  * responsible for toggling the display of the provided menu instance.
  */
 @Directive({
-  selector: '[md-menu-trigger-for], [mat-menu-trigger-for]',
+  selector: '[md-menu-trigger-for], [mat-menu-trigger-for], [mdMenuTriggerFor]',
   host: {
     'aria-haspopup': 'true',
     '(mousedown)': '_handleMousedown($event)',
@@ -51,7 +51,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   // the first item of the list when the menu is opened via the keyboard
   private _openedByMouse: boolean = false;
 
-  @Input('md-menu-trigger-for') menu: MdMenuPanel;
+  @Input('mdMenuTriggerFor') menu: MdMenuPanel;
   @Output() onMenuOpen = new EventEmitter<void>();
   @Output() onMenuClose = new EventEmitter<void>();
 
@@ -157,7 +157,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
 
   /**
    *  This method checks that a valid instance of MdMenu has been passed into
-   *  md-menu-trigger-for.  If not, an exception is thrown.
+   *  mdMenuTriggerFor. If not, an exception is thrown.
    */
   private _checkMenu() {
     if (!this.menu) {

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -284,7 +284,7 @@ describe('MdMenu', () => {
 
 @Component({
   template: `
-    <button [md-menu-trigger-for]="menu" #triggerEl>Toggle menu</button>
+    <button [mdMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
     <md-menu #menu="mdMenu">
       <button md-menu-item> Item </button>
       <button md-menu-item disabled> Disabled </button>
@@ -298,7 +298,7 @@ class SimpleMenu {
 
 @Component({
   template: `
-    <button [md-menu-trigger-for]="menu" #triggerEl>Toggle menu</button>
+    <button [mdMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
     <md-menu x-position="before" y-position="above" #menu="mdMenu">
       <button md-menu-item> Positioned Content </button>
     </md-menu>
@@ -332,7 +332,7 @@ class CustomMenuPanel implements MdMenuPanel {
 
 @Component({
   template: `
-    <button [md-menu-trigger-for]="menu">Toggle menu</button>
+    <button [mdMenuTriggerFor]="menu">Toggle menu</button>
     <custom-menu #menu="mdCustomMenu">
       <button md-menu-item> Custom Content </button>
     </custom-menu>

--- a/src/lib/radio/radio.html
+++ b/src/lib/radio/radio.html
@@ -6,10 +6,10 @@
     <div class="md-radio-outer-circle"></div>
     <div class="md-radio-inner-circle"></div>
     <div md-ripple *ngIf="!_isRippleDisabled()" class="md-radio-ripple"
-         [md-ripple-trigger]="_getHostElement()"
-         [md-ripple-centered]="true"
-         [md-ripple-speed-factor]="0.3"
-         md-ripple-background-color="rgba(0, 0, 0, 0)"></div>
+         [mdRippleTrigger]="_getHostElement()"
+         [mdRippleCentered]="true"
+         [mdRippleSpeedFactor]="0.3"
+         mdRippleBackgroundColor="rgba(0, 0, 0, 0)"></div>
   </div>
 
   <input #input class="md-radio-input md-visually-hidden" type="radio"

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -249,7 +249,7 @@ describe('MdRadio', () => {
       expect(rippleElement).toBeFalsy('Expected a disabled radio button not to have a ripple');
     });
 
-    it('should remove ripple if md-ripple-disabled input is set', async(() => {
+    it('should remove ripple if mdRippleDisabled input is set', async(() => {
       fixture.detectChanges();
       for (let radioNativeElement of radioNativeElements)
       {

--- a/src/lib/select/option.html
+++ b/src/lib/select/option.html
@@ -1,3 +1,3 @@
 <ng-content></ng-content>
-<div class="md-option-ripple" *ngIf="!disabled" md-ripple md-ripple-background-color="rgba(0,0,0,0)"
-     [md-ripple-trigger]="_getHostElement()"></div>
+<div class="md-option-ripple" *ngIf="!disabled" md-ripple mdRippleBackgroundColor="rgba(0,0,0,0)"
+     [mdRippleTrigger]="_getHostElement()"></div>

--- a/src/lib/slider/README.md
+++ b/src/lib/slider/README.md
@@ -43,40 +43,40 @@ value on bottom.
 ### Adding a thumb label
 
 By default the exact selected value of a slider is not visible to the user. However, this value can
-be added to the thumb by adding the `thumb-label` attribute.
+be added to the thumb by adding the `thumbLabel` attribute.
 
 The [material design spec](https://material.google.com/components/sliders.html) recommends using the
-`thumb-label` attribute (along with `tick-interval="1"`) only for sliders that are used to display a
+`thumbLabel` attribute (along with `tickInterval="1"`) only for sliders that are used to display a
 discrete value (such as a 1-5 rating).
 
 ```html
-<md-slider thumb-label tick-interval="1"></md-slider>
+<md-slider thumbLabel tickInterval="1"></md-slider>
 ```
 
 ### Adding ticks
 
 By default a sliders do not show tick marks along the thumb track. They can be enabled using the
-`tick-interval` attribute. The value of `tick-interval` should be a number representing the number
-of steps between between ticks. For example a `tick-interval` of `3` with a `step` of `4` will draw
+`tickInterval` attribute. The value of `tickInterval` should be a number representing the number
+of steps between between ticks. For example a `tickInterval` of `3` with a `step` of `4` will draw
 tick marks at every `3` steps, which is the same as every `12` values.
 
 ```html
-<md-slider step="4" tick-interval="3"></md-slider>
+<md-slider step="4" tickInterval="3"></md-slider>
 ```
 
-The `tick-interval` can also be set to `auto` which will automatically choose the number of steps
+The `tickInterval` can also be set to `auto` which will automatically choose the number of steps
 such that there is at least `30px` of space between ticks.
 
 ```html
-<md-slider tick-interval="auto"></md-slider>
+<md-slider tickInterval="auto"></md-slider>
 ```
- 
+
 The slider will always show a tick at the beginning and end of the track. If the remaining space
 doesn't add up perfectly the last interval will be shortened or lengthened so that the tick can be
 shown at the end of the track.
 
 The [material design spec](https://material.google.com/components/sliders.html) recommends using the
-`tick-interval` attribute (set to `1` along with the `thumb-label` attribute) only for sliders that
+`tickInterval` attribute (set to `1` along with the `thumbLabel` attribute) only for sliders that
 are used to display a discrete value (such as a 1-5 rating).
 
 ### Disabling the slider
@@ -91,7 +91,7 @@ value.
 ### Value binding
 
 `md-slider` supports both 1-way binding and 2-way binding via `ngModel`. It also emits a `change`
-event when the value changes due to user interaction. 
+event when the value changes due to user interaction.
 
 ```html
 <md-slider [value]="myValue" (change)="onChange()"></md-slider>
@@ -132,7 +132,7 @@ right-to-left languages.
 | `max` | number | Optional, the maximum number for the slider. Default = `100`. |
 | `step` | number | Optional, declares where the thumb will snap to. Default = `1`. |
 | `value` | number | Optional, the value to start the slider at. |
-| `tick-interval` | `"auto"` \| number | Optional, how many steps between tick marks. |
+| `tickInterval` | `"auto"` \| number | Optional, how many steps between tick marks. |
 | `invert` | boolean | Optional, whether to invert the axis the thumb moves along. |
 | `vertical` | boolean | Optional, whether the slider should be oriented vertically. |
 | `disabled` | boolean | Optional, whether or not the slider is disabled. Default = `false`. |

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -1041,7 +1041,7 @@ class StandardSlider { }
 class DisabledSlider { }
 
 @Component({
-  template: `<md-slider [min]="min" [max]="max" tick-interval="6"></md-slider>`,
+  template: `<md-slider [min]="min" [max]="max" tickInterval="6"></md-slider>`,
   styles: [styles],
 })
 class SliderWithMinAndMax {
@@ -1062,19 +1062,19 @@ class SliderWithValue { }
 class SliderWithStep { }
 
 @Component({
-  template: `<md-slider step="5" tick-interval="auto"></md-slider>`,
+  template: `<md-slider step="5" tickInterval="auto"></md-slider>`,
   styles: [styles],
 })
 class SliderWithAutoTickInterval { }
 
 @Component({
-  template: `<md-slider step="3" tick-interval="6"></md-slider>`,
+  template: `<md-slider step="3" tickInterval="6"></md-slider>`,
   styles: [styles],
 })
 class SliderWithSetTickInterval { }
 
 @Component({
-  template: `<md-slider thumb-label></md-slider>`,
+  template: `<md-slider thumbLabel></md-slider>`,
   styles: [styles],
 })
 class SliderWithThumbLabel { }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -103,9 +103,14 @@ export class MdSlider implements ControlValueAccessor {
   /** Whether or not to show the thumb label. */
   private _thumbLabel: boolean = false;
 
-  @Input('thumb-label')
+  @Input('thumbLabel')
   get thumbLabel(): boolean { return this._thumbLabel; }
   set thumbLabel(value) { this._thumbLabel = coerceBooleanProperty(value); }
+
+  /** @deprecated */
+  @Input('thumb-label')
+  get _thumbLabelDeprecated(): boolean { return this._thumbLabel; }
+  set _thumbLabelDeprecated(value) { this._thumbLabel = value; }
 
   private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
@@ -140,11 +145,16 @@ export class MdSlider implements ControlValueAccessor {
    */
   private _tickInterval: 'auto' | number = 0;
 
-  @Input('tick-interval')
+  @Input()
   get tickInterval() { return this._tickInterval; }
   set tickInterval(v) {
     this._tickInterval = (v == 'auto') ? v : coerceNumberProperty(v, <number>this._tickInterval);
   }
+
+  /** @deprecated */
+  @Input('tick-interval')
+  get _tickIntervalDeprecated() { return this.tickInterval; }
+  set _tickIntervalDeprecated(v) { this.tickInterval = v; }
 
   /** The size of a tick interval as a percentage of the size of the track. */
   private _tickIntervalPercent: number = 0;

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -38,6 +38,7 @@ md-tab-body {
   @include md-fill;
   display: block;
   overflow: hidden;
+
   &.md-tab-body-active {
     position: relative;
     overflow-x: hidden;
@@ -45,10 +46,9 @@ md-tab-body {
     z-index: 1;
     flex-grow: 1;
   }
-  :host[mdDynamicHeight], :host[md-dynamic-height] {
-    &.md-tab-body-active {
-      overflow-y: hidden;
-    }
+
+  :host.md-tab-group-dynamic-height &.md-tab-body-active {
+    overflow-y: hidden;
   }
 }
 

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -25,7 +25,7 @@
   flex-grow: 1;
 }
 
-// The bottom section of the view; contains the tab bodies 
+// The bottom section of the view; contains the tab bodies
 .md-tab-body-wrapper {
   position: relative;
   overflow: hidden;
@@ -33,7 +33,7 @@
   transition: height $md-tab-animation-duration $ease-in-out-curve-function;
 }
 
-// Wraps each tab body 
+// Wraps each tab body
 md-tab-body {
   @include md-fill;
   display: block;
@@ -45,8 +45,10 @@ md-tab-body {
     z-index: 1;
     flex-grow: 1;
   }
-  :host[md-dynamic-height] &.md-tab-body-active {
-    overflow-y: hidden;
+  :host[mdDynamicHeight], :host[md-dynamic-height] {
+    &.md-tab-body-active {
+      overflow-y: hidden;
+    }
   }
 }
 

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -65,9 +65,14 @@ export class MdTabGroup {
 
   /** Whether the tab group should grow to the size of the active tab */
   private _dynamicHeight: boolean = false;
-  @Input('md-dynamic-height') set dynamicHeight(value: boolean) {
+  @Input('mdDynamicHeight') set dynamicHeight(value: boolean) {
     this._dynamicHeight = coerceBooleanProperty(value);
   }
+
+  /** @deprecated */
+  @Input('md-dynamic-height')
+  get _dynamicHeightDeprecated(): boolean { return this._dynamicHeight; }
+  set _dynamicHeightDeprecated(value: boolean) { this._dynamicHeight = value; }
 
   /** The index of the active tab. */
   private _selectedIndex: number = null;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -48,9 +48,7 @@ export class MdTabChangeEvent {
   selector: 'md-tab-group',
   templateUrl: 'tab-group.html',
   styleUrls: ['tab-group.css'],
-  host: {
-    '[class.md-tab-group-dynamic-height]': '_dynamicHeight'
-  }
+  host: { '[class.md-tab-group-dynamic-height]': 'dynamicHeight' }
 })
 export class MdTabGroup {
   @ContentChildren(MdTab) _tabs: QueryList<MdTab>;
@@ -68,9 +66,9 @@ export class MdTabGroup {
 
   /** Whether the tab group should grow to the size of the active tab */
   private _dynamicHeight: boolean = false;
-  @Input() set dynamicHeight(value: boolean) {
-    this._dynamicHeight = coerceBooleanProperty(value);
-  }
+  @Input()
+  get dynamicHeight(): boolean { return this._dynamicHeight; }
+  set dynamicHeight(value: boolean) { this._dynamicHeight = coerceBooleanProperty(value); }
 
   /** @deprecated */
   @Input('md-dynamic-height')

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -48,6 +48,9 @@ export class MdTabChangeEvent {
   selector: 'md-tab-group',
   templateUrl: 'tab-group.html',
   styleUrls: ['tab-group.css'],
+  host: {
+    '[class.md-tab-group-dynamic-height]': '_dynamicHeight'
+  }
 })
 export class MdTabGroup {
   @ContentChildren(MdTab) _tabs: QueryList<MdTab>;
@@ -65,7 +68,7 @@ export class MdTabGroup {
 
   /** Whether the tab group should grow to the size of the active tab */
   private _dynamicHeight: boolean = false;
-  @Input('mdDynamicHeight') set dynamicHeight(value: boolean) {
+  @Input() set dynamicHeight(value: boolean) {
     this._dynamicHeight = coerceBooleanProperty(value);
   }
 

--- a/src/lib/tabs/tab-header.html
+++ b/src/lib/tabs/tab-header.html
@@ -1,6 +1,6 @@
 <div class="md-tab-header-pagination md-tab-header-pagination-before md-elevation-z4"
      aria-hidden="true"
-     md-ripple [md-ripple-disabled]="_disableScrollBefore"
+     md-ripple [mdRippleDisabled]="_disableScrollBefore"
      [class.md-tab-header-pagination-disabled]="_disableScrollBefore"
      (click)="_scrollHeader('before')">
   <div class="md-tab-header-pagination-chevron"></div>
@@ -16,7 +16,7 @@
 
 <div class="md-tab-header-pagination md-tab-header-pagination-after md-elevation-z4"
      aria-hidden="true"
-     md-ripple [md-ripple-disabled]="_disableScrollAfter"
+     md-ripple [mdRippleDisabled]="_disableScrollAfter"
      [class.md-tab-header-pagination-disabled]="_disableScrollAfter"
      (click)="_scrollHeader('after')">
   <div class="md-tab-header-pagination-chevron"></div>

--- a/src/lib/tooltip/README.md
+++ b/src/lib/tooltip/README.md
@@ -6,18 +6,18 @@ The positions `before` and `after` should be used instead of `left` and `right` 
 ### Examples
 A button with a tooltip
 ```html
-<button md-tooltip="some message" tooltipPosition="below">Button</button>
+<button mdTooltip="some message" mdTooltipPosition="below">Button</button>
 ```
 
 
 
-## `[md-tooltip]`
+## `[mdTooltip]`
 ### Properties
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `md-tooltip` | `string` | The message to be displayed. |
-| `tooltipPosition` | `"before"|"after"|"above"|"below"|"left"|"right"` | The position of the tooltip. |
+| `mdTooltip` | `string` | The message to be displayed. |
+| `mdTooltipPosition` | `"before"|"after"|"above"|"below"|"left"|"right"` | The position of the tooltip. |
 
 ### Methods
 

--- a/src/lib/tooltip/README.md
+++ b/src/lib/tooltip/README.md
@@ -6,7 +6,7 @@ The positions `before` and `after` should be used instead of `left` and `right` 
 ### Examples
 A button with a tooltip
 ```html
-<button md-tooltip="some message" tooltip-position="below">Button</button>
+<button md-tooltip="some message" tooltipPosition="below">Button</button>
 ```
 
 
@@ -17,7 +17,7 @@ A button with a tooltip
 | Name | Type | Description |
 | --- | --- | --- |
 | `md-tooltip` | `string` | The message to be displayed. |
-| `tooltip-position` | `"before"|"after"|"above"|"below"|"left"|"right"` | The position of the tooltip. |
+| `tooltipPosition` | `"before"|"after"|"above"|"below"|"left"|"right"` | The position of the tooltip. |
 
 ### Methods
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -303,7 +303,7 @@ describe('MdTooltip', () => {
   template: `
     <button *ngIf="showButton"
             [md-tooltip]="message"
-            [tooltip-position]="position">
+            [tooltipPosition]="position">
       Button
     </button>`
 })

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -302,8 +302,8 @@ describe('MdTooltip', () => {
   selector: 'app',
   template: `
     <button *ngIf="showButton"
-            [md-tooltip]="message"
-            [tooltipPosition]="position">
+            [mdTooltip]="message"
+            [mdTooltipPosition]="position">
       Button
     </button>`
 })

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -97,6 +97,11 @@ export class MdTooltip {
     }
   }
 
+  /** @deprecated */
+  @Input('md-tooltip')
+  get _deprecatedMessage(): string { return this.message; }
+  set _deprecatedMessage(v: string) { this.message = v; }
+
   constructor(private _overlay: Overlay, private _elementRef: ElementRef,
               private _viewContainerRef: ViewContainerRef, private _ngZone: NgZone,
               @Optional() private _dir: Dir) {}

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -43,7 +43,7 @@ export const TOUCHEND_HIDE_DELAY  = 1500;
  * https://material.google.com/components/tooltips.html
  */
 @Directive({
-  selector: '[md-tooltip], [mat-tooltip]',
+  selector: '[md-tooltip], [mat-tooltip], [mdTooltip]',
   host: {
     '(longpress)': 'show()',
     '(touchend)': 'hide(' + TOUCHEND_HIDE_DELAY + ')',
@@ -58,7 +58,7 @@ export class MdTooltip {
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   private _position: TooltipPosition = 'below';
-  @Input('tooltipPosition') get position(): TooltipPosition {
+  @Input('mdTooltipPosition') get position(): TooltipPosition {
     return this._position;
   }
 
@@ -80,14 +80,14 @@ export class MdTooltip {
   }
 
   /** The default delay in ms before showing the tooltip after show is called */
-  @Input('tooltipShowDelay') showDelay = 0;
+  @Input('mdTooltipShowDelay') showDelay = 0;
 
   /** The default delay in ms before hiding the tooltip after hide is called */
-  @Input('tooltipHideDelay') hideDelay = 0;
+  @Input('mdTooltipHideDelay') hideDelay = 0;
 
   /** The message to be displayed in the tooltip */
   private _message: string;
-  @Input('md-tooltip') get message() {
+  @Input('mdTooltip') get message() {
     return this._message;
   }
   set message(value: string) {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -58,9 +58,14 @@ export class MdTooltip {
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   private _position: TooltipPosition = 'below';
-  @Input('tooltip-position') get position(): TooltipPosition {
+  @Input('tooltipPosition') get position(): TooltipPosition {
     return this._position;
   }
+
+  /** @deprecated */
+  @Input('tooltip-position')
+  get _positionDeprecated(): TooltipPosition { return this._position; }
+  set _positionDeprecated(value: TooltipPosition) { this._position = value; }
 
   set position(value: TooltipPosition) {
     if (value !== this._position) {


### PR DESCRIPTION
Converts any dash-cased `@Input` properties into camelCase and adds a deprecated proxy property with the old naming. The following properties have been renamed:

* `md-ripple-trigger`
* `md-ripple-centered`
* `md-ripple-disabled`
* `md-ripple-max-radius`
* `md-ripple-speed-factor`
* `md-ripple-color`
* `md-ripple-background-color`
* `md-ripple-focused`
* `md-ripple-unbounded`
* `thumb-label`
* `tick-interval`
* `md-dynamic-height`
* `tooltip-position`

The following properties were skipped:
* `md-menu-trigger-for` - Is currently used also as a selector for the menu trigger.
* Any properties that have a native equivalent (e.g. `aria-label`, `aria-labeledby`).