### PR TITLE
docs(typo): correct misspelling in comment

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -40,7 +40,7 @@ export class MdTextareaAutosize implements OnInit {
   }
 
   /**
-   * Cache the hight of a single-row textarea.
+   * Cache the height of a single-row textarea.
    *
    * We need to know how large a single "row" of a textarea is in order to apply minRows and
    * maxRows. For the initial version, we will assume that the height of a single line in the


### PR DESCRIPTION
correct the misspelling of height in comment