### PR TITLE
chore: publish artifacts to organization repository

### DIFF
--- a/scripts/release/publish-build-artifacts.sh
+++ b/scripts/release/publish-build-artifacts.sh
@@ -16,8 +16,8 @@ commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 
-repoName="material-builds"
-repoUrl="http://github.com/DevVersion/material-builds.git"
+repoName="material2-builds"
+repoUrl="https://github.com/angular/material2-builds.git"
 repoDir="tmp/$repoName"
 
 # Create a release of the current repository.


### PR DESCRIPTION
* Currently we are publishing to `DevVersion/material-builds` for testing purposes and everything seems to work as expected.
* Switching the repository to the `material2-builds` repository on the Angular organization
