### PR TITLE
chore(slide-toggle): add initial documentation of properties

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -14,7 +14,7 @@
     </div>
 
     <input #input class="md-slide-toggle-input cdk-visually-hidden" type="checkbox"
-           [id]="getInputId()"
+           [id]="inputId"
            [required]="required"
            [tabIndex]="tabIndex"
            [checked]="checked"

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -72,25 +72,37 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   // Needs to be public to support AOT compilation (as host binding).
   _hasFocus: boolean = false;
 
+  /** Name value will be applied to the input element if present */
   @Input() name: string = null;
+
+  /** A unique id for the slide-toggle input. If none is supplied, it will be auto-generated. */
   @Input() id: string = this._uniqueId;
+
+  /** Used to specify the tabIndex value for the underlying input element. */
   @Input() tabIndex: number = 0;
+
+  /** Used to set the aria-label attribute on the underlying input element. */
   @Input() ariaLabel: string = null;
+
+  /** Used to set the aria-labelledby attribute on the underlying input element. */
   @Input() ariaLabelledby: string = null;
 
+  /** Whether the slide-toggle is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
   set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
+  /** Whether the slide-toggle is required. */
   @Input()
   get required(): boolean { return this._required; }
   set required(value) { this._required = coerceBooleanProperty(value); }
 
   private _change: EventEmitter<MdSlideToggleChange> = new EventEmitter<MdSlideToggleChange>();
+  /** An event will be dispatched each time the slide-toggle changes its value. */
   @Output() change: Observable<MdSlideToggleChange> = this._change.asObservable();
 
-  // Returns the unique id for the visual hidden input.
-  getInputId = () => `${this.id || this._uniqueId}-input`;
+  /** Returns the unique id for the visual hidden input. */
+  get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
   @ViewChild('input') _inputElement: ElementRef;
 
@@ -177,11 +189,13 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     this.disabled = isDisabled;
   }
 
+  /** Focuses the slide-toggle. */
   focus() {
     this._renderer.invokeElementMethod(this._inputElement.nativeElement, 'focus');
     this._onInputFocus();
   }
 
+  /** Whether the slide-toggle is checked. */
   @Input()
   get checked() {
     return !!this._checked;
@@ -194,6 +208,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
+  /** The color of the slide-toggle. Can be primary, accent, or warn. */
   @Input()
   get color(): string {
     return this._color;
@@ -203,6 +218,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     this._updateColor(value);
   }
 
+  /** Toggles the checked state of the slide-toggle. */
   toggle() {
     this.checked = !this.checked;
   }


### PR DESCRIPTION
* Adds a basic documentation of the public properties like in the checkbox component.

**Note**: Still documenting `tabIndex` (regardless of being filtered), because this would allow us in the future to easily remove the filtering and just have it documented. Also just for consistency.

@jelbourn The documentation might be sometimes very bare, but for now it should be good (most of the stuff is similar in the `md-checkbox`)