### PR TITLE
chore(pre-push): added pre-push hook to prevent lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "deploy": "firebase deploy",
     "webdriver-manager": "webdriver-manager",
     "docs": "gulp docs",
-    "api": "gulp api"
+    "api": "gulp api",
+    "prepush": "npm run tslint"
   },
   "version": "2.0.0-alpha.11-2",
   "license": "MIT",
@@ -71,6 +72,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-transform": "^1.1.0",
     "gulp-typescript": "^2.13.6",
+    "husky": "^0.12.0",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.1",
     "karma-browserstack-launcher": "^1.0.1",


### PR DESCRIPTION
Hooks the pre-push in git and runs `lint`, this would prevent ci failures