### PR TITLE
chore: update stylelint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "run-sequence": "^1.2.2",
     "sass": "^0.5.0",
     "strip-ansi": "^3.0.0",
-    "stylelint": "^7.5.0",
+    "stylelint": "^7.7.0",
     "symlink-or-copy": "^1.0.1",
     "travis-after-modes": "0.0.6-2",
     "ts-node": "^0.7.3",


### PR DESCRIPTION
Update the version of `stylelint` to remove `Can not parse selector` messages.

Previously discussed in #2037.