### PR TITLE
feat: make hammerjs optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
     "@angular/platform-browser-dynamic": "^2.2.0",
     "@angular/router": "^3.2.0",
     "core-js": "^2.4.1",
-    "hammerjs": "^2.0.8",
     "rxjs": "5.0.0-beta.12",
     "systemjs": "0.19.38",
     "zone.js": "^0.6.23"
+  },
+  "optionalDependencies": {
+    "hammerjs": "^2.0.8"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^2.2.0",

--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -21,10 +21,7 @@
       "@angular/material": [
         "../../dist/@angular/material"
       ]
-    },
-    "types": [
-      "hammerjs"
-    ]
+    }
   },
   "angularCompilerOptions": {
     "genDir": "../../dist",

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -22,10 +22,7 @@
       "@angular/material": [
         "../../dist/@angular/material"
       ]
-    },
-    "types": [
-      "hammerjs"
-    ]
+    }
   },
   "angularCompilerOptions": {
     "genDir": "../../dist",

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -49,7 +49,7 @@ export * from './overlay/position/connected-position-strategy';
 export * from './overlay/position/connected-position';
 
 // Gestures
-export {GestureConfig} from './gestures/gesture-config';
+export {GestureConfig, MdHammerEvent} from './gestures/gesture-config';
 
 // Ripple
 export {MdRipple, MdRippleModule} from './ripple/ripple';

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -49,7 +49,7 @@ export * from './overlay/position/connected-position-strategy';
 export * from './overlay/position/connected-position';
 
 // Gestures
-export {GestureConfig, MdHammerEvent} from './gestures/gesture-config';
+export {GestureConfig, HammerEvent} from './gestures/gesture-config';
 
 // Ripple
 export {MdRipple, MdRippleModule} from './ripple/ripple';

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -49,7 +49,8 @@ export * from './overlay/position/connected-position-strategy';
 export * from './overlay/position/connected-position';
 
 // Gestures
-export {GestureConfig, HammerEvent} from './gestures/gesture-config';
+export {GestureConfig} from './gestures/gesture-config';
+export * from './gestures/gesture-annotations';
 
 // Ripple
 export {MdRipple, MdRippleModule} from './ripple/ripple';

--- a/src/lib/core/gestures/gesture-annotations.ts
+++ b/src/lib/core/gestures/gesture-annotations.ts
@@ -1,0 +1,48 @@
+/**
+ * Stripped-down HammerJS annotations to be used within Material, which are necessary,
+ * because HammerJS is an optional dependency. For the full annotations see:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/hammerjs
+ */
+
+/** @docs-private */
+export interface HammerInput {
+  preventDefault: () => {};
+  deltaX: number;
+  deltaY: number;
+  center: { x: number; y: number; };
+}
+
+/** @docs-private */
+export interface HammerStatic {
+  new(element: HTMLElement | SVGElement, options?: any): HammerManager;
+
+  Pan: Recognizer;
+  Swipe: Recognizer;
+  Press: Recognizer;
+}
+
+/** @docs-private */
+export interface Recognizer {
+  new(options?: any): Recognizer;
+  recognizeWith(otherRecognizer: Recognizer | string): Recognizer;
+}
+
+/** @docs-private */
+export interface RecognizerStatic {
+  new(options?: any): Recognizer;
+}
+
+/** @docs-private */
+export interface HammerInstance {
+  on(eventName: string, callback: Function): void;
+  off(eventName: string, callback: Function): void;
+}
+
+/** @docs-private */
+export interface HammerManager {
+  add(recogniser: Recognizer | Recognizer[]): Recognizer;
+  set(options: any): HammerManager;
+  emit(event: string, data: any): void;
+  off(events: string, handler?: Function): void;
+  on(events: string, handler: Function): void;
+}

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -1,10 +1,11 @@
 import {Injectable, isDevMode} from '@angular/core';
 import {HammerGestureConfig} from '@angular/platform-browser';
+import {HammerStatic, HammerInstance, Recognizer, RecognizerStatic} from './gesture-annotations';
 
 /* Adjusts configuration of our gesture library, Hammer. */
 @Injectable()
 export class GestureConfig extends HammerGestureConfig {
-  private _hammer = typeof window !== 'undefined' ? (window as any).Hammer : null;
+  private _hammer: HammerStatic = typeof window !== 'undefined' ? (window as any).Hammer : null;
 
   /* List of new event names to add to the gesture support list */
   events: string[] = this._hammer ? [
@@ -20,7 +21,10 @@ export class GestureConfig extends HammerGestureConfig {
     super();
 
     if (!this._hammer && isDevMode()) {
-      console.warn('Could not find HammerJS. Certain Angular Material may not work correctly.');
+      console.warn(
+        'Could not find HammerJS. Certain Angular Material ' +
+        'components may not work correctly.'
+      );
     }
   }
 
@@ -37,7 +41,7 @@ export class GestureConfig extends HammerGestureConfig {
    * TODO: Confirm threshold numbers with Material Design UX Team
    * */
   buildHammer(element: HTMLElement) {
-    const mc: any = super.buildHammer(element);
+    const mc = new this._hammer(element);
 
     // Default Hammer Recognizers.
     let pan = new this._hammer.Pan();
@@ -55,12 +59,12 @@ export class GestureConfig extends HammerGestureConfig {
     // Add customized gestures to Hammer manager
     mc.add([swipe, press, pan, slide, longpress]);
 
-    return mc;
+    return mc as HammerInstance;
   }
 
   /** Creates a new recognizer, without affecting the default recognizers of HammerJS */
-  private _createRecognizer(base: any, options: any, ...inheritances: any[]) {
-    let recognizer = new base.constructor(options);
+  private _createRecognizer(base: Recognizer, options: any, ...inheritances: Recognizer[]) {
+    let recognizer = new (base.constructor as RecognizerStatic)(options);
 
     inheritances.push(base);
     inheritances.forEach(item => recognizer.recognizeWith(item));
@@ -68,19 +72,4 @@ export class GestureConfig extends HammerGestureConfig {
     return recognizer;
   }
 
-}
-
-/**
- * Stripped-down annotation to be used as alternative
- * to the one from HammerJS.
- * @docs-private
- */
-export interface HammerEvent {
-  preventDefault: () => {};
-  deltaX: number;
-  deltaY: number;
-  center: {
-    x: number;
-    y: number;
-  };
 }

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -75,7 +75,7 @@ export class GestureConfig extends HammerGestureConfig {
  * to the one from HammerJS.
  * @docs-private
  */
-export interface MdHammerEvent {
+export interface HammerEvent {
   preventDefault: () => {};
   deltaX: number;
   deltaY: number;

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -1,19 +1,28 @@
-import {Injectable} from '@angular/core';
+import {Injectable, isDevMode} from '@angular/core';
 import {HammerGestureConfig} from '@angular/platform-browser';
 
 /* Adjusts configuration of our gesture library, Hammer. */
 @Injectable()
 export class GestureConfig extends HammerGestureConfig {
+  private _hammer = typeof window !== 'undefined' ? (window as any).Hammer : null;
 
   /* List of new event names to add to the gesture support list */
-  events: string[] = [
+  events: string[] = this._hammer ? [
     'longpress',
     'slide',
     'slidestart',
     'slideend',
     'slideright',
     'slideleft'
-  ];
+  ] : [];
+
+  constructor() {
+    super();
+
+    if (!this._hammer && isDevMode()) {
+      console.warn('Could not find HammerJS. Certain Angular Material may not work correctly.');
+    }
+  }
 
   /*
    * Builds Hammer instance manually to add custom recognizers that match the Material Design spec.
@@ -28,12 +37,12 @@ export class GestureConfig extends HammerGestureConfig {
    * TODO: Confirm threshold numbers with Material Design UX Team
    * */
   buildHammer(element: HTMLElement) {
-    const mc = new Hammer(element);
+    const mc: any = super.buildHammer(element);
 
     // Default Hammer Recognizers.
-    let pan = new Hammer.Pan();
-    let swipe = new Hammer.Swipe();
-    let press = new Hammer.Press();
+    let pan = new this._hammer.Pan();
+    let swipe = new this._hammer.Swipe();
+    let press = new this._hammer.Press();
 
     // Notice that a HammerJS recognizer can only depend on one other recognizer once.
     // Otherwise the previous `recognizeWith` will be dropped.
@@ -50,8 +59,8 @@ export class GestureConfig extends HammerGestureConfig {
   }
 
   /** Creates a new recognizer, without affecting the default recognizers of HammerJS */
-  private _createRecognizer(base: Recognizer, options: any, ...inheritances: Recognizer[]) {
-    let recognizer = new (<RecognizerStatic> base.constructor)(options);
+  private _createRecognizer(base: any, options: any, ...inheritances: any[]) {
+    let recognizer = new base.constructor(options);
 
     inheritances.push(base);
     inheritances.forEach(item => recognizer.recognizeWith(item));
@@ -59,4 +68,19 @@ export class GestureConfig extends HammerGestureConfig {
     return recognizer;
   }
 
+}
+
+/**
+ * Stripped-down annotation to be used as alternative
+ * to the one from HammerJS.
+ * @docs-private
+ */
+export interface MdHammerEvent {
+  preventDefault: () => {};
+  deltaX: number;
+  deltaY: number;
+  center: {
+    x: number;
+    y: number;
+  };
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -19,7 +19,7 @@ import {
   applyCssTransform,
   coerceBooleanProperty,
   GestureConfig,
-  HammerEvent,
+  HammerInput,
   DefaultStyleCompatibilityModeModule,
 } from '../core';
 import {Observable} from 'rxjs/Observable';
@@ -235,7 +235,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  _onDrag(event: HammerEvent) {
+  _onDrag(event: HammerInput) {
     if (this._slideRenderer.isDragging()) {
       this._slideRenderer.updateThumbPosition(event.deltaX);
     }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -19,7 +19,7 @@ import {
   applyCssTransform,
   coerceBooleanProperty,
   GestureConfig,
-  MdHammerEvent,
+  HammerEvent,
   DefaultStyleCompatibilityModeModule,
 } from '../core';
 import {Observable} from 'rxjs/Observable';
@@ -235,7 +235,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  _onDrag(event: MdHammerEvent) {
+  _onDrag(event: HammerEvent) {
     if (this._slideRenderer.isDragging()) {
       this._slideRenderer.updateThumbPosition(event.deltaX);
     }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -19,6 +19,7 @@ import {
   applyCssTransform,
   coerceBooleanProperty,
   GestureConfig,
+  MdHammerEvent,
   DefaultStyleCompatibilityModeModule,
 } from '../core';
 import {Observable} from 'rxjs/Observable';
@@ -234,7 +235,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  _onDrag(event: HammerInput) {
+  _onDrag(event: MdHammerEvent) {
     if (this._slideRenderer.isDragging()) {
       this._slideRenderer.updateThumbPosition(event.deltaX);
     }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -14,7 +14,7 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormsModule} from '@angular/for
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {
   GestureConfig,
-  HammerEvent,
+  HammerInput,
   coerceBooleanProperty,
   coerceNumberProperty,
   DefaultStyleCompatibilityModeModule,
@@ -323,7 +323,7 @@ export class MdSlider implements ControlValueAccessor {
     this._emitValueIfChanged();
   }
 
-  _onSlide(event: HammerEvent) {
+  _onSlide(event: HammerInput) {
     if (this.disabled) {
       return;
     }
@@ -333,7 +333,7 @@ export class MdSlider implements ControlValueAccessor {
     this._updateValueFromPosition({x: event.center.x, y: event.center.y});
   }
 
-  _onSlideStart(event: HammerEvent) {
+  _onSlideStart(event: HammerInput) {
     if (this.disabled) {
       return;
     }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -14,11 +14,11 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormsModule} from '@angular/for
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {
   GestureConfig,
+  MdHammerEvent,
   coerceBooleanProperty,
   coerceNumberProperty,
   DefaultStyleCompatibilityModeModule,
 } from '../core';
-import {Input as HammerInput} from 'hammerjs';
 import {Dir} from '../core/rtl/dir';
 import {CommonModule} from '@angular/common';
 import {
@@ -31,7 +31,6 @@ import {
   RIGHT_ARROW,
   DOWN_ARROW,
 } from '../core/keyboard/keycodes';
-
 
 /**
  * Visually, a 30px separation between tick marks looks best. This is very subjective but it is
@@ -324,7 +323,7 @@ export class MdSlider implements ControlValueAccessor {
     this._emitValueIfChanged();
   }
 
-  _onSlide(event: HammerInput) {
+  _onSlide(event: MdHammerEvent) {
     if (this.disabled) {
       return;
     }
@@ -334,7 +333,7 @@ export class MdSlider implements ControlValueAccessor {
     this._updateValueFromPosition({x: event.center.x, y: event.center.y});
   }
 
-  _onSlideStart(event: HammerInput) {
+  _onSlideStart(event: MdHammerEvent) {
     if (this.disabled) {
       return;
     }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -14,7 +14,7 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormsModule} from '@angular/for
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {
   GestureConfig,
-  MdHammerEvent,
+  HammerEvent,
   coerceBooleanProperty,
   coerceNumberProperty,
   DefaultStyleCompatibilityModeModule,
@@ -323,7 +323,7 @@ export class MdSlider implements ControlValueAccessor {
     this._emitValueIfChanged();
   }
 
-  _onSlide(event: MdHammerEvent) {
+  _onSlide(event: HammerEvent) {
     if (this.disabled) {
       return;
     }
@@ -333,7 +333,7 @@ export class MdSlider implements ControlValueAccessor {
     this._updateValueFromPosition({x: event.center.x, y: event.center.y});
   }
 
-  _onSlideStart(event: MdHammerEvent) {
+  _onSlideStart(event: HammerEvent) {
     if (this.disabled) {
       return;
     }

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -11,7 +11,7 @@ export class TestGestureConfig extends GestureConfig {
    * A map of Hammer instances to element.
    * Used to emit events over instances for an element.
    */
-  hammerInstances: Map<HTMLElement, HammerManager[]> = new Map<HTMLElement, HammerManager[]>();
+  hammerInstances: Map<HTMLElement, any[]> = new Map<HTMLElement, any[]>();
 
   /**
    * Create a mapping of Hammer instances to element so that events can be emitted during testing.

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {GestureConfig} from '../core';
+import {GestureConfig, HammerManager} from '../core';
 
 /**
  * An extension of GestureConfig that exposes the underlying HammerManager instances.
@@ -11,13 +11,13 @@ export class TestGestureConfig extends GestureConfig {
    * A map of Hammer instances to element.
    * Used to emit events over instances for an element.
    */
-  hammerInstances: Map<HTMLElement, any[]> = new Map<HTMLElement, any[]>();
+  hammerInstances: Map<HTMLElement, HammerManager[]> = new Map<HTMLElement, HammerManager[]>();
 
   /**
    * Create a mapping of Hammer instances to element so that events can be emitted during testing.
    */
   buildHammer(element: HTMLElement) {
-    let mc = super.buildHammer(element);
+    let mc = super.buildHammer(element) as HammerManager;
 
     if (this.hammerInstances.get(element)) {
       this.hammerInstances.get(element).push(mc);

--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -17,8 +17,6 @@
     "stripInternal": false,
     "typeRoots": [
       "../../node_modules/@types"
-    ],
-    "types": [
     ]
   },
   "exclude": [


### PR DESCRIPTION
Makes HammerJS and logs a warning if it's missing, instead of crashing the app.