### PR TITLE
chore: fix minified templates in release

### DIFF
--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -17,7 +17,9 @@ export const SASS_AUTOPREFIXER_OPTIONS = {
 
 export const HTML_MINIFIER_OPTIONS = {
   collapseWhitespace: true,
-  removeComments: true
+  removeComments: true,
+  caseSensitive: true,
+  removeAttributeQuotes: false
 };
 
 export const NPM_VENDOR_FILES = [


### PR DESCRIPTION
* Currently the `html-minifier` minifies the attributes in a non-case sensitive way and this breaks the templates in the releases.

@jelbourn This one should be **very** important for releases, because right now the templates in the releases are broken.