### PR TITLE
chore: update test browsers to latest version

### DIFF
--- a/test/browser-providers.ts
+++ b/test/browser-providers.ts
@@ -63,7 +63,7 @@ export const customLaunchers: { [name: string]: BrowserLauncherInfo } = {
   'SL_CHROME': {
     base: 'SauceLabs',
     browserName: 'chrome',
-    version: '46'
+    version: 'latest'
   },
   'SL_CHROMEBETA': {
     base: 'SauceLabs',
@@ -78,7 +78,7 @@ export const customLaunchers: { [name: string]: BrowserLauncherInfo } = {
   'SL_FIREFOX': {
     base: 'SauceLabs',
     browserName: 'firefox',
-    version: '42'
+    version: 'latest'
   },
   'SL_FIREFOXBETA': {
     base: 'SauceLabs',

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -43,7 +43,11 @@ if (process.env['TRAVIS']) {
     'browserName': 'chrome',
     'tunnel-identifier': process.env['TRAVIS_JOB_NUMBER'],
     'build': process.env['TRAVIS_JOB_NUMBER'],
-    'name': 'Material 2 E2E Tests'
+    'name': 'Material 2 E2E Tests',
+
+    // By default Saucelabs tries to record the whole e2e run. This can slow down the builds.
+    'recordVideo': false,
+    'recordScreenshots': false
   };
 }
 


### PR DESCRIPTION
* Updates the Unit test browsers to the `latest` version on Saucelabs
* No longer records videos & screenshots on the e2e mode, because this seems to slow the builds significant.