### PR TITLE
chore(icon): remove rxjs import for throw

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -5,7 +5,6 @@ import {MdError} from '../core';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/do';


### PR DESCRIPTION
Adding this breaks several hundred build targets in google.