### PR TITLE
chore(toolbar): add doc for md-toolbar color input

### DIFF
--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -31,6 +31,7 @@ export class MdToolbar {
 
   constructor(private elementRef: ElementRef, private renderer: Renderer) { }
 
+  /** The color of the toolbar. Can be primary, accent, or warn. */
   @Input()
   get color(): string {
     return this._color;


### PR DESCRIPTION
* Adds a JSDoc documentation for the `md-toolbar` color input.

Addition to #2261 