### PR TITLE
docs: add jsdoc annotations everywhere

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -98,7 +98,6 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   @ContentChildren(forwardRef(() => MdButtonToggle))
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
-  /** @docs-private */
   ngAfterViewInit() {
     this._isInitialized = true;
   }
@@ -342,7 +341,6 @@ export class MdButtonToggle implements OnInit {
     }
   }
 
-  /** @docs-private */
   ngOnInit() {
     if (this.id == null) {
       this.id = `md-button-toggle-${_uniqueIdCounter++}`;

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -26,7 +26,7 @@ import {
   DefaultStyleCompatibilityModeModule,
 } from '../core';
 
-
+/** Acceptable types for a button toggle. */
 export type ToggleType = 'checkbox' | 'radio';
 
 
@@ -98,10 +98,12 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   @ContentChildren(forwardRef(() => MdButtonToggle))
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
+  /** @docs-private */
   ngAfterViewInit() {
     this._isInitialized = true;
   }
 
+  /** `name` attribute for the underlying `input` element. */
   @Input()
   get name(): string {
     return this._name;
@@ -112,6 +114,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     this._updateButtonToggleNames();
   }
 
+  /** Whether the toggle group is disabled. */
   @Input()
   get disabled(): boolean {
     return this._disabled;
@@ -121,6 +124,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     this._disabled = coerceBooleanProperty(value);
   }
 
+  /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean {
     return this._vertical;
@@ -130,6 +134,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     this._vertical = coerceBooleanProperty(value);
   }
 
+  /** Value of the toggle group. */
   @Input()
   get value(): any {
     return this._value;
@@ -149,6 +154,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     }
   }
 
+  /** Whether the toggle group is selected. */
   @Input()
   get selected() {
     return this._selected;
@@ -199,17 +205,28 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     this._change.emit(event);
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets the model value. Implemented as part of ControlValueAccessor.
+   * @param value Value to be set to the model.
+   */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback that will be triggered when the value has changed.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn On change callback function.
+   */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback that will be triggered when the control has been touched.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn On touch callback function.
+   */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
@@ -230,6 +247,7 @@ export class MdButtonToggleGroupMultiple {
   /** Whether the button toggle group should be vertical. */
   private _vertical: boolean = false;
 
+  /** Whether the toggle group is disabled. */
   @Input()
   get disabled(): boolean {
     return this._disabled;
@@ -239,6 +257,7 @@ export class MdButtonToggleGroupMultiple {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
+  /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean {
     return this._vertical;
@@ -250,6 +269,7 @@ export class MdButtonToggleGroupMultiple {
 
 }
 
+/** Single button inside of a toggle group. */
 @Component({
   moduleId: module.id,
   selector: 'md-button-toggle',
@@ -322,6 +342,7 @@ export class MdButtonToggle implements OnInit {
     }
   }
 
+  /** @docs-private */
   ngOnInit() {
     if (this.id == null) {
       this.id = `md-button-toggle-${_uniqueIdCounter++}`;
@@ -332,10 +353,12 @@ export class MdButtonToggle implements OnInit {
     }
   }
 
+  /** Unique ID for the underlying `input` element. */
   get inputId(): string {
     return `${this.id}-input`;
   }
 
+  /** Whether the button is checked. */
   @HostBinding('class.md-button-toggle-checked')
   @Input()
   get checked(): boolean {
@@ -380,6 +403,7 @@ export class MdButtonToggle implements OnInit {
     this._change.emit(event);
   }
 
+  /** Whether the button is disabled. */
   @HostBinding('class.md-button-toggle-disabled')
   @Input()
   get disabled(): boolean {
@@ -425,6 +449,7 @@ export class MdButtonToggle implements OnInit {
     event.stopPropagation();
   }
 
+  /** Focuses the button. */
   focus() {
     this._renderer.invokeElementMethod(this._inputElement.nativeElement, 'focus');
   }

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -17,7 +17,9 @@ import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 // TODO(jelbourn): Make the `isMouseDown` stuff done with one global listener.
 // TODO(kara): Convert attribute selectors to classes when attr maps become available
 
-
+/**
+ * Material design button.
+ */
 @Component({
   moduleId: module.id,
   selector: 'button[md-button], button[md-raised-button], button[md-icon-button], ' +
@@ -114,6 +116,9 @@ export class MdButton {
   }
 }
 
+/**
+ * Raised Material design button.
+ */
 @Component({
   moduleId: module.id,
   selector: 'a[md-button], a[md-raised-button], a[md-icon-button], a[md-fab], a[md-mini-fab]',

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -50,25 +50,17 @@ export class MdCardActions {}
 export class MdCardFooter {}
 
 
-/*
-
-<md-card> is a basic content container component that adds the styles of a material design card.
-
-While you can use this component alone,
-it also provides a number of preset styles for common card sections, including:
- - md-card-title
- - md-card-subtitle
- - md-card-content
- - md-card-actions
- - md-card-footer
-
- You can see some examples of cards here:
- http://embed.plnkr.co/s5O4YcyvbLhIApSrIhtj/
-
- TODO(kara): update link to demo site when it exists
-
-*/
-
+/**
+ * A basic content container component that adds the styles of a Material design card.
+ *
+ * While this component can be used alone, it also provides a number
+ * of preset styles for common card sections, including:
+ * - md-card-title
+ * - md-card-subtitle
+ * - md-card-content
+ * - md-card-actions
+ * - md-card-footer
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-card, mat-card',
@@ -80,20 +72,10 @@ it also provides a number of preset styles for common card sections, including:
 export class MdCard {}
 
 
-/*  The following components don't have any behavior.
- They simply use content projection to wrap user content
- for flex layout purposes in <md-card> (and thus allow a cleaner, boilerplate-free API).
-
-
-<md-card-header> is a component intended to be used within the <md-card> component.
-It adds styles for a preset header section (i.e. a title, subtitle, and avatar layout).
-
-You can see an example of a card with a header here:
-http://embed.plnkr.co/tvJl19z3gZTQd6WmwkIa/
-
-TODO(kara): update link to demo site when it exists
-*/
-
+/**
+ * Component intended to be used within the `<md-card>` component. It adds styles for a
+ * preset header section (i.e. a title, subtitle, and avatar layout).
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-card-header, mat-card-header',
@@ -103,17 +85,11 @@ TODO(kara): update link to demo site when it exists
 })
 export class MdCardHeader {}
 
-/*
 
-<md-card-title-group> is a component intended to be used within the <md-card> component.
-It adds styles for a preset layout that groups an image with a title section.
-
-You can see an example of a card with a title-group section here:
-http://embed.plnkr.co/EDfgCF9eKcXjini1WODm/
-
-TODO(kara): update link to demo site when it exists
-*/
-
+/**
+ * Component intended to be used within the <md-card> component. It adds styles for a preset
+ * layout that groups an image with a title section.
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-card-title-group, mat-card-title-group',

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -57,7 +57,7 @@ export class MdCheckboxChange {
 
 /**
  * A material design checkbox component. Supports all of the functionality of an HTML5 checkbox,
- * and exposes a similar API. An MdCheckbox can be either checked, unchecked, indeterminate, or
+ * and exposes a similar API. A MdCheckbox can be either checked, unchecked, indeterminate, or
  * disabled. Note that all additional accessibility attributes are taken care of by the component,
  * so there is no need to provide them yourself. However, if you want to omit a label and still
  * have the checkbox be accessible, you may supply an [aria-label] input.
@@ -148,7 +148,7 @@ export class MdCheckbox implements ControlValueAccessor {
   /** Event emitted when the checkbox's `checked` value changes. */
   @Output() change: EventEmitter<MdCheckboxChange> = new EventEmitter<MdCheckboxChange>();
 
-  /** The native `<input type=checkbox> element */
+  /** The native `<input type="checkbox"> element */
   @ViewChild('input') _inputElement: ElementRef;
 
   /**
@@ -239,22 +239,36 @@ export class MdCheckbox implements ControlValueAccessor {
     return this.disableRipple || this.disabled;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets the model value. Implemented as part of ControlValueAccessor.
+   * @param value Value to be set to the model.
+   */
   writeValue(value: any) {
     this.checked = !!value;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the value has changed.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Function to be called on change.
+   */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the control has been touched.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be triggered when the checkbox is touched.
+   */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /** Implemented as a part of ControlValueAccessor. */
+  /**
+   * Sets the checkbox's disabled state. Implemented as a part of ControlValueAccessor.
+   * @param isDisabled Whether the checkbox should be disabled.
+   */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }

--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -47,9 +47,7 @@ describe('MdChipList', () => {
     });
 
     it('focuses the first chip on focus', () => {
-      let FOCUS_EVENT: Event = {} as Event;
-
-      chipListInstance.focus(FOCUS_EVENT);
+      chipListInstance.focus();
       fixture.detectChanges();
 
       expect(manager.focusedItemIndex).toBe(0);
@@ -109,7 +107,6 @@ describe('MdChipList', () => {
       });
 
       it('SPACE selects/deselects the currently focused chip', () => {
-        let FOCUS_EVENT: Event = {} as Event;
         let SPACE_EVENT: KeyboardEvent = new FakeEvent(SPACE) as KeyboardEvent;
         let firstChip: MdChip = chips.toArray()[0];
 
@@ -117,7 +114,7 @@ describe('MdChipList', () => {
         spyOn(testComponent, 'chipDeselect');
 
         // Make sure we have the first chip focused
-        chipListInstance.focus(FOCUS_EVENT);
+        chipListInstance.focus();
 
         // Use the spacebar to select the chip
         chipListInstance._keydown(SPACE_EVENT);
@@ -144,14 +141,13 @@ describe('MdChipList', () => {
       });
 
       it('SPACE ignores selection', () => {
-        let FOCUS_EVENT: Event = {} as Event;
         let SPACE_EVENT: KeyboardEvent = new FakeEvent(SPACE) as KeyboardEvent;
         let firstChip: MdChip = chips.toArray()[0];
 
         spyOn(testComponent, 'chipSelect');
 
         // Make sure we have the first chip focused
-        chipListInstance.focus(FOCUS_EVENT);
+        chipListInstance.focus();
 
         // Use the spacebar to attempt to select the chip
         chipListInstance._keydown(SPACE_EVENT);

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -189,7 +189,7 @@ export class MdChipList implements AfterContentInit {
    * Utility to ensure all indexes are valid.
    *
    * @param index The index to be checked.
-   * @returns {boolean} True if the index is valid for our list of chips.
+   * @returns True if the index is valid for our list of chips.
    */
   private _isValidIndex(index: number): boolean {
     return index >= 0 && index < this.chips.length;

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -61,9 +61,9 @@ export class MdChipList implements AfterContentInit {
   /** The chip components contained within this chip list. */
   chips: QueryList<MdChip>;
 
-  constructor(private _elementRef: ElementRef) {
-  }
+  constructor(private _elementRef: ElementRef) { }
 
+  /** @docs-private */
   ngAfterContentInit(): void {
     this._keyManager = new ListKeyManager(this.chips).withFocusWrap();
 
@@ -89,16 +89,15 @@ export class MdChipList implements AfterContentInit {
   }
 
   /**
-   * Programmatically focus the chip list. This in turn focuses the first non-disabled chip in this
-   * chip list.
-   *
-   * TODO: ARIA says this should focus the first `selected` chip.
+   * Programmatically focus the chip list. This in turn focuses the first
+   * non-disabled chip in this chip list.
    */
-  focus(event: Event) {
+  focus() {
+    // TODO: ARIA says this should focus the first `selected` chip.
     this._keyManager.focusFirstItem();
   }
 
-  /** Pass relevant key presses to our key manager. */
+  /** Passes relevant key presses to our key manager. */
   _keydown(event: KeyboardEvent) {
     switch (event.keyCode) {
       case SPACE:

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -63,7 +63,6 @@ export class MdChipList implements AfterContentInit {
 
   constructor(private _elementRef: ElementRef) { }
 
-  /** @docs-private */
   ngAfterContentInit(): void {
     this._keyManager = new ListKeyManager(this.chips).withFocusWrap();
 

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -17,7 +17,7 @@ export interface MdChipEvent {
 }
 
 /**
- * A material design styled Chip component. Used inside the MdChipList component.
+ * Material design styled Chip component. Used inside the MdChipList component.
  */
 @Component({
   selector: 'md-basic-chip, [md-basic-chip], md-chip, [md-chip]',
@@ -56,14 +56,15 @@ export class MdChip implements Focusable, OnInit, OnDestroy {
   /** Emitted when the chip is destroyed. */
   @Output() destroy = new EventEmitter<MdChipEvent>();
 
-  constructor(protected _renderer: Renderer, protected _elementRef: ElementRef) {
-  }
+  constructor(protected _renderer: Renderer, protected _elementRef: ElementRef) { }
 
+  /** @docs-private */
   ngOnInit(): void {
     this._addDefaultCSSClass();
     this._updateColor(this._color);
   }
 
+  /** @docs-private */
   ngOnDestroy(): void {
     this.destroy.emit({chip: this});
   }
@@ -98,7 +99,10 @@ export class MdChip implements Focusable, OnInit, OnDestroy {
     }
   }
 
-  /** Toggles the current selected state of this chip. */
+  /**
+   * Toggles the current selected state of this chip.
+   * @return Whether the chip is selected.
+   */
   toggleSelected(): boolean {
     this.selected = !this.selected;
     return this.selected;

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -58,13 +58,11 @@ export class MdChip implements Focusable, OnInit, OnDestroy {
 
   constructor(protected _renderer: Renderer, protected _elementRef: ElementRef) { }
 
-  /** @docs-private */
   ngOnInit(): void {
     this._addDefaultCSSClass();
     this._updateColor(this._color);
   }
 
-  /** @docs-private */
   ngOnDestroy(): void {
     this.destroy.emit({chip: this});
   }

--- a/src/lib/core/a11y/focus-trap.ts
+++ b/src/lib/core/a11y/focus-trap.ts
@@ -48,7 +48,9 @@ export class FocusTrap {
     });
   }
 
-  /** Focuses the first tabbable element within the focus trap region. */
+  /**
+   * Focuses the first tabbable element within the focus trap region.
+   */
   focusFirstTabbableElement() {
     let rootElement = this.trappedContent.nativeElement;
     let redirectToElement = rootElement.querySelector('[cdk-focus-start]') as HTMLElement ||
@@ -59,7 +61,9 @@ export class FocusTrap {
     }
   }
 
-  /** Focuses the last tabbable element within the focus trap region. */
+  /**
+   * Focuses the last tabbable element within the focus trap region.
+   */
   focusLastTabbableElement() {
     let rootElement = this.trappedContent.nativeElement;
     let focusTargets = rootElement.querySelectorAll('[cdk-focus-end]');

--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -20,7 +20,7 @@ export class InteractivityChecker {
    * Gets whether an element is disabled.
    *
    * @param element Element to be checked.
-   * @returns {boolean} Whether the element is disabled.
+   * @returns Whether the element is disabled.
    */
   isDisabled(element: HTMLElement): boolean {
     // This does not capture some cases, such as a non-form control with a disabled attribute or
@@ -34,7 +34,7 @@ export class InteractivityChecker {
    * This will capture states like `display: none` and `visibility: hidden`, but not things like
    * being clipped by an `overflow: hidden` parent or being outside the viewport.
    *
-   * @returns {boolean} Whether the element is visible.
+   * @returns Whether the element is visible.
    */
   isVisible(element: HTMLElement): boolean {
     return hasGeometry(element) && getComputedStyle(element).visibility === 'visible';
@@ -45,7 +45,7 @@ export class InteractivityChecker {
    * Assumes that the element has already been checked with isFocusable.
    *
    * @param element Element to be checked.
-   * @returns {boolean} Whether the element is tabbable.
+   * @returns Whether the element is tabbable.
    */
   isTabbable(element: HTMLElement): boolean {
 
@@ -122,7 +122,7 @@ export class InteractivityChecker {
    * Gets whether an element can be focused by the user.
    *
    * @param element Element to be checked.
-   * @returns {boolean} Whether the element is focusable.
+   * @returns Whether the element is focusable.
    */
   isFocusable(element: HTMLElement): boolean {
     // Perform checks in order of left to most expensive.

--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -1,7 +1,8 @@
 import {Injectable} from '@angular/core';
 import {Platform} from '../platform/platform';
 
-/* The InteractivityChecker leans heavily on the ally.js accessibility utilities.
+/**
+ * The InteractivityChecker leans heavily on the ally.js accessibility utilities.
  * Methods like `isTabbable` are only covering specific edge-cases for the browsers which are
  * supported.
  */
@@ -15,8 +16,13 @@ export class InteractivityChecker {
 
   constructor(private _platform: Platform) {}
 
-  /** Gets whether an element is disabled. */
-  isDisabled(element: HTMLElement) {
+  /**
+   * Gets whether an element is disabled.
+   *
+   * @param element Element to be checked.
+   * @returns {boolean} Whether the element is disabled.
+   */
+  isDisabled(element: HTMLElement): boolean {
     // This does not capture some cases, such as a non-form control with a disabled attribute or
     // a form control inside of a disabled form, but should capture the most common cases.
     return element.hasAttribute('disabled');
@@ -27,16 +33,21 @@ export class InteractivityChecker {
    *
    * This will capture states like `display: none` and `visibility: hidden`, but not things like
    * being clipped by an `overflow: hidden` parent or being outside the viewport.
+   *
+   * @returns {boolean} Whether the element is visible.
    */
-  isVisible(element: HTMLElement) {
+  isVisible(element: HTMLElement): boolean {
     return hasGeometry(element) && getComputedStyle(element).visibility === 'visible';
   }
 
   /**
    * Gets whether an element can be reached via Tab key.
    * Assumes that the element has already been checked with isFocusable.
+   *
+   * @param element Element to be checked.
+   * @returns {boolean} Whether the element is tabbable.
    */
-  isTabbable(element: HTMLElement) {
+  isTabbable(element: HTMLElement): boolean {
 
     let frameElement = getWindow(element).frameElement as HTMLElement;
 
@@ -107,7 +118,12 @@ export class InteractivityChecker {
     return element.tabIndex >= 0;
   }
 
-  /** Gets whether an element can be focused by the user. */
+  /**
+   * Gets whether an element can be focused by the user.
+   *
+   * @param element Element to be checked.
+   * @returns {boolean} Whether the element is focusable.
+   */
   isFocusable(element: HTMLElement): boolean {
     // Perform checks in order of left to most expensive.
     // Again, naive approach that does not capture many edge cases and browser quirks.

--- a/src/lib/core/a11y/list-key-manager.ts
+++ b/src/lib/core/a11y/list-key-manager.ts
@@ -26,6 +26,8 @@ export class ListKeyManager {
   /**
    * Turns on focus wrapping mode, which ensures that the focus will wrap to
    * the other end of list when there are no more items in the given direction.
+   *
+   * @returns {ListKeyManager} The ListKeyManager that the method was called on.
    */
   withFocusWrap(): this {
     this._wrap = true;
@@ -42,7 +44,10 @@ export class ListKeyManager {
     this._items.toArray()[index].focus();
   }
 
-  /** Sets the focus properly depending on the key event passed in. */
+  /**
+   * Sets the focus depending on the key event passed in.
+   * @param event Keyboard event to be used for determining which element to focus.
+   */
   onKeydown(event: KeyboardEvent): void {
     switch (event.keyCode) {
       case DOWN_ARROW:
@@ -93,7 +98,10 @@ export class ListKeyManager {
     return this._focusedItemIndex;
   }
 
-  /** Allows setting of the focusedItemIndex without focusing the item. */
+  /**
+   * Allows setting of the focusedItemIndex without focusing the item.
+   * @param index The new focusedItemIndex.
+   */
   updateFocusedItemIndex(index: number) {
     this._focusedItemIndex = index;
   }

--- a/src/lib/core/a11y/list-key-manager.ts
+++ b/src/lib/core/a11y/list-key-manager.ts
@@ -27,7 +27,7 @@ export class ListKeyManager {
    * Turns on focus wrapping mode, which ensures that the focus will wrap to
    * the other end of list when there are no more items in the given direction.
    *
-   * @returns {ListKeyManager} The ListKeyManager that the method was called on.
+   * @returns The ListKeyManager that the method was called on.
    */
   withFocusWrap(): this {
     this._wrap = true;

--- a/src/lib/core/a11y/live-announcer.ts
+++ b/src/lib/core/a11y/live-announcer.ts
@@ -7,6 +7,7 @@ import {
 
 export const LIVE_ANNOUNCER_ELEMENT_TOKEN  = new OpaqueToken('liveAnnouncerElement');
 
+/** Possible politeness levels. */
 export type AriaLivePoliteness = 'off' | 'polite' | 'assertive';
 
 @Injectable()
@@ -23,8 +24,9 @@ export class LiveAnnouncer {
   }
 
   /**
+   * Announces a message to screenreaders.
    * @param message Message to be announced to the screenreader
-   * @param politeness The politeness of the announcer element.
+   * @param politeness The politeness of the announcer element
    */
   announce(message: string, politeness: AriaLivePoliteness = 'polite'): void {
     this._liveElement.textContent = '';

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -17,7 +17,11 @@ export type UniqueSelectionDispatcherListener = (id: string, name: string) => vo
 export class UniqueSelectionDispatcher {
   private _listeners: UniqueSelectionDispatcherListener[] = [];
 
-  /** Notify other items that selection for the given name has been set. */
+  /**
+   * Notify other items that selection for the given name has been set.
+   * @param id ID of the item.
+   * @param name Name of the item.
+   */
   notify(id: string, name: string) {
     for (let listener of this._listeners) {
       listener(id, name);

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -39,9 +39,9 @@ export class GestureConfig extends HammerGestureConfig {
    * http://hammerjs.github.io/recognizer-press/
    *
    * @param element Element to which to assign the new HammerJS gestures.
-   * @returns {HammerInstance} Newly-created HammerJS instance.
+   * @returns Newly-created HammerJS instance.
    */
-  buildHammer(element: HTMLElement) {
+  buildHammer(element: HTMLElement): HammerInstance {
     const mc = new this._hammer(element);
 
     // Default Hammer Recognizers.

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -28,7 +28,7 @@ export class GestureConfig extends HammerGestureConfig {
     }
   }
 
-  /*
+  /**
    * Builds Hammer instance manually to add custom recognizers that match the Material Design spec.
    *
    * Our gesture names come from the Material Design gestures spec:
@@ -38,8 +38,9 @@ export class GestureConfig extends HammerGestureConfig {
    * http://hammerjs.github.io/recognizer-pan/
    * http://hammerjs.github.io/recognizer-press/
    *
-   * TODO: Confirm threshold numbers with Material Design UX Team
-   * */
+   * @param element Element to which to assign the new HammerJS gestures.
+   * @returns {HammerInstance} Newly-created HammerJS instance.
+   */
   buildHammer(element: HTMLElement) {
     const mc = new this._hammer(element);
 
@@ -50,6 +51,7 @@ export class GestureConfig extends HammerGestureConfig {
 
     // Notice that a HammerJS recognizer can only depend on one other recognizer once.
     // Otherwise the previous `recognizeWith` will be dropped.
+    // TODO: Confirm threshold numbers with Material Design UX Team
     let slide = this._createRecognizer(pan, {event: 'slide', threshold: 0}, swipe);
     let longpress = this._createRecognizer(press, {event: 'longpress', time: 500});
 

--- a/src/lib/core/observe-content/observe-content.ts
+++ b/src/lib/core/observe-content/observe-content.ts
@@ -24,7 +24,6 @@ export class ObserveContent implements AfterContentInit, OnDestroy {
 
   constructor(private _elementRef: ElementRef) {}
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._observer = new MutationObserver(mutations => mutations.forEach(() => this.event.emit()));
 
@@ -35,7 +34,6 @@ export class ObserveContent implements AfterContentInit, OnDestroy {
     });
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     if (this._observer) {
       this._observer.disconnect();

--- a/src/lib/core/observe-content/observe-content.ts
+++ b/src/lib/core/observe-content/observe-content.ts
@@ -9,16 +9,22 @@ import {
   AfterContentInit
 } from '@angular/core';
 
+/**
+ * Directive that triggers a callback whenever the content of
+ * it's associated element has changed.
+ */
 @Directive({
   selector: '[cdkObserveContent]'
 })
 export class ObserveContent implements AfterContentInit, OnDestroy {
   private _observer: MutationObserver;
 
+  /** Event emitted for each change in the element's content. */
   @Output('cdkObserveContent') event = new EventEmitter<void>();
 
   constructor(private _elementRef: ElementRef) {}
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._observer = new MutationObserver(mutations => mutations.forEach(() => this.event.emit()));
 
@@ -29,6 +35,7 @@ export class ObserveContent implements AfterContentInit, OnDestroy {
     });
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     if (this._observer) {
       this._observer.disconnect();

--- a/src/lib/core/observe-content/observe-content.ts
+++ b/src/lib/core/observe-content/observe-content.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * Directive that triggers a callback whenever the content of
- * it's associated element has changed.
+ * its associated element has changed.
  */
 @Directive({
   selector: '[cdkObserveContent]'

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -9,7 +9,7 @@ export class OverlayContainer {
    * This method returns the overlay container element.  It will lazily
    * create the element the first time  it is called to facilitate using
    * the container in non-browser environments.
-   * @returns {HTMLElement} the container element
+   * @returns the container element
    */
   getContainerElement(): HTMLElement {
     if (!this._containerElement) { this._createContainer(); }

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -45,11 +45,7 @@ let defaultPositionList = [
   exportAs: 'cdkOverlayOrigin',
 })
 export class OverlayOrigin {
-  constructor(private _elementRef: ElementRef) { }
-
-  get elementRef() {
-    return this._elementRef;
-  }
+  constructor(public elementRef: ElementRef) { }
 }
 
 
@@ -72,7 +68,10 @@ export class ConnectedOverlayDirective implements OnDestroy {
   private _offsetY: number = 0;
   private _position: ConnectedPositionStrategy;
 
+  /** Origin for the connected overlay. */
   @Input() origin: OverlayOrigin;
+
+  /** Registered connected position pairs. */
   @Input() positions: ConnectionPositionPair[];
 
   /** The offset in pixels for the overlay connection point on the x-axis */
@@ -139,8 +138,14 @@ export class ConnectedOverlayDirective implements OnDestroy {
 
   /** Event emitted when the backdrop is clicked. */
   @Output() backdropClick = new EventEmitter<void>();
+
+  /** Event emitted when the position has changed. */
   @Output() positionChange = new EventEmitter<ConnectedOverlayPositionChange>();
+
+  /** Event emitted when the overlay has been attached. */
   @Output() attach = new EventEmitter<void>();
+
+  /** Event emitted when the overlay has been detached. */
   @Output() detach = new EventEmitter<void>();
 
   // TODO(jelbourn): inputs for size, scroll behavior, animation, etc.
@@ -153,14 +158,17 @@ export class ConnectedOverlayDirective implements OnDestroy {
     this._templatePortal = new TemplatePortal(templateRef, viewContainerRef);
   }
 
+  /** The associated overlay reference. */
   get overlayRef(): OverlayRef {
     return this._overlayRef;
   }
 
+  /** The element's layout direction. */
   get dir(): LayoutDirection {
     return this._dir ? this._dir.value : 'ltr';
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     this._destroyOverlay();
   }

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -168,7 +168,6 @@ export class ConnectedOverlayDirective implements OnDestroy {
     return this._dir ? this._dir.value : 'ltr';
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     this._destroyOverlay();
   }

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -27,7 +27,7 @@ export class OverlayRef implements PortalHost {
   /**
    * Attaches the overlay to a portal instance and adds the backdrop.
    * @param portal Portal instance to which to attach the overlay.
-   * @returns {any} The portal attachment result.
+   * @returns The portal attachment result.
    */
   attach(portal: Portal<any>): any {
     if (this._state.hasBackdrop) {
@@ -44,7 +44,7 @@ export class OverlayRef implements PortalHost {
 
   /**
    * Detaches an overlay from a portal.
-   * @returns {Promise<any>} Resolves when the overlay has been detached.
+   * @returns Resolves when the overlay has been detached.
    */
   detach(): Promise<any> {
     this._detachBackdrop();
@@ -65,7 +65,6 @@ export class OverlayRef implements PortalHost {
 
   /**
    * Checks whether the overlay has been attached.
-   * @returns {boolean}
    */
   hasAttached(): boolean {
     return this._portalHost.hasAttached();
@@ -73,7 +72,6 @@ export class OverlayRef implements PortalHost {
 
   /**
    * Returns an observable that emits when the backdrop has been clicked.
-   * @returns {Observable<void>}
    */
   backdropClick(): Observable<void> {
     return this._backdropClick.asObservable();
@@ -81,9 +79,8 @@ export class OverlayRef implements PortalHost {
 
   /**
    * Gets the current state config of the overlay.
-   * @returns {OverlayState}
    */
-  getState() {
+  getState(): OverlayState {
     return this._state;
   }
 

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -24,6 +24,11 @@ export class OverlayRef implements PortalHost {
     return this._pane;
   }
 
+  /**
+   * Attaches the overlay to a portal instance and adds the backdrop.
+   * @param portal Portal instance to which to attach the overlay.
+   * @returns {any} The portal attachment result.
+   */
   attach(portal: Portal<any>): any {
     if (this._state.hasBackdrop) {
       this._attachBackdrop();
@@ -37,11 +42,18 @@ export class OverlayRef implements PortalHost {
     return attachResult;
   }
 
+  /**
+   * Detaches an overlay from a portal.
+   * @returns {Promise<any>} Resolves when the overlay has been detached.
+   */
   detach(): Promise<any> {
     this._detachBackdrop();
     return this._portalHost.detach();
   }
 
+  /**
+   * Cleans up the overlay from the DOM.
+   */
   dispose(): void {
     if (this._state.positionStrategy) {
       this._state.positionStrategy.dispose();
@@ -51,15 +63,26 @@ export class OverlayRef implements PortalHost {
     this._portalHost.dispose();
   }
 
+  /**
+   * Checks whether the overlay has been attached.
+   * @returns {boolean}
+   */
   hasAttached(): boolean {
     return this._portalHost.hasAttached();
   }
 
+  /**
+   * Returns an observable that emits when the backdrop has been clicked.
+   * @returns {Observable<void>}
+   */
   backdropClick(): Observable<void> {
     return this._backdropClick.asObservable();
   }
 
-  /** Gets the current state config of the overlay. */
+  /**
+   * Gets the current state config of the overlay.
+   * @returns {OverlayState}
+   */
   getState() {
     return this._state;
   }

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -49,15 +49,14 @@ export class Overlay {
   /**
    * Returns a position builder that can be used, via fluent API,
    * to construct and configure a position strategy.
-   * @returns {OverlayPositionBuilder}
    */
-  position() {
+  position(): OverlayPositionBuilder {
     return this._positionBuilder;
   }
 
   /**
    * Creates the DOM element for an overlay and appends it to the overlay container.
-   * @returns {HTMLElement} Newly-created pane element
+   * @returns Newly-created pane element
    */
   private _createPaneElement(): HTMLElement {
     let pane = document.createElement('div');
@@ -82,7 +81,6 @@ export class Overlay {
    * Creates an OverlayRef for an overlay in the given DOM element.
    * @param pane DOM element for the overlay
    * @param state
-   * @returns {OverlayRef}
    */
   private _createOverlayRef(pane: HTMLElement, state: OverlayState): OverlayRef {
     return new OverlayRef(this._createPortalHost(pane), pane, state, this._ngZone);

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -40,7 +40,7 @@ export class Overlay {
   /**
    * Creates an overlay.
    * @param state State to apply to the overlay.
-   * @returns A reference to the created overlay.
+   * @returns Reference to the created overlay.
    */
   create(state: OverlayState = defaultState): OverlayRef {
     return this._createOverlayRef(this._createPaneElement(), state);
@@ -49,6 +49,7 @@ export class Overlay {
   /**
    * Returns a position builder that can be used, via fluent API,
    * to construct and configure a position strategy.
+   * @returns {OverlayPositionBuilder}
    */
   position() {
     return this._positionBuilder;
@@ -56,7 +57,7 @@ export class Overlay {
 
   /**
    * Creates the DOM element for an overlay and appends it to the overlay container.
-   * @returns Promise resolving to the created element.
+   * @returns {HTMLElement} Newly-created pane element
    */
   private _createPaneElement(): HTMLElement {
     let pane = document.createElement('div');

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -54,6 +54,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     this.withFallbackPosition(_originPos, _overlayPos);
   }
 
+  /** Ordered list of preferred positions, from most to least desirable. */
   get positions() {
     return this._preferredPositions;
   }
@@ -67,6 +68,9 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * Updates the position of the overlay element, using whichever preferred position relative
    * to the origin fits on-screen.
    * @docs-private
+   *
+   * @param element Element to which to apply the CSS styles.
+   * @returns {Promise<void>} Resolves when the styles have been applied.
    */
   apply(element: HTMLElement): Promise<void> {
     // We need the bounding rects for the origin and the overlay to determine how to position
@@ -105,6 +109,12 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     return Promise.resolve(null);
   }
 
+  /**
+   * Adds a new preferred fallback position.
+   * @param originPos
+   * @param overlayPos
+   * @returns {ConnectedPositionStrategy}
+   */
   withFallbackPosition(
       originPos: OriginConnectionPosition,
       overlayPos: OverlayConnectionPosition): this {
@@ -112,19 +122,31 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     return this;
   }
 
-  /** Sets the layout direction so the overlay's position can be adjusted to match. */
+  /**
+   * Sets the layout direction so the overlay's position can be adjusted to match.
+   * @param dir New layout direction.
+   * @returns {ConnectedPositionStrategy}
+   */
   withDirection(dir: 'ltr' | 'rtl'): this {
     this._dir = dir;
     return this;
   }
 
-  /** Sets an offset for the overlay's connection point on the x-axis */
+  /**
+   * Sets an offset for the overlay's connection point on the x-axis
+   * @param offset New offset in the X axis.
+   * @returns {ConnectedPositionStrategy}
+   */
   withOffsetX(offset: number): this {
     this._offsetX = offset;
     return this;
   }
 
-  /** Sets an offset for the overlay's connection point on the y-axis */
+  /**
+   * Sets an offset for the overlay's connection point on the y-axis
+   * @param  offset New offset in the Y axis.
+   * @returns {ConnectedPositionStrategy}
+   */
   withOffsetY(offset: number): this {
     this._offsetY = offset;
     return this;

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -70,7 +70,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * @docs-private
    *
    * @param element Element to which to apply the CSS styles.
-   * @returns {Promise<void>} Resolves when the styles have been applied.
+   * @returns Resolves when the styles have been applied.
    */
   apply(element: HTMLElement): Promise<void> {
     // We need the bounding rects for the origin and the overlay to determine how to position
@@ -113,7 +113,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * Adds a new preferred fallback position.
    * @param originPos
    * @param overlayPos
-   * @returns {ConnectedPositionStrategy}
    */
   withFallbackPosition(
       originPos: OriginConnectionPosition,
@@ -125,7 +124,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   /**
    * Sets the layout direction so the overlay's position can be adjusted to match.
    * @param dir New layout direction.
-   * @returns {ConnectedPositionStrategy}
    */
   withDirection(dir: 'ltr' | 'rtl'): this {
     this._dir = dir;
@@ -135,7 +133,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   /**
    * Sets an offset for the overlay's connection point on the x-axis
    * @param offset New offset in the X axis.
-   * @returns {ConnectedPositionStrategy}
    */
   withOffsetX(offset: number): this {
     this._offsetX = offset;
@@ -145,7 +142,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   /**
    * Sets an offset for the overlay's connection point on the y-axis
    * @param  offset New offset in the Y axis.
-   * @returns {ConnectedPositionStrategy}
    */
   withOffsetY(offset: number): this {
     this._offsetY = offset;

--- a/src/lib/core/overlay/position/fake-viewport-ruler.ts
+++ b/src/lib/core/overlay/position/fake-viewport-ruler.ts
@@ -1,3 +1,4 @@
+/** @docs-private */
 export class FakeViewportRuler {
   getViewportRect() {
     return {

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -24,7 +24,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the top position of the overlay. Clears any previously set vertical position.
    * @param value New top offset.
-   * @returns {GlobalPositionStrategy}
    */
   top(value: string): this {
     this._bottomOffset = '';
@@ -36,7 +35,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the left position of the overlay. Clears any previously set horizontal position.
    * @param value New left offset.
-   * @returns {GlobalPositionStrategy}
    */
   left(value: string): this {
     this._rightOffset = '';
@@ -48,7 +46,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the bottom position of the overlay. Clears any previously set vertical position.
    * @param value New bottom offset.
-   * @returns {GlobalPositionStrategy}
    */
   bottom(value: string): this {
     this._topOffset = '';
@@ -60,7 +57,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the right position of the overlay. Clears any previously set horizontal position.
    * @param value New right offset.
-   * @returns {GlobalPositionStrategy}
    */
   right(value: string): this {
     this._leftOffset = '';
@@ -72,7 +68,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the overlay width and clears any previously set width.
    * @param value New width for the overlay
-   * @returns {GlobalPositionStrategy}
    */
   width(value: string): this {
     this._width = value;
@@ -89,7 +84,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the overlay height and clears any previously set height.
    * @param value New height for the overlay
-   * @returns {GlobalPositionStrategy}
    */
   height(value: string): this {
     this._height = value;
@@ -108,7 +102,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Clears any previously set horizontal position.
    *
    * @param offset Overlay offset from the horizontal center.
-   * @returns {GlobalPositionStrategy}
    */
   centerHorizontally(offset = ''): this {
     this.left(offset);
@@ -121,7 +114,6 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Clears any previously set vertical position.
    *
    * @param offset Overlay offset from the vertical center.
-   * @returns {GlobalPositionStrategy}
    */
   centerVertically(offset = ''): this {
     this.top(offset);
@@ -134,7 +126,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * @docs-private
    *
    * @param element Element to which to apply the CSS.
-   * @returns {Promise<void>} Resolved when the styles have been applied.
+   * @returns Resolved when the styles have been applied.
    */
   apply(element: HTMLElement): Promise<void> {
     if (!this._wrapper) {

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -21,40 +21,60 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /* A lazily-created wrapper for the overlay element that is used as a flex container.  */
   private _wrapper: HTMLElement;
 
-  /** Sets the top position of the overlay. Clears any previously set vertical position. */
-  top(value: string) {
+  /**
+   * Sets the top position of the overlay. Clears any previously set vertical position.
+   * @param value New top offset.
+   * @returns {GlobalPositionStrategy}
+   */
+  top(value: string): this {
     this._bottomOffset = '';
     this._topOffset = value;
     this._alignItems = 'flex-start';
     return this;
   }
 
-  /** Sets the left position of the overlay. Clears any previously set horizontal position. */
-  left(value: string) {
+  /**
+   * Sets the left position of the overlay. Clears any previously set horizontal position.
+   * @param value New left offset.
+   * @returns {GlobalPositionStrategy}
+   */
+  left(value: string): this {
     this._rightOffset = '';
     this._leftOffset = value;
     this._justifyContent = 'flex-start';
     return this;
   }
 
-  /** Sets the bottom position of the overlay. Clears any previously set vertical position. */
-  bottom(value: string) {
+  /**
+   * Sets the bottom position of the overlay. Clears any previously set vertical position.
+   * @param value New bottom offset.
+   * @returns {GlobalPositionStrategy}
+   */
+  bottom(value: string): this {
     this._topOffset = '';
     this._bottomOffset = value;
     this._alignItems = 'flex-end';
     return this;
   }
 
-  /** Sets the right position of the overlay. Clears any previously set horizontal position. */
-  right(value: string) {
+  /**
+   * Sets the right position of the overlay. Clears any previously set horizontal position.
+   * @param value New right offset.
+   * @returns {GlobalPositionStrategy}
+   */
+  right(value: string): this {
     this._leftOffset = '';
     this._rightOffset = value;
     this._justifyContent = 'flex-end';
     return this;
   }
 
-  /** Sets the overlay width and clears any previously set width. */
-  width(value: string) {
+  /**
+   * Sets the overlay width and clears any previously set width.
+   * @param value New width for the overlay
+   * @returns {GlobalPositionStrategy}
+   */
+  width(value: string): this {
     this._width = value;
 
     // When the width is 100%, we should reset the `left` and the offset,
@@ -66,8 +86,12 @@ export class GlobalPositionStrategy implements PositionStrategy {
     return this;
   }
 
-  /** Sets the overlay height and clears any previously set height. */
-  height(value: string) {
+  /**
+   * Sets the overlay height and clears any previously set height.
+   * @param value New height for the overlay
+   * @returns {GlobalPositionStrategy}
+   */
+  height(value: string): this {
     this._height = value;
 
     // When the height is 100%, we should reset the `top` and the offset,
@@ -82,8 +106,11 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Centers the overlay horizontally with an optional offset.
    * Clears any previously set horizontal position.
+   *
+   * @param offset Overlay offset from the horizontal center.
+   * @returns {GlobalPositionStrategy}
    */
-  centerHorizontally(offset = '') {
+  centerHorizontally(offset = ''): this {
     this.left(offset);
     this._justifyContent = 'center';
     return this;
@@ -92,8 +119,11 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Centers the overlay vertically with an optional offset.
    * Clears any previously set vertical position.
+   *
+   * @param offset Overlay offset from the vertical center.
+   * @returns {GlobalPositionStrategy}
    */
-  centerVertically(offset = '') {
+  centerVertically(offset = ''): this {
     this.top(offset);
     this._alignItems = 'center';
     return this;
@@ -102,6 +132,9 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Apply the position to the element.
    * @docs-private
+   *
+   * @param element Element to which to apply the CSS.
+   * @returns {Promise<void>} Resolved when the styles have been applied.
    */
   apply(element: HTMLElement): Promise<void> {
     if (!this._wrapper) {

--- a/src/lib/core/overlay/position/overlay-position-builder.ts
+++ b/src/lib/core/overlay/position/overlay-position-builder.ts
@@ -11,12 +11,21 @@ import {OverlayConnectionPosition, OriginConnectionPosition} from './connected-p
 export class OverlayPositionBuilder {
   constructor(private _viewportRuler: ViewportRuler) { }
 
-  /** Creates a global position strategy. */
+  /**
+   * Creates a global position strategy.
+   * @returns {GlobalPositionStrategy}
+   */
   global() {
     return new GlobalPositionStrategy();
   }
 
-  /** Creates a relative position strategy. */
+  /**
+   * Creates a relative position strategy.
+   * @param elementRef
+   * @param originPos
+   * @param overlayPos
+   * @returns {ConnectedPositionStrategy}
+   */
   connectedTo(
       elementRef: ElementRef,
       originPos: OriginConnectionPosition,

--- a/src/lib/core/overlay/position/overlay-position-builder.ts
+++ b/src/lib/core/overlay/position/overlay-position-builder.ts
@@ -13,9 +13,8 @@ export class OverlayPositionBuilder {
 
   /**
    * Creates a global position strategy.
-   * @returns {GlobalPositionStrategy}
    */
-  global() {
+  global(): GlobalPositionStrategy {
     return new GlobalPositionStrategy();
   }
 
@@ -24,12 +23,11 @@ export class OverlayPositionBuilder {
    * @param elementRef
    * @param originPos
    * @param overlayPos
-   * @returns {ConnectedPositionStrategy}
    */
   connectedTo(
       elementRef: ElementRef,
       originPos: OriginConnectionPosition,
-      overlayPos: OverlayConnectionPosition) {
+      overlayPos: OverlayConnectionPosition): ConnectedPositionStrategy {
     return new ConnectedPositionStrategy(elementRef, originPos, overlayPos, this._viewportRuler);
   }
 }

--- a/src/lib/core/overlay/position/relative-position-strategy.ts
+++ b/src/lib/core/overlay/position/relative-position-strategy.ts
@@ -1,6 +1,7 @@
 import {PositionStrategy} from './position-strategy';
 import {ElementRef} from '@angular/core';
 
+/** @docs-private */
 export class RelativePositionStrategy implements PositionStrategy {
   constructor(private _relativeTo: ElementRef) { }
 

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -51,8 +51,6 @@ export class ScrollDispatcher {
   /**
    * Returns an observable that emits an event whenever any of the registered Scrollable
    * references (or window, document, or body) fire a scrolled event.
-   *
-   * @returns {Observable<void>}
    */
   scrolled(): Observable<void> {
     // TODO: Add an event limiter that includes throttle with the leading and trailing events.

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -30,6 +30,8 @@ export class ScrollDispatcher {
   /**
    * Registers a Scrollable with the service and listens for its scrolled events. When the
    * scrollable is scrolled, the service emits the event in its scrolled observable.
+   *
+   * @param scrollable Scrollable instance to be registered.
    */
   register(scrollable: Scrollable): void {
     const scrollSubscription = scrollable.elementScrolled().subscribe(() => this._notify());
@@ -38,6 +40,8 @@ export class ScrollDispatcher {
 
   /**
    * Deregisters a Scrollable reference and unsubscribes from its scroll event observable.
+   *
+   * @param scrollable Scrollable instance to be deregistered.
    */
   deregister(scrollable: Scrollable): void {
     this.scrollableReferences.get(scrollable).unsubscribe();
@@ -47,9 +51,11 @@ export class ScrollDispatcher {
   /**
    * Returns an observable that emits an event whenever any of the registered Scrollable
    * references (or window, document, or body) fire a scrolled event.
-   * TODO: Add an event limiter that includes throttle with the leading and trailing events.
+   *
+   * @returns {Observable<void>}
    */
   scrolled(): Observable<void> {
+    // TODO: Add an event limiter that includes throttle with the leading and trailing events.
     return this._scrolled.asObservable();
   }
 

--- a/src/lib/core/overlay/scroll/scrollable.ts
+++ b/src/lib/core/overlay/scroll/scrollable.ts
@@ -17,12 +17,10 @@ import 'rxjs/add/observable/fromEvent';
 export class Scrollable implements OnInit, OnDestroy {
   constructor(private _elementRef: ElementRef, private _scroll: ScrollDispatcher) {}
 
-  /** @docs-private */
   ngOnInit() {
     this._scroll.register(this);
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     this._scroll.deregister(this);
   }

--- a/src/lib/core/overlay/scroll/scrollable.ts
+++ b/src/lib/core/overlay/scroll/scrollable.ts
@@ -29,7 +29,6 @@ export class Scrollable implements OnInit, OnDestroy {
 
   /**
    * Returns observable that emits when a scroll event is fired on the host element.
-   * @returns {Observable<any>}
    */
   elementScrolled(): Observable<any> {
     return Observable.fromEvent(this._elementRef.nativeElement, 'scroll');

--- a/src/lib/core/overlay/scroll/scrollable.ts
+++ b/src/lib/core/overlay/scroll/scrollable.ts
@@ -17,15 +17,20 @@ import 'rxjs/add/observable/fromEvent';
 export class Scrollable implements OnInit, OnDestroy {
   constructor(private _elementRef: ElementRef, private _scroll: ScrollDispatcher) {}
 
+  /** @docs-private */
   ngOnInit() {
     this._scroll.register(this);
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     this._scroll.deregister(this);
   }
 
-  /** Returns observable that emits when the scroll event is fired on the host element. */
+  /**
+   * Returns observable that emits when a scroll event is fired on the host element.
+   * @returns {Observable<any>}
+   */
   elementScrolled(): Observable<any> {
     return Observable.fromEvent(this._elementRef.nativeElement, 'scroll');
   }

--- a/src/lib/core/platform/features.ts
+++ b/src/lib/core/platform/features.ts
@@ -1,6 +1,6 @@
 let supportedInputTypes: Set<string>;
 
-/** @returns {Set<string>} the input types supported by this browser. */
+/** @returns The input types supported by this browser. */
 export function getSupportedInputTypes(): Set<string> {
   if (!supportedInputTypes) {
     let featureTestInput = document.createElement('input');

--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -23,7 +23,11 @@ export class DomPortalHost extends BasePortalHost {
     super();
   }
 
-  /** Attach the given ComponentPortal to DOM element using the ComponentFactoryResolver. */
+  /**
+   * Attach the given ComponentPortal to DOM element using the ComponentFactoryResolver.
+   * @param portal Portal to be attached
+   * @returns {ComponentRef<T>}
+   */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     let componentFactory = this._componentFactoryResolver.resolveComponentFactory(portal.component);
     let componentRef: ComponentRef<T>;
@@ -82,6 +86,11 @@ export class DomPortalHost extends BasePortalHost {
     return componentRef;
   }
 
+  /**
+   * Attaches a template portal to the DOM as an embedded view.
+   * @param portal Portal to be attached.
+   * @returns {Map<string, any>}
+   */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     let viewContainer = portal.viewContainerRef;
     let viewRef = viewContainer.createEmbeddedView(portal.templateRef);
@@ -99,6 +108,9 @@ export class DomPortalHost extends BasePortalHost {
     return new Map<string, any>();
   }
 
+  /**
+   * Clears out a portal from the DOM.
+   */
   dispose(): void {
     super.dispose();
     if (this._hostDomElement.parentNode != null) {

--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -26,7 +26,6 @@ export class DomPortalHost extends BasePortalHost {
   /**
    * Attach the given ComponentPortal to DOM element using the ComponentFactoryResolver.
    * @param portal Portal to be attached
-   * @returns {ComponentRef<T>}
    */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     let componentFactory = this._componentFactoryResolver.resolveComponentFactory(portal.component);
@@ -89,7 +88,6 @@ export class DomPortalHost extends BasePortalHost {
   /**
    * Attaches a template portal to the DOM as an embedded view.
    * @param portal Portal to be attached.
-   * @returns {Map<string, any>}
    */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     let viewContainer = portal.viewContainerRef;

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -58,6 +58,7 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
   get _deprecatedPortal() { return this.portal; }
   set _deprecatedPortal(v) { this.portal = v; }
 
+  /** Portal associated with the Portal host. */
   get portal(): Portal<any> {
     return this._portal;
   }
@@ -68,11 +69,17 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
     }
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     this.dispose();
   }
 
-  /** Attach the given ComponentPortal to this PortalHost using the ComponentFactoryResolver. */
+  /**
+   * Attach the given ComponentPortal to this PortalHost using the ComponentFactoryResolver.
+   *
+   * @param portal Portal to be attached to the portal host.
+   * @returns {ComponentRef<T>}
+   */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     portal.setAttachedHost(this);
 
@@ -92,7 +99,11 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
     return ref;
   }
 
-  /** Attach the given TemplatePortal to this PortlHost as an embedded View. */
+  /**
+   * Attach the given TemplatePortal to this PortlHost as an embedded View.
+   * @param portal Portal to be attached.
+   * @returns {Map<string, any>}
+   */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     portal.setAttachedHost(this);
 

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -69,7 +69,6 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
     }
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     this.dispose();
   }

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -78,7 +78,6 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
    * Attach the given ComponentPortal to this PortalHost using the ComponentFactoryResolver.
    *
    * @param portal Portal to be attached to the portal host.
-   * @returns {ComponentRef<T>}
    */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     portal.setAttachedHost(this);
@@ -102,7 +101,6 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
   /**
    * Attach the given TemplatePortal to this PortlHost as an embedded View.
    * @param portal Portal to be attached.
-   * @returns {Map<string, any>}
    */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     portal.setAttachedHost(this);

--- a/src/lib/core/projection/projection.ts
+++ b/src/lib/core/projection/projection.ts
@@ -46,6 +46,9 @@ export class DomProjection {
    * contain the `<div>other</div>` HTML as well as its own children.
    *
    * Note: without `<ng-content></ng-content>` the projection will project an empty element.
+   *
+   * @param ref ElementRef to be projected.
+   * @param host Projection host into which to project the `ElementRef`.
    */
   project(ref: ElementRef, host: DomProjectionHost): void {
     const projectedEl = ref.nativeElement;

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -66,6 +66,8 @@ export class RippleRenderer {
   /**
    * Installs event handlers on the given trigger element, and removes event handlers from the
    * previous trigger if needed.
+   *
+   * @param newTrigger New trigger to which to attach the ripple handlers.
    */
   setTriggerElement(newTrigger: HTMLElement) {
     if (this._triggerElement !== newTrigger) {
@@ -97,6 +99,14 @@ export class RippleRenderer {
    * Creates a foreground ripple and sets its animation to expand and fade in from the position
    * given by rippleOriginLeft and rippleOriginTop (or from the center of the <md-ripple>
    * bounding rect if centered is true).
+   *
+   * @param rippleOriginLeft Left origin of the ripple.
+   * @param rippleOriginTop Top origin of the ripple.
+   * @param color Ripple color.
+   * @param centered Whether the ripple should be centered.
+   * @param radius Radius of the ripple.
+   * @param speedFactor Speed at which the ripple expands towards the edges.
+   * @param transitionEndCallback Callback to be triggered when the ripple transition is done.
    */
   createForegroundRipple(
       rippleOriginLeft: number,
@@ -158,20 +168,29 @@ export class RippleRenderer {
     });
   }
 
-  /** Fades out a foreground ripple after it has fully expanded and faded in. */
+  /**
+   * Fades out a foreground ripple after it has fully expanded and faded in.
+   * @param ripple Ripple to be faded out.
+   */
   fadeOutForegroundRipple(ripple: Element) {
     ripple.classList.remove('md-ripple-fade-in');
     ripple.classList.add('md-ripple-fade-out');
   }
 
-  /** Removes a foreground ripple from the DOM after it has faded out. */
+  /**
+   * Removes a foreground ripple from the DOM after it has faded out.
+   * @param ripple Ripple to be removed from the DOM.
+   */
   removeRippleFromDom(ripple: Element) {
     if (ripple && ripple.parentElement) {
       ripple.parentElement.removeChild(ripple);
     }
   }
 
-  /** Fades in the ripple background. */
+  /**
+   * Fades in the ripple background.
+   * @param color New background color for the ripple.
+   */
   fadeInRippleBackground(color: string) {
     this._backgroundDiv.classList.add('md-ripple-active');
     // If color is not set, this will default to the background color defined in CSS.

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -127,7 +127,6 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     this._ruler = _ruler;
   }
 
-  /** @docs-private */
   ngOnInit() {
     // If no trigger element was explicity set, use the host element
     if (!this.trigger) {
@@ -138,13 +137,11 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     // Remove event listeners on the trigger element.
     this._rippleRenderer.clearTriggerElement();
   }
 
-  /** @docs-private */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     // If the trigger element changed (or is being initially set), add event listeners to it.
     const changedInputs = Object.keys(changes);

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -127,6 +127,7 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     this._ruler = _ruler;
   }
 
+  /** @docs-private */
   ngOnInit() {
     // If no trigger element was explicity set, use the host element
     if (!this.trigger) {
@@ -137,11 +138,13 @@ export class MdRipple implements OnInit, OnDestroy, OnChanges {
     }
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     // Remove event listeners on the trigger element.
     this._rippleRenderer.clearTriggerElement();
   }
 
+  /** @docs-private */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     // If the trigger element changed (or is being initially set), add event listeners to it.
     const changedInputs = Object.keys(changes);

--- a/src/lib/core/rtl/dir.ts
+++ b/src/lib/core/rtl/dir.ts
@@ -11,7 +11,7 @@ import {
 export type LayoutDirection = 'ltr' | 'rtl';
 
 /**
- * Directive to listen to changes of direction of part of the DOM.
+ * Directive to listen for changes of direction of part of the DOM.
  *
  * Applications should use this directive instead of the native attribute so that Material
  * components can listen on changes of direction.
@@ -22,10 +22,13 @@ export type LayoutDirection = 'ltr' | 'rtl';
   exportAs: '$implicit'
 })
 export class Dir {
+  /** Layout direction of the element. */
   @Input('dir') _dir: LayoutDirection = 'ltr';
 
+  /** Event emitted when the direction changes. */
   @Output() dirChange = new EventEmitter<void>();
 
+  /** @docs-private */
   @HostBinding('attr.dir')
   get dir(): LayoutDirection {
     return this._dir;
@@ -38,6 +41,7 @@ export class Dir {
     }
   }
 
+  /** Current layout direction of the element. */
   get value(): LayoutDirection { return this.dir; }
   set value(v: LayoutDirection) { this.dir = v; }
 }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -50,7 +50,11 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
     super();
   }
 
-  /** Attach a portal as content to this dialog container. */
+  /**
+   * Attach a portal as content to this dialog container.
+   * @param portal Portal to be attached as the dialog content.
+   * @returns {ComponentRef<T>}
+   */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     if (this._portalHost.hasAttached()) {
       throw new MdDialogContentAlreadyAttachedError();
@@ -69,17 +73,22 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
     return attachResult;
   }
 
+  /** @docs-private */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     throw Error('Not yet implemented');
   }
 
-  /** Handles the user pressing the Escape key. */
+  /**
+   * Handles the user pressing the Escape key.
+   * @docs-private
+   */
   handleEscapeKey() {
     if (!this.dialogConfig.disableClose) {
       this.dialogRef.close();
     }
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     // When the dialog is destroyed, return focus to the element that originally had it before
     // the dialog was opened. Wait for the DOM to finish settling before changing the focus so

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -53,7 +53,6 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
   /**
    * Attach a portal as content to this dialog container.
    * @param portal Portal to be attached as the dialog content.
-   * @returns {ComponentRef<T>}
    */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     if (this._portalHost.hasAttached()) {

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -87,7 +87,6 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
     }
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     // When the dialog is destroyed, return focus to the element that originally had it before
     // the dialog was opened. Wait for the DOM to finish settling before changing the focus so

--- a/src/lib/dialog/dialog-errors.ts
+++ b/src/lib/dialog/dialog-errors.ts
@@ -1,6 +1,9 @@
 import {MdError} from '../core';
 
-/** Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin. */
+/**
+ * Exception thrown when a ComponentPortal is attached to a DomPortalHost without an origin.
+ * @docs-private
+ */
 export class MdDialogContentAlreadyAttachedError extends MdError {
   constructor() {
       super('Attempting to attach dialog content after content is already attached');

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -31,7 +31,6 @@ export class MdDialogRef<T> {
 
   /**
    * Gets an observable that is notified when the dialog is finished closing.
-   * @returns {Observable<any>}
    */
   afterClosed(): Observable<any> {
     return this._afterClosed.asObservable();

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -29,7 +29,10 @@ export class MdDialogRef<T> {
     this._afterClosed.complete();
   }
 
-  /** Gets an observable that is notified when the dialog is finished closing. */
+  /**
+   * Gets an observable that is notified when the dialog is finished closing.
+   * @returns {Observable<any>}
+   */
   afterClosed(): Observable<any> {
     return this._afterClosed.asObservable();
   }

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -27,7 +27,8 @@ export class MdDialog {
   /**
    * Opens a modal dialog containing the given component.
    * @param component Type of the component to load into the load.
-   * @param config
+   * @param config Extra configuration options.
+   * @returns {MdDialogRef<T>} Reference to the newly-opened dialog.
    */
   open<T>(component: ComponentType<T>, config?: MdDialogConfig): MdDialogRef<T> {
     config = _applyConfigDefaults(config);
@@ -151,6 +152,7 @@ export class MdDialog {
 
   /**
    * Removes a dialog from the array of open dialogs.
+   * @param dialogRef Dialog to be removed.
    */
   private _removeOpenDialog(dialogRef: MdDialogRef<any>) {
     let index = this._openDialogs.indexOf(dialogRef);

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -28,7 +28,7 @@ export class MdDialog {
    * Opens a modal dialog containing the given component.
    * @param component Type of the component to load into the load.
    * @param config Extra configuration options.
-   * @returns {MdDialogRef<T>} Reference to the newly-opened dialog.
+   * @returns Reference to the newly-opened dialog.
    */
   open<T>(component: ComponentType<T>, config?: MdDialogConfig): MdDialogRef<T> {
     config = _applyConfigDefaults(config);

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -65,10 +65,12 @@ export class MdGridList implements OnInit, AfterContentChecked {
       private _element: ElementRef,
       @Optional() private _dir: Dir) {}
 
+  /** Amount of columns in the grid list. */
   @Input()
   get cols() { return this._cols; }
   set cols(value: any) { this._cols = coerceToNumber(value); }
 
+  /** Size of the grid list's gutter in pixels. */
   @Input()
   get gutterSize() { return this._gutter; }
   set gutterSize(value: any) { this._gutter = coerceToString(value); }
@@ -80,6 +82,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
     this._setTileStyler();
   }
 
+  /** @docs-private */
   ngOnInit() {
     this._checkCols();
     this._checkRowHeight();
@@ -88,6 +91,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   /**
    * The layout calculation is fairly cheap if nothing changes, so there's little cost
    * to run it frequently.
+   * @docs-private
    */
   ngAfterContentChecked() {
     this._layoutTiles();

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -82,7 +82,6 @@ export class MdGridList implements OnInit, AfterContentChecked {
     this._setTileStyler();
   }
 
-  /** @docs-private */
   ngOnInit() {
     this._checkCols();
     this._checkRowHeight();
@@ -91,7 +90,6 @@ export class MdGridList implements OnInit, AfterContentChecked {
   /**
    * The layout calculation is fairly cheap if nothing changes, so there's little cost
    * to run it frequently.
-   * @docs-private
    */
   ngAfterContentChecked() {
     this._layoutTiles();

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -8,7 +8,7 @@ import {
   QueryList,
   AfterContentInit
 } from '@angular/core';
-import { MdLine, MdLineSetter } from '../core';
+import {MdLine, MdLineSetter} from '../core';
 import {coerceToNumber} from './grid-list-measure';
 
 @Component({
@@ -25,23 +25,15 @@ export class MdGridTile {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
+  /** Amount of rows that the grid tile takes up. */
   @Input()
-  get rowspan() {
-    return this._rowspan;
-  }
+  get rowspan() { return this._rowspan; }
+  set rowspan(value) { this._rowspan = coerceToNumber(value); }
 
+  /** Amount of columns that the grid tile takes up. */
   @Input()
-  get colspan() {
-    return this._colspan;
-  }
-
-  set rowspan(value) {
-    this._rowspan = coerceToNumber(value);
-  }
-
-  set colspan(value) {
-    this._colspan = coerceToNumber(value);
-  }
+  get colspan() { return this._colspan; }
+  set colspan(value) { this._colspan = coerceToNumber(value); }
 
   /**
    * Sets the style of the grid-tile element.  Needs to be set manually to avoid
@@ -68,6 +60,7 @@ export class MdGridTileText implements AfterContentInit {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -60,7 +60,6 @@ export class MdGridTileText implements AfterContentInit {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -105,7 +105,6 @@ export class TileStyler {
 
   /**
    * Calculates the total size taken up by gutters across one axis of a list.
-   * @returns {string}
    */
   getGutterSpan(): string {
     return `${this._gutterSize} * (${this._rowspan} - 1)`;
@@ -114,7 +113,6 @@ export class TileStyler {
   /**
    * Calculates the total size taken up by tiles across one axis of a list.
    * @param tileHeight Height of the tile.
-   * @returns {string}
    */
   getTileSpan(tileHeight: string): string {
     return `${this._rowspan} * ${this.getTileSize(tileHeight, 1)}`;

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -17,9 +17,14 @@ export class TileStyler {
   /**
    * Adds grid-list layout info once it is available. Cannot be processed in the constructor
    * because these properties haven't been calculated by that point.
+   *
+   * @param gutterSize Size of the grid's gutter.
+   * @param tracker Instance of the TileCoordinator.
+   * @param cols Amount of columns in the grid.
+   * @param direction Layout direction of the grid.
    */
-  init(_gutterSize: string, tracker: TileCoordinator, cols: number, direction: string): void {
-    this._gutterSize = normalizeUnits(_gutterSize);
+  init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string): void {
+    this._gutterSize = normalizeUnits(gutterSize);
     this._rows = tracker.rowCount;
     this._rowspan = tracker.rowspan;
     this._cols = cols;
@@ -67,7 +72,12 @@ export class TileStyler {
   }
 
 
-  /** Gets the style properties to be applied to a tile for the given row and column index. */
+  /**
+   * Sets the style properties to be applied to a tile for the given row and column index.
+   * @param tile Tile to which to apply the styling.
+   * @param rowIndex Index of the tile's row.
+   * @param colIndex Index of the tile's column.
+   */
   setStyle(tile: MdGridTile, rowIndex: number, colIndex: number): void {
     // Percent of the available horizontal space that one column takes up.
     let percentWidthPerTile = 100 / this._cols;
@@ -93,12 +103,19 @@ export class TileStyler {
     tile._setStyle('width', calc(this.getTileSize(baseTileWidth, tile.colspan)));
   }
 
-  /** Calculates the total size taken up by gutters across one axis of a list. */
+  /**
+   * Calculates the total size taken up by gutters across one axis of a list.
+   * @returns {string}
+   */
   getGutterSpan(): string {
     return `${this._gutterSize} * (${this._rowspan} - 1)`;
   }
 
-  /** Calculates the total size taken up by tiles across one axis of a list. */
+  /**
+   * Calculates the total size taken up by tiles across one axis of a list.
+   * @param tileHeight Height of the tile.
+   * @returns {string}
+   */
   getTileSpan(tileHeight: string): string {
     return `${this._rowspan} * ${this.getTileSize(tileHeight, 1)}`;
   }
@@ -106,12 +123,14 @@ export class TileStyler {
   /**
    * Sets the vertical placement of the tile in the list.
    * This method will be implemented by each type of TileStyler.
+   * @docs-private
    */
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number, gutterWidth: number) {}
 
   /**
    * Calculates the computed height and returns the correct style property to set.
    * This method will be implemented by each type of TileStyler.
+   * @docs-private
    */
   getComputedHeight(): [string, string] { return null; }
 }

--- a/src/lib/icon/fake-svgs.ts
+++ b/src/lib/icon/fake-svgs.ts
@@ -4,6 +4,7 @@ import {
 
 /**
  * Fake URLs and associated SVG documents used by tests.
+ * @docs-private
  */
 const FAKE_SVGS = (() => {
   const svgs = new Map<string, string>();
@@ -45,6 +46,7 @@ const FAKE_SVGS = (() => {
 
 /**
  * Returns an HTTP response for a fake SVG URL.
+ * @docs-private
  */
 export function getFakeSvgHttpResponse(url: string) {
   if (FAKE_SVGS.has(url)) {

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -85,24 +85,44 @@ export class MdIconRegistry {
 
   constructor(private _http: Http, private _sanitizer: DomSanitizer) {}
 
-  /** Registers an icon by URL in the default namespace. */
+  /**
+   * Registers an icon by URL in the default namespace.
+   * @param iconName Name under which the icon should be registered.
+   * @param url
+   * @returns {MdIconRegistry}
+   */
   addSvgIcon(iconName: string, url: SafeResourceUrl): this {
     return this.addSvgIconInNamespace('', iconName, url);
   }
 
-  /** Registers an icon by URL in the specified namespace. */
+  /**
+   * Registers an icon by URL in the specified namespace.
+   * @param namespace Namespace in which the icon should be registered.
+   * @param iconName Name under which the icon should be registered.
+   * @param url
+   * @returns {MdIconRegistry}
+   */
   addSvgIconInNamespace(namespace: string, iconName: string, url: SafeResourceUrl): this {
     const key = iconKey(namespace, iconName);
     this._svgIconConfigs.set(key, new SvgIconConfig(url));
     return this;
   }
 
-  /** Registers an icon set by URL in the default namespace. */
+  /**
+   * Registers an icon set by URL in the default namespace.
+   * @param url
+   * @returns {MdIconRegistry}
+   */
   addSvgIconSet(url: SafeResourceUrl): this {
     return this.addSvgIconSetInNamespace('', url);
   }
 
-  /** Registers an icon set by URL in the specified namespace. */
+  /**
+   * Registers an icon set by URL in the specified namespace.
+   * @param namespace Namespace in which to register the icon set.
+   * @param url
+   * @returns {MdIconRegistry}
+   */
   addSvgIconSetInNamespace(namespace: string, url: SafeResourceUrl): this {
     const config = new SvgIconConfig(url);
     if (this._iconSetConfigs.has(namespace)) {
@@ -117,6 +137,10 @@ export class MdIconRegistry {
    * Defines an alias for a CSS class name to be used for icon fonts. Creating an mdIcon
    * component with the alias as the fontSet input will cause the class name to be applied
    * to the <md-icon> element.
+   *
+   * @param alias Alias for the font.
+   * @param className Class name override to be used instead of the alias.
+   * @returns {MdIconRegistry}
    */
   registerFontClassAlias(alias: string, className = alias): this {
     this._fontCssClassesByAlias.set(alias, className);
@@ -126,6 +150,8 @@ export class MdIconRegistry {
   /**
    * Returns the CSS class name associated with the alias by a previous call to
    * registerFontClassAlias. If no CSS class has been associated, returns the alias unmodified.
+   *
+   * @returns {string} Alias for the font.
    */
   classNameForFontAlias(alias: string): string {
     return this._fontCssClassesByAlias.get(alias) || alias;
@@ -134,6 +160,8 @@ export class MdIconRegistry {
   /**
    * Sets the CSS class name to be used for icon fonts when an <md-icon> component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
+   *
+   * @param className
    */
   setDefaultFontSetClass(className: string): this {
     this._defaultFontSetClass = className;
@@ -143,6 +171,8 @@ export class MdIconRegistry {
   /**
    * Returns the CSS class name to be used for icon fonts when an <md-icon> component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
+   *
+   * @returns {string}
    */
   getDefaultFontSetClass(): string {
     return this._defaultFontSetClass;
@@ -153,6 +183,9 @@ export class MdIconRegistry {
    * The response from the URL may be cached so this will not always cause an HTTP request, but
    * the produced element will always be a new copy of the originally fetched icon. (That is,
    * it will not contain any modifications made to elements previously returned).
+   *
+   * @param safeUrl URL from which to fetch the SVG icon.
+   * @returns {Observable<SVGElement>}
    */
   getSvgIconFromUrl(safeUrl: SafeResourceUrl): Observable<SVGElement> {
     let url = this._sanitizer.sanitize(SecurityContext.RESOURCE_URL, safeUrl);
@@ -169,6 +202,8 @@ export class MdIconRegistry {
    * Returns an Observable that produces the icon (as an <svg> DOM element) with the given name
    * and namespace. The icon must have been previously registered with addIcon or addIconSet;
    * if not, the Observable will throw an MdIconNameNotFoundError.
+   *
+   * @returns {string}
    */
   getNamedSvgIcon(name: string, namespace = ''): Observable<SVGElement> {
     // Return (copy of) cached icon if possible.

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -89,7 +89,6 @@ export class MdIconRegistry {
    * Registers an icon by URL in the default namespace.
    * @param iconName Name under which the icon should be registered.
    * @param url
-   * @returns {MdIconRegistry}
    */
   addSvgIcon(iconName: string, url: SafeResourceUrl): this {
     return this.addSvgIconInNamespace('', iconName, url);
@@ -100,7 +99,6 @@ export class MdIconRegistry {
    * @param namespace Namespace in which the icon should be registered.
    * @param iconName Name under which the icon should be registered.
    * @param url
-   * @returns {MdIconRegistry}
    */
   addSvgIconInNamespace(namespace: string, iconName: string, url: SafeResourceUrl): this {
     const key = iconKey(namespace, iconName);
@@ -111,7 +109,6 @@ export class MdIconRegistry {
   /**
    * Registers an icon set by URL in the default namespace.
    * @param url
-   * @returns {MdIconRegistry}
    */
   addSvgIconSet(url: SafeResourceUrl): this {
     return this.addSvgIconSetInNamespace('', url);
@@ -121,7 +118,6 @@ export class MdIconRegistry {
    * Registers an icon set by URL in the specified namespace.
    * @param namespace Namespace in which to register the icon set.
    * @param url
-   * @returns {MdIconRegistry}
    */
   addSvgIconSetInNamespace(namespace: string, url: SafeResourceUrl): this {
     const config = new SvgIconConfig(url);
@@ -140,7 +136,6 @@ export class MdIconRegistry {
    *
    * @param alias Alias for the font.
    * @param className Class name override to be used instead of the alias.
-   * @returns {MdIconRegistry}
    */
   registerFontClassAlias(alias: string, className = alias): this {
     this._fontCssClassesByAlias.set(alias, className);
@@ -150,8 +145,6 @@ export class MdIconRegistry {
   /**
    * Returns the CSS class name associated with the alias by a previous call to
    * registerFontClassAlias. If no CSS class has been associated, returns the alias unmodified.
-   *
-   * @returns {string} Alias for the font.
    */
   classNameForFontAlias(alias: string): string {
     return this._fontCssClassesByAlias.get(alias) || alias;
@@ -171,8 +164,6 @@ export class MdIconRegistry {
   /**
    * Returns the CSS class name to be used for icon fonts when an <md-icon> component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
-   *
-   * @returns {string}
    */
   getDefaultFontSetClass(): string {
     return this._defaultFontSetClass;
@@ -185,7 +176,6 @@ export class MdIconRegistry {
    * it will not contain any modifications made to elements previously returned).
    *
    * @param safeUrl URL from which to fetch the SVG icon.
-   * @returns {Observable<SVGElement>}
    */
   getSvgIconFromUrl(safeUrl: SafeResourceUrl): Observable<SVGElement> {
     let url = this._sanitizer.sanitize(SecurityContext.RESOURCE_URL, safeUrl);
@@ -203,7 +193,8 @@ export class MdIconRegistry {
    * and namespace. The icon must have been previously registered with addIcon or addIconSet;
    * if not, the Observable will throw an MdIconNameNotFoundError.
    *
-   * @returns {string}
+   * @param name Name of the icon to be retrieved.
+   * @param namespace Namespace in which to look for the icon.
    */
   getNamedSvgIcon(name: string, namespace = ''): Observable<SVGElement> {
     // Return (copy of) cached icon if possible.

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -71,21 +71,25 @@ export class MdIconInvalidNameError extends MdError {
 export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
   private _color: string;
 
+  /** Name of the icon in the SVG icon set. */
   @Input() svgIcon: string;
+
+  /** Font set that the icon is a part of. */
   @Input() fontSet: string;
+
+  /** Name of an icon within a font set. */
   @Input() fontIcon: string;
+
+  /** Alt label to be used for accessibility. */
   @Input() alt: string;
 
+  /** Screenreader label for the icon. */
   @Input('aria-label') hostAriaLabel: string = '';
 
+  /** Color of the icon. */
   @Input()
-  get color(): string {
-    return this._color;
-  }
-
-  set color(value: string) {
-    this._updateColor(value);
-  }
+  get color(): string { return this._color; }
+  set color(value: string) { this._updateColor(value); }
 
   private _previousFontSetClass: string;
   private _previousFontIconClass: string;
@@ -136,6 +140,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
+  /** @docs-private */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     const changedInputs = Object.keys(changes);
     // Only update the inline SVG icon if the inputs changed, to avoid unnecessary DOM operations.
@@ -153,6 +158,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     this._updateAriaLabel();
   }
 
+  /** @docs-private */
   ngOnInit() {
     // Update font classes because ngOnChanges won't be called if none of the inputs are present,
     // e.g. <md-icon>arrow</md-icon>. In this case we need to add a CSS class for the default font.
@@ -161,6 +167,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
+  /** @docs-private */
   ngAfterViewChecked() {
     // Update aria label here because it may depend on the projected text content.
     // (e.g. <md-icon>home</md-icon> should use 'home').

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -140,7 +140,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
-  /** @docs-private */
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     const changedInputs = Object.keys(changes);
     // Only update the inline SVG icon if the inputs changed, to avoid unnecessary DOM operations.
@@ -158,7 +157,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     this._updateAriaLabel();
   }
 
-  /** @docs-private */
   ngOnInit() {
     // Update font classes because ngOnChanges won't be called if none of the inputs are present,
     // e.g. <md-icon>arrow</md-icon>. In this case we need to add a CSS class for the default font.
@@ -167,7 +165,6 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 
-  /** @docs-private */
   ngAfterViewChecked() {
     // Update aria label here because it may depend on the projected text content.
     // (e.g. <md-icon>home</md-icon> should use 'home').

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -34,7 +34,6 @@ export class MdTextareaAutosize implements OnInit {
     return this.maxRows ? `${this.maxRows * this._cachedLineHeight}px` : null;
   }
 
-  /** @docs-private */
   ngOnInit() {
     this._cacheTextareaLineHeight();
     this.resizeToFitContent();

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -34,6 +34,7 @@ export class MdTextareaAutosize implements OnInit {
     return this.maxRows ? `${this.maxRows * this._cachedLineHeight}px` : null;
   }
 
+  /** @docs-private */
   ngOnInit() {
     this._cacheTextareaLineHeight();
     this.resizeToFitContent();

--- a/src/lib/input/input-container-errors.ts
+++ b/src/lib/input/input-container-errors.ts
@@ -1,27 +1,27 @@
 import {MdError} from '../core/errors/error';
 
-
+/** @docs-private */
 export class MdInputContainerPlaceholderConflictError extends MdError {
   constructor() {
     super('Placeholder attribute and child element were both specified.');
   }
 }
 
-
+/** @docs-private */
 export class MdInputContainerUnsupportedTypeError extends MdError {
   constructor(type: string) {
     super(`Input type "${type}" isn't supported by md-input-container.`);
   }
 }
 
-
+/** @docs-private */
 export class MdInputContainerDuplicatedHintError extends MdError {
   constructor(align: string) {
     super(`A hint was already declared for 'align="${align}"'.`);
   }
 }
 
-
+/** @docs-private */
 export class MdInputContainerMissingMdInputError extends MdError {
   constructor() {
     super('md-input-container must contain an md-input directive. Did you forget to add md-input ' +

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -153,7 +153,6 @@ export class MdInputDirective implements AfterContentInit {
     }
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     this.value = this._elementRef.nativeElement.value;
   }
@@ -229,7 +228,6 @@ export class MdInputContainer implements AfterContentInit {
 
   @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
 
-  /** @docs-private */
   ngAfterContentInit() {
     if (!this._mdInputChild) {
       throw new MdInputContainerMissingMdInputError();

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -78,16 +78,19 @@ export class MdHint {
   }
 })
 export class MdInputDirective implements AfterContentInit {
+  /** Whether the element is disabled. */
   @Input()
   get disabled() { return this._disabled; }
   set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
   private _disabled = false;
 
+  /** Unique id of the element. */
   @Input()
   get id() { return this._id; };
   set id(value: string) { this._id = value || this._uid; }
   private _id: string;
 
+  /** Placeholder attribute of the element. */
   @Input()
   get placeholder() { return this._placeholder; }
   set placeholder(value: string) {
@@ -98,11 +101,13 @@ export class MdInputDirective implements AfterContentInit {
   }
   private _placeholder = '';
 
+  /** Whether the element is required. */
   @Input()
   get required() { return this._required; }
   set required(value: any) { this._required = coerceBooleanProperty(value); }
   private _required = false;
 
+  /** Input type of the element. */
   @Input()
   get type() { return this._type; }
   set type(value: string) {
@@ -111,6 +116,7 @@ export class MdInputDirective implements AfterContentInit {
   }
   private _type = 'text';
 
+  /** The element's value. */
   value: any;
 
   /**
@@ -147,11 +153,12 @@ export class MdInputDirective implements AfterContentInit {
     }
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     this.value = this._elementRef.nativeElement.value;
   }
 
-  /** Focus the input element. */
+  /** Focuses the input element. */
   focus() { this._renderer.invokeElementMethod(this._elementRef.nativeElement, 'focus'); }
 
   _onFocus() { this.focused = true; }
@@ -195,10 +202,13 @@ export class MdInputDirective implements AfterContentInit {
   encapsulation: ViewEncapsulation.None,
 })
 export class MdInputContainer implements AfterContentInit {
+  /** Alignment of the input container's content. */
   @Input() align: 'start' | 'end' = 'start';
 
+  /** Color of the input divider, based on the theme. */
   @Input() dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
 
+  /** Text for the input hint. */
   @Input()
   get hintLabel() { return this._hintLabel; }
   set hintLabel(value: string) {
@@ -207,6 +217,7 @@ export class MdInputContainer implements AfterContentInit {
   }
   private _hintLabel = '';
 
+  /** Text or the floating placeholder. */
   @Input()
   get floatingPlaceholder(): boolean { return this._floatingPlaceholder; }
   set floatingPlaceholder(value) { this._floatingPlaceholder = coerceBooleanProperty(value); }
@@ -218,6 +229,7 @@ export class MdInputContainer implements AfterContentInit {
 
   @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
 
+  /** @docs-private */
   ngAfterContentInit() {
     if (!this._mdInputChild) {
       throw new MdInputContainerMissingMdInputError();

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -46,19 +46,21 @@ const MD_INPUT_INVALID_INPUT_TYPE = [
 
 let nextUniqueId = 0;
 
-
+/** @docs-private */
 export class MdInputPlaceholderConflictError extends MdError {
   constructor() {
     super('Placeholder attribute and child element were both specified.');
   }
 }
 
+/** @docs-private */
 export class MdInputUnsupportedTypeError extends MdError {
   constructor(type: string) {
     super(`Input type "${type}" isn't supported by md-input.`);
   }
 }
 
+/** @docs-private */
 export class MdInputDuplicatedHintError extends MdError {
   constructor(align: string) {
     super(`A hint was already declared for 'align="${align}"'.`);
@@ -98,14 +100,17 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   private _ariaRequired: boolean;
   private _ariaInvalid: boolean;
 
+  /** Mirrors the native `aria-disabled` attribute. */
   @Input('aria-disabled')
   get ariaDisabled(): boolean { return this._ariaDisabled; }
   set ariaDisabled(value) { this._ariaDisabled = coerceBooleanProperty(value); }
 
+  /** Mirrors the native `aria-required` attribute. */
   @Input('aria-required')
   get ariaRequired(): boolean { return this._ariaRequired; }
   set ariaRequired(value) { this._ariaRequired = coerceBooleanProperty(value); }
 
+  /** Mirrors the native `aria-invalid` attribute. */
   @Input('aria-invalid')
   get ariaInvalid(): boolean { return this._ariaInvalid; }
   set ariaInvalid(value) { this._ariaInvalid = coerceBooleanProperty(value); }
@@ -117,38 +122,80 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
 
   /** Readonly properties. */
+
+  /** Whether the element is focused. */
   get focused() { return this._focused; }
+
+  /** Whether the element is empty. */
   get empty() { return (this._value == null || this._value === '') && this.type !== 'date'; }
+
+  /** Amount of characters inside the element. */
   get characterCount(): number {
     return this.empty ? 0 : ('' + this._value).length;
   }
+
+  /** Unique element id. */
   get inputId(): string { return `${this.id}-input`; }
 
-  /**
-   * Bindings.
-   */
+  /** Alignment of the input container's content. */
   @Input() align: 'start' | 'end' = 'start';
+
+  /** Color of the input divider, based on the theme. */
   @Input() dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
+
+  /** Text for the input hint. */
   @Input() hintLabel: string = '';
 
+  /** Mirrors the native `autocomplete` attribute. */
   @Input() autocomplete: string;
+
+  /** Mirrors the native `autocorrect` attribute. */
   @Input() autocorrect: string;
+
+  /** Mirrors the native `autocapitalize` attribute. */
   @Input() autocapitalize: string;
+
+  /** Unique id for the input element. */
   @Input() id: string = `md-input-${nextUniqueId++}`;
+
+  /** Mirrors the native `list` attribute. */
   @Input() list: string = null;
+
+  /** Mirrors the native `max` attribute. */
   @Input() max: string | number = null;
+
+  /** Mirrors the native `maxlength` attribute. */
   @Input() maxlength: number = null;
+
+  /** Mirrors the native `min` attribute. */
   @Input() min: string | number = null;
+
+  /** Mirrors the native `minlength` attribute. */
   @Input() minlength: number = null;
+
+  /** Mirrors the native `placeholder` attribute. */
   @Input() placeholder: string = null;
+
+  /** Mirrors the native `step` attribute. */
   @Input() step: number = null;
+
+  /** Mirrors the native `tabindex` attribute. */
   @Input() tabindex: number = null;
+
+  /** Mirrors the native `type` attribute. */
   @Input() type: string = 'text';
+
+  /** Mirrors the native `name` attribute. */
   @Input() name: string = null;
 
   // textarea-specific
+  /** Mirrors the native `rows` attribute. */
   @Input() rows: number = null;
+
+  /** Mirrors the native `cols` attribute. */
   @Input() cols: number = null;
+
+  /** Whether to do a soft or hard wrap of the text.. */
   @Input() wrap: 'soft' | 'hard' = null;
 
   private _floatingPlaceholder: boolean = true;
@@ -158,26 +205,32 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   private _required: boolean = false;
   private _spellcheck: boolean = false;
 
+  /** Text for the floating placeholder. */
   @Input()
   get floatingPlaceholder(): boolean { return this._floatingPlaceholder; }
   set floatingPlaceholder(value) { this._floatingPlaceholder = coerceBooleanProperty(value); }
 
+  /** Whether to automatically focus the input. */
   @Input()
   get autofocus(): boolean { return this._autofocus; }
   set autofocus(value) { this._autofocus = coerceBooleanProperty(value); }
 
+  /** Whether the input is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
   set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
+  /** Whether the input is readonly. */
   @Input()
   get readonly(): boolean { return this._readonly; }
   set readonly(value) { this._readonly = coerceBooleanProperty(value); }
 
+  /** Whether the input is required. */
   @Input()
   get required(): boolean { return this._required; }
   set required(value) { this._required = coerceBooleanProperty(value); }
 
+  /** Whether spellchecking is enable on the input. */
   @Input()
   get spellcheck(): boolean { return this._spellcheck; }
   set spellcheck(value) { this._spellcheck = coerceBooleanProperty(value); }
@@ -186,18 +239,22 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
   private _blurEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
   private _focusEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
+  /** Event emitted when the input is blurred. */
   @Output('blur')
   get onBlur(): Observable<FocusEvent> {
     return this._blurEmitter.asObservable();
   }
 
+  /** Event emitted when the input is focused. */
   @Output('focus')
   get onFocus(): Observable<FocusEvent> {
     return this._focusEmitter.asObservable();
   }
 
+  /** Value of the input. */
+  @Input()
   get value(): any { return this._value; };
-  @Input() set value(v: any) {
+  set value(v: any) {
     v = this._convertValueForInputType(v);
     if (v !== this._value) {
       this._value = v;
@@ -247,26 +304,42 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     return !!this.placeholder || this._placeholderChild != null;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets the model value of the input. Implemented as part of ControlValueAccessor.
+   * @param value Value to be set.
+   */
   writeValue(value: any) {
     this._value = value;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the input value has changed.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnChange(fn: any) {
     this._onChangeCallback = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the input has been touched.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnTouched(fn: any) {
     this._onTouchedCallback = fn;
   }
 
-  /** Implemented as a part of ControlValueAccessor. */
+  /**
+   * Sets whether the input is disabled.
+   * Implemented as a part of ControlValueAccessor.
+   * @param isDisabled Whether the input should be disabled.
+   */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._validateConstraints();
 
@@ -276,6 +349,7 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     });
   }
 
+  /** @docs-private */
   ngOnChanges(changes: {[key: string]: SimpleChange}) {
     this._validateConstraints();
   }

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -339,7 +339,6 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     this.disabled = isDisabled;
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._validateConstraints();
 
@@ -349,7 +348,6 @@ export class MdInput implements ControlValueAccessor, AfterContentInit, OnChange
     });
   }
 
-  /** @docs-private */
   ngOnChanges(changes: {[key: string]: SimpleChange}) {
     this._validateConstraints();
   }

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -57,6 +57,7 @@ export class MdListItem implements AfterContentInit {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -57,7 +57,6 @@ export class MdListItem implements AfterContentInit {
 
   constructor(private _renderer: Renderer, private _element: ElementRef) {}
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }

--- a/src/lib/menu/menu-animations.ts
+++ b/src/lib/menu/menu-animations.ts
@@ -20,9 +20,9 @@ import{
  *
  * When the menu panel is removed from the DOM, it simply fades out after a brief
  * delay to display the ripple.
- *
- * TODO(kara): switch to :enter and :leave once Mobile Safari is sorted out.
  */
+
+// TODO(kara): switch to :enter and :leave once Mobile Safari is sorted out.
 export const transformMenu: AnimationEntryMetadata = trigger('transformMenu', [
   state('showing', style({
     opacity: 1,

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -44,7 +44,10 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   /** Config object to be passed into the menu's ngClass */
   _classList: any = {};
 
+  /** Position of the menu in the X axis. */
   positionX: MenuPositionX = 'after';
+
+  /** Position of the menu in the Y axis. */
   positionY: MenuPositionY = 'below';
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
@@ -57,6 +60,7 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     this.setPositionClasses(this.positionX, this.positionY);
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._keyManager = new ListKeyManager(this.items).withFocusWrap();
     this._tabSubscription = this._keyManager.tabOut.subscribe(() => {
@@ -64,10 +68,10 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     });
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     this._tabSubscription.unsubscribe();
   }
-
 
   /**
    * This method takes classes set on the host md-menu element and applies them on the
@@ -84,6 +88,7 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     this.setPositionClasses(this.positionX, this.positionY);
   }
 
+  /** Event emitted when the menu is closed. */
   @Output() close = new EventEmitter<void>();
 
   /**

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -60,7 +60,6 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     this.setPositionClasses(this.positionX, this.positionY);
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._keyManager = new ListKeyManager(this.items).withFocusWrap();
     this._tabSubscription = this._keyManager.tabOut.subscribe(() => {
@@ -68,7 +67,6 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     });
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     this._tabSubscription.unsubscribe();
   }

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -26,25 +26,18 @@ export class MdMenuItem implements Focusable {
   }
 
   // this is necessary to support anchors
+  /** Whether the menu item is disabled. */
   @HostBinding('attr.disabled')
   @Input()
-  get disabled(): boolean {
-    return this._disabled;
-  }
-
+  get disabled(): boolean { return this._disabled; }
   set disabled(value: boolean) {
     this._disabled = (value === false || value === undefined) ? null : true;
   }
 
+  /** Sets the aria-disabled property on the menu item. */
   @HostBinding('attr.aria-disabled')
-  get isAriaDisabled(): string {
-    return String(!!this.disabled);
-  }
-
-  get _tabindex() {
-    return this.disabled ? '-1' : '0';
-  }
-
+  get isAriaDisabled(): string { return String(!!this.disabled); }
+  get _tabindex() { return this.disabled ? '-1' : '0'; }
 
   _getHostElement(): HTMLElement {
     return this._elementRef.nativeElement;

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -56,27 +56,37 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   get _deprecatedMenuTriggerFor(): MdMenuPanel { return this.menu; }
   set _deprecatedMenuTriggerFor(v: MdMenuPanel) { this.menu = v; }
 
+  /** References the menu instance that the trigger is associated with. */
   @Input('mdMenuTriggerFor') menu: MdMenuPanel;
+
+  /** Event emitted when the associated menu is opened. */
   @Output() onMenuOpen = new EventEmitter<void>();
+
+  /** Event emitted when the associated menu is closed. */
   @Output() onMenuClose = new EventEmitter<void>();
 
   constructor(private _overlay: Overlay, private _element: ElementRef,
               private _viewContainerRef: ViewContainerRef, private _renderer: Renderer,
               @Optional() private _dir: Dir) {}
 
+  /** @docs-private */
   ngAfterViewInit() {
     this._checkMenu();
     this.menu.close.subscribe(() => this.closeMenu());
   }
 
+  /** @docs-private */
   ngOnDestroy() { this.destroyMenu(); }
 
+  /** Whether the menu is open. */
   get menuOpen(): boolean { return this._menuOpen; }
 
+  /** Toggles the menu between the open and closed states. */
   toggleMenu(): void {
     return this._menuOpen ? this.closeMenu() : this.openMenu();
   }
 
+  /** Opens the menu. */
   openMenu(): void {
     if (!this._menuOpen) {
       this._createOverlay();
@@ -86,6 +96,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** Closes the menu. */
   closeMenu(): void {
     if (this._overlayRef) {
       this._overlayRef.detach();
@@ -94,6 +105,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** Removes the menu from the DOM. */
   destroyMenu(): void {
     if (this._overlayRef) {
       this._overlayRef.dispose();
@@ -103,6 +115,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
     }
   }
 
+  /** Focuses the menu trigger. */
   focus() {
     this._renderer.invokeElementMethod(this._element.nativeElement, 'focus');
   }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -69,13 +69,11 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
               private _viewContainerRef: ViewContainerRef, private _renderer: Renderer,
               @Optional() private _dir: Dir) {}
 
-  /** @docs-private */
   ngAfterViewInit() {
     this._checkMenu();
     this.menu.close.subscribe(() => this.closeMenu());
   }
 
-  /** @docs-private */
   ngOnDestroy() { this.destroyMenu(); }
 
   /** Whether the menu is open. */

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -32,32 +32,23 @@ import {DefaultStyleCompatibilityModeModule} from '../core/compatibility/default
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdProgressBar {
-  /** Value of the progressbar. Defaults to zero. Mirrored to aria-valuenow. */
-  private _value: number = 0;
-
+  /** Color of the progress bar. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';
 
+  private _value: number = 0;
+
+  /** Value of the progressbar. Defaults to zero. Mirrored to aria-valuenow. */
   @Input()
   @HostBinding('attr.aria-valuenow')
-  get value() {
-    return this._value;
-  }
+  get value() { return this._value; }
+  set value(v: number) { this._value = clamp(v || 0); }
 
-  set value(v: number) {
-    this._value = clamp(v || 0);
-  }
-
-  /** Buffer value of the progress bar. Defaults to zero. */
   private _bufferValue: number = 0;
 
+  /** Buffer value of the progress bar. Defaults to zero. */
   @Input()
-  get bufferValue() {
-    return this._bufferValue;
-  }
-
-  set bufferValue(v: number) {
-    this._bufferValue = clamp(v || 0);
-  }
+  get bufferValue() { return this._bufferValue; }
+  set bufferValue(v: number) { this._bufferValue = clamp(v || 0); }
 
   /**
    * Mode of the progress bar.

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -85,17 +85,15 @@ export class MdProgressSpinner implements OnDestroy {
     this._interdeterminateInterval = interval;
   }
 
-  /** Clean up any animations that were running. */
+  /**
+   * Clean up any animations that were running.
+   * @docs-private
+   */
   ngOnDestroy() {
     this._cleanupIndeterminateAnimation();
   }
 
-  /**
-   * Value of the progress circle.
-   *
-   * Input:number
-   * _value is bound to the host as the attribute aria-valuenow.
-   */
+  /** Value of the progress circle. It is bound to the host as the attribute aria-valuenow. */
   private _value: number;
   @Input()
   @HostBinding('attr.aria-valuenow')
@@ -257,6 +255,7 @@ export class MdSpinner extends MdProgressSpinner implements OnDestroy {
     this.mode = 'indeterminate';
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     // The `ngOnDestroy` from `MdProgressSpinner` should be called explicitly, because
     // in certain cases Angular won't call it (e.g. when using AoT and in unit tests).

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -87,7 +87,6 @@ export class MdProgressSpinner implements OnDestroy {
 
   /**
    * Clean up any animations that were running.
-   * @docs-private
    */
   ngOnDestroy() {
     this._cleanupIndeterminateAnimation();
@@ -255,7 +254,6 @@ export class MdSpinner extends MdProgressSpinner implements OnDestroy {
     this.mode = 'indeterminate';
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     // The `ngOnDestroy` from `MdProgressSpinner` should be called explicitly, because
     // in certain cases Angular won't call it (e.g. when using AoT and in unit tests).

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -102,10 +102,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Name of the radio button group. All radio buttons inside this group will use this name. */
   @Input()
-  get name(): string {
-    return this._name;
-  }
-
+  get name(): string { return this._name; }
   set name(value: string) {
     this._name = value;
     this._updateRadioButtonNames();
@@ -129,21 +126,17 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /** Whether the labels should appear after or before the radio-buttons. Defaults to 'after' */
   @Input() labelPosition: 'before' | 'after' = 'after';
 
+  /** Whether the radio button is disabled. */
   @Input()
-  get disabled(): boolean {
-    return this._disabled;
-  }
-
+  get disabled(): boolean { return this._disabled; }
   set disabled(value) {
     // The presence of *any* disabled value makes the component disabled, *except* for false.
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
+  /** Value of the radio button. */
   @Input()
-  get value(): any {
-    return this._value;
-  }
-
+  get value(): any { return this._value; }
   set value(newValue: any) {
     if (this._value != newValue) {
       // Set this before proceeding to ensure no circular loop occurs with selection.
@@ -160,21 +153,19 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
     }
   }
 
+  /** Whether the radio button is selected. */
   @Input()
-  get selected() {
-    return this._selected;
-  }
-
+  get selected() { return this._selected; }
   set selected(selected: MdRadioButton) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
-
     this._checkSelectedRadioButton();
   }
 
   /**
    * Initialize properties once content children are available.
    * This allows us to propagate relevant attributes to associated buttons.
+   * @docs-private
    */
   ngAfterContentInit() {
     // Mark this component as initialized in AfterContentInit because the initial value can
@@ -227,22 +218,36 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
     }
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets the model value. Implemented as part of ControlValueAccessor.
+   * @param value
+   */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the model value changes.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the control is touched.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /** Implemented as a part of ControlValueAccessor. */
+  /**
+   * Sets the disabled state of the control. Implemented as a part of ControlValueAccessor.
+   * @param isDisabled Whether the control should be disabled.
+   */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
@@ -417,6 +422,7 @@ export class MdRadioButton implements OnInit {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
+  /** @docs-private */
   ngOnInit() {
     if (this.radioGroup) {
       // If the radio is inside a radio group, determine if it should be checked

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -165,7 +165,6 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /**
    * Initialize properties once content children are available.
    * This allows us to propagate relevant attributes to associated buttons.
-   * @docs-private
    */
   ngAfterContentInit() {
     // Mark this component as initialized in AfterContentInit because the initial value can
@@ -422,7 +421,6 @@ export class MdRadioButton implements OnInit {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
-  /** @docs-private */
   ngOnInit() {
     if (this.radioGroup) {
       // If the radio is inside a radio group, determine if it should be checked

--- a/src/lib/select/option.ts
+++ b/src/lib/select/option.ts
@@ -16,6 +16,9 @@ import {coerceBooleanProperty} from '../core/coercion/boolean-property';
  */
 let _uniqueIdCounter = 0;
 
+/**
+ * Single option inside of a `<md-select>` element.
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-option, mat-option',
@@ -48,14 +51,10 @@ export class MdOption {
   /** The form value of the option. */
   @Input() value: any;
 
+  /** Whether the option is disabled. */
   @Input()
-  get disabled() {
-    return this._disabled;
-  }
-
-  set disabled(value: any) {
-    this._disabled = coerceBooleanProperty(value);
-  }
+  get disabled() { return this._disabled; }
+  set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
 
   /** Event emitted when the option is selected. */
   @Output() onSelect = new EventEmitter();
@@ -70,9 +69,9 @@ export class MdOption {
   /**
    * The displayed value of the option. It is necessary to show the selected option in the
    * select's trigger.
-   * TODO(kara): Add input property alternative for node envs.
    */
   get viewValue(): string {
+    // TODO(kara): Add input property alternative for node envs.
     return this._getHostElement().textContent.trim();
   }
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -227,14 +227,12 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     }
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._initKeyManager();
     this._resetOptions();
     this._changeSubscription = this.options.changes.subscribe(() => this._resetOptions());
   }
 
-  /** @docs-private */
   ngOnDestroy() {
     this._dropSubscriptions();
     this._changeSubscription.unsubscribe();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -182,15 +182,18 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     },
   ];
 
+  /** Trigger that opens the select. */
   @ViewChild('trigger') trigger: ElementRef;
+
+  /** Overlay pane containing the options. */
   @ViewChild(ConnectedOverlayDirective) overlayDir: ConnectedOverlayDirective;
+
+  /** All of the defined select options. */
   @ContentChildren(MdOption) options: QueryList<MdOption>;
 
+  /** Placeholder to be shown if no value has been selected. */
   @Input()
-  get placeholder() {
-    return this._placeholder;
-  }
-
+  get placeholder() { return this._placeholder; }
   set placeholder(value: string) {
     this._placeholder = value;
 
@@ -198,25 +201,22 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     Promise.resolve(null).then(() => this._triggerWidth = this._getWidth());
   }
 
+  /** Whether the component is disabled. */
   @Input()
-  get disabled() {
-    return this._disabled;
-  }
-
+  get disabled() { return this._disabled; }
   set disabled(value: any) {
     this._disabled = coerceBooleanProperty(value);
   }
 
+  /** Whether the component is required. */
   @Input()
-  get required() {
-    return this._required;
-  }
+  get required() { return this._required; }
+  set required(value: any) { this._required = coerceBooleanProperty(value); }
 
-  set required(value: any) {
-    this._required = coerceBooleanProperty(value);
-  }
-
+  /** Event emitted when the select has been opened. */
   @Output() onOpen = new EventEmitter();
+
+  /** Event emitted when the select has been closed. */
   @Output() onClose = new EventEmitter();
 
   constructor(private _element: ElementRef, private _renderer: Renderer,
@@ -227,12 +227,14 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     }
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._initKeyManager();
     this._resetOptions();
     this._changeSubscription = this.options.changes.subscribe(() => this._resetOptions());
   }
 
+  /** @docs-private */
   ngOnDestroy() {
     this._dropSubscriptions();
     this._changeSubscription.unsubscribe();
@@ -266,6 +268,8 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   /**
    * Sets the select's value. Part of the ControlValueAccessor interface
    * required to integrate with Angular's core forms API.
+   *
+   * @param value New value to be written to the model.
    */
   writeValue(value: any): void {
     if (!this.options) {
@@ -284,6 +288,8 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
    * Saves a callback function to be invoked when the select's value
    * changes from user input. Part of the ControlValueAccessor interface
    * required to integrate with Angular's core forms API.
+   *
+   * @param fn Callback to be triggered when the value changes.
    */
   registerOnChange(fn: (value: any) => void): void {
     this._onChange = fn;
@@ -293,6 +299,8 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
    * Saves a callback function to be invoked when the select is blurred
    * by the user. Part of the ControlValueAccessor interface required
    * to integrate with Angular's core forms API.
+   *
+   * @param fn Callback to be triggered when the component has been touched.
    */
   registerOnTouched(fn: () => {}): void {
     this._onTouched = fn;
@@ -301,6 +309,8 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   /**
    * Disables the select. Part of the ControlValueAccessor interface required
    * to integrate with Angular's core forms API.
+   *
+   * @param isDisabled Sets whether the component is disabled.
    */
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -160,7 +160,6 @@ export class MdSidenav implements AfterContentInit {
     });
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     // This can happen when the sidenav is set to opened in the template and the transition
     // isn't ended.
@@ -355,7 +354,6 @@ export class MdSidenavContainer implements AfterContentInit {
     }
   }
 
-  /** @docs-private */
   ngAfterContentInit() {
     // On changes, assert on consistency.
     this._sidenavs.changes.subscribe(() => this._validateDrawers());

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -199,7 +199,7 @@ export class MdSidenav implements AfterContentInit {
    * Toggle this sidenav. This is equivalent to calling open() when it's already opened, or
    * close() when it's closed.
    * @param isOpen
-   * @returns {Promise<MdSidenavToggleResult>} Resolves with the result of whether the
+   * @returns Resolves with the result of whether the
    * sidenav was opened or closed.
    */
   toggle(isOpen: boolean = !this.opened): Promise<MdSidenavToggleResult> {

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -77,9 +77,7 @@ export class MdSidenav implements AfterContentInit {
   private _align: 'start' | 'end' = 'start';
 
   /** Whether this md-sidenav is part of a valid md-sidenav-container configuration. */
-  get valid() {
-    return this._valid;
-  }
+  get valid() { return this._valid; }
   set valid(value) {
     value = coerceBooleanProperty(value);
     // When the drawers are not in a valid configuration we close them all until they are in a valid
@@ -91,10 +89,9 @@ export class MdSidenav implements AfterContentInit {
   }
   private _valid = true;
 
+  /** Direction which the sidenav is aligned in. */
   @Input()
-  get align() {
-    return this._align;
-  }
+  get align() { return this._align; }
   set align(value) {
     // Make sure we have a valid value.
     value = (value == 'end') ? 'end' : 'start';
@@ -163,6 +160,7 @@ export class MdSidenav implements AfterContentInit {
     });
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     // This can happen when the sidenav is set to opened in the template and the transition
     // isn't ended.
@@ -201,6 +199,8 @@ export class MdSidenav implements AfterContentInit {
    * Toggle this sidenav. This is equivalent to calling open() when it's already opened, or
    * close() when it's closed.
    * @param isOpen
+   * @returns {Promise<MdSidenavToggleResult>} Resolves with the result of whether the
+   * sidenav was opened or closed.
    */
   toggle(isOpen: boolean = !this.opened): Promise<MdSidenavToggleResult> {
     if (!this.valid) {
@@ -233,6 +233,7 @@ export class MdSidenav implements AfterContentInit {
 
   /**
    * Handles the keyboard events.
+   * @docs-private
    */
   handleKeydown(event: KeyboardEvent) {
     if (event.keyCode === ESCAPE) {
@@ -323,7 +324,10 @@ export class MdSidenav implements AfterContentInit {
 export class MdSidenavContainer implements AfterContentInit {
   @ContentChildren(MdSidenav) _sidenavs: QueryList<MdSidenav>;
 
+  /** The sidenav child with the `start` alignment. */
   get start() { return this._start; }
+
+  /** The sidenav child with the `end` alignment. */
   get end() { return this._end; }
 
   /** Event emitted when the sidenav backdrop is clicked. */
@@ -351,6 +355,7 @@ export class MdSidenavContainer implements AfterContentInit {
     }
   }
 
+  /** @docs-private */
   ngAfterContentInit() {
     // On changes, assert on consistency.
     this._sidenavs.changes.subscribe(() => this._validateDrawers());

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -197,9 +197,8 @@ export class MdSidenav implements AfterContentInit {
   /**
    * Toggle this sidenav. This is equivalent to calling open() when it's already opened, or
    * close() when it's closed.
-   * @param isOpen
-   * @returns Resolves with the result of whether the
-   * sidenav was opened or closed.
+   * @param isOpen Whether the sidenav should be open.
+   * @returns Resolves with the result of whether the sidenav was opened or closed.
    */
   toggle(isOpen: boolean = !this.opened): Promise<MdSidenavToggleResult> {
     if (!this.valid) {

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -40,6 +40,9 @@ export class MdSlideToggleChange {
 // Increasing integer for generating unique ids for slide-toggle components.
 let nextId = 0;
 
+/**
+ * Two-state control, which can be also called `switch`.
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-slide-toggle, mat-slide-toggle',
@@ -109,6 +112,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) {}
 
+  /** @docs-private */
   ngAfterContentInit() {
     this._slideRenderer = new SlideToggleRenderer(this._elementRef);
   }
@@ -198,10 +202,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   /** Whether the slide-toggle is checked. */
   @Input()
-  get checked() {
-    return !!this._checked;
-  }
-
+  get checked() { return !!this._checked; }
   set checked(value) {
     if (this.checked !== !!value) {
       this._checked = value;
@@ -211,10 +212,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   /** The color of the slide-toggle. Can be primary, accent, or warn. */
   @Input()
-  get color(): string {
-    return this._color;
-  }
-
+  get color(): string { return this._color; }
   set color(value: string) {
     this._updateColor(value);
   }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -112,7 +112,6 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) {}
 
-  /** @docs-private */
   ngAfterContentInit() {
     this._slideRenderer = new SlideToggleRenderer(this._elementRef);
   }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -54,6 +54,10 @@ export class MdSliderChange {
   value: number;
 }
 
+/**
+ * Allows users to select from a range of values by moving the slider thumb. It is similar in
+ * behavior to the native `<input type="range">` element.
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-slider, mat-slider',
@@ -92,16 +96,16 @@ export class MdSlider implements ControlValueAccessor {
   /** The dimensions of the slider. */
   private _sliderDimensions: ClientRect = null;
 
-  /** Whether or not the slider is disabled. */
   private _disabled: boolean = false;
 
+  /** Whether or not the slider is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
   set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
-  /** Whether or not to show the thumb label. */
   private _thumbLabel: boolean = false;
 
+  /** Whether or not to show the thumb label. */
   @Input('thumbLabel')
   get thumbLabel(): boolean { return this._thumbLabel; }
   set thumbLabel(value) { this._thumbLabel = coerceBooleanProperty(value); }
@@ -131,19 +135,19 @@ export class MdSlider implements ControlValueAccessor {
    */
   _isActive: boolean = false;
 
-  /** The values at which the thumb will snap. */
   private _step: number = 1;
 
+  /** The values at which the thumb will snap. */
   @Input()
   get step() { return this._step; }
   set step(v) { this._step = coerceNumberProperty(v, this._step); }
+
+  private _tickInterval: 'auto' | number = 0;
 
   /**
    * How often to show ticks. Relative to the step so that a tick always appears on a step.
    * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
    */
-  private _tickInterval: 'auto' | number = 0;
-
   @Input()
   get tickInterval() { return this._tickInterval; }
   set tickInterval(v) {
@@ -155,19 +159,19 @@ export class MdSlider implements ControlValueAccessor {
   get _tickIntervalDeprecated() { return this.tickInterval; }
   set _tickIntervalDeprecated(v) { this.tickInterval = v; }
 
-  /** The size of a tick interval as a percentage of the size of the track. */
   private _tickIntervalPercent: number = 0;
 
+  /** The size of a tick interval as a percentage of the size of the track. */
   get tickIntervalPercent() { return this._tickIntervalPercent; }
 
-  /** The percentage of the slider that coincides with the value. */
   private _percent: number = 0;
 
+  /** The percentage of the slider that coincides with the value. */
   get percent() { return this._clamp(this._percent); }
 
-  /** Value of the slider. */
   private _value: number = null;
 
+  /** Value of the slider. */
   @Input()
   get value() {
     // If the value needs to be read and it is still uninitialized, initialize it to the min.
@@ -181,9 +185,9 @@ export class MdSlider implements ControlValueAccessor {
     this._percent = this._calculatePercentage(this._value);
   }
 
-  /** The miniumum value that the slider can have. */
   private _min: number = 0;
 
+  /** The miniumum value that the slider can have. */
   @Input()
   get min() {
     return this._min;
@@ -198,9 +202,9 @@ export class MdSlider implements ControlValueAccessor {
     this._percent = this._calculatePercentage(this.value);
   }
 
-  /** The maximum value that the slider can have. */
   private _max: number = 100;
 
+  /** The maximum value that the slider can have. */
   @Input()
   get max() {
     return this._max;
@@ -294,6 +298,7 @@ export class MdSlider implements ControlValueAccessor {
     return (this._dir && this._dir.value == 'rtl') ? 'rtl' : 'ltr';
   }
 
+  /** Event emitted when the slider value has changed. */
   @Output() change = new EventEmitter<MdSliderChange>();
 
   constructor(@Optional() private _dir: Dir, elementRef: ElementRef) {
@@ -476,22 +481,37 @@ export class MdSlider implements ControlValueAccessor {
     return Math.max(min, Math.min(value, max));
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets the model value. Implemented as part of ControlValueAccessor.
+   * @param value
+   */
   writeValue(value: any) {
     this.value = value;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to eb triggered when the value has changed.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Registers a callback to be triggered when the component is touched.
+   * Implemented as part of ControlValueAccessor.
+   * @param fn Callback to be registered.
+   */
   registerOnTouched(fn: any) {
     this.onTouched = fn;
   }
 
-  /** Implemented as part of ControlValueAccessor. */
+  /**
+   * Sets whether the component should be disabled.
+   * Implemented as part of ControlValueAccessor.
+   * @param isDisabled
+   */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -129,7 +129,6 @@ export class MdSnackBarContainer extends BasePortalHost implements OnDestroy {
 
   /**
    * Makes sure the exit callbacks have been invoked when the element is destroyed.
-   * @docs-private
    */
   ngOnDestroy() {
     // Wait for the zone to settle before removing the element. Helps prevent

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -33,6 +33,7 @@ export const HIDE_ANIMATION = '195ms cubic-bezier(0.0,0.0,0.2,1)';
 
 /**
  * Internal component that wraps user-provided snack bar content.
+ * @docs-private
  */
 @Component({
   moduleId: module.id,
@@ -126,7 +127,10 @@ export class MdSnackBarContainer extends BasePortalHost implements OnDestroy {
     return this.onExit.asObservable();
   }
 
-  /** Makes sure the exit callbacks have been invoked when the element is destroyed. */
+  /**
+   * Makes sure the exit callbacks have been invoked when the element is destroyed.
+   * @docs-private
+   */
   ngOnDestroy() {
     // Wait for the zone to settle before removing the element. Helps prevent
     // errors where we end up removing an element which is in the middle of an animation.

--- a/src/lib/snack-bar/snack-bar-errors.ts
+++ b/src/lib/snack-bar/snack-bar-errors.ts
@@ -1,8 +1,11 @@
 import {MdError} from '../core';
 
-
+/**
+ * Error that is thrown when attempting to attach a snack bar that is already attached.
+ * @docs-private
+ */
 export class MdSnackBarContentAlreadyAttached extends MdError {
   constructor() {
-      super('Attempting to attach snack bar content after content is already attached');
+    super('Attempting to attach snack bar content after content is already attached');
   }
 }

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -37,6 +37,10 @@ export class MdSnackBar {
   /**
    * Creates and dispatches a snack bar with a custom component for the content, removing any
    * currently opened snack bars.
+   *
+   * @param component Component to be instantiated.
+   * @param config Extra configuration for the snack bar.
+   * @returns {MdSnackBarRef<T>}
    */
   openFromComponent<T>(component: ComponentType<T>, config?: MdSnackBarConfig): MdSnackBarRef<T> {
     config = _applyConfigDefaults(config);
@@ -130,7 +134,7 @@ export class MdSnackBar {
 /**
  * Applies default options to the snackbar config.
  * @param config The configuration to which the defaults will be applied.
- * @returns The new configuration object with defaults applied.
+ * @returns {MdSnackBarConfig} The new configuration object with defaults applied.
  */
 function _applyConfigDefaults(config: MdSnackBarConfig): MdSnackBarConfig {
   return extendObject(new MdSnackBarConfig(), config);

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -40,7 +40,6 @@ export class MdSnackBar {
    *
    * @param component Component to be instantiated.
    * @param config Extra configuration for the snack bar.
-   * @returns {MdSnackBarRef<T>}
    */
   openFromComponent<T>(component: ComponentType<T>, config?: MdSnackBarConfig): MdSnackBarRef<T> {
     config = _applyConfigDefaults(config);
@@ -85,7 +84,6 @@ export class MdSnackBar {
    * @param message The message to show in the snackbar.
    * @param action The label for the snackbar action.
    * @param config Additional configuration options for the snackbar.
-   * @returns {MdSnackBarRef<SimpleSnackBar>}
    */
   open(message: string, action = '', config: MdSnackBarConfig = {}): MdSnackBarRef<SimpleSnackBar> {
     config.announcementMessage = message;
@@ -134,7 +132,7 @@ export class MdSnackBar {
 /**
  * Applies default options to the snackbar config.
  * @param config The configuration to which the defaults will be applied.
- * @returns {MdSnackBarConfig} The new configuration object with defaults applied.
+ * @returns The new configuration object with defaults applied.
  */
 function _applyConfigDefaults(config: MdSnackBarConfig): MdSnackBarConfig {
   return extendObject(new MdSnackBarConfig(), config);

--- a/src/lib/tabs/ink-bar.ts
+++ b/src/lib/tabs/ink-bar.ts
@@ -34,7 +34,6 @@ export class MdInkBar {
   /**
    * Generates the pixel distance from the left based on the provided element in string format.
    * @param element
-   * @returns {string}
    */
   private _getLeftPosition(element: HTMLElement): string {
     return element ? element.offsetLeft + 'px' : '0';
@@ -43,7 +42,6 @@ export class MdInkBar {
   /**
    * Generates the pixel width from the provided element in string format.
    * @param element
-   * @returns {string}
    */
   private _getElementWidth(element: HTMLElement): string {
     return element ? element.offsetWidth + 'px' : '0';

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -173,7 +173,7 @@ describe('MdTabBody', () => {
 
 @Component({
   template: `
-    <template>Tab Body Content</template> 
+    <template>Tab Body Content</template>
     <md-tab-body [content]="content" [position]="position" [origin]="origin"></md-tab-body>
   `
 })
@@ -187,6 +187,7 @@ class SimpleTabBodyApp {
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 
+  /** @docs-private */
   ngAfterContentInit() {
     this.content = new TemplatePortal(this.template, this._viewContainerRef);
   }

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -187,7 +187,6 @@ class SimpleTabBodyApp {
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 
-  /** @docs-private */
   ngAfterContentInit() {
     this.content = new TemplatePortal(this.template, this._viewContainerRef);
   }

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -38,6 +38,9 @@ export type MdTabBodyPositionState =
  */
 export type MdTabBodyOriginState = 'left' | 'right';
 
+/**
+ * Wrapper for the contents of a tab.
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-tab-body',
@@ -89,8 +92,9 @@ export class MdTabBody implements OnInit {
     }
   }
 
-  /** The origin position from which this tab should appear when it is centered into view. */
   _origin: MdTabBodyOriginState;
+
+  /** The origin position from which this tab should appear when it is centered into view. */
   @Input('origin') set origin(origin: number) {
     if (origin == null) { return; }
 
@@ -107,6 +111,7 @@ export class MdTabBody implements OnInit {
   /**
    * After initialized, check if the content is centered and has an origin. If so, set the
    * special position states that transition the tab from the left or right before centering.
+   * @docs-private
    */
   ngOnInit() {
     if (this._position == 'center' && this._origin) {
@@ -117,6 +122,7 @@ export class MdTabBody implements OnInit {
   /**
    * After the view has been set, check if the tab content is set to the center and attach the
    * content if it is not already attached.
+   * @docs-private
    */
   ngAfterViewChecked() {
     if (this._isCenterPosition(this._position) && !this._portalHost.hasAttached()) {

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -111,7 +111,6 @@ export class MdTabBody implements OnInit {
   /**
    * After initialized, check if the content is centered and has an origin. If so, set the
    * special position states that transition the tab from the left or right before centering.
-   * @docs-private
    */
   ngOnInit() {
     if (this._position == 'center' && this._origin) {
@@ -122,7 +121,6 @@ export class MdTabBody implements OnInit {
   /**
    * After the view has been set, check if the tab content is set to the center and attach the
    * content if it is not already attached.
-   * @docs-private
    */
   ngAfterViewChecked() {
     if (this._isCenterPosition(this._position) && !this._portalHost.hasAttached()) {

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -396,7 +396,6 @@ class AsyncTabsTestApp {
 
   tabs: Observable<any>;
 
-  /** @docs-private */
   ngOnInit() {
     // Use ngOnInit because there is some issue with scheduling the async task in the constructor.
     this.tabs = Observable.create((observer: any) => {

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -396,8 +396,9 @@ class AsyncTabsTestApp {
 
   tabs: Observable<any>;
 
-  // Use ngOnInit because there is some issue with scheduling the async task in the constructor.
+  /** @docs-private */
   ngOnInit() {
+    // Use ngOnInit because there is some issue with scheduling the async task in the constructor.
     this.tabs = Observable.create((observer: any) => {
       requestAnimationFrame(() => observer.next(this._tabs));
     });

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -76,14 +76,12 @@ export class MdTabGroup {
   get _dynamicHeightDeprecated(): boolean { return this._dynamicHeight; }
   set _dynamicHeightDeprecated(value: boolean) { this._dynamicHeight = value; }
 
-  /** The index of the active tab. */
   private _selectedIndex: number = null;
-  @Input() set selectedIndex(value: number) {
-    this._indexToSelect = value;
-  }
-  get selectedIndex(): number {
-    return this._selectedIndex;
-  }
+
+  /** The index of the active tab. */
+  @Input()
+  set selectedIndex(value: number) { this._indexToSelect = value; }
+  get selectedIndex(): number { return this._selectedIndex; }
 
   /** Output to enable support for two-way binding on `selectedIndex`. */
   @Output() get selectedIndexChange(): Observable<number> {
@@ -91,12 +89,16 @@ export class MdTabGroup {
   }
 
   private _onFocusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
+
+  /** Event emitted when focus has changed within a tab group. */
   @Output() get focusChange(): Observable<MdTabChangeEvent> {
     return this._onFocusChange.asObservable();
   }
 
   private _onSelectChange: EventEmitter<MdTabChangeEvent> =
       new EventEmitter<MdTabChangeEvent>(true);
+
+  /** Event emitted when the tab selection has changed. */
   @Output() get selectChange(): Observable<MdTabChangeEvent> {
     return this._onSelectChange.asObservable();
   }
@@ -112,6 +114,7 @@ export class MdTabGroup {
    * and what the selected index should be. This is where we can know exactly what position
    * each tab should be in according to the new selected index, and additionally we know how
    * a new selected tab should transition in (from the left or right).
+   * @docs-private
    */
   ngAfterContentChecked(): void {
     // Clamp the next selected index to the bounds of 0 and the tabs length.
@@ -140,7 +143,8 @@ export class MdTabGroup {
 
   /**
    * Waits one frame for the view to update, then updates the ink bar
-   * Note: This must be run outside of the zone or it will create an infinite change detection loop
+   * Note: This must be run outside of the zone or it will create an infinite change detection loop.
+   * @docs-private
    */
   ngAfterViewChecked(): void {
     this._isInitialized = true;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -114,7 +114,6 @@ export class MdTabGroup {
    * and what the selected index should be. This is where we can know exactly what position
    * each tab should be in according to the new selected index, and additionally we know how
    * a new selected tab should transition in (from the left or right).
-   * @docs-private
    */
   ngAfterContentChecked(): void {
     // Clamp the next selected index to the bounds of 0 and the tabs length.
@@ -144,7 +143,6 @@ export class MdTabGroup {
   /**
    * Waits one frame for the view to update, then updates the ink bar
    * Note: This must be run outside of the zone or it will create an infinite change detection loop.
-   * @docs-private
    */
   ngAfterViewChecked(): void {
     this._isInitialized = true;

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -78,8 +78,9 @@ export class MdTabHeader {
   /** Whether the scroll distance has changed and should be applied after the view is checked. */
   private _scrollDistanceChanged: boolean;
 
-  /** The index of the active tab. */
   private _selectedIndex: number = 0;
+
+  /** The index of the active tab. */
   @Input() set selectedIndex(value: number) {
     this._selectedIndexChanged = this._selectedIndex != value;
 
@@ -98,6 +99,7 @@ export class MdTabHeader {
               private _elementRef: ElementRef,
               @Optional() private _dir: Dir) {}
 
+  /** @docs-private */
   ngAfterContentChecked(): void {
     // If the number of tab labels have changed, check if scrolling should be enabled
     if (this._tabLabelCount != this._labelWrappers.length) {
@@ -124,7 +126,8 @@ export class MdTabHeader {
 
   /**
    * Waits one frame for the view to update, then updates the ink bar and scroll.
-   * Note: This must be run outside of the zone or it will create an infinite change detection loop
+   * Note: This must be run outside of the zone or it will create an infinite change detection loop.
+   * @docs-private
    */
   ngAfterViewChecked(): void {
     this._zone.runOutsideAngular(() => {

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -99,7 +99,6 @@ export class MdTabHeader {
               private _elementRef: ElementRef,
               @Optional() private _dir: Dir) {}
 
-  /** @docs-private */
   ngAfterContentChecked(): void {
     // If the number of tab labels have changed, check if scrolling should be enabled
     if (this._tabLabelCount != this._labelWrappers.length) {
@@ -127,7 +126,6 @@ export class MdTabHeader {
   /**
    * Waits one frame for the view to update, then updates the ink bar and scroll.
    * Note: This must be run outside of the zone or it will create an infinite change detection loop.
-   * @docs-private
    */
   ngAfterViewChecked(): void {
     this._zone.runOutsideAngular(() => {

--- a/src/lib/tabs/tab-label-wrapper.ts
+++ b/src/lib/tabs/tab-label-wrapper.ts
@@ -15,6 +15,7 @@ export class MdTabLabelWrapper {
   /** Whether the tab label is disabled.  */
   private _disabled: boolean = false;
 
+  /** Whether the element is disabled. */
   @Input()
   get disabled() { return this._disabled; }
   set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -68,7 +68,6 @@ export class MdTabLinkRipple extends MdRipple implements OnDestroy {
 
   /**
    * In certain cases the parent destroy handler may not get called. See Angular issue #11606.
-   * @docs-private
    */
   ngOnDestroy() {
     super.ngOnDestroy();

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -32,17 +32,18 @@ export class MdTabNavBar {
   }
 }
 
+/**
+ * Link inside of a `md-tab-nav-bar`.
+ */
 @Directive({
   selector: '[md-tab-link], [mat-tab-link]',
 })
 export class MdTabLink {
   private _isActive: boolean = false;
 
+  /** Whether the link is active. */
   @Input()
-  get active(): boolean {
-    return this._isActive;
-  }
-
+  get active(): boolean { return this._isActive; }
   set active(value: boolean) {
     this._isActive = value;
     if (value) {
@@ -65,8 +66,10 @@ export class MdTabLinkRipple extends MdRipple implements OnDestroy {
     super(_element, _ngZone, _ruler);
   }
 
-  // In certain cases the parent destroy handler
-  // may not get called. See Angular issue #11606.
+  /**
+   * In certain cases the parent destroy handler may not get called. See Angular issue #11606.
+   * @docs-private
+   */
   ngOnDestroy() {
     super.ngOnDestroy();
   }

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -47,7 +47,6 @@ export class MdTab implements OnInit {
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 
-  /** @docs-private */
   ngOnInit() {
     this._contentPortal = new TemplatePortal(this._content, this._viewContainerRef);
   }

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -39,11 +39,15 @@ export class MdTab implements OnInit {
   origin: number = null;
 
   private _disabled = false;
-  @Input() set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+
+  /** Whether the tab is disabled */
+  @Input()
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
   get disabled(): boolean { return this._disabled; }
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 
+  /** @docs-private */
   ngOnInit() {
     this._contentPortal = new TemplatePortal(this._content, this._viewContainerRef);
   }

--- a/src/lib/tooltip/tooltip-errors.ts
+++ b/src/lib/tooltip/tooltip-errors.ts
@@ -1,6 +1,9 @@
 import {MdError} from '../core';
 
-/** Exception thrown when a tooltip has an invalid position. */
+/**
+ * Exception thrown when a tooltip has an invalid position.
+ * @docs-private
+ */
 export class MdTooltipInvalidPositionError extends MdError {
   constructor(position: string) {
     super(`Tooltip position "${position}" is invalid.`);

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -111,7 +111,6 @@ export class MdTooltip implements OnInit, OnDestroy {
               private _ngZone: NgZone,
               @Optional() private _dir: Dir) {}
 
-  /** @docs-private */
   ngOnInit() {
     // When a scroll on the page occurs, update the position in case this tooltip needs
     // to be repositioned.
@@ -124,7 +123,6 @@ export class MdTooltip implements OnInit, OnDestroy {
 
   /**
    * Dispose the tooltip when destroyed.
-   * @docs-private
    */
   ngOnDestroy() {
     if (this._tooltipInstance) {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -347,7 +347,6 @@ export class TooltipComponent {
 
   /**
    * Returns an observable that notifies when the tooltip has been hidden from view
-   * @returns {Observable<void>}
    */
   afterHidden(): Observable<void> {
     return this._onHide.asObservable();
@@ -355,7 +354,6 @@ export class TooltipComponent {
 
   /**
    * Whether the tooltip is being displayed
-   * @returns {boolean}
    */
   isVisible(): boolean {
     return this._visibility === 'visible';

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -60,17 +60,11 @@ export class MdTooltip implements OnInit, OnDestroy {
   _overlayRef: OverlayRef;
   _tooltipInstance: TooltipComponent;
 
-  /** Allows the user to define the position of the tooltip relative to the parent element */
   private _position: TooltipPosition = 'below';
-  @Input('mdTooltipPosition') get position(): TooltipPosition {
-    return this._position;
-  }
 
-  /** @deprecated */
-  @Input('tooltip-position')
-  get _positionDeprecated(): TooltipPosition { return this._position; }
-  set _positionDeprecated(value: TooltipPosition) { this._position = value; }
-
+  /** Allows the user to define the position of the tooltip relative to the parent element */
+  @Input('mdTooltipPosition')
+  get position(): TooltipPosition { return this._position; }
   set position(value: TooltipPosition) {
     if (value !== this._position) {
       this._position = value;
@@ -83,17 +77,21 @@ export class MdTooltip implements OnInit, OnDestroy {
     }
   }
 
+  /** @deprecated */
+  @Input('tooltip-position')
+  get _positionDeprecated(): TooltipPosition { return this._position; }
+  set _positionDeprecated(value: TooltipPosition) { this._position = value; }
+
   /** The default delay in ms before showing the tooltip after show is called */
   @Input('mdTooltipShowDelay') showDelay = 0;
 
   /** The default delay in ms before hiding the tooltip after hide is called */
   @Input('mdTooltipHideDelay') hideDelay = 0;
 
-  /** The message to be displayed in the tooltip */
   private _message: string;
-  @Input('mdTooltip') get message() {
-    return this._message;
-  }
+
+  /** The message to be displayed in the tooltip */
+  @Input('mdTooltip') get message() { return this._message; }
   set message(value: string) {
     this._message = value;
     if (this._tooltipInstance) {
@@ -113,6 +111,7 @@ export class MdTooltip implements OnInit, OnDestroy {
               private _ngZone: NgZone,
               @Optional() private _dir: Dir) {}
 
+  /** @docs-private */
   ngOnInit() {
     // When a scroll on the page occurs, update the position in case this tooltip needs
     // to be repositioned.
@@ -123,7 +122,10 @@ export class MdTooltip implements OnInit, OnDestroy {
     });
   }
 
-  /** Dispose the tooltip when destroyed */
+  /**
+   * Dispose the tooltip when destroyed.
+   * @docs-private
+   */
   ngOnDestroy() {
     if (this._tooltipInstance) {
       this._disposeTooltip();
@@ -255,6 +257,10 @@ export class MdTooltip implements OnInit, OnDestroy {
 
 export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
 
+/**
+ * Internal component that wraps the tooltip's content.
+ * @docs-private
+ */
 @Component({
   moduleId: module.id,
   selector: 'md-tooltip-component, mat-tooltip-component',
@@ -298,7 +304,11 @@ export class TooltipComponent {
 
   constructor(@Optional() private _dir: Dir) {}
 
-  /** Shows the tooltip with an animation originating from the provided origin */
+  /**
+   * Shows the tooltip with an animation originating from the provided origin
+   * @param position Position of the tooltip.
+   * @param delay Amount of milliseconds to the delay showing the tooltip.
+   */
   show(position: TooltipPosition, delay: number): void {
     // Cancel the delayed hide if it is scheduled
     if (this._hideTimeoutId) {
@@ -319,7 +329,10 @@ export class TooltipComponent {
     }, delay);
   }
 
-  /** Begins the animation to hide the tooltip after the provided delay in ms */
+  /**
+   * Begins the animation to hide the tooltip after the provided delay in ms.
+   * @param delay Amount of milliseconds to delay showing the tooltip.
+   */
   hide(delay: number): void {
     // Cancel the delayed show if it is scheduled
     if (this._showTimeoutId) {
@@ -332,12 +345,18 @@ export class TooltipComponent {
     }, delay);
   }
 
-  /** Returns an observable that notifies when the tooltip has been hidden from view */
+  /**
+   * Returns an observable that notifies when the tooltip has been hidden from view
+   * @returns {Observable<void>}
+   */
   afterHidden(): Observable<void> {
     return this._onHide.asObservable();
   }
 
-  /** Whether the tooltip is being displayed */
+  /**
+   * Whether the tooltip is being displayed
+   * @returns {boolean}
+   */
   isVisible(): boolean {
     return this._visibility === 'visible';
   }


### PR DESCRIPTION
Adds JSDoc annotations to all of the public properties and methods that were missing them. Also cleans up some random issues that were noticed while going through everything.

**Note:** I've skipped the toolbar component since @DevVersion mentioned that he's doing it already.