### PR TITLE
chore: ensure typescript stays compatible with ngc

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ts-node": "^0.7.3",
     "tslint": "^3.13.0",
     "typedoc": "^0.5.1",
-    "typescript": "^2.0.2",
+    "typescript": "~2.0.10",
     "which": "^1.2.4"
   }
 }


### PR DESCRIPTION
* Ensures that the current `typescript` version is always compatible with the current `@angular/compiler-cli`.