### PR TITLE
fix(button-toggle): conflict with radio component

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -65,7 +65,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   private _value: any = null;
 
   /** The HTML name attribute applied to toggles in this group. */
-  private _name: string = `md-radio-group-${_uniqueIdCounter++}`;
+  private _name: string = `md-button-toggle-group-${_uniqueIdCounter++}`;
 
   /** Disables all toggles in the group. */
   private _disabled: boolean = null;


### PR DESCRIPTION
Prevents the button toggle from conflicting with radio buttons on the same page. This was because both components were using the same pattern to generate unique `name` attributes.

Fixes #2274.