### PR TITLE
chore: generate api docs for additional classes

### DIFF
--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -9,11 +9,18 @@ import {MdSnackBarContainer} from './snack-bar-container';
  * Reference to a snack bar dispatched from the snack bar service.
  */
 export class MdSnackBarRef<T> {
-  /** The instance of the component making up the content of the snack bar. */
-  readonly instance: T;
+  private _instance: T;
 
   /** The instance of the component making up the content of the snack bar. */
-  readonly containerInstance: MdSnackBarContainer;
+  get instance(): T {
+    return this._instance;
+  }
+
+  /**
+   * The instance of the component making up the content of the snack bar.
+   * @docs-private
+   */
+  containerInstance: MdSnackBarContainer;
 
   /** Subject for notifying the user that the snack bar has closed. */
   private _afterClosed: Subject<any> = new Subject();
@@ -28,7 +35,7 @@ export class MdSnackBarRef<T> {
               containerInstance: MdSnackBarContainer,
               private _overlayRef: OverlayRef) {
     // Sets the readonly instance of the snack bar content component.
-    this.instance = instance;
+    this._instance = instance;
     this.containerInstance = containerInstance;
     // Dismiss snackbar on action.
     this.onAction().subscribe(() => this.dismiss());

--- a/tools/dgeni/processors/component-grouper.js
+++ b/tools/dgeni/processors/component-grouper.js
@@ -14,6 +14,7 @@ class ComponentGroup {
     this.docType = 'componentGroup';
     this.directives = [];
     this.services = [];
+    this.additionalClasses = [];
     this.ngModule = null;
   }
 }
@@ -50,6 +51,8 @@ module.exports = function componentGrouper() {
           group.services.push(doc);
         } else if (doc.isNgModule) {
           group.ngModule = doc;
+        } else if (doc.docType == 'class') {
+          group.additionalClasses.push(doc);
         }
       });
 

--- a/tools/dgeni/templates/componentGroup.template.html
+++ b/tools/dgeni/templates/componentGroup.template.html
@@ -52,3 +52,10 @@
     {$ class(directive) $}
   {% endfor %}
 {%- endif -%}
+
+{%- if doc.additionalClasses.length -%}
+  <h2>Additional classes</h2>
+  {% for other in doc.additionalClasses %}
+    {$ class(other) $}
+  {% endfor %}
+{%- endif -%}


### PR DESCRIPTION
Also remove `readonly` keyword from snackbar ref because dgeni super does _not_ know how to understand it (throws off of docs completely). 