### PR TITLE
chore: add license header to umd bundles

### DIFF
--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -1,5 +1,7 @@
 import {join} from 'path';
 
+export const MATERIAL_VERSION = require('../../package.json').version;
+
 export const PROJECT_ROOT = join(__dirname, '../..');
 export const SOURCE_ROOT = join(PROJECT_ROOT, 'src');
 
@@ -21,6 +23,12 @@ export const HTML_MINIFIER_OPTIONS = {
   caseSensitive: true,
   removeAttributeQuotes: false
 };
+
+export const LICENSE_BANNER = `/**
+  * @license Angular Material v${MATERIAL_VERSION}
+  * Copyright (c) 2016 Google, Inc. https://angular.io/
+  * License: MIT
+  */`;
 
 export const NPM_VENDOR_FILES = [
   '@angular', 'core-js/client', 'hammerjs', 'rxjs', 'systemjs/dist', 'zone.js/dist'

--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -26,7 +26,7 @@ export const HTML_MINIFIER_OPTIONS = {
 
 export const LICENSE_BANNER = `/**
   * @license Angular Material v${MATERIAL_VERSION}
-  * Copyright (c) 2016 Google, Inc. https://angular.io/
+  * Copyright (c) 2016 Google, Inc. https://material.angular.io/
   * License: MIT
   */`;
 

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -2,7 +2,7 @@ import {task, watch, src, dest} from 'gulp';
 import * as path from 'path';
 
 import {
-  DIST_COMPONENTS_ROOT, PROJECT_ROOT, COMPONENTS_DIR, HTML_MINIFIER_OPTIONS
+  DIST_COMPONENTS_ROOT, PROJECT_ROOT, COMPONENTS_DIR, HTML_MINIFIER_OPTIONS, LICENSE_BANNER
 } from '../constants';
 import {sassBuildTask, tsBuildTask, execNodeTask, copyTask, sequenceTask} from '../task_helpers';
 
@@ -95,6 +95,7 @@ task(':build:components:rollup', () => {
     moduleName: 'ng.material',
     format: 'umd',
     globals,
+    banner: LICENSE_BANNER,
     dest: 'material.umd.js'
   };
 


### PR DESCRIPTION
* Adds a license header to the UMD bundles. Similar to @angular core packages.

See https://unpkg.com/@angular/core@2.4.1/bundles/core.umd.js


![](https://i.gyazo.com/2a59190083dbcdaa045df3e375c92324.png)
