### PR TITLE
chore(ripple): disable problematic test on iOS Safari

### DIFF
--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -210,6 +210,8 @@ describe('MdRipple', () => {
     });
 
     describe('when page is scrolled', () => {
+      const startingWindowWidth = window.innerWidth;
+      const startingWindowHeight = window.innerHeight;
       var veryLargeElement: HTMLDivElement = document.createElement('div');
       var pageScrollTop = 500;
       var pageScrollLeft = 500;
@@ -263,6 +265,16 @@ describe('MdRipple', () => {
         const expectedTop = top - expectedRadius;
 
         const ripple = <HTMLElement>rippleElement.querySelector('.md-ripple-foreground');
+
+        // In the iOS simulator (BrowserStack & SauceLabs), adding the content to the
+        // body causes karma's iframe for the test to stretch to fit that content once we attempt to
+        // scroll the page. Setting width / height / maxWidth / maxHeight on the iframe does not
+        // successfully constrain its size. As such, skip assertions in environments where the
+        // window size has changed since the start of the test.
+        if (window.innerWidth > startingWindowWidth || window.innerHeight > startingWindowHeight) {
+          return;
+        }
+
         expect(pxStringToFloat(ripple.style.left)).toBeCloseTo(expectedLeft, 1);
         expect(pxStringToFloat(ripple.style.top)).toBeCloseTo(expectedTop, 1);
         expect(pxStringToFloat(ripple.style.width)).toBeCloseTo(2 * expectedRadius, 1);


### PR DESCRIPTION
Disables a problematic unit test that is currently failing on iOS Safari. Similar tests have also been disabled in the ViewportRuler.