### PR TITLE
chore: fix invalid path to umd bundle

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -81,7 +81,7 @@ System.config({
   // existing configuration options
   map: {
     ...,
-    '@angular/material': 'npm:@angular/material/material.umd.js'
+    '@angular/material': 'npm:@angular/material/bundles/material.umd.js'
   }
 });
 ```

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -2,7 +2,7 @@
   "name": "@angular/material",
   "version": "2.0.0-beta.0",
   "description": "Angular 2 Material",
-  "main": "./material.umd.js",
+  "main": "./bundles/material.umd.js",
   "module": "./index.js",
   "typings": "./index.d.ts",
   "repository": {


### PR DESCRIPTION
* Fixes the invalid path to the `bundle` in releases.

@jelbourn This is so weird. We should test our releases in the CI as well.

Closes #2366 