### PR TITLE
chore: remove hammerjs types as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "systemjs": "0.19.38",
     "zone.js": "^0.6.23"
   },
-  "optionalDependencies": {
-    "hammerjs": "^2.0.8"
-  },
   "devDependencies": {
     "@angular/compiler-cli": "^2.2.0",
     "@angular/platform-browser-dynamic": "^2.2.0",
@@ -79,6 +76,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-transform": "^1.1.0",
     "gulp-typescript": "^2.13.6",
+    "hammerjs": "^2.0.8",
     "highlight.js": "^9.9.0",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.1",

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -24,8 +24,5 @@
     "@angular/core": "^2.2.0",
     "@angular/common": "^2.2.0",
     "@angular/http": "^2.2.0"
-  },
-  "dependencies": {
-    "@types/hammerjs": "^2.0.30"
   }
 }


### PR DESCRIPTION
* Removes the hammerjs types as a dependency to the @angular/material package (we don't have a dependency on hammerjs)
* Improves the name in the root `package.json` to show that this pkg file is just for the development (like in Angular)
* Moves hammerjs in development to the `devDependencies` because we need it always in our dev environment (same as in Angular 2)

Follow-up for https://github.com/angular/material2/commit/28691ca78042aed428781a3d88af7fc5cff0f8bb