### PR TITLE
perf(tabs): reduce amount of reflows when aligning the ink bar

### DIFF
--- a/src/lib/tabs/tab-header.html
+++ b/src/lib/tabs/tab-header.html
@@ -8,7 +8,7 @@
 
 <div class="md-tab-label-container" #tabListContainer
      (keydown)="_handleKeydown($event)">
-  <div class="md-tab-list" #tabList role="tablist" (cdkObserveContent)="_updatePagination()">
+  <div class="md-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges()">
     <ng-content></ng-content>
     <md-ink-bar></md-ink-bar>
   </div>


### PR DESCRIPTION
Currently the ink bar gets aligned to the active tab every time change detection runs. These changes switch to aligning it if the selected index has changed or the header's content has changed. This can be improved further if we were to debounce the MutationObserver changes (will add in a follow-up PR).
