### PR TITLE
fix(progress-spinner): fix color input on md-spinner

### DIFF
--- a/src/lib/progress-spinner/progress-spinner.spec.ts
+++ b/src/lib/progress-spinner/progress-spinner.spec.ts
@@ -13,8 +13,10 @@ describe('MdProgressSpinner', () => {
         BasicProgressSpinner,
         IndeterminateProgressSpinner,
         ProgressSpinnerWithValueAndBoundMode,
+        ProgressSpinnerWithColor,
         IndeterminateProgressSpinnerWithNgIf,
         SpinnerWithNgIf,
+        SpinnerWithColor
       ],
     });
 
@@ -105,6 +107,37 @@ describe('MdProgressSpinner', () => {
 
     expect(progressElement.componentInstance.interdeterminateInterval).toBeFalsy();
   });
+
+  it('should set the color class on the md-spinner', () => {
+    let fixture = TestBed.createComponent(SpinnerWithColor);
+    fixture.detectChanges();
+
+    let progressElement = fixture.debugElement.query(By.css('md-spinner'));
+
+    expect(progressElement.nativeElement.classList).toContain('md-primary');
+
+    fixture.debugElement.componentInstance.color = 'accent';
+    fixture.detectChanges();
+
+    expect(progressElement.nativeElement.classList).toContain('md-accent');
+    expect(progressElement.nativeElement.classList).not.toContain('md-primary');
+  });
+
+  it('should set the color class on the md-progress-spinner', () => {
+    let fixture = TestBed.createComponent(ProgressSpinnerWithColor);
+    fixture.detectChanges();
+
+    let progressElement = fixture.debugElement.query(By.css('md-progress-spinner'));
+
+    expect(progressElement.nativeElement.classList).toContain('md-primary');
+
+    fixture.debugElement.componentInstance.color = 'accent';
+    fixture.detectChanges();
+
+    expect(progressElement.nativeElement.classList).toContain('md-accent');
+    expect(progressElement.nativeElement.classList).not.toContain('md-primary');
+  });
+
 });
 
 
@@ -123,3 +156,9 @@ class IndeterminateProgressSpinnerWithNgIf { }
 
 @Component({template: `<md-spinner *ngIf="!isHidden"></md-spinner>`})
 class SpinnerWithNgIf { }
+
+@Component({template: `<md-spinner [color]="color"></md-spinner>`})
+class SpinnerWithColor { color: string = 'primary'; }
+
+@Component({template: `<md-progress-spinner value="50" [color]="color"></md-progress-spinner>`})
+class ProgressSpinnerWithColor { color: string = 'primary'; }


### PR DESCRIPTION
* Makes color application similar to all other components (consistency & preparation for #2394)
* Fixes that the the `md-spinner` doesn't support a `color` binding
* Fixes the missing documentation for the `color` and `value` inputs (See [here](https://material.angular.io/components/component/progress-spinner))
* Removes the unused `changeDetectorRef` from the constructor DI

Fixes #2393