### PR TITLE
chore(checkbox): add e2e test for spacebar checking

### DIFF
--- a/e2e/components/checkbox/checkbox.e2e.ts
+++ b/e2e/components/checkbox/checkbox.e2e.ts
@@ -1,20 +1,41 @@
-import {browser, by, element} from 'protractor';
+import {browser, by, element, Key} from 'protractor';
 
 describe('checkbox', function () {
+
   describe('check behavior', function () {
+
     beforeEach(function() {
       browser.get('/checkbox');
     });
-    it('should be checked when clicked, and be unchecked when clicked again', function () {
-      element(by.id('test-checkbox')).click();
-      element(by.css('input[id=input-test-checkbox]')).getAttribute('checked').then((value: string) => {
+
+    it('should be checked when clicked, and be unchecked when clicked again', () => {
+      let checkboxEl = element(by.id('test-checkbox'));
+      let inputEl = element(by.css('input[id=input-test-checkbox]'));
+
+      checkboxEl.click();
+      inputEl.getAttribute('checked').then((value: string) => {
         expect(value).toBeTruthy('Expect checkbox "checked" property to be true');
       });
 
-      element(by.id('test-checkbox')).click();
-      element(by.css('input[id=input-test-checkbox]')).getAttribute('checked').then((value: string) => {
+      checkboxEl.click();
+      inputEl.getAttribute('checked').then((value: string) => {
         expect(value).toBeFalsy('Expect checkbox "checked" property to be false');
       });
     });
+
+    it('should toggle the checkbox when pressing space', () => {
+      let inputEl = element(by.css('input[id=input-test-checkbox]'));
+
+      inputEl.getAttribute('checked').then((value: string) => {
+        expect(value).toBeFalsy('Expect checkbox "checked" property to be false');
+      });
+
+      inputEl.sendKeys(Key.SPACE);
+
+      inputEl.getAttribute('checked').then((value: string) => {
+        expect(value).toBeTruthy('Expect checkbox "checked" property to be true');
+      });
+    });
+
   });
 });

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -18,7 +18,6 @@ import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 
 
-// TODO: Implement E2E tests for spacebar/click behavior for checking/unchecking
 
 describe('MdCheckbox', () => {
   let fixture: ComponentFixture<any>;


### PR DESCRIPTION
* Adds the missing e2e test for the checkbox, where the space key should toggle the state
* Cleanup the existing e2e test by removing repeating statements