### PR TITLE
chore: switch saucelabs to websocket protocol

### DIFF
--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -103,11 +103,6 @@ export function config(config) {
     if (platform == 'saucelabs') {
       config.sauceLabs.build = buildId;
       config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
-
-      // TODO(mlaval): remove once SauceLabs supports websockets.
-      // This speeds up the capturing a bit, as browsers don't even try to use websocket.
-      console.log('>>>> setting socket.io transport to polling <<<<');
-      config.transports = ['polling'];
     } else if (platform == 'browserstack') {
       config.browserStack.build = buildId;
       config.browserStack.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;


### PR DESCRIPTION
* Since saucelabs already supports Websockets now and it's faster we should use Websockets here.
  Reference: https://saucelabs.com/blog/sauce-connect-gets-a-speed-boost-websocket-support