### PR TITLE
docs(getting-started): fix link to theming

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -37,7 +37,7 @@ export class PizzaPartyAppModule { }
 This is **required** to apply all of the core and theme styles to your application. You can either
 use a pre-built theme, or define your own custom theme.
 
-:trident:  See the [theming guide](guides/theming.md) for instructions.
+:trident:  See the [theming guide](theming.md) for instructions.
 
 ### Additional setup for gestures
 Some components ()`md-slide-toggle`, `md-slider`, `mdTooltip`) rely on 


### PR DESCRIPTION
Since this file was moved from root to guides/,
this link should be updated too.