### PR TITLE
fix(autosize): export md-autosize directive

### DIFF
--- a/src/demo-app/input/input-container-demo.html
+++ b/src/demo-app/input/input-container-demo.html
@@ -260,11 +260,11 @@
 <md-card class="demo-card demo-basic">
   <md-toolbar color="primary">Textarea Autosize</md-toolbar>
   <md-card-content>
-    <textarea md-textarea-autosize class="demo-textarea"></textarea>
+    <textarea mdTextareaAutosize class="demo-textarea"></textarea>
     <div>
       <md-input-container>
         <textarea mdInput
-                  md-textarea-autosize
+                  mdTextareaAutosize
                   placeholder="Autosized textarea"></textarea>
       </md-input-container>
     </div>

--- a/src/demo-app/input/input-container-demo.html
+++ b/src/demo-app/input/input-container-demo.html
@@ -260,11 +260,11 @@
 <md-card class="demo-card demo-basic">
   <md-toolbar color="primary">Textarea Autosize</md-toolbar>
   <md-card-content>
-    <textarea md-autosize class="demo-textarea"></textarea>
+    <textarea md-textarea-autosize class="demo-textarea"></textarea>
     <div>
       <md-input-container>
         <textarea mdInput
-                  md-autosize
+                  md-textarea-autosize
                   placeholder="Autosized textarea"></textarea>
       </md-input-container>
     </div>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -178,5 +178,5 @@
 
 <md-card>
   <h2>textarea autosize</h2>
-  <textarea md-textarea-autosize class="demo-textarea"></textarea>
+  <textarea mdTextareaAutosize class="demo-textarea"></textarea>
 </md-card>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -178,5 +178,5 @@
 
 <md-card>
   <h2>textarea autosize</h2>
-  <textarea md-autosize class="demo-textarea"></textarea>
+  <textarea md-textarea-autosize class="demo-textarea"></textarea>
 </md-card>

--- a/src/lib/input/autosize.spec.ts
+++ b/src/lib/input/autosize.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MdInputModule} from './input';
@@ -97,6 +97,12 @@ describe('MdTextareaAutosize', () => {
     expect(parseInt(textarea.style.maxHeight))
         .toBeGreaterThan(previousMaxHeight, 'Expected increased max-height with maxRows increase.');
   });
+
+  it('should export the mdAutosize reference', () => {
+    expect(fixture.componentInstance.autosize).toBeTruthy();
+    expect(fixture.componentInstance.autosize.resizeToFitContent).toBeTruthy();
+  });
+
 });
 
 
@@ -109,10 +115,14 @@ const textareaStyleReset = `
     }`;
 
 @Component({
-  template: `<textarea md-autosize [minRows]="minRows" [maxRows]="maxRows">{{content}}</textarea>`,
+  template: `
+    <textarea md-autosize [minRows]="minRows" [maxRows]="maxRows" #autosize="mdAutosize">
+      {{content}}
+    </textarea>`,
   styles: [textareaStyleReset],
 })
 class AutosizeTextAreaWithContent {
+  @ViewChild('autosize') autosize: MdTextareaAutosize;
   minRows: number = null;
   maxRows: number = null;
   content: string = '';

--- a/src/lib/input/autosize.spec.ts
+++ b/src/lib/input/autosize.spec.ts
@@ -116,7 +116,7 @@ const textareaStyleReset = `
 
 @Component({
   template: `
-    <textarea md-textarea-autosize [minRows]="minRows" [maxRows]="maxRows" 
+    <textarea mdTextareaAutosize [minRows]="minRows" [maxRows]="maxRows" 
         #autosize="mdTextareaAutosize">
       {{content}}
     </textarea>`,
@@ -130,7 +130,7 @@ class AutosizeTextAreaWithContent {
 }
 
 @Component({
-  template: `<textarea md-textarea-autosize [value]="value"></textarea>`,
+  template: `<textarea mdTextareaAutosize [value]="value"></textarea>`,
   styles: [textareaStyleReset],
 })
 class AutosizeTextAreaWithValue {

--- a/src/lib/input/autosize.spec.ts
+++ b/src/lib/input/autosize.spec.ts
@@ -116,7 +116,8 @@ const textareaStyleReset = `
 
 @Component({
   template: `
-    <textarea md-autosize [minRows]="minRows" [maxRows]="maxRows" #autosize="mdAutosize">
+    <textarea md-textarea-autosize [minRows]="minRows" [maxRows]="maxRows" 
+        #autosize="mdTextareaAutosize">
       {{content}}
     </textarea>`,
   styles: [textareaStyleReset],
@@ -129,7 +130,7 @@ class AutosizeTextAreaWithContent {
 }
 
 @Component({
-  template: `<textarea md-autosize [value]="value"></textarea>`,
+  template: `<textarea md-textarea-autosize [value]="value"></textarea>`,
   styles: [textareaStyleReset],
 })
 class AutosizeTextAreaWithValue {

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -5,7 +5,7 @@ import {Directive, ElementRef, Input, OnInit} from '@angular/core';
  * Directive to automatically resize a textarea to fit its content.
  */
 @Directive({
-  selector: 'textarea[md-textarea-autosize], textarea[mat-textarea-autosize]',
+  selector: 'textarea[md-autosize], textarea[mat-autosize], textarea[mdTextareaAutosize]',
   exportAs: 'mdTextareaAutosize',
   host: {
     '(input)': 'resizeToFitContent()',

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -6,6 +6,7 @@ import {Directive, ElementRef, Input, OnInit} from '@angular/core';
  */
 @Directive({
   selector: 'textarea[md-autosize], textarea[mat-autosize]',
+  exportAs: 'mdAutosize',
   host: {
     '(input)': 'resizeToFitContent()',
     '[style.min-height]': '_minHeight',

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -5,8 +5,8 @@ import {Directive, ElementRef, Input, OnInit} from '@angular/core';
  * Directive to automatically resize a textarea to fit its content.
  */
 @Directive({
-  selector: 'textarea[md-autosize], textarea[mat-autosize]',
-  exportAs: 'mdAutosize',
+  selector: 'textarea[md-textarea-autosize], textarea[mat-textarea-autosize]',
+  exportAs: 'mdTextareaAutosize',
   host: {
     '(input)': 'resizeToFitContent()',
     '[style.min-height]': '_minHeight',


### PR DESCRIPTION
**Note**: Not sure whether `mdTextareaAutosize` is more appropriated here. Also notice that the method is already tested by the first test [here](https://github.com/DevVersion/material2/blob/24cdad73e5a1f89ee761502c5daa99301fcccb64/src/lib/input/autosize.spec.ts#L44)

Closes #2419