### PR TITLE
chore(gestures): fix treeshaking for core

### DIFF
--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -55,7 +55,9 @@ export {ScrollDispatcher} from './overlay/scroll/scroll-dispatcher';
 
 // Gestures
 export {GestureConfig} from './gestures/gesture-config';
-export * from './gestures/gesture-annotations';
+// Explicitly specify the interfaces which should be re-exported, because if everything
+// is re-exported, module bundlers may run into issues with treeshaking.
+export {HammerInput, HammerManager} from './gestures/gesture-annotations';
 
 // Ripple
 export {MdRipple, MdRippleModule} from './ripple/ripple';
@@ -105,7 +107,7 @@ export * from './compatibility/default-mode';
 // Animation
 export * from './animation/animation';
 
-// Coersion
+// Coercion
 export {coerceBooleanProperty} from './coercion/boolean-property';
 export {coerceNumberProperty} from './coercion/number-property';
 


### PR DESCRIPTION
Treeshaking may break in Webpack and other bundlers for the `core` exports because our compiled JavaScript files are trying to export everything (`export *`) from the gesture-annotations file
   
The problem with the `gesture-annotations` is, that the transpiled JavaScript file is barely empty (due to TypeScript-only interfaces)

> When exporting the different interfaces manually, TypeScript is smart-enough to export nothing in the resulting JavaScript file.

See response from the Webpack team - https://github.com/webpack/webpack/issues/3584#issuecomment-269468007

@jelbourn Also thought about moving the annotations to the `gesture-config` file, but it's definitely nicer to have them separated.

Closes #2401