### PR TITLE
fix(toolbar): prevent content overflow and line-wrapping

### DIFF
--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -42,7 +42,8 @@ md-toolbar {
     flex-direction: row;
     align-items: center;
 
-    // The toolbar should not wrap text by default. Developers can still overwrite it.
+    // Per Material specs a toolbar cannot have multiple lines inside of a single row. 
+    // Disable text wrapping inside of the toolbar. Developers are still able to overwrite it.
     white-space: nowrap;
   }
 }

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -41,6 +41,10 @@ md-toolbar {
     // Flexbox Vertical Alignment
     flex-direction: row;
     align-items: center;
+
+    // Ensure toolbar content doesn't wrap and exceed the md-toolbar-row width. Ellipsis doesn't work on flex elements.
+    white-space: nowrap;
+    overflow: hidden;
   }
 }
 

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -42,9 +42,8 @@ md-toolbar {
     flex-direction: row;
     align-items: center;
 
-    // Ensure toolbar content doesn't wrap and exceed the md-toolbar-row width. Ellipsis doesn't work on flex elements.
+    // The toolbar should not wrap text by default. Developers can still overwrite it.
     white-space: nowrap;
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
* No longer wraps lines inside of a `md-toolbar-row`
* Overflow for X-axis and Y-Axis are now hidden. Developers should use multiple `md-toolbar-row` elements or can always overwrite the styles.

**Note**: An ellipsis for flex elements is definitely possible, but it just bloats the toolbar and needs some refactoring. We should revisit this with #1718 

Fixes #2451