### PR TITLE
fix(input): properly determine input value

### DIFF
--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -45,6 +45,7 @@ describe('MdInputContainer', function () {
         MdInputContainerWithType,
         MdInputContainerWithValueBinding,
         MdInputContainerWithFormControl,
+        MdInputContainerWithStaticPlaceholder,
         MdInputContainerMissingMdInputTestController
       ],
     });
@@ -130,6 +131,26 @@ describe('MdInputContainer', function () {
 
     el = fixture.debugElement.query(By.css('label')).nativeElement;
     expect(el.classList.contains('md-empty')).toBe(false, 'should not be empty');
+  }));
+
+  it('should update the placeholder when input entered', async(() => {
+    let fixture = TestBed.createComponent(MdInputContainerWithStaticPlaceholder);
+    fixture.detectChanges();
+
+    let inputEl = fixture.debugElement.query(By.css('input'));
+    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+
+    expect(labelEl.classList).toContain('md-empty');
+    expect(labelEl.classList).not.toContain('md-float');
+
+    // Update the value of the input.
+    inputEl.nativeElement.value = 'Text';
+
+    // Fake behavior of the `(input)` event which should trigger a change detection.
+    fixture.detectChanges();
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).not.toContain('md-float');
   }));
 
   it('should not be empty when the value set before view init', async(() => {
@@ -528,6 +549,15 @@ class MdInputContainerZeroTestController {
 class MdInputContainerWithValueBinding {
   value: string = 'Initial';
 }
+
+@Component({
+  template: `
+    <md-input-container [floatingPlaceholder]="false">
+      <input md-input placeholder="Label">
+    </md-input-container>
+  `
+})
+class MdInputContainerWithStaticPlaceholder {}
 
 @Component({
   template: `

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -1,9 +1,9 @@
 import {async, TestBed, inject} from '@angular/core/testing';
 import {Component} from '@angular/core';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MdInputModule} from './input';
-import {MdInputContainer} from './input-container';
+import {MdInputContainer, MdInputDirective} from './input-container';
 import {Platform} from '../core/platform/platform';
 import {PlatformModule} from '../core/platform/index';
 import {
@@ -43,6 +43,8 @@ describe('MdInputContainer', function () {
         MdInputContainerWithDisabled,
         MdInputContainerWithRequired,
         MdInputContainerWithType,
+        MdInputContainerWithValueBinding,
+        MdInputContainerWithFormControl,
         MdInputContainerMissingMdInputTestController
       ],
     });
@@ -130,6 +132,20 @@ describe('MdInputContainer', function () {
     expect(el.classList.contains('md-empty')).toBe(false, 'should not be empty');
   }));
 
+  it('should not be empty when the value set before view init', async(() => {
+    let fixture = TestBed.createComponent(MdInputContainerWithValueBinding);
+    fixture.detectChanges();
+
+    let placeholderEl = fixture.debugElement.query(By.css('.md-input-placeholder')).nativeElement;
+
+    expect(placeholderEl.classList).not.toContain('md-empty');
+
+    fixture.componentInstance.value = '';
+    fixture.detectChanges();
+
+    expect(placeholderEl.classList).toContain('md-empty');
+  }));
+
   it('should not treat the number 0 as empty', async(() => {
     let fixture = TestBed.createComponent(MdInputContainerZeroTestController);
     fixture.detectChanges();
@@ -142,6 +158,20 @@ describe('MdInputContainer', function () {
       expect(el.classList.contains('md-empty')).toBe(false);
     });
   }));
+
+  it('should update the value when using FormControl.setValue', () => {
+    let fixture = TestBed.createComponent(MdInputContainerWithFormControl);
+    fixture.detectChanges();
+
+    let input = fixture.debugElement.query(By.directive(MdInputDirective))
+      .injector.get(MdInputDirective) as MdInputDirective;
+
+    expect(input.value).toBeFalsy();
+
+    fixture.componentInstance.formControl.setValue('something');
+
+    expect(input.value).toBe('something');
+  });
 
   it('should add id', () => {
     let fixture = TestBed.createComponent(MdInputContainerTextTestController);
@@ -380,6 +410,13 @@ class MdInputContainerPlaceholderElementTestComponent {
 }
 
 @Component({
+  template: `<md-input-container><input md-input [formControl]="formControl"></md-input-container>`
+})
+class MdInputContainerWithFormControl {
+  formControl = new FormControl();
+}
+
+@Component({
   template: `<md-input-container><input mdInput [placeholder]="placeholder"></md-input-container>`
 })
 class MdInputContainerPlaceholderAttrTestComponent {
@@ -480,6 +517,16 @@ class MdInputContainerNumberTestController {}
 })
 class MdInputContainerZeroTestController {
   value = 0;
+}
+
+@Component({
+  template: `
+    <md-input-container>
+      <input mdInput placeholder="Label" [value]="value">
+    </md-input-container>`
+})
+class MdInputContainerWithValueBinding {
+  value: string = 'Initial';
 }
 
 @Component({

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -176,8 +176,13 @@ export class MdInputDirective {
   _onBlur() { this.focused = false; }
 
   _onInput() {
-    // This is a noop function and is used to let Angular recognize the changes
-    // to the input element while typing. Listening to the `input` event is similar to NgControls.
+    // This is a noop function and is used to let Angular know whenever the value changes.
+    // Angular will run a new change detection each time the `input` event has been dispatched.
+    // It's necessary that Angular recognizes the value change, because when floatingLabel
+    // is set to false and Angular forms aren't used, the placeholder won't recognize the
+    // value changes and will not disappear.
+    // Listening to the input event wouldn't be necessary when the input is using the
+    // FormsModule or ReactiveFormsModule, because Angular forms also listens to input events.
   }
 
   /** Make sure the input is a supported type. */

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -83,6 +83,7 @@ export class MdHint {
     '[required]': 'required',
     '(blur)': '_onBlur()',
     '(focus)': '_onFocus()',
+    '(input)': '_onInput()'
   }
 })
 export class MdInputDirective {
@@ -173,6 +174,11 @@ export class MdInputDirective {
   _onFocus() { this.focused = true; }
 
   _onBlur() { this.focused = false; }
+
+  _onInput() {
+    // This is a noop function and is used to let Angular recognize the changes
+    // to the input element while typing. Listening to the `input` event is similar to NgControls.
+  }
 
   /** Make sure the input is a supported type. */
   private _validateType() {

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -83,10 +83,9 @@ export class MdHint {
     '[required]': 'required',
     '(blur)': '_onBlur()',
     '(focus)': '_onFocus()',
-    '(input)': '_onInput()',
   }
 })
-export class MdInputDirective implements AfterContentInit {
+export class MdInputDirective {
 
   /** Variables used as cache for getters and setters. */
   private _type = 'text';
@@ -95,9 +94,6 @@ export class MdInputDirective implements AfterContentInit {
   private _required = false;
   private _id: string;
   private _cachedUid: string;
-
-  /** The element's value. */
-  value: any;
 
   /** Whether the element is focused or not. */
   focused = false;
@@ -141,6 +137,10 @@ export class MdInputDirective implements AfterContentInit {
     }
   }
 
+  /** The input element's value. */
+  get value() { return this._elementRef.nativeElement.value; }
+  set value(value: string) { this._elementRef.nativeElement.value = value; }
+
   /**
    * Emits an event when the placeholder changes so that the `md-input-container` can re-validate.
    */
@@ -162,18 +162,9 @@ export class MdInputDirective implements AfterContentInit {
   constructor(private _elementRef: ElementRef,
               private _renderer: Renderer,
               @Optional() public _ngControl: NgControl) {
+
     // Force setter to be called in case id was not specified.
     this.id = this.id;
-
-    if (this._ngControl && this._ngControl.valueChanges) {
-      this._ngControl.valueChanges.subscribe((value) => {
-        this.value = value;
-      });
-    }
-  }
-
-  ngAfterContentInit() {
-    this.value = this._elementRef.nativeElement.value;
   }
 
   /** Focuses the input element. */
@@ -182,8 +173,6 @@ export class MdInputDirective implements AfterContentInit {
   _onFocus() { this.focused = true; }
 
   _onBlur() { this.focused = false; }
-
-  _onInput() { this.value = this._elementRef.nativeElement.value; }
 
   /** Make sure the input is a supported type. */
   private _validateType() {


### PR DESCRIPTION
Right now the `MdInputDirective` tries to cache the `value` of the input.

To do this, the `MdInputDirective` needs to listen for `NgControl` value changes and for native `(change)` events.

This will be problematic when a value is set directly to the input element (using `[value]` property binding) because Angular is only able to recognize this change in the first ChangeDetection.

```html
<md-input-container>
  <input md-input [value]="myValue" placeholder="Label">
</md-input-container>
```

The approach of updating the value in the `ngAfterViewInit` lifecycle hook, will result in a binding change while being in a ChangeDetection, which leads to a ChangeDetection error.

```
Expression has changed after it was checked. Previous value: 'true'. Current value: 'false'.
```
_The credits for the `should update the value when using FormControl.setValue` test go to @crisbeto_

Fixes #2441. Fixes #2363. Fixes #2477