### PR TITLE
build: avoid typing errors in TypeScript 2.1 and update gulp-typescript

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "target": "es5",
     "typeRoots": [
-      "../node_modules/@types/"
+      "../node_modules/@types"
     ],
     "types": [
       "jasmine"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-transform": "^1.1.0",
-    "gulp-typescript": "^2.13.6",
+    "gulp-typescript": "^3.1.3",
     "hammerjs": "^2.0.8",
     "highlight.js": "^9.9.0",
     "jasmine-core": "^2.4.1",

--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -15,7 +15,7 @@
     "stripInternal": false,
     "baseUrl": "",
     "typeRoots": [
-      "../../node_modules/@types"
+      "../../node_modules/@types/!(node)"
     ],
     "paths": {
       "@angular/material": [

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -15,8 +15,7 @@
     "stripInternal": false,
     "baseUrl": "",
     "typeRoots": [
-      "../../node_modules/@types",
-      "../../node_modules"
+      "../../node_modules/@types/!(node)"
     ],
     "paths": {
       "@angular/material": [

--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -16,7 +16,7 @@
     "inlineSources": true,
     "stripInternal": false,
     "typeRoots": [
-      "../../node_modules/@types"
+      "../../node_modules/@types/!(node)"
     ]
   },
   "exclude": [

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -19,7 +19,7 @@
     "paths": {
     },
     "typeRoots": [
-      "../../node_modules/@types"
+      "../../node_modules/@types/!(node)"
     ],
     "types": [
       "jasmine",

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -53,7 +53,7 @@ export function tsBuildTask(tsConfigPath: string, tsConfigName = 'tsconfig.json'
 
     let pipe = tsProject.src()
       .pipe(gulpSourcemaps.init())
-      .pipe(gulpTs(tsProject));
+      .pipe(tsProject());
     let dts = pipe.dts.pipe(gulp.dest(dest));
 
     return gulpMerge([


### PR DESCRIPTION
* Avoids a couple of errors that show up when trying to compile the project against TypeScript 2.1 ("Cannot redeclare block-scoped variable 'module'" and "Type 'Timer' is not assignable to type 'number'"). Both errors were due to us loading both the Node and browser typings, which were overlapping with each other (e.g. `setTimeout` in the browser returns a `number`, whereas in Node it returns a `NodeJS.Timer`).
* Bumps to the latest version of `gulp-typescript` and switches to the new syntax for defining the Gulp task.
* Fixes an error with the `e2e-app` tsconfig.json that showed up after updating the `gulp-typescript`.

Related to #1998.