### PR TITLE
update(sidenav): remove unnecessary selectors

### DIFF
--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -17,15 +17,10 @@
     // section.
     visibility: hidden;
   }
-  &.md-sidenav-closing {
-    transform: translate3d($close, 0, 0);
-  }
-  &.md-sidenav-opening {
-    @include md-elevation(16);
-    visibility: visible;
-    transform: translate3d($open, 0, 0);
-  }
-  &.md-sidenav-opened {
+
+  &.md-sidenav-opening, &.md-sidenav-opened {
+    // The elevation of z-16 is noted in the design specifications.
+    // See https://material.io/guidelines/patterns/navigation-drawer.html#
     @include md-elevation(16);
     transform: translate3d($open, 0, 0);
   }


### PR DESCRIPTION
* Merges the `md-sidenav-opening` and `md-sidenav-opened` selectors, since they have similar CSS properties (`visibility: visible` is unecessary)
* Remoces the  `md-sidenav-closing` selector, since the `transform` is unnecessary and already set as default.
* Adds a small comment about the elevation of the sidenav which is noted in the Material Design specifications.

References #2158