### PR TITLE
chore: track library payload in database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     # Order: a slower build first, so that we don't occupy an idle travis worker waiting for others to complete.
     - MODE=lint
     - MODE=aot
+    - MODE=payload
     - MODE=e2e
     - MODE=saucelabs_required
     - MODE=browserstack_required

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dgeni": "^0.4.2",
     "dgeni-packages": "^0.16.2",
     "express": "^4.14.0",
+    "firebase-admin": "^4.0.4",
     "firebase-tools": "^2.2.1",
     "fs-extra": "^0.26.5",
     "glob": "^6.0.4",
@@ -102,6 +103,7 @@
     "tslint": "^3.13.0",
     "typedoc": "^0.5.1",
     "typescript": "~2.0.10",
+    "uglify-js": "^2.7.5",
     "which": "^1.2.4"
   }
 }

--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -19,6 +19,8 @@ elif is_e2e; then
   $(npm bin)/gulp ci:e2e
 elif is_aot; then
   $(npm bin)/gulp ci:aot
+elif is_payload; then
+  $(npm bin)/gulp ci:payload
 else
   $(npm bin)/gulp ci:test
 fi

--- a/scripts/ci/sources/mode.sh
+++ b/scripts/ci/sources/mode.sh
@@ -12,3 +12,7 @@ is_lint() {
 is_aot() {
   [[ "$MODE" = aot ]]
 }
+
+is_payload() {
+  [[ "$MODE" = payload ]]
+}

--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -11,3 +11,4 @@ import './tasks/serve';
 import './tasks/unit-test';
 import './tasks/docs';
 import './tasks/aot';
+import './tasks/payload';

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -16,6 +16,7 @@ const gulpSourcemaps = require('gulp-sourcemaps');
 const gulpAutoprefixer = require('gulp-autoprefixer');
 const gulpConnect = require('gulp-connect');
 const resolveBin = require('resolve-bin');
+const firebaseAdmin = require('firebase-admin');
 
 
 /** If the string passed in is a glob, returns it, otherwise append '**\/*' to it. */
@@ -210,4 +211,19 @@ export function sequenceTask(...args: any[]) {
       done
     );
   };
+}
+
+/** Opens a connection to the firebase realtime database. */
+export function openFirebaseDatabase() {
+  // Initialize the Firebase application with admin credentials.
+  firebaseAdmin.initializeApp({
+    credential: firebaseAdmin.credential.cert({
+      project_id: 'material2-dashboard',
+      client_email: 'firebase-adminsdk-ch1ob@material2-dashboard.iam.gserviceaccount.com',
+      private_key: process.env['MATERIAL2_FIREBASE_PRIVATE_KEY']
+    }),
+    databaseURL: 'https://material2-dashboard.firebaseio.com'
+  });
+
+  return firebaseAdmin.database();
 }

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -216,6 +216,7 @@ export function sequenceTask(...args: any[]) {
 /** Opens a connection to the firebase realtime database. */
 export function openFirebaseDatabase() {
   // Initialize the Firebase application with admin credentials.
+  // Credentials need to be for a Service Account, which can be created in the Firebase console.
   firebaseAdmin.initializeApp({
     credential: firebaseAdmin.credential.cert({
       project_id: 'material2-dashboard',
@@ -226,4 +227,9 @@ export function openFirebaseDatabase() {
   });
 
   return firebaseAdmin.database();
+}
+
+/** Whether gulp currently runs inside of Travis as a push. */
+export function isTravisPushBuild() {
+  return process.env['TRAVIS_PULL_REQUEST'] === 'false';
 }

--- a/tools/gulp/tasks/ci.ts
+++ b/tools/gulp/tasks/ci.ts
@@ -14,3 +14,6 @@ task('ci:e2e', ['e2e:single-run']);
 
 /** Task to verify that all components work with AOT compilation. */
 task('ci:aot', ['aot:build']);
+
+/** Task which reports the size of the library and stores it in a database. */
+task('ci:payload', ['payload']);

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -1,0 +1,56 @@
+import {task} from 'gulp';
+import {join} from 'path';
+import {statSync, readFileSync} from 'fs';
+import {DIST_COMPONENTS_ROOT} from '../constants';
+import {openFirebaseDatabase} from '../task_helpers';
+import {spawnSync} from 'child_process';
+
+// Those imports lack types.
+const uglifyJs = require('uglify-js');
+
+const BUNDLE_PATH = join(DIST_COMPONENTS_ROOT, 'bundles', 'material.umd.js');
+
+/** Task which runs test against the size of whole library. */
+task('payload', ['build:release'], () => {
+
+  let results = {
+    normal: getFilesize(BUNDLE_PATH),
+    minified_uglify: getUglifiedSize(BUNDLE_PATH),
+    timestamp: Date.now()
+  };
+
+  // Print the results to the console, so we can read it from the CI.
+  console.log('Payload Results:', JSON.stringify(results, null, 2));
+
+  // Publish the results to firebase when it runs on Travis and not as a PR.
+  if (process.env['TRAVIS_PULL_REQUEST'] === 'false') {
+    return publishResults(results);
+  }
+
+});
+
+/** Returns the size of a file in kilobytes. */
+function getFilesize(filePath: string) {
+  return statSync(filePath).size / 1000;
+}
+
+/** Returns the size of a uglify minified file in kilobytes */
+function getUglifiedSize(filePath: string) {
+  let fileContent = readFileSync(filePath, 'utf-8');
+
+  let compressedFile = uglifyJs.minify(fileContent, {
+    fromString: true
+  });
+
+  return Buffer.byteLength(compressedFile.code, 'utf8') / 1000;
+}
+
+/** Publishes the given results to the firebase database. */
+function publishResults(results: any) {
+  let latestSha = spawnSync('git', ['rev-parse', 'HEAD']).stdout.toString().trim();
+  let database = openFirebaseDatabase();
+
+  // Write the results to the payloads object with the latest Git SHA as key.
+  return database.ref('payloads').child(latestSha).set(results)
+    .then(() => database.goOffline(), () => database.goOffline());
+}

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -2,7 +2,7 @@ import {task} from 'gulp';
 import {join} from 'path';
 import {statSync, readFileSync} from 'fs';
 import {DIST_COMPONENTS_ROOT} from '../constants';
-import {openFirebaseDatabase} from '../task_helpers';
+import {openFirebaseDatabase, isTravisPushBuild} from '../task_helpers';
 import {spawnSync} from 'child_process';
 
 // Those imports lack types.
@@ -14,8 +14,8 @@ const BUNDLE_PATH = join(DIST_COMPONENTS_ROOT, 'bundles', 'material.umd.js');
 task('payload', ['build:release'], () => {
 
   let results = {
-    normal: getFilesize(BUNDLE_PATH),
-    minified_uglify: getUglifiedSize(BUNDLE_PATH),
+    umd_kb: getFilesize(BUNDLE_PATH),
+    umd_minified_uglify_kb: getUglifiedSize(BUNDLE_PATH),
     timestamp: Date.now()
   };
 
@@ -23,7 +23,7 @@ task('payload', ['build:release'], () => {
   console.log('Payload Results:', JSON.stringify(results, null, 2));
 
   // Publish the results to firebase when it runs on Travis and not as a PR.
-  if (process.env['TRAVIS_PULL_REQUEST'] === 'false') {
+  if (isTravisPushBuild()) {
     return publishResults(results);
   }
 


### PR DESCRIPTION
* Adds a new gulp task which tries to compare sizes of the library results.

  Those results will be always announced in the Travis build and when not running as a PR those will be published to firebase (useful for statistics)

Closes #111