### PR TITLE
chore: run e2e tests concurrently in the ci 

### DIFF
--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -45,10 +45,19 @@ if (process.env['TRAVIS']) {
     'build': process.env['TRAVIS_JOB_NUMBER'],
     'name': 'Material 2 E2E Tests',
 
+    // Enables concurrent testing in the Webdriver. Currently runs five e2e files in parallel.
+    maxInstances: 5,
+    shardTestFiles: true,
+
     // By default Saucelabs tries to record the whole e2e run. This can slow down the builds.
     'recordVideo': false,
     'recordScreenshots': false
   };
+
+  // Because Protractor runs selenium instances concurrently in the CI and each instance
+  // will create a bloat of logs we don't want to show any info messages.
+  // Until protractor#1451 is solved, manually disable all info messages.
+  require('protractor/built/logger').Logger.prototype.info = () => {};
 }
 
 


### PR DESCRIPTION
* Now runs the e2e tests concurrently in the CI because currently it takes likely 12 minutes to finsish the e2e mode.