### PR TITLE
fix(input): work around Chrome issue that collapses the input

### DIFF
--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -110,6 +110,26 @@ describe('MdInputContainer', function () {
     expect(el.classList.contains('md-empty')).toBe(true);
   });
 
+  it('should add a default "step" to number inputs', () => {
+    let fixture = TestBed.createComponent(MdInputContainerNumberTestController);
+    fixture.detectChanges();
+
+    let el = fixture.debugElement.query(By.css('input')).nativeElement;
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('step')).toBe('any');
+  });
+
+  it('should should not override the user-supplied "step"', () => {
+    let fixture = TestBed.createComponent(MdInputContainerNumberTestController);
+
+    fixture.componentInstance.step = '10';
+    fixture.detectChanges();
+
+    let el = fixture.debugElement.query(By.css('input')).nativeElement;
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('step')).toBe('10');
+  });
+
   it('should not be empty after input entered', async(() => {
     let fixture = TestBed.createComponent(MdInputContainerTextTestController);
     fixture.detectChanges();
@@ -414,10 +434,14 @@ class MdInputContainerPasswordTestController {}
 @Component({
   template: `
     <md-input-container>
-      <input md-input type="number" placeholder="Placeholder">
+      <input md-input type="number" placeholder="Placeholder" [min]="min" [max]="max" [step]="step">
     </md-input-container>`
 })
-class MdInputContainerNumberTestController {}
+class MdInputContainerNumberTestController {
+  min = 10;
+  max = 100;
+  step: string = null;
+}
 
 @Component({
   template: `

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -75,6 +75,7 @@ export class MdHint {
     '(blur)': '_onBlur()',
     '(focus)': '_onFocus()',
     '(input)': '_onInput()',
+    '[attr.step]': 'step'
   }
 })
 export class MdInputDirective implements AfterContentInit {
@@ -120,6 +121,16 @@ export class MdInputDirective implements AfterContentInit {
   value: any;
 
   /**
+   * Step value if the component is a number input. This is used to work around a bug in Chrome
+   * where number inputs with `min` and `max` collapse, if they don't have a `step` attribute.
+   * We work around it by adding the `any` value, if the user didn't specify anything. The value is
+   * added in the `ngAfterContentInit` hook.
+   * See https://bugs.chromium.org/p/chromium/issues/detail?id=598164
+   * @docs-private
+   */
+  @Input() step: string = null;
+
+  /**
    * Emits an event when the placeholder changes so that the `md-input-container` can re-validate.
    */
   @Output() _placeholderChange = new EventEmitter<string>();
@@ -155,6 +166,10 @@ export class MdInputDirective implements AfterContentInit {
 
   ngAfterContentInit() {
     this.value = this._elementRef.nativeElement.value;
+
+    if (this.type === 'number' && !this.step) {
+      this.step = 'any';
+    }
   }
 
   /** Focuses the input element. */


### PR DESCRIPTION
This fix works around a Chrome bug, where number inputs that have a `min` and a `max`, but not a `step`, will collapse to about 50% their proper width. This most likely isn't a huge use case, but it's probably good to have the inputs be consistent across browsers.

For more info the the bug: https://bugs.chromium.org/p/chromium/issues/detail?id=598164

Fixes #2470.