### PR TITLE
fix(tooltip): better handling of multi-line text

### DIFF
--- a/src/lib/tooltip/tooltip.scss
+++ b/src/lib/tooltip/tooltip.scss
@@ -13,7 +13,7 @@ $md-tooltip-vertical-padding: ($md-tooltip-target-height - $md-tooltip-font-size
 }
 
 .md-tooltip {
-  color: #fff;
+  color: white;
   padding: $md-tooltip-vertical-padding $md-tooltip-horizontal-padding;
   border-radius: 2px;
   font-family: $md-font-family;

--- a/src/lib/tooltip/tooltip.scss
+++ b/src/lib/tooltip/tooltip.scss
@@ -2,23 +2,23 @@
 @import '../core/a11y/a11y';
 
 
-$md-tooltip-height: 22px;
+$md-tooltip-target-height: 22px;
+$md-tooltip-font-size: 10px;
 $md-tooltip-margin: 14px;
-$md-tooltip-padding: 8px;
+$md-tooltip-horizontal-padding: 8px;
+$md-tooltip-vertical-padding: ($md-tooltip-target-height - $md-tooltip-font-size) / 2;
 
 :host {
   pointer-events: none;
 }
 
 .md-tooltip {
-  color: white;
-  padding: 0 $md-tooltip-padding;
+  color: #fff;
+  padding: $md-tooltip-vertical-padding $md-tooltip-horizontal-padding;
   border-radius: 2px;
   font-family: $md-font-family;
-  font-size: 10px;
+  font-size: $md-tooltip-font-size;
   margin: $md-tooltip-margin;
-  height: $md-tooltip-height;
-  line-height: $md-tooltip-height;
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Switches the tooltip from having a hard-coded height to using `padding` and `font-size` to achieve the same height, while allowing the text to wrap. Technically the same could've been achieved by using `min-height`, instead of `height`, however since it was using `line-height` to center the text, multi-line text didn't look too good.

Fixes #2205.