### PR TITLE
chore: remove temporary sleep in menu e2e test

### DIFF
--- a/e2e/components/menu/menu.e2e.ts
+++ b/e2e/components/menu/menu.e2e.ts
@@ -46,8 +46,6 @@ describe('menu', () => {
     page.backdrop().click();
     page.expectMenuPresent(false);
 
-    // TODO(kara): temporary, remove when #1607 is fixed
-    browser.sleep(250);
     page.trigger().click();
     expect(page.menu().getText()).toEqual('One\nTwo\nThree\nFour');
     page.expectMenuAlignedWith(page.menu(), 'trigger');


### PR DESCRIPTION
* Removes the unnecessary `sleep` in the menu e2e test. The sleep became unecessary because #1607 has been fixed.