### PR TITLE
chore(e2e): remove e2e watch task

### DIFF
--- a/tools/gulp/tasks/ci.ts
+++ b/tools/gulp/tasks/ci.ts
@@ -10,7 +10,7 @@ task('ci:forbidden-identifiers', function() {
 // Travis sometimes does not exit the process and times out. This is to prevent that.
 task('ci:test', ['test:single-run'], () => process.exit(0));
 
-task('ci:e2e', ['e2e:single-run']);
+task('ci:e2e', ['e2e']);
 
 /** Task to verify that all components work with AOT compilation. */
 task('ci:aot', ['aot:build']);

--- a/tools/gulp/tasks/e2e.ts
+++ b/tools/gulp/tasks/e2e.ts
@@ -56,31 +56,14 @@ task('serve:e2eapp', sequenceTask('build:components', 'build:e2eapp', ':serve:e2
 task('serve:e2eapp:watch', ['serve:e2eapp', ':watch:components', ':watch:e2eapp']);
 
 /**
- * [Watch task] Serves the e2e app and runs the protractor tests. Rebuilds when sources change.
- *
- * This task should only be used when running the e2e tests locally.
+ * Builds and serves the e2e-app and runs protractor once the e2e-app is ready.
  */
 task('e2e', (done: (err?: string) => void) => {
-  gulpRunSequence(
-    ':test:protractor:setup',
-    'serve:e2eapp:watch',
-    ':test:protractor',
-    ':serve:e2eapp:stop',
-    (err: any) => gulpConnect.serverClose() && done(err)
-  );
-});
-
-/**
- * Runs the e2e once. Does not watch for changes.
- *
- * This task should be used when running tests on the CI server.
- */
-task('e2e:single-run', (done: (err?: string) => void) => {
   gulpRunSequence(
     ':test:protractor:setup',
     'serve:e2eapp',
     ':test:protractor',
     ':serve:e2eapp:stop',
-    (err: any) => gulpConnect.serverClose() && done(err)
+    (err: any) => done(err)
   );
 });


### PR DESCRIPTION
* Removes the `watching` in the e2e task, because Protractor is not able to watch for file-changes (makes it unnecessary)
* Restarting protractor is possible in theory but it would need big refactoring to gain access to the `child_process` and kill protractor on changes.