### PR TITLE
fix(toolbar): correct font-weight

### DIFF
--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -25,7 +25,7 @@ md-toolbar {
 
   // Font Styling
   font-size: $md-toolbar-font-size;
-  font-weight: 400;
+  font-weight: 500;
   font-family: $md-font-family;
 
   padding: 0 $md-toolbar-padding;


### PR DESCRIPTION
[App bar "Title style, Medium 20sp"](https://material.io/guidelines/style/typography.html)