### PR TITLE
fix(input-container): prefix and suffix stretching together with parent

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -30,3 +30,9 @@ md-input-container {
     }
   }
 }
+
+// Prevents the prefix and suffix from stretching together with the container.
+.md-input-prefix, .md-input-suffix {
+  width: 0.1px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Prevents the input's suffix and prefix from stretching together with their parent node and leaving some weird spacing between themselves and the input. This was a side-effect of using `display: table-cell`.

Fixes #2493.
Fixes #1881.
Fixes #1421.