### PR TITLE
update(viewport-ruler): cache document rectangles

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -169,7 +169,7 @@ describe('ConnectedPositionStrategy', () => {
         fakeViewportRuler.fakeRect = {
           top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
         };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler as any);
 
         originElement.style.top = '475px';
         originElement.style.left = '200px';
@@ -195,7 +195,7 @@ describe('ConnectedPositionStrategy', () => {
         fakeViewportRuler.fakeRect = {
           top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
         };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler as any);
 
         originElement.style.top = '200px';
         originElement.style.left = '475px';
@@ -270,7 +270,7 @@ describe('ConnectedPositionStrategy', () => {
       fakeViewportRuler.fakeRect = {
         top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
       };
-      positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+      positionBuilder = new OverlayPositionBuilder(fakeViewportRuler as any);
       originElement.style.top = '200px';
       originElement.style.left = '475px';
 
@@ -296,7 +296,7 @@ describe('ConnectedPositionStrategy', () => {
         fakeViewportRuler.fakeRect = {
           top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
         };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler as any);
 
         originElement.style.top = '200px';
         originElement.style.left = '475px';
@@ -576,7 +576,7 @@ function createOverflowContainerElement() {
 
 
 /** Fake implementation of ViewportRuler that just returns the previously given ClientRect. */
-class FakeViewportRuler implements ViewportRuler {
+class FakeViewportRuler {
   fakeRect: ClientRect = {left: 0, top: 0, width: 1014, height: 686, bottom: 686, right: 1014};
   fakeScrollPos: {top: number, left: number} = {top: 0, left: 0};
 

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -82,6 +82,7 @@ task(':build:components:rollup', () => {
     'rxjs/add/operator/do': 'Rx.Observable.prototype',
     'rxjs/add/operator/share': 'Rx.Observable.prototype',
     'rxjs/add/operator/finally': 'Rx.Observable.prototype',
+    'rxjs/add/operator/debounceTime': 'Rx.Observable.protoype',
     'rxjs/add/operator/catch': 'Rx.Observable.prototype',
     'rxjs/add/operator/first': 'Rx.Observable.prototype',
     'rxjs/Observable': 'Rx'


### PR DESCRIPTION
* The ViewportRuler now caches the document rectangle and only updates it on initialization and when the window gets resized.

**Note**: I had to remove the `implements` from the `FakeViewportRuler` because it looks like it's just impossible to implement a class with private members.

* See: [this sample (try to solve the error by keeping implements)](http://www.typescriptlang.org/play/index.html#src=class%20ViewportRuler%20%7B%0D%0A%20%20%20%20private%20_myProperty%3A%20string%3B%0D%0A%7D%0D%0A%0D%0Aclass%20FakeViewportRuler%20implements%20ViewportRuler%20%7B%0D%0A%20%20%20%20%2F%2F%20INSERT%20HERE%0D%0A%7D)