### PR TITLE
refactor(grid-list): remove unnecessary regex and cast to array

### DIFF
--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -113,7 +113,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   private _setTileStyler(): void {
     if (this._rowHeight === MD_FIT_MODE) {
       this._tileStyler = new FitTileStyler();
-    } else if (this._rowHeight && this._rowHeight.match(/:/g)) {
+    } else if (this._rowHeight && this._rowHeight.indexOf(':') > -1) {
       this._tileStyler = new RatioTileStyler(this._rowHeight);
     } else {
       this._tileStyler = new FixedTileStyler(this._rowHeight);
@@ -122,16 +122,15 @@ export class MdGridList implements OnInit, AfterContentChecked {
 
   /** Computes and applies the size and position for all children grid tiles. */
   private _layoutTiles(): void {
-    let tiles = this._tiles.toArray();
-    let tracker = new TileCoordinator(this.cols, tiles);
+    let tracker = new TileCoordinator(this.cols, this._tiles);
     let direction = this._dir ? this._dir.value : 'ltr';
     this._tileStyler.init(this.gutterSize, tracker, this.cols, direction);
 
-    for (let i = 0; i < tiles.length; i++) {
-      let pos = tracker.positions[i];
-      let tile = tiles[i];
+    this._tiles.forEach((tile, index) => {
+      let pos = tracker.positions[index];
       this._tileStyler.setStyle(tile, pos.row, pos.col);
-    }
+    });
+
     this._setListStyle(this._tileStyler.getComputedHeight());
   }
 

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -1,3 +1,4 @@
+import {QueryList} from '@angular/core';
 import {MdGridTile} from './grid-tile';
 import {MdGridTileTooWideError} from './grid-list-errors';
 
@@ -43,7 +44,7 @@ export class TileCoordinator {
   /** The computed (row, col) position of each tile (the output). */
   positions: TilePosition[];
 
-  constructor(numColumns: number, tiles: MdGridTile[]) {
+  constructor(numColumns: number, tiles: QueryList<MdGridTile>) {
     this.tracker = new Array(numColumns);
     this.tracker.fill(0, 0, this.tracker.length);
 


### PR DESCRIPTION
* Removes a regex that can be replaced by a faster `indexOf` check.
* Removes an unnecessary cast from a QueryList to an Array.