### PR TITLE
chore: don't build aot files for dev app.

### DIFF
--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -23,6 +23,9 @@
       ]
     }
   },
+  "exclude": [
+    "*-aot.ts"
+  ],
   "angularCompilerOptions": {
     "genDir": "../../dist",
     "skipTemplateCodegen": true,


### PR DESCRIPTION
* By default we don't want to build the aot files when just serving the dev-app.