### PR TITLE
fix(input): disabled inputs should be grayed out

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -37,6 +37,10 @@
     }
   }
 
+  .md-input-element:disabled {
+    color: md-color($foreground, disabled-text);
+  }
+
   // See md-input-placeholder-floating mixin in input.scss
   input.md-input-element:-webkit-autofill + .md-input-placeholder,
   .md-input-placeholder.md-float.md-focused {


### PR DESCRIPTION
Disabled md-inputs are displaying the currentColor right now (often black). They should be grayed out when disabled, as in Material 1.