### PR TITLE
feat(dialog): add events (observables) for open & closeAll

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -8,7 +8,7 @@ import {MaterialModule, OverlayContainer,
   FullscreenOverlayContainer} from '@angular/material';
 import {DEMO_APP_ROUTES} from './demo-app/routes';
 import {ProgressBarDemo} from './progress-bar/progress-bar-demo';
-import {JazzDialog, ContentElementDialog, DialogDemo} from './dialog/dialog-demo';
+import {JazzDialog, ContentElementDialog, DialogDemo, IFrameDialog} from './dialog/dialog-demo';
 import {RippleDemo} from './ripple/ripple-demo';
 import {IconDemo} from './icon/icon-demo';
 import {GesturesDemo} from './gestures/gestures-demo';
@@ -67,6 +67,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     InputContainerDemo,
     JazzDialog,
     ContentElementDialog,
+    IFrameDialog,
     ListDemo,
     LiveAnnouncerDemo,
     MdCheckboxDemoNestedChecklist,
@@ -102,6 +103,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     DemoApp,
     JazzDialog,
     ContentElementDialog,
+    IFrameDialog,
     RotiniPanel,
     ScienceJoke,
     SpagettiPanel,

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
 import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 
 @Component({
@@ -23,7 +24,19 @@ export class DialogDemo {
     }
   };
 
-  constructor(public dialog: MdDialog) { }
+  constructor(public dialog: MdDialog, @Inject(DOCUMENT) doc: Document) {
+    // Possible useful example for the open and closeAll events.
+    // Adding a class to the body if a dialog opens and
+    // removing it after all open dialogs are closed
+    dialog.afterOpen().subscribe((ref: MdDialogRef<any>) => {
+      if (!doc.body.classList.contains('no-scroll')) {
+        doc.body.classList.add('no-scroll');
+      }
+    });
+    dialog.afterAllClosed().subscribe(_ => {
+      doc.body.classList.remove('no-scroll');
+    });
+  }
 
   openJazz() {
     this.dialogRef = this.dialog.open(JazzDialog, this.config);
@@ -91,9 +104,46 @@ export class JazzDialog {
         color="primary"
         href="https://en.wikipedia.org/wiki/Neptune"
         target="_blank">Read more on Wikipedia</a>
+      
+      <button
+        md-button
+        color="secondary"
+        (click)="showInStackedDialog()">
+        Show in Dialog</button>
     </md-dialog-actions>
   `
 })
 export class ContentElementDialog {
   actionsAlignment: string;
+
+  constructor(public dialog: MdDialog) { }
+
+  showInStackedDialog(src: string) {
+    this.dialog.open(IFrameDialog);
+  }
+}
+
+@Component({
+  selector: 'demo-iframe-dialog',
+  styles: [
+    `iframe {
+      width: 800px;
+    }`
+  ],
+  template: `
+    <h2 md-dialog-title>Neptune</h2>
+
+    <md-dialog-content>
+      <iframe frameborder="0" src="https://en.wikipedia.org/wiki/Neptune"></iframe>
+    </md-dialog-content>
+
+    <md-dialog-actions>
+      <button
+        md-raised-button
+        color="primary"
+        md-dialog-close>Close</button>
+    </md-dialog-actions>
+  `
+})
+export class IFrameDialog {
 }

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -28,12 +28,12 @@ export class DialogDemo {
     // Possible useful example for the open and closeAll events.
     // Adding a class to the body if a dialog opens and
     // removing it after all open dialogs are closed
-    dialog.afterOpen().subscribe((ref: MdDialogRef<any>) => {
+    dialog.afterOpen.subscribe((ref: MdDialogRef<any>) => {
       if (!doc.body.classList.contains('no-scroll')) {
         doc.body.classList.add('no-scroll');
       }
     });
-    dialog.afterAllClosed().subscribe(_ => {
+    dialog.afterAllClosed.subscribe(() => {
       doc.body.classList.remove('no-scroll');
     });
   }

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -118,7 +118,7 @@ export class ContentElementDialog {
 
   constructor(public dialog: MdDialog) { }
 
-  showInStackedDialog(src: string) {
+  showInStackedDialog() {
     this.dialog.open(IFrameDialog);
   }
 }

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,5 +1,5 @@
-import { Component, Inject } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import {Component, Inject} from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
 import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 
 @Component({

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -24,7 +24,7 @@ export class DialogDemo {
     }
   };
 
-  constructor(public dialog: MdDialog, @Inject(DOCUMENT) doc: Document) {
+  constructor(public dialog: MdDialog, @Inject(DOCUMENT) doc: any) {
     // Possible useful example for the open and closeAll events.
     // Adding a class to the body if a dialog opens and
     // removing it after all open dialogs are closed

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -140,12 +140,18 @@ describe('MdDialog', () => {
     dialog.afterOpen().subscribe(r => {
       ref = r;
     });
-    expect(dialog.open(PizzaMsg)).toBe(ref);
+    expect(dialog.open(PizzaMsg, {
+      viewContainerRef: testViewContainerRef
+    })).toBe(ref);
   });
 
   it('should notify the observers if all open dialogs have finished closing', () => {
-    const ref1 = dialog.open(PizzaMsg);
-    const ref2 = dialog.open(ContentElementDialog);
+    const ref1 = dialog.open(PizzaMsg, {
+      viewContainerRef: testViewContainerRef
+    });
+    const ref2 = dialog.open(ContentElementDialog, {
+      viewContainerRef: testViewContainerRef
+    });
     let allClosed = false;
 
     dialog.afterAllClosed().subscribe(_ => {

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -135,6 +135,29 @@ describe('MdDialog', () => {
     expect(overlayContainerElement.querySelector('md-dialog-container')).toBeFalsy();
   });
 
+  it('should notify the observers if a dialog has been opened', () => {
+    let ref: MdDialogRef<PizzaMsg>;
+    dialog.afterOpen().subscribe(r => {
+      ref = r;
+    });
+    expect(dialog.open(PizzaMsg)).toBe(ref);
+  });
+
+  it('should notify the observers if all open dialogs have finished closing', () => {
+    const ref1 = dialog.open(PizzaMsg);
+    const ref2 = dialog.open(ContentElementDialog);
+    let allClosed = false;
+
+    dialog.afterAllClosed().subscribe(_ => {
+      allClosed = true;
+    });
+
+    ref1.close();
+    expect(allClosed).toBeFalsy();
+    ref2.close();
+    expect(allClosed).toBeTruthy();
+  });
+
   it('should should override the width of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       width: '500px'

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -137,7 +137,7 @@ describe('MdDialog', () => {
 
   it('should notify the observers if a dialog has been opened', () => {
     let ref: MdDialogRef<PizzaMsg>;
-    dialog.afterOpen().subscribe(r => {
+    dialog.afterOpen.subscribe(r => {
       ref = r;
     });
     expect(dialog.open(PizzaMsg, {
@@ -154,7 +154,7 @@ describe('MdDialog', () => {
     });
     let allClosed = false;
 
-    dialog.afterAllClosed().subscribe(_ => {
+    dialog.afterAllClosed.subscribe(() => {
       allClosed = true;
     });
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -29,10 +29,16 @@ export class MdDialog {
   }
 
   /** Subject for notifying the user that all open dialogs have finished closing. */
-  private _afterAllClosed: Subject<any> = new Subject();
+  private _afterAllClosed = new Subject<void>();
 
   /** Subject for notifying the user that a dialog has opened. */
-  private _afterOpen: Subject<any> = new Subject();
+  private _afterOpen = new Subject<MdDialogRef<any>>();
+
+  /** Gets an observable that is notified when a dialog has been opened. */
+  afterOpen = this._afterOpen.asObservable();
+
+  /** Gets an observable that is notified when all open dialog have finished closing. */
+  afterAllClosed = this._afterAllClosed.asObservable();
 
   constructor(
       private _overlay: Overlay,
@@ -72,20 +78,6 @@ export class MdDialog {
       // they'll be removed from the list instantaneously.
       this._openDialogs[i].close();
     }
-  }
-
-  /**
-   * Gets an observable that is notified when a dialog has been opened.
-   */
-  afterOpen(): Observable<any> {
-    return this._afterOpen.asObservable();
-  }
-
-  /**
-   * Gets an observable that is notified when all open dialog have finished closing.
-   */
-  afterAllClosed(): Observable<any> {
-    return this._afterAllClosed.asObservable();
   }
 
   /**

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -181,6 +181,8 @@ export class MdDialog {
 
     if (index > -1) {
       this._openDialogs.splice(index, 1);
+
+      // no open dialogs are left, call next on afterAllClosed Subject
       if (!this._openDialogs.length) {
         this._afterAllClosed.next();
       }

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -35,10 +35,10 @@ export class MdDialog {
   private _afterOpen = new Subject<MdDialogRef<any>>();
 
   /** Gets an observable that is notified when a dialog has been opened. */
-  afterOpen = this._afterOpen.asObservable();
+  afterOpen: Observable<MdDialogRef<any>> = this._afterOpen.asObservable();
 
   /** Gets an observable that is notified when all open dialog have finished closing. */
-  afterAllClosed = this._afterAllClosed.asObservable();
+  afterAllClosed: Observable<void> = this._afterAllClosed.asObservable();
 
   constructor(
       private _overlay: Overlay,

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -36,7 +36,8 @@ export class MdDialog {
   }
   /** Subject for notifying the user that a dialog has opened. */
   get _afterAllClosed(): Subject<void> {
-    return this._parentDialog ? this._parentDialog._afterAllClosed : this._afterAllClosedAtThisLevel;
+    return this._parentDialog ?
+      this._parentDialog._afterAllClosed : this._afterAllClosedAtThisLevel;
   }
 
   /** Gets an observable that is notified when a dialog has been opened. */

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -22,6 +22,8 @@ import {MdDialogContainer} from './dialog-container';
 @Injectable()
 export class MdDialog {
   private _openDialogsAtThisLevel: MdDialogRef<any>[] = [];
+  private _afterAllClosedAtThisLevel = new Subject<void>();
+  private _afterOpenAtThisLevel = new Subject<MdDialogRef<any>>();
 
   /** Keeps track of the currently-open dialogs. */
   get _openDialogs(): MdDialogRef<any>[] {
@@ -29,10 +31,13 @@ export class MdDialog {
   }
 
   /** Subject for notifying the user that all open dialogs have finished closing. */
-  private _afterAllClosed = new Subject<void>();
-
+  get _afterOpen(): Subject<MdDialogRef<any>> {
+    return this._parentDialog ? this._parentDialog._afterOpen : this._afterOpenAtThisLevel;
+  }
   /** Subject for notifying the user that a dialog has opened. */
-  private _afterOpen = new Subject<MdDialogRef<any>>();
+  get _afterAllClosed(): Subject<void> {
+    return this._parentDialog ? this._parentDialog._afterAllClosed : this._afterAllClosedAtThisLevel;
+  }
 
   /** Gets an observable that is notified when a dialog has been opened. */
   afterOpen: Observable<MdDialogRef<any>> = this._afterOpen.asObservable();

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -31,7 +31,7 @@ export class MdDialog {
   /** Subject for notifying the user that all open dialogs have finished closing. */
   private _afterAllClosed: Subject<any> = new Subject();
 
-  /** Subject for notifying the user that a dialogs has opened. */
+  /** Subject for notifying the user that a dialog has opened. */
   private _afterOpen: Subject<any> = new Subject();
 
   constructor(


### PR DESCRIPTION
Adds Observables to NgDialog for open and closeAll.
* afterOpen: Notifies the user that a dialog has been opened
* afterAllClosed: Notifies the user that all open dialogs have finished closing.

Useful if you want to execute logic when a dialog opens or when all dialogs are closed. E.g. adding or removing a `no-scroll` class to the body, ...

```ts
  dialog.afterOpen().subscribe((ref: MdDialogRef<any>) => {
    if (!doc.body.classList.contains('no-scroll')) {
      doc.body.classList.add('no-scroll');
    }
  });
  dialog.afterAllClosed().subscribe(_ => {
    doc.body.classList.remove('no-scroll');
  });
```