### PR TITLE
Reset dir to ltr every test.

### DIFF
--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -21,9 +21,10 @@ import {Dir, LayoutDirection} from '../core/rtl/dir';
 
 describe('MdMenu', () => {
   let overlayContainerElement: HTMLElement;
-  let dir: LayoutDirection = 'ltr';
+  let dir: LayoutDirection;
 
   beforeEach(async(() => {
+    dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [MdMenuModule.forRoot()],
       declarations: [SimpleMenu, PositionedMenu, CustomMenuPanel, CustomMenu],


### PR DESCRIPTION
This was creating test bleed on the remaining menu tests.

This also breaks some of the md-menu tests.