### PR TITLE
chore: gulp-typescript v3 detects typescript version

### DIFF
--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -48,9 +48,7 @@ export function tsBuildTask(tsConfigPath: string, tsConfigName = 'tsconfig.json'
     const tsConfig: any = JSON.parse(fs.readFileSync(tsConfigPath, 'utf-8'));
     const dest: string = path.join(tsConfigDir, tsConfig['compilerOptions']['outDir']);
 
-    const tsProject = gulpTs.createProject(tsConfigPath, {
-      typescript: require('typescript')
-    });
+    const tsProject = gulpTs.createProject(tsConfigPath);
 
     let pipe = tsProject.src()
       .pipe(gulpSourcemaps.init())


### PR DESCRIPTION
* In gulp-typescript ~3.0.0 the `typescript` will be no longer included as a dependency.  
 
This means that it now automatically detects the current installed `typescript` version.
   
>  See http://dev.ivogabe.com/gulp-typescript-3/ - Follow-up to https://github.com/angular/material2/pull/2456#issuecomment-269686767
