### PR TITLE
chore: only publish artifacts once

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "strip-ansi": "^3.0.0",
     "stylelint": "^7.7.0",
     "symlink-or-copy": "^1.0.1",
-    "travis-after-modes": "0.0.6-2",
+    "travis-after-modes": "0.0.7",
     "ts-node": "^0.7.3",
     "tslint": "^3.13.0",
     "typedoc": "^0.5.1",


### PR DESCRIPTION
* Right now Travis tries to publish the build artifacts to the `material2-builds` repository for each mode (6 times - see [here](https://travis-ci.org/angular/material2/jobs/189051174#L462))

  It still only published **once** per build, because Git doesn't allow re-publishing of the same git tags.

* The issue has been fixed with version `0.0.7` of `travis-after-modes` (https://github.com/DevVersion/travis-after-modes/commit/387328ebcb8441f474c2f2823ac6c5785f0938da)