### PR TITLE
docs(README): remove the "2" from Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Material Design for Angular 2
+# Material Design for Angular
 [![npm version](https://badge.fury.io/js/%40angular%2Fmaterial.svg)](https://www.npmjs.com/package/%40angular%2Fmaterial)
 [![Build Status](https://travis-ci.org/angular/material2.svg?branch=master)](https://travis-ci.org/angular/material2)
 [![Gitter](https://badges.gitter.im/angular/material2.svg)](https://gitter.im/angular/material2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-This is the home for the Angular team's Material Design components built on top of Angular 2.
+This is the home for the Angular team's Material Design components built for **Angular version 2 onwards**.
 
 #### Quick links
 [Google group](https://groups.google.com/forum/#!forum/angular-material2),
@@ -140,7 +140,7 @@ High level items planned for January 2017:
 be missing some behaviors or polish.
 
 ## The goal of Angular Material
-Our goal is to build a set of high-quality UI components built with Angular 2 and TypeScript,
+Our goal is to build a set of high-quality UI components built with Angular and TypeScript,
 following the Material Design spec. These
 components will serve as an example of how to write Angular code following best practices.
 


### PR DESCRIPTION
I wanted to support Igor's mission to remove the "2" from Angular on the web. Also the repo description would have to be adjusted. 😊 