### PR TITLE
chore: disable optional travis modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,9 @@ env:
     - MODE=e2e
     - MODE=saucelabs_required
     - MODE=browserstack_required
-    - MODE=saucelabs_optional
-    - MODE=browserstack_optional
+# Temporary disable the optional builds because of potential concurrency flakiness
+#    - MODE=saucelabs_optional
+#    - MODE=browserstack_optional
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ env:
     - MODE=e2e
     - MODE=saucelabs_required
     - MODE=browserstack_required
-# Temporary disable the optional builds because of potential concurrency flakiness
-#    - MODE=saucelabs_optional
-#    - MODE=browserstack_optional
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
* Temporary disable optional travis modes because those always fail at the moment and also can be potential culprits for CI flakiness on Saucelabs & Browserstack. See #2523 