### PR TITLE
chore: update version of sauce connect

### DIFF
--- a/scripts/browserstack/start-tunnel.sh
+++ b/scripts/browserstack/start-tunnel.sh
@@ -33,8 +33,8 @@ rm $TUNNEL_FILE
 ARGS=""
 
 # Set tunnel-id only on Travis, to make local testing easier.
-if [ ! -z "$TRAVIS_JOB_NUMBER" ]; then
-  ARGS="$ARGS --local-identifier $TRAVIS_JOB_NUMBER"
+if [ ! -z "$TRAVIS_JOB_ID" ]; then
+  ARGS="$ARGS --local-identifier $TRAVIS_JOB_ID"
 fi
 
 echo "Starting Browserstack Local in the background, logging into:"

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,58 +2,43 @@
 
 set -e -o pipefail
 
-# Setup and start Sauce Connect for your TravisCI build
-# This script requires your .travis.yml to include the following two private env variables:
-# SAUCE_USERNAME
-# SAUCE_ACCESS_KEY
-# Follow the steps at https://saucelabs.com/opensource/travis to set that up.
-#
-# Curl and run this script as part of your .travis.yml before_script section:
-# before_script:
-#   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
+TUNNEL_FILE="sc-4.4.2-linux.tar.gz"
+TUNNEL_URL="https://saucelabs.com/downloads/$TUNNEL_FILE"
+TUNNEL_DIR="/tmp/saucelabs-connect"
 
-CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
-CONNECT_DOWNLOAD="sc-latest-linux.tar.gz"
-
-CONNECT_LOG="$LOGS_DIR/sauce-connect"
-CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
-CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
-
-# Get the appropriate URL for downloading Sauce Connect
-if [ `uname -s` = "Darwin" ]; then
-  # If the user is running Mac, download the OSX version
-  # https://en.wikipedia.org/wiki/Darwin_(operating_system)
-  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.2-osx.zip"
-else
-  # Otherwise, default to Linux for Travis-CI
-  CONNECT_URL="https://saucelabs.com/downloads/sc-4.4.2-linux.tar.gz"
-fi
-mkdir -p $CONNECT_DIR
-cd $CONNECT_DIR
-curl $CONNECT_URL -o $CONNECT_DOWNLOAD 2> /dev/null 1> /dev/null
-mkdir sauce-connect
-tar --extract --file=$CONNECT_DOWNLOAD --strip-components=1 --directory=sauce-connect > /dev/null
-rm $CONNECT_DOWNLOAD
-
+TUNNEL_LOG="$LOGS_DIR/sauce-connect"
 
 SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+
+# Cleanup and create the folder structure for the tunnel connector.
+rm -rf $TUNNEL_DIR $BROWSER_PROVIDER_READY_FILE
+mkdir -p $TUNNEL_DIR
+
+cd $TUNNEL_DIR
+
+# Download the saucelabs connect binaries.
+curl $TUNNEL_URL -o $TUNNEL_FILE 2> /dev/null 1> /dev/null
+
+# Extract the saucelabs connect binaries from the tarball.
+mkdir -p sauce-connect
+tar --extract --file=$TUNNEL_FILE --strip-components=1 --directory=sauce-connect > /dev/null
+
+# Cleanup the download directory.
+rm $TUNNEL_FILE
 
 ARGS=""
 
 # Set tunnel-id only on Travis, to make local testing easier.
-if [ ! -z "$TRAVIS_JOB_NUMBER" ]; then
-  ARGS="$ARGS --tunnel-identifier $TRAVIS_JOB_NUMBER"
+if [ ! -z "$TRAVIS_JOB_ID" ]; then
+  ARGS="$ARGS --tunnel-identifier $TRAVIS_JOB_ID"
 fi
 if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
   ARGS="$ARGS --readyfile $BROWSER_PROVIDER_READY_FILE"
 fi
 
-
 echo "Starting Sauce Connect in the background, logging into:"
-echo "  $CONNECT_LOG"
-echo "  $CONNECT_STDOUT"
-echo "  $CONNECT_STDERR"
+echo "  $TUNNEL_LOG"
 echo "  ---"
 echo "  $ARGS"
-sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS \
-  --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &
+
+sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS --logfile $TUNNEL_LOG &

--- a/test/karma.config.ts
+++ b/test/karma.config.ts
@@ -105,10 +105,10 @@ export function config(config) {
 
     if (platform === 'saucelabs') {
       config.sauceLabs.build = buildId;
-      config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+      config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_ID;
     } else if (platform === 'browserstack') {
       config.browserStack.build = buildId;
-      config.browserStack.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+      config.browserStack.tunnelIdentifier = process.env.TRAVIS_JOB_ID;
     } else {
       throw new Error(`Platform "${platform}" unknown, but Travis specified. Exiting.`);
     }

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -41,8 +41,8 @@ if (process.env['TRAVIS']) {
   config.sauceKey = key;
   config.capabilities = {
     'browserName': 'chrome',
-    'tunnel-identifier': process.env['TRAVIS_JOB_NUMBER'],
-    'build': process.env['TRAVIS_JOB_NUMBER'],
+    'tunnel-identifier': process.env['TRAVIS_JOB_ID'],
+    'build': process.env['TRAVIS_JOB_ID'],
     'name': 'Material 2 E2E Tests',
 
     // Enables concurrent testing in the Webdriver. Currently runs five e2e files in parallel.


### PR DESCRIPTION
* Updates the version of SauceConnect from v4.4.1 to v4.4.2
* Uses the similar setup as from the docs repository (https://github.com/angular/material.angular.io/blob/master/scripts/saucelabs/start-tunnel.sh)
* Uses a more unique tunnel identifer (the travis job id and not the job number)