### PR TITLE
test(menu): give menu space to open in alt positions

### DIFF
--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -21,9 +21,10 @@ import {Dir, LayoutDirection} from '../core/rtl/dir';
 
 describe('MdMenu', () => {
   let overlayContainerElement: HTMLElement;
-  let dir: LayoutDirection = 'ltr';
+  let dir: LayoutDirection;
 
   beforeEach(async(() => {
+    dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [MdMenuModule.forRoot()],
       declarations: [SimpleMenu, PositionedMenu, CustomMenuPanel, CustomMenu],

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -117,6 +117,9 @@ describe('MdMenu', () => {
       trigger.style.position = 'relative';
       trigger.style.top = '600px';
 
+      // Push trigger to the right, so it has space to open "before"
+      trigger.style.left = '100px';
+
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
     });
@@ -145,7 +148,7 @@ describe('MdMenu', () => {
       // Push trigger to the right side of viewport, so it doesn't have space to open
       // in its default "after" position on the right side.
       trigger.style.position = 'relative';
-      trigger.style.left = '900px';
+      trigger.style.left = '950px';
 
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
@@ -203,7 +206,7 @@ describe('MdMenu', () => {
       // push trigger to the bottom, right part of viewport, so it doesn't have space to open
       // in its default "after below" position.
       trigger.style.position = 'relative';
-      trigger.style.left = '900px';
+      trigger.style.left = '950px';
       trigger.style.top = '600px';
 
       fixture.componentInstance.trigger.openMenu();


### PR DESCRIPTION
Menu tests were not actually resetting state properly. Once that was fixed by @trshafer in the first commit, it exposed that some tests were also not being staged properly to give the menu sufficient space to open within the viewport. The latter is fixed in the second commit. 