### PR TITLE
feat(dialog): add the ability to align the content of md-dialog-actions

### DIFF
--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -26,6 +26,14 @@
 
     <h2>Other options</h2>
 
+    <p>
+      <md-select placeholder="Button alignment" [(ngModel)]="actionsAlignment">
+        <md-option>Start</md-option>
+        <md-option value="end">End</md-option>
+        <md-option value="middle">Middle</md-option>
+      </md-select>
+    </p>
+
     <md-checkbox [(ngModel)]="config.disableClose">Disable close</md-checkbox>
   </md-card-content>
 </md-card>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -30,7 +30,7 @@
       <md-select placeholder="Button alignment" [(ngModel)]="actionsAlignment">
         <md-option>Start</md-option>
         <md-option value="end">End</md-option>
-        <md-option value="middle">Middle</md-option>
+        <md-option value="center">Center</md-option>
       </md-select>
     </p>
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -10,6 +10,7 @@ import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 export class DialogDemo {
   dialogRef: MdDialogRef<JazzDialog>;
   lastCloseResult: string;
+  actionsAlignment: string;
   config: MdDialogConfig = {
     disableClose: false,
     width: '',
@@ -34,7 +35,8 @@ export class DialogDemo {
   }
 
   openContentElement() {
-    this.dialog.open(ContentElementDialog, this.config);
+    let dialogRef = this.dialog.open(ContentElementDialog, this.config);
+    dialogRef.componentInstance.actionsAlignment = this.actionsAlignment;
   }
 }
 
@@ -78,7 +80,7 @@ export class JazzDialog {
       </p>
     </md-dialog-content>
 
-    <md-dialog-actions>
+    <md-dialog-actions [attr.align]="actionsAlignment">
       <button
         md-raised-button
         color="primary"
@@ -92,4 +94,6 @@ export class JazzDialog {
     </md-dialog-actions>
   `
 })
-export class ContentElementDialog { }
+export class ContentElementDialog {
+  actionsAlignment: string;
+}

--- a/src/lib/dialog/README.md
+++ b/src/lib/dialog/README.md
@@ -37,7 +37,7 @@ A reference to the dialog created by the MdDialog `open` method.
 | `md-dialog-title`   | Marks the title of the dialog.
 | `md-dialog-content` | Scrollable content of the dialog.
 | `md-dialog-close`   | When added to a `button`, makes the element act as a close button for the dialog.
-| `md-dialog-actions` | Wrapper for the set of actions at the bottom of a dialog. Typically contains buttons.
+| `md-dialog-actions` | Wrapper for the set of actions at the bottom of a dialog. Typically contains buttons. The element's content can be aligned via the `align` attribute either to the `middle` or the `end`. |
 
 ## Example
 The service can be injected in a component.

--- a/src/lib/dialog/README.md
+++ b/src/lib/dialog/README.md
@@ -37,7 +37,7 @@ A reference to the dialog created by the MdDialog `open` method.
 | `md-dialog-title`   | Marks the title of the dialog.
 | `md-dialog-content` | Scrollable content of the dialog.
 | `md-dialog-close`   | When added to a `button`, makes the element act as a close button for the dialog.
-| `md-dialog-actions` | Wrapper for the set of actions at the bottom of a dialog. Typically contains buttons. The element's content can be aligned via the `align` attribute either to the `middle` or the `end`. |
+| `md-dialog-actions` | Wrapper for the set of actions at the bottom of a dialog. Typically contains buttons. The element's content can be aligned via the `align` attribute either to the `center` or the `end`. |
 
 ## Example
 The service can be injected in a component.

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -52,11 +52,11 @@ md-dialog-actions, [md-dialog-actions], mat-dialog-actions, [mat-dialog-actions]
     margin-bottom: -$md-dialog-padding;
   }
 
-  &[align="end"] {
+  &[align='end'] {
     justify-content: flex-end;
   }
 
-  &[align="middle"] {
+  &[align='middle'] {
     justify-content: center;
   }
 }

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -43,12 +43,20 @@ md-dialog-content, [md-dialog-content], mat-dialog-content, [mat-dialog-content]
 
 md-dialog-actions, [md-dialog-actions], mat-dialog-actions, [mat-dialog-actions] {
   padding: $md-dialog-padding / 2 0;
-  display: block;
+  display: flex;
 
   &:last-child {
     // If the actions are the last element in a dialog, we need to pull them down
     // over the dialog padding, in order to avoid the action's padding stacking
     // with the dialog's.
     margin-bottom: -$md-dialog-padding;
+  }
+
+  &[align="end"] {
+    justify-content: flex-end;
+  }
+
+  &[align="middle"] {
+    justify-content: center;
   }
 }

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -56,7 +56,7 @@ md-dialog-actions, [md-dialog-actions], mat-dialog-actions, [mat-dialog-actions]
     justify-content: flex-end;
   }
 
-  &[align='middle'] {
+  &[align='center'] {
     justify-content: center;
   }
 }


### PR DESCRIPTION
Adds the `align` attribute, which can be set to `end` or `middle`, that allows users to align the content of the `md-dialog-actions`.

Fixes #2483.