### PR TITLE
	fix(select): remove selection if option is removed

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -191,12 +191,12 @@ describe('MdSelect', () => {
       firstOption.click();
       fixture.detectChanges();
 
-      expect(select.selected).toBe(select.options.first);
+      expect(select.selected).toBe(select.options.first, 'Expected first option to be selected.');
 
       fixture.componentInstance.foods = [];
       fixture.detectChanges();
 
-      expect(select.selected).toBe(null);
+      expect(select.selected).toBe(null, 'Expected nothing to be selected.');
     });
 
     it('should display the selected option in the trigger', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -180,7 +180,7 @@ describe('MdSelect', () => {
       expect(optionInstances[2].selected).toBe(false);
     });
 
-    it('should remove an unavailable selected option when the options change', () => {
+    it('should remove selection if option has been removed', () => {
       let select = fixture.componentInstance.select;
 
       trigger.click();

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -196,7 +196,7 @@ describe('MdSelect', () => {
       fixture.componentInstance.foods = [];
       fixture.detectChanges();
 
-      expect(select.selected).toBe(null, 'Expected nothing to be selected.');
+      expect(select.selected).toBe(null, 'Expected selection to be removed when option no longer exists.');
     });
 
     it('should display the selected option in the trigger', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -196,7 +196,8 @@ describe('MdSelect', () => {
       fixture.componentInstance.foods = [];
       fixture.detectChanges();
 
-      expect(select.selected).toBe(null, 'Expected selection to be removed when option no longer exists.');
+      expect(select.selected)
+        .toBe(null, 'Expected selection to be removed when option no longer exists.');
     });
 
     it('should display the selected option in the trigger', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -180,7 +180,7 @@ describe('MdSelect', () => {
       expect(optionInstances[2].selected).toBe(false);
     });
 
-    it('should remove selection if option has been removed', () => {
+    it('should remove selection if option has been removed', async(() => {
       let select = fixture.componentInstance.select;
 
       trigger.click();
@@ -196,9 +196,11 @@ describe('MdSelect', () => {
       fixture.componentInstance.foods = [];
       fixture.detectChanges();
 
-      expect(select.selected)
-        .toBe(null, 'Expected selection to be removed when option no longer exists.');
-    });
+      fixture.whenStable().then(() => {
+        expect(select.selected)
+          .toBe(null, 'Expected selection to be removed when option no longer exists.');
+      });
+    }));
 
     it('should display the selected option in the trigger', () => {
       trigger.click();

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -180,6 +180,25 @@ describe('MdSelect', () => {
       expect(optionInstances[2].selected).toBe(false);
     });
 
+    it('should remove an unavailable selected option when the options change', () => {
+      let select = fixture.componentInstance.select;
+
+      trigger.click();
+      fixture.detectChanges();
+
+      let firstOption = overlayContainerElement.querySelectorAll('md-option')[0] as HTMLElement;
+
+      firstOption.click();
+      fixture.detectChanges();
+
+      expect(select.selected).toBe(select.options.first);
+
+      fixture.componentInstance.foods = [];
+      fixture.detectChanges();
+
+      expect(select.selected).toBe(null);
+    });
+
     it('should display the selected option in the trigger', () => {
       trigger.click();
       fixture.detectChanges();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -441,17 +441,9 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   /** Drops current option subscriptions and IDs and resets from scratch. */
   private _resetOptions(): void {
-    this._checkSelected();
     this._dropSubscriptions();
     this._listenToOptions();
     this._setOptionIds();
-  }
-
-  /** Checks if the current selected value is still a valid option and deselects if not. */
-  private _checkSelected() {
-    if (this.selected && !this.options.some(option => option === this.selected)) {
-      this._selected = null;
-    }
   }
 
   /** Listens to selection events on each option. */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -441,9 +441,17 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   /** Drops current option subscriptions and IDs and resets from scratch. */
   private _resetOptions(): void {
+    this._checkSelected();
     this._dropSubscriptions();
     this._listenToOptions();
     this._setOptionIds();
+  }
+
+  /** Checks if the current selected value is still a valid option and deselects if not. */
+  private _checkSelected() {
+    if (this.selected && !this.options.some(option => option === this.selected)) {
+      this._selected = null;
+    }
   }
 
   /** Listens to selection events on each option. */


### PR DESCRIPTION
* Currenty when an option is selected and the option is somehow programmatically removed the select updates its options.
 
  Right now it does not remove the selection if the selection has been removed from the options.

Fixes #2524 