### PR TITLE
fix(button): only flat button and icon buttons should inherit the color

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -41,7 +41,6 @@ $md-mini-fab-padding: 8px !default;
   font-size: $md-body-font-size-base;
   font-family: $md-font-family;
   font-weight: 500;
-  color: currentColor;
   text-align: center;
 
   // Sizing.

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -8,6 +8,9 @@
 [md-button], [md-icon-button] {
   @extend %md-button-base;
 
+  // Only flat button and icon buttons should inherit the color
+  color: currentColor;
+
   // Only flat buttons and icon buttons (not raised or fabs) have a hover style.
   &:hover {
     // Use the same visual treatment for hover as for focus.


### PR DESCRIPTION
- also fixes raised buttons in toolbar

fixes #2539