### PR TITLE
docs(tabs): add note for core bug that breaks `md-tab-nav-bar`

### DIFF
--- a/src/lib/tabs/OVERVIEW.md
+++ b/src/lib/tabs/OVERVIEW.md
@@ -79,3 +79,7 @@ provides a tab-like UI for navigating between routes.
 The tab-nav-bar is not tied to any particular router; it works with normal `<a>` elements and uses
 the `active` property to determine which tab is currently active. The corresponding 
 `<router-outlet>` can be placed anywhere in the view. 
+
+**Note**: The `md-tab-nav-bar` example above does not work with recent versions of Angular core.
+Please consult [Issue #1967](https://github.com/angular/material2/issues/1967) for more details
+including a work around and a link to the PR that is being reviewed by the Angular core team.


### PR DESCRIPTION
add info to docs to avoid more people hitting this bug
there have been quite a few reports about this recently
it is not obvious to users that it is a core bug and not a bug in their code

Relates to #1967