### PR TITLE
fix(select.scss): parent align affects placeholder

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -45,6 +45,7 @@ md-select {
   &.md-floating-placeholder {
     top: -22px;
     left: -2px;
+    text-align: left;
     transform: scale(0.75);
   }
 
@@ -53,6 +54,7 @@ md-select {
 
     &.md-floating-placeholder {
       left: 2px;
+      text-align: right;
     }
   }
 


### PR DESCRIPTION
When a parent element has the text-align styles applied these affect the `md-select` floating placeholder.

| Before (LTR)                                                                                                       | After (LTR)                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://cloud.githubusercontent.com/assets/10200431/21752438/b7d13720-d5cf-11e6-86b9-7b84c5f2fed7.png) | ![image](https://cloud.githubusercontent.com/assets/10200431/21752391/ea28aad8-d5ce-11e6-939d-88722ff109a4.png) |




