### PR TITLE
feat(input): option to imperatively float placeholder

### DIFF
--- a/src/demo-app/input/input-container-demo.html
+++ b/src/demo-app/input/input-container-demo.html
@@ -180,10 +180,16 @@
       </md-input-container>
     </p>
     <p>
-      <md-checkbox [(ngModel)]="floatingLabel">Toggle Floating Label</md-checkbox>
-      <button md-button (click)="floatingLabel = null">Reset Floating Label</button>
+      <md-button-toggle-group [(ngModel)]="floatingLabel">
+        <md-button-toggle value="auto">Auto Float</md-button-toggle>
+        <md-button-toggle value="always">Always Float</md-button-toggle>
+        <md-button-toggle value="never">Never Float</md-button-toggle>
+      </md-button-toggle-group>
+    </p>
+
+    <p>
       <md-input-container [floatingPlaceholder]="floatingLabel">
-        <input mdInput [placeholder]="floatingLabel ? 'Floating label' : 'Not floating label'">
+        <input mdInput placeholder="Placeholder">
       </md-input-container>
     </p>
 

--- a/src/demo-app/input/input-container-demo.html
+++ b/src/demo-app/input/input-container-demo.html
@@ -180,7 +180,8 @@
       </md-input-container>
     </p>
     <p>
-      <md-checkbox [(ngModel)]="floatingLabel"> Check to make floating label:</md-checkbox>
+      <md-checkbox [(ngModel)]="floatingLabel">Toggle Floating Label</md-checkbox>
+      <button md-button (click)="floatingLabel = null">Reset Floating Label</button>
       <md-input-container [floatingPlaceholder]="floatingLabel">
         <input mdInput [placeholder]="floatingLabel ? 'Floating label' : 'Not floating label'">
       </md-input-container>

--- a/src/demo-app/input/input-container-demo.html
+++ b/src/demo-app/input/input-container-demo.html
@@ -188,7 +188,7 @@
     </p>
 
     <p>
-      <md-input-container [floatingPlaceholder]="floatingLabel">
+      <md-input-container [floatPlaceholder]="floatingLabel">
         <input mdInput placeholder="Placeholder">
       </md-input-container>
     </p>

--- a/src/demo-app/input/input-container-demo.ts
+++ b/src/demo-app/input/input-container-demo.ts
@@ -11,9 +11,9 @@ let max = 5;
   styleUrls: ['input-container-demo.css'],
 })
 export class InputContainerDemo {
+  floatingLabel: string = 'auto';
   dividerColor: boolean;
   requiredField: boolean;
-  floatingLabel: boolean;
   ctrlDisabled = false;
 
   name: string;

--- a/src/lib/input/input-container-errors.ts
+++ b/src/lib/input/input-container-errors.ts
@@ -28,9 +28,3 @@ export class MdInputContainerMissingMdInputError extends MdError {
           'to the native input or textarea element?');
   }
 }
-
-export class MdInputContainerFloatingPlaceholderInvalidError extends MdError {
-  constructor(value: string) {
-    super(`The value "${value}" for the floatingPlaceholder input is not valid.`);
-  }
-}

--- a/src/lib/input/input-container-errors.ts
+++ b/src/lib/input/input-container-errors.ts
@@ -28,3 +28,9 @@ export class MdInputContainerMissingMdInputError extends MdError {
           'to the native input or textarea element?');
   }
 }
+
+export class MdInputContainerFloatingPlaceholderInvalidError extends MdError {
+  constructor(value: string) {
+    super(`The value "${value}" for the floatingPlaceholder input is not valid.`);
+  }
+}

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -7,7 +7,7 @@
 
       <label class="md-input-placeholder"
              [attr.for]="_mdInputChild.id"
-             [class.md-empty]="_mdInputChild.empty"
+             [class.md-empty]="_mdInputChild.empty && !_shouldAlwaysFloat"
              [class.md-focused]="_mdInputChild.focused"
              [class.md-float]="floatingPlaceholder"
              [class.md-accent]="dividerColor == 'accent'"

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -9,7 +9,7 @@
              [attr.for]="_mdInputChild.id"
              [class.md-empty]="_mdInputChild.empty && !_shouldAlwaysFloat"
              [class.md-focused]="_mdInputChild.focused"
-             [class.md-float]="floatingPlaceholder"
+             [class.md-float]="_canPlaceholderFloat"
              [class.md-accent]="dividerColor == 'accent'"
              [class.md-warn]="dividerColor == 'warn'"
              *ngIf="_hasPlaceholder()">

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -62,7 +62,7 @@ describe('MdInputContainer', function () {
 
     let inputContainer = fixture.debugElement.query(By.directive(MdInputContainer))
         .componentInstance as MdInputContainer;
-    expect(inputContainer.floatingPlaceholder).toBe('auto',
+    expect(inputContainer.floatPlaceholder).toBe('auto',
         'Expected MdInputContainer to set floatingLabel to auto by default.');
   });
 
@@ -479,7 +479,7 @@ describe('MdInputContainer', function () {
     expect(ariaValue).toBe(`${hintLabel.getAttribute('id')} ${endLabel.getAttribute('id')}`);
   });
 
-  it('should float when floatingPlaceholder is set to default and text is entered', () => {
+  it('should float when floatPlaceholder is set to default and text is entered', () => {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
     fixture.detectChanges();
 
@@ -505,7 +505,7 @@ describe('MdInputContainer', function () {
     expect(labelEl.classList).toContain('md-float');
   });
 
-  it('should always float the placeholder when floatingPlaceholder is set to true', () => {
+  it('should always float the placeholder when floatPlaceholder is set to true', () => {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
     fixture.detectChanges();
 
@@ -528,7 +528,7 @@ describe('MdInputContainer', function () {
   });
 
 
-  it('should never float the placeholder when floatingPlaceholder is set to false', () => {
+  it('should never float the placeholder when floatPlaceholder is set to false', () => {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
 
     fixture.componentInstance.shouldFloat = 'never';
@@ -741,7 +741,7 @@ class MdInputContainerWithValueBinding {
 
 @Component({
   template: `
-    <md-input-container floatingPlaceholder="never">
+    <md-input-container floatPlaceholder="never">
       <input mdInput placeholder="Label">
     </md-input-container>
   `
@@ -750,8 +750,8 @@ class MdInputContainerWithStaticPlaceholder {}
 
 @Component({
   template: `
-    <md-input-container [floatingPlaceholder]="shouldFloat">
-      <input md-input placeholder="Label">
+    <md-input-container [floatPlaceholder]="shouldFloat">
+      <input mdInput placeholder="Label">
     </md-input-container>`
 })
 class MdInputContainerWithDynamicPlaceholder {

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -62,8 +62,8 @@ describe('MdInputContainer', function () {
 
     let inputContainer = fixture.debugElement.query(By.directive(MdInputContainer))
         .componentInstance as MdInputContainer;
-    expect(inputContainer.floatingPlaceholder).toBe(true,
-        'Expected MdInputContainer to default to having floating placeholders turned on');
+    expect(inputContainer.floatingPlaceholder).toBe('auto',
+        'Expected MdInputContainer to set floatingLabel to auto by default.');
   });
 
   it('should not be treated as empty if type is date',
@@ -483,20 +483,20 @@ describe('MdInputContainer', function () {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'));
+    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
     let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
 
     expect(labelEl.classList).not.toContain('md-empty');
     expect(labelEl.classList).toContain('md-float');
 
-    fixture.componentInstance.shouldFloat = null;
+    fixture.componentInstance.shouldFloat = 'auto';
     fixture.detectChanges();
 
     expect(labelEl.classList).toContain('md-empty');
     expect(labelEl.classList).toContain('md-float');
 
     // Update the value of the input.
-    inputEl.nativeElement.value = 'Text';
+    inputEl.value = 'Text';
 
     // Fake behavior of the `(input)` event which should trigger a change detection.
     fixture.detectChanges();
@@ -509,7 +509,7 @@ describe('MdInputContainer', function () {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'));
+    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
     let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
 
     expect(labelEl.classList).not.toContain('md-empty');
@@ -518,7 +518,7 @@ describe('MdInputContainer', function () {
     fixture.detectChanges();
 
     // Update the value of the input.
-    inputEl.nativeElement.value = 'Text';
+    inputEl.value = 'Text';
 
     // Fake behavior of the `(input)` event which should trigger a change detection.
     fixture.detectChanges();
@@ -531,17 +531,17 @@ describe('MdInputContainer', function () {
   it('should never float the placeholder when floatingPlaceholder is set to false', () => {
     let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
 
-    fixture.componentInstance.shouldFloat = false;
+    fixture.componentInstance.shouldFloat = 'never';
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'));
+    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
     let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
 
     expect(labelEl.classList).toContain('md-empty');
     expect(labelEl.classList).not.toContain('md-float');
 
     // Update the value of the input.
-    inputEl.nativeElement.value = 'Text';
+    inputEl.value = 'Text';
 
     // Fake behavior of the `(input)` event which should trigger a change detection.
     fixture.detectChanges();
@@ -741,7 +741,7 @@ class MdInputContainerWithValueBinding {
 
 @Component({
   template: `
-    <md-input-container [floatingPlaceholder]="false">
+    <md-input-container floatingPlaceholder="never">
       <input mdInput placeholder="Label">
     </md-input-container>
   `
@@ -755,7 +755,7 @@ class MdInputContainerWithStaticPlaceholder {}
     </md-input-container>`
 })
 class MdInputContainerWithDynamicPlaceholder {
-  shouldFloat: boolean = true;
+  shouldFloat: string = 'always';
 }
 
 @Component({

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -48,7 +48,8 @@ describe('MdInputContainer', function () {
         MdInputContainerWithStaticPlaceholder,
         MdInputContainerMissingMdInputTestController,
         MdInputContainerMultipleHintTestController,
-        MdInputContainerMultipleHintMixedTestController
+        MdInputContainerMultipleHintMixedTestController,
+        MdInputContainerWithDynamicPlaceholder
       ],
     });
 
@@ -477,6 +478,78 @@ describe('MdInputContainer', function () {
 
     expect(ariaValue).toBe(`${hintLabel.getAttribute('id')} ${endLabel.getAttribute('id')}`);
   });
+
+  it('should float when floatingPlaceholder is set to default and text is entered', () => {
+    let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
+    fixture.detectChanges();
+
+    let inputEl = fixture.debugElement.query(By.css('input'));
+    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).toContain('md-float');
+
+    fixture.componentInstance.shouldFloat = null;
+    fixture.detectChanges();
+
+    expect(labelEl.classList).toContain('md-empty');
+    expect(labelEl.classList).toContain('md-float');
+
+    // Update the value of the input.
+    inputEl.nativeElement.value = 'Text';
+
+    // Fake behavior of the `(input)` event which should trigger a change detection.
+    fixture.detectChanges();
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).toContain('md-float');
+  });
+
+  it('should always float the placeholder when floatingPlaceholder is set to true', () => {
+    let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
+    fixture.detectChanges();
+
+    let inputEl = fixture.debugElement.query(By.css('input'));
+    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).toContain('md-float');
+
+    fixture.detectChanges();
+
+    // Update the value of the input.
+    inputEl.nativeElement.value = 'Text';
+
+    // Fake behavior of the `(input)` event which should trigger a change detection.
+    fixture.detectChanges();
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).toContain('md-float');
+  });
+
+
+  it('should never float the placeholder when floatingPlaceholder is set to false', () => {
+    let fixture = TestBed.createComponent(MdInputContainerWithDynamicPlaceholder);
+
+    fixture.componentInstance.shouldFloat = false;
+    fixture.detectChanges();
+
+    let inputEl = fixture.debugElement.query(By.css('input'));
+    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+
+    expect(labelEl.classList).toContain('md-empty');
+    expect(labelEl.classList).not.toContain('md-float');
+
+    // Update the value of the input.
+    inputEl.nativeElement.value = 'Text';
+
+    // Fake behavior of the `(input)` event which should trigger a change detection.
+    fixture.detectChanges();
+
+    expect(labelEl.classList).not.toContain('md-empty');
+    expect(labelEl.classList).not.toContain('md-float');
+  });
+
 });
 
 @Component({
@@ -674,6 +747,16 @@ class MdInputContainerWithValueBinding {
   `
 })
 class MdInputContainerWithStaticPlaceholder {}
+
+@Component({
+  template: `
+    <md-input-container [floatingPlaceholder]="shouldFloat">
+      <input md-input placeholder="Label">
+    </md-input-container>`
+})
+class MdInputContainerWithDynamicPlaceholder {
+  shouldFloat: boolean = true;
+}
 
 @Component({
   template: `

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -20,7 +20,7 @@ import {
   MdInputContainerUnsupportedTypeError,
   MdInputContainerPlaceholderConflictError,
   MdInputContainerDuplicatedHintError,
-  MdInputContainerMissingMdInputError, MdInputContainerFloatingPlaceholderInvalidError
+  MdInputContainerMissingMdInputError
 } from './input-container-errors';
 
 
@@ -38,9 +38,8 @@ const MD_INPUT_INVALID_TYPES = [
   'submit'
 ];
 
-/** Valid options for the floatingPlaceholder input binding. */
-export type MD_INPUT_PLACEHOLDER_TYPES = 'always' | 'never' | 'auto';
-const MD_INPUT_PLACEHOLDER_VALUES = ['always', 'never', 'auto'];
+/** Type for the available floatPlaceholder values. */
+export type FloatPlaceholderType = 'always' | 'never' | 'auto';
 
 let nextUniqueId = 0;
 
@@ -257,10 +256,10 @@ export class MdInputContainer implements AfterContentInit {
   @Input() dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
 
   /** Whether the floating label should always float or not. */
-  get _shouldAlwaysFloat() { return this._floatingPlaceholder === 'always'; };
+  get _shouldAlwaysFloat() { return this._floatPlaceholder === 'always'; };
 
   /** Whether the placeholder can float or not. */
-  get _canPlaceholderFloat() { return this._floatingPlaceholder !== 'never'; }
+  get _canPlaceholderFloat() { return this._floatPlaceholder !== 'never'; }
 
   /** Text for the input hint. */
   @Input()
@@ -276,14 +275,11 @@ export class MdInputContainer implements AfterContentInit {
 
   /** Whether the placeholder should always float, never float or float as the user types. */
   @Input()
-  get floatingPlaceholder() { return this._floatingPlaceholder; }
-  set floatingPlaceholder(value: MD_INPUT_PLACEHOLDER_TYPES) {
-    if (value && MD_INPUT_PLACEHOLDER_VALUES.indexOf(value) === -1) {
-      throw new MdInputContainerFloatingPlaceholderInvalidError(value);
-    }
-    this._floatingPlaceholder = value || 'auto';
+  get floatPlaceholder() { return this._floatPlaceholder; }
+  set floatPlaceholder(value: FloatPlaceholderType) {
+    this._floatPlaceholder = value || 'auto';
   }
-  private _floatingPlaceholder: MD_INPUT_PLACEHOLDER_TYPES = 'auto';
+  private _floatPlaceholder: FloatPlaceholderType = 'auto';
 
   @ContentChild(MdInputDirective) _mdInputChild: MdInputDirective;
 

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -253,6 +253,13 @@ export class MdInputContainer implements AfterContentInit {
   /** Color of the input divider, based on the theme. */
   @Input() dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
 
+  /** Whether the floating label should always float or not. */
+  _shouldAlwaysFloat: boolean = false;
+
+  /** Whether the placeholder can float or not. */
+  _floatingPlaceholder: boolean = true;
+
+
   /** Text for the input hint. */
   @Input()
   get hintLabel() { return this._hintLabel; }
@@ -265,11 +272,16 @@ export class MdInputContainer implements AfterContentInit {
   // Unique id for the hint label.
   _hintLabelId: string = `md-input-hint-${nextUniqueId++}`;
 
-  /** Text or the floating placeholder. */
+  /**
+   * Whether the placeholder should always float or just show the placeholder when empty.
+   * If the value is set to null the placeholder will float if text is entered.
+   */
   @Input()
-  get floatingPlaceholder(): boolean { return this._floatingPlaceholder; }
-  set floatingPlaceholder(value) { this._floatingPlaceholder = coerceBooleanProperty(value); }
-  private _floatingPlaceholder: boolean = true;
+  get floatingPlaceholder() { return this._floatingPlaceholder; }
+  set floatingPlaceholder(value: boolean) {
+    this._floatingPlaceholder = value == null || coerceBooleanProperty(value);
+    this._shouldAlwaysFloat = coerceBooleanProperty(value);
+  }
 
   @ContentChild(MdInputDirective) _mdInputChild: MdInputDirective;
 

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -20,7 +20,7 @@ import {
   MdInputContainerUnsupportedTypeError,
   MdInputContainerPlaceholderConflictError,
   MdInputContainerDuplicatedHintError,
-  MdInputContainerMissingMdInputError
+  MdInputContainerMissingMdInputError, MdInputContainerFloatingPlaceholderInvalidError
 } from './input-container-errors';
 
 
@@ -38,6 +38,9 @@ const MD_INPUT_INVALID_TYPES = [
   'submit'
 ];
 
+/** Valid options for the floatingPlaceholder input binding. */
+export type MD_INPUT_PLACEHOLDER_TYPES = 'always' | 'never' | 'auto';
+const MD_INPUT_PLACEHOLDER_VALUES = ['always', 'never', 'auto'];
 
 let nextUniqueId = 0;
 
@@ -254,11 +257,10 @@ export class MdInputContainer implements AfterContentInit {
   @Input() dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
 
   /** Whether the floating label should always float or not. */
-  _shouldAlwaysFloat: boolean = false;
+  get _shouldAlwaysFloat() { return this._floatingPlaceholder === 'always'; };
 
   /** Whether the placeholder can float or not. */
-  _floatingPlaceholder: boolean = true;
-
+  get _canPlaceholderFloat() { return this._floatingPlaceholder !== 'never'; }
 
   /** Text for the input hint. */
   @Input()
@@ -273,15 +275,17 @@ export class MdInputContainer implements AfterContentInit {
   _hintLabelId: string = `md-input-hint-${nextUniqueId++}`;
 
   /**
-   * Whether the placeholder should always float or just show the placeholder when empty.
-   * If the value is set to null the placeholder will float if text is entered.
+   * Whether the placeholder should always float, never float or float as the user types.
    */
   @Input()
   get floatingPlaceholder() { return this._floatingPlaceholder; }
-  set floatingPlaceholder(value: boolean) {
-    this._floatingPlaceholder = value == null || coerceBooleanProperty(value);
-    this._shouldAlwaysFloat = coerceBooleanProperty(value);
+  set floatingPlaceholder(value: MD_INPUT_PLACEHOLDER_TYPES) {
+    if (value && MD_INPUT_PLACEHOLDER_VALUES.indexOf(value) === -1) {
+      throw new MdInputContainerFloatingPlaceholderInvalidError(value);
+    }
+    this._floatingPlaceholder = value || 'auto';
   }
+  private _floatingPlaceholder: MD_INPUT_PLACEHOLDER_TYPES = 'auto';
 
   @ContentChild(MdInputDirective) _mdInputChild: MdInputDirective;
 

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -274,9 +274,7 @@ export class MdInputContainer implements AfterContentInit {
   // Unique id for the hint label.
   _hintLabelId: string = `md-input-hint-${nextUniqueId++}`;
 
-  /**
-   * Whether the placeholder should always float, never float or float as the user types.
-   */
+  /** Whether the placeholder should always float, never float or float as the user types. */
   @Input()
   get floatingPlaceholder() { return this._floatingPlaceholder; }
   set floatingPlaceholder(value: MD_INPUT_PLACEHOLDER_TYPES) {

--- a/src/lib/input/input.md
+++ b/src/lib/input/input.md
@@ -38,10 +38,10 @@ be used with `md-input-container`:
 A placeholder is an indicative text displayed in the input zone when the input does not contain
 text. When text is present, the indicative text will float above this input zone.
 
-The `floatingPlaceholder` attribute of `md-input-container` can be set to `never` to hide the
+The `floatPlaceholder` attribute of `md-input-container` can be set to `never` to hide the
 indicative text instead when text is present in the input.
 
-When setting `floatingPlaceholder` to `always` the floating label will always show above the input.
+When setting `floatPlaceholder` to `always` the floating label will always show above the input.
 
 A placeholder for the input can be specified in one of two ways: either using the `placeholder`
 attribute on the `input` or `textarea`, or using an `md-placeholder` element in the

--- a/src/lib/input/input.md
+++ b/src/lib/input/input.md
@@ -38,8 +38,10 @@ be used with `md-input-container`:
 A placeholder is an indicative text displayed in the input zone when the input does not contain
 text. When text is present, the indicative text will float above this input zone.
 
-The `floatingPlaceholder` attribute of `md-input-container` can be set to `false` to hide the
+The `floatingPlaceholder` attribute of `md-input-container` can be set to `never` to hide the
 indicative text instead when text is present in the input.
+
+When setting `floatingPlaceholder` to `always` the floating label will always show above the input.
 
 A placeholder for the input can be specified in one of two ways: either using the `placeholder`
 attribute on the `input` or `textarea`, or using an `md-placeholder` element in the


### PR DESCRIPTION
Refactors the `[floatingPlaceholder]` input to be able to specifiy whether the label should always float or not.

There are three options for the `floatPlaceholder` input binding now

- If set to `"always"`, the placeholder will *always* float
- If set to `"never"`, the placeholder will *never* float
- If set to `"auto"`, the placeholder will float if text is entered.

Closes #2466

R: @kara @jelbourn 