### PR TITLE
docs(dialog): explain how to disable auto-focus for elements

### DIFF
--- a/src/lib/dialog/OVERVIEW.md
+++ b/src/lib/dialog/OVERVIEW.md
@@ -40,7 +40,8 @@ Several directives are available to make it easier to structure your dialog cont
 | `md-dialog-close`     | \[Attr] Added to a `<button>`, makes the button close the dialog on click|
 
 Once a dialog opens, the dialog will automatically focus the first tabbable element.
-> To avoid that an element will be focused upon opening, developers can set the `tabindex`.
+
+You can control which elements are tab stops with the `tabindex` attribute
 
 ```html
 <button md-button tabindex="-1">Not Tabbable</button>

--- a/src/lib/dialog/OVERVIEW.md
+++ b/src/lib/dialog/OVERVIEW.md
@@ -14,7 +14,8 @@ let dialogRef = dialog.open(UserProfileComponent, {
 ```
 
 The `MdDialogRef` provides a handle on the opened dialog. It can be used to close the dialog and to
-recieve notification when the dialog has been closed.
+receive notification when the dialog has been closed.
+
 ```ts
 dialogRef.afterClosed.then(result => {
   console.log(`Dialog result: ${result}`); // Pizza!
@@ -37,3 +38,10 @@ Several directives are available to make it easier to structure your dialog cont
 | `<md-dialog-content>` | Primary scrollable content of the dialog                                 |
 | `<md-dialog-actions>` | Container for action buttons at the bottom of the dialog                 |
 | `md-dialog-close`     | \[Attr] Added to a `<button>`, makes the button close the dialog on click|
+
+Once a dialog opens, the dialog will automatically focus the first tabbable element.
+> To avoid that an element will be focused upon opening, developers can set the `tabindex`.
+
+```html
+<button md-button tabindex="-1">Not Tabbable</button>
+```


### PR DESCRIPTION
* Explains that the dialog auto-focuses elements, which are tabbable for the user
* Also adds a small example for disabling the auto-focus on specific elements

Closes #2533