### PR TITLE
Allow md-button-toggle color to be easily overwritten

### DIFF
--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -6,15 +6,16 @@
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
 
-  .md-button-toggle-label-content {
+  md-button-toggle {
     color: md-color($foreground, hint-text);
   }
 
-  .md-button-toggle-checked .md-button-toggle-label-content {
+  .md-button-toggle-checked {
     background-color: md-color($md-grey, 300);
     color: md-color($foreground, base);
   }
-  .md-button-toggle-disabled .md-button-toggle-label-content {
+
+  .md-button-toggle-disabled {
     background-color: map_get($md-grey, 200);
     color: md-color($foreground, disabled-button);
   }


### PR DESCRIPTION
fix(md-toggle-button): 

md-toggle-button color can be set to non-default values. Tested by adding a style="color:red" to a toggle-button in the demo app. 

