### PR TITLE
docs(card): fix typo in md-card-title-group (#2579)

### DIFF
--- a/src/lib/card/OVERVIEW.md
+++ b/src/lib/card/OVERVIEW.md
@@ -35,7 +35,7 @@ header to a card. This header can contain:
 
 
 ### Title groups
-An `<md-title-group>` can be used to combine a title, subtitle, and image into a single section.
+An `<md-card-title-group>` can be used to combine a title, subtitle, and image into a single section.
 This element can contain:
 * `<md-card-title>`
 * `<md-card-subtite>`


### PR DESCRIPTION
Associated Issue #2579 

Change `<md-title-group>` to `<md-card-title-group>` in overview docs of card component