### PR TITLE
fix(icon): add caching of md-icon aria-label

### DIFF
--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -333,6 +333,21 @@ describe('MdIcon', () => {
       expect(mdIconElement.getAttribute('aria-label')).toBe('hand');
     });
 
+    it('should not set aria label unless it actually changed', () => {
+      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+
+      const testComponent = fixture.componentInstance;
+      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+      testComponent.iconName = 'home';
+
+      fixture.detectChanges();
+      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
+
+      mdIconElement.removeAttribute('aria-label');
+      fixture.detectChanges();
+      expect(mdIconElement.getAttribute('aria-label')).toBeFalsy();
+    });
+
     it('should use alt tag if aria label is not specified', () => {
       let fixture = TestBed.createComponent(MdIconLigatureWithAriaBindingTestApp);
 

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -96,6 +96,7 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
 
   private _previousFontSetClass: string;
   private _previousFontIconClass: string;
+  private _previousAriaLabel: string;
 
   constructor(
       private _elementRef: ElementRef,
@@ -176,7 +177,8 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
 
   private _updateAriaLabel() {
       const ariaLabel = this._getAriaLabel();
-      if (ariaLabel) {
+      if (ariaLabel && ariaLabel !== this._previousAriaLabel) {
+        this._previousAriaLabel = ariaLabel;
         this._renderer.setElementAttribute(this._elementRef.nativeElement, 'aria-label', ariaLabel);
       }
   }


### PR DESCRIPTION
The md-icon component now caches the aria-label value and
only actually modifies the DOM if the value is unchanged.
This prevents md-icon from modifying the DOM every iteration
of change detection.

Closed #2642