### PR TITLE
chore: properly exit karma runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ sudo: false
 node_js:
   - '6.9.1'
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - libstdc++6
-
 branches:
   only:
   - master
@@ -22,11 +15,8 @@ env:
   - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
   - BROWSER_STACK_USERNAME=angularteam1
   - BROWSER_STACK_ACCESS_KEY=BWCd4SynLzdDcv8xtzsB
-  - ARCH=linux-x64
   - BROWSER_PROVIDER_READY_FILE=/tmp/angular-material2-build/readyfile
   - BROWSER_PROVIDER_ERROR_FILE=/tmp/angular-material2-build/errorfile
-  # GITHUB_TOKEN_ANGULAR
-  - secure: "fq/U7VDMWO8O8SnAQkdbkoSe2X92PVqg4d044HmRYVmcf6YbO48+xeGJ8yOk0pCBwl3ISO4Q2ot0x546kxfiYBuHkZetlngZxZCtQiFT9kyId8ZKcYdXaIW9OVdw3Gh3tQyUwDucfkVhqcs52D6NZjyE2aWZ4/d1V4kWRO/LMgo="
   matrix:
     # Order: a slower build first, so that we don't occupy an idle travis worker waiting for others to complete.
     - MODE=lint

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -46,7 +46,11 @@ gulp.task('test:single-run', [':test:deps:inline'], (done: () => void) => {
   new karma.Server({
     configFile: path.join(PROJECT_ROOT, 'test/karma.conf.js'),
     singleRun: true
-  }, done).start();
+  }, (exitCode: number) => {
+    // Immediately exit the process if Karma reported errors, because due to
+    // potential still running tunnel-browsers gulp won't exit properly.
+    exitCode === 0 ? done() : process.exit(exitCode);
+  }).start();
 });
 
 /**


### PR DESCRIPTION
* Properly exit karma in single-run mode when errors are recognized.
* This looks like its caused by the karma launchers, that connect to Browserstack or Saucelabs and which doesn't close the connection poperly when karma exits with an error code.

Avoids builds like: https://travis-ci.org/angular/material2/jobs/191796967#L320