### PR TITLE
fix(dialog): prevent the close button from submitting forms

### DIFF
--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -9,7 +9,8 @@ import {MdDialogRef} from './dialog-ref';
   selector: 'button[md-dialog-close], button[mat-dialog-close]',
   host: {
     '(click)': 'dialogRef.close()',
-    '[attr.aria-label]': 'ariaLabel'
+    '[attr.aria-label]': 'ariaLabel',
+    'type': 'button', // Prevents accidental form submits.
   }
 })
 export class MdDialogClose {

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -343,6 +343,12 @@ describe('MdDialog', () => {
       expect(button.getAttribute('aria-label')).toBe('Best close button ever');
     });
 
+    it('should override the "type" attribute of the close button', () => {
+      let button = overlayContainerElement.querySelector('button[md-dialog-close]');
+
+      expect(button.getAttribute('type')).toBe('button');
+    });
+
   });
 });
 


### PR DESCRIPTION
Prevents the `md-dialog-close` directive from submitting any forms that it is inside of.

Fixes #2599.