### PR TITLE
fix(connected-position-strategy): wrong logic when determining whether element is on screen

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -255,10 +255,10 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     let y = originPoint.y + overlayStartY + this._offsetY;
 
     // How much the overlay would overflow at this position, on each side.
-    let leftOverflow = viewportRect.left - x;
-    let rightOverflow = (x + overlayRect.width) - viewportRect.right;
-    let topOverflow = viewportRect.top - y;
-    let bottomOverflow = (y + overlayRect.height) - viewportRect.bottom;
+    let leftOverflow = 0 - x;
+    let rightOverflow = (x + overlayRect.width) - viewportRect.width;
+    let topOverflow = 0 - y;
+    let bottomOverflow = (y + overlayRect.height) - viewportRect.height;
 
     // Visible parts of the element on each axis.
     let visibleWidth = this._subtractOverflows(overlayRect.width, leftOverflow, rightOverflow);


### PR DESCRIPTION
Fixes some faulty logic, introduced in #2102, that meant that the overlay considers the viewport's scroll offset when determining how much it overflows on either side.

Fixes #2658.