### PR TITLE
fix(tooltip): provide a maximum width

### DIFF
--- a/src/lib/tooltip/tooltip.scss
+++ b/src/lib/tooltip/tooltip.scss
@@ -3,6 +3,7 @@
 
 
 $md-tooltip-target-height: 22px;
+$md-tooltip-max-width: 250px;
 $md-tooltip-font-size: 10px;
 $md-tooltip-margin: 14px;
 $md-tooltip-horizontal-padding: 8px;
@@ -19,6 +20,7 @@ $md-tooltip-vertical-padding: ($md-tooltip-target-height - $md-tooltip-font-size
   font-family: $md-font-family;
   font-size: $md-tooltip-font-size;
   margin: $md-tooltip-margin;
+  max-width: $md-tooltip-max-width;
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Adds a `max-width` to the tooltip, in order to wrap longer lines of text. Note that the value is arbitrary since there was nothing about it in the spec.

Fixes #2671.