### PR TITLE
fix(slide-toggle): consistent naming of aria attributes

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -16,7 +16,7 @@
     <input #input class="md-slide-toggle-input cdk-visually-hidden" type="checkbox"
            [id]="inputId"
            [required]="required"
-           [tabIndex]="tabindex"
+           [tabIndex]="tabIndex"
            [checked]="checked"
            [disabled]="disabled"
            [attr.name]="name"

--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -16,7 +16,7 @@
     <input #input class="md-slide-toggle-input cdk-visually-hidden" type="checkbox"
            [id]="inputId"
            [required]="required"
-           [tabIndex]="tabIndex"
+           [tabIndex]="tabindex"
            [checked]="checked"
            [disabled]="disabled"
            [attr.name]="name"

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -189,6 +189,17 @@ describe('MdSlideToggle', () => {
       expect(inputElement.id).toMatch(/md-slide-toggle-[0-9]+-input/g);
     });
 
+    it('should forward the tabIndex to the underlying input', () => {
+      fixture.detectChanges();
+
+      expect(inputElement.tabIndex).toBe(0);
+
+      testComponent.slideTabindex = 4;
+      fixture.detectChanges();
+
+      expect(inputElement.tabIndex).toBe(4);
+    });
+
     it('should forward the specified name to the input', () => {
       testComponent.slideName = 'myName';
       fixture.detectChanges();
@@ -570,8 +581,9 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
                      [id]="slideId"
                      [checked]="slideChecked"
                      [name]="slideName"
-                     [ariaLabel]="slideLabel"
-                     [ariaLabelledby]="slideLabelledBy"
+                     [aria-label]="slideLabel"
+                     [aria-labelledby]="slideLabelledBy"
+                     [tabindex]="slideTabindex"
                      (change)="onSlideChange($event)"
                      (click)="onSlideClick($event)">
 
@@ -589,6 +601,7 @@ class SlideToggleTestApp {
   slideName: string;
   slideLabel: string;
   slideLabelledBy: string;
+  slideTabindex: number;
   lastEvent: MdSlideToggleChange;
 
   onSlideClick(event: Event) {}

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -583,7 +583,7 @@ function dispatchFocusChangeEvent(eventName: string, element: HTMLElement): void
                      [name]="slideName"
                      [aria-label]="slideLabel"
                      [aria-labelledby]="slideLabelledBy"
-                     [tabindex]="slideTabindex"
+                     [tabIndex]="slideTabindex"
                      (change)="onSlideChange($event)"
                      (click)="onSlideClick($event)">
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -83,7 +83,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   @Input() id: string = this._uniqueId;
 
   /** Used to specify the tabIndex value for the underlying input element. */
-  @Input() tabindex: number = 0;
+  @Input() tabIndex: number = 0;
 
   /** Used to set the aria-label attribute on the underlying input element. */
   @Input('aria-label') ariaLabel: string = null;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -83,13 +83,13 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   @Input() id: string = this._uniqueId;
 
   /** Used to specify the tabIndex value for the underlying input element. */
-  @Input() tabIndex: number = 0;
+  @Input() tabindex: number = 0;
 
   /** Used to set the aria-label attribute on the underlying input element. */
-  @Input() ariaLabel: string = null;
+  @Input('aria-label') ariaLabel: string = null;
 
   /** Used to set the aria-labelledby attribute on the underlying input element. */
-  @Input() ariaLabelledby: string = null;
+  @Input('aria-labelledby') ariaLabelledby: string = null;
 
   /** Whether the slide-toggle is disabled. */
   @Input()


### PR DESCRIPTION
* Ensures that the slide-toggle uses consistent attribute naming.
  
> Consistent with the native inputs and other Material components.