### PR TITLE
fix(select): fix selection color

### DIFF
--- a/src/lib/autocomplete/_autocomplete-theme.scss
+++ b/src/lib/autocomplete/_autocomplete-theme.scss
@@ -4,13 +4,16 @@
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
 
-  md-option {
+  .md-autocomplete-panel {
     background: md-color($background, card);
     color: md-color($foreground, text);
 
-    &.md-selected {
-      background: md-color($background, card);
-      color: md-color($foreground, text);
+    md-option {
+      &.md-selected {
+        background: md-color($background, card);
+        color: md-color($foreground, text);
+      }
     }
   }
+
 }


### PR DESCRIPTION
Fixes #2696.  The autocomplete styles for md-option need to specify only options within an autocomplete panel.