### PR TITLE
Need to also import hammerjs in systemjs.config.js

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -61,7 +61,7 @@ import 'hammerjs';
 ```
 
 ## Configuring SystemJS
-If your project is using SystemJS for module loading, you will need to add `@angular/material` 
+If your project is using SystemJS for module loading, you will need to add `@angular/material` and `hammerjs`
 to the SystemJS configuration:
 
 ```js
@@ -69,7 +69,8 @@ System.config({
   // existing configuration options
   map: {
     ...,
-    '@angular/material': 'npm:@angular/material/bundles/material.umd.js'
+    '@angular/material': 'npm:@angular/material/bundles/material.umd.js',
+    'hammerjs': 'npm:hammerjs/hammer.js'
   }
 });
 ```


### PR DESCRIPTION
Guide doesn't work as is. 
If you run it it says: "Could not find HammerJS. Certain Angular Material components may not work correctly." material.umd.js:3258

From: http://stackoverflow.com/questions/41322566/could-not-find-hammerjs

Have to  ALSO add to systemjs.config.js in the map section:
'hammerjs': 'npm:hammerjs/hammer.js',

and then it works and it should.