### PR TITLE
chore(checkbox): remove unnecessary will-change

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -240,7 +240,6 @@ md-checkbox {
   background-color: transparent;
   border: $md-checkbox-border-width solid;
   transition: border-color $md-checkbox-transition-duration $md-linear-out-slow-in-timing-function;
-  will-change: border-color;
 }
 
 .md-checkbox-background {
@@ -252,7 +251,6 @@ md-checkbox {
   transition: background-color $md-checkbox-transition-duration
                   $md-linear-out-slow-in-timing-function,
               opacity $md-checkbox-transition-duration $md-linear-out-slow-in-timing-function;
-  will-change: background-color, opacity;
 }
 
 .md-checkbox-checkmark {


### PR DESCRIPTION
Removes a couple of unnecessary usages of `will-change` in the checkbox. They are redundant, because the properties being animated aren't problematic to transition in the first place (`border-color`, `background-color` and `opacity`). In general, we should avoid adding `will-change` like this, until we actually notice a performance issue, and even in that case it should be used sparingly.

More info: https://developer.mozilla.org/en/docs/Web/CSS/will-change