### PR TITLE
build: fix sourcemaps for dev-app and e2e-app.

### DIFF
--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -4,7 +4,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
-    "mapRoot": "/",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -4,7 +4,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
-    "mapRoot": "",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -4,7 +4,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
-    "mapRoot": "",
     "module": "es2015",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -4,7 +4,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
-    "mapRoot": "",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
* Fixes the invalid sourcemaps for the dev-app and e2e-app.
  
  The sourcemaps are currently invalid because the `sourcesContent` couldn't be read due to invalid paths.

This issue is now noticeable because `gulp-typescript` made some changes in regards to the sourcemaps. ([See here](http://dev.ivogabe.com/gulp-typescript-3/))


![](https://i.gyazo.com/cb312b7ba8de70507a95c51ae95aa57d.png)
