### PR TITLE
build: exclude system-config-spec.ts for releases

### DIFF
--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -10,8 +10,9 @@ import {DIST_COMPONENTS_ROOT} from '../constants';
 
 const argv = minimist(process.argv.slice(3));
 
-
-task(':build:release:clean-spec', cleanTask('dist/**/*.spec.*'));
+/** Removes redundant spec files from the release. TypeScript creates definition files for specs. */
+// TODO(devversion): tsconfig files should share code and don't generate spec files for releases.
+task(':build:release:clean-spec', cleanTask('dist/**/*(-|.)spec.*'));
 
 
 task('build:release', function(done: () => void) {


### PR DESCRIPTION
* No longer publishes the `system-config-spec.ts` file in releases. 

> Extending the glob to also remove the `-spec.ts` files. In the future it's planned to not build spec files for releases at all..