### PR TITLE
refactor(button-toggle): switch to SelectionModel

### DIFF
--- a/src/lib/button-toggle/button-toggle-errors.ts
+++ b/src/lib/button-toggle/button-toggle-errors.ts
@@ -1,0 +1,12 @@
+import {MdError} from '../core';
+
+/**
+ * Exception thrown when trying to assign a non-array value
+ * to a button toggle group in multiple selection mode.
+ * @docs-private
+ */
+export class MdButtonToggleGroupNonArrayValueError extends MdError {
+  constructor() {
+    super('Cannot assign non-array value to button toggle group in `multiple` mode.');
+  }
+}

--- a/src/lib/button-toggle/button-toggle.html
+++ b/src/lib/button-toggle/button-toggle.html
@@ -1,7 +1,7 @@
 <label [attr.for]="inputId" class="md-button-toggle-label">
   <input #input class="md-button-toggle-input cdk-visually-hidden"
          [type]="_type"
-         [id]="inputId"
+         [id]="_inputId"
          [checked]="checked"
          [disabled]="disabled"
          [name]="name"

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -11,9 +11,9 @@ import {By} from '@angular/platform-browser';
 import {
     MdButtonToggleGroup,
     MdButtonToggle,
-    MdButtonToggleGroupMultiple,
-    MdButtonToggleChange, MdButtonToggleModule,
-} from './button-toggle';
+    MdButtonToggleChange,
+    MdButtonToggleModule,
+} from './index';
 
 
 describe('MdButtonToggle', () => {
@@ -255,7 +255,7 @@ describe('MdButtonToggle', () => {
       for (let buttonToggle of buttonToggleInstances) {
         expect(buttonToggle.checked).toBe(groupInstance.value === buttonToggle.value);
       }
-      expect(groupInstance.selected.value).toBe(groupInstance.value);
+      expect((groupInstance.selected as MdButtonToggle).value).toBe(groupInstance.value);
     });
 
     it('should have the correct ngControl state initially and after interaction', fakeAsync(() => {
@@ -341,17 +341,20 @@ describe('MdButtonToggle', () => {
       let testComponent = fixture.debugElement.componentInstance;
       let groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
       let groupInstance: MdButtonToggleGroup = groupDebugElement.injector.get(MdButtonToggleGroup);
+      let labels = fixture.debugElement.queryAll(By.css('label'));
 
       fixture.detectChanges();
 
-      expect(groupInstance.value).toBe('red');
-      expect(testComponent.lastEvent).toBeFalsy();
+      fixture.whenStable().then(() => {
+        expect(groupInstance.value).toBe('red');
+        expect(testComponent.lastEvent).toBeFalsy();
 
-      groupInstance.value = 'green';
-      fixture.detectChanges();
+        labels[1].nativeElement.click();
+        fixture.detectChanges();
 
-      expect(groupInstance.value).toBe('green');
-      expect(testComponent.lastEvent.value).toBe('green');
+        expect(groupInstance.value).toBe('green');
+        expect(testComponent.lastEvent.value).toBe('green');
+      });
     });
 
   });
@@ -363,7 +366,7 @@ describe('MdButtonToggle', () => {
     let buttonToggleDebugElements: DebugElement[];
     let buttonToggleNativeElements: HTMLElement[];
     let buttonToggleLabelElements: HTMLLabelElement[];
-    let groupInstance: MdButtonToggleGroupMultiple;
+    let groupInstance: MdButtonToggleGroup;
     let buttonToggleInstances: MdButtonToggle[];
     let testComponent: ButtonTogglesInsideButtonToggleGroupMultiple;
 
@@ -373,9 +376,9 @@ describe('MdButtonToggle', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroupMultiple));
+      groupDebugElement = fixture.debugElement.query(By.directive(MdButtonToggleGroup));
       groupNativeElement = groupDebugElement.nativeElement;
-      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroupMultiple);
+      groupInstance = groupDebugElement.injector.get(MdButtonToggleGroup);
 
       buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MdButtonToggle));
       buttonToggleNativeElements = buttonToggleDebugElements

--- a/src/lib/button-toggle/index.ts
+++ b/src/lib/button-toggle/index.ts
@@ -1,1 +1,27 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {CompatibilityModule} from '../core';
+import {MdButtonToggleGroup, MdButtonToggle} from './button-toggle';
+
 export * from './button-toggle';
+export * from './button-toggle-errors';
+
+
+@NgModule({
+  imports: [FormsModule, CompatibilityModule],
+  exports: [
+    MdButtonToggleGroup,
+    MdButtonToggle,
+    CompatibilityModule,
+  ],
+  declarations: [MdButtonToggleGroup, MdButtonToggle]
+})
+export class MdButtonToggleModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdButtonToggleModule,
+      providers: []
+    };
+  }
+}


### PR DESCRIPTION
* Switches the MdButtonToggleGroup to use the SelectionModel.
* Avoids having to define two toggle group directives.

**Note:** This is still needs some work and cleanup. 