### PR TITLE
chore: run travis with Node LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - '6.9.1'
+  - '6.9.4'
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "material2",
+  "name": "material2-srcs",
   "description": "Material Design components for Angular 2",
   "homepage": "https://github.com/angular/material2",
   "bugs": "https://github.com/angular/material2/issues",


### PR DESCRIPTION
* Switches Travis CI to the NodeJS LTS release. `6.9.4`.
* Changes the package.json name for the sources to be similar as in `angular/angular`.