### PR TITLE
docs: add save option to npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The latest release of Angular Material can be installed from npm
 
 Playing with the latest changes from [master](https://github.com/angular/material2/tree/master) is also possible
 
-`npm install https://github.com/angular/material2-builds.git`
+`npm install --save https://github.com/angular/material2-builds.git`
 
 ### Getting started
 


### PR DESCRIPTION
* Adds the `--save` option to the `npm install` command for the material2-builds repository.
  Follow-Up PR to https://github.com/angular/material2/pull/2752#issuecomment-274332318