### PR TITLE
build: use typescript cli for compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.4.0",
     "gulp-transform": "^1.1.0",
-    "gulp-typescript": "^3.1.4",
     "hammerjs": "^2.0.8",
     "highlight.js": "^9.9.0",
     "jasmine-core": "^2.5.2",

--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": true,
+    "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es6", "es2015", "dom"],
@@ -22,8 +22,11 @@
       ]
     }
   },
-  "exclude": [
-    "*-aot.ts"
+  "files": [
+    "./demo-app-types.d.ts",
+    "./demo-app-module.ts",
+    "./system-config.ts",
+    "./main.ts"
   ],
   "angularCompilerOptions": {
     "genDir": "../../dist",

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -1,7 +1,6 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as gulp from 'gulp';
-import * as gulpTs from 'gulp-typescript';
 import * as path from 'path';
 
 import {NPM_VENDOR_FILES, PROJECT_ROOT, DIST_ROOT, SASS_AUTOPREFIXER_OPTIONS} from './constants';
@@ -34,34 +33,9 @@ function _globify(maybeGlob: string, suffix = '**/*') {
 }
 
 
-/** Create a TS Build Task, based on the options. */
-export function tsBuildTask(tsConfigPath: string, tsConfigName = 'tsconfig.json') {
-  let tsConfigDir = tsConfigPath;
-  if (fs.existsSync(path.join(tsConfigDir, tsConfigName))) {
-    // Append tsconfig.json
-    tsConfigPath = path.join(tsConfigDir, tsConfigName);
-  } else {
-    tsConfigDir = path.dirname(tsConfigDir);
-  }
-
-  return () => {
-    const tsConfig: any = JSON.parse(fs.readFileSync(tsConfigPath, 'utf-8'));
-    const dest: string = path.join(tsConfigDir, tsConfig['compilerOptions']['outDir']);
-
-    const tsProject = gulpTs.createProject(tsConfigPath);
-
-    let pipe = tsProject.src()
-      .pipe(gulpSourcemaps.init())
-      .pipe(tsProject());
-    let dts = pipe.dts.pipe(gulp.dest(dest));
-
-    return gulpMerge([
-      dts,
-      pipe
-        .pipe(gulpSourcemaps.write('.'))
-        .pipe(gulp.dest(dest))
-    ]);
-  };
+/** Creates a task that runs the TypeScript compiler */
+export function tsBuildTask(tsConfigPath: string) {
+  return execNodeTask('typescript', 'tsc', ['-p', tsConfigPath]);
 }
 
 

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -37,7 +37,7 @@ task(':watch:components', () => {
 
 
 /** Builds component typescript only (ESM output). */
-task(':build:components:ts', tsBuildTask(COMPONENTS_DIR, 'tsconfig-srcs.json'));
+task(':build:components:ts', tsBuildTask(path.join(COMPONENTS_DIR, 'tsconfig-srcs.json')));
 
 /** Builds components typescript for tests (CJS output). */
 task(':build:components:spec', tsBuildTask(COMPONENTS_DIR));


### PR DESCRIPTION
* No longer use the `gulp-typescript` gulp package that tries to take care of several options like `sourceMaps` or `declarations`.
* Don't generate declarations when serving the `demo-app`. (Slows down testing)

Advantages:

* Use the `Typescript` compiler CLI to ensure that the `NGC` also works with our `tsconfig.json` files.
* No longer makes our TypeScript build dependent to an external plugin (~with magic)
* Fixes issues like invalid sourceMaps from `gulp-typescript`: https://github.com/angular/material2/pull/2753
* Allows us to take use of all TypeScript features (e.g The `sourceMaps` option)
* This should help for our planned `tsconfig.json` file reduction.