### PR TITLE
fix: apply font-family to text components

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -34,6 +34,7 @@ md-button-toggle-group {
 
 md-button-toggle {
   white-space: nowrap;
+  font-family: $md-font-family;
 }
 
 .md-button-toggle-label-content {

--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -193,6 +193,7 @@ $md-checkbox-ripple-size: 15px;
 
 md-checkbox {
   cursor: pointer;
+  font-family: $md-font-family;
 
   // Animation
   transition: background $swift-ease-out-duration $swift-ease-out-timing-function,

--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -8,6 +8,7 @@ $md-radio-ripple-size: $md-radio-size * 0.75;
 // Top-level host container.
 md-radio-button {
   display: inline-block;
+  font-family: $md-font-family;
 }
 
 // Inner label container, wrapping entire element.

--- a/src/lib/snack-bar/simple-snack-bar.scss
+++ b/src/lib/snack-bar/simple-snack-bar.scss
@@ -1,3 +1,5 @@
+@import '../core/style/variables';
+
 md-simple-snackbar {
   display: flex;
   justify-content: space-between;
@@ -7,7 +9,7 @@ md-simple-snackbar {
   box-sizing: border-box;
   border: none;
   color: white;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  font-family: $md-font-family;
   font-size: 14px;
   line-height: 20px;
   outline: none;


### PR DESCRIPTION
* Applies the `font-family` to all components that use content projection and have a label or a text displayed.
* Switches the hard-coded font-family in the `simple-snack-bar` to the global variable.

**Notes:**
- All families have been applied to the host elements (to simplify font overwriting)
- The dialog font family has been skipped here. Not sure whether we want that for the users instantiated component (I'd only say `md-dialog-content` etc. directives)

References #2750 