### PR TITLE
chore: include web animations polyfill in demo app

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "ts-node": "^2.0.0",
     "tslint": "^3.13.0",
     "typescript": "~2.0.10",
-    "uglify-js": "^2.7.5"
+    "uglify-js": "^2.7.5",
+    "web-animations-js": "^2.2.2"
   }
 }

--- a/src/demo-app/index.html
+++ b/src/demo-app/index.html
@@ -17,6 +17,7 @@
   <demo-app>Loading...</demo-app>
 
   <script src="vendor/core-js/client/core.js"></script>
+  <script src="vendor/web-animations-js/web-animations.min.js"></script>
   <script src="vendor/systemjs/dist/system.src.js"></script>
   <script src="vendor/zone.js/dist/zone.js"></script>
   <script src="vendor/hammerjs/hammer.min.js"></script>

--- a/src/e2e-app/index.html
+++ b/src/e2e-app/index.html
@@ -17,6 +17,7 @@
   <e2e-app>Loading...</e2e-app>
 
   <script src="vendor/core-js/client/core.js"></script>
+  <script src="vendor/web-animations-js/web-animations.min.js"></script>
   <script src="vendor/systemjs/dist/system.src.js"></script>
   <script src="vendor/zone.js/dist/zone.js"></script>
   <script src="vendor/hammerjs/hammer.min.js"></script>

--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -31,7 +31,8 @@ export const LICENSE_BANNER = `/**
   */`;
 
 export const NPM_VENDOR_FILES = [
-  '@angular', 'core-js/client', 'hammerjs', 'rxjs', 'systemjs/dist', 'zone.js/dist'
+  '@angular', 'core-js/client', 'hammerjs', 'rxjs', 'systemjs/dist',
+  'zone.js/dist', 'web-animations-js'
 ];
 
 export const COMPONENTS_DIR = join(SOURCE_ROOT, 'lib');


### PR DESCRIPTION
Currently some of the Material animations (the ones that user the Angular animation API, e.g. tooltip, select) don't work on certain browser, because they depend on the Web Animations API. This change adds a polyfill, in order to have a more consistent debugging experience across browsers.