### PR TITLE
fix(core): log warning if doctype is missing

### DIFF
--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -5,7 +5,9 @@ import {
   OpaqueToken,
   Inject,
   Optional,
+  isDevMode,
 } from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
 
 
 export const MATERIAL_COMPATIBILITY_MODE = new OpaqueToken('md-compatibility-mode');
@@ -71,7 +73,7 @@ export const MAT_ELEMENTS_SELECTOR = `
   mat-toolbar`;
 
 /** Selector that matches all elements that may have style collisions with AngularJS Material. */
-export const MD_ELEMENTS_SELECTOR = `  
+export const MD_ELEMENTS_SELECTOR = `
   [md-button],
   [md-dialog-actions],
   [md-dialog-close],
@@ -166,6 +168,15 @@ export class CompatibilityModule {
       ngModule: CompatibilityModule,
       providers: [],
     };
+  }
+
+  constructor(@Optional() @Inject(DOCUMENT) document: any) {
+    if (isDevMode() && typeof document && !document.doctype) {
+      console.warn(
+        'Current document does not have a doctype. This may cause ' +
+        'some Angular Material components not to behave as expected.'
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Logs a warning if the user's document doesn't have a doctype. This has been an issue in the past with some hard-to-track-down bugs which ended up being due to the browser running in quirks mode.

Fixes #2351.