### PR TITLE
fix(button): add transition to focus overlay

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -9,6 +9,7 @@ $mat-button-min-width: 88px !default;
 $mat-button-margin: 0 !default;
 $mat-button-line-height: 36px !default;
 $mat-button-border-radius: 2px !default;
+$mat-button-focus-transition: opacity 200ms $swift-ease-in-out-timing-function !default;
 
 // Icon Button standards
 $mat-icon-button-size: 40px !default;

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -83,6 +83,8 @@
   pointer-events: none;
   opacity: 0;
 
+  transition: $mat-button-focus-transition;
+
   @include cdk-high-contrast {
     // Note that IE will render this in the same way, no
     // matter whether the theme is light or dark. This helps


### PR DESCRIPTION
* Adds a transition to the button focus overlay -It still shows up very fast, it just feels a bit smoother (similar as in MDL and M1)