### PR TITLE
WIP: feature(dialog): add ability to open dialog with portal 

### DIFF
--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -51,3 +51,11 @@
 </md-card>
 
 <p>Last close result: {{lastCloseResult}}</p>
+
+
+<md-card class="demo-dialog-card">
+  <button md-raised-button color="primary" (click)="openElementDialog()">Open element dialog</button>
+  <md-dialog [open]="elementDialogState" (close)="closeElementDialog()">
+    whatup
+  </md-dialog>
+</md-card>

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -10,6 +10,7 @@ import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 })
 export class DialogDemo {
   dialogRef: MdDialogRef<JazzDialog>;
+  elementDialogState: boolean = false;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -50,6 +51,14 @@ export class DialogDemo {
   openContentElement() {
     let dialogRef = this.dialog.open(ContentElementDialog, this.config);
     dialogRef.componentInstance.actionsAlignment = this.actionsAlignment;
+  }
+
+  openElementDialog() {
+    this.elementDialogState = true;
+  }
+
+  closeElementDialog() {
+    this.elementDialogState = false;
   }
 }
 
@@ -104,7 +113,7 @@ export class JazzDialog {
         color="primary"
         href="https://en.wikipedia.org/wiki/Neptune"
         target="_blank">Read more on Wikipedia</a>
-      
+
       <button
         md-button
         color="secondary"

--- a/src/lib/dialog/dialog-element.html
+++ b/src/lib/dialog/dialog-element.html
@@ -1,0 +1,3 @@
+<template mdDialogPortal>
+  <ng-content></ng-content>
+</template>

--- a/src/lib/dialog/dialog-element.ts
+++ b/src/lib/dialog/dialog-element.ts
@@ -1,0 +1,62 @@
+import {
+  Component,
+  Directive,
+  TemplateRef,
+  ViewContainerRef,
+  Input,
+  ViewChild,
+  Output,
+  EventEmitter,
+  ChangeDetectionStrategy
+} from '@angular/core';
+import {MdDialog} from './dialog';
+import {MdDialogRef} from './dialog-ref';
+import {TemplatePortal} from '../core';
+
+@Directive({
+  selector: '[mdDialogPortal]'
+})
+export class MdDialogPortal extends TemplatePortal {
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}
+
+@Component({
+  selector: 'md-dialog',
+  templateUrl: './dialog-element.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MdDialogElement {
+  dialog: MdDialogRef<any>;
+
+  @Output()
+  close = new EventEmitter<void>(false);
+
+  @ViewChild(MdDialogPortal)
+  dialogPortal: MdDialogPortal;
+
+  @Input()
+  set open(state: boolean) {
+    if (state) {
+      setTimeout(() => {
+
+        this.dialog = this._dialog.openFromPortal(this.dialogPortal, {
+          disableClose: true
+        });
+
+        this.dialog.backdropClick$.subscribe(() => {
+          this.close.emit();
+        });
+
+      });
+
+
+    } else if (this.dialog) {
+      this.dialog.close();
+    }
+  }
+
+  constructor(private _dialog: MdDialog) {}
+}
+

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -14,10 +14,14 @@ export class MdDialogRef<T> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;
 
+  backdropClick$: Observable<void>;
+
   /** Subject for notifying the user that the dialog has finished closing. */
   private _afterClosed: Subject<any> = new Subject();
 
-  constructor(private _overlayRef: OverlayRef) { }
+  constructor(private _overlayRef: OverlayRef) {
+     this.backdropClick$ = this._overlayRef.backdropClick();
+  }
 
   /**
    * Close the dialog.

--- a/src/lib/dialog/index.ts
+++ b/src/lib/dialog/index.ts
@@ -7,13 +7,13 @@ import {
 } from '../core';
 import {MdDialog} from './dialog';
 import {MdDialogContainer} from './dialog-container';
+import {MdDialogElement, MdDialogPortal} from './dialog-element';
 import {
   MdDialogClose,
   MdDialogContent,
   MdDialogTitle,
   MdDialogActions
 } from './dialog-content-directives';
-
 
 @NgModule({
   imports: [
@@ -28,6 +28,8 @@ import {
     MdDialogTitle,
     MdDialogContent,
     MdDialogActions,
+    MdDialogElement,
+    MdDialogPortal,
     CompatibilityModule,
   ],
   declarations: [
@@ -36,6 +38,8 @@ import {
     MdDialogTitle,
     MdDialogActions,
     MdDialogContent,
+    MdDialogElement,
+    MdDialogPortal,
   ],
   providers: [
     MdDialog,
@@ -53,6 +57,7 @@ export class MdDialogModule {
 }
 
 export * from './dialog';
+export * from './dialog-element';
 export * from './dialog-container';
 export * from './dialog-content-directives';
 export * from './dialog-config';


### PR DESCRIPTION
I haven't really created this with hope of it being merged, but rather to get some feedback. There are some unused imports, couple of missing comments, no tests, I'll fix all of those if you tell me if this direction is fine.

1) I tried to make opening just by using `TemplateRef` work, but I couldn't quite figure out which would be the proper `viewContainerRef` to use, there's still no easy way to get root component's `viewContainerRef`, right? I think it could probably use `MdDialogContainer`, `viewContainerRef`, so I could change it to that if you say it's a good idea(here's a branch with that https://github.com/fxck/material2/tree/dialog-templateref)

2) `MdDialog`, `MdDialogRef` and various methods require generics of a component, should it still be required when using templateRef/portal? You don't need to expose `componentInstance` when using templateRef, you can simply use standard inputs.. how should this be reflected?

3) I needed to expose backdropClick event(to be able to make truly stateless components, will explain later), is the way I'e done it ok(apart from `$` suffix which I think you don't really use)

4) I wanted to reuse `_attachDialogContent`, tried couple of things, but the only viable way ended up being adding ability to pass in either component or portal(https://github.com/fxck/material2/blob/15313f94ae75b6464054ada0bbad353eb1c9a0f8/src/lib/dialog/dialog.ts#L168-L169), I don't like it, but since it's a private, internal method, it shouldn't really be that bad, right?

5) I've added `md-dialog` component, which is a component with api following that of https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog I know you are not fan of that, so it just temporar to test my usecase for opening dialog with templateRef/portal, and I encountered one problem, and that is 

> Expression has changed after it was checked. Previous value: 'CD_INIT_VALUE'. Current value 'dialog'

it happens when I try to open the dialog inside `@Input` setter, I think `let overlayRef = this._createOverlay(config);` is what's causing it.. it was fixed by using `setTimeout`, which would be "fine" if it was internal(I assume some `zone` function instead of `setTimeout`would work as well), but you can't expect that from the consumer.. so I could use some help fixing it

---

anyway the idea behind the `md-dialog` component, should you decode it's something you'd want in the repo, is that it's completely stateless by default, which means the consumer is in full control of the state, backdrop / esc key should not close it, they should expose and event that close attempt happened and let the user decide what to do with the state instead.. it's something you totally need when using state manager like https://github.com/ngrx/store I think this behaviour should be by default, but I think it could use another input with config(`MdDialogConfig`), where one could turn `disableClose` back on


@jelbourn @crisbeto @DevVersion maybe?