### PR TITLE
feat(dialog): add ability to open dialog with templateRef

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -8,7 +8,13 @@ import {MaterialModule, OverlayContainer,
   FullscreenOverlayContainer} from '@angular/material';
 import {DEMO_APP_ROUTES} from './demo-app/routes';
 import {ProgressBarDemo} from './progress-bar/progress-bar-demo';
-import {JazzDialog, ContentElementDialog, DialogDemo, IFrameDialog} from './dialog/dialog-demo';
+import {
+  JazzDialog,
+  JazzDialogTemplateRef,
+  ContentElementDialog,
+  DialogDemo,
+  IFrameDialog
+} from './dialog/dialog-demo';
 import {RippleDemo} from './ripple/ripple-demo';
 import {IconDemo} from './icon/icon-demo';
 import {GesturesDemo} from './gestures/gestures-demo';
@@ -64,6 +70,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     IconDemo,
     InputContainerDemo,
     JazzDialog,
+    JazzDialogTemplateRef,
     ContentElementDialog,
     IFrameDialog,
     ListDemo,
@@ -100,6 +107,7 @@ import {InputContainerDemo} from './input/input-container-demo';
   entryComponents: [
     DemoApp,
     JazzDialog,
+    JazzDialogTemplateRef,
     ContentElementDialog,
     IFrameDialog,
     RotiniPanel,

--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -12,6 +12,7 @@ import {
   JazzDialog,
   JazzDialogTemplateRef,
   ContentElementDialog,
+  ContentElementTemplateRefDialog,
   DialogDemo,
   IFrameDialog
 } from './dialog/dialog-demo';
@@ -72,6 +73,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     JazzDialog,
     JazzDialogTemplateRef,
     ContentElementDialog,
+    ContentElementTemplateRefDialog,
     IFrameDialog,
     ListDemo,
     LiveAnnouncerDemo,
@@ -109,6 +111,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     JazzDialog,
     JazzDialogTemplateRef,
     ContentElementDialog,
+    ContentElementTemplateRefDialog,
     IFrameDialog,
     RotiniPanel,
     ScienceJoke,

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -66,4 +66,4 @@
 
 
 <template #contentElementRef>
-  <demo-content-element-dialog [actionsAlignment]="actionsAlignment"></demo-content-element-dialog>
+  <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -67,3 +67,4 @@
 
 <template #contentElementRef>
   <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>
+</template>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -1,7 +1,15 @@
 <h1>Dialog demo</h1>
 
-<button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
-<button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+<div class="demo-button-group">
+  <button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
+  <button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+</div>
+
+<div class="demo-button-group">
+  <button md-raised-button color="primary" (click)="openJazzUsingTemplateRef()" [disabled]="dialogTemplateRef">Open dialog using TemplateRef</button>
+  <button md-raised-button color="accent" (click)="openContentElementUsingTemplateRef()">Open dialog using TemplateRef with content elements</button>
+</div>
+
 
 <md-card class="demo-dialog-card">
   <md-card-content>
@@ -51,3 +59,11 @@
 </md-card>
 
 <p>Last close result: {{lastCloseResult}}</p>
+
+<template #jazzDialogRef>
+  <demo-jazz-dialog-template-ref (close)="closeJazzUsingTemplateRef($event)"></demo-jazz-dialog-template-ref>
+</template>
+
+
+<template #contentElementRef>
+  <demo-content-element-dialog [actionsAlignment]="actionsAlignment"></demo-content-element-dialog>

--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -6,3 +6,7 @@
   max-width: 350px;
   margin: 20px 0;
 }
+
+.demo-button-group {
+  margin-bottom: 20px;
+}

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -18,14 +18,14 @@ import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 })
 export class DialogDemo {
   @ViewChild('jazzDialogRef')
-  jazzDialogRef: TemplateRef<JazzDialogTemplateRef>;
+  jazzDialogRef: TemplateRef<any>;
 
   @ViewChild('contentElementRef')
-  contentElementRef: TemplateRef<ContentElementDialog>;
+  contentElementRef: TemplateRef<any>;
 
   dialogRef: MdDialogRef<JazzDialog>;
-  dialogTemplateRef: MdDialogRef<JazzDialogTemplateRef>;
-  dialogContentTemplateRef: MdDialogRef<ContentElementDialog>;
+  dialogTemplateRef: MdDialogRef<any>;
+  dialogContentTemplateRef: MdDialogRef<any>;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -64,7 +64,7 @@ export class DialogDemo {
   }
 
   openJazzUsingTemplateRef() {
-    this.dialogTemplateRef = this.dialog.openFromTemplateRef(this.jazzDialogRef, this.config);
+    this.dialogTemplateRef = this.dialog.openFromTemplate(this.jazzDialogRef, this.config);
 
     this.dialogTemplateRef.afterClosed().first().subscribe(() => {
       this.dialogTemplateRef = null;
@@ -83,7 +83,7 @@ export class DialogDemo {
   }
 
   openContentElementUsingTemplateRef() {
-    this.dialogContentTemplateRef = this.dialog.openFromTemplateRef(
+    this.dialogContentTemplateRef = this.dialog.openFromTemplate(
       this.contentElementRef,
       this.config
     );

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -25,6 +25,7 @@ export class DialogDemo {
 
   dialogRef: MdDialogRef<JazzDialog>;
   dialogTemplateRef: MdDialogRef<JazzDialogTemplateRef>;
+  dialogContentTemplateRef: MdDialogRef<ContentElementDialog>;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -82,7 +83,16 @@ export class DialogDemo {
   }
 
   openContentElementUsingTemplateRef() {
-    this.dialog.openFromTemplateRef(this.contentElementRef, this.config);
+    this.dialogContentTemplateRef = this.dialog.openFromTemplateRef(
+      this.contentElementRef,
+      this.config
+    );
+  }
+
+  closeContentElementUsingTemplateRef() {
+    if (this.dialogContentTemplateRef) {
+      this.dialogContentTemplateRef.close();
+    }
   }
 }
 
@@ -145,12 +155,10 @@ export class JazzDialogTemplateRef {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
-      <!--
       <button
         md-raised-button
         color="primary"
         md-dialog-close>Close</button>
-      -->
       <a
         md-button
         color="primary"
@@ -166,7 +174,6 @@ export class JazzDialogTemplateRef {
   `
 })
 export class ContentElementDialog {
-  @Input()
   actionsAlignment: string;
 
   constructor(public dialog: MdDialog) { }
@@ -178,7 +185,7 @@ export class ContentElementDialog {
 
 
 @Component({
-  selector: 'demo-content-element-dialog',
+  selector: 'demo-content-element-template-ref-dialog',
   styles: [
     `img {
       max-width: 100%;
@@ -202,12 +209,10 @@ export class ContentElementDialog {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
-      <!--
       <button
         md-raised-button
         color="primary"
-        md-dialog-close>Close</button>
-      -->
+        (click)="!!close.emit()">Close</button>
       <a
         md-button
         color="primary"
@@ -222,9 +227,12 @@ export class ContentElementDialog {
     </md-dialog-actions>
   `
 })
-export class ContentElementDialog {
+export class ContentElementTemplateRefDialog {
   @Input()
   actionsAlignment: string;
+
+  @Output()
+  close = new EventEmitter<void>();
 
   constructor(public dialog: MdDialog) { }
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,4 +1,12 @@
-import {Component, Inject} from '@angular/core';
+import {
+  Component,
+  Inject,
+  Input,
+  Output,
+  ViewChild,
+  TemplateRef,
+  EventEmitter
+} from '@angular/core';
 import {DOCUMENT} from '@angular/platform-browser';
 import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 
@@ -9,7 +17,14 @@ import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
   styleUrls: ['dialog-demo.css'],
 })
 export class DialogDemo {
+  @ViewChild('jazzDialogRef')
+  jazzDialogRef: TemplateRef<JazzDialogTemplateRef>;
+
+  @ViewChild('contentElementRef')
+  contentElementRef: TemplateRef<ContentElementDialog>;
+
   dialogRef: MdDialogRef<JazzDialog>;
+  dialogTemplateRef: MdDialogRef<JazzDialogTemplateRef>;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -41,15 +56,33 @@ export class DialogDemo {
   openJazz() {
     this.dialogRef = this.dialog.open(JazzDialog, this.config);
 
-    this.dialogRef.afterClosed().subscribe(result => {
+    this.dialogRef.afterClosed().first().subscribe(result => {
       this.lastCloseResult = result;
       this.dialogRef = null;
     });
   }
 
+  openJazzUsingTemplateRef() {
+    this.dialogTemplateRef = this.dialog.openFromTemplateRef(this.jazzDialogRef, this.config);
+
+    this.dialogTemplateRef.afterClosed().first().subscribe(() => {
+      this.dialogTemplateRef = null;
+    });
+  }
+
+  closeJazzUsingTemplateRef(result: string) {
+    this.lastCloseResult = result;
+
+    this.dialogTemplateRef.close();
+  }
+
   openContentElement() {
     let dialogRef = this.dialog.open(ContentElementDialog, this.config);
     dialogRef.componentInstance.actionsAlignment = this.actionsAlignment;
+  }
+
+  openContentElementUsingTemplateRef() {
+    this.dialog.openFromTemplateRef(this.contentElementRef, this.config);
   }
 }
 
@@ -66,6 +99,24 @@ export class JazzDialog {
   jazzMessage = 'Jazzy jazz jazz';
 
   constructor(public dialogRef: MdDialogRef<JazzDialog>) { }
+}
+
+
+@Component({
+  selector: 'demo-jazz-dialog-template-ref',
+  template: `
+  <p>It's Jazz!</p>
+  <p><label>How much? <input #howMuch></label></p>
+  <p> {{ jazzMessage }} </p>
+  <button type="button" (click)="close.emit(howMuch.value)">Close dialog</button>`
+})
+export class JazzDialogTemplateRef {
+  jazzMessage = 'Jazzy jazz jazz';
+
+  @Output()
+  close = new EventEmitter<string>(false);
+
+  constructor() { }
 }
 
 
@@ -94,17 +145,18 @@ export class JazzDialog {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
+      <!--
       <button
         md-raised-button
         color="primary"
         md-dialog-close>Close</button>
-
+      -->
       <a
         md-button
         color="primary"
         href="https://en.wikipedia.org/wiki/Neptune"
         target="_blank">Read more on Wikipedia</a>
-      
+
       <button
         md-button
         color="secondary"
@@ -114,6 +166,64 @@ export class JazzDialog {
   `
 })
 export class ContentElementDialog {
+  @Input()
+  actionsAlignment: string;
+
+  constructor(public dialog: MdDialog) { }
+
+  showInStackedDialog() {
+    this.dialog.open(IFrameDialog);
+  }
+}
+
+
+@Component({
+  selector: 'demo-content-element-dialog',
+  styles: [
+    `img {
+      max-width: 100%;
+    }`
+  ],
+  template: `
+    <h2 md-dialog-title>Neptune</h2>
+
+    <md-dialog-content>
+      <img src="https://upload.wikimedia.org/wikipedia/commons/5/56/Neptune_Full.jpg"/>
+
+      <p>
+        Neptune is the eighth and farthest known planet from the Sun in the Solar System. In the
+        Solar System, it is the fourth-largest planet by diameter, the third-most-massive planet,
+        and the densest giant planet. Neptune is 17 times the mass of Earth and is slightly more
+        massive than its near-twin Uranus, which is 15 times the mass of Earth and slightly larger
+        than Neptune. Neptune orbits the Sun once every 164.8 years at an average distance of 30.1
+        astronomical units (4.50×109 km). It is named after the Roman god of the sea and has the
+        astronomical symbol ♆, a stylised version of the god Neptune's trident.
+      </p>
+    </md-dialog-content>
+
+    <md-dialog-actions [attr.align]="actionsAlignment">
+      <!--
+      <button
+        md-raised-button
+        color="primary"
+        md-dialog-close>Close</button>
+      -->
+      <a
+        md-button
+        color="primary"
+        href="https://en.wikipedia.org/wiki/Neptune"
+        target="_blank">Read more on Wikipedia</a>
+
+      <button
+        md-button
+        color="secondary"
+        (click)="showInStackedDialog()">
+        Show in Dialog</button>
+    </md-dialog-actions>
+  `
+})
+export class ContentElementDialog {
+  @Input()
   actionsAlignment: string;
 
   constructor(public dialog: MdDialog) { }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -6,7 +6,6 @@ import {
   NgZone,
   OnDestroy,
   ViewContainerRef,
-  TemplateRef,
 } from '@angular/core';
 import {BasePortalHost, ComponentPortal, PortalHostDirective, TemplatePortal} from '../core';
 import {MdDialogConfig} from './dialog-config';
@@ -48,8 +47,13 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
   /** Reference to the open dialog. */
   dialogRef: MdDialogRef<any>;
 
+  /** Exposes ViewContainerRef */
+  containerRef: ViewContainerRef;
+
   constructor(private _viewContainerRef: ViewContainerRef, private _ngZone: NgZone) {
     super();
+
+    this.containerRef = this._viewContainerRef;
   }
 
   /**
@@ -80,12 +84,6 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
     return attachResult;
   }
 
-  attachTemplateRef<T>(templateRef: TemplateRef<T>) {
-    const portal = new TemplatePortal(templateRef, this._viewContainerRef);
-
-    this.attachTemplatePortal(portal);
-  }
-
   /**
    * Handles the user pressing the Escape key.
    * @docs-private
@@ -95,7 +93,7 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
       this.dialogRef.close();
     }
 
-    this.dialogRef.escapePressed.next();
+    this.dialogRef.escapePress.next();
   }
 
   ngOnDestroy() {

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -15,16 +15,16 @@ export class MdDialogRef<T> {
   componentInstance: T;
 
   /** Expose overlay backdrop click event */
-  backdropClicked: Observable<void>;
+  backdropClick: Observable<void>;
 
   /** Subject for notifying the user that esc key way pressed */
-  escapePressed = new Subject<void>();
+  escapePress = new Subject<void>();
 
   /** Subject for notifying the user that the dialog has finished closing. */
   private _afterClosed: Subject<any> = new Subject();
 
   constructor(private _overlayRef: OverlayRef) {
-    this.backdropClicked = this._overlayRef.backdropClick();
+    this.backdropClick = this._overlayRef.backdropClick();
   }
 
   /**

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -14,10 +14,18 @@ export class MdDialogRef<T> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;
 
+  /** Expose overlay backdrop click event */
+  backdropClicked: Observable<void>;
+
+  /** Subject for notifying the user that esc key way pressed */
+  escapePressed = new Subject<void>();
+
   /** Subject for notifying the user that the dialog has finished closing. */
   private _afterClosed: Subject<any> = new Subject();
 
-  constructor(private _overlayRef: OverlayRef) { }
+  constructor(private _overlayRef: OverlayRef) {
+    this.backdropClicked = this._overlayRef.backdropClick();
+  }
 
   /**
    * Close the dialog.

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -73,15 +73,15 @@ describe('MdDialog', () => {
   });
 
   it('should open a dialog with a templateRef', () => {
-    const pizzaMsgContainer = TestBed.createComponent(PizzaMsgContainer);
+    const catDialogContainer = TestBed.createComponent(CatDialogContainer);
 
-    pizzaMsgContainer.detectChanges();
+    catDialogContainer.detectChanges();
 
-    dialog.openFromTemplateRef(pizzaMsgContainer.componentInstance.pizzaRef);
+    dialog.openFromTemplateRef(catDialogContainer.componentInstance.catRef);
 
     viewContainerFixture.detectChanges();
 
-    expect(overlayContainerElement.textContent).toContain('Pizza');
+    expect(overlayContainerElement.textContent).toContain('Cat');
 
     viewContainerFixture.detectChanges();
     let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
@@ -542,16 +542,19 @@ class ComponentWithChildViewContainer {
 }
 
 /** Simple component for testing ComponentPortal. */
-@Component({selector: 'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
+@Component({template: '<p>Pizza</p> <input> <button>Close</button>'})
 class PizzaMsg {
   constructor(public dialogRef: MdDialogRef<PizzaMsg>,
               public dialogInjector: Injector) {}
 }
 
-/** Simple component for testing dialog using TemplateRef. */
-@Component({template: '<template #pizzaRef><pizza-msg></pizza-msg></template>'})
-class PizzaMsgContainer {
-  @ViewChild('pizzaRef') pizzaRef: TemplateRef<PizzaMsg>;
+/** Components for testing dialog using TemplateRef. */
+@Component({selector: 'cat-dialog', template: '<p>Cat</p> <input> <button>Close</button>'})
+class CatDialog {}
+
+@Component({template: '<template #catRef><cat-dialog></cat-dialog></template>'})
+class CatDialogContainer {
+  @ViewChild('catRef') catRef: TemplateRef<CatDialog>;
 }
 
 @Component({
@@ -581,7 +584,8 @@ class ComponentThatProvidesMdDialog {
 const TEST_DIRECTIVES = [
   ComponentWithChildViewContainer,
   PizzaMsg,
-  PizzaMsgContainer,
+  CatDialog,
+  CatDialogContainer,
   DirectiveWithViewContainer,
   ContentElementDialog
 ];
@@ -593,7 +597,8 @@ const TEST_DIRECTIVES = [
   entryComponents: [
     ComponentWithChildViewContainer,
     PizzaMsg,
-    PizzaMsgContainer,
+    CatDialog,
+    CatDialogContainer,
     ContentElementDialog
   ],
 })

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -75,7 +75,7 @@ describe('MdDialog', () => {
   it('should open a dialog with a templateRef', () => {
     const pizzaMsgContainer = TestBed.createComponent(PizzaMsgContainer);
 
-    viewContainerFixture.detectChanges();
+    pizzaMsgContainer.detectChanges();
 
     dialog.openFromTemplateRef(pizzaMsgContainer.componentInstance.pizzaRef);
 
@@ -542,7 +542,7 @@ class ComponentWithChildViewContainer {
 }
 
 /** Simple component for testing ComponentPortal. */
-@Component({selector:'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
+@Component({selector: 'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
 class PizzaMsg {
   constructor(public dialogRef: MdDialogRef<PizzaMsg>,
               public dialogInjector: Injector) {}

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -77,7 +77,7 @@ describe('MdDialog', () => {
 
     catDialogContainer.detectChanges();
 
-    dialog.openFromTemplateRef(catDialogContainer.componentInstance.catRef);
+    dialog.openFromTemplate(catDialogContainer.componentInstance.catRef);
 
     viewContainerFixture.detectChanges();
 
@@ -171,16 +171,14 @@ describe('MdDialog', () => {
     let dialogContainer: MdDialogContainer =
         viewContainerFixture.debugElement.query(By.directive(MdDialogContainer)).componentInstance;
 
-    let pressed = false;
+    let pressedSpy = jasmine.createSpy('clicked callback');
 
-    dialogRef.escapePressed.subscribe(() => {
-      pressed = true;
-    });
+    dialogRef.escapePress.subscribe(pressedSpy);
 
     // Fake the user pressing the escape key by calling the handler directly.
     dialogContainer.handleEscapeKey();
 
-    expect(pressed).toBe(true);
+    expect(pressedSpy).toHaveBeenCalled();
   });
 
   it('should close when clicking on the overlay backdrop', () => {
@@ -205,14 +203,14 @@ describe('MdDialog', () => {
 
     let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
 
-    let clicked = false;
+    let clickedSpy = jasmine.createSpy('clicked callback');
 
-    dialogRef.backdropClicked.subscribe(() => {
-      clicked = true;
-    });
+    dialogRef.backdropClick.subscribe(clickedSpy);
 
     backdrop.click();
-    expect(clicked).toBe(true);
+
+    expect(clickedSpy).toHaveBeenCalled();
+
   });
 
   it('should notify the observers if a dialog has been opened', () => {


### PR DESCRIPTION
I split https://github.com/angular/material2/pull/2851, used `TemplateRef` instead of `TemplatePortal`, and committed only the part that adds `openFromTemplateRef()`.

Added tests for `backdropClicked`, `escapePressed`(I explained the need for these in the previous PR) and a test for creating a dialog using templateRef. Not sure which other tests would be needed, I think the rest is identical to opening a dialog with `open()`.

Then there's a little "problem" that components inside the `<template>` do not have access to `MdDialogRef`, so `dialogRef.close()` and `md-dialog-close` obviously do not work, but if you are opening a dialog using `TemplateRef`, you likely do not need those anyway.

@jelbourn @crisbeto @DevVersion 
