### PR TITLE
feat(dialog): add md-dialog component

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -8,7 +8,13 @@ import {MaterialModule, OverlayContainer,
   FullscreenOverlayContainer} from '@angular/material';
 import {DEMO_APP_ROUTES} from './demo-app/routes';
 import {ProgressBarDemo} from './progress-bar/progress-bar-demo';
-import {JazzDialog, ContentElementDialog, DialogDemo, IFrameDialog} from './dialog/dialog-demo';
+import {
+  JazzDialog,
+  JazzDialogTemplateRef,
+  ContentElementDialog,
+  DialogDemo,
+  IFrameDialog
+} from './dialog/dialog-demo';
 import {RippleDemo} from './ripple/ripple-demo';
 import {IconDemo} from './icon/icon-demo';
 import {GesturesDemo} from './gestures/gestures-demo';
@@ -64,6 +70,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     IconDemo,
     InputContainerDemo,
     JazzDialog,
+    JazzDialogTemplateRef,
     ContentElementDialog,
     IFrameDialog,
     ListDemo,
@@ -100,6 +107,7 @@ import {InputContainerDemo} from './input/input-container-demo';
   entryComponents: [
     DemoApp,
     JazzDialog,
+    JazzDialogTemplateRef,
     ContentElementDialog,
     IFrameDialog,
     RotiniPanel,

--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -12,6 +12,7 @@ import {
   JazzDialog,
   JazzDialogTemplateRef,
   ContentElementDialog,
+  ContentElementTemplateRefDialog,
   DialogDemo,
   IFrameDialog
 } from './dialog/dialog-demo';
@@ -72,6 +73,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     JazzDialog,
     JazzDialogTemplateRef,
     ContentElementDialog,
+    ContentElementTemplateRefDialog,
     IFrameDialog,
     ListDemo,
     LiveAnnouncerDemo,
@@ -109,6 +111,7 @@ import {InputContainerDemo} from './input/input-container-demo';
     JazzDialog,
     JazzDialogTemplateRef,
     ContentElementDialog,
+    ContentElementTemplateRefDialog,
     IFrameDialog,
     RotiniPanel,
     ScienceJoke,

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -66,4 +66,4 @@
 
 
 <template #contentElementRef>
-  <demo-content-element-dialog [actionsAlignment]="actionsAlignment"></demo-content-element-dialog>
+  <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -67,3 +67,4 @@
 
 <template #contentElementRef>
   <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>
+</template>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -1,70 +1,107 @@
 <h1>Dialog demo</h1>
 
-<div class="demo-button-group">
-  <button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
-  <button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+<div class="demo-dialog-section">
+
+  <h2>Using <strong>MdDialog</strong> service</h2>
+
+  <div class="demo-button-group">
+    <button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
+    <button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+  </div>
+
+  <div class="demo-button-group">
+    <button md-raised-button color="primary" (click)="openJazzUsingTemplateRef()" [disabled]="dialogTemplateRef">Open dialog using TemplateRef</button>
+    <button md-raised-button color="accent" (click)="openContentElementUsingTemplateRef()">Open dialog using TemplateRef with content elements</button>
+  </div>
+
+  <p *ngIf="lastCloseResult">Last close result: {{lastCloseResult}}</p>
+
+  <template #jazzDialogRef>
+    <demo-jazz-dialog-template-ref (close)="closeJazzUsingTemplateRef($event)"></demo-jazz-dialog-template-ref>
+  </template>
+
+  <template #contentElementRef>
+    <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>
+  </template>
+
 </div>
 
-<div class="demo-button-group">
-  <button md-raised-button color="primary" (click)="openJazzUsingTemplateRef()" [disabled]="dialogTemplateRef">Open dialog using TemplateRef</button>
-  <button md-raised-button color="accent" (click)="openContentElementUsingTemplateRef()">Open dialog using TemplateRef with content elements</button>
+<div class="demo-dialog-section">
+
+  <h2>Using <strong>md-dialog</strong> element</h2>
+
+  <div class="demo-button-group">
+    <button
+      md-raised-button
+      color="primary"
+      (click)="changeMdDialogState(true)"
+      [disabled]="mdDialogState">
+      Open md-dialog with content elements
+    </button>
+  </div>
+
+  <md-dialog
+    [open]="mdDialogState"
+    (close)="changeMdDialogState(false)">
+
+    <demo-content-element-template-ref-dialog
+      (close)="changeMdDialogState(false)"
+      [actionsAlignment]="actionsAlignment">
+    </demo-content-element-template-ref-dialog>
+
+  </md-dialog>
+
 </div>
 
+<div class="demo-dialog-section">
 
-<md-card class="demo-dialog-card">
-  <md-card-content>
-    <h2>Dialog dimensions</h2>
+  <h2>Dialog settings</h2>
 
-    <p>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.width" placeholder="Width">
-      </md-input-container>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.height" placeholder="Height">
-      </md-input-container>
-    </p>
+  <md-card class="demo-dialog-card">
+    <md-card-content>
+      <h2>Dialog dimensions</h2>
 
-    <h2>Dialog position</h2>
+      <p>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.width" placeholder="Width">
+        </md-input-container>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.height" placeholder="Height">
+        </md-input-container>
+      </p>
 
-    <p>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''" placeholder="Top">
-      </md-input-container>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''" placeholder="Bottom">
-      </md-input-container>
-    </p>
+      <h2>Dialog position</h2>
 
-    <p>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.position.left" (change)="config.position.right = ''" placeholder="Left">
-      </md-input-container>
-      <md-input-container>
-        <input mdInput [(ngModel)]="config.position.right" (change)="config.position.left = ''" placeholder="Right">
-      </md-input-container>
-    </p>
+      <p>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''" placeholder="Top">
+        </md-input-container>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''" placeholder="Bottom">
+        </md-input-container>
+      </p>
 
-    <h2>Other options</h2>
+      <p>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.position.left" (change)="config.position.right = ''" placeholder="Left">
+        </md-input-container>
+        <md-input-container>
+          <input mdInput [(ngModel)]="config.position.right" (change)="config.position.left = ''" placeholder="Right">
+        </md-input-container>
+      </p>
 
-    <p>
-      <md-select placeholder="Button alignment" [(ngModel)]="actionsAlignment">
-        <md-option>Start</md-option>
-        <md-option value="end">End</md-option>
-        <md-option value="center">Center</md-option>
-      </md-select>
-    </p>
+      <h2>Other options</h2>
 
-    <md-checkbox [(ngModel)]="config.disableClose">Disable close</md-checkbox>
-  </md-card-content>
-</md-card>
+      <p>
+        <md-select placeholder="Button alignment" [(ngModel)]="actionsAlignment">
+          <md-option>Start</md-option>
+          <md-option value="end">End</md-option>
+          <md-option value="center">Center</md-option>
+        </md-select>
+      </p>
 
-<p>Last close result: {{lastCloseResult}}</p>
+      <md-checkbox [(ngModel)]="config.disableClose">Disable close</md-checkbox>
+    </md-card-content>
+  </md-card>
 
-<template #jazzDialogRef>
-  <demo-jazz-dialog-template-ref (close)="closeJazzUsingTemplateRef($event)"></demo-jazz-dialog-template-ref>
-</template>
-
-
-<template #contentElementRef>
-  <demo-content-element-template-ref-dialog (close)="closeContentElementUsingTemplateRef()" [actionsAlignment]="actionsAlignment"></demo-content-element-template-ref-dialog>
-</template>
+</div>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -1,7 +1,15 @@
 <h1>Dialog demo</h1>
 
-<button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
-<button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+<div class="demo-button-group">
+  <button md-raised-button color="primary" (click)="openJazz()" [disabled]="dialogRef">Open dialog</button>
+  <button md-raised-button color="accent" (click)="openContentElement()">Open dialog with content elements</button>
+</div>
+
+<div class="demo-button-group">
+  <button md-raised-button color="primary" (click)="openJazzUsingTemplateRef()" [disabled]="dialogTemplateRef">Open dialog using TemplateRef</button>
+  <button md-raised-button color="accent" (click)="openContentElementUsingTemplateRef()">Open dialog using TemplateRef with content elements</button>
+</div>
+
 
 <md-card class="demo-dialog-card">
   <md-card-content>
@@ -51,3 +59,11 @@
 </md-card>
 
 <p>Last close result: {{lastCloseResult}}</p>
+
+<template #jazzDialogRef>
+  <demo-jazz-dialog-template-ref (close)="closeJazzUsingTemplateRef($event)"></demo-jazz-dialog-template-ref>
+</template>
+
+
+<template #contentElementRef>
+  <demo-content-element-dialog [actionsAlignment]="actionsAlignment"></demo-content-element-dialog>

--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -6,3 +6,7 @@
   max-width: 350px;
   margin: 20px 0;
 }
+
+.demo-button-group {
+  margin-bottom: 20px;
+}

--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -10,3 +10,11 @@
 .demo-button-group {
   margin-bottom: 20px;
 }
+
+.demo-dialog-section {
+  margin-bottom: 40px;
+
+  h2 {
+    font-size: 18px;
+  }
+}

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -28,6 +28,7 @@ export class DialogDemo {
   dialogContentTemplateRef: MdDialogRef<ContentElementDialog>;
   lastCloseResult: string;
   actionsAlignment: string;
+  mdDialogState: boolean = false;
   config: MdDialogConfig = {
     disableClose: false,
     width: '',
@@ -93,6 +94,10 @@ export class DialogDemo {
     if (this.dialogContentTemplateRef) {
       this.dialogContentTemplateRef.close();
     }
+  }
+
+  changeMdDialogState(to: boolean) {
+    this.mdDialogState = to;
   }
 }
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -25,6 +25,7 @@ export class DialogDemo {
 
   dialogRef: MdDialogRef<JazzDialog>;
   dialogTemplateRef: MdDialogRef<JazzDialogTemplateRef>;
+  dialogContentTemplateRef: MdDialogRef<ContentElementDialog>;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -82,7 +83,16 @@ export class DialogDemo {
   }
 
   openContentElementUsingTemplateRef() {
-    this.dialog.openFromTemplateRef(this.contentElementRef, this.config);
+    this.dialogContentTemplateRef = this.dialog.openFromTemplateRef(
+      this.contentElementRef,
+      this.config
+    );
+  }
+
+  closeContentElementUsingTemplateRef() {
+    if (this.dialogContentTemplateRef) {
+      this.dialogContentTemplateRef.close();
+    }
   }
 }
 
@@ -145,12 +155,10 @@ export class JazzDialogTemplateRef {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
-      <!--
       <button
         md-raised-button
         color="primary"
         md-dialog-close>Close</button>
-      -->
       <a
         md-button
         color="primary"
@@ -166,7 +174,6 @@ export class JazzDialogTemplateRef {
   `
 })
 export class ContentElementDialog {
-  @Input()
   actionsAlignment: string;
 
   constructor(public dialog: MdDialog) { }
@@ -178,7 +185,7 @@ export class ContentElementDialog {
 
 
 @Component({
-  selector: 'demo-content-element-dialog',
+  selector: 'demo-content-element-template-ref-dialog',
   styles: [
     `img {
       max-width: 100%;
@@ -202,12 +209,10 @@ export class ContentElementDialog {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
-      <!--
       <button
         md-raised-button
         color="primary"
-        md-dialog-close>Close</button>
-      -->
+        (click)="!!close.emit()">Close</button>
       <a
         md-button
         color="primary"
@@ -222,9 +227,12 @@ export class ContentElementDialog {
     </md-dialog-actions>
   `
 })
-export class ContentElementDialog {
+export class ContentElementTemplateRefDialog {
   @Input()
   actionsAlignment: string;
+
+  @Output()
+  close = new EventEmitter<void>();
 
   constructor(public dialog: MdDialog) { }
 

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,4 +1,12 @@
-import {Component, Inject} from '@angular/core';
+import {
+  Component,
+  Inject,
+  Input,
+  Output,
+  ViewChild,
+  TemplateRef,
+  EventEmitter
+} from '@angular/core';
 import {DOCUMENT} from '@angular/platform-browser';
 import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
 
@@ -9,7 +17,14 @@ import {MdDialog, MdDialogRef, MdDialogConfig} from '@angular/material';
   styleUrls: ['dialog-demo.css'],
 })
 export class DialogDemo {
+  @ViewChild('jazzDialogRef')
+  jazzDialogRef: TemplateRef<JazzDialogTemplateRef>;
+
+  @ViewChild('contentElementRef')
+  contentElementRef: TemplateRef<ContentElementDialog>;
+
   dialogRef: MdDialogRef<JazzDialog>;
+  dialogTemplateRef: MdDialogRef<JazzDialogTemplateRef>;
   lastCloseResult: string;
   actionsAlignment: string;
   config: MdDialogConfig = {
@@ -41,15 +56,33 @@ export class DialogDemo {
   openJazz() {
     this.dialogRef = this.dialog.open(JazzDialog, this.config);
 
-    this.dialogRef.afterClosed().subscribe(result => {
+    this.dialogRef.afterClosed().first().subscribe(result => {
       this.lastCloseResult = result;
       this.dialogRef = null;
     });
   }
 
+  openJazzUsingTemplateRef() {
+    this.dialogTemplateRef = this.dialog.openFromTemplateRef(this.jazzDialogRef, this.config);
+
+    this.dialogTemplateRef.afterClosed().first().subscribe(() => {
+      this.dialogTemplateRef = null;
+    });
+  }
+
+  closeJazzUsingTemplateRef(result: string) {
+    this.lastCloseResult = result;
+
+    this.dialogTemplateRef.close();
+  }
+
   openContentElement() {
     let dialogRef = this.dialog.open(ContentElementDialog, this.config);
     dialogRef.componentInstance.actionsAlignment = this.actionsAlignment;
+  }
+
+  openContentElementUsingTemplateRef() {
+    this.dialog.openFromTemplateRef(this.contentElementRef, this.config);
   }
 }
 
@@ -66,6 +99,24 @@ export class JazzDialog {
   jazzMessage = 'Jazzy jazz jazz';
 
   constructor(public dialogRef: MdDialogRef<JazzDialog>) { }
+}
+
+
+@Component({
+  selector: 'demo-jazz-dialog-template-ref',
+  template: `
+  <p>It's Jazz!</p>
+  <p><label>How much? <input #howMuch></label></p>
+  <p> {{ jazzMessage }} </p>
+  <button type="button" (click)="close.emit(howMuch.value)">Close dialog</button>`
+})
+export class JazzDialogTemplateRef {
+  jazzMessage = 'Jazzy jazz jazz';
+
+  @Output()
+  close = new EventEmitter<string>(false);
+
+  constructor() { }
 }
 
 
@@ -94,17 +145,18 @@ export class JazzDialog {
     </md-dialog-content>
 
     <md-dialog-actions [attr.align]="actionsAlignment">
+      <!--
       <button
         md-raised-button
         color="primary"
         md-dialog-close>Close</button>
-
+      -->
       <a
         md-button
         color="primary"
         href="https://en.wikipedia.org/wiki/Neptune"
         target="_blank">Read more on Wikipedia</a>
-      
+
       <button
         md-button
         color="secondary"
@@ -114,6 +166,64 @@ export class JazzDialog {
   `
 })
 export class ContentElementDialog {
+  @Input()
+  actionsAlignment: string;
+
+  constructor(public dialog: MdDialog) { }
+
+  showInStackedDialog() {
+    this.dialog.open(IFrameDialog);
+  }
+}
+
+
+@Component({
+  selector: 'demo-content-element-dialog',
+  styles: [
+    `img {
+      max-width: 100%;
+    }`
+  ],
+  template: `
+    <h2 md-dialog-title>Neptune</h2>
+
+    <md-dialog-content>
+      <img src="https://upload.wikimedia.org/wikipedia/commons/5/56/Neptune_Full.jpg"/>
+
+      <p>
+        Neptune is the eighth and farthest known planet from the Sun in the Solar System. In the
+        Solar System, it is the fourth-largest planet by diameter, the third-most-massive planet,
+        and the densest giant planet. Neptune is 17 times the mass of Earth and is slightly more
+        massive than its near-twin Uranus, which is 15 times the mass of Earth and slightly larger
+        than Neptune. Neptune orbits the Sun once every 164.8 years at an average distance of 30.1
+        astronomical units (4.50×109 km). It is named after the Roman god of the sea and has the
+        astronomical symbol ♆, a stylised version of the god Neptune's trident.
+      </p>
+    </md-dialog-content>
+
+    <md-dialog-actions [attr.align]="actionsAlignment">
+      <!--
+      <button
+        md-raised-button
+        color="primary"
+        md-dialog-close>Close</button>
+      -->
+      <a
+        md-button
+        color="primary"
+        href="https://en.wikipedia.org/wiki/Neptune"
+        target="_blank">Read more on Wikipedia</a>
+
+      <button
+        md-button
+        color="secondary"
+        (click)="showInStackedDialog()">
+        Show in Dialog</button>
+    </md-dialog-actions>
+  `
+})
+export class ContentElementDialog {
+  @Input()
   actionsAlignment: string;
 
   constructor(public dialog: MdDialog) { }

--- a/src/lib/dialog/dialog-element.html
+++ b/src/lib/dialog/dialog-element.html
@@ -1,0 +1,3 @@
+<template #mdDialogContentTemplateRef>
+  <ng-content></ng-content>
+</template>

--- a/src/lib/dialog/dialog-element.ts
+++ b/src/lib/dialog/dialog-element.ts
@@ -1,0 +1,90 @@
+import {
+  Component,
+  TemplateRef,
+  Input,
+  ViewChild,
+  Output,
+  EventEmitter,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  NgZone
+} from '@angular/core';
+import {MdDialog} from './dialog';
+import {MdDialogConfig} from './dialog-config';
+import {MdDialogRef} from './dialog-ref';
+import {Subscription} from 'rxjs/Subscription';
+
+@Component({
+  selector: 'md-dialog',
+  templateUrl: './dialog-element.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MdDialogElement {
+  dialog: MdDialogRef<any>;
+
+  @Input()
+  set config(v: MdDialogConfig) {
+    if (v) {
+      this._config = Object.assign(this._config, v);
+    }
+  }
+  get config() {
+    return this._config;
+  }
+
+  /** emits event that close attemps happened along with a cause */
+  @Output()
+  close = new EventEmitter<'escape' | 'backdrop'>(false);
+
+  @ViewChild('mdDialogContentTemplateRef')
+  mdDialogContentTemplateRef: TemplateRef<any>;
+
+  @Input()
+  set open(state: boolean) {
+    if (state) {
+      // needede to prevent `Expression has changed after it was checked`
+      this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
+
+        this.dialog = this._dialog.openFromTemplateRef(
+          this.mdDialogContentTemplateRef,
+          this.config
+        );
+
+        this._backdropClickSubscription = this.dialog.backdropClicked
+          .subscribe(() => {
+            this.close.emit('backdrop');
+          });
+
+        this._escapePressSubscription = this.dialog.escapePressed
+          .subscribe(() => {
+            this.close.emit('escape');
+          });
+      });
+
+    } else if (this.dialog) {
+      if (this.dialog) {
+        this.dialog.close();
+
+        // remove backdrop/escape subscription only if dialog is actually closed
+        this._backdropClickSubscription.unsubscribe();
+        this._escapePressSubscription.unsubscribe();
+      }
+    }
+  }
+
+  private _config: MdDialogConfig;
+  private _backdropClickSubscription: Subscription;
+  private _escapePressSubscription: Subscription;
+
+  constructor(private _dialog: MdDialog, private _ngZone: NgZone) {
+    let config = new MdDialogConfig();
+
+    // disable close by default, to make it truly stateless
+    // it's default behaviour of https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog
+    // as well
+    config.disableClose = true;
+
+    this._config = config;
+  }
+}

--- a/src/lib/dialog/dialog-element.ts
+++ b/src/lib/dialog/dialog-element.ts
@@ -15,8 +15,9 @@ import {MdDialogRef} from './dialog-ref';
 import {Subscription} from 'rxjs/Subscription';
 
 @Component({
+  moduleId: module.id,
   selector: 'md-dialog',
-  templateUrl: './dialog-element.html',
+  templateUrl: 'dialog-element.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -43,30 +44,27 @@ export class MdDialogElement {
   @Input()
   set open(state: boolean) {
     if (state) {
-      // needede to prevent `Expression has changed after it was checked`
+      // needed to prevent `Expression has changed after it was checked`
       this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
-
         this.dialog = this._dialog.openFromTemplateRef(
           this.mdDialogContentTemplateRef,
           this.config
         );
 
-        this._backdropClickSubscription = this.dialog.backdropClicked
-          .subscribe(() => {
-            this.close.emit('backdrop');
-          });
+        this._backdropClickSubscription = this.dialog
+          .backdropClicked
+          .subscribe(() => this.close.emit('backdrop'));
 
-        this._escapePressSubscription = this.dialog.escapePressed
-          .subscribe(() => {
-            this.close.emit('escape');
-          });
+        this._escapePressSubscription = this.dialog
+          .escapePressed
+          .subscribe(() => this.close.emit('escape'));
       });
 
     } else if (this.dialog) {
       if (this.dialog) {
         this.dialog.close();
 
-        // remove backdrop/escape subscription only if dialog is actually closed
+        // remove backdrop/escape subscription only if dialog was actually closed
         this._backdropClickSubscription.unsubscribe();
         this._escapePressSubscription.unsubscribe();
       }
@@ -80,8 +78,9 @@ export class MdDialogElement {
   constructor(private _dialog: MdDialog, private _ngZone: NgZone) {
     let config = new MdDialogConfig();
 
-    // disable close by default, to make it truly stateless
-    // it's default behaviour of https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog
+    // disable close by default, to make it
+    // truly stateless it's default behaviour of
+    // https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog
     // as well
     config.disableClose = true;
 

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -14,10 +14,18 @@ export class MdDialogRef<T> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;
 
+  /** Expose overlay backdrop click event */
+  backdropClicked: Observable<void>;
+
+  /** Subject for notifying the user that esc key way pressed */
+  escapePressed = new Subject<void>();
+
   /** Subject for notifying the user that the dialog has finished closing. */
   private _afterClosed: Subject<any> = new Subject();
 
-  constructor(private _overlayRef: OverlayRef) { }
+  constructor(private _overlayRef: OverlayRef) {
+    this.backdropClicked = this._overlayRef.backdropClick();
+  }
 
   /**
    * Close the dialog.

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -19,10 +19,10 @@ import {
 } from '@angular/core';
 import {MdDialogModule} from './index';
 import {MdDialog} from './dialog';
+import {MdDialogConfig} from './dialog-config';
 import {OverlayContainer} from '../core';
 import {MdDialogRef} from './dialog-ref';
 import {MdDialogContainer} from './dialog-container';
-
 
 describe('MdDialog', () => {
   let dialog: MdDialog;
@@ -88,6 +88,81 @@ describe('MdDialog', () => {
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
   });
 
+  it('should open dialog using md-dialog component', () => {
+    const dialogComponentContainer = TestBed.createComponent(DialogComponentContainer);
+
+    dialogComponentContainer.detectChanges();
+
+    expect(overlayContainerElement.textContent).toBe('');
+
+    dialogComponentContainer.componentInstance.changeState(true);
+
+    dialogComponentContainer.detectChanges();
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.textContent).toContain('Hello');
+
+    viewContainerFixture.detectChanges();
+    let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
+    expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
+
+  });
+
+  it('should close md-dialog component by changing "open" input to false', () => {
+    const dialogComponentContainer = TestBed.createComponent(DialogComponentContainer);
+
+    dialogComponentContainer.componentInstance.changeState(true);
+
+    dialogComponentContainer.detectChanges();
+
+    expect(overlayContainerElement.textContent).toContain('Hello');
+
+    dialogComponentContainer.componentInstance.changeState(false);
+
+    dialogComponentContainer.detectChanges();
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
+
+  });
+
+  it('should not close dialog by default when using md-dialog', () => {
+    const dialogComponentContainer = TestBed.createComponent(DialogComponentContainer);
+
+    dialogComponentContainer.componentInstance.changeState(true);
+
+    dialogComponentContainer.detectChanges();
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.textContent).toContain('Hello');
+
+    let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    backdrop.click();
+
+    expect(overlayContainerElement.querySelector('md-dialog-container')).toBeTruthy();
+
+  });
+
+  it('should allow md-dialog settings to be changed with "config" input', () => {
+    const dialogComponentContainer = TestBed.createComponent(DialogComponentContainer);
+
+    dialogComponentContainer.componentInstance.config = {
+      disableClose: false
+    };
+
+    dialogComponentContainer.componentInstance.changeState(true);
+
+    dialogComponentContainer.detectChanges();
+    viewContainerFixture.detectChanges();
+
+    expect(overlayContainerElement.textContent).toContain('Hello');
+
+    let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    backdrop.click();
+
+    expect(overlayContainerElement.querySelector('md-dialog-container')).toBeFalsy();
+
+  });
 
   it('should use injector from viewContainerRef for DialogInjector', () => {
     let dialogRef = dialog.open(PizzaMsg, {
@@ -557,6 +632,26 @@ class CatDialogContainer {
   @ViewChild('catRef') catRef: TemplateRef<CatDialog>;
 }
 
+/** Components for testing md-dialog component. */
+@Component({
+  template: `
+    <md-dialog
+      [config]="config"
+      [open]="state"
+      (close)="changeState(false)">
+      Hello
+    </md-dialog>
+  `
+})
+class DialogComponentContainer {
+  state: boolean = false;
+  config: MdDialogConfig;
+
+  changeState(to: boolean) {
+    this.state = to;
+  }
+}
+
 @Component({
   template: `
     <h1 md-dialog-title>This is the title</h1>
@@ -586,8 +681,9 @@ const TEST_DIRECTIVES = [
   PizzaMsg,
   CatDialog,
   CatDialogContainer,
+  DialogComponentContainer,
   DirectiveWithViewContainer,
-  ContentElementDialog
+  ContentElementDialog,
 ];
 
 @NgModule({
@@ -596,10 +692,11 @@ const TEST_DIRECTIVES = [
   declarations: TEST_DIRECTIVES,
   entryComponents: [
     ComponentWithChildViewContainer,
+    DialogComponentContainer,
     PizzaMsg,
     CatDialog,
     CatDialogContainer,
-    ContentElementDialog
+    ContentElementDialog,
   ],
 })
 class DialogTestModule { }

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -73,15 +73,15 @@ describe('MdDialog', () => {
   });
 
   it('should open a dialog with a templateRef', () => {
-    const pizzaMsgContainer = TestBed.createComponent(PizzaMsgContainer);
+    const catDialogContainer = TestBed.createComponent(CatDialogContainer);
 
-    pizzaMsgContainer.detectChanges();
+    catDialogContainer.detectChanges();
 
-    dialog.openFromTemplateRef(pizzaMsgContainer.componentInstance.pizzaRef);
+    dialog.openFromTemplateRef(catDialogContainer.componentInstance.catRef);
 
     viewContainerFixture.detectChanges();
 
-    expect(overlayContainerElement.textContent).toContain('Pizza');
+    expect(overlayContainerElement.textContent).toContain('Cat');
 
     viewContainerFixture.detectChanges();
     let dialogContainerElement = overlayContainerElement.querySelector('md-dialog-container');
@@ -542,16 +542,19 @@ class ComponentWithChildViewContainer {
 }
 
 /** Simple component for testing ComponentPortal. */
-@Component({selector: 'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
+@Component({template: '<p>Pizza</p> <input> <button>Close</button>'})
 class PizzaMsg {
   constructor(public dialogRef: MdDialogRef<PizzaMsg>,
               public dialogInjector: Injector) {}
 }
 
-/** Simple component for testing dialog using TemplateRef. */
-@Component({template: '<template #pizzaRef><pizza-msg></pizza-msg></template>'})
-class PizzaMsgContainer {
-  @ViewChild('pizzaRef') pizzaRef: TemplateRef<PizzaMsg>;
+/** Components for testing dialog using TemplateRef. */
+@Component({selector: 'cat-dialog', template: '<p>Cat</p> <input> <button>Close</button>'})
+class CatDialog {}
+
+@Component({template: '<template #catRef><cat-dialog></cat-dialog></template>'})
+class CatDialogContainer {
+  @ViewChild('catRef') catRef: TemplateRef<CatDialog>;
 }
 
 @Component({
@@ -581,7 +584,8 @@ class ComponentThatProvidesMdDialog {
 const TEST_DIRECTIVES = [
   ComponentWithChildViewContainer,
   PizzaMsg,
-  PizzaMsgContainer,
+  CatDialog,
+  CatDialogContainer,
   DirectiveWithViewContainer,
   ContentElementDialog
 ];
@@ -593,7 +597,8 @@ const TEST_DIRECTIVES = [
   entryComponents: [
     ComponentWithChildViewContainer,
     PizzaMsg,
-    PizzaMsgContainer,
+    CatDialog,
+    CatDialogContainer,
     ContentElementDialog
   ],
 })

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -75,7 +75,7 @@ describe('MdDialog', () => {
   it('should open a dialog with a templateRef', () => {
     const pizzaMsgContainer = TestBed.createComponent(PizzaMsgContainer);
 
-    viewContainerFixture.detectChanges();
+    pizzaMsgContainer.detectChanges();
 
     dialog.openFromTemplateRef(pizzaMsgContainer.componentInstance.pizzaRef);
 
@@ -542,7 +542,7 @@ class ComponentWithChildViewContainer {
 }
 
 /** Simple component for testing ComponentPortal. */
-@Component({selector:'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
+@Component({selector: 'pizza-msg', template: '<p>Pizza</p> <input> <button>Close</button>'})
 class PizzaMsg {
   constructor(public dialogRef: MdDialogRef<PizzaMsg>,
               public dialogInjector: Injector) {}

--- a/src/lib/dialog/index.ts
+++ b/src/lib/dialog/index.ts
@@ -33,6 +33,7 @@ import {
   ],
   declarations: [
     MdDialogContainer,
+    MdDialogElement,
     MdDialogClose,
     MdDialogTitle,
     MdDialogActions,

--- a/src/lib/dialog/index.ts
+++ b/src/lib/dialog/index.ts
@@ -6,6 +6,7 @@ import {
   CompatibilityModule,
 } from '../core';
 import {MdDialog} from './dialog';
+import {MdDialogElement} from './dialog-element';
 import {MdDialogContainer} from './dialog-container';
 import {
   MdDialogClose,
@@ -13,7 +14,6 @@ import {
   MdDialogTitle,
   MdDialogActions
 } from './dialog-content-directives';
-
 
 @NgModule({
   imports: [
@@ -24,6 +24,7 @@ import {
   ],
   exports: [
     MdDialogContainer,
+    MdDialogElement,
     MdDialogClose,
     MdDialogTitle,
     MdDialogContent,
@@ -53,6 +54,7 @@ export class MdDialogModule {
 }
 
 export * from './dialog';
+export * from './dialog-element';
 export * from './dialog-container';
 export * from './dialog-content-directives';
 export * from './dialog-config';


### PR DESCRIPTION
Needs #2853.

`md-dialog` is a stateless component that's gonna be handy for people that use global state management like redux or @ngrx/store. It's also nice when you want to use standard input/output to pass data to the component inside your dialog(#2552, #2086, #2181 related).

```typescript
<md-dialog [open]="loginDialogState">
  <login-form [data]="loginDefaultData" (submit)="loginSubmitted($event)"></login-form>
</md-dialog>
```

Internally it uses `openFromTemplateRef()` which is added by #2853, it disables closing by backdrop click and escape key by default(to be truly stateless), instead emits `close` event with event data containing what caused it(`escape`, `backdrop`).

It's got similar api to that of https://developer.mozilla.org/en/docs/Web/HTML/Element/dialog

- `[open]` controls whether dialog is shown or not
- `(close)` emits event when either backdrop was clicked or escape was pressed
- `[config]` allows passing in `MdDialogConfig`


@jelbourn @crisbeto 