### PR TITLE
fix(input): hints not being read out by screen readers

### DIFF
--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -30,6 +30,6 @@
           [class.md-warn]="dividerColor == 'warn'"></span>
   </div>
 
-  <div *ngIf="hintLabel != ''" class="md-hint">{{hintLabel}}</div>
+  <div *ngIf="hintLabel != ''" [attr.id]="_hintLabelId" class="md-hint">{{hintLabel}}</div>
   <ng-content select="md-hint"></ng-content>
 </div>

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -46,7 +46,9 @@ describe('MdInputContainer', function () {
         MdInputContainerWithValueBinding,
         MdInputContainerWithFormControl,
         MdInputContainerWithStaticPlaceholder,
-        MdInputContainerMissingMdInputTestController
+        MdInputContainerMissingMdInputTestController,
+        MdInputContainerMultipleHintTestController,
+        MdInputContainerMultipleHintMixedTestController
       ],
     });
 
@@ -271,6 +273,17 @@ describe('MdInputContainer', function () {
     expect(fixture.debugElement.query(By.css('.md-hint'))).not.toBeNull();
   });
 
+  it('sets an id on hint labels', () => {
+    let fixture = TestBed.createComponent(MdInputContainerHintLabelTestController);
+
+    fixture.componentInstance.label = 'label';
+    fixture.detectChanges();
+
+    let hint = fixture.debugElement.query(By.css('.md-hint')).nativeElement;
+
+    expect(hint.getAttribute('id')).toBeTruthy();
+  });
+
   it('supports hint labels elements', () => {
     let fixture = TestBed.createComponent(MdInputContainerHintLabel2TestController);
     fixture.detectChanges();
@@ -283,6 +296,17 @@ describe('MdInputContainer', function () {
     fixture.detectChanges();
     el = fixture.debugElement.query(By.css('md-hint')).nativeElement;
     expect(el.textContent).toBe('label');
+  });
+
+  it('sets an id on the hint element', () => {
+    let fixture = TestBed.createComponent(MdInputContainerHintLabel2TestController);
+
+    fixture.componentInstance.label = 'label';
+    fixture.detectChanges();
+
+    let hint = fixture.debugElement.query(By.css('md-hint')).nativeElement;
+
+    expect(hint.getAttribute('id')).toBeTruthy();
   });
 
   it('supports placeholder attribute', async(() => {
@@ -404,6 +428,55 @@ describe('MdInputContainer', function () {
     const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('textarea');
     expect(textarea).not.toBeNull();
   });
+
+  it('sets the aria-describedby when a hintLabel is set', () => {
+    let fixture = TestBed.createComponent(MdInputContainerHintLabelTestController);
+
+    fixture.componentInstance.label = 'label';
+    fixture.detectChanges();
+
+    let hint = fixture.debugElement.query(By.css('.md-hint')).nativeElement;
+    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(input.getAttribute('aria-describedby')).toBe(hint.getAttribute('id'));
+  });
+
+  it('sets the aria-describedby to the id of the md-hint', () => {
+    let fixture = TestBed.createComponent(MdInputContainerHintLabel2TestController);
+
+    fixture.componentInstance.label = 'label';
+    fixture.detectChanges();
+
+    let hint = fixture.debugElement.query(By.css('.md-hint')).nativeElement;
+    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(input.getAttribute('aria-describedby')).toBe(hint.getAttribute('id'));
+  });
+
+  it('sets the aria-describedby with multiple md-hint instances', () => {
+    let fixture = TestBed.createComponent(MdInputContainerMultipleHintTestController);
+
+    fixture.componentInstance.startId = 'start';
+    fixture.componentInstance.endId = 'end';
+    fixture.detectChanges();
+
+    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(input.getAttribute('aria-describedby')).toBe('start end');
+  });
+
+  it('sets the aria-describedby when a hintLabel is set, in addition to a md-hint', () => {
+    let fixture = TestBed.createComponent(MdInputContainerMultipleHintMixedTestController);
+
+    fixture.detectChanges();
+
+    let hintLabel = fixture.debugElement.query(By.css('.md-hint')).nativeElement;
+    let endLabel = fixture.debugElement.query(By.css('.md-hint[align="end"]')).nativeElement;
+    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+    let ariaValue = input.getAttribute('aria-describedby');
+
+    expect(ariaValue).toBe(`${hintLabel.getAttribute('id')} ${endLabel.getAttribute('id')}`);
+  });
 });
 
 @Component({
@@ -511,6 +584,28 @@ class MdInputContainerInvalidHint2TestController {}
     </md-input-container>`
 })
 class MdInputContainerInvalidHintTestController {}
+
+@Component({
+  template: `
+    <md-input-container>
+      <input mdInput>
+      <md-hint align="start" [id]="startId">Hello</md-hint>
+      <md-hint align="end" [id]="endId">World</md-hint>
+    </md-input-container>`
+})
+class MdInputContainerMultipleHintTestController {
+  startId: string;
+  endId: string;
+}
+
+@Component({
+  template: `
+    <md-input-container hintLabel="Hello">
+      <input mdInput>
+      <md-hint align="end">World</md-hint>
+    </md-input-container>`
+})
+class MdInputContainerMultipleHintMixedTestController {}
 
 @Component({
   template: `<md-input-container><input mdInput [(ngModel)]="model"></md-input-container>`


### PR DESCRIPTION
Adds the `aria-describedby` to inputs within `md-input-container`, which allows screen readers to pick them up and present them to the user.

Fixes #2798.