### PR TITLE
fix(checkbox): ripple color does not change

### DIFF
--- a/src/lib/checkbox/_checkbox-theme.scss
+++ b/src/lib/checkbox/_checkbox-theme.scss
@@ -68,7 +68,7 @@
     }
   }
 
-  .md-checkbox:not(.md-checkbox-disabled) {
+  md-checkbox:not(.md-checkbox-disabled) {
     &.md-primary .md-checkbox-ripple .md-ripple-foreground {
       background-color: md-color($primary, 0.26);
     }


### PR DESCRIPTION
* The ripple color didn't change on the checkbox component because commit 8ce65ca253edc4bf4a47ace970ef441c8b3debe9 accidentally introduced a wrong selector for the checkbox.