### PR TITLE
chore: update saucelabs tunnel binaries

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-TUNNEL_FILE="sc-4.4.2-linux.tar.gz"
+TUNNEL_FILE="sc-4.4.3-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/$TUNNEL_FILE"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 


### PR DESCRIPTION
* Updates the saucelabs tunnel binaries to fix CI flakiness for unit tests and protractor.
  
From what we experienced, older versions of Saucelabs tend to cause flakiness immediately (See `master` branch)

See https://travis-ci.org/angular/material2/jobs/197198984