### PR TITLE
fix(demo): add web animations polyfill to demo site

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "ts-node": "^2.0.0",
     "tslint": "^3.13.0",
     "typescript": "~2.0.10",
-    "uglify-js": "^2.7.5"
+    "uglify-js": "^2.7.5",
+    "web-animations-js": "^2.2.2"
   }
 }

--- a/src/demo-app/index.html
+++ b/src/demo-app/index.html
@@ -20,6 +20,7 @@
   <script src="vendor/systemjs/dist/system.src.js"></script>
   <script src="vendor/zone.js/dist/zone.js"></script>
   <script src="vendor/hammerjs/hammer.min.js"></script>
+  <script src="vendor/web-animations-js/web-animations.min.js"></script>
 
   <script>
     System.import('system-config.js').then(function () {

--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -31,7 +31,13 @@ export const LICENSE_BANNER = `/**
   */`;
 
 export const NPM_VENDOR_FILES = [
-  '@angular', 'core-js/client', 'hammerjs', 'rxjs', 'systemjs/dist', 'zone.js/dist'
+  '@angular',
+  'core-js/client',
+  'hammerjs',
+  'rxjs',
+  'systemjs/dist',
+  'web-animations-js',
+  'zone.js/dist',
 ];
 
 export const COMPONENTS_DIR = join(SOURCE_ROOT, 'lib');


### PR DESCRIPTION
Adds the web animations polyfill to our demo app so that animations work in IE and other browsers that do not natively support them