### PR TITLE
fix(select): only unsubscribe from defined fields in ngOnDestroy

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -55,6 +55,10 @@ describe('MdSelect', () => {
     document.body.removeChild(overlayContainerElement);
   });
 
+  it('does not fail when detectChanges is not called', () => {
+    TestBed.createComponent(BasicSelect);
+  });
+
   describe('overlay panel', () => {
     let fixture: ComponentFixture<BasicSelect>;
     let trigger: HTMLElement;

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -255,8 +255,12 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   ngOnDestroy() {
     this._dropSubscriptions();
-    this._changeSubscription.unsubscribe();
-    this._tabSubscription.unsubscribe();
+    if (this._changeSubscription) {
+      this._changeSubscription.unsubscribe();
+    }
+    if (this._tabSubscription) {
+      this._tabSubscription.unsubscribe();
+    }
   }
 
   /** Toggles the overlay panel open or closed. */


### PR DESCRIPTION
Tests might not call fixture.detectChanges() so the _tabSubscription and _changeSubscription might not be defined in ngOnDestroy because ngAfterContentInit will not be called. When the TestBed is reset, calling unsubscribe on those will result in an error and fail all following tests.