### PR TITLE
fix(toolbar): add toolbar role to host element

### DIFF
--- a/src/lib/toolbar/toolbar.spec.ts
+++ b/src/lib/toolbar/toolbar.spec.ts
@@ -1,10 +1,14 @@
 import {Component} from '@angular/core';
-import {TestBed, async} from '@angular/core/testing';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MdToolbarModule} from './toolbar';
 
 
 describe('MdToolbar', () => {
+
+  let fixture: ComponentFixture<TestApp>;
+  let testComponent: TestApp;
+  let toolbarElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -15,11 +19,13 @@ describe('MdToolbar', () => {
     TestBed.compileComponents();
   }));
 
-  it('should apply class based on color attribute', () => {
-    let fixture = TestBed.createComponent(TestApp);
-    let testComponent = fixture.debugElement.componentInstance;
-    let toolbarElement = fixture.debugElement.query(By.css('md-toolbar')).nativeElement;
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestApp);
+    testComponent = fixture.debugElement.componentInstance;
+    toolbarElement = fixture.debugElement.query(By.css('md-toolbar')).nativeElement;
+  });
 
+  it('should apply class based on color attribute', () => {
     testComponent.toolbarColor = 'primary';
     fixture.detectChanges();
 
@@ -37,6 +43,11 @@ describe('MdToolbar', () => {
     expect(toolbarElement.classList.contains('md-accent')).toBe(false);
     expect(toolbarElement.classList.contains('md-warn')).toBe(true);
   });
+
+  it('should set the toolbar role on the host', () => {
+    expect(toolbarElement.getAttribute('role')).toBe('toolbar');
+  });
+
 });
 
 

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -22,6 +22,9 @@ export class MdToolbarRow {}
   selector: 'md-toolbar, mat-toolbar',
   templateUrl: 'toolbar.html',
   styleUrls: ['toolbar.css'],
+  host: {
+    role: 'toolbar'
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })


### PR DESCRIPTION
* Add the toolbar `role` attribute to the host element to have proper accessibility support.

Fixes #2909