### PR TITLE
docs: fix progress-bar color demo

### DIFF
--- a/src/examples/progress-bar-configurable/progress-bar-configurable-example.html
+++ b/src/examples/progress-bar-configurable/progress-bar-configurable-example.html
@@ -53,7 +53,7 @@
     <section class="example-section">
       <md-progress-bar
           class="example-margin"
-          [attr.color]="color"
+          [color]="color"
           [mode]="mode"
           [value]="value"
           [bufferValue]="bufferValue">


### PR DESCRIPTION
* Fixes the progress-bar demo in the Angular Material docs (https://material.angular.io/components/component/progress-bar)

Fixes #2813