### PR TITLE
fix(select): don't open menu if there are no options

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -117,6 +117,16 @@ describe('MdSelect', () => {
       });
     }));
 
+    it('should not attempt to open a select that does not have any options', () => {
+      fixture.componentInstance.foods = [];
+      fixture.detectChanges();
+
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.select.panelOpen).toBe(false);
+    });
+
   });
 
   describe('selection logic', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -266,7 +266,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   /** Opens the overlay panel. */
   open(): void {
-    if (this.disabled) {
+    if (this.disabled || !this.options.length) {
       return;
     }
     this._calculateOverlayPosition();


### PR DESCRIPTION
Currently the select will attempt to show it's menu when there are no options, which ends up looking like a slight box shadow that shows up above it. This change prevents the menu from opening at all if it's empty.