### PR TITLE
feat(button): add focused state ripple

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -24,10 +24,15 @@ $mat-fab-padding: 16px !default;
 $mat-mini-fab-size: 40px !default;
 $mat-mini-fab-padding: 8px !default;
 
+// Opacity for the focused overlay.
+$md-button-focus-overlay-opacity: 0.12 !default;
+
+
 // Applies base styles to all button types.
 %mat-button-base {
   box-sizing: border-box;
   position: relative;
+  overflow: hidden;
 
   // Reset browser <button> styles.
   @include mat-button-reset();
@@ -51,6 +56,10 @@ $mat-mini-fab-padding: 8px !default;
   padding: $mat-button-padding;
   border-radius: $mat-button-border-radius;
 
+  // Force hardware acceleration. Also helps in certain cases where
+  // the border radius isn't being applied in Chrome.
+  transform: translate3d(0, 0, 0);
+
   &[disabled] {
     cursor: default;
   }
@@ -67,9 +76,6 @@ $mat-mini-fab-padding: 8px !default;
   @extend %mat-button-base;
 
   @include mat-elevation(2);
-
-  // Force hardware acceleration.
-  transform: translate3d(0, 0, 0);
 
   // Animation.
   transition: background $swift-ease-out-duration $swift-ease-out-timing-function,
@@ -108,4 +114,11 @@ $mat-mini-fab-padding: 8px !default;
     padding: $padding 0;
     line-height: $mat-icon-button-line-height;
   }
+}
+
+// Applies a color to the focused state ripple. As per spec, the outer "layer"
+// of the ripple is about twice as opaque as the inside.
+@mixin md-button-ripple-color($color) {
+  box-shadow: rgba($color, $md-button-focus-overlay-opacity) 0 0 0 25px;
+  background-color: rgba($color, $md-button-focus-overlay-opacity / 2);
 }

--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -1,4 +1,5 @@
 @import '../core/theming/theming';
+@import './button-base';
 
 
 // Applies a focus style to an md-button element for each of the supported palettes.
@@ -17,6 +18,25 @@
 
   &.mat-warn .mat-button-focus-overlay {
     background-color: mat-color($warn, 0.12);
+  }
+}
+
+// Applies the focus style color to the focused state ripple for each of the palettes.
+@mixin _md-button-focus-ripple-color($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+
+  &.md-primary .md-button-focus-overlay {
+    @include md-button-ripple-color(md-color($primary));
+  }
+
+  &.md-accent .md-button-focus-overlay {
+    @include md-button-ripple-color(md-color($accent));
+  }
+
+  &.md-warn .md-button-focus-overlay {
+    @include md-button-ripple-color(md-color($warn));
   }
 }
 
@@ -53,14 +73,22 @@
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
-  .mat-button, .mat-icon-button, .mat-raised-button, .mat-fab, .mat-mini-fab {
-    &.cdk-keyboard-focused {
-      @include _mat-button-focus-color($theme);
+  [md-icon-button], [md-raised-button], [md-fab], [md-mini-fab] {
+    &.md-button-focus {
+      @include _md-button-focus-color($theme);
     }
   }
 
-  .mat-button, .mat-icon-button {
-    @include _mat-button-theme-color($theme, 'color');
+  // The colored ripple should only be applied to flat buttons since it's
+  // barely visible on the raised colored buttons.
+  [md-button] {
+    &.md-button-focus {
+      @include _md-button-focus-ripple-color($theme);
+    }
+  }
+
+  [md-button], [md-icon-button] {
+    @include _md-button-theme-color($theme, 'color');
     background: transparent;
 
     // Only flat buttons and icon buttons (not raised or fabs) have a hover style.

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -3,6 +3,7 @@
 
 @import 'button-base';
 @import '../core/a11y/a11y';
+@import '../core/style/variables';
 
 .mat-button, .mat-icon-button {
   @extend %mat-button-base;
@@ -76,12 +77,26 @@
 .mat-button-focus-overlay {
   // The button spec calls for focus on raised buttons (and FABs) to be indicated with a
   // black, 12% opacity shade over the normal color (for both light and dark themes).
-  background-color: rgba(black, 0.12);
-  border-radius: inherit;
+  background-color: rgba(black, $md-button-focus-overlay-opacity);
   pointer-events: none;
   opacity: 0;
 
-  transition: $mat-button-focus-transition;
+  // Adds a slight ripple animation to buttons that were focused via a keyboard interaction.
+  // via https://material.io/guidelines/components/buttons.html#buttons-raised-buttons
+  .md-button-focus[md-button] &, .md-button-focus[md-raised-button] & {
+    @include md-button-ripple-color(black);
+
+    top: 50%;
+    left: 50%;
+    bottom: auto;
+    right: auto;
+
+    width: 80%;
+    padding-bottom: 80%;
+    border-radius: 50%;
+    animation:
+        md-button-focus-ripple 1000ms $md-linear-out-slow-in-timing-function infinite alternate;
+  }
 
   @include cdk-high-contrast {
     // Note that IE will render this in the same way, no
@@ -97,6 +112,13 @@
   // z-index needed to make clipping to border-radius work correctly.
   // http://stackoverflow.com/questions/20001515/chrome-bug-border-radius-not-clipping-contents-when-combined-with-css-transiti
   z-index: 1;
+}
+
+@keyframes md-button-focus-ripple {
+  // Note: these should use `translate3d`, because IE and Edge have some issues where the
+  // translation resets on every iteration when `translate` is used.
+  0% { transform: translate3d(-50%, -50%, 0) scale(1); }
+  100% { transform: translate3d(-50%, -50%, 0) scale(1.1); }
 }
 
 // Add an outline to make it more visible in high contrast mode.


### PR DESCRIPTION
Implements the focused state [pulsing ripple from the spec](https://material.io/guidelines/components/buttons.html#buttons-raised-buttons).

Example:
![buttons](https://cloud.githubusercontent.com/assets/4450522/22619884/563fd86a-eafe-11e6-843f-415a25f5a976.gif)
