### PR TITLE
chore: fix deprecation warning and bump stylelint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "run-sequence": "^1.2.2",
     "sass": "^0.5.0",
     "selenium-webdriver": "^3.0.1",
-    "stylelint": "^7.7.1",
+    "stylelint": "^7.8.0",
     "travis-after-modes": "0.0.7",
     "ts-node": "^2.0.0",
     "tslint": "^3.13.0",

--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -31,7 +31,6 @@
     "declaration-block-no-duplicate-properties": [ true, {
       "ignore": ["consecutive-duplicates-with-different-values"]
     }],
-    "declaration-block-no-ignored-properties": true,
     "declaration-block-trailing-semicolon": "always",
     "declaration-block-single-line-max-declarations": 1,
     "declaration-block-semicolon-space-before": "never",


### PR DESCRIPTION
Removes a deprecated Stylelint rule from our config and bumps the Stylelint version.