### PR TITLE
chore(focus-classes): fix failing tests when browser is blurred

### DIFF
--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -2,34 +2,37 @@
 Error.stackTraceLimit = Infinity;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
 
-__karma__.loaded = function () {
-};
+__karma__.loaded = function () {};
 
-var distPath = '/base/dist/';
+var baseDir = '/base/dist/';
+var configFile = baseDir + '@angular/material/system-config-spec.js';
+var specFiles = Object.keys(window.__karma__.files).filter(isMaterialSpecFile);
 
-function isJsFile(path) {
-  return path.slice(-3) == '.js';
+// Configure the base path for dist/
+System.config({baseURL: baseDir});
+
+// Load the spec SystemJS configuration file.
+System.import(configFile)
+  .then(configureTestBed)
+  .then(runMaterialSpecs)
+  .then(__karma__.start, __karma__.error);
+
+
+/** Runs the Angular Material specs in Karma. */
+function runMaterialSpecs() {
+  // By importing all spec files, Karma will run the tests directly.
+  return Promise.all(specFiles.map(function(fileName) {
+    return System.import(fileName);
+  }));
 }
 
-function isSpecFile(path) {
-  return path.slice(-8) == '.spec.js';
+/** Whether the specified file is part of Angular Material. */
+function isMaterialSpecFile(path) {
+  return path.slice(-8) === '.spec.js' && path.indexOf('vendor') === -1;
 }
 
-function isMaterialFile(path) {
-  return isJsFile(path) && path.indexOf('vendor') == -1;
-}
-
-var allSpecFiles = Object.keys(window.__karma__.files)
-  .filter(isSpecFile)
-  .filter(isMaterialFile);
-
-// Load our SystemJS configuration.
-System.config({
-  baseURL: distPath
-});
-
-System.import(distPath + '@angular/material/system-config-spec.js').then(function() {
-  // Load and configure the TestComponentBuilder.
+/** Configures Angular's TestBed. */
+function configureTestBed() {
   return Promise.all([
     System.import('@angular/core/testing'),
     System.import('@angular/platform-browser-dynamic/testing')
@@ -40,16 +43,8 @@ System.import(distPath + '@angular/material/system-config-spec.js').then(functio
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
     testing.TestBed.initTestEnvironment(
-        testingBrowser.BrowserDynamicTestingModule,
-        testingBrowser.platformBrowserDynamicTesting());
+      testingBrowser.BrowserDynamicTestingModule,
+      testingBrowser.platformBrowserDynamicTesting()
+    );
   });
-}).then(function() {
-  // Finally, load all spec files.
-  // This will run the tests directly.
-  return Promise.all(
-    allSpecFiles.map(function (moduleName) {
-      return System.import(moduleName).then(function(module) {
-        return module;
-      });
-    }));
-}).then(__karma__.start, __karma__.error);
+}


### PR DESCRIPTION
On Saucelabs, browsers will run simultaneously and therefore can't focus all browser windows at the same time.

This is problematic when testing focus states. Chrome and Firefoxonly fire FocusEvents when the window is focused. This issue also appears locally.

Also while investigating the `karma-test-shim.js` file looked very ugly, so I refactored it a bit (ES6 not allowed)

Fixes #2903.