### PR TITLE
chore(autocomplete): Add autocomplete exports to the `index.ts`.

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './core';
 export * from './module';
 
+export * from './autocomplete/index';
 export * from './button/index';
 export * from './button-toggle/index';
 export * from './card/index';


### PR DESCRIPTION
Using the latest nightly build in https://github.com/angular/material2-builds there wasnt a way to import only the `MdAutocompleteModule` nor its components from `@angular/material` because it wasnt in the `index.ts` file.

Looked at the opened PR's and didnt see it in them either, so just creating this PR just in case (Also a nice way to do my first little contribution 😄) 
