### PR TITLE
chore: update tslint to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "travis-after-modes": "0.0.7",
     "ts-node": "^2.0.0",
     "tslint": "^4.4.2",
+    "tslint-no-unused-var": "0.0.6",
     "typescript": "~2.0.10",
     "uglify-js": "^2.7.5",
     "web-animations-js": "^2.2.2"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "stylelint": "^7.7.1",
     "travis-after-modes": "0.0.7",
     "ts-node": "^2.0.0",
-    "tslint": "^3.13.0",
+    "tslint": "^4.4.2",
     "typescript": "~2.0.10",
     "uglify-js": "^2.7.5",
     "web-animations-js": "^2.2.2"

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -21,7 +21,7 @@ export type ElementBoundingPositions = {
   right: number;
   bottom: number;
   left: number;
-}
+};
 
 /**
  * A strategy for positioning overlays. Using this strategy, an overlay is given an

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -31,7 +31,7 @@ const MAX_ANGLE = 359.99 / 100;
 export type ProgressSpinnerMode = 'determinate' | 'indeterminate';
 
 type EasingFn = (currentTime: number, startValue: number,
-                 changeInValue: number, duration: number) => number
+                 changeInValue: number, duration: number) => number;
 
 
 /**

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -331,7 +331,7 @@ export class TooltipComponent {
       // trigger interaction and close the tooltip right after it was displayed.
       this._closeOnInteraction = false;
 
-      // Mark for check so if any parent component has set the 
+      // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
       this._changeDetectorRef.markForCheck();
       setTimeout(() => { this._closeOnInteraction = true; }, 0);
@@ -352,7 +352,7 @@ export class TooltipComponent {
       this._visibility = 'hidden';
       this._closeOnInteraction = false;
 
-      // Mark for check so if any parent component has set the 
+      // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
       this._changeDetectorRef.markForCheck();
     }, delay);

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,5 @@
 {
+  "rulesDirectory": ["node_modules/tslint-no-unused-var"],
   "rules": {
     "max-line-length": [true, 100],
     // Disable this flag because of SHA tslint#48b0c597f9257712c7d1f04b55ed0aa60e333f6a
@@ -23,11 +24,7 @@
     "no-bitwise": true,
     "no-shadowed-variable": true,
     "no-unused-expression": true,
-    // This flag has been deprecated in favor the built-in TypeScript options that detect unused
-    // parameter and locals. See noUnusedLocals and noUnusedParameters. These options now throw
-    // at compilation and reduce flexibility when debugging. We should temporary keep the
-    // deprecated flag and see if TSLint reverts the deprecation.
-    "no-unused-variable": [true, {"ignore-pattern": "^(_.*)$"}],
+    "no-unused-var": [true, {"ignore-pattern": "^(_.*)$"}],
     "one-line": [
       true,
       "check-catch",

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,10 @@
 {
   "rules": {
     "max-line-length": [true, 100],
-    "no-inferrable-types": true,
+    // Disable this flag because of SHA tslint#48b0c597f9257712c7d1f04b55ed0aa60e333f6a
+    // TSLint now shows warnings if types for properties are inferred. This rule needs to be
+    // disabled because all properties need to have explicit types set to work for Dgeni.
+    "no-inferrable-types": false,
     "class-name": true,
     "comment-format": [
       true,
@@ -20,6 +23,10 @@
     "no-bitwise": true,
     "no-shadowed-variable": true,
     "no-unused-expression": true,
+    // This flag has been deprecated in favor the built-in TypeScript options that detect unused
+    // parameter and locals. See noUnusedLocals and noUnusedParameters. These options now throw
+    // at compilation and reduce flexibility when debugging. We should temporary keep the
+    // deprecated flag and see if TSLint reverts the deprecation.
     "no-unused-variable": [true, {"ignore-pattern": "^(_.*)$"}],
     "one-line": [
       true,


### PR DESCRIPTION
* Updates TSLint to the latest version.
* Due to some breaking changes we had to temporary disable the `no-inferrable-types` rule. Need to revisit once https://github.com/palantir/tslint/issues/2158 is addressed.

**Note**: I wrote a TSLint modification that fixes all warnings for `no-inferrable-types`, but since Dgeni explicitly needs types the changes are obsolete (See [here](https://i.gyazo.com/c64e00a5ee66feed48ee7cbb3d527e39.png))

**Note**: This change is mostly in favor of #2175 because we want to have our own custom TSLint rules instead of having the `forbidden-identifiers` script.

References #2175