### PR TITLE
fix(checkbox): rename tabindex to tabIndex

### DIFF
--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -7,7 +7,7 @@
            [checked]="checked"
            [disabled]="disabled"
            [name]="name"
-           [tabIndex]="tabindex"
+           [tabIndex]="tabIndex"
            [indeterminate]="indeterminate"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -724,7 +724,7 @@ class MultipleCheckboxes { }
 @Component({
   template: `
     <md-checkbox
-        [tabindex]="customTabIndex"
+        [tabIndex]="customTabIndex"
         [disabled]="isDisabled"
         [disableRipple]="disableRipple">
     </md-checkbox>`,

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -138,8 +138,8 @@ export class MdCheckbox implements ControlValueAccessor {
   get disabled(): boolean { return this._disabled; }
   set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
-  /** @docs-private */
-  @Input() tabindex: number = 0;
+  /** Tabindex value that is passed to the underlying input element. */
+  @Input() tabIndex: number = 0;
 
   /** Name value will be applied to the input element if present */
   @Input() name: string = null;


### PR DESCRIPTION
* Renames the checkbox `tabindex` input to the `tabIndex` input. 

This is consistent with other API's like for the slide-toggle and also with native inputs. See https://github.com/angular/material2/pull/2688#discussion_r96473347