### PR TITLE
build: no longer run dgeni twice

### DIFF
--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -142,10 +142,3 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
 
 
 module.exports = apiDocsPackage;
-
-// Run the dgeni pipeline, generating documentation.
-// TODO(jelbourn): remove this once the process is more final in favor of gulp.
-let dgeni = new Dgeni([apiDocsPackage]);
-dgeni.generate().then(docs => {
-  console.log(docs);
-});


### PR DESCRIPTION
* Currently when running dgeni using the `gulp api` task, Dgeni will run twice.
  This happens because the `dgeni/index.js` file calls `generate()` and the gulp task does that as well.

The `dgeni/index.js` file should be just responsible for exporting the dgeni package.