### PR TITLE
fix(select): set default font size

### DIFF
--- a/src/lib/core/option/_option.scss
+++ b/src/lib/core/option/_option.scss
@@ -1,6 +1,9 @@
 @import '../style/menu-common';
 @import '../a11y/a11y';
 
+/** Default size of option text. */
+$mat-option-font-size: 16px !default;
+
 /**
  * This mixin contains shared option styles between the select and
  * autocomplete components.
@@ -11,6 +14,7 @@
     position: relative;
     cursor: pointer;
     outline: none;
+    font-size: $mat-option-font-size;
 
     &[aria-disabled='true'] {
       cursor: default;

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -8,6 +8,7 @@ $mat-select-trigger-min-width: 112px !default;
 $mat-select-arrow-size: 5px !default;
 $mat-select-arrow-margin: 4px !default;
 $mat-select-panel-max-height: 256px !default;
+$mat-select-trigger-font-size: 16px !default;
 
 .mat-select {
   display: inline-block;
@@ -23,6 +24,7 @@ $mat-select-panel-max-height: 256px !default;
   cursor: pointer;
   position: relative;
   box-sizing: border-box;
+  font-size: $mat-select-trigger-font-size;
 
   [aria-disabled='true'] & {
     @include mat-control-disabled-underline();


### PR DESCRIPTION
Currently the font size in the trigger is purely inherited, which causes weirdness when inheriting a font size that's different from the default option size.