### PR TITLE
fix(snack-bar): SimpleSnackBar not being exported

### DIFF
--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -27,7 +27,7 @@ import {MdIconModule} from './icon/index';
 import {MdProgressSpinnerModule} from './progress-spinner/index';
 import {MdProgressBarModule} from './progress-bar/index';
 import {MdInputModule} from './input/index';
-import {MdSnackBarModule} from './snack-bar/snack-bar';
+import {MdSnackBarModule} from './snack-bar/index';
 import {MdTabsModule} from './tabs/index';
 import {MdToolbarModule} from './toolbar/index';
 import {MdTooltipModule} from './tooltip/index';

--- a/src/lib/snack-bar/index.ts
+++ b/src/lib/snack-bar/index.ts
@@ -1,4 +1,29 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {OverlayModule, PortalModule, CompatibilityModule, LIVE_ANNOUNCER_PROVIDER} from '../core';
+import {CommonModule} from '@angular/common';
+import {MdSnackBar} from './snack-bar';
+import {MdSnackBarContainer} from './snack-bar-container';
+import {SimpleSnackBar} from './simple-snack-bar';
+
+@NgModule({
+  imports: [OverlayModule, PortalModule, CommonModule, CompatibilityModule],
+  exports: [MdSnackBarContainer, CompatibilityModule],
+  declarations: [MdSnackBarContainer, SimpleSnackBar],
+  entryComponents: [MdSnackBarContainer, SimpleSnackBar],
+  providers: [MdSnackBar, LIVE_ANNOUNCER_PROVIDER]
+})
+export class MdSnackBarModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSnackBarModule,
+      providers: []
+    };
+  }
+}
+
 export * from './snack-bar';
 export * from './snack-bar-container';
 export * from './snack-bar-config';
 export * from './snack-bar-ref';
+export * from './simple-snack-bar';

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -9,10 +9,8 @@ import {
 } from '@angular/core/testing';
 import {NgModule, Component, Directive, ViewChild, ViewContainerRef} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {MdSnackBar, MdSnackBarModule} from './snack-bar';
-import {MdSnackBarConfig} from './snack-bar-config';
+import {MdSnackBarModule, MdSnackBar, MdSnackBarConfig, SimpleSnackBar} from './index';
 import {OverlayContainer, LiveAnnouncer} from '../core';
-import {SimpleSnackBar} from './simple-snack-bar';
 
 
 // TODO(josephperrott): Update tests to mock waiting for time to complete for animations.

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -1,24 +1,12 @@
-import {
-  NgModule,
-  ModuleWithProviders,
-  Injectable,
-  ComponentRef,
-  Optional,
-  SkipSelf,
-} from '@angular/core';
+import {Injectable, ComponentRef, Optional, SkipSelf} from '@angular/core';
 import {
   ComponentType,
   ComponentPortal,
   Overlay,
-  OverlayModule,
   OverlayRef,
   OverlayState,
-  PortalModule,
   LiveAnnouncer,
-  CompatibilityModule,
-  LIVE_ANNOUNCER_PROVIDER,
 } from '../core';
-import {CommonModule} from '@angular/common';
 import {MdSnackBarConfig} from './snack-bar-config';
 import {MdSnackBarRef} from './snack-bar-ref';
 import {MdSnackBarContainer} from './snack-bar-container';
@@ -159,22 +147,4 @@ export class MdSnackBar {
  */
 function _applyConfigDefaults(config: MdSnackBarConfig): MdSnackBarConfig {
   return extendObject(new MdSnackBarConfig(), config);
-}
-
-
-@NgModule({
-  imports: [OverlayModule, PortalModule, CommonModule, CompatibilityModule],
-  exports: [MdSnackBarContainer, CompatibilityModule],
-  declarations: [MdSnackBarContainer, SimpleSnackBar],
-  entryComponents: [MdSnackBarContainer, SimpleSnackBar],
-  providers: [MdSnackBar, LIVE_ANNOUNCER_PROVIDER]
-})
-export class MdSnackBarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSnackBarModule,
-      providers: []
-    };
-  }
 }


### PR DESCRIPTION
* Fixes the `SimpleSnackBar` class not being exported.
* Moves the `MdSnackBarModule` to the `index.ts` for consistency with other modules.

Fixes #3010.