### PR TITLE
build: fix invalid glob to remove specs

### DIFF
--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -12,7 +12,7 @@ const argv = minimist(process.argv.slice(3));
 
 /** Removes redundant spec files from the release. TypeScript creates definition files for specs. */
 // TODO(devversion): tsconfig files should share code and don't generate spec files for releases.
-task(':build:release:clean-spec', cleanTask('dist/**/*(-|.)spec.*'));
+task(':build:release:clean-spec', cleanTask('dist/**/*+(-|.)spec.*'));
 
 
 task('build:release', function(done: () => void) {


### PR DESCRIPTION
* Fixes an invalid glob that is used to cleanup the dist folder before cutting a release. Currently all `spec.d.ts` files will be shipped.

@kara This should be pretty important for future releases ;)