### PR TITLE
fix(select): set select value to trigger height and center text

### DIFF
--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -19,7 +19,7 @@
     }
   }
 
-  .mat-select-border {
+  .mat-select-underline {
     background-color: mat-color($foreground, divider);
 
     .mat-select:focus:not(.mat-select-disabled) & {

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -9,16 +9,25 @@
 
   .mat-select-trigger {
     color: mat-color($foreground, hint-text);
-    border-bottom: 1px solid mat-color($foreground, divider);
 
     .mat-select:focus:not(.mat-select-disabled) & {
       color: mat-color($primary);
-      border-bottom: 1px solid mat-color($primary);
     }
 
     .mat-select.ng-invalid.ng-touched:not(.mat-select-disabled) & {
       color: mat-color($warn);
-      border-bottom: 1px solid mat-color($warn);
+    }
+  }
+
+  .mat-select-border {
+    background-color: mat-color($foreground, divider);
+
+    .mat-select:focus:not(.mat-select-disabled) & {
+      background-color: mat-color($primary);
+    }
+
+    .mat-select.ng-invalid.ng-touched:not(.mat-select-disabled) & {
+      background-color: mat-color($warn);
     }
   }
 

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -5,7 +5,7 @@
     <span class="mat-select-value-text">{{ selected?.viewValue }}</span>
   </span>
   <span class="mat-select-arrow"></span>
-  <span class="mat-select-border"></span>
+  <span class="mat-select-underline"></span>
 </div>
 
 <template cdk-connected-overlay [origin]="origin" [open]="panelOpen" hasBackdrop (backdropClick)="close()"

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -1,8 +1,11 @@
 <div class="mat-select-trigger" cdk-overlay-origin (click)="toggle()" #origin="cdkOverlayOrigin" #trigger>
   <span class="mat-select-placeholder" [class.mat-floating-placeholder]="this.selected"
    [@transformPlaceholder]="_placeholderState" [style.width.px]="_selectedValueWidth"> {{ placeholder }} </span>
-  <span class="mat-select-value" *ngIf="selected"> {{ selected?.viewValue }} </span>
+  <span class="mat-select-value" *ngIf="selected">
+    <span class="mat-select-value-text">{{ selected?.viewValue }}</span>
+  </span>
   <span class="mat-select-arrow"></span>
+  <span class="mat-select-border"></span>
 </div>
 
 <template cdk-connected-overlay [origin]="origin" [open]="panelOpen" hasBackdrop (backdropClick)="close()"

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -29,7 +29,6 @@ $mat-select-trigger-font-size: 16px !default;
   font-size: $mat-select-trigger-font-size;
 
   [aria-disabled='true'] & {
-    background-position: 0 bottom;
     cursor: default;
     user-select: none;
   }
@@ -82,7 +81,7 @@ $mat-select-trigger-font-size: 16px !default;
 
 .mat-select-value {
   position: absolute;
-  max-width: calc(100% - #{$mat-select-arrow-size * 2});
+  max-width: calc(100% - #{($mat-select-arrow-size + $mat-select-arrow-margin) * 2});
 
   // Firefox and some versions of IE incorrectly keep absolutely
   // positioned children of flex containers in the flex flow when calculating

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -78,13 +78,16 @@ $mat-select-trigger-font-size: 16px !default;
   // position. This has been fixed for Firefox 52, slated for early 2017.
   // Bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=874718
   //
-  // In the meantime, we must adjust the left position to 0 to mimic where it
-  // would be if it were correctly taken out of the flex flow. It's also necessary
-  // to adjust the top value because absolutely positioned elements should not be
-  // affected by the flex container's "align-items" property either. To center the text,
-  // we must offset by 6px (6px top + 6px bottom + 18px text height = 30px total height).
+  // In the meantime, we must adjust the position to fit the top and left edge of the
+  // containing element with a height matching the trigger container.
+  // In doing so, we can use align-items: center to allow the text to
+  // correctly position itself in the middle of the container.
+  top: 0;
   left: 0;
-  top: 6px;
+  height: $mat-select-trigger-height;
+
+  display: flex;
+  align-items: center;
 
   [dir='rtl'] & {
     left: auto;

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -19,7 +19,6 @@ $mat-select-trigger-font-size: 16px !default;
 
 .mat-select-trigger {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   height: $mat-select-trigger-height;
   min-width: $mat-select-trigger-min-width;
@@ -34,7 +33,7 @@ $mat-select-trigger-font-size: 16px !default;
   }
 }
 
-.mat-select-border {
+.mat-select-underline {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -52,6 +51,7 @@ $mat-select-trigger-font-size: 16px !default;
   position: relative;
   padding: 0 2px;
   transform-origin: left top;
+  flex-grow: 1;
 
   // These values are duplicated from animation code in order to
   // allow placeholders to sometimes float without animating,
@@ -82,6 +82,7 @@ $mat-select-trigger-font-size: 16px !default;
 .mat-select-value {
   position: absolute;
   max-width: calc(100% - #{($mat-select-arrow-size + $mat-select-arrow-margin) * 2});
+  flex-grow: 1;
 
   // Firefox and some versions of IE incorrectly keep absolutely
   // positioned children of flex containers in the flex flow when calculating

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -29,11 +29,23 @@ $mat-select-trigger-font-size: 16px !default;
   font-size: $mat-select-trigger-font-size;
 
   [aria-disabled='true'] & {
-    @include mat-control-disabled-underline();
-    border-bottom: transparent;
     background-position: 0 bottom;
     cursor: default;
     user-select: none;
+  }
+}
+
+.mat-select-border {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+
+  [aria-disabled='true'] & {
+    @include mat-control-disabled-underline();
+    background-color: transparent;
+    background-position: 0 bottom;
   }
 }
 
@@ -69,7 +81,6 @@ $mat-select-trigger-font-size: 16px !default;
 }
 
 .mat-select-value {
-  @include mat-truncate-line();
   position: absolute;
   max-width: calc(100% - #{$mat-select-arrow-size * 2});
 
@@ -78,13 +89,12 @@ $mat-select-trigger-font-size: 16px !default;
   // position. This has been fixed for Firefox 52, slated for early 2017.
   // Bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=874718
   //
-  // In the meantime, we must adjust the position to fit the top and left edge of the
-  // containing element with a height matching the trigger container.
-  // In doing so, we can use align-items: center to allow the text to
+  // In the meantime, we must adjust the position to fit the top, left, and bottom edge of the
+  // containing trigger element. In doing so, we can use align-items: center to allow the text to
   // correctly position itself in the middle of the container.
   top: 0;
   left: 0;
-  height: $mat-select-trigger-height;
+  bottom: 0;
 
   display: flex;
   align-items: center;
@@ -93,6 +103,11 @@ $mat-select-trigger-font-size: 16px !default;
     left: auto;
     right: 0;
   }
+}
+
+.mat-select-value-text {
+  @include mat-truncate-line();
+  line-height: $mat-select-trigger-height;
 }
 
 .mat-select-arrow {


### PR DESCRIPTION
Issue was that the text div was actually being calculated as 29px, not 30px, because the trigger had a border bottom of 1px. This made the following code incorrect since the option value height was actually 29px:

```
/**
 * Must adjust for the difference in height between the option and the trigger,
 * so the text will align on the y axis.
 * (SELECT_OPTION_HEIGHT (48) - SELECT_TRIGGER_HEIGHT (30)) / 2 = 9
 */
export const SELECT_OPTION_HEIGHT_ADJUSTMENT = 9;
``` 

This change forces the option value to be 30px and centers the text using flex. Tested on Linux Chrome, Linux FF, Windows IE11 & Edge, Mac Chrome, and Mac FF. 

Closes #2977 