### PR TITLE
fix(overlay): fix pointer events for ie11

### DIFF
--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -40,7 +40,7 @@ describe('Overlay directives', () => {
 
     expect(overlayContainerElement.textContent).toContain('Menu content');
     expect(getPaneElement().style.pointerEvents)
-      .toBeFalsy('Expected the overlay pane to enable pointerEvents when attached.');
+      .toBe('auto', 'Expected the overlay pane to enable pointerEvents when attached.');
 
     fixture.componentInstance.isOpen = false;
     fixture.detectChanges();

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -128,7 +128,7 @@ export class OverlayRef implements PortalHost {
 
   /** Toggles the pointer events for the overlay pane element. */
   private _togglePointerEvents(enablePointer: boolean) {
-    this._pane.style.pointerEvents = enablePointer ? null : 'none';
+    this._pane.style.pointerEvents = enablePointer ? 'auto' : 'none';
   }
 
   /** Attaches a backdrop for this overlay. */

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -67,10 +67,11 @@ describe('Overlay', () => {
     let paneElement = overlayRef.overlayElement;
 
     overlayRef.attach(componentPortal);
+    viewContainerFixture.detectChanges();
 
     expect(paneElement.childNodes.length).not.toBe(0);
     expect(paneElement.style.pointerEvents)
-      .toBeFalsy('Expected the overlay pane to enable pointerEvents when attached.');
+      .toBe('auto', 'Expected the overlay pane to enable pointerEvents when attached.');
 
     overlayRef.detach();
 


### PR DESCRIPTION
Fixes https://github.com/angular/material2/issues/3022. 

`pointer-events` CSS property was being overwritten to `null` when the overlay pane was re-attached. In IE11, setting to null does not clear the property. Pointer events remained turned off.  It needs to be set explicitly to `auto` or it won't work after the first time.