### PR TITLE
refactor(input): alternative approach to sizing the placeholder

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -173,7 +173,8 @@ $mat-input-underline-disabled-background-image:
 
   // Keeps the element height since the placeholder text is `position: absolute`.
   &::after {
-    content: '\\00a0';
+    content: '';
+    display: inline-table;
   }
 }
 


### PR DESCRIPTION
Switches to an alternative approach, using `display: inline-table`, to set the size of the `.mat-input-placeholder-wrapper`, because there are reports that the unicode content may end up getting rendered in some browsers.

CC @kara 