### PR TITLE
fix(sidenav): use vw instead of percentage for sidenav min width

### DIFF
--- a/src/demo-app/demo-app/demo-app.scss
+++ b/src/demo-app/demo-app/demo-app.scss
@@ -9,7 +9,7 @@ body {
   }
 
   .mat-sidenav {
-    min-width: 15%;
+    min-width: 15vw;
 
     .mat-button {
       width: 100%;

--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -98,7 +98,7 @@
   top: 0;
   bottom: 0;
   z-index: 3;
-  min-width: 5%;
+  min-width: 5vw;
   outline: 0;
 
   @include mat-sidenav-transition(0, -100%);


### PR DESCRIPTION
There was a problem with using a percentage based width since the width could have changed between the beginning animation of opening the sidenav and ending animation, resulting in the sidenav content being pushed too far one way or the other. Using a default fixed width reduces the chance of this occurring.