### PR TITLE
feat(snack-bar): add `dismiss` method to `MdSnackBar` service

### DIFF
--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -150,6 +150,19 @@ describe('MdSnackBar', () => {
     });
   }));
 
+  it('should be able to get dismissed through the service', async(() => {
+    snackBar.open(simpleMessage);
+    viewContainerFixture.detectChanges();
+    expect(overlayContainerElement.childElementCount).toBeGreaterThan(0);
+
+    snackBar.dismiss();
+    viewContainerFixture.detectChanges();
+
+    viewContainerFixture.whenStable().then(() => {
+      expect(overlayContainerElement.childElementCount).toBe(0);
+    });
+  }));
+
   it('should clean itself up when the view container gets destroyed', async(() => {
     snackBar.open(simpleMessage, null, { viewContainerRef: testViewContainerRef });
     viewContainerFixture.detectChanges();

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -106,6 +106,15 @@ export class MdSnackBar {
   }
 
   /**
+   * Dismisses the currently-visible snack bar.
+   */
+  dismiss(): void {
+    if (this._openedSnackBarRef) {
+      this._openedSnackBarRef.dismiss();
+    }
+  }
+
+  /**
    * Attaches the snack bar container component to the overlay.
    */
   private _attachSnackBarContainer(overlayRef: OverlayRef,


### PR DESCRIPTION
Adds a `dismiss` method to the snack bar service, which dismisses the currently-open instance. This is mostly for convenience since the spec only allows for one snack bar to open at a time.