### PR TITLE
fix(button): raised buttons in dark theme

### DIFF
--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -71,9 +71,12 @@
   }
 
   .mat-raised-button, .mat-fab, .mat-mini-fab {
+    // Default properties when not using any [color] value.
+    color: mat-color($foreground, text);
+    background-color: mat-color($background, raised-button);
+
     @include _mat-button-theme-color($theme, 'color', default-contrast);
     @include _mat-button-theme-color($theme, 'background-color');
-    background-color: mat-color($background, background);
   }
 
   .mat-fab, .mat-mini-fab {

--- a/src/lib/core/theming/_palette.scss
+++ b/src/lib/core/theming/_palette.scss
@@ -649,7 +649,8 @@ $mat-light-theme-background: (
   hover:      rgba(black, 0.04), // TODO(kara): check style with Material Design UX
   card:       white,
   dialog:     white,
-  disabled-button:   rgba(black, 0.12)
+  disabled-button: rgba(black, 0.12),
+  raised-button: white,
 );
 
 // Background palette for dark themes.
@@ -660,7 +661,8 @@ $mat-dark-theme-background: (
   hover:      rgba(white, 0.04), // TODO(kara): check style with Material Design UX
   card:       map_get($mat-grey, 800),
   dialog:     map_get($mat-grey, 800),
-  disabled-button: rgba(white, 0.12)
+  disabled-button: rgba(white, 0.12),
+  raised-button: map-get($mat-grey, 800),
 );
 
 // Foreground palette for light themes.


### PR DESCRIPTION
* Fixes the wrong background and foreground color for raised buttons in a dark theme.

_Also here is an comparison of an Android app using AppCompat (dark theme)_

| Before | After | Expected
| ------- | ------ | ---- |
| <img src="https://i.gyazo.com/22b21077d14c5f2bb7717886f3fb7b04.png" width="200px"> |  <img src="https://i.gyazo.com/293047c691122c3663824a17a4138e92.png" width="200px"> | <img src="https://cloud.githubusercontent.com/assets/4987015/22864186/04e35a46-f14d-11e6-9b21-b20711faf14d.png" width="400px"> |


The background and foreground hues are specified to be `grey@800` [here](https://material.io/guidelines/style/color.html#color-text-background-colors)



