### PR TITLE
build: fix jasmine types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/glob": "^5.0.30",
     "@types/gulp": "^3.8.32",
     "@types/hammerjs": "^2.0.34",
-    "@types/jasmine": "^2.5.41",
+    "@types/jasmine": "2.5.41",
     "@types/merge2": "^0.3.29",
     "@types/minimist": "^1.2.0",
     "@types/node": "^7.0.4",


### PR DESCRIPTION
Currently `gulp test` shows some issues with the jasmine types. 

These are now appearing because we didn't lock the dependency and with SHA [DefinitelyTyped#4a80522](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/4a8052290cc86a13f677cc25a5a9b82a64318b47#diff-6048ce6cebea783b369f5ad74fe66cffR39) an TS issue has been introduced.

Just locking to the type version before fixes the issue.

Fixes #3074