### PR TITLE
fix(dialog): escape key not working once element loses focus

### DIFF
--- a/e2e/components/dialog/dialog.e2e.ts
+++ b/e2e/components/dialog/dialog.e2e.ts
@@ -35,6 +35,16 @@ describe('dialog', () => {
     });
   });
 
+  it('should close by pressing escape when the first tabbable element has lost focus', () => {
+    element(by.id('default')).click();
+
+    waitForDialog().then(() => {
+      clickElementAtPoint('md-dialog-container', { x: 0, y: 0 });
+      pressKeys(Key.ESCAPE);
+      expectToExist('md-dialog-container', false);
+    });
+  });
+
   it('should close by clicking on the "close" button', () => {
     element(by.id('default')).click();
 

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -27,7 +27,6 @@ import 'rxjs/add/operator/first';
   host: {
     '[class.mat-dialog-container]': 'true',
     '[attr.role]': 'dialogConfig?.role',
-    '(keydown.escape)': 'handleEscapeKey()',
   },
   encapsulation: ViewEncapsulation.None,
 })
@@ -91,16 +90,6 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
       this._elementFocusedBeforeDialogWasOpened = document.activeElement;
       this._focusTrap.focusFirstTabbableElement();
     });
-  }
-
-  /**
-   * Handles the user pressing the Escape key.
-   * @docs-private
-   */
-  handleEscapeKey() {
-    if (!this.dialogConfig.disableClose) {
-      this.dialogRef.close();
-    }
   }
 
   ngOnDestroy() {

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -1,4 +1,5 @@
 import {OverlayRef} from '../core';
+import {MdDialogConfig} from './dialog-config';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
@@ -17,7 +18,7 @@ export class MdDialogRef<T> {
   /** Subject for notifying the user that the dialog has finished closing. */
   private _afterClosed: Subject<any> = new Subject();
 
-  constructor(private _overlayRef: OverlayRef) { }
+  constructor(private _overlayRef: OverlayRef, public config: MdDialogConfig) { }
 
   /**
    * Close the dialog.

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -15,13 +15,12 @@ import {NgModule,
   Injector,
   Inject,
 } from '@angular/core';
-import {By} from '@angular/platform-browser';
 import {MdDialogModule} from './index';
 import {MdDialog} from './dialog';
 import {OverlayContainer} from '../core';
 import {MdDialogRef} from './dialog-ref';
-import {MdDialogContainer} from './dialog-container';
 import {MD_DIALOG_DATA} from './dialog-injector';
+import {ESCAPE} from '../core/keyboard/keycodes';
 
 
 describe('MdDialog', () => {
@@ -136,11 +135,7 @@ describe('MdDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let dialogContainer: MdDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(MdDialogContainer)).componentInstance;
-
-    // Fake the user pressing the escape key by calling the handler directly.
-    dialogContainer.handleEscapeKey();
+    dispatchKeydownEvent(document, ESCAPE);
 
     expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
   });
@@ -324,11 +319,7 @@ describe('MdDialog', () => {
 
       viewContainerFixture.detectChanges();
 
-      let dialogContainer: MdDialogContainer = viewContainerFixture.debugElement.query(
-          By.directive(MdDialogContainer)).componentInstance;
-
-      // Fake the user pressing the escape key by calling the handler directly.
-      dialogContainer.handleEscapeKey();
+      dispatchKeydownEvent(document, ESCAPE);
 
       expect(overlayContainerElement.querySelector('md-dialog-container')).toBeTruthy();
     });
@@ -565,3 +556,15 @@ const TEST_DIRECTIVES = [
   ],
 })
 class DialogTestModule { }
+
+
+// TODO(crisbeto): switch to using function from common testing utils once #2943 is merged.
+function dispatchKeydownEvent(element: Node, keyCode: number) {
+  let event: any = document.createEvent('KeyboardEvent');
+  (event.initKeyEvent || event.initKeyboardEvent).bind(event)(
+      'keydown', true, true, window, 0, 0, 0, 0, 0, keyCode);
+  Object.defineProperty(event, 'keyCode', {
+    get: function() { return keyCode; }
+  });
+  element.dispatchEvent(event);
+}


### PR DESCRIPTION
Fixes issue in the dialog that prevented the user from being able to close via the escape key, if any of the elements inside the dialog loses focus.

Fixes #3009.