### PR TITLE
refactor: consistent module declaration

### DIFF
--- a/src/lib/autocomplete/index.ts
+++ b/src/lib/autocomplete/index.ts
@@ -4,8 +4,6 @@ import {MdOptionModule, OverlayModule, OVERLAY_PROVIDERS, CompatibilityModule} f
 import {CommonModule} from '@angular/common';
 import {MdAutocomplete} from './autocomplete';
 import {MdAutocompleteTrigger} from './autocomplete-trigger';
-export * from './autocomplete';
-export * from './autocomplete-trigger';
 
 @NgModule({
   imports: [MdOptionModule, OverlayModule, CompatibilityModule, CommonModule],
@@ -21,3 +19,7 @@ export class MdAutocompleteModule {
     };
   }
 }
+
+
+export * from './autocomplete';
+export * from './autocomplete-trigger';

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -9,11 +9,12 @@ import {NgControl, FormsModule, ReactiveFormsModule, FormControl} from '@angular
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
-    MdButtonToggleGroup,
-    MdButtonToggle,
-    MdButtonToggleGroupMultiple,
-    MdButtonToggleChange, MdButtonToggleModule,
-} from './button-toggle';
+  MdButtonToggleGroup,
+  MdButtonToggle,
+  MdButtonToggleGroupMultiple,
+  MdButtonToggleChange,
+  MdButtonToggleModule,
+} from './index';
 
 
 describe('MdButtonToggle', () => {

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -1,32 +1,24 @@
 import {
-    NgModule,
-    ModuleWithProviders,
-    Component,
-    ContentChildren,
-    Directive,
-    ElementRef,
-    Renderer,
-    EventEmitter,
-    HostBinding,
-    Input,
-    OnInit,
-    Optional,
-    Output,
-    QueryList,
-    ViewChild,
-    ViewEncapsulation,
-    forwardRef,
-    AfterViewInit
+  Component,
+  ContentChildren,
+  Directive,
+  ElementRef,
+  Renderer,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnInit,
+  Optional,
+  Output,
+  QueryList,
+  ViewChild,
+  ViewEncapsulation,
+  forwardRef,
+  AfterViewInit,
 } from '@angular/core';
-import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormsModule} from '@angular/forms';
+import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {Observable} from 'rxjs/Observable';
-import {
-  FocusOriginMonitor,
-  UniqueSelectionDispatcher,
-  coerceBooleanProperty,
-  UNIQUE_SELECTION_DISPATCHER_PROVIDER,
-  CompatibilityModule,
-} from '../core';
+import {UniqueSelectionDispatcher, coerceBooleanProperty, FocusOriginMonitor} from '../core';
 
 /** Acceptable types for a button toggle. */
 export type ToggleType = 'checkbox' | 'radio';
@@ -467,27 +459,5 @@ export class MdButtonToggle implements OnInit {
   /** Focuses the button. */
   focus() {
     this._renderer.invokeElementMethod(this._inputElement.nativeElement, 'focus');
-  }
-}
-
-
-@NgModule({
-  imports: [FormsModule, CompatibilityModule],
-  exports: [
-    MdButtonToggleGroup,
-    MdButtonToggleGroupMultiple,
-    MdButtonToggle,
-    CompatibilityModule,
-  ],
-  declarations: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
-  providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, FocusOriginMonitor]
-})
-export class MdButtonToggleModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdButtonToggleModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/button-toggle/index.ts
+++ b/src/lib/button-toggle/index.ts
@@ -1,1 +1,33 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle} from './button-toggle';
+import {
+  UNIQUE_SELECTION_DISPATCHER_PROVIDER,
+  CompatibilityModule,
+  FocusOriginMonitor,
+} from '../core';
+
+
+@NgModule({
+  imports: [FormsModule, CompatibilityModule],
+  exports: [
+    MdButtonToggleGroup,
+    MdButtonToggleGroupMultiple,
+    MdButtonToggle,
+    CompatibilityModule,
+  ],
+  declarations: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
+  providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, FocusOriginMonitor]
+})
+export class MdButtonToggleModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdButtonToggleModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './button-toggle';

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -1,7 +1,7 @@
 import {async, TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdButtonModule} from './button';
+import {MdButtonModule} from './index';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -6,11 +6,9 @@ import {
   ChangeDetectionStrategy,
   ElementRef,
   Renderer,
-  NgModule,
-  ModuleWithProviders, Directive,
+  Directive,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {MdRippleModule, coerceBooleanProperty, CompatibilityModule} from '../core';
+import {coerceBooleanProperty} from '../core';
 
 
 // TODO(jelbourn): Make the `isMouseDown` stuff done with one global listener.
@@ -217,37 +215,5 @@ export class MdAnchor extends MdButton {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
-  }
-}
-
-
-@NgModule({
-  imports: [CommonModule, MdRippleModule, CompatibilityModule],
-  exports: [
-    MdButton, MdAnchor,
-    CompatibilityModule,
-    MdButtonCssMatStyler,
-    MdRaisedButtonCssMatStyler,
-    MdIconButtonCssMatStyler,
-    MdFabCssMatStyler,
-    MdMiniFabCssMatStyler
-  ],
-  declarations: [
-    MdButton,
-    MdAnchor,
-    MdButtonCssMatStyler,
-    MdRaisedButtonCssMatStyler,
-    MdIconButtonCssMatStyler,
-    MdFabCssMatStyler,
-    MdMiniFabCssMatStyler
-  ],
-})
-export class MdButtonModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdButtonModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/button/index.ts
+++ b/src/lib/button/index.ts
@@ -1,1 +1,48 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MdRippleModule, CompatibilityModule} from '../core';
+import {
+  MdButton,
+  MdAnchor,
+  MdButtonCssMatStyler,
+  MdRaisedButtonCssMatStyler,
+  MdIconButtonCssMatStyler,
+  MdFabCssMatStyler,
+  MdMiniFabCssMatStyler,
+} from './button';
+
+
+@NgModule({
+  imports: [CommonModule, MdRippleModule, CompatibilityModule],
+  exports: [
+    MdButton,
+    MdAnchor,
+    CompatibilityModule,
+    MdButtonCssMatStyler,
+    MdRaisedButtonCssMatStyler,
+    MdIconButtonCssMatStyler,
+    MdFabCssMatStyler,
+    MdMiniFabCssMatStyler
+  ],
+  declarations: [
+    MdButton,
+    MdAnchor,
+    MdButtonCssMatStyler,
+    MdRaisedButtonCssMatStyler,
+    MdIconButtonCssMatStyler,
+    MdFabCssMatStyler,
+    MdMiniFabCssMatStyler
+  ],
+})
+export class MdButtonModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdButtonModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './button';

--- a/src/lib/card/card.ts
+++ b/src/lib/card/card.ts
@@ -1,12 +1,9 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   ViewEncapsulation,
   ChangeDetectionStrategy,
   Directive
 } from '@angular/core';
-import {CompatibilityModule} from '../core';
 
 
 /**
@@ -188,39 +185,3 @@ export class MdCardHeader {}
   }
 })
 export class MdCardTitleGroup {}
-
-
-@NgModule({
-  imports: [CompatibilityModule],
-  exports: [
-    MdCard,
-    MdCardHeader,
-    MdCardTitleGroup,
-    MdCardContent,
-    MdCardTitle,
-    MdCardSubtitle,
-    MdCardActions,
-    MdCardFooter,
-    MdCardSmImage,
-    MdCardMdImage,
-    MdCardLgImage,
-    MdCardImage,
-    MdCardXlImage,
-    MdCardAvatar,
-    CompatibilityModule,
-  ],
-  declarations: [
-    MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
-    MdCardActions, MdCardFooter, MdCardSmImage, MdCardMdImage, MdCardLgImage, MdCardImage,
-    MdCardXlImage, MdCardAvatar,
-  ],
-})
-export class MdCardModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdCardModule,
-      providers: []
-    };
-  }
-}

--- a/src/lib/card/index.ts
+++ b/src/lib/card/index.ts
@@ -1,1 +1,57 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CompatibilityModule} from '../core';
+import {
+  MdCard,
+  MdCardHeader,
+  MdCardTitleGroup,
+  MdCardContent,
+  MdCardTitle,
+  MdCardSubtitle,
+  MdCardActions,
+  MdCardFooter,
+  MdCardSmImage,
+  MdCardMdImage,
+  MdCardLgImage,
+  MdCardImage,
+  MdCardXlImage,
+  MdCardAvatar,
+} from './card';
+
+
+@NgModule({
+  imports: [CompatibilityModule],
+  exports: [
+    MdCard,
+    MdCardHeader,
+    MdCardTitleGroup,
+    MdCardContent,
+    MdCardTitle,
+    MdCardSubtitle,
+    MdCardActions,
+    MdCardFooter,
+    MdCardSmImage,
+    MdCardMdImage,
+    MdCardLgImage,
+    MdCardImage,
+    MdCardXlImage,
+    MdCardAvatar,
+    CompatibilityModule,
+  ],
+  declarations: [
+    MdCard, MdCardHeader, MdCardTitleGroup, MdCardContent, MdCardTitle, MdCardSubtitle,
+    MdCardActions, MdCardFooter, MdCardSmImage, MdCardMdImage, MdCardLgImage, MdCardImage,
+    MdCardXlImage, MdCardAvatar,
+  ],
+})
+export class MdCardModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdCardModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './card';

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -9,7 +9,7 @@ import {
 import {NgControl, FormsModule, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdCheckbox, MdCheckboxChange, MdCheckboxModule} from './checkbox';
+import {MdCheckbox, MdCheckboxChange, MdCheckboxModule} from './index';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 import {dispatchFakeEvent} from '../core/testing/dispatch-events';

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -1,27 +1,22 @@
 import {
-    ChangeDetectorRef,
-    ChangeDetectionStrategy,
-    Component,
-    ElementRef,
-    EventEmitter,
-    Input,
-    Output,
-    Renderer,
-    ViewEncapsulation,
-    forwardRef,
-    NgModule,
-    ModuleWithProviders,
-    ViewChild,
-    AfterViewInit,
-    OnDestroy,
+  ChangeDetectorRef,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer,
+  ViewEncapsulation,
+  forwardRef,
+  ViewChild,
+  AfterViewInit,
+  OnDestroy,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {coerceBooleanProperty} from '../core/coercion/boolean-property';
 import {Subscription} from 'rxjs/Subscription';
 import {
-  CompatibilityModule,
-  MdRippleModule,
   MdRipple,
   RippleRef,
   FocusOriginMonitor,
@@ -441,22 +436,5 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
       this._focusedRipple.fadeOut();
       this._focusedRipple = null;
     }
-  }
-}
-
-
-@NgModule({
-  imports: [CommonModule, MdRippleModule, CompatibilityModule],
-  exports: [MdCheckbox, CompatibilityModule],
-  declarations: [MdCheckbox],
-  providers: [FocusOriginMonitor]
-})
-export class MdCheckboxModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdCheckboxModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/checkbox/index.ts
+++ b/src/lib/checkbox/index.ts
@@ -1,1 +1,24 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MdRippleModule, CompatibilityModule, FocusOriginMonitor} from '../core';
+import {MdCheckbox} from './checkbox';
+
+
+@NgModule({
+  imports: [CommonModule, MdRippleModule, CompatibilityModule],
+  exports: [MdCheckbox, CompatibilityModule],
+  declarations: [MdCheckbox],
+  providers: [FocusOriginMonitor]
+})
+export class MdCheckboxModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdCheckboxModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './checkbox';

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -5,8 +5,6 @@ import {
   ContentChildren,
   ElementRef,
   Input,
-  ModuleWithProviders,
-  NgModule,
   QueryList,
   ViewEncapsulation
 } from '@angular/core';
@@ -207,19 +205,4 @@ export class MdChipList implements AfterContentInit {
     return index >= 0 && index < this.chips.length;
   }
 
-}
-
-@NgModule({
-  imports: [],
-  exports: [MdChipList, MdChip],
-  declarations: [MdChipList, MdChip]
-})
-export class MdChipsModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdChipsModule,
-      providers: []
-    };
-  }
 }

--- a/src/lib/chips/index.ts
+++ b/src/lib/chips/index.ts
@@ -1,2 +1,23 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {MdChipList} from './chip-list';
+import {MdChip} from './chip';
+
+
+@NgModule({
+  imports: [],
+  exports: [MdChipList, MdChip],
+  declarations: [MdChipList, MdChip]
+})
+export class MdChipsModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdChipsModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './chip-list';
 export * from './chip';

--- a/src/lib/core/compatibility/compatibility.spec.ts
+++ b/src/lib/core/compatibility/compatibility.spec.ts
@@ -1,6 +1,6 @@
 import {Component, NgModule} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
-import {MdCheckboxModule} from '../../checkbox/checkbox';
+import {MdCheckboxModule} from '../../checkbox/index';
 import {
   NoConflictStyleCompatibilityMode,
   MAT_ELEMENTS_SELECTOR,

--- a/src/lib/core/platform/index.ts
+++ b/src/lib/core/platform/index.ts
@@ -1,9 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {Platform} from './platform';
 
-export * from './platform';
-export * from './features';
-
 
 @NgModule({
   providers: [Platform]
@@ -17,3 +14,7 @@ export class PlatformModule {
     };
   }
 }
+
+
+export * from './platform';
+export * from './features';

--- a/src/lib/core/selection/index.ts
+++ b/src/lib/core/selection/index.ts
@@ -1,10 +1,12 @@
 import {NgModule} from '@angular/core';
 import {MdPseudoCheckbox} from './pseudo-checkbox/pseudo-checkbox';
 
-export * from './pseudo-checkbox/pseudo-checkbox';
 
 @NgModule({
   exports: [MdPseudoCheckbox],
   declarations: [MdPseudoCheckbox]
 })
 export class MdSelectionModule { }
+
+
+export * from './pseudo-checkbox/pseudo-checkbox';

--- a/src/lib/core/style/index.ts
+++ b/src/lib/core/style/index.ts
@@ -1,9 +1,6 @@
 import {NgModule} from '@angular/core';
 import {CdkMonitorFocus, FOCUS_ORIGIN_MONITOR_PROVIDER} from './focus-origin-monitor';
 
-export * from './focus-origin-monitor';
-export * from './apply-transform';
-
 
 @NgModule({
   declarations: [CdkMonitorFocus],
@@ -11,3 +8,7 @@ export * from './apply-transform';
   providers: [FOCUS_ORIGIN_MONITOR_PROVIDER],
 })
 export class StyleModule {}
+
+
+export * from './focus-origin-monitor';
+export * from './apply-transform';

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -1,7 +1,7 @@
 import {async, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdGridList, MdGridListModule} from './grid-list';
+import {MdGridList, MdGridListModule} from './index';
 import {MdGridTile, MdGridTileText} from './grid-tile';
 
 

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   ViewEncapsulation,
   AfterContentChecked,
@@ -12,14 +10,11 @@ import {
   ElementRef,
   Optional,
 } from '@angular/core';
-import {
-  MdGridTile, MdGridTileText, MdGridTileFooterCssMatStyler,
-  MdGridTileHeaderCssMatStyler, MdGridAvatarCssMatStyler
-} from './grid-tile';
+import {MdGridTile} from './grid-tile';
 import {TileCoordinator} from './tile-coordinator';
 import {TileStyler, FitTileStyler, RatioTileStyler, FixedTileStyler} from './tile-styler';
 import {MdGridListColsError} from './grid-list-errors';
-import {Dir, MdLineModule, CompatibilityModule} from '../core';
+import {Dir} from '../core';
 import {
   coerceToString,
   coerceToNumber,
@@ -143,36 +138,5 @@ export class MdGridList implements OnInit, AfterContentChecked {
     if (style) {
       this._renderer.setElementStyle(this._element.nativeElement, style[0], style[1]);
     }
-  }
-}
-
-
-@NgModule({
-  imports: [MdLineModule, CompatibilityModule],
-  exports: [
-    MdGridList,
-    MdGridTile,
-    MdGridTileText,
-    MdLineModule,
-    CompatibilityModule,
-    MdGridTileHeaderCssMatStyler,
-    MdGridTileFooterCssMatStyler,
-    MdGridAvatarCssMatStyler
-  ],
-  declarations: [
-    MdGridList,
-    MdGridTile,
-    MdGridTileText,
-    MdGridTileHeaderCssMatStyler,
-    MdGridTileFooterCssMatStyler,
-    MdGridAvatarCssMatStyler],
-})
-export class MdGridListModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdGridListModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/grid-list/index.ts
+++ b/src/lib/grid-list/index.ts
@@ -1,1 +1,42 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {MdLineModule, CompatibilityModule} from '../core';
+import {
+  MdGridTile, MdGridTileText, MdGridTileFooterCssMatStyler,
+  MdGridTileHeaderCssMatStyler, MdGridAvatarCssMatStyler
+} from './grid-tile';
+import {MdGridList} from './grid-list';
+
+
+@NgModule({
+  imports: [MdLineModule, CompatibilityModule],
+  exports: [
+    MdGridList,
+    MdGridTile,
+    MdGridTileText,
+    MdLineModule,
+    CompatibilityModule,
+    MdGridTileHeaderCssMatStyler,
+    MdGridTileFooterCssMatStyler,
+    MdGridAvatarCssMatStyler
+  ],
+  declarations: [
+    MdGridList,
+    MdGridTile,
+    MdGridTileText,
+    MdGridTileHeaderCssMatStyler,
+    MdGridTileFooterCssMatStyler,
+    MdGridAvatarCssMatStyler
+  ],
+})
+export class MdGridListModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdGridListModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './grid-list';

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -3,7 +3,7 @@ import {SafeResourceUrl, DomSanitizer} from '@angular/platform-browser';
 import {XHRBackend} from '@angular/http';
 import {MockBackend} from '@angular/http/testing';
 import {Component} from '@angular/core';
-import {MdIconModule} from './icon';
+import {MdIconModule} from './index';
 import {MdIconRegistry} from './icon-registry';
 import {getFakeSvgHttpResponse} from './fake-svgs';
 

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
@@ -14,11 +12,10 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core';
-import {HttpModule, Http} from '@angular/http';
+import {Http} from '@angular/http';
 import {DomSanitizer} from '@angular/platform-browser';
-import {MdError, CompatibilityModule} from '../core';
+import {MdError} from '../core';
 import {MdIconRegistry, MdIconNameNotFoundError} from './icon-registry';
-export {MdIconRegistry} from './icon-registry';
 
 /** Exception thrown when an invalid icon name is passed to an md-icon component. */
 export class MdIconInvalidNameError extends MdError {
@@ -261,19 +258,3 @@ export const ICON_REGISTRY_PROVIDER = {
   deps: [[new Optional(), new SkipSelf(), MdIconRegistry], Http, DomSanitizer],
   useFactory: ICON_REGISTRY_PROVIDER_FACTORY,
 };
-
-@NgModule({
-  imports: [HttpModule, CompatibilityModule],
-  exports: [MdIcon, CompatibilityModule],
-  declarations: [MdIcon],
-  providers: [ICON_REGISTRY_PROVIDER],
-})
-export class MdIconModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdIconModule,
-      providers: [],
-    };
-  }
-}

--- a/src/lib/icon/index.ts
+++ b/src/lib/icon/index.ts
@@ -1,1 +1,25 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {HttpModule} from '@angular/http';
+import {CompatibilityModule} from '../core';
+import {MdIcon, ICON_REGISTRY_PROVIDER} from './icon';
+
+
+@NgModule({
+  imports: [HttpModule, CompatibilityModule],
+  exports: [MdIcon, CompatibilityModule],
+  declarations: [MdIcon],
+  providers: [ICON_REGISTRY_PROVIDER],
+})
+export class MdIconModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdIconModule,
+      providers: [],
+    };
+  }
+}
+
+
 export * from './icon';
+export {MdIconRegistry} from './icon-registry';

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -6,11 +6,6 @@ import {FormsModule} from '@angular/forms';
 import {PlatformModule} from '../core/platform/index';
 
 
-export * from './autosize'
-export * from './input-container';
-export * from './input-container-errors';
-
-
 @NgModule({
   declarations: [
     MdPlaceholder,
@@ -41,3 +36,9 @@ export class MdInputModule {
     };
   }
 }
+
+
+export * from './autosize'
+export * from './input-container';
+export * from './input-container-errors';
+

--- a/src/lib/list/index.ts
+++ b/src/lib/list/index.ts
@@ -1,1 +1,54 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {MdLineModule, CompatibilityModule} from '../core';
+import {
+  MdList,
+  MdListItem,
+  MdListDivider,
+  MdListAvatarCssMatStyler,
+  MdListIconCssMatStyler,
+  MdListCssMatStyler,
+  MdNavListCssMatStyler,
+  MdDividerCssMatStyler,
+  MdListSubheaderCssMatStyler,
+} from './list';
+
+
+@NgModule({
+  imports: [MdLineModule, CompatibilityModule],
+  exports: [
+    MdList,
+    MdListItem,
+    MdListDivider,
+    MdListAvatarCssMatStyler,
+    MdLineModule,
+    CompatibilityModule,
+    MdListIconCssMatStyler,
+    MdListCssMatStyler,
+    MdNavListCssMatStyler,
+    MdDividerCssMatStyler,
+    MdListSubheaderCssMatStyler
+  ],
+  declarations: [
+    MdList,
+    MdListItem,
+    MdListDivider,
+    MdListAvatarCssMatStyler,
+    MdListIconCssMatStyler,
+    MdListCssMatStyler,
+    MdNavListCssMatStyler,
+    MdDividerCssMatStyler,
+    MdListSubheaderCssMatStyler
+  ],
+})
+export class MdListModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdListModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './list';

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -1,7 +1,7 @@
 import {async, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdListItem, MdListModule} from './list';
+import {MdListItem, MdListModule} from './index';
 
 
 describe('MdList', () => {

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -1,17 +1,15 @@
 import {
-    Component,
-    ViewEncapsulation,
-    ContentChildren,
-    ContentChild,
-    QueryList,
-    Directive,
-    ElementRef,
-    Renderer,
-    AfterContentInit,
-    NgModule,
-    ModuleWithProviders,
+  Component,
+  ViewEncapsulation,
+  ContentChildren,
+  ContentChild,
+  QueryList,
+  Directive,
+  ElementRef,
+  Renderer,
+  AfterContentInit,
 } from '@angular/core';
-import {MdLine, MdLineSetter, MdLineModule, CompatibilityModule} from '../core';
+import {MdLine, MdLineSetter} from '../core';
 
 @Directive({
   selector: 'md-divider, mat-divider'
@@ -128,43 +126,5 @@ export class MdListItem implements AfterContentInit {
 
   _handleBlur() {
     this._hasFocus = false;
-  }
-}
-
-
-@NgModule({
-  imports: [MdLineModule, CompatibilityModule],
-  exports: [
-    MdList,
-    MdListItem,
-    MdListDivider,
-    MdListAvatarCssMatStyler,
-    MdLineModule,
-    CompatibilityModule,
-    MdListIconCssMatStyler,
-    MdListCssMatStyler,
-    MdNavListCssMatStyler,
-    MdDividerCssMatStyler,
-    MdListSubheaderCssMatStyler
-  ],
-  declarations: [
-    MdList,
-    MdListItem,
-    MdListDivider,
-    MdListAvatarCssMatStyler,
-    MdListIconCssMatStyler,
-    MdListCssMatStyler,
-    MdNavListCssMatStyler,
-    MdDividerCssMatStyler,
-    MdListSubheaderCssMatStyler
-  ],
-})
-export class MdListModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdListModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/menu/index.ts
+++ b/src/lib/menu/index.ts
@@ -1,3 +1,28 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {OverlayModule, CompatibilityModule} from '../core';
+import {MdMenu} from './menu-directive';
+import {MdMenuItem} from './menu-item';
+import {MdMenuTrigger} from './menu-trigger';
+import {MdRippleModule} from '../core/ripple/index';
+
+
+@NgModule({
+  imports: [OverlayModule, CommonModule, MdRippleModule, CompatibilityModule],
+  exports: [MdMenu, MdMenuItem, MdMenuTrigger, CompatibilityModule],
+  declarations: [MdMenu, MdMenuItem, MdMenuTrigger],
+})
+export class MdMenuModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdMenuModule,
+      providers: [],
+    };
+  }
+}
+
+
 export * from './menu';
 export {MdMenuTrigger} from './menu-trigger';
 export {fadeInItems, transformMenu} from './menu-animations';

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -15,7 +15,7 @@ import {
   MdMenuPanel,
   MenuPositionX,
   MenuPositionY
-} from './menu';
+} from './index';
 import {OverlayContainer} from '../core/overlay/overlay-container';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {Dir, LayoutDirection} from '../core/rtl/dir';

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -1,28 +1,5 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {OverlayModule, CompatibilityModule} from '../core';
-import {MdMenu} from './menu-directive';
-import {MdMenuItem} from './menu-item';
-import {MdMenuTrigger} from './menu-trigger';
-import {MdRippleModule} from '../core/ripple/index';
 export {MdMenu} from './menu-directive';
 export {MdMenuItem} from './menu-item';
 export {MdMenuTrigger} from './menu-trigger';
 export {MdMenuPanel} from './menu-panel';
 export {MenuPositionX, MenuPositionY} from './menu-positions';
-
-
-@NgModule({
-  imports: [OverlayModule, CommonModule, MdRippleModule, CompatibilityModule],
-  exports: [MdMenu, MdMenuItem, MdMenuTrigger, CompatibilityModule],
-  declarations: [MdMenu, MdMenuItem, MdMenuTrigger],
-})
-export class MdMenuModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdMenuModule,
-      providers: [],
-    };
-  }
-}

--- a/src/lib/progress-bar/index.ts
+++ b/src/lib/progress-bar/index.ts
@@ -1,1 +1,23 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {CompatibilityModule} from '../core/compatibility/compatibility';
+import {MdProgressBar} from './progress-bar';
+
+
+@NgModule({
+  imports: [CommonModule, CompatibilityModule],
+  exports: [MdProgressBar, CompatibilityModule],
+  declarations: [MdProgressBar],
+})
+export class MdProgressBarModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdProgressBarModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './progress-bar';

--- a/src/lib/progress-bar/progress-bar.spec.ts
+++ b/src/lib/progress-bar/progress-bar.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdProgressBarModule} from './progress-bar';
+import {MdProgressBarModule} from './index';
 
 
 describe('MdProgressBar', () => {

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -1,13 +1,9 @@
 import {
-    NgModule,
-    ModuleWithProviders,
-    Component,
-    ChangeDetectionStrategy,
-    HostBinding,
-    Input,
+  Component,
+  ChangeDetectionStrategy,
+  HostBinding,
+  Input,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {CompatibilityModule} from '../core/compatibility/compatibility';
 
 // TODO(josephperrott): Benchpress tests.
 // TODO(josephperrott): Add ARIA attributes for progressbar "for".
@@ -83,20 +79,4 @@ export class MdProgressBar {
 /** Clamps a value to be between two numbers, by default 0 and 100. */
 function clamp(v: number, min = 0, max = 100) {
   return Math.max(min, Math.min(max, v));
-}
-
-
-@NgModule({
-  imports: [CommonModule, CompatibilityModule],
-  exports: [MdProgressBar, CompatibilityModule],
-  declarations: [MdProgressBar],
-})
-export class MdProgressBarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdProgressBarModule,
-      providers: []
-    };
-  }
 }

--- a/src/lib/progress-spinner/index.ts
+++ b/src/lib/progress-spinner/index.ts
@@ -1,2 +1,42 @@
-export * from './progress-circle';
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CompatibilityModule} from '../core';
+import {
+  MdProgressSpinner,
+  MdSpinner,
+  MdProgressSpinnerCssMatStyler,
+  MdProgressCircleCssMatStyler
+} from './progress-spinner';
+
+
+@NgModule({
+  imports: [CompatibilityModule],
+  exports: [
+    MdProgressSpinner,
+    MdSpinner,
+    CompatibilityModule,
+    MdProgressSpinnerCssMatStyler,
+    MdProgressCircleCssMatStyler
+  ],
+  declarations: [
+    MdProgressSpinner,
+    MdSpinner,
+    MdProgressSpinnerCssMatStyler,
+    MdProgressCircleCssMatStyler
+  ],
+})
+class MdProgressSpinnerModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdProgressSpinnerModule,
+      providers: []
+    };
+  }
+}
+
+export {MdProgressSpinnerModule};
 export * from './progress-spinner';
+
+/** @deprecated */
+export {MdProgressSpinnerModule as MdProgressCircleModule};
+export {MdProgressSpinner as MdProgressCircle};

--- a/src/lib/progress-spinner/progress-circle.ts
+++ b/src/lib/progress-spinner/progress-circle.ts
@@ -1,4 +1,0 @@
-/** @deprecated */
-export {MdProgressSpinner as MdProgressCircle} from './progress-spinner';
-/** @deprecated */
-export {MdProgressSpinnerModule as MdProgressCircleModule} from './progress-spinner';

--- a/src/lib/progress-spinner/progress-spinner.spec.ts
+++ b/src/lib/progress-spinner/progress-spinner.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed, async} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdProgressSpinnerModule} from './progress-spinner';
+import {MdProgressSpinnerModule} from './index';
 
 
 describe('MdProgressSpinner', () => {

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   HostBinding,
   ChangeDetectionStrategy,
@@ -10,7 +8,6 @@ import {
   NgZone,
   Renderer, Directive
 } from '@angular/core';
-import {CompatibilityModule} from '../core';
 
 
 // TODO(josephperrott): Benchpress tests.
@@ -381,31 +378,4 @@ function getSvgArc(currentValue: number, rotation: number) {
   }
 
   return `M${start}A${pathRadius},${pathRadius} 0 ${largeArcFlag},${arcSweep} ${end}`;
-}
-
-
-@NgModule({
-  imports: [CompatibilityModule],
-  exports: [
-    MdProgressSpinner,
-    MdSpinner,
-    CompatibilityModule,
-    MdProgressSpinnerCssMatStyler,
-    MdProgressCircleCssMatStyler
-  ],
-  declarations: [
-    MdProgressSpinner,
-    MdSpinner,
-    MdProgressSpinnerCssMatStyler,
-    MdProgressCircleCssMatStyler
-  ],
-})
-export class MdProgressSpinnerModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdProgressSpinnerModule,
-      providers: []
-    };
-  }
 }

--- a/src/lib/radio/index.ts
+++ b/src/lib/radio/index.ts
@@ -1,1 +1,30 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {VIEWPORT_RULER_PROVIDER} from '../core/overlay/position/viewport-ruler';
+import {
+  MdRippleModule,
+  CompatibilityModule,
+  UNIQUE_SELECTION_DISPATCHER_PROVIDER,
+  FocusOriginMonitor,
+} from '../core';
+import {MdRadioGroup, MdRadioButton} from './radio';
+
+
+@NgModule({
+  imports: [CommonModule, MdRippleModule, CompatibilityModule],
+  exports: [MdRadioGroup, MdRadioButton, CompatibilityModule],
+  providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, VIEWPORT_RULER_PROVIDER, FocusOriginMonitor],
+  declarations: [MdRadioGroup, MdRadioButton],
+})
+export class MdRadioModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdRadioModule,
+      providers: [],
+    };
+  }
+}
+
+
 export * from './radio';

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -2,7 +2,7 @@ import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/t
 import {NgControl, FormsModule, ReactiveFormsModule, FormControl} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdRadioGroup, MdRadioButton, MdRadioChange, MdRadioModule} from './radio';
+import {MdRadioGroup, MdRadioButton, MdRadioChange, MdRadioModule} from './index';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 import {dispatchFakeEvent} from '../core/testing/dispatch-events';

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -13,25 +13,18 @@ import {
   QueryList,
   ViewEncapsulation,
   forwardRef,
-  NgModule,
-  ModuleWithProviders,
   ViewChild,
   OnDestroy,
   AfterViewInit,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {
-  MdRippleModule,
   RippleRef,
   UniqueSelectionDispatcher,
-  CompatibilityModule,
-  UNIQUE_SELECTION_DISPATCHER_PROVIDER,
   MdRipple,
   FocusOriginMonitor,
 } from '../core';
 import {coerceBooleanProperty} from '../core/coercion/boolean-property';
-import {VIEWPORT_RULER_PROVIDER} from '../core/overlay/position/viewport-ruler';
 import {Subscription} from 'rxjs/Subscription';
 
 
@@ -526,21 +519,4 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-}
-
-
-@NgModule({
-  imports: [CommonModule, MdRippleModule, CompatibilityModule],
-  exports: [MdRadioGroup, MdRadioButton, CompatibilityModule],
-  providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, VIEWPORT_RULER_PROVIDER, FocusOriginMonitor],
-  declarations: [MdRadioGroup, MdRadioButton],
-})
-export class MdRadioModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdRadioModule,
-      providers: [],
-    };
-  }
 }

--- a/src/lib/select/index.ts
+++ b/src/lib/select/index.ts
@@ -6,8 +6,6 @@ import {
   CompatibilityModule,
   OverlayModule,
 } from '../core';
-export * from './select';
-export {fadeInContent, transformPanel, transformPlaceholder} from './select-animations';
 
 
 @NgModule({
@@ -24,3 +22,7 @@ export class MdSelectModule {
     };
   }
 }
+
+
+export * from './select';
+export {fadeInContent, transformPanel, transformPlaceholder} from './select-animations';

--- a/src/lib/sidenav/index.ts
+++ b/src/lib/sidenav/index.ts
@@ -1,1 +1,25 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {CompatibilityModule} from '../core';
+import {A11yModule} from '../core/a11y/index';
+import {OverlayModule} from '../core/overlay/overlay-directives';
+import {MdSidenav, MdSidenavContainer} from './sidenav';
+
+
+@NgModule({
+  imports: [CommonModule, CompatibilityModule, A11yModule, OverlayModule],
+  exports: [MdSidenavContainer, MdSidenav, CompatibilityModule],
+  declarations: [MdSidenavContainer, MdSidenav],
+})
+export class MdSidenavModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSidenavModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './sidenav';

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -1,7 +1,7 @@
 import {fakeAsync, async, tick, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdSidenav, MdSidenavModule, MdSidenavToggleResult} from './sidenav';
+import {MdSidenav, MdSidenavModule, MdSidenavToggleResult} from './index';
 import {A11yModule} from '../core/a11y/index';
 import {PlatformModule} from '../core/platform/index';
 import {ESCAPE} from '../core/keyboard/keycodes';

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   AfterContentInit,
   Component,
   ContentChildren,
@@ -16,12 +14,9 @@ import {
   NgZone,
   OnDestroy,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {Dir, MdError, coerceBooleanProperty, CompatibilityModule} from '../core';
-import {A11yModule} from '../core/a11y/index';
+import {Dir, MdError, coerceBooleanProperty} from '../core';
 import {FocusTrapFactory, FocusTrap} from '../core/a11y/focus-trap';
 import {ESCAPE} from '../core/keyboard/keycodes';
-import {OverlayModule} from '../core/overlay/overlay-directives';
 import 'rxjs/add/operator/first';
 
 
@@ -504,22 +499,6 @@ export class MdSidenavContainer implements AfterContentInit {
       marginLeft: `${this._getMarginLeft()}px`,
       marginRight: `${this._getMarginRight()}px`,
       transform: `translate3d(${this._getPositionOffset()}px, 0, 0)`
-    };
-  }
-}
-
-
-@NgModule({
-  imports: [CommonModule, CompatibilityModule, A11yModule, OverlayModule],
-  exports: [MdSidenavContainer, MdSidenav, CompatibilityModule],
-  declarations: [MdSidenavContainer, MdSidenav],
-})
-export class MdSidenavModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSidenavModule,
-      providers: []
     };
   }
 }

--- a/src/lib/slide-toggle/index.ts
+++ b/src/lib/slide-toggle/index.ts
@@ -1,1 +1,26 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {GestureConfig, CompatibilityModule} from '../core';
+import {MdSlideToggle} from './slide-toggle';
+import {MdRippleModule} from '../core/ripple/index';
+
+
+@NgModule({
+  imports: [FormsModule, MdRippleModule, CompatibilityModule],
+  exports: [MdSlideToggle, CompatibilityModule],
+  declarations: [MdSlideToggle],
+  providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}],
+})
+export class MdSlideToggleModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSlideToggleModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './slide-toggle';

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -1,8 +1,8 @@
-import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
-import {By, HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {Component} from '@angular/core';
-import {MdSlideToggle, MdSlideToggleChange, MdSlideToggleModule} from './slide-toggle';
+import {By, HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {FormsModule, NgControl, ReactiveFormsModule, FormControl} from '@angular/forms';
+import {MdSlideToggle, MdSlideToggleChange, MdSlideToggleModule} from './index';
 import {TestGestureConfig} from '../slider/test-gesture-config';
 import {dispatchFakeEvent} from '../core/testing/dispatch-events';
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -8,22 +8,12 @@ import {
   Output,
   EventEmitter,
   AfterContentInit,
-  NgModule,
-  ModuleWithProviders,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {FormsModule, ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {
-  applyCssTransform,
-  coerceBooleanProperty,
-  GestureConfig,
-  HammerInput,
-  CompatibilityModule,
-} from '../core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {applyCssTransform, coerceBooleanProperty, HammerInput} from '../core';
 import {Observable} from 'rxjs/Observable';
-import {MdRippleModule} from '../core/ripple/index';
 
 
 export const MD_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
@@ -351,21 +341,4 @@ class SlideToggleRenderer {
     return Math.max(0, Math.min(percentage, 100));
   }
 
-}
-
-
-@NgModule({
-  imports: [FormsModule, MdRippleModule, CompatibilityModule],
-  exports: [MdSlideToggle, CompatibilityModule],
-  declarations: [MdSlideToggle],
-  providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}],
-})
-export class MdSlideToggleModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSlideToggleModule,
-      providers: []
-    };
-  }
 }

--- a/src/lib/slider/index.ts
+++ b/src/lib/slider/index.ts
@@ -1,1 +1,26 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {GestureConfig, CompatibilityModule} from '../core';
+import {MdSlider} from './slider';
+
+
+@NgModule({
+  imports: [CommonModule, FormsModule, CompatibilityModule],
+  exports: [MdSlider, CompatibilityModule],
+  declarations: [MdSlider],
+  providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
+})
+export class MdSliderModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdSliderModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './slider';

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -2,7 +2,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule, FormControl, FormsModule} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By, HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {MdSlider, MdSliderModule} from './slider';
+import {MdSlider, MdSliderModule} from './index';
 import {TestGestureConfig} from './test-gesture-config';
 import {RtlModule} from '../core/rtl/dir';
 import {

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   ElementRef,
   Input,
@@ -10,17 +8,9 @@ import {
   EventEmitter,
   Optional
 } from '@angular/core';
-import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormsModule} from '@angular/forms';
-import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {
-  GestureConfig,
-  HammerInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  CompatibilityModule,
-} from '../core';
+import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
+import {HammerInput, coerceBooleanProperty, coerceNumberProperty} from '../core';
 import {Dir} from '../core/rtl/dir';
-import {CommonModule} from '@angular/common';
 import {
   PAGE_UP,
   PAGE_DOWN,
@@ -650,22 +640,5 @@ export class SliderRenderer {
    */
   addFocus() {
     this._sliderElement.focus();
-  }
-}
-
-
-@NgModule({
-  imports: [CommonModule, FormsModule, CompatibilityModule],
-  exports: [MdSlider, CompatibilityModule],
-  declarations: [MdSlider],
-  providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
-})
-export class MdSliderModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSliderModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/snack-bar/index.ts
+++ b/src/lib/snack-bar/index.ts
@@ -5,6 +5,7 @@ import {MdSnackBar} from './snack-bar';
 import {MdSnackBarContainer} from './snack-bar-container';
 import {SimpleSnackBar} from './simple-snack-bar';
 
+
 @NgModule({
   imports: [OverlayModule, PortalModule, CommonModule, CompatibilityModule],
   exports: [MdSnackBarContainer, CompatibilityModule],
@@ -21,6 +22,7 @@ export class MdSnackBarModule {
     };
   }
 }
+
 
 export * from './snack-bar';
 export * from './snack-bar-container';

--- a/src/lib/tabs/index.ts
+++ b/src/lib/tabs/index.ts
@@ -1,3 +1,39 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {PortalModule} from '../core';
+import {MdRippleModule} from '../core/ripple/index';
+import {ObserveContentModule} from '../core/observe-content/observe-content';
+import {MdTab} from './tab';
+import {MdTabGroup} from './tab-group';
+import {MdTabLabel} from './tab-label';
+import {MdTabLabelWrapper} from './tab-label-wrapper';
+import {MdTabNavBar, MdTabLink, MdTabLinkRipple} from './tab-nav-bar/tab-nav-bar';
+import {MdInkBar} from './ink-bar';
+import {MdTabBody} from './tab-body';
+import {VIEWPORT_RULER_PROVIDER} from '../core/overlay/position/viewport-ruler';
+import {MdTabHeader} from './tab-header';
+import {SCROLL_DISPATCHER_PROVIDER} from '../core/overlay/scroll/scroll-dispatcher';
+
+
+@NgModule({
+  imports: [CommonModule, PortalModule, MdRippleModule, ObserveContentModule],
+  // Don't export all components because some are only to be used internally.
+  exports: [MdTabGroup, MdTabLabel, MdTab, MdTabNavBar, MdTabLink, MdTabLinkRipple],
+  declarations: [MdTabGroup, MdTabLabel, MdTab, MdInkBar, MdTabLabelWrapper,
+    MdTabNavBar, MdTabLink, MdTabBody, MdTabLinkRipple, MdTabHeader],
+  providers: [VIEWPORT_RULER_PROVIDER, SCROLL_DISPATCHER_PROVIDER],
+})
+export class MdTabsModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdTabsModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './tab-group';
 export {MdInkBar} from './ink-bar';
 export {MdTabBody, MdTabBodyOriginState, MdTabBodyPositionState} from './tab-body';

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -1,7 +1,7 @@
 import {
     async, fakeAsync, tick, ComponentFixture, TestBed
 } from '@angular/core/testing';
-import {MdTabGroup, MdTabsModule, MdTabHeaderPosition} from './tab-group';
+import {MdTabGroup, MdTabsModule, MdTabHeaderPosition} from './index';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {Observable} from 'rxjs/Observable';

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   ViewChild,
   Component,
   Input,
@@ -11,24 +9,10 @@ import {
   ElementRef,
   Renderer
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {
-  PortalModule,
-  coerceBooleanProperty
-} from '../core';
-import {MdTabLabel} from './tab-label';
-import {MdTabLabelWrapper} from './tab-label-wrapper';
-import {MdTabNavBar, MdTabLink, MdTabLinkRipple} from './tab-nav-bar/tab-nav-bar';
-import {MdInkBar} from './ink-bar';
+import {coerceBooleanProperty} from '../core';
 import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import {MdRippleModule} from '../core/ripple/index';
-import {ObserveContentModule} from '../core/observe-content/observe-content';
 import {MdTab} from './tab';
-import {MdTabBody} from './tab-body';
-import {VIEWPORT_RULER_PROVIDER} from '../core/overlay/position/viewport-ruler';
-import {MdTabHeader} from './tab-header';
-import {SCROLL_DISPATCHER_PROVIDER} from '../core/overlay/scroll/scroll-dispatcher';
+import 'rxjs/add/operator/map';
 
 
 /** Used to generate unique ID's for each tab component */
@@ -207,23 +191,5 @@ export class MdTabGroup {
   _removeTabBodyWrapperHeight(): void {
     this._tabBodyWrapperHeight = this._tabBodyWrapper.nativeElement.clientHeight;
     this._renderer.setElementStyle(this._tabBodyWrapper.nativeElement, 'height', '');
-  }
-}
-
-@NgModule({
-  imports: [CommonModule, PortalModule, MdRippleModule, ObserveContentModule],
-  // Don't export all components because some are only to be used internally.
-  exports: [MdTabGroup, MdTabLabel, MdTab, MdTabNavBar, MdTabLink, MdTabLinkRipple],
-  declarations: [MdTabGroup, MdTabLabel, MdTab, MdInkBar, MdTabLabelWrapper,
-    MdTabNavBar, MdTabLink, MdTabBody, MdTabLinkRipple, MdTabHeader],
-  providers: [VIEWPORT_RULER_PROVIDER, SCROLL_DISPATCHER_PROVIDER],
-})
-export class MdTabsModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdTabsModule,
-      providers: []
-    };
   }
 }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -1,5 +1,5 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MdTabsModule} from '../tab-group';
+import {MdTabsModule} from '../index';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {ViewportRuler} from '../../core/overlay/position/viewport-ruler';

--- a/src/lib/toolbar/index.ts
+++ b/src/lib/toolbar/index.ts
@@ -1,1 +1,22 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CompatibilityModule} from '../core';
+import {MdToolbar, MdToolbarRow} from './toolbar';
+
+
+@NgModule({
+  imports: [CompatibilityModule],
+  exports: [MdToolbar, MdToolbarRow, CompatibilityModule],
+  declarations: [MdToolbar, MdToolbarRow],
+})
+export class MdToolbarModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdToolbarModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './toolbar';

--- a/src/lib/toolbar/toolbar.spec.ts
+++ b/src/lib/toolbar/toolbar.spec.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {MdToolbarModule} from './toolbar';
+import {MdToolbarModule} from './index';
 
 
 describe('MdToolbar', () => {

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   ChangeDetectionStrategy,
   Input,
@@ -9,7 +7,6 @@ import {
   ElementRef,
   Renderer
 } from '@angular/core';
-import {CompatibilityModule} from '../core';
 
 
 @Directive({
@@ -60,20 +57,4 @@ export class MdToolbar {
     }
   }
 
-}
-
-
-@NgModule({
-  imports: [CompatibilityModule],
-  exports: [MdToolbar, MdToolbarRow, CompatibilityModule],
-  declarations: [MdToolbar, MdToolbarRow],
-})
-export class MdToolbarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdToolbarModule,
-      providers: []
-    };
-  }
 }

--- a/src/lib/tooltip/index.ts
+++ b/src/lib/tooltip/index.ts
@@ -1,1 +1,24 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {OverlayModule, CompatibilityModule} from '../core';
+import {PlatformModule} from '../core/platform/index';
+import {MdTooltip, TooltipComponent} from './tooltip';
+
+
+@NgModule({
+  imports: [OverlayModule, CompatibilityModule, PlatformModule],
+  exports: [MdTooltip, TooltipComponent, CompatibilityModule],
+  declarations: [MdTooltip, TooltipComponent],
+  entryComponents: [TooltipComponent],
+})
+export class MdTooltipModule {
+  /** @deprecated */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MdTooltipModule,
+      providers: []
+    };
+  }
+}
+
+
 export * from './tooltip';

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -14,7 +14,7 @@ import {
   ChangeDetectionStrategy
 } from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {TooltipPosition, MdTooltip, MdTooltipModule, SCROLL_THROTTLE_MS} from './tooltip';
+import {TooltipPosition, MdTooltip, MdTooltipModule, SCROLL_THROTTLE_MS} from './index';
 import {OverlayContainer} from '../core';
 import {Dir, LayoutDirection} from '../core/rtl/dir';
 import {OverlayModule} from '../core/overlay/overlay-directives';

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -1,6 +1,4 @@
 import {
-  NgModule,
-  ModuleWithProviders,
   Component,
   Directive,
   Input,
@@ -22,18 +20,16 @@ import {
 import {
   Overlay,
   OverlayState,
-  OverlayModule,
   OverlayRef,
   ComponentPortal,
   OverlayConnectionPosition,
   OriginConnectionPosition,
-  CompatibilityModule
 } from '../core';
 import {MdTooltipInvalidPositionError} from './tooltip-errors';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {Dir} from '../core/rtl/dir';
-import {PlatformModule, Platform} from '../core/platform/index';
+import {Platform} from '../core/platform/index';
 import 'rxjs/add/operator/first';
 import {ScrollDispatcher} from '../core/overlay/scroll/scroll-dispatcher';
 import {Subscription} from 'rxjs/Subscription';
@@ -443,22 +439,5 @@ export class TooltipComponent {
     if (this._closeOnInteraction) {
       this.hide(0);
     }
-  }
-}
-
-
-@NgModule({
-  imports: [OverlayModule, CompatibilityModule, PlatformModule],
-  exports: [MdTooltip, TooltipComponent, CompatibilityModule],
-  declarations: [MdTooltip, TooltipComponent],
-  entryComponents: [TooltipComponent],
-})
-export class MdTooltipModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdTooltipModule,
-      providers: []
-    };
   }
 }


### PR DESCRIPTION
Makes the module declarations consistent between components, by moving them all to their respective `index.ts` files.