### PR TITLE
feat(snack-bar): Optionally pass action value through MdSnackBarRef onAction observable

### DIFF
--- a/src/examples/example-module.ts
+++ b/src/examples/example-module.ts
@@ -36,6 +36,10 @@ import {
 import {ListSectionsExample} from './list-sections/list-sections-example';
 import {SnackBarOverviewExample} from './snack-bar-overview/snack-bar-overview-example';
 import {
+  SnackBarMultipleActionsExample,
+  MultipleActionsComponent
+} from './snack-bar-multiple-actions/snack-bar-multiple-actions-example';
+import {
   DialogResultExampleDialog,
   DialogResultExample
 } from './dialog-result/dialog-result-example';
@@ -146,6 +150,10 @@ export const EXAMPLE_COMPONENTS = {
     component: SnackBarComponentExample
   },
   'snack-bar-overview': {title: 'Basic snack-bar', component: SnackBarOverviewExample},
+  'snack-bar-multiple-actions': {
+    title: 'Snack-bar with multiple actions',
+    component: SnackBarMultipleActionsExample
+  },
   'tabs-overview': {title: 'Basic tabs', component: TabsOverviewExample},
   'tabs-template-label': {title: 'Coming soon!', component: TabsTemplateLabelExample},
   'toolbar-multirow': {title: 'Multi-row toolbar', component: ToolbarMultirowExample},
@@ -199,6 +207,8 @@ export const EXAMPLE_LIST = [
   SlideToggleOverviewExample,
   SnackBarComponentExample,
   PizzaPartyComponent,
+  SnackBarMultipleActionsExample,
+  MultipleActionsComponent,
   SnackBarOverviewExample,
   TabsOverviewExample,
   TabsTemplateLabelExample,

--- a/src/examples/snack-bar-multiple-actions/snack-bar-multiple-actions-example.html
+++ b/src/examples/snack-bar-multiple-actions/snack-bar-multiple-actions-example.html
@@ -1,0 +1,3 @@
+<button md-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+  Open a snack bar with multiple actions
+</button>

--- a/src/examples/snack-bar-multiple-actions/snack-bar-multiple-actions-example.ts
+++ b/src/examples/snack-bar-multiple-actions/snack-bar-multiple-actions-example.ts
@@ -1,0 +1,43 @@
+import {Component} from '@angular/core';
+import {MdSnackBar, MdSnackBarRef} from '@angular/material';
+
+
+@Component({
+  selector: 'snack-bar-multiple-actions-example',
+  templateUrl: './snack-bar-multiple-actions-example.html',
+})
+export class SnackBarMultipleActionsExample {
+  constructor(public snackBar: MdSnackBar) {}
+
+  openSnackBar() {
+    let snackBarRef = this.snackBar.openFromComponent(MultipleActionsComponent, {
+      duration: 1000,
+    });
+
+    snackBarRef.instance.actions = ['Action One', 'Action Two'];
+    snackBarRef.instance.snackBarRef = snackBarRef;
+
+    snackBarRef.onAction().subscribe(result => {
+      this.snackBar.open(`User picked ${result}!`);
+    });
+  }
+}
+
+
+@Component({
+  selector: 'snack-bar-multiple-actions-example-snack',
+  template: `
+    <span class="snack-message">Pick one!</span>
+    <span *ngFor="let action of actions" (click)="dismiss(action)">{{action}}</span>
+  `,
+  styleUrls: ['./snack-bar-multiple-actions-example-snack.css'],
+})
+export class MultipleActionsComponent {
+  actions: string[];
+
+  snackBarRef: MdSnackBarRef<MultipleActionsComponent>;
+
+  dismiss(action: string): void {
+    this.snackBarRef._action(action);
+  }
+}

--- a/src/lib/snack-bar/simple-snack-bar.ts
+++ b/src/lib/snack-bar/simple-snack-bar.ts
@@ -27,7 +27,7 @@ export class SimpleSnackBar {
 
   /** Dismisses the snack bar. */
   dismiss(): void {
-    this.snackBarRef._action();
+    this.snackBarRef._action(this.action);
   }
 
   /** If the action button should be shown. */

--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -50,9 +50,9 @@ export class MdSnackBarRef<T> {
   }
 
   /** Marks the snackbar action clicked. */
-  _action(): void {
+  _action(result?: string): void {
     if (!this._onAction.closed) {
-      this._onAction.next();
+      this._onAction.next(result);
       this._onAction.complete();
     }
   }

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -278,13 +278,16 @@ describe('MdSnackBar', () => {
      fakeAsync(() => {
        let dismissObservableCompleted = false;
        let actionObservableCompleted = false;
-       let snackBarRef = snackBar.open('Some content', 'dismiss');
+       let action = 'dismiss';
+       let snackBarRef = snackBar.open('Some content', action);
        viewContainerFixture.detectChanges();
 
        snackBarRef.afterDismissed().subscribe(null, null, () => {
          dismissObservableCompleted = true;
        });
-       snackBarRef.onAction().subscribe(null, null, () => {
+       snackBarRef.onAction().subscribe((result) => {
+         expect(result).toBe(action);
+       }, null, () => {
          actionObservableCompleted = true;
       });
 


### PR DESCRIPTION
#### Bug, feature request, or proposal:
Allows for passing the value of a snack bar action through the onAction observable so multiple actions can be passed to the snack bar's hosted component and identified when clicked. This makes snack bars with multiple actions possible as devs can now identify which of multiple actions have been clicked.

I've added a demo to the `/src/examples` directory in hopes that this will be added to the material.angular.io docs knowledge base (wasn't sure how to render non-Typedoc documentation locally, so let me know if I set up something wrong there).

I also updated the SimpleSnackBar component to pass the given action into its dismiss call.

#### What is the expected behavior?
Subscribers to MdSnackBarRef's onAction observable will receive an update with an optional argument that describes which snack bar action has been selected.

#### What is the current behavior?
Currently, the onAction observable only indicates *that* a snack bar action has been triggered, but no indication of which one.

#### What is the use-case or motivation for changing an existing behavior?
I needed a snack bar which allowed for multiple actions for the user to choose from, and a way to identify which action the user clicked. This seemed to be the simplest implementation, which still requires a custom component to render a snack bar with multiple action buttons. I am interested in eventually updating the signature for `MdSnackBar.open` to allow an array of action strings to be passed to the default snack bar if this PR is accepted.

#### Is there anything else we should know?
This is my first open source contribution of any sort, and I'm very nervous.