### PR TITLE
feat(FocusOriginMonitor): support monitoring subtree focus as well as element

### DIFF
--- a/src/demo-app/style/style-demo.html
+++ b/src/demo-app/style/style-demo.html
@@ -1,4 +1,4 @@
-<button #b class="demo-button" cdkFocusClasses>focus me!</button>
+<button #b class="demo-focusable" cdkMonitorElementFocus>focus me!</button>
 <button (click)="b.focus()">focus programmatically</button>
 
 <button (click)="fom.focusVia(b, renderer, 'mouse')">focusVia: mouse</button>
@@ -7,3 +7,15 @@
 <button (click)="fom.focusVia(b, renderer, 'program')">focusVia: program</button>
 
 <div>Active classes: {{b.classList}}</div>
+
+<br>
+
+<div class="demo-focusable" tabindex="0" cdkMonitorElementFocus>
+  <p>div with element focus monitored</p>
+  <button>1</button><button>2</button>
+</div>
+
+<div class="demo-focusable" tabindex="0" cdkMonitorSubtreeFocus>
+  <p>div with subtree focus monitored</p>
+  <button>1</button><button>2</button>
+</div>

--- a/src/demo-app/style/style-demo.scss
+++ b/src/demo-app/style/style-demo.scss
@@ -1,19 +1,19 @@
-.demo-button.cdk-focused {
+.demo-focusable.cdk-focused {
   border: 2px solid red;
 }
 
-.demo-button.cdk-mouse-focused {
+.demo-focusable.cdk-mouse-focused {
   background: green;
 }
 
-.demo-button.cdk-keyboard-focused {
+.demo-focusable.cdk-keyboard-focused {
   background: yellow;
 }
 
-.demo-button.cdk-program-focused {
+.demo-focusable.cdk-program-focused {
   background: blue;
 }
 
-.demo-button.cdk-touch-focused {
+.demo-focusable.cdk-touch-focused {
   background: purple;
 }

--- a/src/lib/core/style/focus-classes.spec.ts
+++ b/src/lib/core/style/focus-classes.spec.ts
@@ -1,9 +1,9 @@
-import {async, ComponentFixture, TestBed, inject} from '@angular/core/testing';
+import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {Component, Renderer, ViewChild} from '@angular/core';
 import {StyleModule} from './index';
 import {By} from '@angular/platform-browser';
 import {TAB} from '../keyboard/keycodes';
-import {FocusOriginMonitor, FocusOrigin, CdkFocusClasses, TOUCH_BUFFER_MS} from './focus-classes';
+import {CdkMonitorFocus, FocusOrigin, FocusOriginMonitor, TOUCH_BUFFER_MS} from './focus-classes';
 
 describe('FocusOriginMonitor', () => {
   let fixture: ComponentFixture<PlainButton>;
@@ -32,8 +32,7 @@ describe('FocusOriginMonitor', () => {
     focusOriginMonitor = fom;
 
     changeHandler = jasmine.createSpy('focus origin change handler');
-    focusOriginMonitor.monitor(buttonElement, buttonRenderer)
-        .subscribe(changeHandler);
+    focusOriginMonitor.monitor(buttonElement, buttonRenderer, false).subscribe(changeHandler);
 
     // Patch the element focus to properly emit focus events when the browser is blurred.
     patchElementFocus(buttonElement);
@@ -214,135 +213,240 @@ describe('FocusOriginMonitor', () => {
       expect(changeHandler).toHaveBeenCalledWith(null);
     }, 0);
   }));
+
+  it('should remove classes on unmonitor', async(() => {
+    buttonElement.focus();
+    fixture.detectChanges();
+
+    setTimeout(() => {
+      fixture.detectChanges();
+
+      expect(buttonElement.classList.length)
+          .toBe(2, 'button should have exactly 2 focus classes');
+
+      focusOriginMonitor.unmonitor(buttonElement);
+      fixture.detectChanges();
+
+      expect(buttonElement.classList.length).toBe(0, 'button should not have any focus classes');
+    }, 0);
+  }));
 });
 
 
-describe('cdkFocusClasses', () => {
-  let fixture: ComponentFixture<ButtonWithFocusClasses>;
-  let buttonElement: HTMLElement;
-  let changeHandler: (origin: FocusOrigin) => void;
-
+describe('cdkMonitorFocus', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [StyleModule],
       declarations: [
         ButtonWithFocusClasses,
+        ComplexComponentWithMonitorElementFocus,
+        ComplexComponentWithMonitorSubtreeFocus,
       ],
     });
 
     TestBed.compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ButtonWithFocusClasses);
-    fixture.detectChanges();
+  describe('button with cdkMonitorElementFocus', () => {
+    let fixture: ComponentFixture<ButtonWithFocusClasses>;
+    let buttonElement: HTMLElement;
+    let changeHandler: (origin: FocusOrigin) => void;
 
-    changeHandler = jasmine.createSpy('focus origin change handler');
-    fixture.componentInstance.cdkFocusClasses.changes.subscribe(changeHandler);
-    buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ButtonWithFocusClasses);
+      fixture.detectChanges();
 
-    // Patch the element focus to properly emit focus events when the browser is blurred.
-    patchElementFocus(buttonElement);
+      changeHandler = jasmine.createSpy('focus origin change handler');
+      fixture.componentInstance.cdkMonitorElementFocus.changes.subscribe(changeHandler);
+      buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+
+      // Patch the element focus to properly emit focus events when the browser is blurred.
+      patchElementFocus(buttonElement);
+    });
+
+    it('should initially not be focused', () => {
+      expect(buttonElement.classList.length).toBe(0, 'button should not have focus classes');
+    });
+
+    it('should detect focus via keyboard', async(() => {
+      // Simulate focus via keyboard.
+      dispatchKeydownEvent(document, TAB);
+      buttonElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+        expect(buttonElement.classList.contains('cdk-focused'))
+            .toBe(true, 'button should have cdk-focused class');
+        expect(buttonElement.classList.contains('cdk-keyboard-focused'))
+            .toBe(true, 'button should have cdk-keyboard-focused class');
+        expect(changeHandler).toHaveBeenCalledWith('keyboard');
+      }, 0);
+    }));
+
+    it('should detect focus via mouse', async(() => {
+      // Simulate focus via mouse.
+      dispatchMousedownEvent(buttonElement);
+      buttonElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+        expect(buttonElement.classList.contains('cdk-focused'))
+            .toBe(true, 'button should have cdk-focused class');
+        expect(buttonElement.classList.contains('cdk-mouse-focused'))
+            .toBe(true, 'button should have cdk-mouse-focused class');
+        expect(changeHandler).toHaveBeenCalledWith('mouse');
+      }, 0);
+    }));
+
+    it('should detect focus via touch', async(() => {
+      // Simulate focus via touch.
+      dispatchTouchstartEvent(buttonElement);
+      buttonElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+        expect(buttonElement.classList.contains('cdk-focused'))
+            .toBe(true, 'button should have cdk-focused class');
+        expect(buttonElement.classList.contains('cdk-touch-focused'))
+            .toBe(true, 'button should have cdk-touch-focused class');
+        expect(changeHandler).toHaveBeenCalledWith('touch');
+      }, TOUCH_BUFFER_MS);
+    }));
+
+    it('should detect programmatic focus', async(() => {
+      // Programmatically focus.
+      buttonElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+        expect(buttonElement.classList.contains('cdk-focused'))
+            .toBe(true, 'button should have cdk-focused class');
+        expect(buttonElement.classList.contains('cdk-program-focused'))
+            .toBe(true, 'button should have cdk-program-focused class');
+        expect(changeHandler).toHaveBeenCalledWith('program');
+      }, 0);
+    }));
+
+    it('should remove focus classes on blur', async(() => {
+      buttonElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+        expect(changeHandler).toHaveBeenCalledWith('program');
+
+        buttonElement.blur();
+        fixture.detectChanges();
+
+        expect(buttonElement.classList.length)
+            .toBe(0, 'button should not have any focus classes');
+        expect(changeHandler).toHaveBeenCalledWith(null);
+      }, 0);
+    }));
   });
 
-  it('should initially not be focused', () => {
-    expect(buttonElement.classList.length).toBe(0, 'button should not have focus classes');
+  describe('complex component with cdkMonitorElementFocus', () => {
+    let fixture: ComponentFixture<ComplexComponentWithMonitorElementFocus>;
+    let parentElement: HTMLElement;
+    let childElement: HTMLElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ComplexComponentWithMonitorElementFocus);
+      fixture.detectChanges();
+
+      parentElement = fixture.debugElement.query(By.css('div')).nativeElement;
+      childElement = fixture.debugElement.query(By.css('button')).nativeElement;
+
+      // Patch the element focus to properly emit focus events when the browser is blurred.
+      patchElementFocus(parentElement);
+      patchElementFocus(childElement);
+    });
+
+    it('should add focus classes on parent focus', async(() => {
+      parentElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(parentElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+      }, 0);
+    }));
+
+    it('should not add focus classes on child focus', async(() => {
+      childElement.focus();
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+
+        expect(parentElement.classList.length)
+            .toBe(0, 'button should not have any focus classes');
+      }, 0);
+    }));
   });
 
-  it('should detect focus via keyboard', async(() => {
-    // Simulate focus via keyboard.
-    dispatchKeydownEvent(document, TAB);
-    buttonElement.focus();
-    fixture.detectChanges();
+  describe('complex component with cdkMonitorSubtreeFocus', () => {
+    let fixture: ComponentFixture<ComplexComponentWithMonitorSubtreeFocus>;
+    let parentElement: HTMLElement;
+    let childElement: HTMLElement;
 
-    setTimeout(() => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ComplexComponentWithMonitorSubtreeFocus);
       fixture.detectChanges();
 
-      expect(buttonElement.classList.length)
-          .toBe(2, 'button should have exactly 2 focus classes');
-      expect(buttonElement.classList.contains('cdk-focused'))
-          .toBe(true, 'button should have cdk-focused class');
-      expect(buttonElement.classList.contains('cdk-keyboard-focused'))
-          .toBe(true, 'button should have cdk-keyboard-focused class');
-      expect(changeHandler).toHaveBeenCalledWith('keyboard');
-    }, 0);
-  }));
+      parentElement = fixture.debugElement.query(By.css('div')).nativeElement;
+      childElement = fixture.debugElement.query(By.css('button')).nativeElement;
 
-  it('should detect focus via mouse', async(() => {
-    // Simulate focus via mouse.
-    dispatchMousedownEvent(buttonElement);
-    buttonElement.focus();
-    fixture.detectChanges();
+      // Patch the element focus to properly emit focus events when the browser is blurred.
+      patchElementFocus(parentElement);
+      patchElementFocus(childElement);
+    });
 
-    setTimeout(() => {
+    it('should add focus classes on parent focus', async(() => {
+      parentElement.focus();
       fixture.detectChanges();
 
-      expect(buttonElement.classList.length)
-          .toBe(2, 'button should have exactly 2 focus classes');
-      expect(buttonElement.classList.contains('cdk-focused'))
-          .toBe(true, 'button should have cdk-focused class');
-      expect(buttonElement.classList.contains('cdk-mouse-focused'))
-          .toBe(true, 'button should have cdk-mouse-focused class');
-      expect(changeHandler).toHaveBeenCalledWith('mouse');
-    }, 0);
-  }));
+      setTimeout(() => {
+        fixture.detectChanges();
 
-  it('should detect focus via touch', async(() => {
-    // Simulate focus via touch.
-    dispatchTouchstartEvent(buttonElement);
-    buttonElement.focus();
-    fixture.detectChanges();
+        expect(parentElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+      }, 0);
+    }));
 
-    setTimeout(() => {
+    it('should add focus classes on child focus', async(() => {
+      childElement.focus();
       fixture.detectChanges();
 
-      expect(buttonElement.classList.length)
-          .toBe(2, 'button should have exactly 2 focus classes');
-      expect(buttonElement.classList.contains('cdk-focused'))
-          .toBe(true, 'button should have cdk-focused class');
-      expect(buttonElement.classList.contains('cdk-touch-focused'))
-          .toBe(true, 'button should have cdk-touch-focused class');
-      expect(changeHandler).toHaveBeenCalledWith('touch');
-    }, TOUCH_BUFFER_MS);
-  }));
+      setTimeout(() => {
+        fixture.detectChanges();
 
-  it('should detect programmatic focus', async(() => {
-    // Programmatically focus.
-    buttonElement.focus();
-    fixture.detectChanges();
-
-    setTimeout(() => {
-      fixture.detectChanges();
-
-      expect(buttonElement.classList.length)
-          .toBe(2, 'button should have exactly 2 focus classes');
-      expect(buttonElement.classList.contains('cdk-focused'))
-          .toBe(true, 'button should have cdk-focused class');
-      expect(buttonElement.classList.contains('cdk-program-focused'))
-          .toBe(true, 'button should have cdk-program-focused class');
-      expect(changeHandler).toHaveBeenCalledWith('program');
-    }, 0);
-  }));
-
-  it('should remove focus classes on blur', async(() => {
-    buttonElement.focus();
-    fixture.detectChanges();
-
-    setTimeout(() => {
-      fixture.detectChanges();
-
-      expect(buttonElement.classList.length)
-          .toBe(2, 'button should have exactly 2 focus classes');
-      expect(changeHandler).toHaveBeenCalledWith('program');
-
-      buttonElement.blur();
-      fixture.detectChanges();
-
-      expect(buttonElement.classList.length)
-          .toBe(0, 'button should not have any focus classes');
-      expect(changeHandler).toHaveBeenCalledWith(null);
-    }, 0);
-  }));
+        expect(parentElement.classList.length)
+            .toBe(2, 'button should have exactly 2 focus classes');
+      }, 0);
+    }));
+  });
 });
 
 
@@ -352,10 +456,23 @@ class PlainButton {
 }
 
 
-@Component({template: `<button cdkFocusClasses>focus me!</button>`})
+@Component({template: `<button cdkMonitorElementFocus>focus me!</button>`})
 class ButtonWithFocusClasses {
-  @ViewChild(CdkFocusClasses) cdkFocusClasses: CdkFocusClasses;
+  @ViewChild(CdkMonitorFocus) cdkMonitorElementFocus: CdkMonitorFocus;
 }
+
+
+@Component({
+  template: `<div tabindex="0" cdkMonitorElementFocus><button></button></div>`
+})
+class ComplexComponentWithMonitorElementFocus {}
+
+
+@Component({
+  template: `<div tabindex="0" cdkMonitorSubtreeFocus><button></button></div>`
+})
+class ComplexComponentWithMonitorSubtreeFocus {}
+
 
 // TODO(devversion): move helper functions into a global utility file. See #2902
 

--- a/src/lib/core/style/focus-classes.spec.ts
+++ b/src/lib/core/style/focus-classes.spec.ts
@@ -1,9 +1,9 @@
 import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
-import {Component, Renderer, ViewChild} from '@angular/core';
+import {Component, Renderer} from '@angular/core';
 import {StyleModule} from './index';
 import {By} from '@angular/platform-browser';
 import {TAB} from '../keyboard/keycodes';
-import {CdkMonitorFocus, FocusOrigin, FocusOriginMonitor, TOUCH_BUFFER_MS} from './focus-classes';
+import {FocusOrigin, FocusOriginMonitor, TOUCH_BUFFER_MS} from './focus-classes';
 
 describe('FocusOriginMonitor', () => {
   let fixture: ComponentFixture<PlainButton>;
@@ -250,14 +250,12 @@ describe('cdkMonitorFocus', () => {
   describe('button with cdkMonitorElementFocus', () => {
     let fixture: ComponentFixture<ButtonWithFocusClasses>;
     let buttonElement: HTMLElement;
-    let changeHandler: (origin: FocusOrigin) => void;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(ButtonWithFocusClasses);
       fixture.detectChanges();
 
-      changeHandler = jasmine.createSpy('focus origin change handler');
-      fixture.componentInstance.cdkMonitorElementFocus.changes.subscribe(changeHandler);
+      spyOn(fixture.componentInstance, 'focusChanged');
       buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
 
       // Patch the element focus to properly emit focus events when the browser is blurred.
@@ -283,7 +281,7 @@ describe('cdkMonitorFocus', () => {
             .toBe(true, 'button should have cdk-focused class');
         expect(buttonElement.classList.contains('cdk-keyboard-focused'))
             .toBe(true, 'button should have cdk-keyboard-focused class');
-        expect(changeHandler).toHaveBeenCalledWith('keyboard');
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith('keyboard');
       }, 0);
     }));
 
@@ -302,7 +300,7 @@ describe('cdkMonitorFocus', () => {
             .toBe(true, 'button should have cdk-focused class');
         expect(buttonElement.classList.contains('cdk-mouse-focused'))
             .toBe(true, 'button should have cdk-mouse-focused class');
-        expect(changeHandler).toHaveBeenCalledWith('mouse');
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith('mouse');
       }, 0);
     }));
 
@@ -321,7 +319,7 @@ describe('cdkMonitorFocus', () => {
             .toBe(true, 'button should have cdk-focused class');
         expect(buttonElement.classList.contains('cdk-touch-focused'))
             .toBe(true, 'button should have cdk-touch-focused class');
-        expect(changeHandler).toHaveBeenCalledWith('touch');
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith('touch');
       }, TOUCH_BUFFER_MS);
     }));
 
@@ -339,7 +337,7 @@ describe('cdkMonitorFocus', () => {
             .toBe(true, 'button should have cdk-focused class');
         expect(buttonElement.classList.contains('cdk-program-focused'))
             .toBe(true, 'button should have cdk-program-focused class');
-        expect(changeHandler).toHaveBeenCalledWith('program');
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith('program');
       }, 0);
     }));
 
@@ -352,14 +350,14 @@ describe('cdkMonitorFocus', () => {
 
         expect(buttonElement.classList.length)
             .toBe(2, 'button should have exactly 2 focus classes');
-        expect(changeHandler).toHaveBeenCalledWith('program');
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith('program');
 
         buttonElement.blur();
         fixture.detectChanges();
 
         expect(buttonElement.classList.length)
             .toBe(0, 'button should not have any focus classes');
-        expect(changeHandler).toHaveBeenCalledWith(null);
+        expect(fixture.componentInstance.focusChanged).toHaveBeenCalledWith(null);
       }, 0);
     }));
   });
@@ -450,15 +448,19 @@ describe('cdkMonitorFocus', () => {
 });
 
 
-@Component({template: `<button>focus me!</button>`})
+@Component({
+  template: `<button>focus me!</button>`
+})
 class PlainButton {
   constructor(public renderer: Renderer) {}
 }
 
 
-@Component({template: `<button cdkMonitorElementFocus>focus me!</button>`})
+@Component({
+  template: `<button cdkMonitorElementFocus (cdkFocusChange)="focusChanged($event)"></button>`
+})
 class ButtonWithFocusClasses {
-  @ViewChild(CdkMonitorFocus) cdkMonitorElementFocus: CdkMonitorFocus;
+  focusChanged(origin: FocusOrigin) {};
 }
 
 

--- a/src/lib/core/style/focus-classes.spec.ts
+++ b/src/lib/core/style/focus-classes.spec.ts
@@ -32,7 +32,7 @@ describe('FocusOriginMonitor', () => {
     focusOriginMonitor = fom;
 
     changeHandler = jasmine.createSpy('focus origin change handler');
-    focusOriginMonitor.registerElementForFocusClasses(buttonElement, buttonRenderer)
+    focusOriginMonitor.monitor(buttonElement, buttonRenderer)
         .subscribe(changeHandler);
 
     // Patch the element focus to properly emit focus events when the browser is blurred.

--- a/src/lib/core/style/focus-classes.ts
+++ b/src/lib/core/style/focus-classes.ts
@@ -281,9 +281,7 @@ export class CdkMonitorFocus implements OnDestroy {
     this._focusOriginMonitor.monitor(
         this._elementRef.nativeElement, renderer,
         this._elementRef.nativeElement.hasAttribute('cdkMonitorSubtreeFocus'))
-        .subscribe((origin) => {
-          this.cdkFocusChange.emit(origin);
-        });
+        .subscribe(origin => this.cdkFocusChange.emit(origin));
   }
 
   ngOnDestroy() {

--- a/src/lib/core/style/focus-origin-monitor.spec.ts
+++ b/src/lib/core/style/focus-origin-monitor.spec.ts
@@ -3,7 +3,7 @@ import {Component, Renderer} from '@angular/core';
 import {StyleModule} from './index';
 import {By} from '@angular/platform-browser';
 import {TAB} from '../keyboard/keycodes';
-import {FocusOrigin, FocusOriginMonitor, TOUCH_BUFFER_MS} from './focus-classes';
+import {FocusOrigin, FocusOriginMonitor, TOUCH_BUFFER_MS} from './focus-origin-monitor';
 
 describe('FocusOriginMonitor', () => {
   let fixture: ComponentFixture<PlainButton>;

--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -1,6 +1,14 @@
 import {
-  Directive, Injectable, Optional, SkipSelf, Renderer, ElementRef,
-  OnDestroy, NgZone, EventEmitter, Output
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Injectable,
+  NgZone,
+  OnDestroy,
+  Optional,
+  Output,
+  Renderer,
+  SkipSelf
 } from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';

--- a/src/lib/core/style/index.ts
+++ b/src/lib/core/style/index.ts
@@ -1,13 +1,13 @@
 import {NgModule} from '@angular/core';
-import {CdkFocusClasses, FOCUS_ORIGIN_MONITOR_PROVIDER} from './focus-classes';
+import {CdkMonitorFocus, FOCUS_ORIGIN_MONITOR_PROVIDER} from './focus-classes';
 
 export * from './focus-classes';
 export * from './apply-transform';
 
 
 @NgModule({
-  declarations: [CdkFocusClasses],
-  exports: [CdkFocusClasses],
+  declarations: [CdkMonitorFocus],
+  exports: [CdkMonitorFocus],
   providers: [FOCUS_ORIGIN_MONITOR_PROVIDER],
 })
 export class StyleModule {}

--- a/src/lib/core/style/index.ts
+++ b/src/lib/core/style/index.ts
@@ -1,7 +1,7 @@
 import {NgModule} from '@angular/core';
-import {CdkMonitorFocus, FOCUS_ORIGIN_MONITOR_PROVIDER} from './focus-classes';
+import {CdkMonitorFocus, FOCUS_ORIGIN_MONITOR_PROVIDER} from './focus-origin-monitor';
 
-export * from './focus-classes';
+export * from './focus-origin-monitor';
 export * from './apply-transform';
 
 


### PR DESCRIPTION
Also includes some cleanup:
* rename `registerElementForFocusClasses` to `monitor`
* add `unmonitor` method and call on directive destroyed
* do all listening outside angular
* replace `cdkFocusClasses` with `cdkMonitorElementFocus` and `cdkMonitorSubtreeFocus`
