### PR TITLE
docs(guide): remove .forRoot() in guide

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -27,7 +27,7 @@ npm install --save @angular/material
 import { MaterialModule } from '@angular/material';
 // other imports 
 @NgModule({
-  imports: [MaterialModule.forRoot()],
+  imports: [MaterialModule],
   ...
 })
 export class PizzaPartyAppModule { }


### PR DESCRIPTION
In beta 2.0.0-beta.2, forRoot is deprecated.