### PR TITLE
fix(card): unable to override elevation

### DIFF
--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -9,13 +9,16 @@ $mat-card-border-radius: 2px !default;
 $mat-card-header-size: 40px !default;
 
 .mat-card {
-  @include mat-elevation(2);
   @include mat-elevation-transition;
   display: block;
   position: relative;
   padding: $mat-card-default-padding;
   border-radius: $mat-card-border-radius;
   font-family: $mat-font-family;
+
+  &:not([class*='mat-elevation-z']) {
+    @include mat-elevation(2);
+  }
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Fixes an issue that prevents users from overriding the elevation of cards. The issue was introduced with the switch to the `mat-` prefix which changed the styling of cards from an element selector to a class, which has a higher specificity than the elevation classes. This change only adds the card shadow if it doesn't have an elevation class.

Fixes #3123.