### PR TITLE
fix(select): allow option with undefined or null value to clear selection

### DIFF
--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -6,6 +6,8 @@
 
     <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired" [disabled]="drinksDisabled"
       [floatPlaceholder]="floatPlaceholder" #drinkControl="ngModel">
+      #drinkControl="ngModel">
+      <md-option>None</md-option>
       <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
         {{ drink.viewValue }}
       </md-option>

--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -4,9 +4,8 @@
   <md-card>
     <md-card-subtitle>ngModel</md-card-subtitle>
 
-    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired" [disabled]="drinksDisabled"
-      [floatPlaceholder]="floatPlaceholder" #drinkControl="ngModel">
-      #drinkControl="ngModel">
+    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired"
+      [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder" #drinkControl="ngModel">
       <md-option>None</md-option>
       <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
         {{ drink.viewValue }}

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -23,6 +23,7 @@ export class SelectDemo {
   pokemonTheme = 'primary';
 
   foods = [
+    {value: null, viewValue: 'None'},
     {value: 'steak-0', viewValue: 'Steak'},
     {value: 'pizza-1', viewValue: 'Pizza'},
     {value: 'tacos-2', viewValue: 'Tacos'}

--- a/src/lib/select/select.md
+++ b/src/lib/select/select.md
@@ -1,13 +1,13 @@
 `<md-select>` is a form control for selecting a value from a set of options, similar to the native
-`<select>` element. You can read more about selects in the 
+`<select>` element. You can read more about selects in the
 [Material Design spec](https://material.google.com/components/menus.html).
 
 <!-- example(select-overview) -->
 
 ### Simple select
 
-In your template, create an `md-select` element. For each option you'd like in your select, add an 
-`md-option` tag. Note that you can disable items by adding the `disabled` boolean attribute or 
+In your template, create an `md-select` element. For each option you'd like in your select, add an
+`md-option` tag. Note that you can disable items by adding the `disabled` boolean attribute or
 binding to it.
 
 *my-comp.html*
@@ -19,7 +19,7 @@ binding to it.
 
 ### Getting and setting the select value
 
-The select component is set up as a custom value accessor, so you can manipulate the select's value using 
+The select component is set up as a custom value accessor, so you can manipulate the select's value using
 any of the form directives from the core `FormsModule` or `ReactiveFormsModule`: `ngModel`, `formControl`, etc.
 
 *my-comp.html*
@@ -37,18 +37,30 @@ class MyComp {
 }
 ```
 
+### Resetting the select value
+
+If you want one of your options to reset the select's value, you can omit specifying its value:
+
+*my-comp.html*
+```html
+<md-select placeholder="State">
+   <md-option>None</md-option>
+   <md-option *ngFor="let state of states" [value]="state.code">{{ state.name }}</md-option>
+</md-select>
+```
+
 ### Setting a static placeholder
 
 It's possible to turn off the placeholder's floating animation using the `floatPlaceholder` property. It accepts one of three string options:
 - `'auto'`: This is the default floating placeholder animation. It will float up when a selection is made.
 - `'never'`: This makes the placeholder static. Rather than floating, it will disappear once a selection is made.
 - `'always'`: This makes the placeholder permanently float above the input. It will not animate up or down.
-    
+
 ```html
 <md-select placeholder="State" [(ngModel)]="myState" floatPlaceholder="never">
    <md-option *ngFor="let state of states" [value]="state.code">{{ state.name }}</md-option>
 </md-select>
-``` 
+```
 
 #### Keyboard interaction:
 - <kbd>DOWN_ARROW</kbd>: Focus next option

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -56,7 +56,8 @@ describe('MdSelect', () => {
         SelectEarlyAccessSibling,
         BasicSelectInitiallyHidden,
         BasicSelectNoPlaceholder,
-        BasicSelectWithTheming
+        BasicSelectWithTheming,
+        ResetValuesSelect
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -1995,6 +1996,72 @@ describe('MdSelect', () => {
 
   });
 
+
+  describe('reset values', () => {
+    let fixture: ComponentFixture<ResetValuesSelect>;
+    let trigger: HTMLElement;
+    let placeholder: HTMLElement;
+    let options: NodeListOf<HTMLElement>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ResetValuesSelect);
+      fixture.detectChanges();
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      placeholder = fixture.debugElement.query(By.css('.mat-select-placeholder')).nativeElement;
+
+      trigger.click();
+      fixture.detectChanges();
+      options = overlayContainerElement.querySelectorAll('md-option') as NodeListOf<HTMLElement>;
+
+      options[0].click();
+      fixture.detectChanges();
+    });
+
+    it('should reset when an option with an undefined value is selected', () => {
+      options[4].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBeUndefined();
+      expect(fixture.componentInstance.select.selected).toBeFalsy();
+      expect(placeholder.classList).not.toContain('mat-floating-placeholder');
+      expect(trigger.textContent).not.toContain('Undefined');
+    });
+
+    it('should reset when an option with a null value is selected', () => {
+      options[5].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBeNull();
+      expect(fixture.componentInstance.select.selected).toBeFalsy();
+      expect(placeholder.classList).not.toContain('mat-floating-placeholder');
+      expect(trigger.textContent).not.toContain('Null');
+    });
+
+    it('should not reset when any other falsy option is selected', () => {
+      options[3].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBe(false);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(placeholder.classList).toContain('mat-floating-placeholder');
+      expect(trigger.textContent).toContain('Falsy');
+    });
+
+    it('should not consider the reset values as selected when resetting the form control', () => {
+      expect(placeholder.classList).toContain('mat-floating-placeholder');
+
+      fixture.componentInstance.control.reset();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBeNull();
+      expect(fixture.componentInstance.select.selected).toBeFalsy();
+      expect(placeholder.classList).not.toContain('mat-floating-placeholder');
+      expect(trigger.textContent).not.toContain('Null');
+      expect(trigger.textContent).not.toContain('Undefined');
+    });
+
+  });
+
 });
 
 
@@ -2338,4 +2405,30 @@ class BasicSelectNoPlaceholder { }
 class BasicSelectWithTheming {
   @ViewChild(MdSelect) select: MdSelect;
   theme: string;
+}
+
+@Component({
+  selector: 'reset-values-select',
+  template: `
+    <md-select placeholder="Food" [formControl]="control" [required]="isRequired">
+      <md-option *ngFor="let food of foods" [value]="food.value">
+        {{ food.viewValue }}
+      </md-option>
+    </md-select>
+  `
+})
+class ResetValuesSelect {
+  foods: any[] = [
+    { value: 'steak-0', viewValue: 'Steak' },
+    { value: 'pizza-1', viewValue: 'Pizza' },
+    { value: 'tacos-2', viewValue: 'Tacos' },
+    { value: false, viewValue: 'Falsy' },
+    { viewValue: 'Undefined' },
+    { value: null, viewValue: 'Null' },
+  ];
+  control = new FormControl();
+  isRequired: boolean;
+
+  @ViewChild(MdSelect) select: MdSelect;
+  @ViewChildren(MdOption) options: QueryList<MdOption>;
 }

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2037,6 +2037,16 @@ describe('MdSelect', () => {
       expect(trigger.textContent).not.toContain('Null');
     });
 
+    it('should reset when a blank option is selected', () => {
+      options[6].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBeUndefined();
+      expect(fixture.componentInstance.select.selected).toBeFalsy();
+      expect(placeholder.classList).not.toContain('mat-floating-placeholder');
+      expect(trigger.textContent).not.toContain('None');
+    });
+
     it('should not reset when any other falsy option is selected', () => {
       options[3].click();
       fixture.detectChanges();
@@ -2410,10 +2420,12 @@ class BasicSelectWithTheming {
 @Component({
   selector: 'reset-values-select',
   template: `
-    <md-select placeholder="Food" [formControl]="control" [required]="isRequired">
+    <md-select placeholder="Food" [formControl]="control">
       <md-option *ngFor="let food of foods" [value]="food.value">
         {{ food.viewValue }}
       </md-option>
+
+      <md-option>None</md-option>
     </md-select>
   `
 })
@@ -2427,8 +2439,6 @@ class ResetValuesSelect {
     { value: null, viewValue: 'Null' },
   ];
   control = new FormControl();
-  isRequired: boolean;
 
   @ViewChild(MdSelect) select: MdSelect;
-  @ViewChildren(MdOption) options: QueryList<MdOption>;
 }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -567,7 +567,7 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
    */
   private _selectValue(value: any): MdOption {
     let optionsArray = this.options.toArray();
-    let correspondingOption = optionsArray.find(option => option.value === value);
+    let correspondingOption = optionsArray.find(option => option.value && option.value === value);
 
     if (correspondingOption) {
       correspondingOption.select();
@@ -632,8 +632,14 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
       wasSelected ? option.deselect() : option.select();
       this._sortValues();
     } else {
-      this._clearSelection(option);
-      this._selectionModel.select(option);
+      if (option.value == null) {
+        this._clearSelection();
+        this._onChange(option.value);
+        this.change.emit(new MdSelectChange(this, option.value));
+      } else {
+        this._clearSelection(option);
+        this._selectionModel.select(option);
+      }
     }
 
     if (wasSelected !== this._selectionModel.isSelected(option)) {


### PR DESCRIPTION
Allows for options with a value of `null` or `undefined` to clear the select. This is similar to the way the native select works.

Fixes #3110.
Fixes #2634.