### PR TITLE
fix(tabs): remove body and header from compatibility

### DIFF
--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -68,8 +68,6 @@ export const MAT_ELEMENTS_SELECTOR = `
   mat-slider,
   mat-spinner,
   mat-tab,
-  mat-tab-body,
-  mat-tab-header,
   mat-tab-group,
   mat-toolbar`;
 
@@ -131,8 +129,6 @@ export const MD_ELEMENTS_SELECTOR = `
   md-slider,
   md-spinner,
   md-tab,
-  md-tab-body,
-  md-tab-header,
   md-tab-group,
   md-toolbar`;
 


### PR DESCRIPTION
Tabs component always adds in md-tab-body and md-tab-header, so this cannot be checked against for compatibility. They are not exported anyways so users cannot use them.

Closes #3166