### PR TITLE
fix(slide-toggle): ripple fade-in too slow

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -12,8 +12,7 @@
         <div class="mat-slide-toggle-ripple" md-ripple
              [mdRippleTrigger]="label"
              [mdRippleCentered]="true"
-             [mdRippleDisabled]="disableRipple || disabled"
-             [mdRippleSpeedFactor]="0.3">
+             [mdRippleDisabled]="disableRipple || disabled">
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Since PR #3136 changed the default duration for ripple elements, the slide-toggle ripples are now way too slow.