### PR TITLE
fix(autocomplete): blur not being handled in compatibility mode

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -222,7 +222,7 @@ export class MdAutocompleteTrigger implements AfterContentInit, ControlValueAcce
     this._onTouched();
 
     // Only emit blur event if the new focus is *not* on an option.
-    if (newlyFocusedTag !== 'MD-OPTION') {
+    if (newlyFocusedTag !== 'MD-OPTION' && newlyFocusedTag !== 'MAT-OPTION') {
       this._blurStream.next(null);
     }
   }


### PR DESCRIPTION
Fixes the blur event not being handled properly if the user uses `mat-option`, instead of `md-option`.