### PR TITLE
refactor(focus-trap): convert to directive

### DIFF
--- a/src/lib/core/a11y/focus-trap.html
+++ b/src/lib/core/a11y/focus-trap.html
@@ -1,3 +1,0 @@
-<div *ngIf="!disabled" tabindex="0" (focus)="focusLastTabbableElement()"></div>
-<div #trappedContent class="cdk-focus-trap-content"><ng-content></ng-content></div>
-<div *ngIf="!disabled" tabindex="0" (focus)="focusFirstTabbableElement()"></div>

--- a/src/lib/core/a11y/focus-trap.ts
+++ b/src/lib/core/a11y/focus-trap.ts
@@ -1,78 +1,122 @@
-import {Component, ViewEncapsulation, ViewChild, ElementRef, Input, NgZone} from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  AfterContentInit,
+  Injectable,
+} from '@angular/core';
 import {InteractivityChecker} from './interactivity-checker';
 import {coerceBooleanProperty} from '../coercion/boolean-property';
 
 
 /**
- * Directive for trapping focus within a region.
+ * Class that allows for trapping focus within a DOM element.
  *
- * NOTE: This directive currently uses a very simple (naive) approach to focus trapping.
+ * NOTE: This class currently uses a very simple (naive) approach to focus trapping.
  * It assumes that the tab order is the same as DOM order, which is not necessarily true.
  * Things like tabIndex > 0, flex `order`, and shadow roots can cause to two to misalign.
  * This will be replaced with a more intelligent solution before the library is considered stable.
  */
-@Component({
-  moduleId: module.id,
-  selector: 'cdk-focus-trap, focus-trap',
-  templateUrl: 'focus-trap.html',
-  encapsulation: ViewEncapsulation.None,
-})
 export class FocusTrap {
-  @ViewChild('trappedContent') trappedContent: ElementRef;
+  private _startAnchor: HTMLElement;
+  private _endAnchor: HTMLElement;
 
   /** Whether the focus trap is active. */
-  @Input()
-  get disabled(): boolean { return this._disabled; }
-  set disabled(val: boolean) { this._disabled = coerceBooleanProperty(val); }
-  private _disabled: boolean = false;
+  get enabled(): boolean { return this._enabled; }
+  set enabled(val: boolean) {
+    this._enabled = val;
 
-  constructor(private _checker: InteractivityChecker, private _ngZone: NgZone) { }
+    if (this._startAnchor && this._endAnchor) {
+      this._startAnchor.tabIndex = this._endAnchor.tabIndex = this._enabled ? 0 : -1;
+    }
+  }
+  private _enabled: boolean = true;
+
+  constructor(
+    private _element: HTMLElement,
+    private _checker: InteractivityChecker,
+    private _ngZone: NgZone,
+    deferAnchors = false) {
+
+    if (!deferAnchors) {
+      this.attachAnchors();
+    }
+  }
+
+  /** Destroys the focus trap by cleaning up the anchors. */
+  destroy() {
+    if (this._startAnchor && this._startAnchor.parentNode) {
+      this._startAnchor.parentNode.removeChild(this._startAnchor);
+    }
+
+    if (this._endAnchor && this._endAnchor.parentNode) {
+      this._endAnchor.parentNode.removeChild(this._endAnchor);
+    }
+
+    this._startAnchor = this._endAnchor = null;
+  }
 
   /**
-   * Waits for microtask queue to empty, then focuses the first tabbable element within the focus
-   * trap region.
+   * Inserts the anchors into the DOM. This is usually done automatically
+   * in the constructor, but can be deferred for cases like directives with `*ngIf`.
+   */
+  attachAnchors(): void {
+    if (!this._startAnchor) {
+      this._startAnchor = this._createAnchor();
+    }
+
+    if (!this._endAnchor) {
+      this._endAnchor = this._createAnchor();
+    }
+
+    this._ngZone.runOutsideAngular(() => {
+      this._element
+        .insertAdjacentElement('beforebegin', this._startAnchor)
+        .addEventListener('focus', () => this.focusLastTabbableElement());
+
+      this._element
+        .insertAdjacentElement('afterend', this._endAnchor)
+        .addEventListener('focus', () => this.focusFirstTabbableElement());
+    });
+  }
+
+  /**
+   * Waits for microtask queue to empty, then focuses
+   * the first tabbable element within the focus trap region.
    */
   focusFirstTabbableElementWhenReady() {
-    this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
-      this.focusFirstTabbableElement();
-    });
+    this._ngZone.onMicrotaskEmpty.first().subscribe(() => this.focusFirstTabbableElement());
   }
 
   /**
-   * Waits for microtask queue to empty, then focuses the last tabbable element within the focus
-   * trap region.
+   * Waits for microtask queue to empty, then focuses
+   * the last tabbable element within the focus trap region.
    */
   focusLastTabbableElementWhenReady() {
-    this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
-      this.focusLastTabbableElement();
-    });
+    this._ngZone.onMicrotaskEmpty.first().subscribe(() => this.focusLastTabbableElement());
   }
 
-  /**
-   * Focuses the first tabbable element within the focus trap region.
-   */
+  /** Focuses the first tabbable element within the focus trap region. */
   focusFirstTabbableElement() {
-    let rootElement = this.trappedContent.nativeElement;
-    let redirectToElement = rootElement.querySelector('[cdk-focus-start]') as HTMLElement ||
-                            this._getFirstTabbableElement(rootElement);
+    let redirectToElement = this._element.querySelector('[cdk-focus-start]') as HTMLElement ||
+                            this._getFirstTabbableElement(this._element);
 
     if (redirectToElement) {
       redirectToElement.focus();
     }
   }
 
-  /**
-   * Focuses the last tabbable element within the focus trap region.
-   */
+  /** Focuses the last tabbable element within the focus trap region. */
   focusLastTabbableElement() {
-    let rootElement = this.trappedContent.nativeElement;
-    let focusTargets = rootElement.querySelectorAll('[cdk-focus-end]');
+    let focusTargets = this._element.querySelectorAll('[cdk-focus-end]');
     let redirectToElement: HTMLElement = null;
 
     if (focusTargets.length) {
       redirectToElement = focusTargets[focusTargets.length - 1] as HTMLElement;
     } else {
-      redirectToElement = this._getLastTabbableElement(rootElement);
+      redirectToElement = this._getLastTabbableElement(this._element);
     }
 
     if (redirectToElement) {
@@ -113,5 +157,82 @@ export class FocusTrap {
     }
 
     return null;
+  }
+
+  /** Creates an anchor element. */
+  private _createAnchor(): HTMLElement {
+    let anchor = document.createElement('div');
+    anchor.tabIndex = this._enabled ? 0 : -1;
+    anchor.classList.add('cdk-visually-hidden');
+    anchor.classList.add('cdk-focus-trap-anchor');
+    return anchor;
+  }
+}
+
+
+/** Factory that allows easy instantiation of focus traps. */
+@Injectable()
+export class FocusTrapFactory {
+  constructor(private _checker: InteractivityChecker, private _ngZone: NgZone) { }
+
+  create(element: HTMLElement, deferAnchors = false): FocusTrap {
+    return new FocusTrap(element, this._checker, this._ngZone, deferAnchors);
+  }
+}
+
+
+/**
+ * Directive for trapping focus within a region.
+ * @deprecated
+ */
+@Directive({
+  selector: 'cdk-focus-trap',
+})
+export class FocusTrapDeprecatedDirective implements OnDestroy, AfterContentInit {
+  focusTrap: FocusTrap;
+
+  /** Whether the focus trap is active. */
+  @Input()
+  get disabled(): boolean { return !this.focusTrap.enabled; }
+  set disabled(val: boolean) {
+    this.focusTrap.enabled = !coerceBooleanProperty(val);
+  }
+
+  constructor(private _elementRef: ElementRef, private _focusTrapFactory: FocusTrapFactory) {
+    this.focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement, true);
+  }
+
+  ngOnDestroy() {
+    this.focusTrap.destroy();
+  }
+
+  ngAfterContentInit() {
+    this.focusTrap.attachAnchors();
+  }
+}
+
+
+/** Directive for trapping focus within a region. */
+@Directive({
+  selector: '[cdkTrapFocus]'
+})
+export class FocusTrapDirective implements OnDestroy, AfterContentInit {
+  focusTrap: FocusTrap;
+
+  /** Whether the focus trap is active. */
+  @Input('cdkTrapFocus')
+  get enabled(): boolean { return this.focusTrap.enabled; }
+  set enabled(val: boolean) { this.focusTrap.enabled = val; }
+
+  constructor(private _elementRef: ElementRef, private _focusTrapFactory: FocusTrapFactory) {
+    this.focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement, true);
+  }
+
+  ngOnDestroy() {
+    this.focusTrap.destroy();
+  }
+
+  ngAfterContentInit() {
+    this.focusTrap.attachAnchors();
   }
 }

--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -1,5 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {FocusTrap} from './focus-trap';
+import {FocusTrapDirective, FocusTrapDeprecatedDirective, FocusTrapFactory} from './focus-trap';
 import {LIVE_ANNOUNCER_PROVIDER} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
 import {CommonModule} from '@angular/common';
@@ -7,9 +7,9 @@ import {PlatformModule} from '../platform/index';
 
 @NgModule({
   imports: [CommonModule, PlatformModule],
-  declarations: [FocusTrap],
-  exports: [FocusTrap],
-  providers: [InteractivityChecker, LIVE_ANNOUNCER_PROVIDER]
+  declarations: [FocusTrapDirective, FocusTrapDeprecatedDirective],
+  exports: [FocusTrapDirective, FocusTrapDeprecatedDirective],
+  providers: [InteractivityChecker, FocusTrapFactory, LIVE_ANNOUNCER_PROVIDER]
 })
 export class A11yModule {
   /** @deprecated */

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -80,7 +80,7 @@ export * from './selection/selection';
 /** @deprecated */
 export {LiveAnnouncer as MdLiveAnnouncer} from './a11y/live-announcer';
 
-export {FocusTrap} from './a11y/focus-trap';
+export * from './a11y/focus-trap';
 export {InteractivityChecker} from './a11y/interactivity-checker';
 export {isFakeMousedownFromScreenReader} from './a11y/fake-mousedown';
 

--- a/src/lib/dialog/dialog-container.html
+++ b/src/lib/dialog/dialog-container.html
@@ -1,3 +1,1 @@
-<cdk-focus-trap>
-  <template cdkPortalHost></template>
-</cdk-focus-trap>
+<template cdkPortalHost></template>

--- a/src/lib/sidenav/sidenav.html
+++ b/src/lib/sidenav/sidenav.html
@@ -1,3 +1,1 @@
-<cdk-focus-trap class="mat-sidenav-focus-trap" [disabled]="isFocusTrapDisabled">
-  <ng-content></ng-content>
-</cdk-focus-trap>
+<ng-content></ng-content>

--- a/src/lib/sidenav/sidenav.scss
+++ b/src/lib/sidenav/sidenav.scss
@@ -100,6 +100,9 @@
   z-index: 3;
   min-width: 5vw;
   outline: 0;
+  box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto; // TODO(kara): revisit scrolling behavior for sidenavs
 
   @include mat-sidenav-transition(0, -100%);
 
@@ -130,19 +133,6 @@
       // See https://material.io/guidelines/patterns/navigation-drawer.html#
       @include mat-elevation(16);
     }
-  }
-}
-
-.mat-sidenav-focus-trap {
-  height: 100%;
-
-  > .cdk-focus-trap-content {
-    box-sizing: border-box;
-    height: 100%;
-    overflow-y: auto; // TODO(kara): revisit scrolling behavior for sidenavs
-
-    // Prevents unnecessary repaints while scrolling.
-    transform: translateZ(0);
   }
 }
 


### PR DESCRIPTION
Refactors the focus trap to be used as a directive, rather than a component. This gives us a couple of advantages:
* It can be used on the same node as other components.
* It removes a level of nesting in the DOM. This makes it slightly more convenient to style projected in cases like the dialog (see #2546), where flexbox needs to be applied to the closest possible ancestor.

Also includes the following improvements:
* Adds a service for setting up a focus trap without direct access to the template.
* No longer triggers change detection when focus hits the start/end anchors.
* Resets the anchor tab index when trapping is disabled, instead of removing elements from the DOM.
* Adds missing unit tests for the disabled and cleanup logic.