### PR TITLE
feat(select): add md-select-header directive

### DIFF
--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -113,5 +113,20 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     </md-card>
   </div>
 
+  <md-card *ngIf="showSelect">
+    <md-select placeholder="Drink" [(ngModel)]="currentDrink" #selectWitHeader="mdSelect">
+      <md-select-header>
+        <input type="search" [(ngModel)]="searchTerm" role="combobox" [attr.aria-owns]="selectWitHeader.panelId"
+          (ngModelChange)="filterDrinks()" placeholder="Search for a drink"/>
+      </md-select-header>
+
+      <md-option *ngFor="let drink of filteredDrinks" [value]="drink.value" [disabled]="drink.disabled">
+        {{ drink.viewValue }}
+      </md-option>
+
+    </md-select>
+  </md-card>
+
+
 </div>
 <div style="height: 500px">This div is for testing scrolled selects.</div>

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -17,6 +17,7 @@ export class SelectDemo {
   currentDrink: string;
   currentPokemon: string[];
   currentPokemonFromGroup: string;
+  searchTerm: string;
   latestChangeEvent: MdSelectChange;
   floatPlaceholder: string = 'auto';
   foodControl = new FormControl('pizza-1');
@@ -42,6 +43,8 @@ export class SelectDemo {
     {value: 'wine-7', viewValue: 'Wine'},
     {value: 'milk-8', viewValue: 'Milk'},
   ];
+
+  filteredDrinks = this.drinks.slice();
 
   pokemon = [
     {value: 'bulbasaur-0', viewValue: 'Bulbasaur'},
@@ -100,5 +103,11 @@ export class SelectDemo {
 
   setPokemonValue() {
     this.currentPokemon = ['eevee-4', 'psyduck-6'];
+  }
+
+  filterDrinks() {
+    this.filteredDrinks = this.searchTerm ? this.drinks.filter(item => {
+      return item.viewValue.toLowerCase().indexOf(this.searchTerm.toLowerCase()) > -1;
+    }) : this.drinks.slice();
   }
 }

--- a/src/examples/select-header/select-header-example.css
+++ b/src/examples/select-header/select-header-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/examples/select-header/select-header-example.html
+++ b/src/examples/select-header/select-header-example.html
@@ -1,0 +1,12 @@
+<md-select placeholder="Favorite food" [(ngModel)]="currentDrink" name="food" #select="mdSelect">
+  <md-select-header>
+    <input type="search" [(ngModel)]="searchString" role="combobox" [attr.aria-owns]="select.panelId"
+      (ngModelChange)="filterFoods()" placeholder="Search for food"/>
+  </md-select-header>
+
+  <md-option *ngFor="let food of foods" [value]="food.value">
+    {{food.viewValue}}
+  </md-option>
+</md-select>
+
+<p> Selected value: {{selectedValue}} </p>

--- a/src/examples/select-header/select-header-example.html
+++ b/src/examples/select-header/select-header-example.html
@@ -1,4 +1,4 @@
-<md-select placeholder="Favorite food" [(ngModel)]="currentDrink" name="food" #select="mdSelect">
+<md-select placeholder="Favorite food" [(ngModel)]="selectedValue" name="food" #select="mdSelect">
   <md-select-header>
     <input type="search" [(ngModel)]="searchString" role="combobox" [attr.aria-owns]="select.panelId"
       (ngModelChange)="filterFoods()" placeholder="Search for food"/>

--- a/src/examples/select-header/select-header-example.ts
+++ b/src/examples/select-header/select-header-example.ts
@@ -1,0 +1,30 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'select-form-example',
+  templateUrl: './select-form-example.html',
+})
+export class SelectHeaderExample {
+  selectedValue: string;
+  searchString: string;
+
+  initialFoods = [
+    { value: 'steak-0', viewValue: 'Steak' },
+    { value: 'pizza-1', viewValue: 'Pizza' },
+    { value: 'tacos-2', viewValue: 'Tacos' },
+    { value: 'sandwich-3', viewValue: 'Sandwich' },
+    { value: 'chips-4', viewValue: 'Chips' },
+    { value: 'eggs-5', viewValue: 'Eggs' },
+    { value: 'pasta-6', viewValue: 'Pasta' },
+    { value: 'sushi-7', viewValue: 'Sushi' },
+  ];
+
+  foods = this.initialFoods.slice();
+
+  filterFoods() {
+    this.foods = this.searchString ? this.initialFoods.filter(item => {
+      return item.viewValue.toLowerCase().indexOf(this.searchString.toLowerCase()) > -1;
+    }) : this.initialFoods.slice();
+  }
+}

--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -15,11 +15,10 @@ $mat-menu-icon-margin: 16px !default;
 
 @mixin mat-menu-base() {
   @include mat-elevation(8);
+  @include mat-menu-scrollable();
+
   min-width: $mat-menu-overlay-min-width;
   max-width: $mat-menu-overlay-max-width;
-
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;   // for momentum scroll on mobile
 }
 
 @mixin mat-menu-item-base() {
@@ -90,4 +89,9 @@ $mat-menu-icon-margin: 16px !default;
       transform-origin: left bottom;
     }
   }
+}
+
+@mixin mat-menu-scrollable() {
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;   // for momentum scroll on mobile
 }

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -26,6 +26,10 @@
     color: mat-color($foreground, hint-text);
   }
 
+  .mat-select-header {
+    color: mat-color($foreground, divider);
+  }
+
   .mat-select-underline {
     background-color: mat-color($foreground, divider);
   }

--- a/src/lib/select/index.ts
+++ b/src/lib/select/index.ts
@@ -9,6 +9,7 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdSelect} from './select';
+import {MdSelectHeader} from './select-header';
 import {MdCommonModule, OverlayModule, MdOptionModule} from '../core';
 
 
@@ -19,11 +20,12 @@ import {MdCommonModule, OverlayModule, MdOptionModule} from '../core';
     MdOptionModule,
     MdCommonModule,
   ],
-  exports: [MdSelect, MdOptionModule, MdCommonModule],
-  declarations: [MdSelect],
+  exports: [MdSelect, MdSelectHeader, MdOptionModule, MdCommonModule],
+  declarations: [MdSelect, MdSelectHeader],
 })
 export class MdSelectModule {}
 
 
 export * from './select';
+export * from './select-header';
 export {fadeInContent, transformPanel, transformPlaceholder} from './select-animations';

--- a/src/lib/select/select-header.ts
+++ b/src/lib/select/select-header.ts
@@ -1,0 +1,13 @@
+import {Directive} from '@angular/core';
+
+
+/**
+ * Fixed header that will be rendered above a select's options.
+ */
+@Directive({
+  selector: 'md-select-header, mat-select-header',
+  host: {
+    'class': 'mat-select-header',
+  }
+})
+export class MdSelectHeader { }

--- a/src/lib/select/select-header.ts
+++ b/src/lib/select/select-header.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Directive} from '@angular/core';
 
 

--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -35,7 +35,12 @@
     [style.transformOrigin]="_transformOrigin"
     [class.mat-select-panel-done-animating]="_panelDoneAnimating">
 
-    <div class="mat-select-content" [@fadeInContent]="'showing'" (@fadeInContent.done)="_onFadeInDone()">
+    <div [@fadeInContent]="'showing'">
+      <ng-content select="md-select-header, mat-select-header"></ng-content>
+    </div>
+
+    <div class="mat-select-content" [attr.id]="panelId" [@fadeInContent]="'showing'"
+      (@fadeInContent.done)="_onFadeInDone()">
       <ng-content></ng-content>
     </div>
   </div>

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -117,14 +117,33 @@ $mat-select-panel-max-height: 256px !default;
   margin: 0 $mat-select-arrow-margin;
 }
 
-.mat-select-panel {
-  @include mat-menu-base();
-  padding-top: 0;
-  padding-bottom: 0;
+.mat-select-content {
+  @include mat-menu-scrollable();
   max-height: $mat-select-panel-max-height;
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
 
   @include cdk-high-contrast {
     outline: solid 1px;
+  }
+}
+
+.mat-select-panel {
+  @include mat-menu-base();
+  border: none;
+}
+
+.mat-select-header {
+  @include mat-menu-item-base();
+  border-bottom: solid 1px;
+  box-sizing: border-box;
+
+  input {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+    outline: none;
+    padding: 0;
+    background: transparent;
   }
 }

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -32,7 +32,7 @@ import {
 import {map} from 'rxjs/operator/map';
 
 
-describe('MdSelect', () => {
+fdescribe('MdSelect', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: 'ltr'|'rtl'};
   let scrolledSubject = new Subject();
@@ -1320,15 +1320,23 @@ describe('MdSelect', () => {
     describe('x-axis positioning', () => {
 
       beforeEach(() => {
+<<<<<<< HEAD
         select.style.position = 'fixed';
         select.style.left = '30px';
       });
 
       it('should align the trigger and the selected option on the x-axis in ltr', fakeAsync(() => {
+=======
+        select.style.marginLeft = select.style.marginRight = '50px';
+      });
+
+      it('should align the trigger and the selected option on the x-axis in ltr', async(() => {
+>>>>>>> chore: try to fix edge tests
         trigger.click();
         tick(400);
         fixture.detectChanges();
 
+<<<<<<< HEAD
         const triggerLeft = trigger.getBoundingClientRect().left;
         const firstOptionLeft = document.querySelector('.cdk-overlay-pane md-option')
             .getBoundingClientRect().left;
@@ -1340,6 +1348,22 @@ describe('MdSelect', () => {
       }));
 
       it('should align the trigger and the selected option on the x-axis in rtl', fakeAsync(() => {
+=======
+        fixture.whenStable().then(() => {
+          const triggerLeft = trigger.getBoundingClientRect().left;
+          const firstOptionLeft =
+              document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().left;
+
+          // Each option is 32px wider than the trigger, so it must be adjusted 16px
+          // to ensure the text overlaps correctly.
+          expect(firstOptionLeft.toFixed(2))
+              .toEqual((triggerLeft - 16).toFixed(2),
+                  `Expected trigger to align with the selected option on the x-axis in LTR.`);
+        });
+      }));
+
+      it('should align the trigger and the selected option on the x-axis in rtl', async(() => {
+>>>>>>> chore: try to fix edge tests
         dir.value = 'rtl';
         fixture.detectChanges();
 
@@ -1347,6 +1371,7 @@ describe('MdSelect', () => {
         tick(400);
         fixture.detectChanges();
 
+<<<<<<< HEAD
         const triggerRight = trigger.getBoundingClientRect().right;
         const firstOptionRight =
             document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().right;
@@ -1469,6 +1494,21 @@ describe('MdSelect', () => {
           expect(Math.floor(selectedOptionLeft)).toEqual(Math.floor(triggerLeft - 16));
         }));
 
+=======
+        fixture.whenStable().then(() => {
+          const triggerRight = trigger.getBoundingClientRect().right;
+          const firstOptionRight =
+              document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().right;
+
+          // Each option is 32px wider than the trigger, so it must be adjusted 16px
+          // to ensure the text overlaps correctly.
+          expect(firstOptionRight.toFixed(2))
+              .toEqual((triggerRight + 16).toFixed(2),
+                  `Expected trigger to align with the selected option on the x-axis in RTL.`);
+        });
+      }));
+
+>>>>>>> chore: try to fix edge tests
     });
 
     describe('with header', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1320,23 +1320,15 @@ fdescribe('MdSelect', () => {
     describe('x-axis positioning', () => {
 
       beforeEach(() => {
-<<<<<<< HEAD
         select.style.position = 'fixed';
         select.style.left = '30px';
       });
 
       it('should align the trigger and the selected option on the x-axis in ltr', fakeAsync(() => {
-=======
-        select.style.marginLeft = select.style.marginRight = '50px';
-      });
-
-      it('should align the trigger and the selected option on the x-axis in ltr', async(() => {
->>>>>>> chore: try to fix edge tests
         trigger.click();
         tick(400);
         fixture.detectChanges();
 
-<<<<<<< HEAD
         const triggerLeft = trigger.getBoundingClientRect().left;
         const firstOptionLeft = document.querySelector('.cdk-overlay-pane md-option')
             .getBoundingClientRect().left;
@@ -1348,22 +1340,6 @@ fdescribe('MdSelect', () => {
       }));
 
       it('should align the trigger and the selected option on the x-axis in rtl', fakeAsync(() => {
-=======
-        fixture.whenStable().then(() => {
-          const triggerLeft = trigger.getBoundingClientRect().left;
-          const firstOptionLeft =
-              document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().left;
-
-          // Each option is 32px wider than the trigger, so it must be adjusted 16px
-          // to ensure the text overlaps correctly.
-          expect(firstOptionLeft.toFixed(2))
-              .toEqual((triggerLeft - 16).toFixed(2),
-                  `Expected trigger to align with the selected option on the x-axis in LTR.`);
-        });
-      }));
-
-      it('should align the trigger and the selected option on the x-axis in rtl', async(() => {
->>>>>>> chore: try to fix edge tests
         dir.value = 'rtl';
         fixture.detectChanges();
 
@@ -1371,7 +1347,6 @@ fdescribe('MdSelect', () => {
         tick(400);
         fixture.detectChanges();
 
-<<<<<<< HEAD
         const triggerRight = trigger.getBoundingClientRect().right;
         const firstOptionRight =
             document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().right;
@@ -1494,21 +1469,6 @@ fdescribe('MdSelect', () => {
           expect(Math.floor(selectedOptionLeft)).toEqual(Math.floor(triggerLeft - 16));
         }));
 
-=======
-        fixture.whenStable().then(() => {
-          const triggerRight = trigger.getBoundingClientRect().right;
-          const firstOptionRight =
-              document.querySelector('.cdk-overlay-pane md-option').getBoundingClientRect().right;
-
-          // Each option is 32px wider than the trigger, so it must be adjusted 16px
-          // to ensure the text overlaps correctly.
-          expect(firstOptionRight.toFixed(2))
-              .toEqual((triggerRight + 16).toFixed(2),
-                  `Expected trigger to align with the selected option on the x-axis in RTL.`);
-        });
-      }));
-
->>>>>>> chore: try to fix edge tests
     });
 
     describe('with header', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -32,7 +32,7 @@ import {
 import {map} from 'rxjs/operator/map';
 
 
-fdescribe('MdSelect', () => {
+describe('MdSelect', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: 'ltr'|'rtl'};
   let scrolledSubject = new Subject();
@@ -984,7 +984,7 @@ fdescribe('MdSelect', () => {
         trigger.click();
         groupFixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // The selected option should be scrolled to the center of the panel.
         // This will be its original offset from the scrollTop - half the panel height + half the

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -63,7 +63,8 @@ describe('MdSelect', () => {
         BasicSelectWithTheming,
         ResetValuesSelect,
         FalsyValueSelect,
-        SelectWithGroups
+        SelectWithGroups,
+        BasicSelectWithHeader
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -275,6 +276,17 @@ describe('MdSelect', () => {
 
       expect(panel.classList).toContain('custom-one');
       expect(panel.classList).toContain('custom-two');
+    });
+
+    it('should set an id on the select panel', () => {
+      trigger.click();
+      fixture.detectChanges();
+
+      const panel = document.querySelector('.cdk-overlay-pane .mat-select-content');
+      const instance = fixture.componentInstance.select;
+
+      expect(instance.panelId).toBeTruthy();
+      expect(panel.getAttribute('id')).toBe(instance.panelId);
     });
 
   });
@@ -890,7 +902,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // The panel should be scrolled to 0 because centering the option is not possible.
         expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to be scrolled.`);
@@ -906,7 +918,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // The panel should be scrolled to 0 because centering the option is not possible.
         expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to be scrolled.`);
@@ -922,7 +934,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // The selected option should be scrolled to the center of the panel.
         // This will be its original offset from the scrollTop - half the panel height + half the
@@ -942,7 +954,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // The selected option should be scrolled to the max scroll position.
         // This will be the height of the scrollContainer - the panel height.
@@ -1005,7 +1017,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // Scroll should adjust by the difference between the top space available (85px + 8px
         // viewport padding = 77px) and the height of the panel above the option (113px).
@@ -1028,7 +1040,7 @@ describe('MdSelect', () => {
         trigger.click();
         fixture.detectChanges();
 
-        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-panel');
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
 
         // Scroll should adjust by the difference between the bottom space available
         // (56px from the bottom of the screen - 8px padding = 48px)
@@ -1055,7 +1067,7 @@ describe('MdSelect', () => {
         const overlayPane = document.querySelector('.cdk-overlay-pane');
         const triggerBottom = trigger.getBoundingClientRect().bottom;
         const overlayBottom = overlayPane.getBoundingClientRect().bottom;
-        const scrollContainer = overlayPane.querySelector('.mat-select-panel');
+        const scrollContainer = overlayPane.querySelector('.mat-select-content');
 
         // Expect no scroll to be attempted
         expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to be scrolled.`);
@@ -1082,7 +1094,7 @@ describe('MdSelect', () => {
         const overlayPane = document.querySelector('.cdk-overlay-pane');
         const triggerTop = trigger.getBoundingClientRect().top;
         const overlayTop = overlayPane.getBoundingClientRect().top;
-        const scrollContainer = overlayPane.querySelector('.mat-select-panel');
+        const scrollContainer = overlayPane.querySelector('.mat-select-content');
 
         // Expect scroll to remain at the max scroll position
         expect(scrollContainer.scrollTop).toEqual(128, `Expected panel to be at max scroll.`);
@@ -1457,6 +1469,51 @@ describe('MdSelect', () => {
           expect(Math.floor(selectedOptionLeft)).toEqual(Math.floor(triggerLeft - 16));
         }));
 
+    });
+
+    describe('with header', () => {
+      let headerFixture: ComponentFixture<BasicSelectWithHeader>;
+
+      beforeEach(() => {
+        headerFixture = TestBed.createComponent(BasicSelectWithHeader);
+        headerFixture.detectChanges();
+        trigger = headerFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        select = headerFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+        select.style.marginTop = '300px';
+        select.style.marginLeft = '20px';
+        select.style.marginRight = '20px';
+      });
+
+      it('should account for the header when there is no value', () => {
+        trigger.click();
+        headerFixture.detectChanges();
+
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
+
+        expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to be scrolled.`);
+        checkTriggerAlignedWithOption(0, headerFixture.componentInstance.select);
+      });
+
+      it('should align a selected option in the middle with the trigger text', () => {
+        // Select the fifth option, which has enough space to scroll to the center
+        headerFixture.componentInstance.control.setValue('chips-4');
+        headerFixture.detectChanges();
+
+        trigger.click();
+        headerFixture.detectChanges();
+
+        const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-select-content');
+
+        // The selected option should be scrolled to the center of the panel.
+        // This will be its original offset from the scrollTop - half the panel height + half the
+        // option height. 4 (index) * 48 (option height) = 192px offset from scrollTop
+        // 192 - 256/2 + 48/2 = 88px
+        expect(scrollContainer.scrollTop)
+            .toEqual(88, `Expected overlay panel to be scrolled to center the selected option.`);
+
+        checkTriggerAlignedWithOption(4, headerFixture.componentInstance.select);
+      });
     });
 
   });
@@ -2797,6 +2854,37 @@ class SelectWithGroups {
       ]
     }
   ];
+
+  @ViewChild(MdSelect) select: MdSelect;
+  @ViewChildren(MdOption) options: QueryList<MdOption>;
+}
+
+@Component({
+  selector: 'basic-select-with-header',
+  template: `
+    <md-select placeholder="Food" [formControl]="control">
+      <md-select-header>
+        <input placeholder="Search for food" />
+      </md-select-header>
+
+      <md-option *ngFor="let food of foods" [value]="food.value">
+        {{ food.viewValue }}
+      </md-option>
+    </md-select>
+  `
+})
+class BasicSelectWithHeader {
+  foods: any[] = [
+    { value: 'steak-0', viewValue: 'Steak' },
+    { value: 'pizza-1', viewValue: 'Pizza' },
+    { value: 'tacos-2', viewValue: 'Tacos' },
+    { value: 'sandwich-3', viewValue: 'Sandwich' },
+    { value: 'chips-4', viewValue: 'Chips' },
+    { value: 'eggs-5', viewValue: 'Eggs' },
+    { value: 'pasta-6', viewValue: 'Pasta' },
+    { value: 'sushi-7', viewValue: 'Sushi' },
+  ];
+  control = new FormControl();
 
   @ViewChild(MdSelect) select: MdSelect;
   @ViewChildren(MdOption) options: QueryList<MdOption>;

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -810,9 +810,8 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
       // we must only adjust for the height difference between the option element
       // and the trigger element, then multiply it by -1 to ensure the panel moves
       // in the correct direction up the page.
-      this._offsetY = (SELECT_ITEM_HEIGHT - SELECT_TRIGGER_HEIGHT) / 2 * -1;
-      // this._offsetY = (SELECT_OPTION_HEIGHT - SELECT_TRIGGER_HEIGHT) / 2 * -1 -
-      //     (this.header ? SELECT_OPTION_HEIGHT : 0);
+      this._offsetY = (SELECT_ITEM_HEIGHT - SELECT_TRIGGER_HEIGHT) / 2 * -1 -
+          (this.header ? SELECT_ITEM_HEIGHT : 0);
     }
 
     this._checkOverlayWithinViewport(maxScroll);
@@ -966,7 +965,6 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
     const panelHeightTop = Math.abs(this._offsetY);
     const totalPanelHeight =
         Math.min(this._getItemCount() * SELECT_ITEM_HEIGHT, SELECT_PANEL_MAX_HEIGHT);
-        // Math.min(this.options.length * SELECT_OPTION_HEIGHT, SELECT_PANEL_MAX_HEIGHT);
     const panelHeightBottom = totalPanelHeight - panelHeightTop - triggerRect.height;
 
     if (panelHeightBottom > bottomSpaceAvailable) {

--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -70,6 +70,7 @@ import {SelectOverviewExample} from './select-overview/select-overview-example';
 import {ChipsOverviewExample} from './chips-overview/chips-overview-example';
 import {ChipsStackedExample} from './chips-stacked/chips-stacked-example';
 import {SelectFormExample} from './select-form/select-form-example';
+import {SelectHeaderExample} from './select-header/select-header-example';
 import {DatepickerOverviewExample} from './datepicker-overview/datepicker-overview-example';
 import {
   MdAutocompleteModule, MdButtonModule, MdButtonToggleModule, MdCardModule, MdCheckboxModule,
@@ -78,6 +79,7 @@ import {
   MdSelectModule, MdSliderModule, MdSlideToggleModule, MdSnackBarModule, MdTabsModule,
   MdToolbarModule, MdTooltipModule
 } from '@angular/material';
+
 
 export interface LiveExample {
   title: string;
@@ -152,6 +154,7 @@ export const EXAMPLE_COMPONENTS = {
   'radio-overview': {title: 'Basic radios', component: RadioOverviewExample},
   'select-overview': {title: 'Basic select', component: SelectOverviewExample},
   'select-form': {title: 'Select in a form', component: SelectFormExample},
+  'select-header': {title: 'Select header', component: SelectHeaderExample},
   'sidenav-fab': {title: 'Sidenav with a FAB', component: SidenavFabExample},
   'sidenav-overview': {title: 'Basic sidenav', component: SidenavOverviewExample},
   'slider-configurable': {title: 'Configurable slider', component: SliderConfigurableExample},
@@ -249,6 +252,7 @@ export const EXAMPLE_LIST = [
   SidenavFabExample,
   SelectOverviewExample,
   SelectFormExample,
+  SelectHeaderExample,
   SidenavOverviewExample,
   SliderConfigurableExample,
   SliderOverviewExample,


### PR DESCRIPTION
Adds a `md-select-header` component, which is a fixed header above the select's options. It allows for the user to project an input to be used for filtering long lists of options.

**Note:** This component only handles the positioning, styling and exposes the panel id for a11y. The functionality is up to the user to handle.

Fixes #2812.