### PR TITLE
refactor(autocomplete): merge optionSelections into single observable

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -153,15 +153,15 @@ export class MdAutocompleteTrigger implements AfterContentInit, ControlValueAcce
    */
   get panelClosingActions(): Observable<MdOptionSelectEvent> {
     return Observable.merge(
-        ...this.optionSelections,
+        this.optionSelections,
         this._blurStream.asObservable(),
         this._keyManager.tabOut
     );
   }
 
   /** Stream of autocomplete option selections. */
-  get optionSelections(): Observable<MdOptionSelectEvent>[] {
-    return this.autocomplete.options.map(option => option.onSelect);
+  get optionSelections(): Observable<MdOptionSelectEvent> {
+    return Observable.merge(...this.autocomplete.options.map(option => option.onSelect));
   }
 
   /** The currently active option, coerced to MdOption type. */


### PR DESCRIPTION
Merges the `optionSelections` into a single observable, in order to make it easier to consume.

Fixes #3205.