### PR TITLE
refactor(connected-overlay-directive): avoid issues with property initialization

### DIFF
--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -1,7 +1,7 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {ConnectedOverlayDirective, OverlayModule} from './overlay-directives';
+import {ConnectedOverlayDirective, OverlayModule, OverlayOrigin} from './overlay-directives';
 import {OverlayContainer} from './overlay-container';
 import {ConnectedPositionStrategy} from './position/connected-position-strategy';
 import {ConnectedOverlayPositionChange} from './position/connected-position';
@@ -18,7 +18,7 @@ describe('Overlay directives', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [OverlayModule],
-      declarations: [ConnectedOverlayDirectiveTest],
+      declarations: [ConnectedOverlayDirectiveTest, ConnectedOverlayPropertyInitOrder],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
@@ -110,6 +110,21 @@ describe('Overlay directives', () => {
     expect(overlayContainerElement.textContent.trim()).toBe('',
         'Expected overlay to have been detached.');
   });
+
+  it('should not depend on the order in which the `origin` and `open` are set', async(() => {
+    fixture.destroy();
+
+    const propOrderFixture = TestBed.createComponent(ConnectedOverlayPropertyInitOrder);
+    propOrderFixture.detectChanges();
+
+    const overlayDirective = propOrderFixture.componentInstance.connectedOverlayDirective;
+
+    expect(() => {
+      overlayDirective.open = true;
+      overlayDirective.origin = propOrderFixture.componentInstance.trigger;
+      propOrderFixture.detectChanges();
+    }).not.toThrow();
+  }));
 
   describe('inputs', () => {
 
@@ -310,3 +325,14 @@ class ConnectedOverlayDirectiveTest {
 
   @ViewChild(ConnectedOverlayDirective) connectedOverlayDirective: ConnectedOverlayDirective;
 }
+
+@Component({
+  template: `
+  <button cdk-overlay-origin #trigger="cdkOverlayOrigin">Toggle menu</button>
+  <ng-template cdk-connected-overlay>Menu content</ng-template>`,
+})
+class ConnectedOverlayPropertyInitOrder {
+  @ViewChild(ConnectedOverlayDirective) connectedOverlayDirective: ConnectedOverlayDirective;
+  @ViewChild('trigger') trigger: OverlayOrigin;
+}
+

--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -194,6 +194,8 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.offsetX = 15;
+      fixture.detectChanges();
+
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
 
@@ -223,6 +225,8 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.offsetY = 55;
+      fixture.detectChanges();
+
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
       expect(pane.style.top)

--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -194,8 +194,6 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.offsetX = 15;
-      fixture.detectChanges();
-
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
 
@@ -225,8 +223,6 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.offsetY = 55;
-      fixture.detectChanges();
-
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
       expect(pane.style.top)

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -179,7 +179,7 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['open']) {
-      changes['open'].currentValue ? this._attachOverlay() : this._detachOverlay();
+      this.open ? this._attachOverlay() : this._detachOverlay();
     }
   }
 

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -10,6 +10,8 @@ import {
     Output,
     ElementRef,
     Renderer2,
+    OnChanges,
+    SimpleChanges,
 } from '@angular/core';
 import {Overlay, OVERLAY_PROVIDERS} from './overlay';
 import {OverlayRef} from './overlay-ref';
@@ -63,10 +65,9 @@ export class OverlayOrigin {
   selector: '[cdk-connected-overlay], [connected-overlay], [cdkConnectedOverlay]',
   exportAs: 'cdkConnectedOverlay'
 })
-export class ConnectedOverlayDirective implements OnDestroy {
+export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
   private _overlayRef: OverlayRef;
   private _templatePortal: TemplatePortal;
-  private _open = false;
   private _hasBackdrop = false;
   private _backdropSubscription: Subscription;
   private _positionSubscription: Subscription;
@@ -125,6 +126,9 @@ export class ConnectedOverlayDirective implements OnDestroy {
   /** Strategy to be used when handling scroll events while the overlay is open. */
   @Input() scrollStrategy: ScrollStrategy = new RepositionScrollStrategy(this._scrollDispatcher);
 
+  /** Whether the overlay is open. */
+  @Input() open: boolean = false;
+
   /** Whether or not the overlay should attach a backdrop. */
   @Input()
   get hasBackdrop() {
@@ -133,16 +137,6 @@ export class ConnectedOverlayDirective implements OnDestroy {
 
   set hasBackdrop(value: any) {
     this._hasBackdrop = coerceBooleanProperty(value);
-  }
-
-  @Input()
-  get open() {
-    return this._open;
-  }
-
-  set open(value: boolean) {
-    value ? this._attachOverlay() : this._detachOverlay();
-    this._open = value;
   }
 
   /** Event emitted when the backdrop is clicked. */
@@ -181,6 +175,12 @@ export class ConnectedOverlayDirective implements OnDestroy {
 
   ngOnDestroy() {
     this._destroyOverlay();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['open']) {
+      changes['open'].currentValue ? this._attachOverlay() : this._detachOverlay();
+    }
   }
 
   /** Creates an overlay */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -748,10 +748,6 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
     }
 
     this._checkOverlayWithinViewport(maxScroll);
-
-    // Change detection needs to be triggered in order for
-    // the overlay's position to get updated in time.
-    this._changeDetectorRef.detectChanges();
   }
 
   /**

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -748,6 +748,10 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
     }
 
     this._checkOverlayWithinViewport(maxScroll);
+
+    // Change detection needs to be triggered in order for
+    // the overlay's position to get updated in time.
+    this._changeDetectorRef.detectChanges();
   }
 
   /**


### PR DESCRIPTION
* Refactors the `ConnectedOverlayDirective` not to depend on the order in which the `open` and `origin` properties are set.
* Moves the `open`, `offsetX` and `offsetY` properties from using setters to `ngOnChanges` since the latter tends to output less JS.

Fixes #3225.