### PR TITLE
fix(select): incorrect menu width when there is no placeholder

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -43,7 +43,8 @@ describe('MdSelect', () => {
         ThrowsErrorOnInit,
         BasicSelectOnPush,
         BasicSelectOnPushPreselected,
-        SelectWithPlainTabindex
+        SelectWithPlainTabindex,
+        BasicSelectNoPlaceholder
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -145,13 +146,27 @@ describe('MdSelect', () => {
     }));
 
     it('should set the width of the overlay based on the trigger', async(() => {
-      trigger.style.width = '200px';
-
       fixture.whenStable().then(() => {
         trigger.click();
         fixture.detectChanges();
+
         const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-        expect(pane.style.minWidth).toBe('200px');
+        expect(pane.style.minWidth).toBe(trigger.getBoundingClientRect().width + 'px');
+      });
+    }));
+
+    it('should set the width of the overlay if there is no placeholder', async(() => {
+      let noPlaceholder = TestBed.createComponent(BasicSelectNoPlaceholder);
+
+      noPlaceholder.detectChanges();
+      trigger = noPlaceholder.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+
+      noPlaceholder.whenStable().then(() => {
+        trigger.click();
+        noPlaceholder.detectChanges();
+
+        const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+        expect(parseInt(pane.style.minWidth)).toBeGreaterThan(0);
       });
     }));
 
@@ -1892,6 +1907,16 @@ class MultiSelect {
   `
 })
 class SelectWithPlainTabindex { }
+
+@Component({
+  selector: 'basic-select-no-placeholder',
+  template: `
+    <md-select>
+      <md-option value="value">There are no other options</md-option>
+    </md-select>
+  `
+})
+class BasicSelectNoPlaceholder { }
 
 
 class FakeViewportRuler {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -146,12 +146,14 @@ describe('MdSelect', () => {
     }));
 
     it('should set the width of the overlay based on the trigger', async(() => {
+      trigger.style.width = '200px';
+
       fixture.whenStable().then(() => {
         trigger.click();
         fixture.detectChanges();
 
         const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-        expect(pane.style.minWidth).toBe(trigger.getBoundingClientRect().width + 'px');
+        expect(pane.style.minWidth).toBe('200px');
       });
     }));
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -308,6 +308,11 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     this._selectionModel = new SelectionModel<MdOption>(this.multiple, null, false);
     this._initKeyManager();
 
+    // If there is no placeholder, the setter won't fire so we need to trigger it from here.
+    if (!this._placeholder) {
+      this._triggerWidth = this._getWidth();
+    }
+
     this._changeSubscription = this.options.changes.startWith(null).subscribe(() => {
       this._resetOptions();
 


### PR DESCRIPTION
The select pane's width wasn't being set properly, when it doesn't have a placeholder, because the width usually gets set within the placeholder's setter.

Fixes #3244.