### PR TITLE
fix(button): clip button text when overflow

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -50,6 +50,8 @@ $mat-mini-fab-padding: 8px !default;
   line-height: $mat-button-line-height;
   padding: $mat-button-padding;
   border-radius: $mat-button-border-radius;
+  
+  overflow: hidden;
 
   &[disabled] {
     cursor: default;


### PR DESCRIPTION
This is my first contribution, so I'm not completely sure what steps are required to merge this. I'm porting over an AngularJS application to Angular and discovered a discrepancy in the button behavior.

Angular Material has this feature here: https://github.com/angular/material/blob/master/src/components/button/button.scss#L75

