### PR TITLE
fix(menu): incorrect text alignment in IE/Edge

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -32,11 +32,15 @@ $mat-menu-side-padding: 16px !default;
 
   font-size: $mat-menu-font-size;
   font-family: $mat-font-family;
-  text-align: start;
+  text-align: left;
   text-decoration: none;   // necessary to reset anchor tags
 
   &[disabled] {
     cursor: default;
+  }
+
+  [dir='rtl'] & {
+    text-align: right;
   }
 
   .mat-icon {


### PR DESCRIPTION
Fixes the text being centered in menu items on IE and Edge. It was due to the fact that they don't support `text-align: start/end`.

Fixes #3254.