### PR TITLE
perf(scroll-dispatcher): lazily subscribe to global events

### DIFF
--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -17,7 +17,7 @@ export class ViewportRuler {
     this._cacheViewportGeometry();
 
     // Subscribe to scroll and resize events and update the document rectangle on changes.
-    scrollDispatcher.scrolled(0, () => this._cacheViewportGeometry());
+    scrollDispatcher.scrolled(null, () => this._cacheViewportGeometry());
   }
 
   /** Gets a ClientRect for the viewport's bounds. */

--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -17,7 +17,7 @@ export class ViewportRuler {
     this._cacheViewportGeometry();
 
     // Subscribe to scroll and resize events and update the document rectangle on changes.
-    scrollDispatcher.scrolled().subscribe(() => this._cacheViewportGeometry());
+    scrollDispatcher.scrolled(0, () => this._cacheViewportGeometry());
   }
 
   /** Gets a ClientRect for the viewport's bounds. */

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
@@ -98,21 +98,6 @@ describe('Scroll Dispatcher', () => {
       scroll = s;
     }));
 
-    it('should lazily add global listeners as Scrollable instances are added and removed', () => {
-      expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
-
-      let fixture = TestBed.createComponent(ScrollingComponent);
-      fixture.detectChanges();
-
-      expect(scroll._globalSubscription).toBeTruthy(
-          'Expected global listeners after a scrollable is added.');
-
-      fixture.destroy();
-
-      expect(scroll._globalSubscription).toBeNull(
-          'Expected global listeners to be removed after scrollable is destroyed.');
-    });
-
     it('should lazily add global listeners as service subscriptions are added and removed', () => {
       expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
 

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
@@ -48,7 +48,7 @@ describe('Scroll Dispatcher', () => {
       // Listen for notifications from scroll service with a throttle of 100ms
       const throttleTime = 100;
       let hasServiceScrollNotified = false;
-      scroll.scrolled(throttleTime).subscribe(() => { hasServiceScrollNotified = true; });
+      scroll.scrolled(throttleTime, () => { hasServiceScrollNotified = true; });
 
       // Emit a scroll event from the scrolling element in our component.
       // This event should be picked up by the scrollable directive and notify.
@@ -89,6 +89,44 @@ describe('Scroll Dispatcher', () => {
 
       expect(scrollableElementIds).toEqual(['scrollable-1', 'scrollable-1a']);
     });
+  });
+
+  describe('lazy subscription', () => {
+    let scroll: ScrollDispatcher;
+
+    beforeEach(inject([ScrollDispatcher], (s: ScrollDispatcher) => {
+      scroll = s;
+    }));
+
+    it('should lazily add global listeners as Scrollable instances are added and removed', () => {
+      expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
+
+      let fixture = TestBed.createComponent(ScrollingComponent);
+      fixture.detectChanges();
+
+      expect(scroll._globalSubscription).toBeTruthy(
+          'Expected global listeners after a scrollable is added.');
+
+      fixture.destroy();
+
+      expect(scroll._globalSubscription).toBeNull(
+          'Expected global listeners to be removed after scrollable is destroyed.');
+    });
+
+    it('should lazily add global listeners as service subscriptions are added and removed', () => {
+      expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
+
+      const subscription = scroll.scrolled(0, () => {});
+
+      expect(scroll._globalSubscription).toBeTruthy(
+          'Expected global listeners after a subscription has been added.');
+
+      subscription.unsubscribe();
+
+      expect(scroll._globalSubscription).toBeNull(
+          'Expected global listeners to have been removed after the subscription has stopped.');
+    });
+
   });
 });
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -150,7 +150,7 @@ export class MdTooltip implements OnInit, OnDestroy {
   ngOnInit() {
     // When a scroll on the page occurs, update the position in case this tooltip needs
     // to be repositioned.
-    this.scrollSubscription = this._scrollDispatcher.scrolled(SCROLL_THROTTLE_MS).subscribe(() => {
+    this.scrollSubscription = this._scrollDispatcher.scrolled(SCROLL_THROTTLE_MS, () => {
       if (this._overlayRef) {
         this._overlayRef.updatePosition();
       }


### PR DESCRIPTION
Switches the `ScrollDispatcher` to only subscribe to `scroll` and `resize` events if there any registered callbacks. Also unsubscribes once there are no more callbacks.

Fixes #3237.