### PR TITLE
docs(dialog): Add note about AOT compilation.

### DIFF
--- a/src/lib/core/portal/portal.ts
+++ b/src/lib/core/portal/portal.ts
@@ -74,7 +74,7 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
   /**
    * [Optional] Where the attached component should live in Angular's *logical* component tree.
    * This is different from where the component *renders*, which is determined by the PortalHost.
-   * The origin necessary when the host is outside of the Angular application context.
+   * The origin is necessary when the host is outside of the Angular application context.
    */
   viewContainerRef: ViewContainerRef;
 

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -46,3 +46,34 @@ You can control which elements are tab stops with the `tabindex` attribute
 ```html
 <button md-button tabindex="-1">Not Tabbable</button>
 ```
+
+### AOT Compilation
+
+Due to the dynamic nature of the `MdDialog`, and its usage of `ViewContainerRef#createComponent()`
+to create the component on the fly, the AOT compiler will not know to create the proper
+`ComponentFactory` for your dialog component by default.
+
+You must include your dialog class in the list of `entryComponents` in your module definition so
+that the AOT compiler knows to create the `ComponentFactory` for it.
+
+```ts
+@NgModule({
+  imports: [
+    // ...
+    MaterialModule
+  ],
+
+  declarations: [
+    AppComponent,
+    ExampleDialogComponent
+  ],
+
+  entryComponents: [
+    ExampleDialogComponent
+  ]
+
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule() {}
+```


### PR DESCRIPTION
Add a note to the `MdDialog` documentation discussing proper usage with the Ahead of Time compiler.

Also fix a small typo in the Portal docs.

Fixes #2686.