### PR TITLE
fix(autocomplete): fix key manager instantiation

### DIFF
--- a/src/demo-app/autocomplete/autocomplete-demo.html
+++ b/src/demo-app/autocomplete/autocomplete-demo.html
@@ -21,11 +21,13 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
   </md-card>
 
   <md-card>
-    <div>Template-driven value (currentState): {{ currentState }}</div>
-    <div>Template-driven dirty: {{ modelDir.dirty }}</div>
 
-    <md-input-container>
-      <input mdInput placeholder="State" [mdAutocomplete]="tdAuto" [(ngModel)]="currentState" #modelDir="ngModel"
+    <div>Template-driven value (currentState): {{ currentState }}</div>
+    <div>Template-driven dirty: {{ modelDir?.dirty }}</div>
+
+    <!-- Added an ngIf below to test that autocomplete works with ngIf -->
+    <md-input-container *ngIf="true">
+      <input mdInput placeholder="State" [mdAutocomplete]="tdAuto" [(ngModel)]="currentState"
         (ngModelChange)="tdStates = filterStates(currentState)" [disabled]="tdDisabled">
     </md-input-container>
 

--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -1,5 +1,5 @@
-import {Component, ViewEncapsulation} from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {FormControl, NgModel} from '@angular/forms';
 import 'rxjs/add/operator/startWith';
 
 @Component({
@@ -18,6 +18,8 @@ export class AutocompleteDemo {
   tdStates: any[];
 
   tdDisabled = false;
+
+  @ViewChild(NgModel) modelDir: NgModel;
 
   states = [
     {code: 'AL', name: 'Alabama'},

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -1,4 +1,5 @@
 import {
+  AfterContentInit,
   Component,
   ContentChildren,
   ElementRef,
@@ -9,6 +10,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {MdOption} from '../core';
+import {ActiveDescendantKeyManager} from '../core/a11y/activedescendant-key-manager';
 
 /**
  * Autocomplete IDs need to be unique across components, so this counter exists outside of
@@ -29,7 +31,10 @@ export type AutocompletePositionY = 'above' | 'below';
     '[class.mat-autocomplete]': 'true'
   }
 })
-export class MdAutocomplete {
+export class MdAutocomplete implements AfterContentInit {
+
+  /** Manages active item in option list based on key events. */
+  _keyManager: ActiveDescendantKeyManager;
 
   /** Whether the autocomplete panel displays above or below its trigger. */
   positionY: AutocompletePositionY = 'below';
@@ -46,6 +51,10 @@ export class MdAutocomplete {
 
   /** Unique ID to be used by autocomplete trigger's "aria-owns" property. */
   id: string = `md-autocomplete-${_uniqueAutocompleteIdCounter++}`;
+
+  ngAfterContentInit() {
+    this._keyManager = new ActiveDescendantKeyManager(this.options).withWrap();
+  }
 
   /**
    * Sets the panel scrollTop. This allows us to manually scroll to display


### PR DESCRIPTION
The key manager was placed on the trigger's ngAfterContentInit hook instead of the panel's, so sometimes the events were occurring in the wrong order.

Fixes #3269 
