### PR TITLE
fix(interactivity-checker): cast node name to lowercase for isInputElement function

### DIFF
--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -160,7 +160,7 @@ function isAnchorWithHref(element: HTMLElement): boolean {
 
 /** Gets whether an element is an input element. */
 function isInputElement(element: HTMLElement): element is HTMLInputElement {
-  return element.nodeName == 'input';
+  return element.nodeName.toLowerCase() == 'input';
 }
 
 /** Gets whether an element is an anchor element. */


### PR DESCRIPTION
Have to cast to lowercase for nodeName "INPUT" 