### PR TITLE
docs(list): use md-list-icon in example code

### DIFF
--- a/src/examples/list-sections/list-sections-example.html
+++ b/src/examples/list-sections/list-sections-example.html
@@ -1,14 +1,14 @@
 <md-list>
   <h3 md-subheader>Folders</h3>
   <md-list-item *ngFor="let folder of folders">
-    <md-icon md-list-avatar>folder</md-icon>
+    <md-icon md-list-icon>folder</md-icon>
     <h4 md-line>{{folder.name}}</h4>
     <p md-line> {{folder.updated | date}} </p>
   </md-list-item>
   <md-divider></md-divider>
   <h3 md-subheader>Notes</h3>
   <md-list-item *ngFor="let note of notes">
-    <md-icon md-list-avatar>note</md-icon>
+    <md-icon md-list-icon>note</md-icon>
     <h4 md-line>{{note.name}}</h4>
     <p md-line> {{note.updated | date}} </p>
   </md-list-item>


### PR DESCRIPTION
Change `md-list-avatar` to `md-list-icon` in example code.
According to documentation `md-list-icon` is used with `md-icon`
and `md-list-avatar` is used with image tag.

Fixes: #3217