### PR TITLE
No max-width for autocomplete panel

### DIFF
--- a/src/lib/autocomplete/autocomplete.scss
+++ b/src/lib/autocomplete/autocomplete.scss
@@ -15,7 +15,8 @@ $mat-autocomplete-panel-above-offset: -24px !default;
 .mat-autocomplete-panel {
   @include mat-menu-base();
   visibility: hidden;
-
+  
+  max-width: none;
   max-height: $mat-autocomplete-panel-max-height;
   position: relative;
 


### PR DESCRIPTION
Currently, the max-width is inherited from the mat-menu-base mixin forcing the panel to have  a width of 280px. Overriding it here with none so that the panel can expand out as necessary.

Fix based on comments in issue #3198.