### PR TITLE
docs(progress-spinner): fix typo in progress spinner example

### DIFF
--- a/src/examples/progress-spinner-configurable/progress-spinner-configurable-example.ts
+++ b/src/examples/progress-spinner-configurable/progress-spinner-configurable-example.ts
@@ -7,7 +7,7 @@ import {Component} from '@angular/core';
   styleUrls: ['./progress-spinner-configurable-example.css'],
 })
 export class ProgressSpinnerConfigurableExample {
-  color = 'praimry';
+  color = 'primary';
   mode = 'determinate';
   value = 50;
 }


### PR DESCRIPTION
Change `praimry` to `primary` in typescript code of progress spinner example.

Fixes: #3148