### PR TITLE
fix(select): animation jump in Chrome and blurry text in IE

### DIFF
--- a/src/lib/select/select-animations.ts
+++ b/src/lib/select/select-animations.ts
@@ -46,13 +46,13 @@ export const transformPanel: AnimationEntryMetadata = trigger('transformPanel', 
   state('showing', style({
     opacity: 1,
     minWidth: 'calc(100% + 32px)',
-    transform: `translate3d(0,0,0) scaleY(1)`
+    transform: `scaleY(1)`
   })),
   transition('void => *', [
     style({
       opacity: 0,
       minWidth: '100%',
-      transform: `translate3d(0, 0, 0) scaleY(0)`
+      transform: `scaleY(0)`
     }),
     animate(`150ms cubic-bezier(0.25, 0.8, 0.25, 1)`)
   ]),


### PR DESCRIPTION
Fixes a bug that caused `md-select` to:
1. Shift slightly on Chrome when the opening animation is done in RTL.
2. Have blurry text in IE.

The issue seems to be due to the `translate3d` temporarily creating a new stacking context while the panel is animating.

Fixes #3327.
Fixes #1953.