### PR TITLE
fix(docs): only rewrite relative links

### DIFF
--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -82,7 +82,9 @@ function transformMarkdownFiles(buffer: Buffer, file: any): string {
 
 /** Fixes paths in the markdown files to work in the material-docs-io. */
 function fixMarkdownDocLinks(link: string, filePath: string): string {
-  if (link.startsWith('http') && filePath.indexOf('guides/') === -1) {
+  // As for now, only markdown links that are relative and inside of the guides/ directory
+  // will be rewritten.
+  if (!filePath.includes(path.normalize('guides/')) || link.startsWith('http')) {
     return link;
   }
 


### PR DESCRIPTION
* Right now the script actually seemed to work on Windows because the delimiters were different and the `indexOf` check passed therefore.
* It didn't work on non-windows platforms (but the `indexOf` worked), because the logic was incorrect. Previously only links that are not inside of `guides/` have been rewritten.

Fixes #3147