### PR TITLE
build: make app tasks optional

### DIFF
--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -135,7 +135,8 @@ export function cleanTask(glob: string) {
 /** Build an task that depends on all application build tasks. */
 export function buildAppTask(appName: string) {
   const buildTasks = ['vendor', 'ts', 'scss', 'assets']
-    .map(taskName => `:build:${appName}:${taskName}`);
+    .map(taskName => `:build:${appName}:${taskName}`)
+    .filter(taskName => gulp.hasTask(taskName));
 
   return (done: () => void) => {
     gulpRunSequence(

--- a/tools/gulp/tasks/e2e.ts
+++ b/tools/gulp/tasks/e2e.ts
@@ -25,9 +25,6 @@ task(':build:e2eapp:vendor', vendorTask());
 /** Builds e2e app ts to js. */
 task(':build:e2eapp:ts', tsBuildTask(appDir));
 
-/** No-op (needed by buildAppTask). */
-task(':build:e2eapp:scss', sassBuildTask(outDir, appDir));
-
 /** Copies e2e app assets (html, css) to build output. */
 task(':build:e2eapp:assets', copyTask(appDir, outDir));
 


### PR DESCRIPTION
* Now all related app-tasks like `scss`, `html`, `assets` or `ts` are optional.
* This way app-tasks like for the `e2e-app` don't need to run no-op tasks (and also it is more convenient)