### PR TITLE
build: fix dgeni warnings for component-groups

### DIFF
--- a/tools/dgeni/processors/component-grouper.js
+++ b/tools/dgeni/processors/component-grouper.js
@@ -11,6 +11,7 @@ class ComponentGroup {
   constructor(name) {
     this.name = name;
     this.id = `component-group-${name}`;
+    this.aliases = [];
     this.docType = 'componentGroup';
     this.directives = [];
     this.services = [];


### PR DESCRIPTION
* Since we create our own `componentGroup` docs inside of Dgeni, the `computeIdsProcessor` is looking for aliases for those Dgeni docs.
* Right now those docs don't contain any `aliases` property and therefore Dgeni shows warnings and wants to have a `getAliases` function.

![](https://i.gyazo.com/8b9a5573369028a288c8079223b66c8b.png)
