### PR TITLE
feat(menu): allow use of input components in menu

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -112,4 +112,56 @@
       </button>
     </md-menu>
   </div>
+  <div class="menu-section">
+    <p>Menu as a form to take user input</p>
+
+    <md-toolbar>
+      <button md-icon-button [mdMenuTriggerFor]="formMenu" aria-label="Open basic menu">
+        <md-icon>more_vert</md-icon>
+      </button>
+    </md-toolbar>
+
+    <md-menu #formMenu="mdMenu">
+
+      <md-input-container md-menu-intput-item>
+        <input mdInput [(ngModel)]="user.email" placeholder="Email Address">
+      </md-input-container>
+
+      <md-checkbox md-menu-intput-item
+                   [(ngModel)]="user.subscribe"
+                   name="subscibe"
+                   color="primary"
+                   align="start">
+        Subscribe to our newsletter?
+      </md-checkbox>
+
+      <md-radio-group md-menu-intput-item name="favorite_season" [(ngModel)]="user.favoriteSeason">
+        Favorite Season?
+        <md-radio-button *ngFor="let season of seasonOptions" name="more_options" [value]="season">
+          {{season}}
+        </md-radio-button>
+      </md-radio-group>
+
+      <md-select md-menu-intput-item placeholder="Drink" [(ngModel)]="user.favoriteDrink" #drinkControl="ngModel">
+        <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
+          {{ drink.viewValue }}
+        </md-option>
+      </md-select>
+
+      <md-slide-toggle md-menu-intput-item color="primary" [(ngModel)]="user.isVegetarian">
+        Vegetarian
+      </md-slide-toggle>
+      <div md-menu-intput-item>
+        Age
+        <md-slider [(ngModel)]="user.age" #slider2></md-slider>
+        {{slider2.value}}
+      </div>
+
+      <button md-menu-item>
+        Register
+      </button>
+    </md-menu>
+    <p>User data from menu form</p>
+    <pre>{{user | json}}</pre>
+  </div>
 </div>

--- a/src/demo-app/menu/menu-demo.ts
+++ b/src/demo-app/menu/menu-demo.ts
@@ -23,13 +23,13 @@ export class MenuDemo {
   ];
   // User data pulled from menu form
   user = {
-    email: "",
+    email: '',
     subscribe: false,
     favoriteSeason: 'Autumn',
     favoriteDrink: 'Lemonade',
     isVegetarian: false,
     age: 0,
-  }
+  };
   // Select box option in menu form
   drinks = [
     {value: 'coke-0', viewValue: 'Coke'},
@@ -37,7 +37,7 @@ export class MenuDemo {
     {value: 'water-2', viewValue: 'Water'},
     {value: 'pepper-3', viewValue: 'Dr. Pepper'},
   ];
-  //Radio option in menu form
+  // Radio option in menu form
   seasonOptions = [
     'Winter',
     'Spring',

--- a/src/demo-app/menu/menu-demo.ts
+++ b/src/demo-app/menu/menu-demo.ts
@@ -21,6 +21,28 @@ export class MenuDemo {
     {text: 'Check voicemail', icon: 'voicemail', disabled: true},
     {text: 'Disable alerts', icon: 'notifications_off'}
   ];
-
+  // User data pulled from menu form
+  user = {
+    email: "",
+    subscribe: false,
+    favoriteSeason: 'Autumn',
+    favoriteDrink: 'Lemonade',
+    isVegetarian: false,
+    age: 0,
+  }
+  // Select box option in menu form
+  drinks = [
+    {value: 'coke-0', viewValue: 'Coke'},
+    {value: 'long-name-1', viewValue: 'Decaf Chocolate Brownie Vanilla Gingerbread Frappuccino'},
+    {value: 'water-2', viewValue: 'Water'},
+    {value: 'pepper-3', viewValue: 'Dr. Pepper'},
+  ];
+  //Radio option in menu form
+  seasonOptions = [
+    'Winter',
+    'Spring',
+    'Summer',
+    'Autumn',
+  ];
   select(text: string) { this.selected = text; }
 }

--- a/src/lib/menu/menu-input-item.ts
+++ b/src/lib/menu/menu-input-item.ts
@@ -23,13 +23,13 @@ export class MdMenuInputItem  {
     event.stopPropagation();
   }
 
-  onClickFocus(event: MouseEvent){
+  onClickFocus(event: MouseEvent) {
     this.holdMenuOpen(event);
   }
 
-  onTabFocus(event: KeyboardEvent){
-    if(event.key === "Tab"){
+  onTabFocus(event: KeyboardEvent) {
+    if (event.key === 'Tab') {
       this.holdMenuOpen(event);
-    }    
+    }
   }
 }

--- a/src/lib/menu/menu-input-item.ts
+++ b/src/lib/menu/menu-input-item.ts
@@ -1,0 +1,35 @@
+import {Directive} from '@angular/core';
+
+
+/**
+ * Directive to allow users to use menu for user input by holding
+ * menu open when input containers are focused via click or tab.
+ */
+@Directive({
+  selector: '[md-menu-intput-item], [mdMenuInputItem], [mat-menu-intput-item], [matMenuInputItem]',
+  exportAs: 'mdMenuInputItem',
+  host: {
+    '(click)': 'onClickFocus($event)',
+    '(keydown)': 'onTabFocus($event)',
+    'class': 'mat-menu-input-item'
+  },
+})
+export class MdMenuInputItem  {
+
+  constructor() { }
+
+  /** Keep menu open */
+  holdMenuOpen(event: MouseEvent | KeyboardEvent) {
+    event.stopPropagation();
+  }
+
+  onClickFocus(event: MouseEvent){
+    this.holdMenuOpen(event);
+  }
+
+  onTabFocus(event: KeyboardEvent){
+    if(event.key === "Tab"){
+      this.holdMenuOpen(event);
+    }    
+  }
+}

--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -31,6 +31,29 @@ $mat-menu-vertical-padding: 8px !default;
   position: relative;
 }
 
+.mat-menu-input-item{
+  // These margins work well for most of the input elements
+  margin: 16px 16px;
+  // The select box needs a little padding on top to make room for the floating placeholder
+  &.mat-select{
+    padding-top: 8px;
+  }
+  // Flex box stretches the input container across the menu for us and we don't need the margins on top or bottom
+  &.mat-input-container{
+    display:flex;
+    margin: 0 16px;
+  }
+  // This stacks our radios vertically
+  &.mat-radio-group{
+    display: inline-flex;
+    flex-direction: column;
+  }
+  // mat-slide-toggle needs more CSS specifity points to override margins from another class
+  &.mat-slide-toggle{
+    margin: 16px 16px;
+  }
+}
+
 button.mat-menu-item {
   width: 100%;
 }

--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -31,26 +31,26 @@ $mat-menu-vertical-padding: 8px !default;
   position: relative;
 }
 
-.mat-menu-input-item{
+.mat-menu-input-item {
   // These margins work well for most of the input elements
-  margin: 16px 16px;
+  margin: 16px;
   // The select box needs a little padding on top to make room for the floating placeholder
-  &.mat-select{
+  &.mat-select {
     padding-top: 8px;
   }
   // Flex box stretches the input container across the menu for us and we don't need the margins on top or bottom
-  &.mat-input-container{
+  &.mat-input-container {
     display:flex;
     margin: 0 16px;
   }
   // This stacks our radios vertically
-  &.mat-radio-group{
+  &.mat-radio-group {
     display: inline-flex;
     flex-direction: column;
   }
   // mat-slide-toggle needs more CSS specifity points to override margins from another class
-  &.mat-slide-toggle{
-    margin: 16px 16px;
+  &.mat-slide-toggle {
+    margin: 16px;
   }
 }
 

--- a/src/lib/menu/menu.ts
+++ b/src/lib/menu/menu.ts
@@ -3,10 +3,12 @@ import {CommonModule} from '@angular/common';
 import {OverlayModule, CompatibilityModule} from '../core';
 import {MdMenu} from './menu-directive';
 import {MdMenuItem} from './menu-item';
+import {MdMenuInputItem} from './menu-input-item';
 import {MdMenuTrigger} from './menu-trigger';
 import {MdRippleModule} from '../core/ripple/ripple';
 export {MdMenu} from './menu-directive';
 export {MdMenuItem} from './menu-item';
+export {MdMenuInputItem} from './menu-input-item';
 export {MdMenuTrigger} from './menu-trigger';
 export {MdMenuPanel} from './menu-panel';
 export {MenuPositionX, MenuPositionY} from './menu-positions';
@@ -14,8 +16,8 @@ export {MenuPositionX, MenuPositionY} from './menu-positions';
 
 @NgModule({
   imports: [OverlayModule, CommonModule, MdRippleModule, CompatibilityModule],
-  exports: [MdMenu, MdMenuItem, MdMenuTrigger, CompatibilityModule],
-  declarations: [MdMenu, MdMenuItem, MdMenuTrigger],
+  exports: [MdMenu, MdMenuItem, MdMenuInputItem, MdMenuTrigger, CompatibilityModule],
+  declarations: [MdMenu, MdMenuItem, MdMenuInputItem, MdMenuTrigger],
 })
 export class MdMenuModule {
   /** @deprecated */


### PR DESCRIPTION
use attribute directive md-menu-input-item on input components (e.g.
md-slider, md-input, etc) inside of menu to prevent menu from closing when
components are focused via click or tab. this will allow users to use menu
as a short form to input data without redirecting to another page or
calling a dialog box. Add styles to menu.scss to space and stretch components
properly. Add additional card to menu-demo to demonstrate use with all input 
components.

closes issue 2612