### PR TITLE
fix(checkbox): no focus indication

### DIFF
--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -12,7 +12,6 @@
            [indeterminate]="indeterminate"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
-           (focus)="_onInputFocus()"
            (blur)="_onInputBlur()"
            (change)="_onInteractionEvent($event)"
            (click)="_onInputClick($event)">


### PR DESCRIPTION
Fixes the checkbox not having focus indication when the element is focused via the keyboard.

Fixes #3102.