### PR TITLE
refactor(focus-origin-monitor): complete stream when stopping monitor

### DIFF
--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -102,12 +102,15 @@ export class FocusOriginMonitor {
    * @param element The element to stop monitoring.
    */
   unmonitor(element: Element): void {
-    if (!this._elementInfo.has(element)) {
-      return;
+    let elementInfo = this._elementInfo.get(element);
+
+    if (elementInfo) {
+      elementInfo.unlisten();
+      elementInfo.subject.complete();
+
+      this._setClasses(element, null);
+      this._elementInfo.delete(element);
     }
-    this._elementInfo.get(element).unlisten();
-    this._setClasses(element, null);
-    this._elementInfo.delete(element);
   }
 
   /**


### PR DESCRIPTION
Completes the `monitor` stream when an instance is destroyed. This makes it less error-prone and more convenient since we don't have to unsubscribe manually.