### PR TITLE
Verbose flex declaration for IE11

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -54,7 +54,7 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
 // It has to be a label, to support accessibility for the visual hidden input.
 .mat-slide-toggle-label {
   display: flex;
-  flex: 1;
+  flex: 1 1 auto;
   flex-direction: row;
   align-items: center;
 


### PR DESCRIPTION
IE11 requires the verbose format in order display properly, otherwise the flex-basis property inherits a width of "0px";