### PR TITLE
fix(list-key-manager): exception when no initial active item

### DIFF
--- a/src/lib/core/a11y/list-key-manager.spec.ts
+++ b/src/lib/core/a11y/list-key-manager.spec.ts
@@ -240,6 +240,16 @@ describe('Key managers', () => {
         expect(TAB_EVENT.defaultPrevented).toBe(false);
       });
 
+      it('it should activate the first item when pressing down on a clean key manager', () => {
+        keyManager = new ListKeyManager<FakeFocusable>(itemList);
+
+        expect(keyManager.activeItemIndex).toBeNull('Expected active index to default to null.');
+
+        keyManager.onKeydown(DOWN_ARROW_EVENT);
+
+        expect(keyManager.activeItemIndex).toBe(0, 'Expected first item to become active.');
+      });
+
     });
 
     describe('programmatic focus', () => {

--- a/src/lib/core/a11y/list-key-manager.spec.ts
+++ b/src/lib/core/a11y/list-key-manager.spec.ts
@@ -240,7 +240,7 @@ describe('Key managers', () => {
         expect(TAB_EVENT.defaultPrevented).toBe(false);
       });
 
-      it('it should activate the first item when pressing down on a clean key manager', () => {
+      it('should activate the first item when pressing down on a clean key manager', () => {
         keyManager = new ListKeyManager<FakeFocusable>(itemList);
 
         expect(keyManager.activeItemIndex).toBeNull('Expected active index to default to null.');

--- a/src/lib/core/a11y/list-key-manager.ts
+++ b/src/lib/core/a11y/list-key-manager.ts
@@ -16,7 +16,7 @@ export interface CanDisable {
  * of items, it will set the active item correctly when arrow events occur.
  */
 export class ListKeyManager<T extends CanDisable> {
-  private _activeItemIndex: number;
+  private _activeItemIndex: number = null;
   private _activeItem: T;
   private _tabOut: Subject<any> = new Subject();
   private _wrap: boolean = false;

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -169,7 +169,7 @@ describe('MdTabBody', () => {
     }));
   });
 
-  it('it should toggle the canBeAnimated flag', () => {
+  it('should toggle the canBeAnimated flag', () => {
     let fixture: ComponentFixture<SimpleTabBodyApp>;
     let tabBody: MdTabBody;
 


### PR DESCRIPTION
Fixes an exception that is thrown when the user presses a key on ListKeyManager that doesn't have a default active item. The problem was due to the fact that we have a check for `null` a little bit down, that handles cases like this, however the active index is `undefined` by default.

Fixes #3317.