### PR TITLE
feat(ripple): support for global ripple options

### DIFF
--- a/src/lib/core/ripple/index.ts
+++ b/src/lib/core/ripple/index.ts
@@ -4,7 +4,7 @@ import {CompatibilityModule} from '../compatibility/compatibility';
 import {VIEWPORT_RULER_PROVIDER} from '../overlay/position/viewport-ruler';
 import {SCROLL_DISPATCHER_PROVIDER} from '../overlay/scroll/scroll-dispatcher';
 
-export {MdRipple, MD_DISABLE_RIPPLES} from './ripple';
+export {MdRipple, RippleGlobalOptions, MD_RIPPLE_GLOBAL_OPTIONS} from './ripple';
 export {RippleRef, RippleState} from './ripple-ref';
 export {RippleConfig} from './ripple-renderer';
 

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -14,7 +14,7 @@ import {RippleConfig, RippleRenderer} from './ripple-renderer';
 import {ViewportRuler} from '../overlay/position/viewport-ruler';
 import {RippleRef} from './ripple-ref';
 
-/** OpqaueToken that can be used to specify the global ripple options. */
+/** OpaqueToken that can be used to specify the global ripple options. */
 export const MD_RIPPLE_GLOBAL_OPTIONS = new OpaqueToken('md-ripple-global-options');
 
 export type RippleGlobalOptions = {
@@ -75,13 +75,18 @@ export class MdRipple implements OnChanges, OnDestroy {
   /** Renderer for the ripple DOM manipulations. */
   private _rippleRenderer: RippleRenderer;
 
+  /** Options that are set globally for all ripples. */
+  private _globalOptions: RippleGlobalOptions;
+
   constructor(
     elementRef: ElementRef,
     ngZone: NgZone,
     ruler: ViewportRuler,
-    @Optional() @Inject(MD_RIPPLE_GLOBAL_OPTIONS) private _globalOptions: RippleGlobalOptions
+    // Type needs to be `any` because of https://github.com/angular/angular/issues/12631
+    @Optional() @Inject(MD_RIPPLE_GLOBAL_OPTIONS) globalOptions: any
   ) {
     this._rippleRenderer = new RippleRenderer(elementRef, ngZone, ruler);
+    this._globalOptions = globalOptions ? globalOptions : {};
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -14,8 +14,13 @@ import {RippleConfig, RippleRenderer} from './ripple-renderer';
 import {ViewportRuler} from '../overlay/position/viewport-ruler';
 import {RippleRef} from './ripple-ref';
 
-/** OpaqueToken that can be used to globally disable all ripples. Except programmatic ones. */
-export const MD_DISABLE_RIPPLES = new OpaqueToken('md-disable-ripples');
+/** OpqaueToken that can be used to specify the global ripple options. */
+export const MD_RIPPLE_GLOBAL_OPTIONS = new OpaqueToken('md-ripple-global-options');
+
+export type RippleGlobalOptions = {
+  disabled?: boolean;
+  baseSpeedFactor?: number;
+};
 
 @Directive({
   selector: '[md-ripple], [mat-ripple]',
@@ -70,9 +75,12 @@ export class MdRipple implements OnChanges, OnDestroy {
   /** Renderer for the ripple DOM manipulations. */
   private _rippleRenderer: RippleRenderer;
 
-  constructor(elementRef: ElementRef, ngZone: NgZone, ruler: ViewportRuler,
-              @Optional() @Inject(MD_DISABLE_RIPPLES) private _forceDisableRipples: boolean) {
-
+  constructor(
+    elementRef: ElementRef,
+    ngZone: NgZone,
+    ruler: ViewportRuler,
+    @Optional() @Inject(MD_RIPPLE_GLOBAL_OPTIONS) private _globalOptions: RippleGlobalOptions
+  ) {
     this._rippleRenderer = new RippleRenderer(elementRef, ngZone, ruler);
   }
 
@@ -81,7 +89,7 @@ export class MdRipple implements OnChanges, OnDestroy {
       this._rippleRenderer.setTriggerElement(this.trigger);
     }
 
-    this._rippleRenderer.rippleDisabled = this._forceDisableRipples || this.disabled;
+    this._rippleRenderer.rippleDisabled = this._globalOptions.disabled || this.disabled;
     this._rippleRenderer.rippleConfig = this.rippleConfig;
   }
 
@@ -104,7 +112,7 @@ export class MdRipple implements OnChanges, OnDestroy {
   get rippleConfig(): RippleConfig {
     return {
       centered: this.centered,
-      speedFactor: this.speedFactor,
+      speedFactor: this.speedFactor * (this._globalOptions.baseSpeedFactor || 1),
       radius: this.radius,
       color: this.color
     };


### PR DESCRIPTION
* Adds a new DI token that can be used to specify global ripple options.
* The `RippleRef` options are not related to the `MD_DISABLE_RIPPLES` DI token (for API convenience)

@mmalerba I'm not really sure about the naming of the DI token. Let me know if you have any better ideas.

Closes #3454