### PR TITLE
feat (grid-list): add possibility to ignore order

### DIFF
--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -247,8 +247,6 @@ describe('MdGridList', () => {
         { cols: 1, rows: 1 },
         { cols: 2, rows: 2 },
         { cols: 1, rows: 1 },
-        { cols: 1, rows: 1 },
-        { cols: 2, rows: 2 },
         { cols: 2, rows: 2 },
         { cols: 1, rows: 1 },
         { cols: 1, rows: 1 }
@@ -257,46 +255,35 @@ describe('MdGridList', () => {
       fixture.detectChanges();
       let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
 
-      expect(getStyle(tiles[0], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[0], 'width')).toBe('99.25px');
       expect(getStyle(tiles[0], 'height')).toBe('100px');
       expect(getComputedLeft(tiles[0])).toBe(0);
       expect(getStyle(tiles[0], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[1], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[1], 'width')).toBe('199.5px');
       expect(getStyle(tiles[1], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[1])).toBe(100.1875);
+      expect(getComputedLeft(tiles[1])).toBe(100.25);
       expect(getStyle(tiles[1], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[2], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[2], 'width')).toBe('99.25px');
       expect(getStyle(tiles[2], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[2])).toBe(300.59375);
+      expect(getComputedLeft(tiles[2])).toBe(300.75);
       expect(getStyle(tiles[2], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[3], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[3], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[3])).toBe(400.796875);
-      expect(getStyle(tiles[3], 'top')).toBe('0px');
+      expect(getStyle(tiles[3], 'width')).toBe('199.5px');
+      expect(getStyle(tiles[3], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[3])).toBe(0);
+      expect(getStyle(tiles[3], 'top')).toBe('202px');
 
-      // causes gap
-      expect(getStyle(tiles[4], 'width')).toBe('199.391px');
-      expect(getStyle(tiles[4], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[4])).toBe(300.59375);
-      expect(getStyle(tiles[4], 'top')).toBe('101px');
+      expect(getStyle(tiles[4], 'width')).toBe('99.25px');
+      expect(getStyle(tiles[4], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[4])).toBe(200.5);
+      expect(getStyle(tiles[4], 'top')).toBe('202px');
 
-      expect(getStyle(tiles[5], 'width')).toBe('199.391px');
-      expect(getStyle(tiles[5], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[5])).toBe(0);
+      expect(getStyle(tiles[5], 'width')).toBe('99.25px');
+      expect(getStyle(tiles[5], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[5])).toBe(300.75);
       expect(getStyle(tiles[5], 'top')).toBe('202px');
-
-      expect(getStyle(tiles[6], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[6], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[6])).toBe(200.390625);
-      expect(getStyle(tiles[6], 'top')).toBe('202px');
-
-      expect(getStyle(tiles[7], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[7], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[7])).toBe(200.390625);
-      expect(getStyle(tiles[7], 'top')).toBe('303px');
   });
 
   it('should lay out tiles filling gaps, when order can be ignored', () => {
@@ -306,8 +293,6 @@ describe('MdGridList', () => {
         { cols: 1, rows: 1 },
         { cols: 2, rows: 2 },
         { cols: 1, rows: 1 },
-        { cols: 1, rows: 1 },
-        { cols: 2, rows: 2 },
         { cols: 2, rows: 2 },
         { cols: 1, rows: 1 },
         { cols: 1, rows: 1 }
@@ -316,48 +301,35 @@ describe('MdGridList', () => {
       fixture.detectChanges();
       let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
 
-      expect(getStyle(tiles[0], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[0], 'width')).toBe('99.25px');
       expect(getStyle(tiles[0], 'height')).toBe('100px');
       expect(getComputedLeft(tiles[0])).toBe(0);
       expect(getStyle(tiles[0], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[1], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[1], 'width')).toBe('199.5px');
       expect(getStyle(tiles[1], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[1])).toBe(100.1875);
+      expect(getComputedLeft(tiles[1])).toBe(100.25);
       expect(getStyle(tiles[1], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[2], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[2], 'width')).toBe('99.25px');
       expect(getStyle(tiles[2], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[2])).toBe(300.59375);
+      expect(getComputedLeft(tiles[2])).toBe(300.75);
       expect(getStyle(tiles[2], 'top')).toBe('0px');
 
-      expect(getStyle(tiles[3], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[3], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[3])).toBe(400.796875);
-      expect(getStyle(tiles[3], 'top')).toBe('0px');
+      expect(getStyle(tiles[3], 'width')).toBe('199.5px');
+      expect(getStyle(tiles[3], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[3])).toBe(0);
+      expect(getStyle(tiles[3], 'top')).toBe('202px');
 
-      // causes gap
-      expect(getStyle(tiles[4], 'width')).toBe('199.391px');
-      expect(getStyle(tiles[4], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[4])).toBe(300.59375);
+      expect(getStyle(tiles[4], 'width')).toBe('99.25px');
+      expect(getStyle(tiles[4], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[4])).toBe(0);
       expect(getStyle(tiles[4], 'top')).toBe('101px');
 
-      // to large for gap
-      expect(getStyle(tiles[5], 'width')).toBe('199.391px');
-      expect(getStyle(tiles[5], 'height')).toBe('201px');
-      expect(getComputedLeft(tiles[5])).toBe(0);
-      expect(getStyle(tiles[5], 'top')).toBe('202px');
-
-      // fills gap
-      expect(getStyle(tiles[6], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[6], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[6])).toBe(0);
-      expect(getStyle(tiles[6], 'top')).toBe('101px');
-
-      expect(getStyle(tiles[7], 'width')).toBe('99.1875px');
-      expect(getStyle(tiles[7], 'height')).toBe('100px');
-      expect(getComputedLeft(tiles[7])).toBe(200.390625);
-      expect(getStyle(tiles[7], 'top')).toBe('202px');
+      expect(getStyle(tiles[5], 'width')).toBe('99.25px');
+      expect(getStyle(tiles[5], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[5])).toBe(300.75);
+      expect(getStyle(tiles[5], 'top')).toBe('101px');
   });
 
   it('should not add any classes to footers without lines', () => {
@@ -525,8 +497,8 @@ class GridListWithComplexLayout {
 }
 
 @Component({template: `
-    <div style="width:500px">
-      <md-grid-list cols="5" rowHeight="100px">
+    <div style="width:400px">
+      <md-grid-list cols="4" rowHeight="100px">
         <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows">
         </md-grid-tile>
       </md-grid-list>
@@ -536,8 +508,8 @@ class GridListWithGaps {
 }
 
 @Component({template: `
-    <div style="width:500px">
-      <md-grid-list cols="5" rowHeight="100px" ignoreOrder="true">
+    <div style="width:400px">
+      <md-grid-list cols="4" rowHeight="100px" ignoreOrder="true">
         <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows">
         </md-grid-tile>
       </md-grid-list>

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -26,6 +26,8 @@ describe('MdGridList', () => {
         GridListWithColspanBinding,
         GridListWithRowspanBinding,
         GridListWithComplexLayout,
+        GridListWithGaps,
+        GridListWithIgnoredOrder,
         GridListWithFootersWithoutLines,
         GridListWithFooterContainingTwoLines,
       ],
@@ -238,7 +240,127 @@ describe('MdGridList', () => {
       expect(getStyle(tiles[3], 'top')).toBe('101px');
   });
 
-  it('should add not add any classes to footers without lines', () => {
+  it('should lay out tiles in order even if this causes gaps', () => {
+    let fixture = TestBed.createComponent(GridListWithGaps);
+
+      fixture.componentInstance.tiles = [
+        { cols: 1, rows: 1 },
+        { cols: 2, rows: 2 },
+        { cols: 1, rows: 1 },
+        { cols: 1, rows: 1 },
+        { cols: 2, rows: 2 },
+        { cols: 2, rows: 2 },
+        { cols: 1, rows: 1 },
+        { cols: 1, rows: 1 }
+      ];
+
+      fixture.detectChanges();
+      let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+
+      expect(getStyle(tiles[0], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[0], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[0])).toBe(0);
+      expect(getStyle(tiles[0], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[1], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[1], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[1])).toBe(100.1875);
+      expect(getStyle(tiles[1], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[2], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[2], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[2])).toBe(300.59375);
+      expect(getStyle(tiles[2], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[3], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[3], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[3])).toBe(400.796875);
+      expect(getStyle(tiles[3], 'top')).toBe('0px');
+
+      // causes gap
+      expect(getStyle(tiles[4], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[4], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[4])).toBe(300.59375);
+      expect(getStyle(tiles[4], 'top')).toBe('101px');
+
+      expect(getStyle(tiles[5], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[5], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[5])).toBe(0);
+      expect(getStyle(tiles[5], 'top')).toBe('202px');
+
+      expect(getStyle(tiles[6], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[6], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[6])).toBe(200.390625);
+      expect(getStyle(tiles[6], 'top')).toBe('202px');
+
+      expect(getStyle(tiles[7], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[7], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[7])).toBe(200.390625);
+      expect(getStyle(tiles[7], 'top')).toBe('303px');
+  });
+
+  it('should lay out tiles filling gaps, when order can be ignored', () => {
+    let fixture = TestBed.createComponent(GridListWithIgnoredOrder);
+
+      fixture.componentInstance.tiles = [
+        { cols: 1, rows: 1 },
+        { cols: 2, rows: 2 },
+        { cols: 1, rows: 1 },
+        { cols: 1, rows: 1 },
+        { cols: 2, rows: 2 },
+        { cols: 2, rows: 2 },
+        { cols: 1, rows: 1 },
+        { cols: 1, rows: 1 }
+      ];
+
+      fixture.detectChanges();
+      let tiles = fixture.debugElement.queryAll(By.css('md-grid-tile'));
+
+      expect(getStyle(tiles[0], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[0], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[0])).toBe(0);
+      expect(getStyle(tiles[0], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[1], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[1], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[1])).toBe(100.1875);
+      expect(getStyle(tiles[1], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[2], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[2], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[2])).toBe(300.59375);
+      expect(getStyle(tiles[2], 'top')).toBe('0px');
+
+      expect(getStyle(tiles[3], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[3], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[3])).toBe(400.796875);
+      expect(getStyle(tiles[3], 'top')).toBe('0px');
+
+      // causes gap
+      expect(getStyle(tiles[4], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[4], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[4])).toBe(300.59375);
+      expect(getStyle(tiles[4], 'top')).toBe('101px');
+
+      // to large for gap
+      expect(getStyle(tiles[5], 'width')).toBe('199.391px');
+      expect(getStyle(tiles[5], 'height')).toBe('201px');
+      expect(getComputedLeft(tiles[5])).toBe(0);
+      expect(getStyle(tiles[5], 'top')).toBe('202px');
+
+      // fills gap
+      expect(getStyle(tiles[6], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[6], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[6])).toBe(0);
+      expect(getStyle(tiles[6], 'top')).toBe('101px');
+
+      expect(getStyle(tiles[7], 'width')).toBe('99.1875px');
+      expect(getStyle(tiles[7], 'height')).toBe('100px');
+      expect(getComputedLeft(tiles[7])).toBe(200.390625);
+      expect(getStyle(tiles[7], 'top')).toBe('202px');
+  });
+
+  it('should not add any classes to footers without lines', () => {
     let fixture = TestBed.createComponent(GridListWithFootersWithoutLines);
     fixture.detectChanges();
 
@@ -394,13 +516,33 @@ class GridListWithRowspanBinding {
 @Component({template: `
     <div style="width:400px">
       <md-grid-list cols="4" rowHeight="100px">
-        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
-                      [style.background]="tile.color">
-          {{tile.text}}
+        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows">
         </md-grid-tile>
       </md-grid-list>
     </div>`})
 class GridListWithComplexLayout {
+  tiles: any[];
+}
+
+@Component({template: `
+    <div style="width:500px">
+      <md-grid-list cols="5" rowHeight="100px">
+        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows">
+        </md-grid-tile>
+      </md-grid-list>
+    </div>`})
+class GridListWithGaps {
+  tiles: any[];
+}
+
+@Component({template: `
+    <div style="width:500px">
+      <md-grid-list cols="5" rowHeight="100px" ignoreOrder="true">
+        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows">
+        </md-grid-tile>
+      </md-grid-list>
+    </div>`})
+class GridListWithIgnoredOrder {
   tiles: any[];
 }
 

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -50,6 +50,9 @@ export class MdGridList implements OnInit, AfterContentChecked {
    */
   private _rowHeight: string;
 
+  /** Flag if order has to be respected or can be ignored to fill gaps */
+  private _ignoreOrder: boolean = false;
+
   /** The amount of space between tiles. This will be something like '5px' or '2em'. */
   private _gutter: string = '1px';
 
@@ -79,6 +82,12 @@ export class MdGridList implements OnInit, AfterContentChecked {
   set rowHeight(value: string | number) {
     this._rowHeight = coerceToString(value);
     this._setTileStyler();
+  }
+
+  /** Set flag to ignore order in tile coordination. */
+  @Input()
+  set ignoreOrder(value: boolean) {
+    this._ignoreOrder = value;
   }
 
   ngOnInit() {
@@ -121,7 +130,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
 
   /** Computes and applies the size and position for all children grid tiles. */
   private _layoutTiles(): void {
-    let tracker = new TileCoordinator(this.cols, this._tiles);
+    let tracker = new TileCoordinator(this.cols, this._tiles, this._ignoreOrder);
     let direction = this._dir ? this._dir.value : 'ltr';
     this._tileStyler.init(this.gutterSize, tracker, this.cols, direction);
 

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -12,10 +12,10 @@ import {MdGridTileTooWideError} from './grid-list-errors';
  * are given.
  *
  * If the order should be ignored, we start from the beginning for each tile
- * 
- * The basis of the algorithm is the use of an two-dimensional array to track the already placed 
+ *
+ * The basis of the algorithm is the use of an two-dimensional array to track the already placed
  * tiles. Each element of the array corresponds to a row, each element of a row corresponds to a
- * cell. True indicates that the cell is already occupied; false indicates an empty cell. 
+ * cell. True indicates that the cell is already occupied; false indicates an empty cell.
  *
  * @docs-private
  */
@@ -63,7 +63,7 @@ export class TileCoordinator {
 
     // if order is ignored, reset the indexes
     if (ignoreOrder) {
-      // The next time we look for a gap, we start at the beginning 
+      // The next time we look for a gap, we start at the beginning
       this.columnIndex = 0;
       this.rowIndex = 0;
     } else {
@@ -83,7 +83,6 @@ export class TileCoordinator {
 
     // Start index is inclusive, end index is exclusive.
     let gapStartIndex = -1;
-    let gapEndIndex = -1;
     let gapIsLargeEnough = false;
 
     // Look for a gap large enough to fit the given tile. Empty spaces are marked with false.
@@ -103,7 +102,7 @@ export class TileCoordinator {
       }
 
       // if no cell has been occupied the gap sure is large enough
-      if(this.tracker[this.rowIndex].indexOf(true, this.columnIndex) == -1){
+      if (this.tracker[this.rowIndex].indexOf(true, this.columnIndex) == -1) {
         gapIsLargeEnough = true;
       } else {
         gapIsLargeEnough = this._checkGapSize(gapStartIndex, tileCols, tileRows);
@@ -140,9 +139,9 @@ export class TileCoordinator {
    * the tile cols and rows. The gap ends when a occupied cell is found.
    */
   private _checkGapSize(gapStartIndex: number, tileCols: number, tileRows: number): boolean {
-    for (let i = 0; i < tileRows; i++){
+    for (let i = 0; i < tileRows; i++) {
 
-      // if we would have to check a not yet tracked row, we know it is empty 
+      // if we would have to check a not yet tracked row, we know it is empty
       // and that the gap is large enough
       if (this.rowIndex + i  >= this.tracker.length) {
         break;
@@ -153,7 +152,7 @@ export class TileCoordinator {
       for (let j = gapStartIndex; j < gapStartIndex + tileCols; j++) {
 
         // if we encounter a occupied cell the gap isn't large enough
-        if (this.tracker[this.rowIndex + i][j]) {
+        if (this.tracker[this.rowIndex + i][j] !== false) {
           return false;
         }
       }
@@ -165,7 +164,7 @@ export class TileCoordinator {
 
   /** Update the tile tracker to account for the given tile in the given space. */
   private _markTilePosition(start: number, tile: MdGridTile): void {
-    for (let i = 0; i < tile.rowspan; i++){
+    for (let i = 0; i < tile.rowspan; i++) {
 
       // if the row wasn't create yet
       if (this.rowIndex + i >= this.tracker.length) {

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -10,7 +10,6 @@ import {MdGridListBadRatioError} from './grid-list-errors';
 export class TileStyler {
   _gutterSize: string;
   _rows: number = 0;
-  _rowspan: number = 0;
   _cols: number;
   _direction: string;
 
@@ -25,8 +24,7 @@ export class TileStyler {
    */
   init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string): void {
     this._gutterSize = normalizeUnits(gutterSize);
-    this._rows = tracker.rowCount;
-    this._rowspan = tracker.rowspan;
+    this._rows = tracker.rows;
     this._cols = cols;
     this._direction = direction;
   }
@@ -107,7 +105,7 @@ export class TileStyler {
    * Calculates the total size taken up by gutters across one axis of a list.
    */
   getGutterSpan(): string {
-    return `${this._gutterSize} * (${this._rowspan} - 1)`;
+    return `${this._gutterSize} * (${this._rows} - 1)`;
   }
 
   /**
@@ -115,7 +113,7 @@ export class TileStyler {
    * @param tileHeight Height of the tile.
    */
   getTileSpan(tileHeight: string): string {
-    return `${this._rowspan} * ${this.getTileSize(tileHeight, 1)}`;
+    return `${this._rows} * ${this.getTileSize(tileHeight, 1)}`;
   }
 
   /**
@@ -219,7 +217,7 @@ export class FitTileStyler extends TileStyler {
   setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
                gutterWidth: number): void {
     // Percent of the available vertical space that one row takes up.
-    let percentHeightPerTile = 100 / this._rowspan;
+    let percentHeightPerTile = 100 / this._rows;
 
     // Fraction of the horizontal gutter size that each column takes up.
     let gutterHeightPerTile = (this._rows - 1) / this._rows;


### PR DESCRIPTION
new input to ignore initial order of grid tiles, so that all gaps are filled

#3354