### PR TITLE
build: fix karma console log

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -86,7 +86,13 @@ module.exports = (config) => {
     captureTimeout: 120000,
     browsers: ['Chrome_1024x768'],
 
-    singleRun: false
+    singleRun: false,
+
+    browserConsoleLogOptions: {
+      terminal: true,
+      level: 'log'
+    }
+
   });
 
   if (process.env['TRAVIS']) {


### PR DESCRIPTION
Karma recently introduced a breaking change, that **hasn't** been noted (https://github.com/karma-runner/karma/issues/2582) and now causes `console.log` calls to no longer show up.

Karma doesn't show any `console.log` calls anymore, because the priority order of the `LogLevel`'s has been changed and the default log level for the `browserConsoleLog` does no longer include the `LOG` log-level.