### PR TITLE
feat: support strictNullChecks

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "../dist/e2e/",
     "rootDir": ".",
     "sourceMap": true,
+    "strictNullChecks": true,
     "target": "es5",
     "typeRoots": [
       "../node_modules/@types"

--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "target": "es5",
     "baseUrl": "",
     "typeRoots": [

--- a/src/demo-app/tsconfig.json
+++ b/src/demo-app/tsconfig.json
@@ -12,6 +12,7 @@
     "sourceMap": true,
     "target": "es5",
     "stripInternal": false,
+    "strictNullChecks": true,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types/!(node)"

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -12,6 +12,7 @@
     "sourceMap": true,
     "target": "es5",
     "stripInternal": false,
+    "strictNullChecks": true,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types/!(node)"

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -65,7 +65,7 @@ export const MD_AUTOCOMPLETE_VALUE_ACCESSOR: any = {
   providers: [MD_AUTOCOMPLETE_VALUE_ACCESSOR]
 })
 export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayRef|null;
   private _portal: TemplatePortal;
   private _panelOpen: boolean = false;
 
@@ -123,7 +123,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
       this._createOverlay();
     }
 
-    if (!this._overlayRef.hasAttached()) {
+    if (this._overlayRef && !this._overlayRef.hasAttached()) {
       this._overlayRef.attach(this._portal);
       this._subscribeToClosingActions();
     }
@@ -160,7 +160,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   /** The currently active option, coerced to MdOption type. */
-  get activeOption(): MdOption {
+  get activeOption(): MdOption|undefined {
     if (this.autocomplete._keyManager) {
       return this.autocomplete._keyManager.activeItem as MdOption;
     }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -40,7 +40,7 @@ var _uniqueIdCounter = 0;
 
 /** Change event object emitted by MdButtonToggle. */
 export class MdButtonToggleChange {
-  source: MdButtonToggle;
+  source: MdButtonToggle|null;
   value: any;
 }
 
@@ -63,13 +63,13 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   private _name: string = `md-button-toggle-group-${_uniqueIdCounter++}`;
 
   /** Disables all toggles in the group. */
-  private _disabled: boolean = null;
+  private _disabled: boolean|null = null;
 
   /** Whether the button toggle group should be vertical. */
   private _vertical: boolean = false;
 
   /** The currently selected button toggle, should match the value. */
-  private _selected: MdButtonToggle = null;
+  private _selected: MdButtonToggle|null = null;
 
   /** Whether the button toggle group is initialized or not. */
   private _isInitialized: boolean = false;
@@ -91,7 +91,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
 
   /** Child button toggle buttons. */
   @ContentChildren(forwardRef(() => MdButtonToggle))
-  _buttonToggles: QueryList<MdButtonToggle> = null;
+  _buttonToggles: QueryList<MdButtonToggle>|null = null;
 
   ngAfterViewInit() {
     this._isInitialized = true;
@@ -110,7 +110,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
 
   /** Whether the toggle group is disabled. */
   @Input()
-  get disabled(): boolean {
+  get disabled(): boolean|null {
     return this._disabled;
   }
 
@@ -154,7 +154,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     return this._selected;
   }
 
-  set selected(selected: MdButtonToggle) {
+  set selected(selected: MdButtonToggle|null) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
 
@@ -245,27 +245,21 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
 })
 export class MdButtonToggleGroupMultiple {
   /** Disables all toggles in the group. */
-  private _disabled: boolean = null;
+  private _disabled: boolean|null = null;
 
   /** Whether the button toggle group should be vertical. */
   private _vertical: boolean = false;
 
   /** Whether the toggle group is disabled. */
   @Input()
-  get disabled(): boolean {
-    return this._disabled;
-  }
-
+  get disabled(): boolean|null { return this._disabled; }
   set disabled(value) {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 
   /** Whether the toggle group is vertical. */
   @Input()
-  get vertical(): boolean {
-    return this._vertical;
-  }
-
+  get vertical(): boolean { return this._vertical; }
   set vertical(value) {
     this._vertical = coerceBooleanProperty(value);
   }
@@ -299,13 +293,13 @@ export class MdButtonToggle implements OnInit {
   name: string;
 
   /** Whether or not this button toggle is disabled. */
-  private _disabled: boolean = null;
+  private _disabled: boolean|null = null;
 
   /** Value assigned to this button toggle. */
   private _value: any = null;
 
   /** Whether or not the button toggle is a single selection. */
-  private _isSingleSelector: boolean = null;
+  private _isSingleSelector: boolean = false;
 
   /** The parent button toggle group (exclusive selection). Optional. */
   buttonToggleGroup: MdButtonToggleGroup;
@@ -413,12 +407,12 @@ export class MdButtonToggle implements OnInit {
   /** Whether the button is disabled. */
   @HostBinding('class.mat-button-toggle-disabled')
   @Input()
-  get disabled(): boolean {
+  get disabled(): boolean|null {
     return this._disabled || (this.buttonToggleGroup != null && this.buttonToggleGroup.disabled) ||
         (this.buttonToggleGroupMultiple != null && this.buttonToggleGroupMultiple.disabled);
   }
 
-  set disabled(value: boolean) {
+  set disabled(value: boolean|null) {
     this._disabled = (value != null && value !== false) ? true : null;
   }
 

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -112,7 +112,7 @@ export class MdButton {
 
   /** Whether the ripple effect on click should be disabled. */
   private _disableRipple: boolean = false;
-  private _disabled: boolean = null;
+  private _disabled: boolean|null = null;
 
   /** Whether the ripple effect for this button is disabled. */
   @Input()
@@ -122,7 +122,7 @@ export class MdButton {
   /** Whether the button is disabled. */
   @Input()
   get disabled() { return this._disabled; }
-  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value) ? true : null; }
+  set disabled(value: boolean|null) { this._disabled = coerceBooleanProperty(value) ? true : null; }
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) { }
 

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -92,7 +92,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   /**
    * Users can specify the `aria-labelledby` attribute which will be forwarded to the input element
    */
-  @Input('aria-labelledby') ariaLabelledby: string = null;
+  @Input('aria-labelledby') ariaLabelledby: string|null = null;
 
   /** A unique id for the checkbox. If one is not supplied, it is auto-generated. */
   @Input() id: string = `md-checkbox-${++nextId}`;
@@ -146,7 +146,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   @Input() tabIndex: number = 0;
 
   /** Name value will be applied to the input element if present */
-  @Input() name: string = null;
+  @Input() name: string|null = null;
 
   /** Event emitted when the checkbox's `checked` value changes. */
   @Output() change: EventEmitter<MdCheckboxChange> = new EventEmitter<MdCheckboxChange>();
@@ -181,10 +181,10 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   private _controlValueAccessorChangeFn: (value: any) => void = (value) => {};
 
   /** Reference to the focused state ripple. */
-  private _focusedRipple: RippleRef;
+  private _focusedRipple: RippleRef|null = null;
 
   /** Reference to the focus origin monitor subscription. */
-  private _focusedSubscription: Subscription;
+  private _focusedSubscription: Subscription|null = null;
 
   constructor(private _renderer: Renderer,
               private _elementRef: ElementRef,
@@ -400,31 +400,32 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
 
   private _getAnimationClassForCheckStateTransition(
       oldState: TransitionCheckState, newState: TransitionCheckState): string {
-    var animSuffix: string;
+
+    let animSuffix = '';
 
     switch (oldState) {
-    case TransitionCheckState.Init:
-      // Handle edge case where user interacts with checkbox that does not have [(ngModel)] or
-      // [checked] bound to it.
-      if (newState === TransitionCheckState.Checked) {
-        animSuffix = 'unchecked-checked';
-      } else if (newState == TransitionCheckState.Indeterminate) {
-        animSuffix = 'unchecked-indeterminate';
-      } else {
-        return '';
-      }
-      break;
-    case TransitionCheckState.Unchecked:
-      animSuffix = newState === TransitionCheckState.Checked ?
-          'unchecked-checked' : 'unchecked-indeterminate';
-      break;
-    case TransitionCheckState.Checked:
-      animSuffix = newState === TransitionCheckState.Unchecked ?
-          'checked-unchecked' : 'checked-indeterminate';
-      break;
-    case TransitionCheckState.Indeterminate:
-      animSuffix = newState === TransitionCheckState.Checked ?
-          'indeterminate-checked' : 'indeterminate-unchecked';
+      case TransitionCheckState.Init:
+        // Handle edge case where user interacts with checkbox that does not have [(ngModel)] or
+        // [checked] bound to it.
+        if (newState === TransitionCheckState.Checked) {
+          animSuffix = 'unchecked-checked';
+        } else if (newState == TransitionCheckState.Indeterminate) {
+          animSuffix = 'unchecked-indeterminate';
+        } else {
+          return '';
+        }
+        break;
+      case TransitionCheckState.Unchecked:
+        animSuffix = newState === TransitionCheckState.Checked ?
+            'unchecked-checked' : 'unchecked-indeterminate';
+        break;
+      case TransitionCheckState.Checked:
+        animSuffix = newState === TransitionCheckState.Unchecked ?
+            'checked-unchecked' : 'checked-indeterminate';
+        break;
+      case TransitionCheckState.Indeterminate:
+        animSuffix = newState === TransitionCheckState.Checked ?
+            'indeterminate-checked' : 'indeterminate-unchecked';
     }
 
     return `mat-checkbox-anim-${animSuffix}`;

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -134,7 +134,7 @@ export class MdChipList implements AfterContentInit {
     let focusedIndex = this._keyManager.activeItemIndex;
 
     if (this._isValidIndex(focusedIndex)) {
-      let focusedChip: MdChip = this.chips.toArray()[focusedIndex];
+      let focusedChip: MdChip = this.chips.toArray()[focusedIndex as number];
 
       if (focusedChip) {
         focusedChip.toggleSelected();
@@ -201,8 +201,8 @@ export class MdChipList implements AfterContentInit {
    * @param index The index to be checked.
    * @returns True if the index is valid for our list of chips.
    */
-  private _isValidIndex(index: number): boolean {
-    return index >= 0 && index < this.chips.length;
+  private _isValidIndex(index: number|null): boolean {
+    return typeof index === 'number' && index >= 0 && index < this.chips.length;
   }
 
 }

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -38,7 +38,7 @@ export interface MdChipEvent {
 export class MdChip implements Focusable, OnInit, OnDestroy {
 
   /** Whether or not the chip is disabled. Disabled chips cannot be focused. */
-  protected _disabled: boolean = null;
+  protected _disabled: boolean|null = null;
 
   /** Whether or not the chip is selected. */
   protected _selected: boolean = false;
@@ -70,12 +70,12 @@ export class MdChip implements Focusable, OnInit, OnDestroy {
   }
 
   /** Whether or not the chip is disabled. */
-  @Input() get disabled(): boolean {
+  @Input() get disabled(): boolean|null {
     return this._disabled;
   }
 
   /** Sets the disabled state of the chip. */
-  set disabled(value: boolean) {
+  set disabled(value: boolean|null) {
     this._disabled = coerceBooleanProperty(value) ? true : null;
   }
 

--- a/src/lib/core/a11y/activedescendant-key-manager.ts
+++ b/src/lib/core/a11y/activedescendant-key-manager.ts
@@ -22,7 +22,7 @@ export class ActiveDescendantKeyManager extends ListKeyManager<Highlightable> {
    * It also adds active styles to the newly active item and removes active
    * styles from the previously active item.
    */
-  setActiveItem(index: number): void {
+  setActiveItem(index: number|null): void {
     if (this.activeItem) {
       this.activeItem.setInactiveStyles();
     }

--- a/src/lib/core/a11y/focus-key-manager.ts
+++ b/src/lib/core/a11y/focus-key-manager.ts
@@ -21,9 +21,12 @@ export class FocusKeyManager extends ListKeyManager<Focusable> {
    * This method sets the active item to the item at the specified index.
    * It also adds focuses the newly active item.
    */
-  setActiveItem(index: number): void {
+  setActiveItem(index: number|null): void {
     super.setActiveItem(index);
-    this.activeItem.focus();
+
+    if (this.activeItem) {
+      this.activeItem.focus();
+    }
   }
 
 }

--- a/src/lib/core/a11y/focus-trap.ts
+++ b/src/lib/core/a11y/focus-trap.ts
@@ -20,8 +20,8 @@ import {coerceBooleanProperty} from '../coercion/boolean-property';
  * This will be replaced with a more intelligent solution before the library is considered stable.
  */
 export class FocusTrap {
-  private _startAnchor: HTMLElement;
-  private _endAnchor: HTMLElement;
+  private _startAnchor: HTMLElement|null;
+  private _endAnchor: HTMLElement|null;
 
   /** Whether the focus trap is active. */
   get enabled(): boolean { return this._enabled; }
@@ -63,20 +63,21 @@ export class FocusTrap {
    * in the constructor, but can be deferred for cases like directives with `*ngIf`.
    */
   attachAnchors(): void {
-    if (!this._startAnchor) {
-      this._startAnchor = this._createAnchor();
-    }
-
-    if (!this._endAnchor) {
-      this._endAnchor = this._createAnchor();
-    }
-
     this._ngZone.runOutsideAngular(() => {
-      this._startAnchor.addEventListener('focus', () => this.focusLastTabbableElement());
-      this._endAnchor.addEventListener('focus', () => this.focusFirstTabbableElement());
+      if (!this._startAnchor) {
+        this._startAnchor = this._createAnchor();
+        this._startAnchor.addEventListener('focus', () => this.focusLastTabbableElement());
+      }
 
-      this._element.parentNode.insertBefore(this._startAnchor, this._element);
-      this._element.parentNode.insertBefore(this._endAnchor, this._element.nextSibling);
+      if (!this._endAnchor) {
+        this._endAnchor = this._createAnchor();
+        this._endAnchor.addEventListener('focus', () => this.focusFirstTabbableElement());
+      }
+
+      if (this._element.parentNode) {
+        this._element.parentNode.insertBefore(this._startAnchor, this._element);
+        this._element.parentNode.insertBefore(this._endAnchor, this._element.nextSibling);
+      }
     });
   }
 
@@ -109,7 +110,7 @@ export class FocusTrap {
   /** Focuses the last tabbable element within the focus trap region. */
   focusLastTabbableElement() {
     let focusTargets = this._element.querySelectorAll('[cdk-focus-end]');
-    let redirectToElement: HTMLElement = null;
+    let redirectToElement: HTMLElement|null = null;
 
     if (focusTargets.length) {
       redirectToElement = focusTargets[focusTargets.length - 1] as HTMLElement;
@@ -123,7 +124,7 @@ export class FocusTrap {
   }
 
   /** Get the first tabbable element from a DOM subtree (inclusive). */
-  private _getFirstTabbableElement(root: HTMLElement): HTMLElement {
+  private _getFirstTabbableElement(root: HTMLElement): HTMLElement|null {
     if (this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
       return root;
     }
@@ -146,7 +147,7 @@ export class FocusTrap {
   }
 
   /** Get the last tabbable element from a DOM subtree (inclusive). */
-  private _getLastTabbableElement(root: HTMLElement): HTMLElement {
+  private _getLastTabbableElement(root: HTMLElement): HTMLElement|null {
     if (this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
       return root;
     }

--- a/src/lib/core/a11y/interactivity-checker.ts
+++ b/src/lib/core/a11y/interactivity-checker.ts
@@ -188,15 +188,20 @@ function hasValidTabIndex(element: HTMLElement): boolean {
  * Returns the parsed tabindex from the element attributes instead of returning the
  * evaluated tabindex from the browsers defaults.
  */
-function getTabIndexValue(element: HTMLElement): number {
+function getTabIndexValue(element: HTMLElement): number|null {
   if (!hasValidTabIndex(element)) {
     return null;
   }
 
   // See browser issue in Gecko https://bugzilla.mozilla.org/show_bug.cgi?id=1128054
-  const tabIndex = parseInt(element.getAttribute('tabindex'), 10);
+  const rawTabIndex = element.getAttribute('tabindex');
 
-  return isNaN(tabIndex) ? -1 : tabIndex;
+  if (rawTabIndex) {
+    const tabIndex = parseInt(rawTabIndex, 10);
+    return isNaN(tabIndex) ? -1 : tabIndex;
+  }
+
+  return -1;
 }
 
 /** Checks whether the specified element is potentially tabbable on iOS */

--- a/src/lib/core/a11y/list-key-manager.ts
+++ b/src/lib/core/a11y/list-key-manager.ts
@@ -8,7 +8,7 @@ import {Subject} from 'rxjs/Subject';
  * ListKeyManager must extend this interface.
  */
 export interface CanDisable {
-  disabled?: boolean;
+  disabled?: boolean|null;
 }
 
 /**
@@ -16,8 +16,8 @@ export interface CanDisable {
  * of items, it will set the active item correctly when arrow events occur.
  */
 export class ListKeyManager<T extends CanDisable> {
-  private _activeItemIndex: number = null;
-  private _activeItem: T;
+  private _activeItemIndex: number|null = null;
+  private _activeItem: T|null;
   private _tabOut: Subject<any> = new Subject();
   private _wrap: boolean = false;
 
@@ -40,9 +40,9 @@ export class ListKeyManager<T extends CanDisable> {
    *
    * @param index The index of the item to be set as active.
    */
-  setActiveItem(index: number): void {
+  setActiveItem(index: number|null): void {
     this._activeItemIndex = index;
-    this._activeItem = this._items.toArray()[index];
+    this._activeItem = typeof index === 'number' ? this._items.toArray()[index] : null;
   }
 
   /**
@@ -75,12 +75,12 @@ export class ListKeyManager<T extends CanDisable> {
   }
 
   /** Returns the index of the currently active item. */
-  get activeItemIndex(): number {
+  get activeItemIndex(): number|null {
     return this._activeItemIndex;
   }
 
   /** Returns the currently active item. */
-  get activeItem(): T {
+  get activeItem(): T|null {
     return this._activeItem;
   }
 

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -94,7 +94,8 @@ export class MdOption {
    */
   get viewValue(): string {
     // TODO(kara): Add input property alternative for node envs.
-    return this._getHostElement().textContent.trim();
+    let textContent = this._getHostElement().textContent;
+    return textContent ? textContent.trim() : '';
   }
 
   /** Selects the option. */

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -63,7 +63,7 @@ export class ConnectedOverlayDirective implements OnDestroy {
   private _templatePortal: TemplatePortal;
   private _open = false;
   private _hasBackdrop = false;
-  private _backdropSubscription: Subscription;
+  private _backdropSubscription: Subscription|null;
   private _positionSubscription: Subscription;
   private _offsetX: number = 0;
   private _offsetY: number = 0;

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -10,7 +10,7 @@ import {Subject} from 'rxjs/Subject';
  * Used to manipulate or dispose of said overlay.
  */
 export class OverlayRef implements PortalHost {
-  private _backdropElement: HTMLElement = null;
+  private _backdropElement: HTMLElement | null = null;
   private _backdropClick: Subject<any> = new Subject();
 
   constructor(
@@ -139,7 +139,9 @@ export class OverlayRef implements PortalHost {
 
     // Insert the backdrop before the pane in the DOM order,
     // in order to handle stacked overlays properly.
-    this._pane.parentElement.insertBefore(this._backdropElement, this._pane);
+    if (this._pane.parentElement) {
+      this._pane.parentElement.insertBefore(this._backdropElement, this._pane);
+    }
 
     // Forward backdrop clicks such that the consumer of the overlay can perform whatever
     // action desired when such a click occurs (usually closing the overlay).

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -107,7 +107,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     const viewportRect = this._viewportRuler.getViewportRect();
 
     // Fallback point if none of the fallbacks fit into the viewport.
-    let fallbackPoint: OverlayPoint = null;
+    let fallbackPoint: OverlayPoint|null = null;
 
     // We want to place the overlay in the first of the preferred positions such that the
     // overlay fits on-screen.
@@ -129,7 +129,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
         const positionChange = new ConnectedOverlayPositionChange(pos, scrollableViewProperties);
         this._onPositionChange.next(positionChange);
 
-        return Promise.resolve(null);
+        return Promise.resolve();
       } else if (!fallbackPoint || fallbackPoint.visibleArea < overlayPoint.visibleArea) {
         fallbackPoint = overlayPoint;
       }
@@ -137,9 +137,11 @@ export class ConnectedPositionStrategy implements PositionStrategy {
 
     // If none of the preferred positions were in the viewport, take the one
     // with the largest visible area.
-    this._setElementPosition(element, fallbackPoint);
+    if (fallbackPoint) {
+      this._setElementPosition(element, fallbackPoint);
+    }
 
-    return Promise.resolve(null);
+    return Promise.resolve();
   }
 
   /**

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -19,7 +19,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
   private _height: string = '';
 
   /* A lazily-created wrapper for the overlay element that is used as a flex container.  */
-  private _wrapper: HTMLElement;
+  private _wrapper: HTMLElement|null = null;
 
   /**
    * Sets the top position of the overlay. Clears any previously set vertical position.
@@ -36,7 +36,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the left position of the overlay. Clears any previously set horizontal position.
    * @param value New left offset.
    */
-  left(value: string): this {
+  left(value = ''): this {
     this._rightOffset = '';
     this._leftOffset = value;
     this._justifyContent = 'flex-start';
@@ -47,7 +47,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the bottom position of the overlay. Clears any previously set vertical position.
    * @param value New bottom offset.
    */
-  bottom(value: string): this {
+  bottom(value = ''): this {
     this._topOffset = '';
     this._bottomOffset = value;
     this._alignItems = 'flex-end';
@@ -58,7 +58,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the right position of the overlay. Clears any previously set horizontal position.
    * @param value New right offset.
    */
-  right(value: string): this {
+  right(value = ''): this {
     this._leftOffset = '';
     this._rightOffset = value;
     this._justifyContent = 'flex-end';
@@ -69,7 +69,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the overlay width and clears any previously set width.
    * @param value New width for the overlay
    */
-  width(value: string): this {
+  width(value = 'auto'): this {
     this._width = value;
 
     // When the width is 100%, we should reset the `left` and the offset,
@@ -85,7 +85,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the overlay height and clears any previously set height.
    * @param value New height for the overlay
    */
-  height(value: string): this {
+  height(value = 'auto'): this {
     this._height = value;
 
     // When the height is 100%, we should reset the `top` and the offset,
@@ -129,7 +129,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * @returns Resolved when the styles have been applied.
    */
   apply(element: HTMLElement): Promise<void> {
-    if (!this._wrapper) {
+    if (!this._wrapper && element.parentNode) {
       this._wrapper = document.createElement('div');
       this._wrapper.classList.add('cdk-global-overlay-wrapper');
       element.parentNode.insertBefore(this._wrapper, element);
@@ -150,7 +150,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
     parentStyles.justifyContent = this._justifyContent;
     parentStyles.alignItems = this._alignItems;
 
-    return Promise.resolve(null);
+    return Promise.resolve();
   }
 
   /**

--- a/src/lib/core/overlay/position/relative-position-strategy.ts
+++ b/src/lib/core/overlay/position/relative-position-strategy.ts
@@ -7,7 +7,7 @@ export class RelativePositionStrategy implements PositionStrategy {
 
   apply(element: Element): Promise<void> {
     // Not yet implemented.
-    return null;
+    return Promise.resolve();
   }
 
   dispose() {

--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -10,7 +10,7 @@ import {ScrollDispatcher} from '../scroll/scroll-dispatcher';
 export class ViewportRuler {
 
   /** Cached document client rectangle. */
-  private _documentRect?: ClientRect;
+  private _documentRect: ClientRect|null = null;
 
   constructor(scrollDispatcher: ScrollDispatcher) {
     // Initially cache the document rectangle.
@@ -57,14 +57,21 @@ export class ViewportRuler {
     // `scrollTop` and `scrollLeft` is inconsistent. However, using the bounding rect of
     // `document.documentElement` works consistently, where the `top` and `left` values will
     // equal negative the scroll position.
-    const top = -documentRect.top || document.body.scrollTop || window.scrollY || 0;
-    const left = -documentRect.left || document.body.scrollLeft || window.scrollX || 0;
+    const top = (documentRect ? -documentRect.top : 0) ||
+                document.body.scrollTop ||
+                window.scrollY ||
+                0;
+
+    const left = (documentRect ? -documentRect.left : 0) ||
+                 document.body.scrollLeft ||
+                 window.scrollX ||
+                 0;
 
     return {top, left};
   }
 
   /** Caches the latest client rectangle of the document element. */
-  _cacheViewportGeometry?() {
+  _cacheViewportGeometry() {
     this._documentRect = document.documentElement.getBoundingClientRect();
   }
 

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -46,8 +46,10 @@ export class ScrollDispatcher {
    * @param scrollable Scrollable instance to be deregistered.
    */
   deregister(scrollable: Scrollable): void {
-    if (this.scrollableReferences.has(scrollable)) {
-      this.scrollableReferences.get(scrollable).unsubscribe();
+    let scrollableReference = this.scrollableReferences.get(scrollable);
+
+    if (scrollableReference) {
+      scrollableReference.unsubscribe();
       this.scrollableReferences.delete(scrollable);
     }
   }
@@ -90,6 +92,8 @@ export class ScrollDispatcher {
     do {
       if (element == scrollableElement) { return true; }
     } while (element = element.parentElement);
+
+    return false;
   }
 
   /** Sends a notification that a scroll event has been fired. */

--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -63,19 +63,26 @@ export class DomPortalHost extends BasePortalHost {
    */
   attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
     let viewContainer = portal.viewContainerRef;
-    let viewRef = viewContainer.createEmbeddedView(portal.templateRef);
 
-    // The method `createEmbeddedView` will add the view as a child of the viewContainer.
-    // But for the DomPortalHost the view can be added everywhere in the DOM (e.g Overlay Container)
-    // To move the view to the specified host element. We just re-append the existing root nodes.
-    viewRef.rootNodes.forEach(rootNode => this._hostDomElement.appendChild(rootNode));
+    if (viewContainer) {
+      let viewRef = viewContainer.createEmbeddedView(portal.templateRef);
 
-    this.setDisposeFn((() => {
-      let index = viewContainer.indexOf(viewRef);
-      if (index !== -1) {
-        viewContainer.remove(index);
-      }
-    }));
+      // The method `createEmbeddedView` will add the view as a child of the viewContainer.
+      // But for the DomPortalHost the view can be added everywhere in the DOM (e.g Overlay
+      // Container) To move the view to the specified host element. We just re-append the
+      // existing root nodes.
+      viewRef.rootNodes.forEach(rootNode => this._hostDomElement.appendChild(rootNode));
+
+      this.setDisposeFn(() => {
+        if (viewContainer) {
+          let index = viewContainer.indexOf(viewRef);
+
+          if (index !== -1) {
+            viewContainer.remove(index);
+          }
+        }
+      });
+    }
 
     // TODO(jelbourn): Return locals from view.
     return new Map<string, any>();

--- a/src/lib/core/portal/portal.ts
+++ b/src/lib/core/portal/portal.ts
@@ -22,7 +22,7 @@ import {ComponentType} from '../overlay/generic-component-type';
  * It can be attach to / detached from a `PortalHost`.
  */
 export abstract class Portal<T> {
-  private _attachedHost: PortalHost;
+  private _attachedHost: PortalHost|null = null;
 
   /** Attach this portal to a host. */
   attach(host: PortalHost): T {
@@ -58,7 +58,7 @@ export abstract class Portal<T> {
    * Sets the PortalHost reference without performing `attach()`. This is used directly by
    * the PortalHost when it is performing an `attach()` or `detach()`.
    */
-  setAttachedHost(host: PortalHost) {
+  setAttachedHost(host: PortalHost|null) {
     this._attachedHost = host;
   }
 }
@@ -76,15 +76,15 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
    * This is different from where the component *renders*, which is determined by the PortalHost.
    * The origin is necessary when the host is outside of the Angular application context.
    */
-  viewContainerRef: ViewContainerRef;
+  viewContainerRef: ViewContainerRef|undefined;
 
   /** [Optional] Injector used for the instantiation of the component. */
-  injector: Injector;
+  injector: Injector|undefined;
 
   constructor(
       component: ComponentType<T>,
-      viewContainerRef: ViewContainerRef = null,
-      injector: Injector = null) {
+      viewContainerRef?: ViewContainerRef,
+      injector?: Injector) {
     super();
     this.component = component;
     this.viewContainerRef = viewContainerRef;
@@ -101,7 +101,7 @@ export class TemplatePortal extends Portal<Map<string, any>> {
   templateRef: TemplateRef<any>;
 
   /** Reference to the ViewContainer into which the template will be stamped out. */
-  viewContainerRef: ViewContainerRef;
+  viewContainerRef: ViewContainerRef|undefined;
 
   /**
    * Additional locals for the instantiated embedded view.
@@ -111,7 +111,7 @@ export class TemplatePortal extends Portal<Map<string, any>> {
    */
   locals: Map<string, any> = new Map<string, any>();
 
-  constructor(template: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+  constructor(template: TemplateRef<any>, viewContainerRef?: ViewContainerRef) {
     super();
     this.templateRef = template;
     this.viewContainerRef = viewContainerRef;
@@ -153,10 +153,10 @@ export interface PortalHost {
  */
 export abstract class BasePortalHost implements PortalHost {
   /** The portal currently attached to the host. */
-  private _attachedPortal: Portal<any>;
+  private _attachedPortal: Portal<any>|null;
 
   /** A function that will permanently dispose this host. */
-  private _disposeFn: () => void;
+  private _disposeFn: (() => void)|null;
 
   /** Whether this host has already been permanently disposed. */
   private _isDisposed: boolean = false;

--- a/src/lib/core/projection/projection.ts
+++ b/src/lib/core/projection/projection.ts
@@ -4,7 +4,9 @@ import {Injectable, Directive, ModuleWithProviders, NgModule, ElementRef} from '
 // "Polyfill" for `Node.replaceWith()`.
 // cf. https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/replaceWith
 function _replaceWith(toReplaceEl: HTMLElement, otherEl: HTMLElement) {
-  toReplaceEl.parentElement.replaceChild(otherEl, toReplaceEl);
+  if (toReplaceEl.parentElement) {
+    toReplaceEl.parentElement.replaceChild(otherEl, toReplaceEl);
+  }
 }
 
 /** @docs-private */

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -29,7 +29,7 @@ export class RippleRenderer {
   private _containerElement: HTMLElement;
 
   /** Element which triggers the ripple elements on mouse events. */
-  private _triggerElement: HTMLElement;
+  private _triggerElement: HTMLElement|null = null;
 
   /** Whether the mouse is currently down or not. */
   private _isMousedown: boolean = false;
@@ -87,7 +87,7 @@ export class RippleRenderer {
     ripple.style.width = `${radius * 2}px`;
 
     // If the color is not set, the default CSS color will be used.
-    ripple.style.backgroundColor = config.color;
+    ripple.style.backgroundColor = config.color || null;
     ripple.style.transitionDuration = `${duration}ms`;
 
     this._containerElement.appendChild(ripple);
@@ -136,7 +136,10 @@ export class RippleRenderer {
     // Once the ripple faded out, the ripple can be safely removed from the DOM.
     this.runTimeoutOutsideZone(() => {
       rippleRef.state = RippleState.HIDDEN;
-      rippleEl.parentNode.removeChild(rippleEl);
+
+      if (rippleEl.parentNode) {
+        rippleEl.parentNode.removeChild(rippleEl);
+      }
     }, RIPPLE_FADE_OUT_DURATION);
   }
 
@@ -146,11 +149,13 @@ export class RippleRenderer {
   }
 
   /** Sets the trigger element and registers the mouse events. */
-  setTriggerElement(element: HTMLElement) {
+  setTriggerElement(element: HTMLElement|null) {
     // Remove all previously register event listeners from the trigger element.
-    if (this._triggerElement) {
-      this._triggerEvents.forEach((fn, type) => this._triggerElement.removeEventListener(type, fn));
-    }
+    this._triggerEvents.forEach((fn, type) => {
+      if (this._triggerElement) {
+        this._triggerElement.removeEventListener(type, fn);
+      }
+    });
 
     if (element) {
       // If the element is not null, register all event listeners on the trigger element.

--- a/src/lib/core/selection/selection.ts
+++ b/src/lib/core/selection/selection.ts
@@ -16,7 +16,7 @@ export class SelectionModel<T> {
   private _selectedToEmit: T[] = [];
 
   /** Cache for the array value of the selected items. */
-  private _selected: T[];
+  private _selected: T[]|null = null;
 
   /** Selected value(s). */
   get selected(): T[] {

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -60,7 +60,7 @@ export class MdDialogContainer extends BasePortalHost implements OnDestroy {
   private _focusTrap: FocusTrap;
 
   /** Element that was focused before the dialog was opened. Save this to restore upon close. */
-  private _elementFocusedBeforeDialogWasOpened: HTMLElement = null;
+  private _elementFocusedBeforeDialogWasOpened: HTMLElement|null = null;
 
   /** The dialog configuration. */
   dialogConfig: MdDialogConfig;

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -56,9 +56,9 @@ export class MdDialog {
    * @returns Reference to the newly-opened dialog.
    */
   open<T>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MdDialogConfig): MdDialogRef<T> {
-    config = _applyConfigDefaults(config);
+          userConfig?: MdDialogConfig): MdDialogRef<T> {
 
+    let config = _applyConfigDefaults(userConfig);
     let overlayRef = this._createOverlay(config);
     let dialogContainer = this._attachDialogContainer(overlayRef, config);
     let dialogRef =
@@ -107,7 +107,7 @@ export class MdDialog {
    * @returns A promise resolving to a ComponentRef for the attached container.
    */
   private _attachDialogContainer(overlay: OverlayRef, config: MdDialogConfig): MdDialogContainer {
-    let viewContainer = config ? config.viewContainerRef : null;
+    let viewContainer = config ? config.viewContainerRef : undefined;
     let containerPortal = new ComponentPortal(MdDialogContainer, viewContainer);
 
     let containerRef: ComponentRef<MdDialogContainer> = overlay.attach(containerPortal);
@@ -129,7 +129,7 @@ export class MdDialog {
       componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
       dialogContainer: MdDialogContainer,
       overlayRef: OverlayRef,
-      config?: MdDialogConfig): MdDialogRef<T> {
+      config: MdDialogConfig): MdDialogRef<T> {
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
     let dialogRef = new MdDialogRef(overlayRef, dialogContainer) as MdDialogRef<T>;
@@ -146,10 +146,10 @@ export class MdDialog {
     let dialogInjector = new DialogInjector(userInjector || this._injector, dialogRef, config.data);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
-      dialogContainer.attachTemplatePortal(new TemplatePortal(componentOrTemplateRef, null));
+      dialogContainer.attachTemplatePortal(new TemplatePortal(componentOrTemplateRef));
     } else {
       let contentRef = dialogContainer.attachComponentPortal(
-          new ComponentPortal(componentOrTemplateRef, null, dialogInjector));
+          new ComponentPortal(componentOrTemplateRef, undefined, dialogInjector));
       dialogRef.componentInstance = contentRef.instance;
     }
 
@@ -224,7 +224,7 @@ export class MdDialog {
  * @param dialogConfig Config to be modified.
  * @returns The new configuration object.
  */
-function _applyConfigDefaults(dialogConfig: MdDialogConfig): MdDialogConfig {
+function _applyConfigDefaults(dialogConfig?: MdDialogConfig): MdDialogConfig {
   return extendObject(new MdDialogConfig(), dialogConfig);
 }
 

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -130,7 +130,7 @@ export class TileStyler {
    * This method will be implemented by each type of TileStyler.
    * @docs-private
    */
-  getComputedHeight(): [string, string] { return null; }
+  getComputedHeight(): [string, string] { return ['0px', '0px']; }
 }
 
 

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -82,9 +82,11 @@ export class MdTextareaAutosize implements OnInit {
     textareaClone.style.minHeight = '';
     textareaClone.style.maxHeight = '';
 
-    textarea.parentNode.appendChild(textareaClone);
-    this._cachedLineHeight = textareaClone.offsetHeight;
-    textarea.parentNode.removeChild(textareaClone);
+    if (textarea.parentNode) {
+      textarea.parentNode.appendChild(textareaClone);
+      this._cachedLineHeight = textareaClone.offsetHeight;
+      textarea.parentNode.removeChild(textareaClone);
+    }
   }
 
   /** Resize the textarea to fit its content. */

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -338,8 +338,9 @@ export class MdInputContainer implements AfterContentInit {
    */
   private _validateHints() {
     if (this._hintChildren) {
-      let startHint: MdHint = null;
-      let endHint: MdHint = null;
+      let startHint: MdHint;
+      let endHint: MdHint;
+
       this._hintChildren.forEach((hint: MdHint) => {
         if (hint.align == 'start') {
           if (startHint || this.hintLabel) {

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -44,7 +44,7 @@ export class MdMenuItem implements Focusable {
   }
 
   /** Used to set the HTML `disabled` attribute. Necessary for links to be disabled properly. */
-  _getDisabledAttr(): boolean {
+  _getDisabledAttr(): boolean|null {
     return this._disabled ? true : null;
   }
 

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -33,7 +33,7 @@ import {MenuPositionX, MenuPositionY} from './menu-positions';
  * TODO(andrewseguin): Remove the kebab versions in favor of camelCased attribute selectors
  */
 @Directive({
-  selector: `[md-menu-trigger-for], [mat-menu-trigger-for], 
+  selector: `[md-menu-trigger-for], [mat-menu-trigger-for],
              [mdMenuTriggerFor], [matMenuTriggerFor]`,
   host: {
     'aria-haspopup': 'true',
@@ -44,7 +44,7 @@ import {MenuPositionX, MenuPositionY} from './menu-positions';
 })
 export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   private _portal: TemplatePortal;
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayRef|null = null;
   private _menuOpen: boolean = false;
   private _backdropSubscription: Subscription;
   private _positionSubscription: Subscription;
@@ -100,7 +100,11 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   openMenu(): void {
     if (!this._menuOpen) {
       this._createOverlay();
-      this._overlayRef.attach(this._portal);
+
+      if (this._overlayRef) {
+        this._overlayRef.attach(this._portal);
+      }
+
       this._subscribeToBackdrop();
       this._initMenu();
     }
@@ -142,9 +146,11 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
    * explicitly when the menu is closed or destroyed.
    */
   private _subscribeToBackdrop(): void {
-    this._backdropSubscription = this._overlayRef.backdropClick().subscribe(() => {
-      this.closeMenu();
-    });
+    if (this._overlayRef) {
+      this._backdropSubscription = this._overlayRef.backdropClick().subscribe(() => {
+        this.closeMenu();
+      });
+    }
   }
 
   /**

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -75,7 +75,7 @@ export class MdProgressSpinner implements OnDestroy {
   private _lastAnimationId: number = 0;
 
   /** The id of the indeterminate interval. */
-  private _interdeterminateInterval: number;
+  private _interdeterminateInterval: number|null = null;
 
   /** The SVG <path> node that is used to draw the circle. */
   private _path: SVGPathElement;
@@ -102,8 +102,11 @@ export class MdProgressSpinner implements OnDestroy {
     return this._interdeterminateInterval;
   }
   /** @docs-private */
-  set interdeterminateInterval(interval: number) {
-    clearInterval(this._interdeterminateInterval);
+  set interdeterminateInterval(interval: number|null) {
+    if (this._interdeterminateInterval) {
+      clearInterval(this._interdeterminateInterval);
+    }
+
     this._interdeterminateInterval = interval;
   }
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -71,10 +71,10 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   private _name: string = `md-radio-group-${_uniqueIdCounter++}`;
 
   /** Disables all individual radio buttons assigned to this group. */
-  private _disabled: boolean = false;
+  private _disabled: boolean|null = null;
 
   /** The currently selected radio button. Should match value. */
-  private _selected: MdRadioButton = null;
+  private _selected: MdRadioButton|undefined;
 
   /** Whether the `value` has been set to its initial value. */
   private _isInitialized: boolean = false;
@@ -93,12 +93,10 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
    * Change events are only emitted when the value changes due to user interaction with
    * a radio button (the same behavior as `<input type-"radio">`).
    */
-  @Output()
-  change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
+  @Output() change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
 
   /** Child radio buttons. */
-  @ContentChildren(forwardRef(() => MdRadioButton))
-  _radios: QueryList<MdRadioButton> = null;
+  @ContentChildren(forwardRef(() => MdRadioButton)) _radios: QueryList<MdRadioButton>;
 
   /** Name of the radio button group. All radio buttons inside this group will use this name. */
   @Input()
@@ -128,8 +126,8 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Whether the radio button is disabled. */
   @Input()
-  get disabled(): boolean { return this._disabled; }
-  set disabled(value) {
+  get disabled(): boolean|null { return this._disabled; }
+  set disabled(value: boolean|null) {
     // The presence of *any* disabled value makes the component disabled, *except* for false.
     this._disabled = (value != null && value !== false) ? true : null;
   }
@@ -148,7 +146,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   }
 
   _checkSelectedRadioButton() {
-    if (this.selected && !this._selected.checked) {
+    if (this._selected && !this._selected.checked) {
       this._selected.checked = true;
     }
   }
@@ -156,7 +154,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /** Whether the radio button is selected. */
   @Input()
   get selected() { return this._selected; }
-  set selected(selected: MdRadioButton) {
+  set selected(selected: MdRadioButton|undefined) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
     this._checkSelectedRadioButton();
@@ -194,10 +192,10 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
   /** Updates the `selected` radio button from the internal _value state. */
   private _updateSelectedRadioFromValue(): void {
     // If the value already matches the selected radio, do nothing.
-    let isAlreadySelected = this._selected != null && this._selected.value == this._value;
+    let isAlreadySelected = this._selected && this._selected.value == this._value;
 
     if (this._radios != null && !isAlreadySelected) {
-      this._selected = null;
+      this._selected = undefined;
       this._radios.forEach(radio => {
         radio.checked = this.value == radio.value;
         if (radio.checked) {
@@ -209,7 +207,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Dispatch change event with current selection and group value. */
   _emitChangeEvent(): void {
-    if (this._isInitialized) {
+    if (this._isInitialized && this._selected) {
       let event = new MdRadioChange();
       event.source = this._selected;
       event.value = this._value;
@@ -286,7 +284,7 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
   @Input('aria-labelledby') ariaLabelledby: string;
 
   /** Whether this radio is disabled. */
-  private _disabled: boolean;
+  private _disabled: boolean|null = null;
 
   /** Value assigned to this radio.*/
   private _value: any = null;
@@ -298,10 +296,10 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(MdRipple) _ripple: MdRipple;
 
   /** Stream of focus event from the focus origin monitor. */
-  private _focusOriginMonitorSubscription: Subscription;
+  private _focusOriginMonitorSubscription: Subscription|null = null;
 
   /** Reference to the current focus ripple. */
-  private _focusedRippleRef: RippleRef;
+  private _focusedRippleRef: RippleRef|null = null;
 
   /** The parent radio group. May or may not be present. */
   radioGroup: MdRadioGroup;
@@ -359,7 +357,7 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
       } else if (!newCheckedState && this.radioGroup && this.radioGroup.value == this.value) {
         // When unchecking the selected radio button, update the selected radio
         // property on the group.
-        this.radioGroup.selected = null;
+        this.radioGroup.selected = undefined;
       }
 
       if (newCheckedState) {
@@ -420,11 +418,11 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
 
   /** Whether the radio button is disabled. */
   @Input()
-  get disabled(): boolean {
+  get disabled(): boolean|null {
     return this._disabled || (this.radioGroup != null && this.radioGroup.disabled);
   }
 
-  set disabled(value: boolean) {
+  set disabled(value: boolean|null) {
     // The presence of *any* disabled value makes the component disabled, *except* for false.
     this._disabled = (value != null && value !== false) ? true : null;
   }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -107,7 +107,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   private _panelOpen = false;
 
   /** The currently selected option. */
-  private _selected: MdOption;
+  private _selected: MdOption|undefined;
 
   /** Subscriptions to option events. */
   private _subscriptions: Subscription[] = [];
@@ -354,7 +354,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   }
 
   /** The currently selected option. */
-  get selected(): MdOption {
+  get selected(): MdOption|undefined {
     return this._selected;
   }
 
@@ -421,7 +421,10 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   _setScrollTop(): void {
     const scrollContainer =
         this.overlayDir.overlayRef.overlayElement.querySelector('.mat-select-panel');
-    scrollContainer.scrollTop = this._scrollTop;
+
+    if (scrollContainer) {
+      scrollContainer.scrollTop = this._scrollTop;
+    }
   }
 
   /**
@@ -436,7 +439,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   /** Clears the select trigger and deselects every option in the list. */
   private _clearSelection(): void {
-    this._selected = null;
+    this._selected = undefined;
     this._updateOptions();
   }
 
@@ -535,10 +538,10 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   }
 
   /** Gets the index of the provided option in the option list. */
-  private _getOptionIndex(option: MdOption): number {
-    return this.options.reduce((result: number, current: MdOption, index: number) => {
+  private _getOptionIndex(option: MdOption): number|null {
+    return this.options.reduce((result: number|undefined, current: MdOption, index: number) => {
       return result === undefined ? (option === current ? index : undefined) : result;
-    }, undefined);
+    }, undefined) || null;
   }
 
   /** Calculates the scroll position and x- and y-offsets of the overlay panel. */
@@ -577,8 +580,13 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
    * too high or too low in the panel to be scrolled to the center, it clamps the
    * scroll position to the min or max scroll positions respectively.
    */
-  _calculateOverlayScroll(selectedIndex: number, scrollBuffer: number,
+  _calculateOverlayScroll(selectedIndex: number|null, scrollBuffer: number,
                           maxScroll: number): number {
+
+    if (typeof selectedIndex !== 'number') {
+      return 0;
+    }
+
     const optionOffsetFromScrollTop = SELECT_OPTION_HEIGHT * selectedIndex;
     const halfOptionHeight = SELECT_OPTION_HEIGHT / 2;
 
@@ -617,8 +625,13 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
    * top start corner of the trigger. It has to be adjusted in order for the
    * selected option to be aligned over the trigger when the panel opens.
    */
-  private _calculateOverlayOffset(selectedIndex: number, scrollBuffer: number,
+  private _calculateOverlayOffset(selectedIndex: number|null, scrollBuffer: number,
                                   maxScroll: number): number {
+
+    if (typeof selectedIndex !== 'number') {
+      return 0;
+    }
+
     let optionOffsetFromPanelTop: number;
 
     if (this._scrollTop === 0) {

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -62,7 +62,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   private _checked: boolean = false;
   private _color: string;
   private _isMousedown: boolean = false;
-  private _slideRenderer: SlideToggleRenderer = null;
+  private _slideRenderer: SlideToggleRenderer;
   private _disabled: boolean = false;
   private _required: boolean = false;
   private _disableRipple: boolean = false;
@@ -71,7 +71,7 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   _hasFocus: boolean = false;
 
   /** Name value will be applied to the input element if present */
-  @Input() name: string = null;
+  @Input() name: string;
 
   /** A unique id for the slide-toggle input. If none is supplied, it will be auto-generated. */
   @Input() id: string = this._uniqueId;
@@ -83,10 +83,10 @@ export class MdSlideToggle implements AfterContentInit, ControlValueAccessor {
   @Input() labelPosition: 'before' | 'after' = 'after';
 
   /** Used to set the aria-label attribute on the underlying input element. */
-  @Input('aria-label') ariaLabel: string = null;
+  @Input('aria-label') ariaLabel: string;
 
   /** Used to set the aria-labelledby attribute on the underlying input element. */
-  @Input('aria-labelledby') ariaLabelledby: string = null;
+  @Input('aria-labelledby') ariaLabelledby: string;
 
   /** Whether the slide-toggle is disabled. */
   @Input()
@@ -310,7 +310,7 @@ class SlideToggleRenderer {
 
   /** Resets the current drag and returns the new checked value. */
   stopThumbDrag(): boolean {
-    if (!this.dragging) { return; }
+    if (!this.dragging) { return false; }
 
     this.dragging = false;
     this._thumbEl.classList.remove('mat-dragging');

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -18,9 +18,10 @@ export class TestGestureConfig extends GestureConfig {
    */
   buildHammer(element: HTMLElement) {
     let mc = super.buildHammer(element) as HammerManager;
+    let hammerInstance = this.hammerInstances.get(element);
 
-    if (this.hammerInstances.get(element)) {
-      this.hammerInstances.get(element).push(mc);
+    if (hammerInstance) {
+      hammerInstance.push(mc);
     } else {
       this.hammerInstances.set(element, [mc]);
     }
@@ -34,6 +35,9 @@ export class TestGestureConfig extends GestureConfig {
    */
   emitEventForElement(eventType: string, element: HTMLElement, eventData = {}) {
     let instances = this.hammerInstances.get(element);
-    instances.forEach(instance => instance.emit(eventType, eventData));
+
+    if (instances) {
+      instances.forEach(instance => instance.emit(eventType, eventData));
+    }
   }
 }

--- a/src/lib/snack-bar/snack-bar-config.ts
+++ b/src/lib/snack-bar/snack-bar-config.ts
@@ -12,7 +12,7 @@ export class MdSnackBarConfig {
   announcementMessage?: string = '';
 
   /** The view container to place the overlay for the snack bar into. */
-  viewContainerRef?: ViewContainerRef = null;
+  viewContainerRef?: ViewContainerRef;
 
   /** The length of time in milliseconds to wait before automatically dismissing the snack bar. */
   duration?: number = 0;

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -24,15 +24,15 @@ export class MdSnackBar {
    * If there is a parent snack-bar service, all operations should delegate to that parent
    * via `_openedSnackBarRef`.
    */
-  private _snackBarRefAtThisLevel: MdSnackBarRef<any>;
+  private _snackBarRefAtThisLevel: MdSnackBarRef<any>|null;
 
   /** Reference to the currently opened snackbar at *any* level. */
-  get _openedSnackBarRef(): MdSnackBarRef<any> {
+  get _openedSnackBarRef(): MdSnackBarRef<any>|null {
     return this._parentSnackBar ?
         this._parentSnackBar._openedSnackBarRef : this._snackBarRefAtThisLevel;
   }
 
-  set _openedSnackBarRef(value: MdSnackBarRef<any>) {
+  set _openedSnackBarRef(value: MdSnackBarRef<any>|null) {
     if (this._parentSnackBar) {
       this._parentSnackBar._openedSnackBarRef = value;
     } else {
@@ -52,8 +52,10 @@ export class MdSnackBar {
    * @param component Component to be instantiated.
    * @param config Extra configuration for the snack bar.
    */
-  openFromComponent<T>(component: ComponentType<T>, config?: MdSnackBarConfig): MdSnackBarRef<T> {
-    config = _applyConfigDefaults(config);
+  openFromComponent<T>(component: ComponentType<T>, userConfig?: MdSnackBarConfig):
+    MdSnackBarRef<T> {
+
+    let config = _applyConfigDefaults(userConfig);
     let overlayRef = this._createOverlay();
     let snackBarContainer = this._attachSnackBarContainer(overlayRef, config);
     let snackBarRef = this._attachSnackbarContent(component, snackBarContainer, overlayRef);
@@ -85,7 +87,10 @@ export class MdSnackBar {
       });
     }
 
-    this._live.announce(config.announcementMessage, config.politeness);
+    if (config.announcementMessage) {
+      this._live.announce(config.announcementMessage, config.politeness);
+    }
+
     this._openedSnackBarRef = snackBarRef;
     return this._openedSnackBarRef;
   }
@@ -154,6 +159,6 @@ export class MdSnackBar {
  * @param config The configuration to which the defaults will be applied.
  * @returns The new configuration object with defaults applied.
  */
-function _applyConfigDefaults(config: MdSnackBarConfig): MdSnackBarConfig {
+function _applyConfigDefaults(config: MdSnackBarConfig|undefined): MdSnackBarConfig {
   return extendObject(new MdSnackBarConfig(), config);
 }

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -52,10 +52,10 @@ export class MdTabGroup {
   private _isInitialized: boolean = false;
 
   /** The tab index that should be selected after the content has been checked. */
-  private _indexToSelect = 0;
+  private _indexToSelect: number|null = 0;
 
   /** Snapshot of the height of the tab body wrapper before another tab is activated. */
-  private _tabBodyWrapperHeight: number = null;
+  private _tabBodyWrapperHeight: number|null = null;
 
   /** Whether the tab group should grow to the size of the active tab */
   private _dynamicHeight: boolean = false;
@@ -68,12 +68,12 @@ export class MdTabGroup {
   get _dynamicHeightDeprecated(): boolean { return this._dynamicHeight; }
   set _dynamicHeightDeprecated(value: boolean) { this._dynamicHeight = value; }
 
-  private _selectedIndex: number = null;
+  private _selectedIndex: number|null = null;
 
   /** The index of the active tab. */
   @Input()
-  set selectedIndex(value: number) { this._indexToSelect = value; }
-  get selectedIndex(): number { return this._selectedIndex; }
+  set selectedIndex(value: number|null) { this._indexToSelect = value; }
+  get selectedIndex(): number|null { return this._selectedIndex; }
 
   /** Position of the tab header. */
   @Input()

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -185,10 +185,17 @@ export class MdTabHeader implements AfterContentChecked, AfterContentInit {
    * providing a valid index and return true.
    */
   _isValidIndex(index: number): boolean {
-    if (!this._labelWrappers) { return true; }
+    if (!this._labelWrappers) {
+      return true;
+    }
 
     const tab = this._labelWrappers ? this._labelWrappers.toArray()[index] : null;
-    return tab && !tab.disabled;
+
+    if (tab) {
+      return !tab.disabled;
+    }
+
+    return false;
   }
 
   /**

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -23,20 +23,20 @@ export class MdTab implements OnInit {
   @Input('label') textLabel: string = '';
 
   /** The portal that will be the hosted content of the tab */
-  private _contentPortal: TemplatePortal = null;
-  get content(): TemplatePortal { return this._contentPortal; }
+  private _contentPortal: TemplatePortal|null = null;
+  get content(): TemplatePortal|null { return this._contentPortal; }
 
   /**
    * The relatively indexed position where 0 represents the center, negative is left, and positive
    * represents the right.
    */
-  position: number = null;
+  position: number|null = null;
 
   /**
    * The initial relatively index origin of the tab if it was created and selected after there
    * was already a selected tab. Provides context of what position the tab should originate from.
    */
-  origin: number = null;
+  origin: number|null = null;
 
   private _disabled = false;
 

--- a/src/lib/tsconfig-srcs.json
+++ b/src/lib/tsconfig-srcs.json
@@ -14,6 +14,7 @@
     "target": "es5",
     "inlineSources": true,
     "stripInternal": false,
+    "strictNullChecks": true,
     "typeRoots": [
       "../../node_modules/@types/!(node)"
     ]

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -14,6 +14,7 @@
     "target": "es5",
     "inlineSources": true,
     "stripInternal": false,
+    "strictNullChecks": true,
     "baseUrl": "",
     "paths": {
     },

--- a/tools/gulp/task_helpers.ts
+++ b/tools/gulp/task_helpers.ts
@@ -94,8 +94,8 @@ export function execTask(binPath: string, args: string[], options: ExecTaskOptio
  * binaries that are normally in the `./node_modules/.bin` directory, but their name might differ
  * from the package. Examples are typescript, ngc and gulp itself.
  */
-export function execNodeTask(packageName: string, executable: string | string[], args?: string[],
-                             options: ExecTaskOptions = {}) {
+export function execNodeTask(packageName: string, executable: string | string[] | void,
+                             args: string[] = [], options: ExecTaskOptions = {}) {
   if (!args) {
     args = <string[]>executable;
     executable = undefined;

--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -35,10 +35,10 @@ task(':publish:whoami', execTask('npm', ['whoami'], {
 task(':publish:logout', execTask('npm', ['logout']));
 
 
-function _execNpmPublish(label: string): Promise<{}> {
+function _execNpmPublish(label: string): Promise<{}|void> {
   const packageDir = DIST_COMPONENTS_ROOT;
   if (!statSync(packageDir).isDirectory()) {
-    return;
+    return Promise.resolve();
   }
 
   if (!existsSync(path.join(packageDir, 'package.json'))) {
@@ -49,7 +49,7 @@ function _execNpmPublish(label: string): Promise<{}> {
   console.log(`Publishing material...`);
 
   const command = 'npm';
-  const args = ['publish', '--access', 'public', label ? `--tag` : undefined, label || undefined];
+  const args = ['publish', '--access', 'public', label ? `--tag` : '', label || ''];
   return new Promise((resolve, reject) => {
     console.log(`  Executing "${command} ${args.join(' ')}"...`);
     if (argv['dry']) {

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -14,6 +14,7 @@
     "target": "es5",
     "inlineSources": true,
     "stripInternal": false,
+    "strictNullChecks": true,
     "baseUrl": "",
     "typeRoots": [
       "../../node_modules/@types"


### PR DESCRIPTION
Turns on `strictNullChecks` everywhere and refactors all of the code to make it compliant. This makes us consistent with the core Angular modules which support `strictNullChecks` after 4.0.

Fixes #3465.

**Note:** This is pretty conflict-prone and is blocked on a couple of things:
1. We need to bump to Angular 4.0+ to be able to compile.
2. `@angular/forms` doesn't support `strictNullChecks` as of 4.0 RC2, which means that our code won't be able to compile until it does.