### PR TITLE
fix(slider): unable to reset tickInterval after it has been set

### DIFF
--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -517,6 +517,17 @@ describe('MdSlider', () => {
       expect(ticksElement.style.transform).toContain('translateX(9%)');
       expect(ticksContainerElement.style.transform).toBe('translateX(-9%)');
     });
+
+    it('should be able to reset the tick interval after it has been set', () => {
+      expect(sliderNativeElement.classList)
+          .toContain('mat-slider-has-ticks', 'Expected element to have ticks initially.');
+
+      fixture.componentInstance.tickInterval = null;
+      fixture.detectChanges();
+
+      expect(sliderNativeElement.classList)
+          .not.toContain('mat-slider-has-ticks', 'Expected element not to have ticks after reset.');
+    });
   });
 
   describe('slider with thumb label', () => {
@@ -1248,10 +1259,12 @@ class SliderWithStep {
 class SliderWithAutoTickInterval { }
 
 @Component({
-  template: `<md-slider step="3" tickInterval="6"></md-slider>`,
+  template: `<md-slider step="3" [tickInterval]="tickInterval"></md-slider>`,
   styles: [styles],
 })
-class SliderWithSetTickInterval { }
+class SliderWithSetTickInterval {
+  tickInterval = 6;
+}
 
 @Component({
   template: `<md-slider thumbLabel></md-slider>`,

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -163,8 +163,14 @@ export class MdSlider implements ControlValueAccessor {
    */
   @Input()
   get tickInterval() { return this._tickInterval; }
-  set tickInterval(v) {
-    this._tickInterval = (v == 'auto') ? v : coerceNumberProperty(v, <number>this._tickInterval);
+  set tickInterval(value) {
+    if (value === 'auto') {
+      this._tickInterval = 'auto';
+    } else if (typeof value === 'number' || typeof value === 'string') {
+      this._tickInterval = coerceNumberProperty(value, this._tickInterval as number);
+    } else {
+      this._tickInterval = 0;
+    }
   }
 
   /** @deprecated */


### PR DESCRIPTION
Fixes user not being allowed to reset the `tickInterval` after it has been set to a valid value.

Fixes #3452.