### PR TITLE
fix(input): make all icons in input containers the correct size

### DIFF
--- a/src/demo-app/baseline/baseline-demo.scss
+++ b/src/demo-app/baseline/baseline-demo.scss
@@ -9,13 +9,6 @@
   width: 100%;
 }
 
-.demo-icons {
-  font-size: 100%;
-  height: inherit;
-  vertical-align: top;
-  width: inherit;
-}
-
 .demo-card {
   margin: 16px;
 }

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -40,7 +40,10 @@
         <td>
           <md-input-container class="demo-full-width">
             <input mdInput #postalCode maxLength="5" placeholder="Postal Code" value="94043">
-            <md-hint align="end">{{postalCode.value.length}} / 5</md-hint>
+            <md-hint align="end">
+              <md-icon>mode_edit</md-icon>
+              {{postalCode.value.length}} / 5
+            </md-hint>
           </md-input-container>
         </td>
       </tr></table>
@@ -152,10 +155,10 @@
       <md-input-container>
         <input mdInput>
         <md-placeholder>
-          I <md-icon class="demo-icons">favorite</md-icon> <b>bold</b> placeholder
+          I <md-icon>favorite</md-icon> <b>bold</b> placeholder
         </md-placeholder>
         <md-hint>
-          I also <md-icon class="demo-icons">home</md-icon> <i>italic</i> hint labels
+          I also <md-icon>home</md-icon> <i>italic</i> hint labels
         </md-hint>
       </md-input-container>
     </p>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -54,10 +54,18 @@
 <md-card class="demo-card demo-basic">
   <md-toolbar color="primary">Prefix + Suffix</md-toolbar>
   <md-card-content>
+    <h4>Text</h4>
     <md-input-container align="end">
       <input mdInput placeholder="amount">
       <span mdPrefix>$&nbsp;</span>
       <span mdSuffix>.00</span>
+    </md-input-container>
+
+    <h4>Icons</h4>
+    <md-input-container>
+      <input mdInput placeholder="amount">
+      <md-icon mdPrefix>attach_money</md-icon>
+      <md-icon mdSuffix>mode_edit</md-icon>
     </md-input-container>
   </md-card-content>
 </md-card>

--- a/src/demo-app/input/input-demo.scss
+++ b/src/demo-app/input/input-demo.scss
@@ -8,13 +8,6 @@
   width: 100%;
 }
 
-.demo-icons {
-  font-size: 100%;
-  height: inherit;
-  vertical-align: top;
-  width: inherit;
-}
-
 .demo-card {
   margin: 16px;
 }

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -27,6 +27,14 @@ $mat-input-underline-disabled-background-image:
   [dir='rtl'] & {
     text-align: right;
   }
+
+  // Allow icons in a prefix/suffix/hint/etc to adapt to the correct size.
+  & .mat-icon {
+    width: auto;
+    height: auto;
+    font-size: 100%;
+    vertical-align: top;
+  }
 }
 
 // Global wrapper. We need to apply margin to the element for spacing, but
@@ -238,12 +246,4 @@ $mat-input-underline-disabled-background-image:
   // Prevents the prefix and suffix from stretching together with the container.
   width: 0.1px;
   white-space: nowrap;
-
-  // Allow icons in a prefix/suffix to adapt to the correct size.
-  & .mat-icon {
-    width: auto;
-    height: auto;
-    font-size: 100%;
-    vertical-align: top;
-  }
 }


### PR DESCRIPTION
Fixes #2586 and #3229. This is a more general solution to #3342, which also handles the `md-hint` case. See https://github.com/angular/material2/issues/2586#issuecomment-284899825 for more details.

I haven't noticed any issues doing this at the `.mat-input-container` level. If there are any I think this solution is still more robust overall and we should handle those specific cases individually.