### PR TITLE
chore(): remove TODO from menu trigger desc

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -27,10 +27,11 @@ import {
 import {Subscription} from 'rxjs/Subscription';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
 
+// TODO(andrewseguin): Remove the kebab versions in favor of camelCased attribute selectors
+
 /**
  * This directive is intended to be used in conjunction with an md-menu tag.  It is
  * responsible for toggling the display of the provided menu instance.
- * TODO(andrewseguin): Remove the kebab versions in favor of camelCased attribute selectors
  */
 @Directive({
   selector: `[md-menu-trigger-for], [mat-menu-trigger-for], 


### PR DESCRIPTION
Move the TODO so it doesn't appear on the docs site.