### PR TITLE
fix(autocomplete): "undefined" being displayed on empty control with ngModel

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -292,8 +292,8 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   private _setTriggerValue(value: any): void {
-    this._element.nativeElement.value =
-        this.autocomplete.displayWith ? this.autocomplete.displayWith(value) : value;
+    let toDisplay = this.autocomplete.displayWith ? this.autocomplete.displayWith(value) : value;
+    this._element.nativeElement.value = toDisplay || '';
   }
 
    /**

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -292,7 +292,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   private _setTriggerValue(value: any): void {
-    let toDisplay = this.autocomplete.displayWith ? this.autocomplete.displayWith(value) : value;
+    const toDisplay = this.autocomplete.displayWith ? this.autocomplete.displayWith(value) : value;
     this._element.nativeElement.value = toDisplay || '';
   }
 


### PR DESCRIPTION
Fixes "undefined" being displayed as the autocomplete input's value, if the value is undefined and the input uses `ngModel`.

Fixes #3529.