### PR TITLE
fix: remove deprecated forRoot functions

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -53,7 +53,7 @@ import {StyleDemo} from './style/style-demo';
     HttpModule,
     ReactiveFormsModule,
     RouterModule.forRoot(DEMO_APP_ROUTES),
-    MaterialModule.forRoot(),
+    MaterialModule,
     MdSelectionModule,
   ],
   declarations: [

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -24,7 +24,7 @@ import {InputE2E} from './input/input-e2e';
   imports: [
     BrowserModule,
     RouterModule.forRoot(E2E_APP_ROUTES),
-    MaterialModule.forRoot(),
+    MaterialModule,
     NoopAnimationsModule,
   ],
   declarations: [

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -39,8 +39,8 @@ describe('MdAutocomplete', () => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [
-        MdAutocompleteModule.forRoot(),
-        MdInputModule.forRoot(),
+        MdAutocompleteModule,
+        MdInputModule,
         FormsModule,
         ReactiveFormsModule,
         NoopAnimationsModule

--- a/src/lib/autocomplete/index.ts
+++ b/src/lib/autocomplete/index.ts
@@ -1,6 +1,5 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
-
-import {MdOptionModule, OverlayModule, OVERLAY_PROVIDERS, MdCommonModule} from '../core';
+import {NgModule} from '@angular/core';
+import {MdOptionModule, OverlayModule, MdCommonModule} from '../core';
 import {CommonModule} from '@angular/common';
 import {MdAutocomplete} from './autocomplete';
 import {MdAutocompleteTrigger} from './autocomplete-trigger';
@@ -10,15 +9,7 @@ import {MdAutocompleteTrigger} from './autocomplete-trigger';
   exports: [MdAutocomplete, MdOptionModule, MdAutocompleteTrigger, MdCommonModule],
   declarations: [MdAutocomplete, MdAutocompleteTrigger],
 })
-export class MdAutocompleteModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdAutocompleteModule,
-      providers: [OVERLAY_PROVIDERS]
-    };
-  }
-}
+export class MdAutocompleteModule {}
 
 
 export * from './autocomplete';

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -21,7 +21,7 @@ describe('MdButtonToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdButtonToggleModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [MdButtonToggleModule, FormsModule, ReactiveFormsModule],
       declarations: [
         ButtonTogglesInsideButtonToggleGroup,
         ButtonToggleGroupWithNgModel,

--- a/src/lib/button-toggle/index.ts
+++ b/src/lib/button-toggle/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle} from './button-toggle';
 import {
@@ -19,15 +19,7 @@ import {
   declarations: [MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle],
   providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, FocusOriginMonitor]
 })
-export class MdButtonToggleModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdButtonToggleModule,
-      providers: []
-    };
-  }
-}
+export class MdButtonToggleModule {}
 
 
 export * from './button-toggle';

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -10,7 +10,7 @@ describe('MdButton', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdButtonModule.forRoot()],
+      imports: [MdButtonModule],
       declarations: [TestApp],
       providers: [
         {provide: ViewportRuler, useClass: FakeViewportRuler},

--- a/src/lib/button/index.ts
+++ b/src/lib/button/index.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdCommonModule, MdRippleModule, StyleModule} from '../core';
 import {
@@ -42,12 +42,4 @@ export * from './button';
     MdMiniFabCssMatStyler,
   ],
 })
-export class MdButtonModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdButtonModule,
-      providers: []
-    };
-  }
-}
+export class MdButtonModule {}

--- a/src/lib/card/index.ts
+++ b/src/lib/card/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdCommonModule} from '../core';
 import {
   MdCard,
@@ -43,15 +43,7 @@ import {
     MdCardXlImage, MdCardAvatar,
   ],
 })
-export class MdCardModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdCardModule,
-      providers: []
-    };
-  }
-}
+export class MdCardModule {}
 
 
 export * from './card';

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -21,7 +21,7 @@ describe('MdCheckbox', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdCheckboxModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [MdCheckboxModule, FormsModule, ReactiveFormsModule],
       declarations: [
         SingleCheckbox,
         CheckboxWithFormDirectives,

--- a/src/lib/checkbox/index.ts
+++ b/src/lib/checkbox/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdRippleModule, MdCommonModule, FocusOriginMonitor} from '../core';
 import {MdCheckbox} from './checkbox';
@@ -10,15 +10,7 @@ import {MdCheckbox} from './checkbox';
   declarations: [MdCheckbox],
   providers: [FocusOriginMonitor]
 })
-export class MdCheckboxModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdCheckboxModule,
-      providers: []
-    };
-  }
-}
+export class MdCheckboxModule {}
 
 
 export * from './checkbox';

--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -25,7 +25,7 @@ describe('MdChipList', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdChipsModule.forRoot()],
+      imports: [MdChipsModule],
       declarations: [
         StaticChipList
       ]

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -12,7 +12,7 @@ describe('Chips', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdChipsModule.forRoot()],
+      imports: [MdChipsModule],
       declarations: [
         BasicChip, SingleChip
       ]

--- a/src/lib/chips/index.ts
+++ b/src/lib/chips/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdChipList} from './chip-list';
 import {MdChip} from './chip';
 
@@ -8,15 +8,7 @@ import {MdChip} from './chip';
   exports: [MdChipList, MdChip],
   declarations: [MdChipList, MdChip]
 })
-export class MdChipsModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdChipsModule,
-      providers: []
-    };
-  }
-}
+export class MdChipsModule {}
 
 
 export * from './chip-list';

--- a/src/lib/core/a11y/index.ts
+++ b/src/lib/core/a11y/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {FocusTrapDirective, FocusTrapDeprecatedDirective, FocusTrapFactory} from './focus-trap';
 import {LIVE_ANNOUNCER_PROVIDER} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
@@ -11,12 +11,4 @@ import {PlatformModule} from '../platform/index';
   exports: [FocusTrapDirective, FocusTrapDeprecatedDirective],
   providers: [InteractivityChecker, FocusTrapFactory, LIVE_ANNOUNCER_PROVIDER]
 })
-export class A11yModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: A11yModule,
-      providers: [],
-    };
-  }
-}
+export class A11yModule {}

--- a/src/lib/core/compatibility/compatibility.spec.ts
+++ b/src/lib/core/compatibility/compatibility.spec.ts
@@ -26,7 +26,7 @@ describe('Style compatibility', () => {
       TestBed.configureTestingModule({
         // Specifically do *not* directly import the DefaultStyleCompatibilityModeModule
         // to ensure that it is the default behavior.
-        imports: [MdCheckboxModule.forRoot()],
+        imports: [MdCheckboxModule],
         declarations: [ComponentWithMdCheckbox, ComponentWithMatCheckbox],
       });
 
@@ -45,7 +45,7 @@ describe('Style compatibility', () => {
   describe('in no-conflict mode', () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: [MdCheckboxModule.forRoot(), NoConflictStyleCompatibilityMode],
+        imports: [MdCheckboxModule, NoConflictStyleCompatibilityMode],
         declarations: [ComponentWithMdCheckbox, ComponentWithMatCheckbox],
       });
 
@@ -97,7 +97,7 @@ class ComponentWithMatCheckbox { }
 
 
 @NgModule({
-  imports: [MdCheckboxModule.forRoot()],
+  imports: [MdCheckboxModule],
   exports: [ComponentWithMdCheckbox, ComponentWithMatCheckbox],
   declarations: [ComponentWithMdCheckbox, ComponentWithMatCheckbox],
 })

--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -1,6 +1,5 @@
 import {
   NgModule,
-  ModuleWithProviders,
   Directive,
   OpaqueToken,
   Inject,
@@ -196,13 +195,6 @@ export class MdPrefixRejector {
 export class CompatibilityModule {
   /** Whether we've done the global sanity checks (e.g. a theme is loaded, there is a doctype). */
   private _hasDoneGlobalChecks = false;
-
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CompatibilityModule,
-      providers: [],
-    };
-  }
 
   constructor(
     @Optional() @Inject(DOCUMENT) private _document: any,

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdLineModule} from './line/line';
 import {RtlModule} from './rtl/dir';
 import {ObserveContentModule} from './observe-content/observe-content';
@@ -141,12 +141,4 @@ export {MdCommonModule} from './common-behaviors/common-module';
     MdSelectionModule,
   ],
 })
-export class MdCoreModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdCoreModule,
-      providers: [],
-    };
-  }
-}
+export class MdCoreModule {}

--- a/src/lib/core/observe-content/observe-content.ts
+++ b/src/lib/core/observe-content/observe-content.ts
@@ -2,7 +2,6 @@ import {
   Directive,
   ElementRef,
   NgModule,
-  ModuleWithProviders,
   Output,
   EventEmitter,
   OnDestroy,
@@ -45,12 +44,4 @@ export class ObserveContent implements AfterContentInit, OnDestroy {
   exports: [ObserveContent],
   declarations: [ObserveContent]
 })
-export class ObserveContentModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: ObserveContentModule,
-      providers: []
-    };
-  }
-}
+export class ObserveContentModule {}

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -5,7 +5,6 @@ import {
   Input,
   Output,
   NgModule,
-  ModuleWithProviders,
   ViewEncapsulation,
   Inject,
   Optional,
@@ -179,11 +178,4 @@ export class MdOption {
   exports: [MdOption],
   declarations: [MdOption]
 })
-export class MdOptionModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdOptionModule,
-      providers: []
-    };
-  }
-}
+export class MdOptionModule {}

--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -17,7 +17,7 @@ describe('Overlay directives', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule.forRoot()],
+      imports: [OverlayModule],
       declarations: [ConnectedOverlayDirectiveTest],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -1,6 +1,5 @@
 import {
     NgModule,
-    ModuleWithProviders,
     Directive,
     EventEmitter,
     TemplateRef,
@@ -321,12 +320,4 @@ export class ConnectedOverlayDirective implements OnDestroy {
   declarations: [ConnectedOverlayDirective, OverlayOrigin, Scrollable],
   providers: [OVERLAY_PROVIDERS],
 })
-export class OverlayModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: OverlayModule,
-      providers: [],
-    };
-  }
-}
+export class OverlayModule {}

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -18,7 +18,7 @@ describe('Overlay', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule.forRoot(), PortalModule, OverlayTestModule],
+      imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
@@ -9,7 +9,7 @@ describe('Scroll Dispatcher', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule.forRoot(), ScrollTestModule],
+      imports: [OverlayModule, ScrollTestModule],
     });
 
     TestBed.compileComponents();

--- a/src/lib/core/platform/index.ts
+++ b/src/lib/core/platform/index.ts
@@ -1,19 +1,11 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {Platform} from './platform';
 
 
 @NgModule({
   providers: [Platform]
 })
-export class PlatformModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: PlatformModule,
-      providers: [],
-    };
-  }
-}
+export class PlatformModule {}
 
 
 export * from './platform';

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -1,6 +1,5 @@
 import {
     NgModule,
-    ModuleWithProviders,
     ComponentRef,
     Directive,
     TemplateRef,
@@ -128,12 +127,4 @@ export class PortalHostDirective extends BasePortalHost implements OnDestroy {
   exports: [TemplatePortalDirective, PortalHostDirective],
   declarations: [TemplatePortalDirective, PortalHostDirective],
 })
-export class PortalModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: PortalModule,
-      providers: []
-    };
-  }
-}
+export class PortalModule {}

--- a/src/lib/core/portal/portal.spec.ts
+++ b/src/lib/core/portal/portal.spec.ts
@@ -21,7 +21,7 @@ describe('Portals', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [PortalModule.forRoot(), PortalTestModule],
+      imports: [PortalModule, PortalTestModule],
     });
 
     TestBed.compileComponents();

--- a/src/lib/core/ripple/index.ts
+++ b/src/lib/core/ripple/index.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdRipple} from './ripple';
 import {MdCommonModule} from '../common-behaviors/common-module';
 import {VIEWPORT_RULER_PROVIDER} from '../overlay/position/viewport-ruler';
@@ -14,12 +14,4 @@ export {RippleConfig, RIPPLE_FADE_IN_DURATION, RIPPLE_FADE_OUT_DURATION} from '.
   declarations: [MdRipple],
   providers: [VIEWPORT_RULER_PROVIDER, SCROLL_DISPATCHER_PROVIDER],
 })
-export class MdRippleModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdRippleModule,
-      providers: []
-    };
-  }
-}
+export class MdRippleModule {}

--- a/src/lib/core/rtl/dir.ts
+++ b/src/lib/core/rtl/dir.ts
@@ -1,6 +1,5 @@
 import {
   NgModule,
-  ModuleWithProviders,
   Directive,
   HostBinding,
   Output,
@@ -51,12 +50,4 @@ export class Dir {
   exports: [Dir],
   declarations: [Dir]
 })
-export class RtlModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: RtlModule,
-      providers: []
-    };
-  }
-}
+export class RtlModule {}

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -39,7 +39,7 @@ describe('MdDialog', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdDialogModule.forRoot(), DialogTestModule],
+      imports: [MdDialogModule, DialogTestModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
@@ -615,7 +615,7 @@ describe('MdDialog with a parent MdDialog', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdDialogModule.forRoot(), DialogTestModule],
+      imports: [MdDialogModule, DialogTestModule],
       declarations: [ComponentThatProvidesMdDialog],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/dialog/index.ts
+++ b/src/lib/dialog/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {
   OverlayModule,
@@ -44,15 +44,7 @@ import {
   ],
   entryComponents: [MdDialogContainer],
 })
-export class MdDialogModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdDialogModule,
-      providers: [],
-    };
-  }
-}
+export class MdDialogModule {}
 
 export * from './dialog';
 export * from './dialog-container';

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -8,7 +8,7 @@ import {MdGridTile, MdGridTileText} from './grid-tile';
 describe('MdGridList', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdGridListModule.forRoot()],
+      imports: [MdGridListModule],
       declarations: [
         GridListWithoutCols,
         GridListWithInvalidRowHeightRatio,

--- a/src/lib/grid-list/index.ts
+++ b/src/lib/grid-list/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdLineModule, MdCommonModule} from '../core';
 import {
   MdGridTile, MdGridTileText, MdGridTileFooterCssMatStyler,
@@ -28,15 +28,7 @@ import {MdGridList} from './grid-list';
     MdGridAvatarCssMatStyler
   ],
 })
-export class MdGridListModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdGridListModule,
-      providers: []
-    };
-  }
-}
+export class MdGridListModule {}
 
 
 export * from './grid-list';

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -36,7 +36,7 @@ describe('MdIcon', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdIconModule.forRoot()],
+      imports: [MdIconModule],
       declarations: [
         MdIconColorTestApp,
         MdIconLigatureTestApp,

--- a/src/lib/icon/index.ts
+++ b/src/lib/icon/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {HttpModule} from '@angular/http';
 import {MdCommonModule} from '../core';
 import {MdIcon, ICON_REGISTRY_PROVIDER} from './icon';
@@ -10,15 +10,7 @@ import {MdIcon, ICON_REGISTRY_PROVIDER} from './icon';
   declarations: [MdIcon],
   providers: [ICON_REGISTRY_PROVIDER],
 })
-export class MdIconModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdIconModule,
-      providers: [],
-    };
-  }
-}
+export class MdIconModule {}
 
 
 export * from './icon';

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {
   MdErrorDirective,
   MdHint,
@@ -41,15 +41,7 @@ import {PlatformModule} from '../core/platform/index';
     MdTextareaAutosize,
   ],
 })
-export class MdInputModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdInputModule,
-      providers: [],
-    };
-  }
-}
+export class MdInputModule {}
 
 
 export * from './autosize';

--- a/src/lib/list/index.ts
+++ b/src/lib/list/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdLineModule, MdRippleModule, MdCommonModule} from '../core';
 import {
   MdList,
@@ -40,15 +40,7 @@ import {
     MdListSubheaderCssMatStyler,
   ],
 })
-export class MdListModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdListModule,
-      providers: []
-    };
-  }
-}
+export class MdListModule {}
 
 
 export * from './list';

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -8,7 +8,7 @@ describe('MdList', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdListModule.forRoot()],
+      imports: [MdListModule],
       declarations: [
         ListWithOneAnchorItem,
         ListWithOneItem,

--- a/src/lib/menu/index.ts
+++ b/src/lib/menu/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {OverlayModule, MdCommonModule} from '../core';
 import {MdMenu} from './menu-directive';
@@ -17,15 +17,7 @@ import {MdRippleModule} from '../core/ripple/index';
   exports: [MdMenu, MdMenuItem, MdMenuTrigger, MdCommonModule],
   declarations: [MdMenu, MdMenuItem, MdMenuTrigger],
 })
-export class MdMenuModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdMenuModule,
-      providers: [],
-    };
-  }
-}
+export class MdMenuModule {}
 
 
 export * from './menu';

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -29,7 +29,7 @@ describe('MdMenu', () => {
   beforeEach(async(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
-      imports: [MdMenuModule.forRoot(), NoopAnimationsModule],
+      imports: [MdMenuModule, NoopAnimationsModule],
       declarations: [SimpleMenu, PositionedMenu, OverlapMenu, CustomMenuPanel, CustomMenu],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {
   MdRippleModule,
@@ -73,53 +73,7 @@ const MATERIAL_MODULES = [
 
 /** @deprecated */
 @NgModule({
-  imports: [
-    MdAutocompleteModule.forRoot(),
-    MdButtonModule.forRoot(),
-    MdCardModule.forRoot(),
-    MdChipsModule.forRoot(),
-    MdCheckboxModule.forRoot(),
-    MdGridListModule.forRoot(),
-    MdInputModule.forRoot(),
-    MdListModule.forRoot(),
-    MdProgressBarModule.forRoot(),
-    MdProgressSpinnerModule.forRoot(),
-    MdRippleModule.forRoot(),
-    MdSelectModule.forRoot(),
-    MdSidenavModule.forRoot(),
-    MdTabsModule.forRoot(),
-    MdToolbarModule.forRoot(),
-    PortalModule.forRoot(),
-    RtlModule.forRoot(),
-    ObserveContentModule.forRoot(),
-
-    // These modules include providers.
-    A11yModule.forRoot(),
-    MdButtonToggleModule.forRoot(),
-    MdDialogModule.forRoot(),
-    MdIconModule.forRoot(),
-    MdMenuModule.forRoot(),
-    MdRadioModule.forRoot(),
-    MdSliderModule.forRoot(),
-    MdSlideToggleModule.forRoot(),
-    MdSnackBarModule.forRoot(),
-    MdTooltipModule.forRoot(),
-    PlatformModule.forRoot(),
-    OverlayModule.forRoot(),
-    MdCommonModule,
-  ],
-  exports: MATERIAL_MODULES,
-})
-export class MaterialRootModule { }
-
-/** @deprecated */
-@NgModule({
   imports: MATERIAL_MODULES,
   exports: MATERIAL_MODULES,
 })
-export class MaterialModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {ngModule: MaterialRootModule};
-  }
-}
+export class MaterialModule {}

--- a/src/lib/progress-bar/index.ts
+++ b/src/lib/progress-bar/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdCommonModule} from '../core';
 import {MdProgressBar} from './progress-bar';
@@ -9,15 +9,7 @@ import {MdProgressBar} from './progress-bar';
   exports: [MdProgressBar, MdCommonModule],
   declarations: [MdProgressBar],
 })
-export class MdProgressBarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdProgressBarModule,
-      providers: []
-    };
-  }
-}
+export class MdProgressBarModule {}
 
 
 export * from './progress-bar';

--- a/src/lib/progress-bar/progress-bar.spec.ts
+++ b/src/lib/progress-bar/progress-bar.spec.ts
@@ -8,7 +8,7 @@ describe('MdProgressBar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdProgressBarModule.forRoot()],
+      imports: [MdProgressBarModule],
       declarations: [
         BasicProgressBar,
         BufferProgressBar,

--- a/src/lib/progress-spinner/index.ts
+++ b/src/lib/progress-spinner/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdCommonModule} from '../core';
 import {
   MdProgressSpinner,
@@ -21,15 +21,7 @@ import {
     MdProgressSpinnerCssMatStyler
   ],
 })
-class MdProgressSpinnerModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdProgressSpinnerModule,
-      providers: []
-    };
-  }
-}
+class MdProgressSpinnerModule {}
 
 export {MdProgressSpinnerModule};
 export * from './progress-spinner';

--- a/src/lib/progress-spinner/progress-spinner.spec.ts
+++ b/src/lib/progress-spinner/progress-spinner.spec.ts
@@ -9,7 +9,7 @@ describe('MdProgressSpinner', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdProgressSpinnerModule.forRoot()],
+      imports: [MdProgressSpinnerModule],
       declarations: [
         BasicProgressSpinner,
         IndeterminateProgressSpinner,

--- a/src/lib/radio/index.ts
+++ b/src/lib/radio/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {VIEWPORT_RULER_PROVIDER} from '../core/overlay/position/viewport-ruler';
 import {
@@ -16,15 +16,7 @@ import {MdRadioGroup, MdRadioButton} from './radio';
   providers: [UNIQUE_SELECTION_DISPATCHER_PROVIDER, VIEWPORT_RULER_PROVIDER, FocusOriginMonitor],
   declarations: [MdRadioGroup, MdRadioButton],
 })
-export class MdRadioModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdRadioModule,
-      providers: [],
-    };
-  }
-}
+export class MdRadioModule {}
 
 
 export * from './radio';

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -13,7 +13,7 @@ describe('MdRadio', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdRadioModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [MdRadioModule, FormsModule, ReactiveFormsModule],
       declarations: [
         RadiosInsideRadioGroup,
         RadioGroupWithNgModel,

--- a/src/lib/select/index.ts
+++ b/src/lib/select/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdSelect} from './select';
 import {MdOptionModule} from '../core/option/option';
@@ -15,15 +15,7 @@ import {MdCommonModule, OverlayModule} from '../core';
   exports: [MdSelect, MdOptionModule, MdCommonModule],
   declarations: [MdSelect],
 })
-export class MdSelectModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSelectModule,
-      providers: []
-    };
-  }
-}
+export class MdSelectModule {}
 
 
 export * from './select';

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -48,7 +48,7 @@ describe('MdSelect', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSelectModule.forRoot(), ReactiveFormsModule, FormsModule, NoopAnimationsModule],
+      imports: [MdSelectModule, ReactiveFormsModule, FormsModule, NoopAnimationsModule],
       declarations: [
         BasicSelect,
         NgModelSelect,

--- a/src/lib/sidenav/index.ts
+++ b/src/lib/sidenav/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdCommonModule} from '../core';
 import {A11yModule} from '../core/a11y/index';
@@ -11,15 +11,7 @@ import {MdSidenav, MdSidenavContainer} from './sidenav';
   exports: [MdSidenavContainer, MdSidenav, MdCommonModule],
   declarations: [MdSidenavContainer, MdSidenav],
 })
-export class MdSidenavModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSidenavModule,
-      providers: []
-    };
-  }
-}
+export class MdSidenavModule {}
 
 
 export * from './sidenav';

--- a/src/lib/sidenav/sidenav.spec.ts
+++ b/src/lib/sidenav/sidenav.spec.ts
@@ -19,7 +19,7 @@ function endSidenavTransition(fixture: ComponentFixture<any>) {
 describe('MdSidenav', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSidenavModule.forRoot(), A11yModule.forRoot(), PlatformModule.forRoot()],
+      imports: [MdSidenavModule, A11yModule, PlatformModule],
       declarations: [
         BasicTestApp,
         SidenavContainerNoSidenavTestApp,
@@ -447,7 +447,7 @@ describe('MdSidenav', () => {
 describe('MdSidenavContainer', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSidenavModule.forRoot(), A11yModule.forRoot(), PlatformModule.forRoot()],
+      imports: [MdSidenavModule, A11yModule, PlatformModule],
       declarations: [
         SidenavContainerTwoSidenavTestApp
       ],

--- a/src/lib/slide-toggle/index.ts
+++ b/src/lib/slide-toggle/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {MdSlideToggle} from './slide-toggle';
@@ -15,15 +15,7 @@ import {
     { provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig }
   ],
 })
-export class MdSlideToggleModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSlideToggleModule,
-      providers: []
-    };
-  }
-}
+export class MdSlideToggleModule {}
 
 
 export * from './slide-toggle';

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -13,7 +13,7 @@ describe('MdSlideToggle', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSlideToggleModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [MdSlideToggleModule, FormsModule, ReactiveFormsModule],
       declarations: [SlideToggleTestApp, SlideToggleFormsTestApp, SlideToggleWithFormControl],
       providers: [
         {provide: HAMMER_GESTURE_CONFIG, useFactory: () => gestureConfig = new TestGestureConfig()}

--- a/src/lib/slider/index.ts
+++ b/src/lib/slider/index.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
@@ -13,15 +13,7 @@ import {RtlModule} from '../core/rtl/dir';
   declarations: [MdSlider],
   providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
 })
-export class MdSliderModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSliderModule,
-      providers: []
-    };
-  }
-}
+export class MdSliderModule {}
 
 
 export * from './slider';

--- a/src/lib/snack-bar/index.ts
+++ b/src/lib/snack-bar/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {OverlayModule, PortalModule, MdCommonModule, LIVE_ANNOUNCER_PROVIDER} from '../core';
 import {CommonModule} from '@angular/common';
 import {MdSnackBar} from './snack-bar';
@@ -18,15 +18,7 @@ import {SimpleSnackBar} from './simple-snack-bar';
   entryComponents: [MdSnackBarContainer, SimpleSnackBar],
   providers: [MdSnackBar, LIVE_ANNOUNCER_PROVIDER]
 })
-export class MdSnackBarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdSnackBarModule,
-      providers: []
-    };
-  }
-}
+export class MdSnackBarModule {}
 
 
 export * from './snack-bar';

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -29,7 +29,7 @@ describe('MdSnackBar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSnackBarModule.forRoot(), SnackBarTestModule, NoopAnimationsModule],
+      imports: [MdSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
@@ -352,7 +352,7 @@ describe('MdSnackBar with parent MdSnackBar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdSnackBarModule.forRoot(), SnackBarTestModule, NoopAnimationsModule],
+      imports: [MdSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMdSnackBar],
       providers: [
         {provide: OverlayContainer, useFactory: () => {

--- a/src/lib/tabs/index.ts
+++ b/src/lib/tabs/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {PortalModule} from '../core';
 import {MdRippleModule} from '../core/ripple/index';
@@ -45,15 +45,7 @@ import {SCROLL_DISPATCHER_PROVIDER} from '../core/overlay/scroll/scroll-dispatch
   ],
   providers: [VIEWPORT_RULER_PROVIDER, SCROLL_DISPATCHER_PROVIDER],
 })
-export class MdTabsModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdTabsModule,
-      providers: []
-    };
-  }
-}
+export class MdTabsModule {}
 
 
 export * from './tab-group';

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -14,7 +14,7 @@ import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 describe('MdTabGroup', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTabsModule.forRoot(), NoopAnimationsModule],
+      imports: [MdTabsModule, NoopAnimationsModule],
       declarations: [
         SimpleTabsTestApp,
         SimpleDynamicTabsTestApp,

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -16,7 +16,7 @@ describe('MdTabNavBar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTabsModule.forRoot()],
+      imports: [MdTabsModule],
       declarations: [
         SimpleTabNavBarTestApp,
         TabLinkWithNgIf,

--- a/src/lib/toolbar/index.ts
+++ b/src/lib/toolbar/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {MdCommonModule} from '../core';
 import {MdToolbar, MdToolbarRow} from './toolbar';
 
@@ -8,15 +8,7 @@ import {MdToolbar, MdToolbarRow} from './toolbar';
   exports: [MdToolbar, MdToolbarRow, MdCommonModule],
   declarations: [MdToolbar, MdToolbarRow],
 })
-export class MdToolbarModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdToolbarModule,
-      providers: []
-    };
-  }
-}
+export class MdToolbarModule {}
 
 
 export * from './toolbar';

--- a/src/lib/toolbar/toolbar.spec.ts
+++ b/src/lib/toolbar/toolbar.spec.ts
@@ -12,7 +12,7 @@ describe('MdToolbar', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdToolbarModule.forRoot()],
+      imports: [MdToolbarModule],
       declarations: [TestApp],
     });
 

--- a/src/lib/tooltip/index.ts
+++ b/src/lib/tooltip/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {OverlayModule, MdCommonModule} from '../core';
 import {PlatformModule} from '../core/platform/index';
 import {MdTooltip, TooltipComponent} from './tooltip';
@@ -10,15 +10,7 @@ import {MdTooltip, TooltipComponent} from './tooltip';
   declarations: [MdTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
 })
-export class MdTooltipModule {
-  /** @deprecated */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MdTooltipModule,
-      providers: []
-    };
-  }
-}
+export class MdTooltipModule {}
 
 
 export * from './tooltip';

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -32,7 +32,7 @@ describe('MdTooltip', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MdTooltipModule.forRoot(), OverlayModule, NoopAnimationsModule],
+      imports: [MdTooltipModule, OverlayModule, NoopAnimationsModule],
       declarations: [BasicTooltipDemo, ScrollableTooltipDemo, OnPushTooltipDemo],
       providers: [
         {provide: Platform, useValue: {IOS: false}},


### PR DESCRIPTION
* In beta.2 the `forRoot` calls have been deprecated, and it was stated that those will be removed in the next release (https://goo.gl/2yFPFc)