### PR TITLE
build: include license in docs-content

### DIFF
--- a/scripts/release/publish-docs-content.sh
+++ b/scripts/release/publish-docs-content.sh
@@ -63,6 +63,9 @@ done
 # Move highlighted examples into $repoPath
 cp -r $examplesSource/* $repoPath/examples
 
+# Copies assets over to the docs-content repository.
+cp LICENSE $repoPath/
+
 # Push content to repo
 cd $repoPath
 git config user.name "$commitAuthorName"


### PR DESCRIPTION
* Includes the `LICENSE` file in the `material2-docs-content` repository.  Similar as for `material2-builds`.