### PR TITLE
feat(input): add directive for displaying error messages

### DIFF
--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -64,8 +64,10 @@
 
       <md-input-container>
         <input mdInput placeholder="email" [formControl]="emailFormControl">
-        <md-error *ngIf="emailFormControl.errors['required']">This field is required</md-error>
-        <md-error *ngIf="emailFormControl.errors['pattern']">
+        <md-error *ngIf="emailFormControl.errors ? emailFormControl.errors['required'] : false">
+          This field is required
+        </md-error>
+        <md-error *ngIf="emailFormControl.errors ? emailFormControl.errors['pattern'] : false">
           Please enter a valid email address
         </md-error>
       </md-input-container>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -64,10 +64,10 @@
 
       <md-input-container>
         <input mdInput placeholder="email" [formControl]="emailFormControl">
-        <md-error *ngIf="emailFormControl.errors ? emailFormControl.errors['required'] : false">
+        <md-error *ngIf="emailFormControl.hasError('required')">
           This field is required
         </md-error>
-        <md-error *ngIf="emailFormControl.errors ? emailFormControl.errors['pattern'] : false">
+        <md-error *ngIf="emailFormControl.hasError('pattern')">
           Please enter a valid email address
         </md-error>
       </md-input-container>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -64,8 +64,8 @@
 
       <md-input-container>
         <input mdInput placeholder="email" [formControl]="emailFormControl">
-        <md-error *ngIf="emailFormControl.errors.required">This field is required</md-error>
-        <md-error *ngIf="emailFormControl.errors.pattern">
+        <md-error *ngIf="emailFormControl.errors['required']">This field is required</md-error>
+        <md-error *ngIf="emailFormControl.errors['pattern']">
           Please enter a valid email address
         </md-error>
       </md-input-container>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -52,6 +52,49 @@
 </md-card>
 
 <md-card class="demo-card demo-basic">
+  <md-toolbar color="primary">Error messages</md-toolbar>
+  <md-card-content>
+    <h4>Regular</h4>
+
+    <p>
+      <md-input-container>
+        <input mdInput placeholder="example" [(ngModel)]="errorMessageExample1" required>
+        <md-error>This field is required</md-error>
+      </md-input-container>
+
+      <md-input-container>
+        <input mdInput placeholder="email" [formControl]="emailFormControl">
+        <md-error *ngIf="emailFormControl.errors.required">This field is required</md-error>
+        <md-error *ngIf="emailFormControl.errors.pattern">
+          Please enter a valid email address
+        </md-error>
+      </md-input-container>
+    </p>
+
+    <h4>With hint</h4>
+
+    <md-input-container>
+      <input mdInput placeholder="example" [(ngModel)]="errorMessageExample2" required>
+      <md-error>This field is required</md-error>
+      <md-hint>Please type something here</md-hint>
+    </md-input-container>
+
+
+    <form novalidate>
+      <h4>Inside a form</h4>
+
+      <md-input-container>
+        <input mdInput name="example" placeholder="example"
+          [(ngModel)]="errorMessageExample3" required>
+        <md-error>This field is required</md-error>
+      </md-input-container>
+
+      <button color="primary" md-raised-button>Submit</button>
+    </form>
+  </md-card-content>
+</md-card>
+
+<md-card class="demo-card demo-basic">
   <md-toolbar color="primary">Prefix + Suffix</md-toolbar>
   <md-card-content>
     <h4>Text</h4>

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -4,6 +4,8 @@ import {FormControl, Validators} from '@angular/forms';
 
 let max = 5;
 
+const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+
 @Component({
   moduleId: module.id,
   selector: 'input-demo',
@@ -17,6 +19,9 @@ export class InputDemo {
   ctrlDisabled = false;
 
   name: string;
+  errorMessageExample1: string;
+  errorMessageExample2: string;
+  errorMessageExample3: string;
   items: any[] = [
     { value: 10 },
     { value: 20 },
@@ -26,6 +31,7 @@ export class InputDemo {
   ];
   rows = 8;
   formControl = new FormControl('hello', Validators.required);
+  emailFormControl = new FormControl('', [Validators.required, Validators.pattern(EMAIL_REGEX)]);
   model = 'hello';
 
   addABunch(n: number) {

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1,6 +1,7 @@
 import {TestBed, async, fakeAsync, tick, ComponentFixture} from '@angular/core/testing';
 import {Component, OnDestroy, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MdAutocompleteModule, MdAutocompleteTrigger} from './index';
 import {OverlayContainer} from '../core/overlay/overlay-container';
 import {MdInputModule} from '../input/index';
@@ -27,7 +28,11 @@ describe('MdAutocomplete', () => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [
-          MdAutocompleteModule.forRoot(), MdInputModule.forRoot(), FormsModule, ReactiveFormsModule
+        MdAutocompleteModule.forRoot(),
+        MdInputModule.forRoot(),
+        FormsModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule
       ],
       declarations: [
         SimpleAutocomplete,

--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -70,7 +70,8 @@ export const MAT_ELEMENTS_SELECTOR = `
   mat-spinner,
   mat-tab,
   mat-tab-group,
-  mat-toolbar`;
+  mat-toolbar,
+  mat-error`;
 
 /** Selector that matches all elements that may have style collisions with AngularJS Material. */
 export const MD_ELEMENTS_SELECTOR = `
@@ -130,7 +131,8 @@ export const MD_ELEMENTS_SELECTOR = `
   md-spinner,
   md-tab,
   md-tab-group,
-  md-toolbar`;
+  md-toolbar,
+  md-error`;
 
 /** Directive that enforces that the `mat-` prefix cannot be used. */
 @Directive({selector: MAT_ELEMENTS_SELECTOR})

--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -64,6 +64,9 @@
     }
   }
 
+  // Styling for the error state of the input container. Note that while the same can be
+  // achieved with the ng-* classes, we use this approach in order to ensure that the same
+  // logic is used to style the error state and to show the error messages.
   .mat-input-invalid {
     .mat-input-placeholder,
     .mat-placeholder-required {

--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -8,12 +8,12 @@
   $warn: map-get($theme, warn);
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
-  
+
   // Placeholder colors. Required is used for the `*` star shown in the placeholder.
   $input-placeholder-color: mat-color($foreground, hint-text);
   $input-floating-placeholder-color: mat-color($primary);
   $input-required-placeholder-color: mat-color($accent);
-  
+
   // Underline colors.
   $input-underline-color: mat-color($foreground, divider);
   $input-underline-color-accent: mat-color($accent);
@@ -64,7 +64,7 @@
     }
   }
 
-  .mat-input-container.ng-invalid.ng-touched:not(.mat-focused) {
+  .mat-input-invalid {
     .mat-input-placeholder,
     .mat-placeholder-required {
       color: $input-underline-color-warn;
@@ -73,5 +73,13 @@
     .mat-input-underline {
       border-color: $input-underline-color-warn;
     }
+
+    .mat-input-ripple {
+      background-color: $input-underline-color-warn;
+    }
+  }
+
+  .mat-input-error {
+    color: $input-underline-color-warn;
   }
 }

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -1,5 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {MdPlaceholder, MdInputContainer, MdHint, MdInputDirective} from './input-container';
+import {MdPlaceholder, MdInputContainer, MdHint, MdInputDirective, MdErrorDirective} from './input-container';
 import {MdTextareaAutosize} from './autosize';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
@@ -12,7 +12,8 @@ import {PlatformModule} from '../core/platform/index';
     MdInputContainer,
     MdHint,
     MdTextareaAutosize,
-    MdInputDirective
+    MdInputDirective,
+    MdErrorDirective
   ],
   imports: [
     CommonModule,
@@ -24,7 +25,8 @@ import {PlatformModule} from '../core/platform/index';
     MdInputContainer,
     MdHint,
     MdTextareaAutosize,
-    MdInputDirective
+    MdInputDirective,
+    MdErrorDirective
   ],
 })
 export class MdInputModule {

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -1,5 +1,11 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {MdPlaceholder, MdInputContainer, MdHint, MdInputDirective, MdErrorDirective} from './input-container';
+import {
+  MdPlaceholder,
+  MdInputContainer,
+  MdHint,
+  MdInputDirective,
+  MdErrorDirective,
+} from './input-container';
 import {MdTextareaAutosize} from './autosize';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -37,12 +37,12 @@
   </div>
 
   <div class="mat-input-hint-wrapper" [ngSwitch]="_getDisplayedMessages()">
-    <div *ngSwitchCase="'error'" [@transitionMessages]="_messageAnimationState">
+    <div *ngSwitchCase="'error'" [@transitionMessages]="_subscriptAnimationState">
       <ng-content select="md-error, mat-error"></ng-content>
     </div>
 
-    <div *ngSwitchCase="'hint'" [@transitionMessages]="_messageAnimationState">
-      <div *ngIf="hintLabel != ''" [attr.id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
+    <div *ngSwitchCase="'hint'" [@transitionMessages]="_subscriptAnimationState">
+      <div *ngIf="hintLabel" [id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
       <ng-content select="md-hint, mat-hint"></ng-content>
     </div>
   </div>

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -36,12 +36,13 @@
           [class.mat-warn]="dividerColor == 'warn'"></span>
   </div>
 
-  <div class="mat-input-hint-wrapper" [ngSwitch]="_getDisplayedMessages()">
+  <div class="mat-input-subscript-wrapper" [ngSwitch]="_getDisplayedMessages()">
     <div *ngSwitchCase="'error'" [@transitionMessages]="_subscriptAnimationState">
       <ng-content select="md-error, mat-error"></ng-content>
     </div>
 
-    <div *ngSwitchCase="'hint'" [@transitionMessages]="_subscriptAnimationState">
+    <div class="mat-input-hint-wrapper" *ngSwitchCase="'hint'"
+      [@transitionMessages]="_subscriptAnimationState">
       <div *ngIf="hintLabel" [id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
       <ng-content select="md-hint, mat-hint"></ng-content>
     </div>

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -41,7 +41,7 @@
       <ng-content select="md-error, mat-error"></ng-content>
     </div>
 
-    <div *ngSwitchCase="'hint'" class="mat-input-hint-clearfix" [@transitionMessages]="_messageAnimationState">
+    <div *ngSwitchCase="'hint'" [@transitionMessages]="_messageAnimationState">
       <div *ngIf="hintLabel != ''" [attr.id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
       <ng-content select="md-hint, mat-hint"></ng-content>
     </div>

--- a/src/lib/input/input-container.html
+++ b/src/lib/input/input-container.html
@@ -36,6 +36,14 @@
           [class.mat-warn]="dividerColor == 'warn'"></span>
   </div>
 
-  <div *ngIf="hintLabel != ''" [attr.id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
-  <ng-content select="md-hint, mat-hint"></ng-content>
+  <div class="mat-input-hint-wrapper" [ngSwitch]="_getDisplayedMessages()">
+    <div *ngSwitchCase="'error'" [@transitionMessages]="_messageAnimationState">
+      <ng-content select="md-error, mat-error"></ng-content>
+    </div>
+
+    <div *ngSwitchCase="'hint'" class="mat-input-hint-clearfix" [@transitionMessages]="_messageAnimationState">
+      <div *ngIf="hintLabel != ''" [attr.id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>
+      <ng-content select="md-hint, mat-hint"></ng-content>
+    </div>
+  </div>
 </div>

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -237,6 +237,9 @@ $mat-input-underline-disabled-background-image:
   display: block;
   float: left;
 
+  // We use floats here, as opposed to flexbox, in order to make it
+  // easier to reverse their location in rtl and to ensure that they're
+  // aligned properly in some cases (e.g. when there is only an `end` hint).
   &.mat-right {
     float: right;
   }

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -228,6 +228,7 @@ $mat-input-underline-disabled-background-image:
   top: 100%;
   width: 100%;
   margin-top: -$mat-input-wrapper-spacing;
+  overflow: hidden; // prevents multi-line errors from overlapping the input
 }
 
 // The hint is shown below the underline. There can be
@@ -246,19 +247,6 @@ $mat-input-underline-disabled-background-image:
     &.mat-right {
       float: left;
     }
-  }
-}
-
-// Clears the floats on the hints. Necessary for the `transform` animation to work.
-.mat-input-hint-clearfix {
-  &::before,
-  &::after {
-    content: '';
-    display: table;
-  }
-
-  &::after {
-    clear: both;
   }
 }
 

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -4,6 +4,7 @@
 
 
 $mat-input-floating-placeholder-scale-factor: 0.75 !default;
+$mat-input-wrapper-spacing: 1em !default;
 
 // Gradient for showing the dashed line when the input is disabled.
 $mat-input-underline-disabled-background-image:
@@ -41,7 +42,7 @@ $mat-input-underline-disabled-background-image:
 // Global wrapper. We need to apply margin to the element for spacing, but
 // cannot apply it to the host element directly.
 .mat-input-wrapper {
-  margin: 1em 0;
+  margin: $mat-input-wrapper-spacing 0;
   // Account for the underline which has 4px of margin + 2px of border.
   padding-bottom: 6px;
 }
@@ -219,27 +220,51 @@ $mat-input-underline-disabled-background-image:
   }
 }
 
-// The hint is shown below the underline. There can be more than one; one at the start
-// and one at the end.
-.mat-hint {
-  display: block;
+// Wrapper for the hints and error messages. Provides positioning and text size.
+// Note that we're using `top` in order to allow for stacked children to flow downwards.
+.mat-input-hint-wrapper {
   position: absolute;
   font-size: 75%;
-  bottom: 0;
+  top: 100%;
+  width: 100%;
+  margin-top: -$mat-input-wrapper-spacing;
+}
+
+// The hint is shown below the underline. There can be
+// more than one; one at the start and one at the end.
+.mat-hint {
+  display: block;
+  float: left;
 
   &.mat-right {
-    right: 0;
+    float: right;
   }
 
   [dir='rtl'] & {
-    right: 0;
-    left: auto;
+    float: right;
 
     &.mat-right {
-      right: auto;
-      left: 0;
+      float: left;
     }
   }
+}
+
+// Clears the floats on the hints. Necessary for the `transform` animation to work.
+.mat-input-hint-clearfix {
+  &::before,
+  &::after {
+    content: '';
+    display: table;
+  }
+
+  &::after {
+    clear: both;
+  }
+}
+
+// Single errror message displayed beneath the input.
+.mat-input-error {
+  display: block;
 }
 
 .mat-input-prefix, .mat-input-suffix {

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -222,13 +222,26 @@ $mat-input-underline-disabled-background-image:
 
 // Wrapper for the hints and error messages. Provides positioning and text size.
 // Note that we're using `top` in order to allow for stacked children to flow downwards.
-.mat-input-hint-wrapper {
+.mat-input-subscript-wrapper {
   position: absolute;
   font-size: 75%;
   top: 100%;
   width: 100%;
   margin-top: -$mat-input-wrapper-spacing;
   overflow: hidden; // prevents multi-line errors from overlapping the input
+}
+
+// Clears the floats on the hints. This is necessary for the hint animation to work.
+.mat-input-hint-wrapper {
+  &::before,
+  &::after {
+    content: ' ';
+    display: table;
+  }
+
+  &::after {
+    clear: both;
+  }
 }
 
 // The hint is shown below the underline. There can be

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -266,7 +266,7 @@ $mat-input-underline-disabled-background-image:
   }
 }
 
-// Single errror message displayed beneath the input.
+// Single error message displayed beneath the input.
 .mat-input-error {
   display: block;
 }

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -623,7 +623,7 @@ describe('MdInputContainer', function () {
       component = groupFixture.componentInstance;
       containerEl = groupFixture.debugElement.query(By.css('md-input-container')).nativeElement;
 
-      expect(component.formControl.invalid).toBe(true, 'Expected form control to be invalid');
+      expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('md-error').length).toBe(0, 'Expected no error messages');
       expect(component.formGroupDirective.submitted)
           .toBe(false, 'Expected form not to have been submitted');
@@ -955,9 +955,9 @@ class MdInputContainerWithFormErrorMessages {
 
 @Component({
   template: `
-    <form [formGroup]="formGroup" (ngSubmit)="onSubmit()" novalidate>
+    <form [formGroup]="formGroup" novalidate>
       <md-input-container>
-        <input mdInput [formControl]="formControl">
+        <input mdInput formControlName="name">
         <md-hint>Please type something</md-hint>
         <md-error>This field is required</md-error>
       </md-input-container>
@@ -966,7 +966,7 @@ class MdInputContainerWithFormErrorMessages {
 })
 class MdInputContainerWithFormGroupErrorMessages {
   @ViewChild(FormGroupDirective) formGroupDirective: FormGroupDirective;
-  onSubmit() { }
-  formControl = new FormControl('', Validators.required);
-  formGroup = new FormGroup({ name: this.formControl });
+  formGroup = new FormGroup({
+    name: new FormControl('', Validators.required)
+  });
 }

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -641,7 +641,7 @@ describe('MdInputContainer', function () {
       });
     }));
 
-    it('should hide the error messages once the input becomes valid', async(() => {
+    it('should hide the errors and show the hints once the input becomes valid', async(() => {
       testComponent.formControl.markAsTouched();
       fixture.detectChanges();
 
@@ -650,6 +650,8 @@ describe('MdInputContainer', function () {
             .toContain('mat-input-invalid', 'Expected container to have the invalid CSS class.');
         expect(containerEl.querySelectorAll('md-error').length)
             .toBe(1, 'Expected one error message to have been rendered.');
+        expect(containerEl.querySelectorAll('md-hint').length)
+            .toBe(0, 'Expected no hints to be shown.');
 
         testComponent.formControl.setValue('something');
         fixture.detectChanges();
@@ -659,38 +661,11 @@ describe('MdInputContainer', function () {
               'Expected container not to have the invalid class when valid.');
           expect(containerEl.querySelectorAll('md-error').length)
               .toBe(0, 'Expected no error messages when the input is valid.');
+          expect(containerEl.querySelectorAll('md-hint').length)
+              .toBe(1, 'Expected one hint to be shown once the input is valid.');
         });
       });
     }));
-
-    it('should hide the hints when there are errors and not show them again when' +
-      ' the input becomes valid', async(() => {
-
-        expect(containerEl.querySelectorAll('md-hint').length)
-            .toBe(1, 'Expected one hint to be shown on load.');
-        expect(containerEl.querySelectorAll('md-error').length)
-            .toBe(0, 'Expected no errors to be shown on load.');
-
-        testComponent.formControl.markAsTouched();
-        fixture.detectChanges();
-
-        fixture.whenStable().then(() => {
-          expect(containerEl.querySelectorAll('md-hint').length)
-              .toBe(0, 'Expected no hints to be shown after interaction.');
-          expect(containerEl.querySelectorAll('md-error').length)
-              .toBe(1, 'Expected one error to be shown after interaction.');
-
-          testComponent.formControl.setValue('something');
-          fixture.detectChanges();
-
-          fixture.whenStable().then(() => {
-            expect(containerEl.querySelectorAll('md-hint').length)
-                .toBe(0, 'Expected no hints to be shown after the value is set.');
-            expect(containerEl.querySelectorAll('md-error').length)
-                .toBe(0, 'Expected no errors to be shown after the value is set.');
-          });
-        });
-      }));
 
     it('should not hide the hint if there are no error messages', async(() => {
       testComponent.renderError = false;

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -24,7 +24,7 @@ import {
   trigger,
 } from '@angular/animations';
 import {coerceBooleanProperty} from '../core';
-import {NgControl, NgForm} from '@angular/forms';
+import {NgControl, NgForm, FormGroupDirective} from '@angular/forms';
 import {getSupportedInputTypes} from '../core/platform/features';
 import {
   MdInputContainerDuplicatedHintError,
@@ -257,7 +257,7 @@ export class MdInputDirective {
       state('enter', style({ opacity: 1, transform: 'translateY(0%)' })),
       transition('void => enter', [
         style({ opacity: 0, transform: 'translateY(-100%)' }),
-        animate('300ms')
+        animate('300ms cubic-bezier(0.55, 0, 0.55, 0.2)')
       ])
     ])
   ],
@@ -292,7 +292,7 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
   get _canPlaceholderFloat() { return this._floatPlaceholder !== 'never'; }
 
   /** State of the md-hint and md-error animations. */
-  _messageAnimationState: string = '';
+  _subscriptAnimationState: string = '';
 
   /** Text for the input hint. */
   @Input()
@@ -324,7 +324,8 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
 
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
-    @Optional() private _parentForm: NgForm) { }
+    @Optional() private _parentForm: NgForm,
+    @Optional() private _parentFormGroup: FormGroupDirective) { }
 
   ngAfterContentInit() {
     if (!this._mdInputChild) {
@@ -341,7 +342,7 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
 
   ngAfterViewInit() {
     // Avoid animations on load.
-    this._messageAnimationState = 'enter';
+    this._subscriptAnimationState = 'enter';
     this._changeDetectorRef.detectChanges();
   }
 
@@ -360,11 +361,12 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
   /** Whether the input container is in an error state. */
   _isErrorState(): boolean {
     const control = this._mdInputChild._ngControl;
-    const isInvalid = control ? control.invalid : false;
-    const isTouched = control ? control.touched : false;
-    const isSubmitted = this._parentForm ? this._parentForm.submitted : false;
+    const isInvalid = control && control.invalid;
+    const isTouched = control && control.touched;
+    const isSubmitted = (this._parentFormGroup && this._parentFormGroup.submitted) ||
+        (this._parentForm && this._parentForm.submitted);
 
-    return isInvalid && (isTouched || isSubmitted);
+    return !!(isInvalid && (isTouched || isSubmitted));
   }
 
   /** Determines whether to display hints, errors or no messages at all. */

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -1,21 +1,30 @@
 import {
+  AfterViewInit,
   AfterContentInit,
   Component,
   ContentChild,
   ContentChildren,
   Directive,
   ElementRef,
-  EventEmitter,
   Input,
   Optional,
   Output,
-  QueryList,
+  EventEmitter,
   Renderer,
+  ChangeDetectorRef,
+  ViewEncapsulation,
   Self,
-  ViewEncapsulation
+  QueryList,
 } from '@angular/core';
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 import {coerceBooleanProperty} from '../core';
-import {NgControl} from '@angular/forms';
+import {NgControl, NgForm} from '@angular/forms';
 import {getSupportedInputTypes} from '../core/platform/features';
 import {
   MdInputContainerDuplicatedHintError,
@@ -72,6 +81,14 @@ export class MdHint {
   @Input() id: string = `md-input-hint-${nextUniqueId++}`;
 }
 
+/** Directive, used to display a single error message under the input. */
+@Directive({
+  selector: 'md-error, mat-error',
+  host: {
+    '[class.mat-input-error]': 'true'
+  }
+})
+export class MdErrorDirective { }
 
 /** The input directive, used to mark the input that `MdInputContainer` is wrapping. */
 @Directive({
@@ -235,10 +252,20 @@ export class MdInputDirective {
   selector: 'md-input-container, mat-input-container',
   templateUrl: 'input-container.html',
   styleUrls: ['input-container.css'],
+  animations: [
+    trigger('transitionMessages', [
+      state('enter', style({ opacity: 1, transform: 'translateY(0%)' })),
+      transition('void => enter', [
+        style({ opacity: 0, transform: 'translateY(-100%)' }),
+        animate('300ms')
+      ])
+    ])
+  ],
   host: {
     // Remove align attribute to prevent it from interfering with layout.
     '[attr.align]': 'null',
     '[class.mat-input-container]': 'true',
+    '[class.mat-input-invalid]': '_isErrorState()',
     '[class.mat-focused]': '_mdInputChild.focused',
     '[class.ng-untouched]': '_shouldForward("untouched")',
     '[class.ng-touched]': '_shouldForward("touched")',
@@ -251,7 +278,7 @@ export class MdInputDirective {
   },
   encapsulation: ViewEncapsulation.None,
 })
-export class MdInputContainer implements AfterContentInit {
+export class MdInputContainer implements AfterViewInit, AfterContentInit {
   /** Alignment of the input container's content. */
   @Input() align: 'start' | 'end' = 'start';
 
@@ -263,6 +290,9 @@ export class MdInputContainer implements AfterContentInit {
 
   /** Whether the placeholder can float or not. */
   get _canPlaceholderFloat() { return this._floatPlaceholder !== 'never'; }
+
+  /** State of the md-hint and md-error animations. */
+  _messageAnimationState: string = '';
 
   /** Text for the input hint. */
   @Input()
@@ -288,7 +318,13 @@ export class MdInputContainer implements AfterContentInit {
 
   @ContentChild(MdPlaceholder) _placeholderChild: MdPlaceholder;
 
+  @ContentChildren(MdErrorDirective) _errorChildren: QueryList<MdErrorDirective>;
+
   @ContentChildren(MdHint) _hintChildren: QueryList<MdHint>;
+
+  constructor(
+    private _changeDetectorRef: ChangeDetectorRef,
+    @Optional() private _parentForm: NgForm) { }
 
   ngAfterContentInit() {
     if (!this._mdInputChild) {
@@ -303,6 +339,12 @@ export class MdInputContainer implements AfterContentInit {
     this._mdInputChild._placeholderChange.subscribe(() => this._validatePlaceholders());
   }
 
+  ngAfterViewInit() {
+    // Avoid animations on load.
+    this._messageAnimationState = 'enter';
+    this._changeDetectorRef.detectChanges();
+  }
+
   /** Determines whether a class from the NgControl should be forwarded to the host element. */
   _shouldForward(prop: string): boolean {
     let control = this._mdInputChild ? this._mdInputChild._ngControl : null;
@@ -314,6 +356,30 @@ export class MdInputContainer implements AfterContentInit {
 
   /** Focuses the underlying input. */
   _focusInput() { this._mdInputChild.focus(); }
+
+  /** Whether the input container is in an error state. */
+  _isErrorState(): boolean {
+    const control = this._mdInputChild._ngControl;
+    const isInvalid = control ? control.invalid : false;
+    const isTouched = control ? control.touched : false;
+    const isSubmitted = this._parentForm ? this._parentForm.submitted : false;
+
+    return isInvalid && (isTouched || isSubmitted);
+  }
+
+  /** Determines whether to display hints, errors or no messages at all. */
+  _getDisplayedMessages(): 'error'|'hint'|'none' {
+    if (this._errorChildren.length > 0) {
+      if (this._isErrorState()) {
+        return 'error';
+      } else if (this._mdInputChild._ngControl) {
+        let control = this._mdInputChild._ngControl;
+        return (control.valid && control.touched) ? 'none' : 'hint';
+      }
+    }
+
+    return 'hint';
+  }
 
   /**
    * Ensure that there is only one placeholder (either `input` attribute or child element with the

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -368,7 +368,7 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
   }
 
   /** Determines whether to display hints, errors or no messages at all. */
-  _getDisplayedMessages(): 'error'|'hint'|'none' {
+  _getDisplayedMessages(): 'error' | 'hint' | 'none' {
     if (this._errorChildren.length > 0) {
       if (this._isErrorState()) {
         return 'error';

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -369,18 +369,9 @@ export class MdInputContainer implements AfterViewInit, AfterContentInit {
     return !!(isInvalid && (isTouched || isSubmitted));
   }
 
-  /** Determines whether to display hints, errors or no messages at all. */
-  _getDisplayedMessages(): 'error' | 'hint' | 'none' {
-    if (this._errorChildren.length > 0) {
-      if (this._isErrorState()) {
-        return 'error';
-      } else if (this._mdInputChild._ngControl) {
-        let control = this._mdInputChild._ngControl;
-        return (control.valid && control.touched) ? 'none' : 'hint';
-      }
-    }
-
-    return 'hint';
+  /** Determines whether to display hints or errors. */
+  _getDisplayedMessages(): 'error' | 'hint' {
+    return (this._errorChildren.length > 0 && this._isErrorState()) ? 'error' : 'hint';
   }
 
   /**

--- a/src/lib/input/input.md
+++ b/src/lib/input/input.md
@@ -1,4 +1,4 @@
-`<md-input-container>` is a wrapper for native `input` and `textarea` elements. This container 
+`<md-input-container>` is a wrapper for native `input` and `textarea` elements. This container
 applies Material Design styles and behavior while still allowing direct access to the underlying
 native element.
 
@@ -14,7 +14,7 @@ elements inside `md-input-container` as well. This includes Angular directives s
 
 The only limitations are that the `type` attribute can only be one of the values supported by
 `md-input-container` and the native element cannot specify a `placeholder` attribute if the
-`md-input-container` also contains a `md-placeholder` element. 
+`md-input-container` also contains a `md-placeholder` element.
 
 ### Supported `input` types
 
@@ -32,6 +32,19 @@ be used with `md-input-container`:
 * time
 * url
 * week
+
+### Error messages
+
+Error messages can be shown beneath an input by specifying `md-error` elements inside the
+`md-input-container`. Errors are hidden by default and will be displayed on invalid inputs after
+the user has interacted with the element or the parent form has been submitted. In addition,
+whenever errors are displayed, the container's `md-hint` labels will be hidden.
+
+If an input element can have more than one error state, it is up to the consumer to toggle which
+messages should be displayed. This can be done with CSS, `ngIf` or `ngSwitch`.
+
+Note that, while multiple error messages can be displayed at the same time, it is recommended to
+only show one at a time.
 
 ### Placeholder
 


### PR DESCRIPTION
Adds the `md-error` directive that can be utilised to display validation errors to the user. Example:

```html
<md-input-container>
  <input mdInput placeholder="email" [formControl]="emailFormControl">
  <md-error *ngIf="emailFormControl.errors.required">This field is required</md-error>
  <md-error *ngIf="emailFormControl.errors.pattern">
    Please enter a valid email address
  </md-error>
</md-input-container>
```

The `md-input-container` behavior is as follows:
* If there is an error and the user interacted with the input, the errors will be shown.
* If there is an error and the user submitted the a form that wraps the input, the errors will be shown.
* If there are errors to be shown on an input container that has `md-hint`-s, the hints will be hidden.
* If an input with hints and errors becomes valid, the hint won't be displayed anymore.

**Note:** At the moment, all hints will be hidden when an error is shown. This might not be intended for some cases (e.g. with a character counter). It might make sense to only hide the one in the `start` slot, but this could be addressed separately.