### PR TITLE
fix(input): label animation shifting sibling labels

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -178,6 +178,7 @@ $mat-input-underline-disabled-background-image:
   padding-top: 1em;
   overflow: hidden;
   pointer-events: none;  // We shouldn't catch mouse events (let them through).
+  transform: translate3d(0, 0, 0); // Prevents the label from shifting after the animation is done.
 
   // Keeps the element height since the placeholder text is `position: absolute`.
   &::after {


### PR DESCRIPTION
Prevents the focused animation in inputs from causing sibling inputs to shift slightly.

Fixes #3541.

For reference:
![a](https://cloud.githubusercontent.com/assets/4450522/23831389/598820a2-0720-11e7-81f1-100c7399cc66.gif)
