### PR TITLE
fix(input): overflow-y scrollbar is displayed (IE)

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -143,7 +143,7 @@ $mat-input-underline-disabled-background-image:
   display: none;
   white-space: nowrap;
   text-overflow: ellipsis;
-  overflow-x: hidden;
+  overflow: hidden;
 
   transform: translateY(0);
   transform-origin: bottom left;


### PR DESCRIPTION
y-scrollbar is displayed when placeholder text line-height is bigger than md-input-placeholder height (on IE browser)

fixes #3570 