### PR TITLE
fix(autocomplete): update overlay ref width on menu trigger

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -122,7 +122,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     if (!this._overlayRef) {
       this._createOverlay();
     } else {
-      /** Gets width of host incase this has changed, and updated the Overlay reference */
+      /** Update the panel width, in case the host width has changed */
       this._overlayRef.getState().width = this._getHostWidth();
     }
 

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -121,6 +121,9 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   openPanel(): void {
     if (!this._overlayRef) {
       this._createOverlay();
+    } else {
+      /** Gets width of host incase this has changed, and updated the Overlay reference */
+      this._overlayRef.getState().width = this._getHostWidth();
     }
 
     if (!this._overlayRef.hasAttached()) {

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -948,7 +948,8 @@ describe('MdAutocomplete', () => {
     widthFixture.detectChanges();
 
     const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-    expect(overlayPane.style.width).toEqual('300px');
+    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    expect(Math.ceil(parseFloat(overlayPane.style.width))).toEqual(300);
 
     widthFixture.componentInstance.trigger.closePanel();
     widthFixture.detectChanges();
@@ -959,7 +960,8 @@ describe('MdAutocomplete', () => {
     widthFixture.componentInstance.trigger.openPanel();
     widthFixture.detectChanges();
 
-    expect(overlayPane.style.width).toEqual('500px');
+    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    expect(Math.ceil(parseFloat(overlayPane.style.width))).toEqual(500);
 
   });
 });

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -938,11 +938,35 @@ describe('MdAutocomplete', () => {
     }));
 
   });
+
+  it('should have correct width when opened', () => {
+    const widthFixture = TestBed.createComponent(SimpleAutocomplete);
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    expect(overlayPane.style.width).toEqual('300px');
+
+    widthFixture.componentInstance.trigger.closePanel();
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.width = 500;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    expect(overlayPane.style.width).toEqual('500px');
+
+  });
 });
 
 @Component({
   template: `
-    <md-input-container [floatPlaceholder]="placeholder">
+    <md-input-container [floatPlaceholder]="placeholder" [style.width.px]="width">
       <input mdInput placeholder="State" [mdAutocomplete]="auto" [formControl]="stateCtrl">
     </md-input-container>
 
@@ -958,6 +982,7 @@ class SimpleAutocomplete implements OnDestroy {
   filteredStates: any[];
   valueSub: Subscription;
   placeholder = 'auto';
+  width: number;
 
   @ViewChild(MdAutocompleteTrigger) trigger: MdAutocompleteTrigger;
   @ViewChild(MdAutocomplete) panel: MdAutocomplete;


### PR DESCRIPTION
When changing the width of the `host` (e.g. using flex box) after the first time the `autocomplete` menu is opened, the `div.cdk-overlay-pane` is not updated and keeps the `width` that the `host` had when it was initially opened.

https://github.com/angular/material2/blob/master/src/lib/autocomplete/autocomplete-trigger.ts#L123

Here is a plnkr to demonstrate the issue. http://plnkr.co/edit/Evz0KLvvkFcmerIoca42?p=preview

### Steps to reproduce

- First focus the `md-input` component to initialize the `md-autocomplete`s `cdk-overlay-pane`.
- Change the `width` of the `md-input` component by entering a diff value in the `width` input box under it.
- Focus the `md-input` component again, and notice the `width` of the `autocomplete`'s `cdk-overlay-pane` remained the same as when it was initialized.

### Proposed fix in PR

We just need to set the new `width` every time the `autocomplete`'s panel is opened (`openPanel()`) and leverage that the `updateSize()` method is called when the `portal` is reattached.

https://github.com/angular/material2/blob/master/src/lib/autocomplete/autocomplete-trigger.ts#L127

https://github.com/angular/material2/blob/master/src/lib/core/overlay/overlay-ref.ts#L40

```typescript
if (!this._overlayRef) {
     this._createOverlay();
 } else {
   /** Gets width of host incase this has changed, and updated the Overlay reference */
   this._overlayRef.getState().width = this._getHostWidth();
 }
```