### PR TITLE
feat(tooltip): allow tooltip be disabled

### DIFF
--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -7,6 +7,7 @@
             color="primary"
             [mdTooltip]="message"
             [mdTooltipPosition]="position"
+            [mdTooltipDisabled]="disabled"
             [mdTooltipShowDelay]="showDelay"
             [mdTooltipHideDelay]="hideDelay">
       Mouse over to see the tooltip
@@ -25,10 +26,14 @@
       <md-radio-button value="after">After</md-radio-button>
     </md-radio-group>
   </p>
-
   <p>
     <strong>Message: </strong>
     <md-input-container><input mdInput type="text" [(ngModel)]="message"></md-input-container>
+  </p>
+
+  <p>
+    <strong>Disabled: </strong>
+    <md-checkbox [(ngModel)]="disabled"></md-checkbox>
   </p>
 
   <p>

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -12,6 +12,7 @@ import {TooltipPosition} from '@angular/material';
 export class TooltipDemo {
   position: TooltipPosition = 'below';
   message: string = 'Here is the tooltip';
+  disabled = false;
   showDelay = 0;
   hideDelay = 1000;
 }

--- a/src/lib/tooltip/tooltip.md
+++ b/src/lib/tooltip/tooltip.md
@@ -33,3 +33,5 @@ delay of 1500ms. The longpress behavior requires HammerJS to be loaded on the pa
 The tooltip can also be shown and hidden through the `show` and `hide` directive methods,
 which both accept a number in milliseconds to delay before applying the display change.
 
+To turn off the tooltip and prevent it from showing to the user, use the `mdTooltipDisabled` input flag.
+

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -112,6 +112,23 @@ describe('MdTooltip', () => {
       expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
     }));
 
+    fit('should not show if disabled', fakeAsync(() => {
+      // Test that disabling the tooltip will not set the tooltip visible
+      tooltipDirective.disabled = true;
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick(0);
+      expect(tooltipDirective._isTooltipVisible()).toBe(false);
+
+      // Test to make sure setting disabled to false will show the tooltip
+      // Sanity check to make sure everything was correct before (detectChanges, tick)
+      tooltipDirective.disabled = false;
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick(0);
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+    }));
+
     it('should not show if hide is called before delay finishes', fakeAsync(() => {
       expect(tooltipDirective._tooltipInstance).toBeUndefined();
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -112,7 +112,7 @@ describe('MdTooltip', () => {
       expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
     }));
 
-    fit('should not show if disabled', fakeAsync(() => {
+    it('should not show if disabled', fakeAsync(() => {
       // Test that disabling the tooltip will not set the tooltip visible
       tooltipDirective.disabled = true;
       tooltipDirective.show();
@@ -127,6 +127,20 @@ describe('MdTooltip', () => {
       fixture.detectChanges();
       tick(0);
       expect(tooltipDirective._isTooltipVisible()).toBe(true);
+    }));
+
+    it('should hide if disabled while visible', fakeAsync(() => {
+      // Display the tooltip with a timeout before hiding.
+      tooltipDirective.hideDelay = 1000;
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick(0);
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      // Set tooltip to be disabled and verify that the tooltip hides.
+      tooltipDirective.disabled = true;
+      tick(0);
+      expect(tooltipDirective._isTooltipVisible()).toBe(false);
     }));
 
     it('should not show if hide is called before delay finishes', fakeAsync(() => {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -83,7 +83,14 @@ export class MdTooltip implements OnInit, OnDestroy {
   /** Disables the display of the tooltip. */
   @Input('mdTooltipDisabled')
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) { this._disabled = coerceBooleanProperty(value); }
+  set disabled(value) {
+    this._disabled = coerceBooleanProperty(value);
+
+    // If tooltip is disabled, hide immediately.
+    if (this._disabled) {
+      this.hide(0);
+    }
+  }
 
   /** @deprecated */
   @Input('tooltip-position')

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -33,6 +33,7 @@ import {Platform} from '../core/platform/index';
 import 'rxjs/add/operator/first';
 import {ScrollDispatcher} from '../core/overlay/scroll/scroll-dispatcher';
 import {Subscription} from 'rxjs/Subscription';
+import {coerceBooleanProperty} from '../core/coercion/boolean-property';
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
 
@@ -62,6 +63,7 @@ export class MdTooltip implements OnInit, OnDestroy {
   scrollSubscription: Subscription;
 
   private _position: TooltipPosition = 'below';
+  private _disabled: boolean = false;
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   @Input('mdTooltipPosition')
@@ -77,6 +79,11 @@ export class MdTooltip implements OnInit, OnDestroy {
       }
     }
   }
+
+  /** Disables the display of the tooltip. */
+  @Input('mdTooltipDisabled')
+  get disabled(): boolean { return this._disabled; }
+  set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
   /** @deprecated */
   @Input('tooltip-position')
@@ -114,6 +121,11 @@ export class MdTooltip implements OnInit, OnDestroy {
   @Input('matTooltipPosition')
   get _matPosition() { return this.position; }
   set _matPosition(v) { this.position = v; }
+
+  // Properties with `mat-` prefix for noconflict mode.
+  @Input('matTooltipDisabled')
+  get _matDisabled() { return this.disabled; }
+  set _matDisabled(v) { this.disabled = v; }
 
   // Properties with `mat-` prefix for noconflict mode.
   @Input('matTooltipHideDelay')
@@ -168,7 +180,7 @@ export class MdTooltip implements OnInit, OnDestroy {
 
   /** Shows the tooltip after the delay in ms, defaults to tooltip-delay-show or 0ms if no input */
   show(delay: number = this.showDelay): void {
-    if (!this._message || !this._message.trim()) { return; }
+    if (this.disabled || !this._message || !this._message.trim()) { return; }
 
     if (!this._tooltipInstance) {
       this._createTooltip();
@@ -192,7 +204,7 @@ export class MdTooltip implements OnInit, OnDestroy {
 
   /** Returns true if the tooltip is currently visible to the user */
   _isTooltipVisible(): boolean {
-    return this._tooltipInstance && this._tooltipInstance.isVisible();
+    return !!this._tooltipInstance && this._tooltipInstance.isVisible();
   }
 
   /** Create the tooltip to display */


### PR DESCRIPTION
It is not uncommon to disable tooltips, e.g. removing tooltip on disabled buttons. This adds an API `mdTooltipDisabled` to prevent the tooltip from displaying.