### PR TITLE
build(tslint): disallow var keyword

### DIFF
--- a/src/examples/example-data.ts
+++ b/src/examples/example-data.ts
@@ -28,9 +28,7 @@ export class ExampleData {
       }
       this.selectorName = this.indexFilename = `${example}-example`;
 
-      var exampleName = example.replace(/(?:^\w|\b\w)/g, function(letter) {
-        return letter.toUpperCase();
-      });
+      let exampleName = example.replace(/(?:^\w|\b\w)/g, letter => letter.toUpperCase());
 
       if (EXAMPLE_COMPONENTS[example].title) {
         this.description = EXAMPLE_COMPONENTS[example].title;

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -36,7 +36,7 @@ export const MD_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
   multi: true
 };
 
-var _uniqueIdCounter = 0;
+let _uniqueIdCounter = 0;
 
 /** Change event object emitted by MdButtonToggle. */
 export class MdButtonToggleChange {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -402,7 +402,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
 
   private _getAnimationClassForCheckStateTransition(
       oldState: TransitionCheckState, newState: TransitionCheckState): string {
-    var animSuffix: string;
+    let animSuffix: string;
 
     switch (oldState) {
     case TransitionCheckState.Init:

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -39,7 +39,7 @@ export const MD_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
   multi: true
 };
 
-var _uniqueIdCounter = 0;
+let _uniqueIdCounter = 0;
 
 /** Change event object emitted by MdRadio and MdRadioGroup. */
 export class MdRadioChange {

--- a/tslint.json
+++ b/tslint.json
@@ -25,6 +25,7 @@
     "no-shadowed-variable": true,
     "no-unused-expression": true,
     "no-unused-var": [true, {"ignore-pattern": "^(_.*)$"}],
+    "no-var-keyword": true,
     "no-debugger": true,
     "one-line": [
       true,


### PR DESCRIPTION
* Disallows the var-keyboard in the source files. `var` mostly causes issues with variables, and can be safely replaced with `let`.

The **var-keyword** mostly causes issues with variable initializers, and should be avoided in general.