### PR TITLE
fix(button): persist theme color of button when leaving hover state

### DIFF
--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -18,6 +18,10 @@
   &.mat-warn .mat-button-focus-overlay {
     background-color: mat-color($warn, 0.12);
   }
+
+  &[disabled] .mat-button-focus-overlay {
+    background-color: transparent;
+  }
 }
 
 // Applies a property to an md-button element for each of the supported palettes.
@@ -54,20 +58,15 @@
   $foreground: map-get($theme, foreground);
 
   .mat-button, .mat-icon-button, .mat-raised-button, .mat-fab, .mat-mini-fab {
-    &.cdk-keyboard-focused {
-      @include _mat-button-focus-color($theme);
-    }
+    // Appy color to focus overlay.
+    // The focus overlay will be visible when any button type is focused or when
+    // flat buttons or icon buttons are hovered.
+    @include _mat-button-focus-color($theme);
   }
 
   .mat-button, .mat-icon-button {
     @include _mat-button-theme-color($theme, 'color');
     background: transparent;
-
-    // Only flat buttons and icon buttons (not raised or fabs) have a hover style.
-    // Use the same visual treatment for hover as for focus.
-    &:hover {
-      @include _mat-button-focus-color($theme);
-    }
   }
 
   .mat-raised-button, .mat-fab, .mat-mini-fab {

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -14,12 +14,6 @@
       opacity: 1;
     }
   }
-
-  &[disabled]:hover {
-    &.mat-primary, &.mat-accent, &.mat-warn, .mat-button-focus-overlay {
-      background-color: transparent;
-    }
-  }
 }
 
 .mat-raised-button {


### PR DESCRIPTION
Leaving the hover state of colored flat and icon buttons exhibited a flicker of an uncolored focus overlay ([see this plunk](http://plnkr.co/edit/fkxW9Ll6G3jn3gIp4a0O?p=preview)). By slowing down the opacity transition, you can see it more clearly:

#### Before
![before slowed hover animation](https://cloud.githubusercontent.com/assets/6475576/23973003/8c1e99a6-09aa-11e7-9a51-864364f4d67e.gif)

This is due to the focus overlay colors only being added to flat and icon buttons while the button is hovered. Thus, the *colored* focus overlay will show up immediately on hover and persist through the opacity transition to 1, but will also disappear immediately and **not** persist through the opacity transition back to 0.

Since the focus and hover states are already showing/hiding the focus overlay via opacity, the background color of the focus overlay can be set to the theme color all the time.

#### After
![after slowed hover animation](https://cloud.githubusercontent.com/assets/6475576/23973015/92648b4a-09aa-11e7-81e6-fa6bf83bf27d.gif)