### PR TITLE
Export RIPPLE_FADE_IN_DURATION so that material users can import it

### DIFF
--- a/src/lib/core/ripple/index.ts
+++ b/src/lib/core/ripple/index.ts
@@ -6,7 +6,7 @@ import {SCROLL_DISPATCHER_PROVIDER} from '../overlay/scroll/scroll-dispatcher';
 
 export {MdRipple, RippleGlobalOptions, MD_RIPPLE_GLOBAL_OPTIONS} from './ripple';
 export {RippleRef, RippleState} from './ripple-ref';
-export {RippleConfig, RIPPLE_FADE_IN_DURATION} from './ripple-renderer';
+export {RippleConfig, RIPPLE_FADE_IN_DURATION, RIPPLE_FADE_OUT_DURATION} from './ripple-renderer';
 
 @NgModule({
   imports: [CompatibilityModule],

--- a/src/lib/core/ripple/index.ts
+++ b/src/lib/core/ripple/index.ts
@@ -6,7 +6,7 @@ import {SCROLL_DISPATCHER_PROVIDER} from '../overlay/scroll/scroll-dispatcher';
 
 export {MdRipple, RippleGlobalOptions, MD_RIPPLE_GLOBAL_OPTIONS} from './ripple';
 export {RippleRef, RippleState} from './ripple-ref';
-export {RippleConfig} from './ripple-renderer';
+export {RippleConfig, RIPPLE_FADE_IN_DURATION} from './ripple-renderer';
 
 @NgModule({
   imports: [CompatibilityModule],


### PR DESCRIPTION
I see that there are some material tests that use this variable within fakeAsync tests. It looks like RIPPLE_FADE_IN_DURATION is not exported from material code base.

But material users might also need this in their unit tests.