### PR TITLE
build: include scss files in releases

### DIFF
--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -22,6 +22,7 @@ const tsconfigPath = path.join(COMPONENTS_DIR, 'tsconfig.json');
 /** Asset files to be added to the components output. */
 const assetFiles = [
   path.join(COMPONENTS_DIR, '**/*.html'),
+  path.join(COMPONENTS_DIR, '**/*.scss'),
   path.join(COMPONENTS_DIR, 'package.json'),
   path.join(PROJECT_ROOT, 'README.md'),
   path.join(PROJECT_ROOT, 'LICENSE'),


### PR DESCRIPTION
* Includes the SCSS files in releases. This has been accidentally disabled in PR #3443