### PR TITLE
build: dont run karma if compilation failed

### DIFF
--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -75,13 +75,15 @@ gulp.task('test', [':test:deps'], () => {
   });
 
   // Refreshes Karma's file list and schedules a test run.
-  let runTests = () => {
-    server.refreshFiles().then(() => server._injector.get('executor').schedule());
+  let runTests = (err?: Error) => {
+    if (!err) {
+      server.refreshFiles().then(() => server._injector.get('executor').schedule());
+    }
   };
 
   // Boot up the test server and run the tests whenever a new browser connects.
   server.start();
-  server.on('browser_register', runTests);
+  server.on('browser_register', () => runTests());
 
   // Watch for file changes, rebuild and run the tests.
   gulp.watch(patternRoot + '.ts', () => runSequence(':build:components:ts:spec', runTests));

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -74,7 +74,8 @@ gulp.task('test', [':test:deps'], () => {
     singleRun: false
   });
 
-  // Refreshes Karma's file list and schedules a test run.
+  // Refreshes Karma's file list and schedules a test run. 
+  // Tests will only run if TypeScript compilation was successful.
   let runTests = (err?: Error) => {
     if (!err) {
       server.refreshFiles().then(() => server._injector.get('executor').schedule());

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -74,7 +74,7 @@ gulp.task('test', [':test:deps'], () => {
     singleRun: false
   });
 
-  // Refreshes Karma's file list and schedules a test run. 
+  // Refreshes Karma's file list and schedules a test run.
   // Tests will only run if TypeScript compilation was successful.
   let runTests = (err?: Error) => {
     if (!err) {

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -35,9 +35,7 @@ function _globify(maybeGlob: string, suffix = '**/*') {
 
 /** Creates a task that runs the TypeScript compiler */
 export function tsBuildTask(tsConfigPath: string, extraOptions?: CompilerOptions) {
-  return () => {
-    compileProject(tsConfigPath, extraOptions);
-  };
+  return () => compileProject(tsConfigPath, extraOptions);
 }
 
 


### PR DESCRIPTION
* Currently when the TypeScript compilation fails, our gulp process will still call the `runTests` method. 
* Also fixes that the TS-compiler exits the process. Gulp should handle the error (similar as before)
* Improves formatting of the diagnostics in the `ts-compiler`.