### PR TITLE
fix(tooltip): wrong position when using OnPush change detection

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -410,7 +410,7 @@ describe('MdTooltip', () => {
 
       fixture.detectChanges();
 
-      // wait till animation has finished
+      // wait until animation has finished
       tick(500);
 
       // Make sure tooltip is shown to the user and animation has finished
@@ -431,6 +431,14 @@ describe('MdTooltip', () => {
       // On animation complete, should expect that the tooltip has been detached.
       flushMicrotasks();
       expect(tooltipDirective._tooltipInstance).toBeNull();
+    }));
+
+    it('should have rendered the tooltip text on init', fakeAsync(() => {
+      dispatchFakeEvent(buttonElement, 'mouseenter');
+      tick(0);
+
+      const tooltipElement = overlayContainerElement.querySelector('.mat-tooltip') as HTMLElement;
+      expect(tooltipElement.textContent).toContain('initial tooltip message');
     }));
   });
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -34,7 +34,7 @@ describe('MdTooltip', () => {
       imports: [MdTooltipModule.forRoot(), OverlayModule],
       declarations: [BasicTooltipDemo, ScrollableTooltipDemo, OnPushTooltipDemo],
       providers: [
-        Platform,
+        {provide: Platform, useValue: {IOS: false}},
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
           document.body.appendChild(overlayContainerElement);
@@ -435,6 +435,7 @@ describe('MdTooltip', () => {
 
     it('should have rendered the tooltip text on init', fakeAsync(() => {
       dispatchFakeEvent(buttonElement, 'mouseenter');
+      fixture.detectChanges();
       tick(0);
 
       const tooltipElement = overlayContainerElement.querySelector('.mat-tooltip') as HTMLElement;

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -15,7 +15,7 @@ import {
   OnDestroy,
   Renderer,
   OnInit,
-  ChangeDetectorRef
+  ChangeDetectorRef,
 } from '@angular/core';
 import {
   Overlay,
@@ -155,7 +155,7 @@ export class MdTooltip implements OnInit, OnDestroy {
     @Optional() private _dir: Dir) {
 
     // The mouse events shouldn't be bound on iOS devices, because
-    // they can prevent the first tap from firing it's click event.
+    // they can prevent the first tap from firing its click event.
     if (!_platform.IOS) {
       _renderer.listen(_elementRef.nativeElement, 'mouseenter', () => this.show());
       _renderer.listen(_elementRef.nativeElement, 'mouseleave', () => this.hide());
@@ -311,6 +311,8 @@ export class MdTooltip implements OnInit, OnDestroy {
     // Must wait for the message to be painted to the tooltip so that the overlay can properly
     // calculate the correct positioning based on the size of the text.
     this._tooltipInstance.message = message;
+    this._tooltipInstance._updateView();
+
     this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
       if (this._tooltipInstance) {
         this._overlayRef.updatePosition();
@@ -393,7 +395,7 @@ export class TooltipComponent {
       // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
       this._changeDetectorRef.markForCheck();
-      setTimeout(() => { this._closeOnInteraction = true; }, 0);
+      setTimeout(() => this._closeOnInteraction = true, 0);
     }, delay);
   }
 
@@ -439,8 +441,8 @@ export class TooltipComponent {
       case 'after':  this._transformOrigin = isLtr ? 'left' : 'right'; break;
       case 'left':   this._transformOrigin = 'right'; break;
       case 'right':  this._transformOrigin = 'left'; break;
-      case 'above':    this._transformOrigin = 'bottom'; break;
-      case 'below': this._transformOrigin = 'top'; break;
+      case 'above':  this._transformOrigin = 'bottom'; break;
+      case 'below':  this._transformOrigin = 'top'; break;
       default: throw new MdTooltipInvalidPositionError(value);
     }
   }
@@ -460,5 +462,14 @@ export class TooltipComponent {
     if (this._closeOnInteraction) {
       this.hide(0);
     }
+  }
+
+  /**
+   * Ensures that the tooltip text has rendered. Mainly used for rendering the initial text
+   * before positioning a tooltip, which can be problematic in components with OnPush change
+   * detection.
+   */
+  _updateView(): void {
+    this._changeDetectorRef.detectChanges();
   }
 }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -311,7 +311,7 @@ export class MdTooltip implements OnInit, OnDestroy {
     // Must wait for the message to be painted to the tooltip so that the overlay can properly
     // calculate the correct positioning based on the size of the text.
     this._tooltipInstance.message = message;
-    this._tooltipInstance._updateView();
+    this._tooltipInstance._markForCheck();
 
     this._ngZone.onMicrotaskEmpty.first().subscribe(() => {
       if (this._tooltipInstance) {
@@ -394,7 +394,7 @@ export class TooltipComponent {
 
       // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
-      this._changeDetectorRef.markForCheck();
+      this._markForCheck();
       setTimeout(() => this._closeOnInteraction = true, 0);
     }, delay);
   }
@@ -415,7 +415,7 @@ export class TooltipComponent {
 
       // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
-      this._changeDetectorRef.markForCheck();
+      this._markForCheck();
     }, delay);
   }
 
@@ -465,11 +465,11 @@ export class TooltipComponent {
   }
 
   /**
-   * Ensures that the tooltip text has rendered. Mainly used for rendering the initial text
-   * before positioning a tooltip, which can be problematic in components with OnPush change
-   * detection.
+   * Marks that the tooltip needs to be checked in the next change detection run.
+   * Mainly used for rendering the initial text before positioning a tooltip, which
+   * can be problematic in components with OnPush change detection.
    */
-  _updateView(): void {
-    this._changeDetectorRef.detectChanges();
+  _markForCheck(): void {
+    this._changeDetectorRef.markForCheck();
   }
 }


### PR DESCRIPTION
Fixes the tooltip having a wrong position if it is inside a component with `OnPush` change detection. The issue was due to the fact that when `OnPush` is used, the tooltip text isn't rendered at the moment when the element is positioned.

Fixes #3497.