### PR TITLE
perf(scroll-dispatcher): avoid triggering change detection on scroll

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -534,7 +534,9 @@ describe('ConnectedPositionStrategy', () => {
           fakeElementRef,
           {originX: 'start', originY: 'bottom'},
           {overlayX: 'start', overlayY: 'top'});
-      strategy.withScrollableContainers([new Scrollable(new FakeElementRef(scrollable), null)]);
+
+      strategy.withScrollableContainers([
+          new Scrollable(new FakeElementRef(scrollable), null, null, null)]);
 
       positionChangeHandler = jasmine.createSpy('positionChangeHandler');
       onPositionChangeSubscription = strategy.onPositionChange.subscribe(positionChangeHandler);

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -1,4 +1,4 @@
-import {Injectable, ElementRef, Optional, SkipSelf} from '@angular/core';
+import {Injectable, ElementRef, Optional, SkipSelf, NgZone} from '@angular/core';
 import {Scrollable} from './scrollable';
 import {Subject} from 'rxjs/Subject';
 import {Observable} from 'rxjs/Observable';
@@ -17,6 +17,8 @@ export const DEFAULT_SCROLL_TIME = 20;
  */
 @Injectable()
 export class ScrollDispatcher {
+  constructor(private _ngZone: NgZone) { }
+
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
   _scrolled: Subject<void> = new Subject<void>();
 
@@ -69,10 +71,12 @@ export class ScrollDispatcher {
     this._scrolledCount++;
 
     if (!this._globalSubscription) {
-      this._globalSubscription = Observable.merge(
-        Observable.fromEvent(window.document, 'scroll'),
-        Observable.fromEvent(window, 'resize')
-      ).subscribe(() => this._notify());
+      this._globalSubscription = this._ngZone.runOutsideAngular(() => {
+        return Observable.merge(
+          Observable.fromEvent(window.document, 'scroll'),
+          Observable.fromEvent(window, 'resize')
+        ).subscribe(() => this._notify());
+      });
     }
 
     // Note that we need to do the subscribing from here, in order to be able to remove
@@ -118,13 +122,14 @@ export class ScrollDispatcher {
   }
 }
 
-export function SCROLL_DISPATCHER_PROVIDER_FACTORY(parentDispatcher: ScrollDispatcher) {
-  return parentDispatcher || new ScrollDispatcher();
+export function SCROLL_DISPATCHER_PROVIDER_FACTORY(parentDispatcher: ScrollDispatcher,
+                                                   ngZone: NgZone) {
+  return parentDispatcher || new ScrollDispatcher(ngZone);
 }
 
 export const SCROLL_DISPATCHER_PROVIDER = {
   // If there is already a ScrollDispatcher available, use that. Otherwise, provide a new one.
   provide: ScrollDispatcher,
-  deps: [[new Optional(), new SkipSelf(), ScrollDispatcher]],
+  deps: [[new Optional(), new SkipSelf(), ScrollDispatcher], NgZone],
   useFactory: SCROLL_DISPATCHER_PROVIDER_FACTORY
 };

--- a/src/lib/core/overlay/scroll/scrollable.ts
+++ b/src/lib/core/overlay/scroll/scrollable.ts
@@ -1,5 +1,6 @@
-import {Directive, ElementRef, OnInit, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, OnInit, OnDestroy, NgZone, Renderer} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import 'rxjs/add/observable/fromEvent';
 
@@ -13,22 +14,38 @@ import 'rxjs/add/observable/fromEvent';
   selector: '[cdk-scrollable]'
 })
 export class Scrollable implements OnInit, OnDestroy {
+  private _elementScrolled: Subject<Event> = new Subject();
+  private _scrollListener: Function;
+
   constructor(private _elementRef: ElementRef,
-              private _scroll: ScrollDispatcher) {}
+              private _scroll: ScrollDispatcher,
+              private _ngZone: NgZone,
+              private _renderer: Renderer) {}
 
   ngOnInit() {
+    this._scrollListener = this._ngZone.runOutsideAngular(() => {
+      return this._renderer.listen(this.getElementRef().nativeElement, 'scroll', (event: Event) => {
+        this._elementScrolled.next(event);
+      });
+    });
+
     this._scroll.register(this);
   }
 
   ngOnDestroy() {
     this._scroll.deregister(this);
+
+    if (this._scrollListener) {
+      this._scrollListener();
+      this._scrollListener = null;
+    }
   }
 
   /**
    * Returns observable that emits when a scroll event is fired on the host element.
    */
   elementScrolled(): Observable<any> {
-    return Observable.fromEvent(this._elementRef.nativeElement, 'scroll');
+    return this._elementScrolled.asObservable();
   }
 
   getElementRef(): ElementRef {

--- a/src/lib/core/testing/dispatch-events.ts
+++ b/src/lib/core/testing/dispatch-events.ts
@@ -5,7 +5,7 @@ import {
 } from './event-objects';
 
 /** Shorthand to dispatch a fake event on a specified node. */
-export function dispatchFakeEvent(node: Node, type: string) {
+export function dispatchFakeEvent(node: Node | Window, type: string) {
   node.dispatchEvent(createFakeEvent(type));
 }
 


### PR DESCRIPTION
* Avoids triggering change detection when listening to global scroll events in the `ScrollDispatcher`.
* Avoids triggering change detection when scrolling inside of `Scrollable` instances.
* Switches a `ScrollDispatcher` test to use spies, instead of toggling booleans.