### PR TITLE
chore: remove leftover expression

### DIFF
--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -171,7 +171,7 @@ export class CompatibilityModule {
   }
 
   constructor(@Optional() @Inject(DOCUMENT) document: any) {
-    if (isDevMode() && typeof document && !document.doctype) {
+    if (isDevMode() && document && !document.doctype) {
       console.warn(
         'Current document does not have a doctype. This may cause ' +
         'some Angular Material components not to behave as expected.'


### PR DESCRIPTION
This is a follow-up to #2849. It looks like I was a little too quick to switch the statement and forgot to remove the `typeof`.