### PR TITLE
fix(autocomplete): do not trigger submit on ENTER

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -204,6 +204,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   _handleKeydown(event: KeyboardEvent): void {
     if (this.activeOption && event.keyCode === ENTER) {
       this.activeOption._selectViaInteraction();
+      event.preventDefault();
     } else {
       this.autocomplete._keyManager.onKeydown(event);
       if (event.keyCode === UP_ARROW || event.keyCode === DOWN_ARROW) {

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -611,6 +611,24 @@ describe('MdAutocomplete', () => {
       });
     }));
 
+    it('should not call the default input behaviour when an option is selected with ENTER',
+        async(() => {
+      fixture.whenStable().then(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+
+          spyOn(ENTER_EVENT, 'preventDefault');
+
+          fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+          fixture.detectChanges();
+
+          expect(ENTER_EVENT.preventDefault).toHaveBeenCalled();
+        });
+      });
+    }));
+
     it('should fill the text field, not select an option, when SPACE is entered', async(() => {
       fixture.whenStable().then(() => {
         typeInElement('New', input);

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -611,18 +611,14 @@ describe('MdAutocomplete', () => {
       });
     }));
 
-    it('should not call the default input behaviour when an option is selected with ENTER',
-        async(() => {
+    it('should prevent the default enter key action', async(() => {
       fixture.whenStable().then(() => {
         fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
 
         fixture.whenStable().then(() => {
-          fixture.detectChanges();
-
           spyOn(ENTER_EVENT, 'preventDefault');
 
           fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
-          fixture.detectChanges();
 
           expect(ENTER_EVENT.preventDefault).toHaveBeenCalled();
         });


### PR DESCRIPTION
When an option is selected with the ENTER key, it should not submit the form and prevent the default input behavior

Fixes #3159