### PR TITLE
fix(scroll-dispatcher): unable to unsubscribe from global listener

### DIFF
--- a/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
@@ -89,6 +89,19 @@ describe('Scroll Dispatcher', () => {
       expect(spy).not.toHaveBeenCalled();
       subscription.unsubscribe();
     });
+
+    it('should be able to unsubscribe from the global scrollable', () => {
+      const spy = jasmine.createSpy('global scroll callback');
+      const subscription = scroll.scrolled(0, spy);
+
+      dispatchFakeEvent(document, 'scroll');
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      subscription.unsubscribe();
+      dispatchFakeEvent(document, 'scroll');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Nested scrollables', () => {

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -81,7 +81,9 @@ export class ScrollDispatcher {
 
     // Note that we need to do the subscribing from here, in order to be able to remove
     // the global event listeners once there are no more subscriptions.
-    return observable.subscribe(callback).add(() => {
+    let subscription = observable.subscribe(callback);
+
+    subscription.add(() => {
       this._scrolledCount--;
 
       if (this._globalSubscription && !this.scrollableReferences.size && !this._scrolledCount) {
@@ -89,6 +91,8 @@ export class ScrollDispatcher {
         this._globalSubscription = null;
       }
     });
+
+    return subscription;
   }
 
   /** Returns all registered Scrollables that contain the provided element. */


### PR DESCRIPTION
Fixes not being able to unsubscribe from the global `scrolled` listener.