### PR TITLE
fix(select): allow custom aria-label

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1085,6 +1085,21 @@ describe('MdSelect', () => {
         expect(select.getAttribute('aria-label')).toEqual('Food');
       });
 
+      it('should support setting a custom aria-label', () => {
+        fixture.componentInstance.ariaLabel = 'Custom Label';
+        fixture.detectChanges();
+
+        expect(select.getAttribute('aria-label')).toEqual('Custom Label');
+      });
+
+      it('should not set a aria-label if aria-labelledby is specified', () => {
+        fixture.componentInstance.ariaLabelledby = 'myLabelId';
+        fixture.detectChanges();
+
+        expect(select.getAttribute('aria-label')).toBeFalsy('Expected no aria-label to be set.');
+        expect(select.getAttribute('aria-labelledby')).toBe('myLabelId');
+      });
+
       it('should set the tabindex of the select to 0 by default', () => {
         expect(select.getAttribute('tabindex')).toEqual('0');
       });
@@ -1606,7 +1621,7 @@ describe('MdSelect', () => {
   template: `
     <div [style.height.px]="heightAbove"></div>
     <md-select placeholder="Food" [formControl]="control" [required]="isRequired"
-      [tabIndex]="tabIndexOverride">
+      [tabIndex]="tabIndexOverride" [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby">
       <md-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
         {{ food.viewValue }}
       </md-option>
@@ -1630,6 +1645,8 @@ class BasicSelect {
   heightAbove = 0;
   heightBelow = 0;
   tabIndexOverride: number;
+  ariaLabel: string;
+  ariaLabelledby: string;
 
   @ViewChild(MdSelect) select: MdSelect;
   @ViewChildren(MdOption) options: QueryList<MdOption>;

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1092,7 +1092,7 @@ describe('MdSelect', () => {
         expect(select.getAttribute('aria-label')).toEqual('Custom Label');
       });
 
-      it('should not set a aria-label if aria-labelledby is specified', () => {
+      it('should not set an aria-label if aria-labelledby is specified', () => {
         fixture.componentInstance.ariaLabelledby = 'myLabelId';
         fixture.detectChanges();
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -756,7 +756,7 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
 
   /** Returns the aria-label of the select component. */
   get _ariaLabel(): string {
-    // If a ariaLabelledby value has been set, the select should not overwrite the
+    // If an ariaLabelledby value has been set, the select should not overwrite the
     // `aria-labelledby` value by setting the ariaLabel to the placeholder.
     return this.ariaLabelledby ? null : this.ariaLabel || this.placeholder;
   }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -101,7 +101,8 @@ export type MdSelectFloatPlaceholderType = 'always' | 'never' | 'auto';
   host: {
     'role': 'listbox',
     '[attr.tabindex]': 'tabIndex',
-    '[attr.aria-label]': 'placeholder',
+    '[attr.aria-label]': '_ariaLabel',
+    '[attr.aria-labelledby]': 'ariaLabelledby',
     '[attr.aria-required]': 'required.toString()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': '_control?.invalid || "false"',
@@ -278,6 +279,12 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
       this._tabIndex = value;
     }
   }
+
+  /** Aria label of the select. If not specified, the placeholder will be used as label. */
+  @Input('aria-label') ariaLabel: string = '';
+
+  /** Input that can be used to specify the `aria-labelledby` attribute. */
+  @Input('aria-labelledby') ariaLabelledby: string = '';
 
   /** Combined stream of all of the child options' change events. */
   get optionSelectionChanges(): Observable<MdOptionSelectionChange> {
@@ -745,6 +752,13 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
   _getPlaceholderVisibility(): 'visible'|'hidden' {
     return (this.floatPlaceholder !== 'never' || this._selectionModel.isEmpty()) ?
         'visible' : 'hidden';
+  }
+
+  /** Returns the aria-label of the select component. */
+  get _ariaLabel(): string {
+    // If a ariaLabelledby value has been set, the select should not overwrite the
+    // `aria-labelledby` value by setting the ariaLabel to the placeholder.
+    return this.ariaLabelledby ? null : this.ariaLabel || this.placeholder;
   }
 
   /**


### PR DESCRIPTION
* Adds support for custom `aria-label` attributes on the select host element.
* Also fixes that the `aria-labelledby` attribute is overwritten by the placeholder `aria-label`.

Fixes #3762.