### PR TITLE
build: fix build artifacts

### DIFF
--- a/scripts/release/publish-build-artifacts.sh
+++ b/scripts/release/publish-build-artifacts.sh
@@ -8,7 +8,7 @@ set -e -o pipefail
 # Go to the project root directory
 cd $(dirname $0)/../..
 
-buildDir="dist/@angular/material"
+buildDir="dist/release"
 buildVersion=$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)
 
 commitSha=$(git rev-parse --short HEAD)


### PR DESCRIPTION
* The distribution folder structure has changed, and the path `dist/@angular/material` is no longer valid.