### PR TITLE
fix(autocomplete): not showing panel on first focus in certain cases

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -131,8 +131,9 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
       this._subscribeToClosingActions();
     }
 
-    this._panelOpen = true;
+    this.autocomplete._setVisibility();
     this._floatPlaceholder();
+    this._panelOpen = true;
   }
 
   /** Closes the autocomplete suggestion panel. */

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -101,6 +101,21 @@ describe('MdAutocomplete', () => {
       });
     }));
 
+    it('should show the panel when the first open is after the initial zone stabilization',
+      async(() => {
+        // Note that we're running outside the Angular zone, in order to be able
+        // to test properly without the subscription from `_subscribeToClosingActions`
+        // giving us a false positive.
+        fixture.ngZone.runOutsideAngular(() => {
+          fixture.componentInstance.trigger.openPanel();
+
+          Promise.resolve().then(() => {
+            expect(fixture.componentInstance.panel.showPanel)
+                .toBe(true, `Expected panel to be visible.`);
+          });
+        });
+      }));
+
     it('should close the panel when blurred', async(() => {
       dispatchFakeEvent(input, 'focus');
       fixture.detectChanges();


### PR DESCRIPTION
Fixes a case where the first time an autocomplete is focused by clicking within its input container (note not directly on the input), the panel is invisible, because its `showPanel` flag hasn't been set yet.

Relates to #3722.