### PR TITLE
refactor(focus-origin-monitor): rename unmonitor to stopMonitoring

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -125,7 +125,7 @@ export class MdButton implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._elementRef.nativeElement);
+    this._focusOriginMonitor.stopMonitoring(this._elementRef.nativeElement);
   }
 
   /** The color of the button. Can be `primary`, `accent`, or `warn`. */

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -13,22 +13,11 @@ import {MdCheckbox, MdCheckboxChange, MdCheckboxModule} from './index';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 import {dispatchFakeEvent} from '../core/testing/dispatch-events';
-import {FocusOriginMonitor, FocusOrigin} from '../core';
 import {RIPPLE_FADE_IN_DURATION, RIPPLE_FADE_OUT_DURATION} from '../core/ripple/ripple-renderer';
-import {Subject} from 'rxjs/Subject';
 
 
 describe('MdCheckbox', () => {
   let fixture: ComponentFixture<any>;
-  let fakeFocusOriginMonitorSubject: Subject<FocusOrigin> = new Subject();
-  let fakeFocusOriginMonitor = {
-    monitor: () => fakeFocusOriginMonitorSubject.asObservable(),
-    unmonitor: () => {},
-    focusVia: (element: HTMLElement, renderer: any, focusOrigin: FocusOrigin) => {
-      element.focus();
-      fakeFocusOriginMonitorSubject.next(focusOrigin);
-    }
-  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -45,8 +34,7 @@ describe('MdCheckbox', () => {
         CheckboxWithFormControl,
       ],
       providers: [
-        {provide: ViewportRuler, useClass: FakeViewportRuler},
-        {provide: FocusOriginMonitor, useValue: fakeFocusOriginMonitor}
+        {provide: ViewportRuler, useClass: FakeViewportRuler}
       ]
     });
 
@@ -356,7 +344,9 @@ describe('MdCheckbox', () => {
       expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)
           .toBe(0, 'Expected no ripples on load.');
 
-      fakeFocusOriginMonitorSubject.next('keyboard');
+      dispatchFakeEvent(inputElement, 'keydown');
+      dispatchFakeEvent(inputElement, 'focus');
+
       tick(RIPPLE_FADE_IN_DURATION);
 
       expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -206,12 +206,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._inputElement.nativeElement);
-
-    if (this._focusedSubscription) {
-      this._focusedSubscription.unsubscribe();
-      this._focusedSubscription = null;
-    }
+    this._focusOriginMonitor.stopMonitoring(this._inputElement.nativeElement);
   }
 
   /**

--- a/src/lib/core/style/focus-origin-monitor.spec.ts
+++ b/src/lib/core/style/focus-origin-monitor.spec.ts
@@ -218,7 +218,7 @@ describe('FocusOriginMonitor', () => {
     }, 0);
   }));
 
-  it('should remove classes on unmonitor', async(() => {
+  it('should remove classes on stopMonitoring', async(() => {
     buttonElement.focus();
     fixture.detectChanges();
 
@@ -228,7 +228,7 @@ describe('FocusOriginMonitor', () => {
       expect(buttonElement.classList.length)
           .toBe(2, 'button should have exactly 2 focus classes');
 
-      focusOriginMonitor.unmonitor(buttonElement);
+      focusOriginMonitor.stopMonitoring(buttonElement);
       fixture.detectChanges();
 
       expect(buttonElement.classList.length).toBe(0, 'button should not have any focus classes');

--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -101,7 +101,7 @@ export class FocusOriginMonitor {
    * Stops monitoring an element and removes all focus classes.
    * @param element The element to stop monitoring.
    */
-  unmonitor(element: Element): void {
+  stopMonitoring(element: Element): void {
     let elementInfo = this._elementInfo.get(element);
 
     if (elementInfo) {
@@ -296,7 +296,7 @@ export class CdkMonitorFocus implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._elementRef.nativeElement);
+    this._focusOriginMonitor.stopMonitoring(this._elementRef.nativeElement);
   }
 }
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -456,12 +456,7 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._inputElement.nativeElement);
-
-    if (this._focusOriginMonitorSubscription) {
-      this._focusOriginMonitorSubscription.unsubscribe();
-      this._focusOriginMonitorSubscription = null;
-    }
+    this._focusOriginMonitor.stopMonitoring(this._inputElement.nativeElement);
   }
 
   /** Dispatch change event with current value. */

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -380,7 +380,7 @@ export class MdSlider implements ControlValueAccessor, OnDestroy {
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._elementRef.nativeElement);
+    this._focusOriginMonitor.stopMonitoring(this._elementRef.nativeElement);
   }
 
   _onMouseenter() {


### PR DESCRIPTION
* Renames the `unmonitor` function to `stopMonitoring` (As requested in https://github.com/angular/material2/pull/3739#discussion_r108026958)
* Removes unnecessary code that keeps track of the `FocusOriginMonitor` subscription. After calling `stopMonitoring` the observable will complete.