### PR TITLE
build: silent sass bundling

### DIFF
--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -98,11 +98,10 @@ task(':package:theming', [':bundle:theming-scss'],
 
 /** Bundles all scss requires for theming into a single scss file in the root of the package. */
 task(':bundle:theming-scss', execNodeTask(
-    'scss-bundle',
-    'scss-bundle', [
-    '-e', themingEntryPointPath,
-    '-d', themingBundlePath,
-]));
+  'scss-bundle', 'scss-bundle', ['-e', themingEntryPointPath, '-d', themingBundlePath], {
+    silentStdout: true
+  }
+));
 
 /** Make sure we're logged in. */
 task(':publish:whoami', execTask('npm', ['whoami'], {

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -54,8 +54,10 @@ export function sassBuildTask(dest: string, root: string, minify = false) {
 
 /** Options that can be passed to execTask or execNodeTask. */
 export interface ExecTaskOptions {
-  // Whether to output to STDERR and STDOUT.
+  // Whether STDOUT and STDERR messages should be printed.
   silent?: boolean;
+  // Whether STDOUT messages should be printed.
+  silentStdout?: boolean;
   // If an error happens, this will replace the standard error.
   errMessage?: string;
 }
@@ -65,14 +67,12 @@ export function execTask(binPath: string, args: string[], options: ExecTaskOptio
   return (done: (err?: string) => void) => {
     const childProcess = child_process.spawn(binPath, args);
 
-    if (!options.silent) {
-      childProcess.stdout.on('data', (data: string) => {
-        process.stdout.write(data);
-      });
+    if (!options.silentStdout && !options.silent) {
+      childProcess.stdout.on('data', (data: string) => process.stdout.write(data));
+    }
 
-      childProcess.stderr.on('data', (data: string) => {
-        process.stderr.write(data);
-      });
+    if (!options.silent) {
+      childProcess.stderr.on('data', (data: string) => process.stderr.write(data));
     }
 
     childProcess.on('close', (code: number) => {


### PR DESCRIPTION
* No longer prints the whole SASS file-tree when running the `build:release` task.
* Added a new options that allows disabling STDOUT messages. STDERR is important for error messages.

@jelbourn I was not really sure about the name. I don't wanted to interfere with the `silent` option.