### PR TITLE
fix(select): exception if selected value is accessed on init

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -46,7 +46,8 @@ describe('MdSelect', () => {
         ThrowsErrorOnInit,
         BasicSelectOnPush,
         BasicSelectOnPushPreselected,
-        SelectWithPlainTabindex
+        SelectWithPlainTabindex,
+        SelectEarlyAccessSibling
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -1322,6 +1323,12 @@ describe('MdSelect', () => {
       }).toThrowError(new RegExp('Oh no!', 'g'));
     }));
 
+    it('should not throw when trying to access the selected value on init', async(() => {
+      expect(() => {
+        TestBed.createComponent(SelectEarlyAccessSibling).detectChanges();
+      }).not.toThrow();
+    }));
+
   });
 
   describe('change event', () => {
@@ -1895,6 +1902,15 @@ class MultiSelect {
   `
 })
 class SelectWithPlainTabindex { }
+
+@Component({
+  selector: 'select-early-sibling-access',
+  template: `
+    <md-select #select="mdSelect"></md-select>
+    <div *ngIf="select.selected"></div>
+  `
+})
+class SelectEarlyAccessSibling { }
 
 
 class FakeViewportRuler {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -15,6 +15,7 @@ import {
   ViewChild,
   ChangeDetectorRef,
   Attribute,
+  OnInit,
 } from '@angular/core';
 import {MdOption, MdOptionSelectionChange} from '../core/option/option';
 import {ENTER, SPACE} from '../core/keyboard/keycodes';
@@ -118,7 +119,7 @@ export type MdSelectFloatPlaceholderType = 'always' | 'never' | 'auto';
   ],
   exportAs: 'mdSelect',
 })
-export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestroy {
+export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlValueAccessor {
   /** Whether or not the overlay panel is open. */
   private _panelOpen = false;
 
@@ -304,8 +305,11 @@ export class MdSelect implements AfterContentInit, ControlValueAccessor, OnDestr
     this._tabIndex = parseInt(tabIndex) || 0;
   }
 
-  ngAfterContentInit() {
+  ngOnInit() {
     this._selectionModel = new SelectionModel<MdOption>(this.multiple, null, false);
+  }
+
+  ngAfterContentInit() {
     this._initKeyManager();
 
     this._changeSubscription = this.options.changes.startWith(null).subscribe(() => {


### PR DESCRIPTION
Fixes an error that is thrown if something attempts to access the `selected` value of `md-select` too early. The issue comes from the fact that the underlying `SelectionModel` gets initialized too late in `ngAfterContentInit`.

Fixes #3750.