### PR TITLE
fix(dialog): unable to press escape to close in lazy-loaded module

### DIFF
--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -127,7 +127,6 @@ describe('MdDialog', () => {
     });
   }));
 
-
   it('should close a dialog via the escape key', async(() => {
     dialog.open(PizzaMsg, {
       viewContainerRef: testViewContainerRef
@@ -553,6 +552,17 @@ describe('MdDialog with a parent MdDialog', () => {
             .toBe('', 'Expected closeAll on parent MdDialog to close dialog opened by child');
       });
     }));
+
+  it('should close the top dialog via the escape key', async(() => {
+    childDialog.open(PizzaMsg);
+
+    dispatchKeyboardEvent(document, 'keydown', ESCAPE);
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      expect(overlayContainerElement.querySelector('md-dialog-container')).toBeNull();
+    });
+  }));
 });
 
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -64,7 +64,7 @@ export class MdDialog {
     let dialogRef =
         this._attachDialogContent(componentOrTemplateRef, dialogContainer, overlayRef, config);
 
-    if (!this._openDialogs.length && !this._parentDialog) {
+    if (!this._openDialogs.length) {
       document.addEventListener('keydown', this._boundKeydown);
     }
 
@@ -210,10 +210,9 @@ export class MdDialog {
    */
   private _handleKeydown(event: KeyboardEvent): void {
     let topDialog = this._openDialogs[this._openDialogs.length - 1];
+    let canClose = topDialog ? !topDialog._containerInstance.dialogConfig.disableClose : false;
 
-    if (event.keyCode === ESCAPE && topDialog &&
-      !topDialog._containerInstance.dialogConfig.disableClose) {
-
+    if (event.keyCode === ESCAPE && canClose) {
       topDialog.close();
     }
   }


### PR DESCRIPTION
Fixes not being able to use the escape key to close a dialog that was opened from a lazy-loaded module.

Fixes #3737.