### PR TITLE
feat: remove hard dependency on @angular/http

### DIFF
--- a/src/lib/icon/fake-svgs.ts
+++ b/src/lib/icon/fake-svgs.ts
@@ -1,6 +1,4 @@
-import {
-  Response,
-  ResponseOptions} from '@angular/http';
+import {Response, ResponseOptions} from '@angular/http';
 
 /**
  * Fake URLs and associated SVG documents used by tests.

--- a/src/lib/icon/icon-errors.ts
+++ b/src/lib/icon/icon-errors.ts
@@ -1,0 +1,43 @@
+import {MdError} from '../core';
+
+/**
+ * Exception thrown when attempting to load an icon with a name that cannot be found.
+ * @docs-private
+ */
+export class MdIconNameNotFoundError extends MdError {
+  constructor(iconName: string) {
+    super(`Unable to find icon with the name "${iconName}"`);
+  }
+}
+
+/**
+ * Exception thrown when attempting to load SVG content that does not contain the expected
+ * <svg> tag.
+ * @docs-private
+ */
+export class MdIconSvgTagNotFoundError extends MdError {
+  constructor() {
+    super('<svg> tag not found');
+  }
+}
+
+/**
+ * Exception thrown when the consumer attempts to use `<md-icon>` without including @angular/http.
+ * @docs-private
+ */
+export class MdIconNoHttpProviderError extends MdError {
+  constructor() {
+    super('Could not find Http provider for use with Angular Material icons. ' +
+          'Please include the HttpModule from @angular/http in your app imports.');
+  }
+}
+
+/**
+ * Exception thrown when an invalid icon name is passed to an md-icon component.
+ * @docs-private
+ */
+export class MdIconInvalidNameError extends MdError {
+  constructor(iconName: string) {
+    super(`Invalid icon name: "${iconName}"`);
+  }
+}

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -9,20 +9,10 @@ import {
   SimpleChange,
   ViewEncapsulation,
   AfterViewChecked,
-  Optional,
-  SkipSelf,
 } from '@angular/core';
-import {Http} from '@angular/http';
-import {DomSanitizer} from '@angular/platform-browser';
-import {MdError} from '../core';
-import {MdIconRegistry, MdIconNameNotFoundError} from './icon-registry';
+import {MdIconRegistry} from './icon-registry';
+import {MdIconNameNotFoundError, MdIconInvalidNameError} from './icon-errors';
 
-/** Exception thrown when an invalid icon name is passed to an md-icon component. */
-export class MdIconInvalidNameError extends MdError {
-  constructor(iconName: string) {
-      super(`Invalid icon name: "${iconName}"`);
-  }
-}
 
 /**
  * Component to display an icon. It can be used in the following ways:
@@ -250,15 +240,3 @@ export class MdIcon implements OnChanges, OnInit, AfterViewChecked {
     }
   }
 }
-
-export function ICON_REGISTRY_PROVIDER_FACTORY(
-    parentRegistry: MdIconRegistry, http: Http, sanitizer: DomSanitizer) {
-  return parentRegistry || new MdIconRegistry(http, sanitizer);
-}
-
-export const ICON_REGISTRY_PROVIDER = {
-  // If there is already an MdIconRegistry available, use that. Otherwise, provide a new one.
-  provide: MdIconRegistry,
-  deps: [[new Optional(), new SkipSelf(), MdIconRegistry], Http, DomSanitizer],
-  useFactory: ICON_REGISTRY_PROVIDER_FACTORY,
-};

--- a/src/lib/icon/index.ts
+++ b/src/lib/icon/index.ts
@@ -1,11 +1,11 @@
 import {NgModule} from '@angular/core';
-import {HttpModule} from '@angular/http';
 import {MdCommonModule} from '../core';
-import {MdIcon, ICON_REGISTRY_PROVIDER} from './icon';
+import {MdIcon} from './icon';
+import {ICON_REGISTRY_PROVIDER} from './icon-registry';
 
 
 @NgModule({
-  imports: [HttpModule, MdCommonModule],
+  imports: [MdCommonModule],
   exports: [MdIcon, MdCommonModule],
   declarations: [MdIcon],
   providers: [ICON_REGISTRY_PROVIDER],
@@ -14,4 +14,5 @@ export class MdIconModule {}
 
 
 export * from './icon';
-export {MdIconRegistry} from './icon-registry';
+export * from './icon-errors';
+export * from './icon-registry';

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
     "@angular/core": "^4.0.0",
-    "@angular/common": "^4.0.0",
-    "@angular/http": "^4.0.0"
+    "@angular/common": "^4.0.0"
   }
 }


### PR DESCRIPTION
* Makes `@angular/http` an optional dependency since it is only being used by the icon module. An error will be thrown only if the user runs into something that requires the `HttpModule`.
* Moves the various icon error classes into `icon-errors.ts`.
* Moves the icon registry provider next to the registry itself, instead of in the same file as the icon directive.

Fixes #2616.