### PR TITLE
demo(slide-toggle): fix slide-toggle required demo

### DIFF
--- a/src/demo-app/slide-toggle/slide-toggle-demo.html
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.html
@@ -14,7 +14,7 @@
 
   <p>Example where the slide toggle is required inside of a form.</p>
 
-  <form #form="ngForm" (ngSubmit)="onFormSubmit()">
+  <form #form="ngForm" (ngSubmit)="onFormSubmit()" ngNativeValidate>
 
     <md-slide-toggle name="slideToggle" required ngModel>
       Slide Toggle


### PR DESCRIPTION
Fixes the slide-toggle required demo, where the component will be compared with the native required state.

Basically in the demo, the form should be validated native and should show the browsers popup if the slide-toggle is required.

Caused by breaking change: https://github.com/angular/angular/commit/874243279d5fd2bef567a13e0cef8d0cdf68eec1