### PR TITLE
build: fix serve task

### DIFF
--- a/tools/gulp/tasks/library.ts
+++ b/tools/gulp/tasks/library.ts
@@ -21,8 +21,9 @@ const bundlesDir = DIST_BUNDLES;
 
 const esmMainFile = join(materialDir, 'index.js');
 
+task('library', sequenceTask('clean', 'library:build'));
+
 task('library:build', sequenceTask(
-  'clean',
   ['library:build:esm', 'library:assets'],
   // Inline assets into ESM output.
   'library:assets:inline',

--- a/tools/gulp/tasks/library.ts
+++ b/tools/gulp/tasks/library.ts
@@ -21,7 +21,7 @@ const bundlesDir = DIST_BUNDLES;
 
 const esmMainFile = join(materialDir, 'index.js');
 
-task('library', sequenceTask('clean', 'library:build'));
+task('library:clean-build', sequenceTask('clean', 'library:build'));
 
 task('library:build', sequenceTask(
   ['library:build:esm', 'library:assets'],

--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -5,7 +5,7 @@ import {DIST_MATERIAL} from '../constants';
 gulp.task('lint', ['tslint', 'stylelint', 'madge']);
 
 /** Task that runs madge to detect circular dependencies. */
-gulp.task('madge', ['library:build'], execNodeTask('madge', ['--circular', DIST_MATERIAL]));
+gulp.task('madge', ['library'], execNodeTask('madge', ['--circular', DIST_MATERIAL]));
 
 /** Task to lint Angular Material's scss stylesheets. */
 gulp.task('stylelint', execNodeTask(

--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -5,7 +5,7 @@ import {DIST_MATERIAL} from '../constants';
 gulp.task('lint', ['tslint', 'stylelint', 'madge']);
 
 /** Task that runs madge to detect circular dependencies. */
-gulp.task('madge', ['library'], execNodeTask('madge', ['--circular', DIST_MATERIAL]));
+gulp.task('madge', ['library:clean-build'], execNodeTask('madge', ['--circular', DIST_MATERIAL]));
 
 /** Task to lint Angular Material's scss stylesheets. */
 gulp.task('stylelint', execNodeTask(

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -9,7 +9,7 @@ import {openFirebaseDashboardDatabase} from '../util/firebase';
 const bundlesDir = join(DIST_ROOT, 'bundles');
 
 /** Task which runs test against the size of whole library. */
-task('payload', ['library:build'], () => {
+task('payload', ['library'], () => {
 
   let results = {
     umd_kb: getBundleSize('material.umd.js'),

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -9,7 +9,7 @@ import {openFirebaseDashboardDatabase} from '../util/firebase';
 const bundlesDir = join(DIST_ROOT, 'bundles');
 
 /** Task which runs test against the size of whole library. */
-task('payload', ['library'], () => {
+task('payload', ['library:clean-build'], () => {
 
   let results = {
     umd_kb: getBundleSize('material.umd.js'),

--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -34,7 +34,7 @@ const themingBundlePath = join(DIST_RELEASE, '_theming.scss');
 const prebuiltThemeGlob = join(DIST_MATERIAL, '**/theming/prebuilt/*.css');
 
 task('build:release', sequenceTask(
-  'library:build',
+  'library',
   ':package:release',
 ));
 

--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -34,7 +34,7 @@ const themingBundlePath = join(DIST_RELEASE, '_theming.scss');
 const prebuiltThemeGlob = join(DIST_MATERIAL, '**/theming/prebuilt/*.css');
 
 task('build:release', sequenceTask(
-  'library',
+  'library:clean-build',
   ':package:release',
 ));
 


### PR DESCRIPTION
* Currently when serving the dev-app or e2e-app and changes are recognized, the library task will run. This task clears the whole `dist/` folder and rebuilds then.

* This is problematic because sometimes only the library will be rebuilt and for example the `dev-app` won't rebuild. Once the task finished, the `dev-app` is removed and the serve task will crash.