### PR TITLE
fix: aot runtime issues

### DIFF
--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "experimentalDecorators": true,
+    "outDir": ".",
     "paths": {
       "@angular/material": ["./material"]
     }

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -36,9 +36,6 @@ export {DomPortalHost} from './portal/dom-portal-host';
 // Platform
 export * from './platform/index';
 
-/** @deprecated */
-export {Platform as MdPlatform} from './platform/platform';
-
 // Overlay
 export {Overlay, OVERLAY_PROVIDERS} from './overlay/overlay';
 export {OverlayContainer} from './overlay/overlay-container';
@@ -73,9 +70,6 @@ export {
 
 // Selection
 export * from './selection/selection';
-
-/** @deprecated */
-export {LiveAnnouncer as MdLiveAnnouncer} from './a11y/live-announcer';
 
 export * from './a11y/focus-trap';
 export {InteractivityChecker} from './a11y/interactivity-checker';

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -82,10 +82,6 @@ export {
   UniqueSelectionDispatcherListener,
   UNIQUE_SELECTION_DISPATCHER_PROVIDER,
 } from './coordination/unique-selection-dispatcher';
-/** @deprecated */
-export {
-  UniqueSelectionDispatcher as MdUniqueSelectionDispatcher
-} from './coordination/unique-selection-dispatcher';
 
 export {MdLineModule, MdLine, MdLineSetter} from './line/line';
 


### PR DESCRIPTION
* Currently when using the `MdSnackBar` in AOT, there will be runtime exceptions from the NgFactory. Those are caused by the re-exports of DI tokens.

* Since this deprecation is pretty old we can safely remove it anyways. Although this is probably an Angular that should be reported separately.

* Also fixes the output directory of the `aot` gulp task. Currently it outputs the factories in a wrong directory. (This allows us to serve the aot demo-app in the future)

<p>
<details>
  <summary>More in depth</summary>


  >
  >  The Angular compiler will then look for the first export e.g `MdLiveAnnouncer` and the normal 
  `LiveAnnouncer` export wont be included in the factory.

  > This is breaking at runtime now, because the NgFactory searches for `LiveAnnouncer` but there is only 
  the `LiveAnnouncer` (DI exception)
 </details>
</p>

@jelbourn To be able to detect such runtime issues we should serve the e2e-app with AOT? Also this should be the same issue I already talked to you about.

![image](https://cloud.githubusercontent.com/assets/4987015/24369493/79b5f56a-1324-11e7-8681-42c621cb3213.png)


Fixes #3798.