### PR TITLE
fix: deprecate MaterialModule

### DIFF
--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -71,6 +71,7 @@ const MATERIAL_MODULES = [
   ObserveContentModule
 ];
 
+/** @deprecated */
 @NgModule({
   imports: [
     MdAutocompleteModule.forRoot(),
@@ -111,7 +112,7 @@ const MATERIAL_MODULES = [
 })
 export class MaterialRootModule { }
 
-
+/** @deprecated */
 @NgModule({
   imports: MATERIAL_MODULES,
   exports: MATERIAL_MODULES,


### PR DESCRIPTION
We've found that, with the current state of tree-shaking in the world,
that using an aggregate NgModule like `MaterialModule` leads to tools
not being able to eliminate code for components that aren't used.

In order to ensure that users end up with the smallest code size
possible, we're deprecating MaterialModule, to be removed in the a
subsequent release.

To replace `MaterialModule`, users can create their own "Material"
module within their application (e.g., `GmailMaterialModule`) that
imports only the set of components actually used in the application.