### PR TITLE
chore: remove unused providers in demo-app

### DIFF
--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -1,11 +1,9 @@
 import {Component} from '@angular/core';
-import {UniqueSelectionDispatcher} from '@angular/material';
 
 @Component({
   moduleId: module.id,
   selector: 'button-toggle-demo',
-  templateUrl: 'button-toggle-demo.html',
-  providers: [UniqueSelectionDispatcher],
+  templateUrl: 'button-toggle-demo.html'
 })
 export class ButtonToggleDemo {
   isVertical = false;

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -13,7 +13,6 @@ export class Home {}
 @Component({
   moduleId: module.id,
   selector: 'demo-app',
-  providers: [],
   templateUrl: 'demo-app.html',
   styleUrls: ['demo-app.css'],
   encapsulation: ViewEncapsulation.None,

--- a/src/demo-app/grid-list/grid-list-demo.ts
+++ b/src/demo-app/grid-list/grid-list-demo.ts
@@ -1,13 +1,11 @@
 import {Component} from '@angular/core';
-import {MdIconRegistry} from '@angular/material';
 
 
 @Component({
   moduleId: module.id,
   selector: 'grid-list-demo',
   templateUrl: 'grid-list-demo.html',
-  styleUrls: ['grid-list-demo.css'],
-  providers: [MdIconRegistry]
+  styleUrls: ['grid-list-demo.css']
 })
 export class GridListDemo {
   tiles: any[] = [

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -7,7 +7,6 @@ import {MdIconRegistry} from '@angular/material';
   selector: 'md-icon-demo',
   templateUrl: 'icon-demo.html',
   styleUrls: ['icon-demo.css'],
-  viewProviders: [MdIconRegistry],
   encapsulation: ViewEncapsulation.None,
 })
 export class IconDemo {


### PR DESCRIPTION
* Since the different component modules or the `MaterialModule` now include all necessary providers, the old explicit providers on the demo-app components are unnecessary. Those can be removed safely.