### PR TITLE
fix(slide-toggle): fix unavailable unmonitor call

### DIFF
--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -363,7 +363,7 @@ describe('MdCheckbox', () => {
       expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)
         .toBe(0, 'Expected no ripples to be present.');
 
-      fakeFocusOriginMonitorSubject.next('program');
+      dispatchFakeEvent(inputElement, 'focus');
       tick(RIPPLE_FADE_IN_DURATION);
 
       expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -23,7 +23,6 @@ import {
 } from '../core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Observable} from 'rxjs/Observable';
-import {Subscription} from 'rxjs/Subscription';
 
 export const MD_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -76,9 +75,6 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
 
   /** Reference to the focus state ripple. */
   private _focusRipple: RippleRef;
-
-  /** Subscription to focus-origin changes. */
-  private _focusOriginSubscription: Subscription;
 
   /** Name value will be applied to the input element if present */
   @Input() name: string = null;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -133,18 +133,13 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
   ngAfterContentInit() {
     this._slideRenderer = new SlideToggleRenderer(this._elementRef);
 
-    this._focusOriginSubscription = this._focusOriginMonitor
+    this._focusOriginMonitor
       .monitor(this._inputElement.nativeElement, this._renderer, false)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 
   ngOnDestroy() {
-    this._focusOriginMonitor.unmonitor(this._inputElement.nativeElement);
-
-    if (this._focusOriginSubscription) {
-      this._focusOriginSubscription.unsubscribe();
-      this._focusOriginSubscription = null;
-    }
+    this._focusOriginMonitor.stopMonitoring(this._inputElement.nativeElement);
   }
 
   /**


### PR DESCRIPTION
* Looks like the slide-toggle tests are failing now because we changed `unmonitor` to `stopMonitoring` and the PR didn't have any merge conflicts (This is the second time.. 😩)

* Also fixes the unavailable `fakeFocusMonitorSubject` call. For some reason it didn't throw.