### PR TITLE
fix(select): prevent the panel from going outside the viewport horizontally

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -15,7 +15,7 @@
 
 <ng-template cdk-connected-overlay [origin]="origin" [open]="panelOpen" hasBackdrop (backdropClick)="close()"
   backdropClass="cdk-overlay-transparent-backdrop" [positions]="_positions" [minWidth]="_triggerWidth"
-  [offsetY]="_offsetY" [offsetX]="_offsetX" (attach)="_setScrollTop()" (detach)="close()">
+  [offsetY]="_offsetY" (attach)="_onAttached()" (detach)="close()">
   <div class="mat-select-panel" [@transformPanel]="'showing'" (@transformPanel.done)="_onPanelDone()"
     (keydown)="_keyManager.onKeydown($event)" [style.transformOrigin]="_transformOrigin"
       [class.mat-select-panel-done-animating]="_panelDoneAnimating" [ngClass]="'mat-' + color">


### PR DESCRIPTION
Prevents the select panel from going outside the viewport along the x axis.

Fixes #3504.
Fixes #3831.