### PR TITLE
fix(chips): focus next chip correctly when a middle chip is removed

### DIFF
--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -75,9 +75,14 @@ describe('MdChipList', () => {
     });
 
     describe('on chip destroy', () => {
-      it('focuses the next item', () => {
+      it('focuses the next item', async(() => {
         let array = chips.toArray();
         let midItem = array[2];
+
+        // Next item to focus
+        let nextFocusedItem = array[3];
+        // Spy on its focus() method
+        spyOn(nextFocusedItem, 'focus');
 
         // Focus the middle item
         midItem.focus();
@@ -86,9 +91,14 @@ describe('MdChipList', () => {
         testComponent.remove = 2;
         fixture.detectChanges();
 
-        // It focuses the 4th item (now at index 2)
+        // It focuses the 3th item (now at index 2)
         expect(manager.activeItemIndex).toEqual(2);
-      });
+
+        fixture.whenStable().then(() => {
+          // Expect to focus the next item
+          expect(nextFocusedItem.focus).toHaveBeenCalledTimes(1);
+        });
+      }));
 
       it('focuses the previous item', () => {
         let array = chips.toArray();

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -182,7 +182,10 @@ export class MdChipList implements AfterContentInit {
       if (this._isValidIndex(chipIndex)) {
         // Check whether the chip is the last item
         if (chipIndex < this.chips.length - 1) {
-          this._keyManager.setActiveItem(chipIndex);
+          /** Wait until chip has been removed from children to focus chip at current index */
+          Promise.resolve(null).then(() => {
+            this._keyManager.setActiveItem(chipIndex);
+          });
         } else if (chipIndex - 1 >= 0) {
           this._keyManager.setActiveItem(chipIndex - 1);
         }


### PR DESCRIPTION
there is a need to wait until a middle chip has been removed from children to focus the chip that will be set at the same index.

currently it works fine when you remove the final chip since it just tries to focus the previous chip.

https://github.com/angular/material2/blob/master/src/lib/chips/chip-list.ts#L186-L188

but when a middle chip is removed, it just focuses the same one before its removed so the focus is lost after that.

https://github.com/angular/material2/blob/master/src/lib/chips/chip-list.ts#L180-L185

Here is a plnkr to demonstrate the issue: http://plnkr.co/edit/LdDUdrQ2vuhgVYLfWxj1?p=preview

### Steps to reproduce

- Click on the last chip and see the focus move to the previous chip
- Now click on a middle chip and see the focus go away. (we lose it because of this)

![md-chip-list-focus-bug](https://cloud.githubusercontent.com/assets/5846742/24571997/f936a840-1629-11e7-8dc0-61c02e98b3e2.gif)


### Proposed fix in PR

We need to push the `this._keyManager.setActiveItem(chipIndex);` at the end of the queue of the change detection so it happens after the `chip` has been remove. (removed as a child)