### PR TITLE
fix(list): set explicit box-sizing on icon

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -88,6 +88,7 @@ $mat-dense-list-icon-size: 20px;
     width: $icon-size;
     height: $icon-size;
     font-size: $icon-size;
+    box-sizing: content-box;
     border-radius: 50%;
     padding: 4px;
   }


### PR DESCRIPTION
Sets an explicit `box-sizing` on the icons inside of lists, in order to avoid alignment issues if the consumer uses `border-box` globally.

Fixes #3863.