### PR TITLE
fix(input): allow pointer events on placeholder

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -131,7 +131,6 @@ $mat-input-underline-disabled-background-image:
   top: 0;
 
   font-size: 100%;
-  pointer-events: none;  // We shouldn't catch mouse events (let them through).
   z-index: 1;
   padding-top: 1em;
 
@@ -180,7 +179,6 @@ $mat-input-underline-disabled-background-image:
   width: 100%;
   padding-top: 1em;
   overflow: hidden;
-  pointer-events: none;  // We shouldn't catch mouse events (let them through).
   transform: translate3d(0, 0, 0); // Prevents the label from shifting after the animation is done.
 
   // Keeps the element height since the placeholder text is `position: absolute`.


### PR DESCRIPTION
Removes the `pointer-events: none` from the input placeholder in order to allow for users to bind events to it. Clicking through isn't necessary anyway, because it automatically redirects focus to the underlying input already.