### PR TITLE
fix(MdIcon): import Observable throw static method

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -5,6 +5,7 @@ import {MdError} from '../core';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/do';


### PR DESCRIPTION
Observable.throw is being called without explicitly importing
the throw operator, which was causing exceptions to be raised
when trying to call Observable.throw (since no other module
had patched throw onto the Observable yet).