### PR TITLE
Docs (MdTabGroup): made API References painfully explicit about two-way binding

### DIFF
--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -79,7 +79,7 @@ export class MdTabGroup {
   @Input()
   headerPosition: MdTabHeaderPosition = 'above';
 
-  /** Output to enable support for two-way binding on `selectedIndex`. */
+  /** Output to enable support for two-way binding on (['selectedIndex']) */
   @Output() get selectedIndexChange(): Observable<number> {
     return this.selectChange.map(event => event.index);
   }

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -79,7 +79,7 @@ export class MdTabGroup {
   @Input()
   headerPosition: MdTabHeaderPosition = 'above';
 
-  /** Output to enable support for two-way binding on (['selectedIndex']) */
+  /** Output to enable support for two-way binding on ([selectedIndex]) */
   @Output() get selectedIndexChange(): Observable<number> {
     return this.selectChange.map(event => event.index);
   }


### PR DESCRIPTION
Explicit stated that the two way binding syntax can be used. #3364 