### PR TITLE
Docs (snack-bar-component): added additional files and selectors

### DIFF
--- a/src/examples/example-module.ts
+++ b/src/examples/example-module.ts
@@ -156,7 +156,10 @@ export const EXAMPLE_COMPONENTS = {
   'snack-bar-component': {
     title: 'Snack-bar with a custom component',
     component: SnackBarComponentExample,
-    additionalFiles: ['snack-bar-component-example-snack.html','snack-bar-component-example-snack.css'],
+    additionalFiles: [
+      'snack-bar-component-example-snack.html',
+      'snack-bar-component-example-snack.css'
+    ],
     selectorName: 'SnackBarComponentExample, SnackBarComponentExampleSnack',
   },
   'snack-bar-overview': {title: 'Basic snack-bar', component: SnackBarOverviewExample},

--- a/src/examples/example-module.ts
+++ b/src/examples/example-module.ts
@@ -157,8 +157,7 @@ export const EXAMPLE_COMPONENTS = {
     title: 'Snack-bar with a custom component',
     component: SnackBarComponentExample,
     additionalFiles: [
-      'snack-bar-component-example-snack.html',
-      'snack-bar-component-example-snack.css'
+      'snack-bar-component-example-snack.html', 'snack-bar-component-example-snack.css'
     ],
     selectorName: 'SnackBarComponentExample, SnackBarComponentExampleSnack',
   },

--- a/src/examples/example-module.ts
+++ b/src/examples/example-module.ts
@@ -155,7 +155,9 @@ export const EXAMPLE_COMPONENTS = {
   'slide-toggle-overview': {title: 'Basic slide-toggles', component: SlideToggleOverviewExample},
   'snack-bar-component': {
     title: 'Snack-bar with a custom component',
-    component: SnackBarComponentExample
+    component: SnackBarComponentExample,
+    additionalFiles: ['snack-bar-component-example-snack.html','snack-bar-component-example-snack.css'],
+    selectorName: 'SnackBarComponentExample, SnackBarComponentExampleSnack',
   },
   'snack-bar-overview': {title: 'Basic snack-bar', component: SnackBarOverviewExample},
   'tabs-overview': {title: 'Basic tabs', component: TabsOverviewExample},


### PR DESCRIPTION
put missing files in the additionalFiles array.
* snack-bar-component-example-snack.css
* snack-bar-component-example-snack.html
#3002 

Also note that this is related to #2934 
As adding these files probably wont fix the fact that these additional files don't show up for some reason in the docs.