### PR TITLE
docs(dialog): fix misleading code comment

### DIFF
--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -27,11 +27,12 @@ export class MdDialog {
     return this._parentDialog ? this._parentDialog._openDialogs : this._openDialogsAtThisLevel;
   }
 
-  /** Subject for notifying the user that all open dialogs have finished closing. */
+  /** Subject for notifying the user that a dialog has opened. */
   get _afterOpen(): Subject<MdDialogRef<any>> {
     return this._parentDialog ? this._parentDialog._afterOpen : this._afterOpenAtThisLevel;
   }
-  /** Subject for notifying the user that a dialog has opened. */
+
+  /** Subject for notifying the user that all open dialogs have finished closing. */
   get _afterAllClosed(): Subject<void> {
     return this._parentDialog ?
       this._parentDialog._afterAllClosed : this._afterAllClosedAtThisLevel;
@@ -215,4 +216,3 @@ export class MdDialog {
 function _applyConfigDefaults(config: MdDialogConfig): MdDialogConfig {
   return extendObject(new MdDialogConfig(), config);
 }
-


### PR DESCRIPTION
When reading the source I noticed 2 code comments where positioned above the wrong method. This PR positions the code comments above the correct method again. 

This misleading code comment was introduced here: https://github.com/angular/material2/pull/2522/files