### PR TITLE
ci: run with lts node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - '6.9.4'
+  - '6.10.2'
 
 addons:
   jwt:


### PR DESCRIPTION
* Updates the previous LTS version to the current LTS version of node.

**Note**: CI Fails due to an issue with Travis CI fetching the latest node version. Will re-run travis once fixed on their side.