### PR TITLE
Docs (DialogMd data input): addresses confusion with injecting data

### DIFF
--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -30,16 +30,12 @@ in which they are contained. When closing, an optional result value can be provi
 value is forwarded as the result of the `afterClosed` promise. 
 
 ### Sharing Data with the Dialog component.
-Depending on what you are doing you might want to share data with your dialog component. The dialog component has a data option that you can include in order to pass data from the open to the dialog. 
+Depending on what you are doing you might want to share data with your dialog component. The dialog component has a `data` option allowing you to pass data to the component.
 
 Passing outside data to your component is as simple as.
 ```ts
-import {MdDialog} from '@angular/material';
-
-private dialog: MdDialog;
-
 let dialogRef = dialog.open(DialogName, {
-  data:'your data',
+  data: 'your data',
 });
 ```
 
@@ -49,11 +45,11 @@ import {Component, Inject} from '@angular/core';
 import {MD_DIALOG_DATA} from '@angular/material';
 
 @Component({
-  selector: 'dialog-selector',
+  selector: 'your-dialog',
   template: 'passed in {{ data }}',
 })
 
-export class DialogName {
+export class YourDialog {
   constructor(@Inject(MD_DIALOG_DATA) public data: any) { }
 }
 ```

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -33,7 +33,7 @@ value is forwarded as the result of the `afterClosed` promise.
 If you want to share data with your dialog, you can use the `data` option to pass information to the dialog component.
 
 ```ts
-let dialogRef = dialog.open(DialogName, {
+let dialogRef = dialog.open(YourDialog, {
   data: 'your data',
 });
 ```

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -29,6 +29,33 @@ Components created via `MdDialog` can _inject_ `MdDialogRef` and use it to close
 in which they are contained. When closing, an optional result value can be provided. This result
 value is forwarded as the result of the `afterClosed` promise. 
 
+### Sharing Data with the Dialog component.
+Depending on what you are doing you might want to share data with your dialog component. Angular has documentation that explains in general how to share data between any components using [`services`](https://angular.io/docs/ts/latest/cookbook/component-communication.html#!#bidirectional-service).
+
+Passing outside data to your component is as simple as.
+```ts
+let dialogRef = dialog.open(DialogName, {
+  data:'your data',
+});
+```
+
+Here is an example component you can pass data to.
+```ts
+import {Component, Inject} from '@angular/core';
+import {MdDialog, MD_DIALOG_DATA} from '@angular/material';
+
+@Component({
+  selector: 'dialog-selector',
+  template: 'passed in {{ data }}',
+})
+
+export class DialogName {
+  constructor@Inject(MD_DIALOG_DATA) public data: any) { }
+}
+```
+ 
+
+
 ### Dialog content
 Several directives are available to make it easier to structure your dialog content:
 

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -50,7 +50,7 @@ import {MdDialog, MD_DIALOG_DATA} from '@angular/material';
 })
 
 export class DialogName {
-  constructor@Inject(MD_DIALOG_DATA) public data: any) { }
+  constructor( @Inject(MD_DIALOG_DATA) public data: any ) { }
 }
 ```
  

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -30,10 +30,14 @@ in which they are contained. When closing, an optional result value can be provi
 value is forwarded as the result of the `afterClosed` promise. 
 
 ### Sharing Data with the Dialog component.
-Depending on what you are doing you might want to share data with your dialog component. Angular has documentation that explains in general how to share data between any components using [`services`](https://angular.io/docs/ts/latest/cookbook/component-communication.html#!#bidirectional-service).
+Depending on what you are doing you might want to share data with your dialog component. The dialog component has a data option that you can include in order to pass data from the open to the dialog. 
 
 Passing outside data to your component is as simple as.
 ```ts
+import {MdDialog} from '@angular/material';
+
+private dialog: MdDialog;
+
 let dialogRef = dialog.open(DialogName, {
   data:'your data',
 });
@@ -42,7 +46,7 @@ let dialogRef = dialog.open(DialogName, {
 Here is an example component you can pass data to.
 ```ts
 import {Component, Inject} from '@angular/core';
-import {MdDialog, MD_DIALOG_DATA} from '@angular/material';
+import {MD_DIALOG_DATA} from '@angular/material';
 
 @Component({
   selector: 'dialog-selector',
@@ -50,7 +54,7 @@ import {MdDialog, MD_DIALOG_DATA} from '@angular/material';
 })
 
 export class DialogName {
-  constructor( @Inject(MD_DIALOG_DATA) public data: any ) { }
+  constructor(@Inject(MD_DIALOG_DATA) public data: any) { }
 }
 ```
  

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -29,17 +29,16 @@ Components created via `MdDialog` can _inject_ `MdDialogRef` and use it to close
 in which they are contained. When closing, an optional result value can be provided. This result
 value is forwarded as the result of the `afterClosed` promise. 
 
-### Sharing Data with the Dialog component.
-Depending on what you are doing you might want to share data with your dialog component. The dialog component has a `data` option allowing you to pass data to the component.
+### Sharing data with the Dialog component.
+If you want to share data with your dialog, you can use the `data` option to pass information to the dialog component.
 
-Passing outside data to your component is as simple as.
 ```ts
 let dialogRef = dialog.open(DialogName, {
   data: 'your data',
 });
 ```
 
-Here is an example component you can pass data to.
+To access the data in your dialog component, you have to use the MD_DIALOG_DATA injection token:
 ```ts
 import {Component, Inject} from '@angular/core';
 import {MD_DIALOG_DATA} from '@angular/material';
@@ -53,8 +52,6 @@ export class YourDialog {
   constructor(@Inject(MD_DIALOG_DATA) public data: any) { }
 }
 ```
- 
-
 
 ### Dialog content
 Several directives are available to make it easier to structure your dialog content:


### PR DESCRIPTION
* Explained that services are a best practice if you need to pass data back and forth, depending on use case.
* Added an example to show how to inject data into a Dialog.
Fixes #1947 