### PR TITLE
fix (Menus): max-height: calc(100vh + 48px); and goes off page

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -12,8 +12,8 @@ $mat-menu-vertical-padding: 8px !default;
   @include mat-menu-base();
   @include mat-menu-positions();
 
-  // max height must be 100% of the viewport height + one row height
-  max-height: calc(100vh + 48px);
+  // max height must be 100% of the viewport height - one row height
+  max-height: calc(100vh - 48px);
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
The Material Design spec says the max height of a menu should be one row height less than the page height.

Fixes #2725 

Brings up more questions like:
* Is there a minimum height in the MD spec?
* Should vh really be used because menus can be inside of components?