### PR TITLE
style(menu): apply theme bg color to menu panel rather than content

### DIFF
--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -6,7 +6,7 @@
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
-  .mat-menu-content {
+  .mat-menu-panel {
     background: mat-color($background, 'card');
   }
 


### PR DESCRIPTION
Previously, the menu's background opacity did not start animating until the menu had scaled to it's full size, despite the menu's drop shadow existing through the animation.

![before-menu-light](https://cloud.githubusercontent.com/assets/6475576/24773757/6353d11c-1ae4-11e7-9931-98ac5e38d9cb.gif)

Now, the menu's background opacity transitions in sync with the scaling. The content transitions in after scaling is nearly complete.

![after-menu-light](https://cloud.githubusercontent.com/assets/6475576/24773760/67c2101a-1ae4-11e7-980a-b17a89d79bb9.gif)

[*animations are slowed down 10x*]

cc @kara 