### PR TITLE
Fix Beta 3 release notes typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ possible, we're deprecating MaterialModule, to be removed in the a
 subsequent release.
 
 To replace `MaterialModule`, users can create their own "Material"
-modul within their application (e.g., `GmailMaterialModule`) that
+module within their application (e.g., `GmailMaterialModule`) that
 imports only the set of components actually used in the application.
 
 #### Angular 4


### PR DESCRIPTION
Modul is used instead of module

See: https://github.com/angular/material2/issues/3961