### PR TITLE
guides(getting-started): update `MaterialModule` section

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -43,19 +43,20 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 export class PizzaPartyAppModule { }
 ```
 
-## Step 3: Import the Module
+## Step 3: Create Your "Material" Module
 
-Add MaterialModule as an import in your app's root NgModule.
+Create a module that imports and exports modules of material components your app uses and add it as an import in your app's root NgModule. Read more about module creation at [angular.io](https://angular.io/docs/ts/latest/guide/ngmodule.html#!#shared-module).
 
 ```ts
-import {MaterialModule} from '@angular/material';
+import {MdButtonModule, MdInputModule} from '@angular/material';
 
 @NgModule({
   ...
-  imports: [MaterialModule],
+  imports: [MdButtonModule, MdInputModule],
+  exports: [MdButtonModule, MdInputModule],
   ...
 })
-export class PizzaPartyAppModule { }
+export class MyMaterialModule { }
 ```
 
 ## Step 4: Include Theming


### PR DESCRIPTION
should close https://github.com/angular/material2/issues/3973

I'm not 100% sure this is necessary just yet, since `MaterialModule` was only marked as deprecated, not removed, so it's up to you.