### PR TITLE
Fixed stylesheet path to match the relevant path that is produced by …

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -65,7 +65,7 @@ Including a theme is **required** to apply all of the core and theme styles to y
 To get started with a prebuilt theme, include the following in your app's index.html:
 
 ```html
-<link href="node_modules/@angular/material/prebuilt-themes/indigo-pink.css" rel="stylesheet">
+<link href="../node_modules/@angular/material/prebuilt-themes/indigo-pink.css" rel="stylesheet">
 ```
 
 Note that your app's project structure may have a different relative location for your node_modules.


### PR DESCRIPTION
…ngCLI

Using the CLI is recommended at the top, therefore, the path in the example should match for a project produced from  ng new <project>

Also, The Path on the website itself is not updated (very different)