### PR TITLE
test(menu): Fix intermitent failure in e2e test

### DIFF
--- a/e2e/components/menu/menu-page.ts
+++ b/e2e/components/menu/menu-page.ts
@@ -11,7 +11,7 @@ export class MenuPage {
 
   triggerTwo(): ElementFinder { return element(by.id('trigger-two')); }
 
-  backdrop(): ElementFinder { return element(by.css('.cdk-overlay-backdrop')); }
+  backdrop(): ElementFinder { return element(by.css('.cdk-overlay-backdrop-showing')); }
 
   items(index: number): ElementFinder { return element.all(by.css('[md-menu-item]')).get(index); }
 


### PR DESCRIPTION
This test fails intermittently due to the fact that there can be a scenario where there are multiple `.cdk-overlay-backdrop` elements and the first one is not clickable. Having the test click the `showing` overlay consistently passes the test.  

Fix #3838