### PR TITLE
fix(checkbox): do not set `indeterminate` when set `checked` programmatically

### DIFF
--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -101,7 +101,7 @@ describe('MdCheckbox', () => {
       expect(inputElement.indeterminate).toBe(false);
     });
 
-    it('should set indeterminate to false when set checked', async(() => {
+    it('should set indeterminate to false when input clicked', async(() => {
       testComponent.isIndeterminate = true;
       fixture.detectChanges();
 
@@ -109,7 +109,7 @@ describe('MdCheckbox', () => {
       expect(inputElement.indeterminate).toBe(true);
       expect(testComponent.isIndeterminate).toBe(true);
 
-      testComponent.isChecked = true;
+      inputElement.click();
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -127,7 +127,7 @@ describe('MdCheckbox', () => {
         expect(inputElement.checked).toBe(true);
         expect(testComponent.isIndeterminate).toBe(true);
 
-        testComponent.isChecked = false;
+        inputElement.click();
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
@@ -136,6 +136,38 @@ describe('MdCheckbox', () => {
           expect(inputElement.indeterminate).toBe(false);
           expect(inputElement.checked).toBe(false);
           expect(testComponent.isIndeterminate).toBe(false);
+        });
+      });
+
+    }));
+
+    it('should not set indeterminate to false when checked is set programmatically', async(() => {
+      testComponent.isIndeterminate = true;
+      fixture.detectChanges();
+
+      expect(checkboxInstance.indeterminate).toBe(true);
+      expect(inputElement.indeterminate).toBe(true);
+      expect(testComponent.isIndeterminate).toBe(true);
+
+      testComponent.isChecked = true;
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(checkboxInstance.checked).toBe(true);
+        expect(inputElement.indeterminate).toBe(true);
+        expect(inputElement.checked).toBe(true);
+        expect(testComponent.isIndeterminate).toBe(true);
+
+        testComponent.isChecked = false;
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(checkboxInstance.checked).toBe(false);
+          expect(inputElement.indeterminate).toBe(true);
+          expect(inputElement.checked).toBe(false);
+          expect(testComponent.isIndeterminate).toBe(true);
         });
       });
 
@@ -216,11 +248,11 @@ describe('MdCheckbox', () => {
       expect(checkboxInstance.checked).toBe(false);
     });
 
-    it('should overwrite indeterminate state when checked is re-set', async(() => {
+    it('should overwrite indeterminate state when clicked', async(() => {
       testComponent.isIndeterminate = true;
       fixture.detectChanges();
 
-      testComponent.isChecked = true;
+      inputElement.click();
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -152,25 +152,18 @@ describe('MdCheckbox', () => {
       testComponent.isChecked = true;
       fixture.detectChanges();
 
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        expect(checkboxInstance.checked).toBe(true);
-        expect(inputElement.indeterminate).toBe(true);
-        expect(inputElement.checked).toBe(true);
-        expect(testComponent.isIndeterminate).toBe(true);
+      expect(checkboxInstance.checked).toBe(true);
+      expect(inputElement.indeterminate).toBe(true);
+      expect(inputElement.checked).toBe(true);
+      expect(testComponent.isIndeterminate).toBe(true);
 
-        testComponent.isChecked = false;
-        fixture.detectChanges();
+      testComponent.isChecked = false;
+      fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          expect(checkboxInstance.checked).toBe(false);
-          expect(inputElement.indeterminate).toBe(true);
-          expect(inputElement.checked).toBe(false);
-          expect(testComponent.isIndeterminate).toBe(true);
-        });
-      });
-
+      expect(checkboxInstance.checked).toBe(false);
+      expect(inputElement.indeterminate).toBe(true);
+      expect(inputElement.checked).toBe(false);
+      expect(testComponent.isIndeterminate).toBe(true);
     }));
 
     it('should change native element checked when check programmatically', () => {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -203,8 +203,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   }
 
   /**
-   * Whether the checkbox is checked. Note that setting `checked` will immediately set
-   * `indeterminate` to false.
+   * Whether the checkbox is checked.
    */
   @Input() get checked() {
     return this._checked;
@@ -212,12 +211,6 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
 
   set checked(checked: boolean) {
     if (checked != this.checked) {
-      if (this._indeterminate) {
-        Promise.resolve().then(() => {
-          this._indeterminate = false;
-          this.indeterminateChange.emit(this._indeterminate);
-        });
-      }
       this._checked = checked;
       this._changeDetectorRef.markForCheck();
     }
@@ -226,11 +219,8 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   /**
    * Whether the checkbox is indeterminate. This is also known as "mixed" mode and can be used to
    * represent a checkbox with three states, e.g. a checkbox that represents a nested list of
-   * checkable items. Note that whenever `checked` is set, indeterminate is immediately set to
-   * false. This differs from the web platform in that indeterminate state on native
-   * checkboxes is only remove when the user manually checks the checkbox (rather than setting the
-   * `checked` property programmatically). However, we feel that this behavior is more accommodating
-   * to the way consumers would envision using this component.
+   * checkable items. Note that whenever checkbox is manually clicked, indeterminate is immediately
+   * set to false.
    */
   @Input() get indeterminate() {
     return this._indeterminate;
@@ -371,6 +361,14 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
     this._removeFocusRipple();
 
     if (!this.disabled) {
+      // When user manually click on the checkbox, `indeterminate` is set to false.
+      if (this._indeterminate) {
+        Promise.resolve().then(() => {
+          this._indeterminate = false;
+          this.indeterminateChange.emit(this._indeterminate);
+        });
+      }
+
       this.toggle();
       this._transitionCheckState(
         this._checked ? TransitionCheckState.Checked : TransitionCheckState.Unchecked);


### PR DESCRIPTION
- Only set `indeterminate` when user manually click on the checkbox
- Fixes #2883