### PR TITLE
build: dgeni add deprecated marker

### DIFF
--- a/tools/dgeni/processors/categorizer.js
+++ b/tools/dgeni/processors/categorizer.js
@@ -68,14 +68,11 @@ module.exports = function categorizer() {
   }
 
   /**
-   * Decorates public exposed docs. Creates a property with CSS classes that will be 
-   * added to the template.
+   * Decorates public exposed docs. Creates a property on the doc that indicates whether
+   * the item is deprecated or not.
    **/
   function decoratePublicDoc(doc) {
-    // Specific classes that will can added to the Dgeni doc template.
-    doc.docClasses = [
-      isDeprecatedDoc(doc) ? 'docs-api-deprecated' : ''
-    ].join(' ');
+    doc.isDeprecated = isDeprecatedDoc(doc);
   }
 };
 

--- a/tools/dgeni/processors/categorizer.js
+++ b/tools/dgeni/processors/categorizer.js
@@ -28,6 +28,8 @@ module.exports = function categorizer() {
     classDoc.methods.forEach(doc => decorateMethodDoc(doc));
     classDoc.properties.forEach(doc => decoratePropertyDoc(doc));
 
+    decoratePublicDoc(classDoc);
+    
     // Categorize the current visited classDoc into its Angular type.
     if (isDirective(classDoc)) {
       classDoc.isDirective = true;
@@ -45,6 +47,7 @@ module.exports = function categorizer() {
    */
   function decorateMethodDoc(methodDoc) {
     normalizeMethodParameters(methodDoc);
+    decoratePublicDoc(methodDoc);
 
     // Mark methods with a `void` return type so we can omit show the return type in the docs.
     methodDoc.showReturns = methodDoc.returnType && methodDoc.returnType != 'void';
@@ -55,11 +58,24 @@ module.exports = function categorizer() {
    * outputs will be marked. Aliases for the inputs or outputs will be stored as well.
    */
   function decoratePropertyDoc(propertyDoc) {
+    decoratePublicDoc(propertyDoc);
+
     propertyDoc.isDirectiveInput = isDirectiveInput(propertyDoc);
     propertyDoc.directiveInputAlias = getDirectiveInputAlias(propertyDoc);
 
     propertyDoc.isDirectiveOutput = isDirectiveOutput(propertyDoc);
     propertyDoc.directiveOutputAlias = getDirectiveOutputAlias(propertyDoc);
+  }
+
+  /**
+   * Decorates public exposed docs. Creates a property with CSS classes that will be 
+   * added to the template.
+   **/
+  function decoratePublicDoc(doc) {
+    // Specific classes that will can added to the Dgeni doc template.
+    doc.docClasses = [
+      isDeprecatedDoc(doc) ? 'docs-api-deprecated' : ''
+    ].join(' ');
   }
 };
 
@@ -144,6 +160,10 @@ function isDirectiveOutput(doc) {
 
 function isDirectiveInput(doc) {
   return hasMemberDecorator(doc, 'Input');
+}
+
+function isDeprecatedDoc(doc) {
+  return (doc.tags && doc.tags.tags || []).some(tag => tag.tagName === 'deprecated');
 }
 
 function getDirectiveInputAlias(doc) {

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -1,15 +1,17 @@
-<div class="{$ class.docClasses $}">
-  <h4 class="docs-api-h4 docs-api-class-name">
-    <code>{$ class.name $}</code>
-  </h4>
-  <p class="docs-api-class-description">{$ class.description $}</p>
+<h4 class="docs-api-h4 docs-api-class-name">
+  <code>{$ class.name $}</code>
+</h4>
+<p class="docs-api-class-description">{$ class.description $}</p>
 
-  {%- if class.directiveExportAs -%}
-  <span class="docs-api-h4 docs-api-class-export-label">Exported as:</span>
-  <span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
-  {%- endif -%}
+{%- if class.directiveExportAs -%}
+<span class="docs-api-h4 docs-api-class-export-label">Exported as:</span>
+<span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
+{%- endif -%}
 
-  {$ propertyList(class.properties) $}
+{%- if class.isDeprecated -%}
+<div class="docs-api-class-deprecated-marker">Deprecated</div>
+{%- endif -%}   
 
-  {$ methodList(class.methods) $}
-</div>
+{$ propertyList(class.properties) $}
+
+{$ methodList(class.methods) $}

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -1,13 +1,15 @@
-<h4 class="docs-api-h4 docs-api-class-name">
-  <code>{$ class.name $}</code>
-</h4>
-<p class="docs-api-class-description">{$ class.description $}</p>
+<div class="{$ class.docClasses $}">
+  <h4 class="docs-api-h4 docs-api-class-name">
+    <code>{$ class.name $}</code>
+  </h4>
+  <p class="docs-api-class-description">{$ class.description $}</p>
 
-{%- if class.directiveExportAs -%}
-<span class="docs-api-h4 docs-api-class-export-label">Exported as:</span>
-<span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
-{%- endif -%}
+  {%- if class.directiveExportAs -%}
+  <span class="docs-api-h4 docs-api-class-export-label">Exported as:</span>
+  <span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
+  {%- endif -%}
 
-{$ propertyList(class.properties) $}
+  {$ propertyList(class.properties) $}
 
-{$ methodList(class.methods) $}
+  {$ methodList(class.methods) $}
+</div>

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -1,7 +1,12 @@
-<table class="docs-api-method-table {$ method.docClasses $}">
+<table class="docs-api-method-table">
   <thead>
     <tr class="docs-api-method-name-row">
-      <th colspan="2" class="docs-api-method-name-cell">{$ method.name $}</th>
+      <th colspan="2" class="docs-api-method-name-cell">
+        {%- if method.isDeprecated -%}
+          <div class="docs-api-deprecated-marker">Deprecated</div>
+        {%- endif -%}   
+        {$ method.name $}
+      </th>
     </tr>
   </thead>
   <tr class="docs-api-method-description-row">

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -1,4 +1,4 @@
-<table class="docs-api-method-table">
+<table class="docs-api-method-table {$ method.docClasses $}">
   <thead>
     <tr class="docs-api-method-name-row">
       <th colspan="2" class="docs-api-method-name-cell">{$ method.name $}</th>

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -1,4 +1,4 @@
-<tr class="docs-api-properties-row {$ property.docClasses $}">
+<tr class="docs-api-properties-row">
   <td class="docs-api-properties-name-cell">
     {%- if property.isDirectiveInput -%}
       <div class="docs-api-input-marker">
@@ -18,6 +18,9 @@
         {%- endif -%}
       </div>
     {%- endif -%}
+    {%- if property.isDeprecated -%}
+      <div class="docs-api-deprecated-marker">Deprecated</div>
+    {%- endif -%}   
 
     <p class="docs-api-property-name">
       {$ property.name $}

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -1,4 +1,4 @@
-<tr class="docs-api-properties-row">
+<tr class="docs-api-properties-row {$ property.docClasses $}">
   <td class="docs-api-properties-name-cell">
     {%- if property.isDirectiveInput -%}
       <div class="docs-api-input-marker">


### PR DESCRIPTION
* Adds a class in docs templates that can be used to distinguish between deprecated and stable APIs.

Fixes #3981.