### PR TITLE
Docs (Components / Coding Standards): fix typos.

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -143,7 +143,7 @@ All public APIs must have user-facing comments. These are extracted and shown in
 on [material.angular.io](https://material.angular.io).
 
 Private and internal APIs should have JsDoc when they are not obvious. Ultimately it is the purview
-of the code reviwer as to what is "obvious", but the rule of thumb is that *most* classes,
+of the code reviewer as to what is "obvious", but the rule of thumb is that *most* classes,
 properties, and methods should have a JsDoc description.
 
 Properties should have a concise description of what the property means:

--- a/src/lib/list/list.md
+++ b/src/lib/list/list.md
@@ -44,7 +44,7 @@ element in an `<md-list-item>`.
 
 ### Multi-line lists
 For lists that require multiple lines per item, annotate each line with an `md-line` attribute.
-Whichever heading tag is appropriate for your DOM hierarchy should be used (not necesarily `<h3>`
+Whichever heading tag is appropriate for your DOM hierarchy should be used (not necessarily `<h3>`
 as shown in the example).
 
 ```html

--- a/src/lib/snack-bar/snack-bar.md
+++ b/src/lib/snack-bar/snack-bar.md
@@ -16,7 +16,7 @@ let snackBarRef = snackbar.openFromComponent(MessageArchivedComponent);
 ```
 
 In either case, an `MdSnackBarRef` is returned. This can be used to dismiss the snack-bar or to 
-recieve notification of when the snack-bar is dismissed. For simple messages with an action, the 
+receive notification of when the snack-bar is dismissed. For simple messages with an action, the 
 `MdSnackBarRef` exposes an observable for when the action is triggered.
 
 ```ts

--- a/src/lib/toolbar/toolbar.md
+++ b/src/lib/toolbar/toolbar.md
@@ -4,7 +4,7 @@
 
 ### Multiple rows
 Toolbars can have multiple rows using `<md-toolbar-row>` elements. Any content outside of an 
-`<md-toolbar-row>` element are automatically placed inside of one at the begining of the toolbar.
+`<md-toolbar-row>` element are automatically placed inside of one at the beginning of the toolbar.
 Each toolbar row is a `display: flex` container.
 
 ```html


### PR DESCRIPTION
reviwer -> reviewer
necesarily -> necessarily
recieve -> receive
begining -> beginning

