### PR TITLE
fix: add camelCase selectors for cdk directives

### DIFF
--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -42,7 +42,7 @@ let defaultPositionList = [
  * ConnectedPositionStrategy.
  */
 @Directive({
-  selector: '[cdk-overlay-origin], [overlay-origin]',
+  selector: '[cdk-overlay-origin], [overlay-origin], [cdkOverlayOrigin]',
   exportAs: 'cdkOverlayOrigin',
 })
 export class OverlayOrigin {
@@ -55,7 +55,7 @@ export class OverlayOrigin {
  * Directive to facilitate declarative creation of an Overlay using a ConnectedPositionStrategy.
  */
 @Directive({
-  selector: '[cdk-connected-overlay], [connected-overlay]',
+  selector: '[cdk-connected-overlay], [connected-overlay], [cdkConnectedOverlay]',
   exportAs: 'cdkConnectedOverlay'
 })
 export class ConnectedOverlayDirective implements OnDestroy {

--- a/src/lib/core/overlay/scroll/scrollable.ts
+++ b/src/lib/core/overlay/scroll/scrollable.ts
@@ -11,7 +11,7 @@ import 'rxjs/add/observable/fromEvent';
  * can be listened to through the service.
  */
 @Directive({
-  selector: '[cdk-scrollable]'
+  selector: '[cdk-scrollable], [cdkScrollable]'
 })
 export class Scrollable implements OnInit, OnDestroy {
   private _elementScrolled: Subject<Event> = new Subject();

--- a/src/lib/core/portal/portal-directives.ts
+++ b/src/lib/core/portal/portal-directives.ts
@@ -22,7 +22,7 @@ import {Portal, TemplatePortal, ComponentPortal, BasePortalHost} from './portal'
  * </ng-template>
  */
 @Directive({
-  selector: '[cdk-portal], [portal]',
+  selector: '[cdk-portal], [cdkPortal], [portal]',
   exportAs: 'cdkPortal',
 })
 export class TemplatePortalDirective extends TemplatePortal {


### PR DESCRIPTION
Some of the cdk directives used the incorrect selector style. This
change adds the proper camelCase selectors. The dash-case selectors will
be considered deprecated in the next release and then removed in a
subsequent release.