### PR TITLE
build: fix karma pattern warnings

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,9 +35,10 @@ module.exports = (config) => {
       // Include a Material theme in the test suite.
       {pattern: 'dist/**/core/theming/prebuilt/indigo-pink.css', included: true, watched: true},
 
-      {pattern: 'dist/packages/material/**/*', included: false, watched: true},
+      // Includes Material spec and source files into karma. Those files will be watched.
+      {pattern: 'dist/packages/material/**/*.js', included: false, watched: true},
 
-      // paths to support debugging with source maps in dev tools
+      // Paths to support debugging with source maps in dev tools
       {pattern: 'dist/**/*.ts', included: false, watched: false},
       {pattern: 'dist/**/*.js.map', included: false, watched: false}
     ],


### PR DESCRIPTION
* Fixes the karma pattern warnings. Those showed up because there was a pattern that included all files (and watched them)

* Therefore it no longer watches the `.map` files.

<img width="1035" alt="screen shot 2017-04-12 at 10 22 04" src="https://cloud.githubusercontent.com/assets/4987015/24970684/1d76610c-1f6a-11e7-9e22-9ab77edf8bf9.png">

