### PR TITLE
fix(tabs): unnecessary scrollbar if content has a margin

### DIFF
--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,3 +1,4 @@
 .mat-tab-body-content {
   height: 100%;
+  overflow: auto;
 }


### PR DESCRIPTION
Fixes the tabs having a scrollbar if their inner content has a margin. This seems to be a side-effect of #3162.

Fixes #4035.