### PR TITLE
build: publish material-examples package

### DIFF
--- a/scripts/release/publish-docs-content.sh
+++ b/scripts/release/publish-docs-content.sh
@@ -6,14 +6,13 @@
 cd "$(dirname $0)/../../"
 
 docsPath="./dist/docs"
+packagePath="./dist/releases/material-examples"
 repoPath="/tmp/material2-docs-content"
 repoUrl="https://github.com/angular/material2-docs-content"
 examplesSource="./dist/docs/examples"
 
-# If the docs directory is not present, generate docs
-if [ ! -d $docsPath ]; then
-  $(npm bin)/gulp docs
-fi
+$(npm bin)/gulp examples:release
+$(npm bin)/gulp docs
 
 # Get git meta info for commit
 commitSha="$(git rev-parse --short HEAD)"
@@ -28,14 +27,15 @@ git clone $repoUrl $repoPath
 
 # Clean out repo directory and copy contents of dist/docs into it
 rm -rf $repoPath/*
-mkdir $repoPath/overview
-mkdir $repoPath/guides
-mkdir $repoPath/api
-mkdir $repoPath/examples
-mkdir $repoPath/plunker
+
+# Create folders that will contain docs content files.  
+mkdir $repoPath/{overview,guides,api,examples,plunker,examples-package}
 
 # Copy api files over to $repoPath/api
 cp -r $docsPath/api/* $repoPath/api
+
+# Copy the material-examples package to the docs content repository.
+cp -r $packagePath/* $repoPath/examples-package
 
 # Flatten the markdown docs structure and move it into $repoPath/overview
 overviewFiles=$docsPath/markdown/

--- a/scripts/release/publish-docs-content.sh
+++ b/scripts/release/publish-docs-content.sh
@@ -65,7 +65,7 @@ done
 cp -r $examplesSource/* $repoPath/examples
 
 # Copy example plunker assets
-rsync -a $docsPath/plunker $repoPath/plunker
+cp -r $docsPath/plunker/* $repoPath/plunker
 
 # Copies assets over to the docs-content repository.
 cp LICENSE $repoPath/

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -88,7 +88,7 @@ task('highlight-examples', () => {
     path.basename = `${path.basename}-${extension}`;
   };
 
-  return src('src/examples/**/*.+(html|css|ts)')
+  return src('src/material-examples/**/*.+(html|css|ts)')
       .pipe(flatten())
       .pipe(rename(renameFile))
       .pipe(highlight())
@@ -111,7 +111,7 @@ task('minified-api-docs', ['api-docs'], () => {
 
 /** Copies example sources to be used as plunker assets for the docs site. */
 task('plunker-example-assets', () => {
-  src(path.join(SOURCE_ROOT, 'examples', '**/*'))
+  src(path.join(SOURCE_ROOT, 'material-examples', '**/*'))
       .pipe(dest(path.join(DIST_DOCS, 'plunker', 'examples')));
 });
 


### PR DESCRIPTION
* Publish the `material-examples` package in the `material2-docs-content` repository.

Fixes #3518.