### PR TITLE
build: use version placeholder in packages

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/material",
-  "version": "2.0.0-beta.3",
+  "version": "0.0.0-PLACEHOLDER",
   "description": "Angular Material",
   "main": "./bundles/material.umd.js",
   "module": "./@angular/material.es5.js",

--- a/src/material-examples/package.json
+++ b/src/material-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/material-examples",
-  "version": "2.0.0-beta.3",
+  "version": "0.0.0-PLACEHOLDER",
   "description": "Angular Material Examples",
   "main": "./bundles/material-examples.umd.js",
   "module": "./@angular/material-examples.es5.js",


### PR DESCRIPTION
* Introduces a version placeholder (as in angular/angular) that will be replaced with the version string form the root `package.json` file.

* This ensures that the different packages are always having the correct version and it also ensures that there is no version-mismatch.