### PR TITLE
build: copy readme to releases

### DIFF
--- a/tools/gulp/util/package-build.ts
+++ b/tools/gulp/util/package-build.ts
@@ -31,7 +31,7 @@ export function composeRelease(packageName: string) {
   copyFiles(DIST_BUNDLES, `${packageName}.umd?(.min).js`, join(releasePath, 'bundles'));
   copyFiles(DIST_BUNDLES, `${packageName}?(.es5).js`, join(releasePath, '@angular'));
   copyFiles(PROJECT_ROOT, 'LICENSE', releasePath);
-  copyFiles(SOURCE_ROOT, 'README', releasePath);
+  copyFiles(SOURCE_ROOT, 'README.md', releasePath);
   copyFiles(sourcePath, 'package.json', releasePath);
 
   updatePackageVersion(releasePath);


### PR DESCRIPTION
* Due to a typo the `README.md` file is not copied properly to the releases.