### PR TITLE
fix(checkbox): 	Fix disabled checkbox throw error when clicked

### DIFF
--- a/e2e/screenshot.ts
+++ b/e2e/screenshot.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import {browser} from 'protractor';
 
 const OUTPUT_DIR = './screenshots/';
-const HEIGHT = 768;
-const WIDTH = 1024;
+const HEIGHT = 788;
+const WIDTH = 1034;
 
 let currentJasmineSpecName = '';
 

--- a/e2e/screenshot.ts
+++ b/e2e/screenshot.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import {browser} from 'protractor';
 
 const OUTPUT_DIR = './screenshots/';
-const HEIGHT = 788;
-const WIDTH = 1034;
+const HEIGHT = 768;
+const WIDTH = 1024;
 
 let currentJasmineSpecName = '';
 

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -710,6 +710,7 @@ describe('MdCheckbox', () => {
     let checkboxDebugElement: DebugElement;
     let checkboxInstance: MdCheckbox;
     let testComponent: CheckboxWithFormControl;
+    let inputElement: HTMLInputElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(CheckboxWithFormControl);
@@ -718,6 +719,7 @@ describe('MdCheckbox', () => {
       checkboxDebugElement = fixture.debugElement.query(By.directive(MdCheckbox));
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
+      inputElement = <HTMLInputElement>checkboxDebugElement.nativeElement.querySelector('input');
     });
 
     it('should toggle the disabled state', () => {
@@ -727,11 +729,13 @@ describe('MdCheckbox', () => {
       fixture.detectChanges();
 
       expect(checkboxInstance.disabled).toBe(true);
+      expect(inputElement.disabled).toBe(true);
 
       testComponent.formControl.enable();
       fixture.detectChanges();
 
       expect(checkboxInstance.disabled).toBe(false);
+      expect(inputElement.disabled).toBe(false);
     });
   });
 });

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -142,7 +142,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   /** Whether the checkbox is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) { this._disabled = coerceBooleanProperty(value);}
+  set disabled(value) { this._disabled = coerceBooleanProperty(value); }
 
   /** Tabindex value that is passed to the underlying input element. */
   @Input() tabIndex: number = 0;

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -142,10 +142,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   /** Whether the checkbox is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) {
-    this._disabled = coerceBooleanProperty(value);
-    this._changeDetectorRef.markForCheck();
-  }
+  set disabled(value) { this._disabled = coerceBooleanProperty(value);}
 
   /** Tabindex value that is passed to the underlying input element. */
   @Input() tabIndex: number = 0;
@@ -307,6 +304,7 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
    */
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
+    this._changeDetectorRef.markForCheck();
   }
 
   private _transitionCheckState(newState: TransitionCheckState) {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -142,7 +142,10 @@ export class MdCheckbox implements ControlValueAccessor, AfterViewInit, OnDestro
   /** Whether the checkbox is disabled. */
   @Input()
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) { this._disabled = coerceBooleanProperty(value); }
+  set disabled(value) {
+    this._disabled = coerceBooleanProperty(value);
+    this._changeDetectorRef.markForCheck();
+  }
 
   /** Tabindex value that is passed to the underlying input element. */
   @Input() tabIndex: number = 0;


### PR DESCRIPTION
Related to #4037
The change detection in checkbox isn't working properly.  `disabled` is not updated in view.