### PR TITLE
Docs: cleanup grammar on overlay theming

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -165,9 +165,9 @@ interaction (how to lazily load the CSS assets will vary based on your applicati
 It's important to remember, however, that the `mat-core` mixin should only ever be included _once_.
 
 ##### Multiple themes and overlay-based components
-Since certain components (e.g. `dialog`) are inside of a global overlay container, the css class
-that determines the theme (such as the `.unicorn-dark-theme` example above), an additional step is
-needed to affect overlay-based components (menu, select, dialog, etc.).
+Since certain components (e.g. menu, select, dialog, etc.) are inside of a global overlay container,
+an additional step is required for those components to be affected by the theme's css class selector 
+(`.unicorn-dark-theme` in the example above).
 
 To do this, you can specify a `themeClass` on the global overlay container. For the example above,
 this would look like:


### PR DESCRIPTION
[This conversation](https://github.com/angular/material2/pull/4021#discussion_r110721506) got buried under other changes.

@jelbourn, this reword removes the run-on sentence. Does it still accurately match the original intent?