### PR TITLE
feat(list): input binding for dense mode

### DIFF
--- a/src/demo-app/list/list-demo.html
+++ b/src/demo-app/list/list-demo.html
@@ -1,7 +1,12 @@
 
 <h1>md-list demo</h1>
 
-<button md-raised-button (click)="thirdLine=!thirdLine" class="demo-button">Show third line</button>
+<button md-raised-button (click)="thirdLine=!thirdLine" class="demo-button">
+  Toggle third line
+</button>
+<button md-raised-button (click)="showDense=!showDense" class="demo-button">
+  Toggle dense mode
+</button>
 
 <div class="demo">
   <div>
@@ -43,21 +48,21 @@
 
   <div>
     <h2>Dense lists</h2>
-    <md-list dense>
+    <md-list [dense]="showDense">
       <h3 md-subheader>Items</h3>
       <md-list-item *ngFor="let item of items">
         {{item}}
       </md-list-item>
     </md-list>
 
-    <md-list dense>
+    <md-list [dense]="showDense">
       <md-list-item *ngFor="let contact of contacts">
         <h3 md-line>{{contact.name}}</h3>
         <p md-line class="demo-secondary-text">{{contact.headline}}</p>
       </md-list-item>
     </md-list>
 
-    <md-list dense>
+    <md-list [dense]="showDense">
       <h3 md-subheader>Today</h3>
       <md-list-item *ngFor="let message of messages">
         <img md-list-avatar [src]="message.image" alt="Image of {{message.from}}">

--- a/src/demo-app/list/list-demo.ts
+++ b/src/demo-app/list/list-demo.ts
@@ -50,5 +50,6 @@ export class ListDemo {
   ];
 
   thirdLine: boolean = false;
+  showDense: boolean = true;
   infoClicked: boolean = false;
 }

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -139,7 +139,7 @@ $mat-dense-list-icon-size: 20px;
 }
 
 
-.mat-list[dense], .mat-nav-list[dense] {
+.mat-dense-list {
   padding-top: $mat-dense-top-padding;
   display: block;
 

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -49,6 +49,20 @@ describe('MdList', () => {
     expect(listItem.nativeElement.className).toBe('mat-list-item');
   });
 
+  it('should support toggling dense mode using an input', () => {
+    let fixture = TestBed.createComponent(ListWithOneItem);
+    let listElement = fixture.debugElement.query(By.css('md-list'));
+
+    fixture.detectChanges();
+
+    expect(listElement.nativeElement.className).not.toContain('mat-dense-list');
+
+    fixture.componentInstance.showDense = true;
+    fixture.detectChanges();
+
+    expect(listElement.nativeElement.className).toContain('mat-dense-list');
+  });
+
   it('should apply mat-2-line class to lists with two lines', () => {
     let fixture = TestBed.createComponent(ListWithTwoLineItem);
     fixture.detectChanges();
@@ -174,12 +188,14 @@ class NavListWithOneAnchorItem extends BaseTestList {
 }
 
 @Component({template: `
-  <md-list>
+  <md-list [dense]="showDense">
     <md-list-item>
       Paprika
     </md-list-item>
   </md-list>`})
-class ListWithOneItem extends BaseTestList { }
+class ListWithOneItem extends BaseTestList {
+  showDense: boolean = false;
+}
 
 @Component({template: `
   <md-list>

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -13,7 +13,7 @@ import {
   Renderer,
   AfterContentInit,
 } from '@angular/core';
-import {MdLine, MdLineSetter} from '../core';
+import {MdLine, MdLineSetter, coerceBooleanProperty} from '../core';
 
 @Directive({
   selector: 'md-divider, mat-divider'
@@ -33,13 +33,23 @@ const NAV_LIST_TYPE = 'nav_list_type';
   moduleId: module.id,
   selector: 'md-list, mat-list, md-nav-list, mat-nav-list',
   host: {
-    'role': 'list'},
+    'role': 'list',
+    '[class.mat-dense-list]': 'dense'
+  },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
   providers: [{ provide: LIST_TYPE_TOKEN, useValue: NORMAL_LIST_TYPE }],
   encapsulation: ViewEncapsulation.None
 })
-export class MdList {}
+export class MdList {
+
+  private _dense: boolean = false;
+
+  /** Whether the list should display in dense mode or not. */
+  @Input()
+  get dense(): boolean { return this._dense; }
+  set dense(value) { this._dense = coerceBooleanProperty(value); }
+}
 
 /**
  * Directive whose purpose is to add the mat- CSS styling to this selector.


### PR DESCRIPTION
* Replaces the attribute selector for dense mode with an Angular input binding.

**Note**: As mentioned in the issue, it's currently possible to change `dense` mode dynamically using `[attr.dense]` .. but the API is not very elegant and you have to use `null` to disable dense mode.

Fixes #3882