### PR TITLE
fix(dialog): provide default value for MD_DIALOG_DATA token

### DIFF
--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -40,7 +40,7 @@ export class MdDialogConfig {
   position?: DialogPosition;
 
   /** Data being injected into the child component. */
-  data?: any = {};
+  data?: any = null;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -40,7 +40,7 @@ export class MdDialogConfig {
   position?: DialogPosition;
 
   /** Data being injected into the child component. */
-  data?: any;
+  data?: any = {};
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/lib/dialog/dialog-injector.ts
+++ b/src/lib/dialog/dialog-injector.ts
@@ -15,7 +15,7 @@ export class DialogInjector implements Injector {
       return this._dialogRef;
     }
 
-    if (token === MD_DIALOG_DATA && this._data) {
+    if (token === MD_DIALOG_DATA) {
       return this._data;
     }
 

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -371,11 +371,11 @@ describe('MdDialog', () => {
       expect(instance.data.dateParam).toBe(config.data.dateParam);
     });
 
-    it('should default to an empty object if no data is passed', () => {
+    it('should default to null if no data is passed', () => {
       let dialogRef: MdDialogRef<DialogWithInjectedData>;
 
       expect(() => dialogRef = dialog.open(DialogWithInjectedData)).not.toThrow();
-      expect(dialogRef.componentInstance.data).toEqual({});
+      expect(dialogRef.componentInstance.data).toBeNull();
     });
   });
 

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -371,10 +371,11 @@ describe('MdDialog', () => {
       expect(instance.data.dateParam).toBe(config.data.dateParam);
     });
 
-    it('should throw if injected data is expected but none is passed', () => {
-      expect(() => {
-        dialog.open(DialogWithInjectedData);
-      }).toThrow();
+    it('should default to an empty object if no data is passed', () => {
+      let dialogRef: MdDialogRef<DialogWithInjectedData>;
+
+      expect(() => dialogRef = dialog.open(DialogWithInjectedData)).not.toThrow();
+      expect(dialogRef.componentInstance.data).toEqual({});
     });
   });
 


### PR DESCRIPTION
Adds a default value for the `MD_DIALOG_DATA` injection token, instead of throwing an error when it's not defined.

Fixes #4086.