### PR TITLE
build: remove outdated tslint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,7 @@
     "stylelint": "^7.8.0",
     "travis-after-modes": "0.0.7",
     "ts-node": "^3.0.0",
-    "tslint": "^5.0.0",
-    "tslint-no-unused-var": "0.0.6",
+    "tslint": "^5.1.0",
     "typescript": "~2.2.1",
     "uglify-js": "^2.8.14",
     "web-animations-js": "^2.2.2"

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,5 @@
 {
   "rulesDirectory": [
-    "./node_modules/tslint-no-unused-var/", 
     "./tools/tslint-rules/"
   ],
   "rules": {
@@ -27,7 +26,6 @@
     "no-bitwise": true,
     "no-shadowed-variable": true,
     "no-unused-expression": true,
-    "no-unused-var": [true, {"ignore-pattern": "^(_.*)$"}],
     "no-var-keyword": true,
     "no-exposed-todo": true,
     "no-debugger": true,


### PR DESCRIPTION
* At some point in tslint the `no-unused-variable` rule has been deprecated in favor of `noUnusedLocals` and `noUnusedParameters`. Since we don't want to have compilation errors for unused variables we re-implemented the `no-unused-variable` rule ourself and used it as a custom rule.

* Recently we switched to a newer version of TSLint and TypeScript and the custom tslint rule won't ever work again. (tslint now requires a type-checker to be enabled). The custom rule fails currently and causes TSLint to not work with some editors (e.g Webstorm).

**Note**: TSLint un-deprecated the `no-unused-variable` rule again and it now requires the type-checker (and an according TypeScript project). 

We are holding off with updating to the "new" `no-unused-variable` rule because:
* It incorrectly adds failures: https://github.com/palantir/tslint/issues/2470
* It would be easier to use when https://github.com/angular/material2/pull/4111 is merged (module.id fix)
* There is no good approach yet. We have multiple `tsconfig.json` files inside of the whole repository.
