### PR TITLE
build: fix screenshot golden upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "fs-extra": "^2.0.0",
     "glob": "^7.1.1",
     "google-closure-compiler": "^20170218.0.0",
-    "google-cloud": "^0.48.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-clean-css": "^3.0.3",

--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -1,6 +1,6 @@
 const firebaseAdmin = require('firebase-admin');
 const firebase = require('firebase');
-const gcloud = require('google-cloud');
+const cloudStorage = require('@google-cloud/storage');
 
 const config = require('../../../functions/config.json');
 
@@ -27,7 +27,7 @@ export function openFirebaseDashboardDatabase() {
  * The files uploaded to google cloud are also available to firebase storage.
  */
 export function openScreenshotsBucket() {
-  let gcs = gcloud.storage({
+  let gcs = cloudStorage({
     projectId: 'material2-screenshots',
     credentials: {
       client_email: 'firebase-adminsdk-t4209@material2-screenshots.iam.gserviceaccount.com',


### PR DESCRIPTION
* Fixes the Google Cloud Storage upload for the goldens (fixes the e2e errors on master right now)

**Note**: The issue seems to happen because the `@google-cloud/storage` package has been installed manually and the `google-cloud` now uses a different storage version than before. 

Noticed this while debugging the `google-cloud` package.

<details>

Related **outdated** issue: https://github.com/GoogleCloudPlatform/google-cloud-node/issues/2078. But same issue under-the-hood.

![](https://i.gyazo.com/36e2d9f4e14f0a0dae6eafb1262ce6b4.png)

</details>
