### PR TITLE
demo(slide-toggle): change outdated switch selector

### DIFF
--- a/src/demo-app/slide-toggle/slide-toggle-demo.ts
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 
 @Component({
   moduleId: module.id,
-  selector: 'switch-demo',
+  selector: 'slide-toggle-demo',
   templateUrl: 'slide-toggle-demo.html',
   styleUrls: ['slide-toggle-demo.css'],
 })


### PR DESCRIPTION
At some point the `slide-toggle` has been called `switch`. 

The selector inside of the demo-app is still using `switch` instead of `slide-toggle`.

> Noticed this while debugging the slide-toggle with Augury.