### PR TITLE
build: update saucelabs connector

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-TUNNEL_FILE="sc-4.4.5-linux.tar.gz"
+TUNNEL_FILE="sc-4.4.6-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/$TUNNEL_FILE"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 


### PR DESCRIPTION
Updates the Saucelabs connector to a more recent version. 

> Outdated Saucelabs connector versions tend to be more flaky.