### PR TITLE
feat: add initial sass typography API

### DIFF
--- a/src/lib/core/style/_variables.scss
+++ b/src/lib/core/style/_variables.scss
@@ -1,8 +1,5 @@
-@import '../typography/typography';
-
-
 // Typography
-$mat-body-font-size-base: rem(1.4) !default;
+$mat-body-font-size-base: 14px !default;
 $mat-font-family: Roboto, 'Helvetica Neue', sans-serif !default;
 
 // Media queries

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -3,19 +3,24 @@
   @return map-get(map-get($config, $level), $name);
 }
 
-// Returns the font size for a level inside a typography config.
+// Gets the font size for a level inside a typography config.
 @function mat-font-size($config, $level) {
   @return _mat-get-type-value($config, $level, font-size);
 }
 
-// Returns the line height for a level inside a typography config.
+// Gets the line height for a level inside a typography config.
 @function mat-line-height($config, $level) {
   @return _mat-get-type-value($config, $level, line-height);
 }
 
-// Returns the font weight for a level inside a typography config.
+// Gets the font weight for a level inside a typography config.
 @function mat-font-weight($config, $level) {
   @return _mat-get-type-value($config, $level, font-weight);
+}
+
+// Gets the font-family from a typography config and removes the quotes around it.
+@function mat-font-family($config) {
+  @return unquote(map-get($config, font-family));
 }
 
 // Converts a typography level into CSS styles.
@@ -23,6 +28,10 @@
   $font-size: mat-font-size($config, $level);
   $font-weight: mat-font-weight($config, $level);
   $line-height: mat-line-height($config, $level);
+  $font-family: mat-font-family($config);
 
-  font: $font-weight #{$font-size}/#{$line-height} unquote(map-get($config, font-family));
+  // Use the shorthand `font` to represent a typography level, because it's the shortest. Notes that
+  // we need to use interpolation for `font-size/line-height` in order to prevent SASS from diving
+  // the two values.
+  font: $font-weight #{$font-size}/#{$line-height} $font-family;
 }

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -31,7 +31,7 @@
   $font-family: mat-font-family($config);
 
   // Use the shorthand `font` to represent a typography level, because it's the shortest. Notes that
-  // we need to use interpolation for `font-size/line-height` in order to prevent SASS from diving
+  // we need to use interpolation for `font-size/line-height` in order to prevent SASS from dividing
   // the two values.
   font: $font-weight #{$font-size}/#{$line-height} $font-family;
 }

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -1,0 +1,28 @@
+// Utility for fetching a nested value from a typography config.
+@function _mat-get-type-value($config, $level, $name) {
+  @return map-get(map-get($config, $level), $name);
+}
+
+// Returns the font size for a level inside a typography config.
+@function mat-font-size($config, $level) {
+  @return _mat-get-type-value($config, $level, font-size);
+}
+
+// Returns the line height for a level inside a typography config.
+@function mat-line-height($config, $level) {
+  @return _mat-get-type-value($config, $level, line-height);
+}
+
+// Returns the font weight for a level inside a typography config.
+@function mat-font-weight($config, $level) {
+  @return _mat-get-type-value($config, $level, font-weight);
+}
+
+// Converts a typography level into CSS styles.
+@mixin mat-typography-level-to-styles($config, $level) {
+  $font-size: mat-font-size($config, $level);
+  $font-weight: mat-font-weight($config, $level);
+  $line-height: mat-line-height($config, $level);
+
+  font: $font-weight #{$font-size}/#{$line-height} unquote(map-get($config, font-family));
+}

--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -1,6 +1,85 @@
-// Implement the rem unit with SCSS so we don't have to actually set a font-size on
-// the user's body element.
-@function rem($multiplier) {
-  $font-size: 10px;
-  @return $multiplier * $font-size;
+@import 'typography-utils';
+
+// Represents a typography level from the Material design spec.
+@function mat-typography-level($font-size, $line-height: $font-size, $font-weight: 400) {
+  @return (
+    font-size: $font-size,
+    line-height: $line-height,
+    font-weight: $font-weight
+  );
+}
+
+// Represents a collection of typography levels.
+// Defaults come from https://material.io/guidelines/style/typography.html
+@function mat-typography-config(
+  $font-family: 'Roboto, sans-serif',
+  $display-4:   mat-typography-level(112px, 112px, 300),
+  $display-3:   mat-typography-level(56px, 56px, 400),
+  $display-2:   mat-typography-level(45px, 48px, 400),
+  $display-1:   mat-typography-level(34px, 40px, 400),
+  $headline:    mat-typography-level(24px, 32px, 400),
+  $title:       mat-typography-level(20px, 20px, 500),
+  $subheading:  mat-typography-level(16px, 28px, 400),
+  $body-2:      mat-typography-level(14px, 24px, 500),
+  $body-1:      mat-typography-level(14px, 20px, 400),
+  $caption:     mat-typography-level(12px, 12px, 400),
+  $button:      mat-typography-level(14px, 14px, 500)
+) {
+  @return (
+    font-family: $font-family,
+    display-4:   $display-4,
+    display-3:   $display-3,
+    display-2:   $display-2,
+    display-1:   $display-1,
+    headline:    $headline,
+    title:       $title,
+    subheading:  $subheading,
+    body-2:      $body-2,
+    body-1:      $body-1,
+    caption:     $caption,
+    button:      $button
+  );
+}
+
+// Adds the base typography styles, based on a config.
+@mixin mat-typography($config: mat-typography-config(), $selector: '.mat-typography') {
+  .mat-h0, .mat-hero-header {
+    @include mat-typography-level-to-styles($config, display-4);
+  }
+
+  .mat-h1, #{$selector} h1 {
+    @include mat-typography-level-to-styles($config, display-3);
+  }
+
+  .mat-h2, #{$selector} h2 {
+    @include mat-typography-level-to-styles($config, display-2);
+  }
+
+  .mat-h3, #{$selector} h3 {
+    @include mat-typography-level-to-styles($config, display-1);
+  }
+
+  .mat-h4, #{$selector} h4 {
+    @include mat-typography-level-to-styles($config, headline);
+  }
+
+  .mat-h5, #{$selector} h5 {
+    @include mat-typography-level-to-styles($config, title);
+  }
+
+  .mat-h6, #{$selector} h6 {
+    @include mat-typography-level-to-styles($config, subheading);
+  }
+
+  .mat-body-strong {
+    @include mat-typography-level-to-styles($config, body-2);
+  }
+
+  .mat-body, #{$selector} {
+    @include mat-typography-level-to-styles($config, body-1);
+  }
+
+  .mat-small {
+    @include mat-typography-level-to-styles($config, caption);
+  }
 }


### PR DESCRIPTION
Adds an initial implementation for the API that'll be used to do the Material typography.

**Note:** These are just the various functions and mixins, they aren't being used anywhere yet. The usage for the `mat-typography` mixin can be:

```scss
// Includes the default typography styles.
@include mat-typography();

// Overrides one of the typography levels
@include mat-typography(
  $display-2: mat-typography-level(50px, 52px, 600)
);
```