### PR TITLE
build: dedupe theming scss bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rollup": "^0.41.6",
     "run-sequence": "^1.2.2",
     "sass": "^0.5.0",
-    "scss-bundle": "^1.0.1",
+    "scss-bundle": "^2.0.1-beta.7",
     "selenium-webdriver": "^3.1.0",
     "sorcery": "^0.10.0",
     "stylelint": "^7.8.0",

--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -1,23 +1,18 @@
 import {spawn} from 'child_process';
-import {existsSync, readFileSync, statSync, writeFileSync} from 'fs-extra';
-import {basename, join} from 'path';
+import {existsSync, statSync, writeFileSync} from 'fs-extra';
+import {join} from 'path';
 import {dest, src, task} from 'gulp';
-import {inlineMetadataResources} from '../util/inline-resources';
-import {execNodeTask, execTask, sequenceTask} from '../util/task_helpers';
+import {execTask, sequenceTask} from '../util/task_helpers';
 import {composeRelease} from '../util/package-build';
+import {Bundler} from 'scss-bundle';
 import {
   COMPONENTS_DIR,
-  DIST_BUNDLES,
   DIST_MATERIAL,
   DIST_RELEASES,
-  DIST_ROOT,
-  LICENSE_BANNER,
-  PROJECT_ROOT,
 } from '../constants';
 import * as minimist from 'minimist';
 
 // There are no type definitions available for these imports.
-const glob = require('glob');
 const gulpRename = require('gulp-rename');
 
 /** Parse command-line arguments for release task. */
@@ -31,6 +26,10 @@ const themingEntryPointPath = join(COMPONENTS_DIR, 'core', 'theming', '_all-them
 
 // Output path for the scss theming bundle.
 const themingBundlePath = join(releasePath, '_theming.scss');
+
+// Glob that matches all files that might be imported multiple times.
+// Necessary for deduping inside of scss-bundle.
+const themingBundleDedupeGlob = join(COMPONENTS_DIR, '**/*.scss');
 
 // Matches all pre-built theme css files
 const prebuiltThemeGlob = join(DIST_MATERIAL, '**/theming/prebuilt/*.css');
@@ -51,26 +50,17 @@ task(':package:theming', [':bundle:theming-scss'], () => {
 });
 
 /** Bundles all scss requires for theming into a single scss file in the root of the package. */
-task(':bundle:theming-scss', execNodeTask(
-  'scss-bundle',
-  'scss-bundle', [
-    '-e', themingEntryPointPath,
-    '-d', themingBundlePath
-  ], {silentStdout: true}
-));
+task(':bundle:theming-scss', () => {
+  new Bundler().Bundle(themingEntryPointPath, [themingBundleDedupeGlob]).then(result => {
+    writeFileSync(themingBundlePath, result.bundledContent);
+  });
+});
 
 /** Make sure we're logged in. */
 task(':publish:whoami', execTask('npm', ['whoami'], {
   silent: true,
   errMessage: 'You must be logged in to publish.'
 }));
-
-/** Create a typing file that links to the bundled definitions of NGC. */
-function createTypingFile() {
-  writeFileSync(join(releasePath, 'material.d.ts'),
-    LICENSE_BANNER + '\nexport * from "./typings/index";'
-  );
-}
 
 task(':publish:logout', execTask('npm', ['logout']));
 

--- a/tools/gulp/tasks/release.ts
+++ b/tools/gulp/tasks/release.ts
@@ -27,9 +27,8 @@ const themingEntryPointPath = join(COMPONENTS_DIR, 'core', 'theming', '_all-them
 // Output path for the scss theming bundle.
 const themingBundlePath = join(releasePath, '_theming.scss');
 
-// Glob that matches all files that might be imported multiple times.
-// Necessary for deduping inside of scss-bundle.
-const themingBundleDedupeGlob = join(COMPONENTS_DIR, '**/*.scss');
+// Matches all SCSS files in the library.
+const allScssGlob = join(COMPONENTS_DIR, '**/*.scss');
 
 // Matches all pre-built theme css files
 const prebuiltThemeGlob = join(DIST_MATERIAL, '**/theming/prebuilt/*.css');
@@ -51,7 +50,10 @@ task(':package:theming', [':bundle:theming-scss'], () => {
 
 /** Bundles all scss requires for theming into a single scss file in the root of the package. */
 task(':bundle:theming-scss', () => {
-  new Bundler().Bundle(themingEntryPointPath, [themingBundleDedupeGlob]).then(result => {
+  // Instantiates the SCSS bundler and bundles all imports of the specified entry point SCSS file.
+  // A glob of all SCSS files in the library will be passed to the bundler. The bundler takes an
+  // array of globs, which will match SCSS files that will be only included once in the bundle.
+  new Bundler().Bundle(themingEntryPointPath, [allScssGlob]).then(result => {
     writeFileSync(themingBundlePath, result.bundledContent);
   });
 });


### PR DESCRIPTION
* Updates to a more recent version of SCSS-bundle that has support for deduping. The dedupe process is very naive and only disallows importing a file multiple times.
* Switches to the programmatic API of `scss-bundle`
* Removes unused functions and imports / leftovers.

Fixes #3931