### PR TITLE
fix(slide-toggle): remove unused mousedown listener

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -50,7 +50,6 @@ let nextId = 0;
     '[class.mat-checked]': 'checked',
     '[class.mat-disabled]': 'disabled',
     '[class.mat-slide-toggle-label-before]': 'labelPosition == "before"',
-    '(mousedown)': '_setMousedown()'
   },
   templateUrl: 'slide-toggle.html',
   styleUrls: ['slide-toggle.css'],
@@ -67,7 +66,6 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
   private _uniqueId = `md-slide-toggle-${++nextId}`;
   private _checked: boolean = false;
   private _color: string;
-  private _isMousedown: boolean = false;
   private _slideRenderer: SlideToggleRenderer = null;
   private _disabled: boolean = false;
   private _required: boolean = false;
@@ -171,15 +169,6 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
     // This will lead to multiple click events.
     // Preventing bubbling for the second event will solve that issue.
     event.stopPropagation();
-  }
-
-  _setMousedown() {
-    // We only *show* the focus style when focus has come to the button via the keyboard.
-    // The Material Design spec is silent on this topic, and without doing this, the
-    // button continues to look :active after clicking.
-    // @see http://marcysutton.com/button-focus-hell/
-    this._isMousedown = true;
-    setTimeout(() => this._isMousedown = false, 100);
   }
 
   /** Implemented as part of ControlValueAccessor. */


### PR DESCRIPTION
Removes the unused `setMousedown` listener for the temporary ripples. 

The slide-toggle now uses the real `MdRipple` service and therefore the listener is unnecessary.