### PR TITLE
build: output directory for gulp tsconfig

### DIFF
--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "outDir": "../../dist/tools/gulp",
     "noEmitOnError": true,
     "noImplicitAny": true,
     "target": "es5",


### PR DESCRIPTION
At some point the `outDir` of the gulp `tsconfig` has been removed.

Sometimes when debugging the gulp tools you might want to see the compiled JS files and running `tsc` will now output all files next to the sources. (bad for SCM)

Every `tsconfig.json` file should have a `outDir` to avoid creating sources next to the files and also to simplify debugging.