### PR TITLE
refactor: remove @output privatization

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -160,10 +160,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   }
 
   /** Event emitted when the group's value changes. */
-  @Output() get change(): Observable<MdButtonToggleChange> {
-    return this._change.asObservable();
-  }
-  private _change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
+  @Output() change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
 
   private _updateButtonToggleNames(): void {
     if (this._buttonToggles) {
@@ -198,7 +195,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
     event.source = this._selected;
     event.value = this._value;
     this._controlValueAccessorChangeFn(event.value);
-    this._change.emit(event);
+    this.change.emit(event);
   }
 
   /**
@@ -372,10 +369,7 @@ export class MdButtonToggle implements OnInit {
   }
 
   /** Event emitted when the group value changes. */
-  private _change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
-  @Output() get change(): Observable<MdButtonToggleChange> {
-    return this._change.asObservable();
-  }
+  @Output() change: EventEmitter<MdButtonToggleChange> = new EventEmitter<MdButtonToggleChange>();
 
   constructor(@Optional() toggleGroup: MdButtonToggleGroup,
               @Optional() toggleGroupMultiple: MdButtonToggleGroupMultiple,
@@ -460,6 +454,6 @@ export class MdButtonToggle implements OnInit {
     let event = new MdButtonToggleChange();
     event.source = this;
     event.value = this._value;
-    this._change.emit(event);
+    this.change.emit(event);
   }
 }

--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -284,8 +284,7 @@ export class FocusOriginMonitor {
   selector: '[cdkMonitorElementFocus], [cdkMonitorSubtreeFocus]',
 })
 export class CdkMonitorFocus implements OnDestroy {
-  @Output()
-  cdkFocusChange = new EventEmitter<FocusOrigin>();
+  @Output() cdkFocusChange = new EventEmitter<FocusOrigin>();
 
   constructor(private _elementRef: ElementRef, private _focusOriginMonitor: FocusOriginMonitor,
               renderer: Renderer) {

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -95,8 +95,7 @@ export class MdRadioGroup implements AfterContentInit, ControlValueAccessor {
    * Change events are only emitted when the value changes due to user interaction with
    * a radio button (the same behavior as `<input type-"radio">`).
    */
-  @Output()
-  change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
+  @Output() change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
 
   /** Child radio buttons. */
   @ContentChildren(forwardRef(() => MdRadioButton))
@@ -379,8 +378,7 @@ export class MdRadioButton implements OnInit, AfterViewInit, OnDestroy {
    * Change events are only emitted when the value changes due to user interaction with
    * the radio button (the same behavior as `<input type-"radio">`).
    */
-  @Output()
-  change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
+  @Output() change: EventEmitter<MdRadioChange> = new EventEmitter<MdRadioChange>();
 
   /** The parent radio group. May or may not be present. */
   radioGroup: MdRadioGroup;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -109,9 +109,8 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
   get disableRipple(): boolean { return this._disableRipple; }
   set disableRipple(value) { this._disableRipple = coerceBooleanProperty(value); }
 
-  private _change: EventEmitter<MdSlideToggleChange> = new EventEmitter<MdSlideToggleChange>();
   /** An event will be dispatched each time the slide-toggle changes its value. */
-  @Output() change: Observable<MdSlideToggleChange> = this._change.asObservable();
+  @Output() change: EventEmitter<MdSlideToggleChange> = new EventEmitter<MdSlideToggleChange>();
 
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
@@ -262,7 +261,7 @@ export class MdSlideToggle implements OnDestroy, AfterContentInit, ControlValueA
     let event = new MdSlideToggleChange();
     event.source = this;
     event.checked = this.checked;
-    this._change.emit(event);
+    this.change.emit(event);
   }
 
 

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -78,12 +78,10 @@ export class MdTabBody implements OnInit, AfterViewChecked {
   @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
 
   /** Event emitted when the tab begins to animate towards the center as the active tab. */
-  @Output()
-  onCentering: EventEmitter<number> = new EventEmitter<number>();
+  @Output() onCentering: EventEmitter<number> = new EventEmitter<number>();
 
   /** Event emitted when the tab completes its animation towards the center. */
-  @Output()
-  onCentered: EventEmitter<void> = new EventEmitter<void>(true);
+  @Output() onCentered: EventEmitter<void> = new EventEmitter<void>(true);
 
   /** The tab body content to display. */
   @Input('content') _content: TemplatePortal;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -84,20 +84,11 @@ export class MdTabGroup {
     return this.selectChange.map(event => event.index);
   }
 
-  private _onFocusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
-
   /** Event emitted when focus has changed within a tab group. */
-  @Output() get focusChange(): Observable<MdTabChangeEvent> {
-    return this._onFocusChange.asObservable();
-  }
-
-  private _onSelectChange: EventEmitter<MdTabChangeEvent> =
-      new EventEmitter<MdTabChangeEvent>(true);
+  @Output() focusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
 
   /** Event emitted when the tab selection has changed. */
-  @Output() get selectChange(): Observable<MdTabChangeEvent> {
-    return this._onSelectChange.asObservable();
-  }
+  @Output() selectChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>(true);
 
   private _groupId: number;
 
@@ -121,7 +112,7 @@ export class MdTabGroup {
     // If there is a change in selected index, emit a change event. Should not trigger if
     // the selected index has not yet been initialized.
     if (this._selectedIndex != this._indexToSelect && this._selectedIndex != null) {
-      this._onSelectChange.emit(this._createChangeEvent(this._indexToSelect));
+      this.selectChange.emit(this._createChangeEvent(this._indexToSelect));
     }
 
     // Setup the position for each tab and optionally setup an origin on the next selected tab.
@@ -147,7 +138,7 @@ export class MdTabGroup {
   }
 
   _focusChanged(index: number) {
-    this._onFocusChange.emit(this._createChangeEvent(index));
+    this.focusChange.emit(this._createChangeEvent(index));
   }
 
   private _createChangeEvent(index: number): MdTabChangeEvent {


### PR DESCRIPTION
Removes the privatized `EventEmitter`-s as discussed. This adds some code bloat without a lot of benefits.

Fixes #4188.