### PR TITLE
build: disallow uses of the "initial" value

### DIFF
--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -41,6 +41,10 @@
     "declaration-block-semicolon-space-after": "always-single-line",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-property-value-blacklist": [
+        { "/.*/": ["initial"] },
+        { "message": "The `initial` value is not supported in IE."}
+    ],
 
     "block-closing-brace-newline-after": "always",
     "block-closing-brace-newline-before": "always-multi-line",


### PR DESCRIPTION
Throws a Stylelint error when using the `initial` value for a property. `initial` doesn't work in IE and is easy to work around by looking up the default value for the property.

Related to https://github.com/angular/material2/pull/4191#discussion_r112735007.