### PR TITLE
fix(select): tab opening multiple select and space scrolling page

### DIFF
--- a/src/lib/core/testing/dispatch-events.ts
+++ b/src/lib/core/testing/dispatch-events.ts
@@ -6,15 +6,21 @@ import {
 
 /** Shorthand to dispatch a fake event on a specified node. */
 export function dispatchFakeEvent(node: Node | Window, type: string) {
-  node.dispatchEvent(createFakeEvent(type));
+  let event = createFakeEvent(type);
+  node.dispatchEvent(event);
+  return event;
 }
 
 /** Shorthand to dispatch a keyboard event with a specified key code. */
 export function dispatchKeyboardEvent(node: Node, type: string, keyCode: number) {
-  node.dispatchEvent(createKeyboardEvent(type, keyCode));
+  let event = createKeyboardEvent(type, keyCode);
+  node.dispatchEvent(event);
+  return event;
 }
 
 /** Shorthand to dispatch a mouse event on the specified coordinates. */
 export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0) {
-  node.dispatchEvent(createMouseEvent(type, x, y));
+  let event = createMouseEvent(type, x, y);
+  node.dispatchEvent(event);
+  return event;
 }

--- a/src/lib/core/testing/dispatch-events.ts
+++ b/src/lib/core/testing/dispatch-events.ts
@@ -1,26 +1,22 @@
-import {
-  createFakeEvent,
-  createKeyboardEvent,
-  createMouseEvent
-} from './event-objects';
+import {createFakeEvent, createKeyboardEvent, createMouseEvent} from './event-objects';
 
-/** Shorthand to dispatch a fake event on a specified node. */
-export function dispatchFakeEvent(node: Node | Window, type: string) {
-  let event = createFakeEvent(type);
+/** Utility to dispatch any event on a Node. */
+export function dispatchEvent(node: Node | Window, event: Event): Event {
   node.dispatchEvent(event);
   return event;
+}
+
+/** Shorthand to dispatch a fake event on a specified node. */
+export function dispatchFakeEvent(node: Node | Window, type: string): Event {
+  return dispatchEvent(node, createFakeEvent(type));
 }
 
 /** Shorthand to dispatch a keyboard event with a specified key code. */
-export function dispatchKeyboardEvent(node: Node, type: string, keyCode: number) {
-  let event = createKeyboardEvent(type, keyCode);
-  node.dispatchEvent(event);
-  return event;
+export function dispatchKeyboardEvent(node: Node, type: string, keyCode: number): KeyboardEvent {
+  return dispatchEvent(node, createKeyboardEvent(type, keyCode)) as KeyboardEvent;
 }
 
 /** Shorthand to dispatch a mouse event on the specified coordinates. */
-export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0) {
-  let event = createMouseEvent(type, x, y);
-  node.dispatchEvent(event);
-  return event;
+export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0): MouseEvent {
+  return dispatchEvent(node, createMouseEvent(type, x, y)) as MouseEvent;
 }

--- a/src/lib/core/testing/event-objects.ts
+++ b/src/lib/core/testing/event-objects.ts
@@ -26,14 +26,19 @@ export function createKeyboardEvent(type: string, keyCode: number) {
   let event = document.createEvent('KeyboardEvent') as any;
   // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
   let initEventFn = (event.initKeyEvent || event.initKeyboardEvent).bind(event);
+  let originalPreventDefault = event.preventDefault;
 
   initEventFn(type, true, true, window, 0, 0, 0, 0, 0, keyCode);
 
   // Webkit Browsers don't set the keyCode when calling the init function.
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
-  Object.defineProperty(event, 'keyCode', {
-    get: function() { return keyCode; }
-  });
+  Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+
+  // IE won't set `defaultPrevented` on syntetic events so we need to do it manually.
+  event.preventDefault = function() {
+    Object.defineProperty(event, 'defaultPrevented', { get: () => true });
+    return originalPreventDefault.apply(this, arguments);
+  };
 
   return event;
 }

--- a/src/lib/core/testing/event-objects.ts
+++ b/src/lib/core/testing/event-objects.ts
@@ -34,7 +34,7 @@ export function createKeyboardEvent(type: string, keyCode: number) {
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
   Object.defineProperty(event, 'keyCode', { get: () => keyCode });
 
-  // IE won't set `defaultPrevented` on syntetic events so we need to do it manually.
+  // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
   event.preventDefault = function() {
     Object.defineProperty(event, 'defaultPrevented', { get: () => true });
     return originalPreventDefault.apply(this, arguments);

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -16,7 +16,7 @@ import {MdSelect, MdSelectFloatPlaceholderType} from './select';
 import {MdSelectDynamicMultipleError, MdSelectNonArrayValueError} from './select-errors';
 import {MdOption} from '../core/option/option';
 import {Dir} from '../core/rtl/dir';
-import {DOWN_ARROW, UP_ARROW} from '../core/keyboard/keycodes';
+import {DOWN_ARROW, UP_ARROW, ENTER, SPACE} from '../core/keyboard/keycodes';
 import {
   ControlValueAccessor, FormControl, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule
 } from '@angular/forms';
@@ -1370,6 +1370,26 @@ describe('MdSelect', () => {
           'Expected value from second option to have been set on the model.');
       });
 
+      it('should open the panel when pressing the arrow keys on a closed multiple select', () => {
+        fixture.destroy();
+
+        const multiFixture = TestBed.createComponent(MultiSelect);
+        const instance = multiFixture.componentInstance;
+
+        multiFixture.detectChanges();
+        select = multiFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+        const initialValue = instance.control.value;
+
+        expect(instance.select.panelOpen).toBe(false, 'Expected panel to be closed.');
+
+        const event = dispatchKeyboardEvent(select, 'keydown', DOWN_ARROW);
+
+        expect(instance.select.panelOpen).toBe(true, 'Expected panel to be open.');
+        expect(instance.control.value).toBe(initialValue, 'Expected value to stay the same.');
+        expect(event.defaultPrevented).toBe(true, 'Expected default to be prevented.');
+      });
+
       it('should do nothing if the key manager did not change the active item', () => {
         const formControl = fixture.componentInstance.control;
 
@@ -1416,6 +1436,29 @@ describe('MdSelect', () => {
         dispatchKeyboardEvent(select, 'keydown', DOWN_ARROW);
 
         expect(lastOption.selected).toBe(true, 'Expected last option to stay selected.');
+      });
+
+      it('should not open a multiple select when tabbing through', () => {
+        fixture.destroy();
+
+        const multiFixture = TestBed.createComponent(MultiSelect);
+
+        multiFixture.detectChanges();
+        select = multiFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+        expect(multiFixture.componentInstance.select.panelOpen)
+            .toBe(false, 'Expected panel to be closed initially.');
+
+        dispatchKeyboardEvent(select, 'keydown', TAB);
+
+        expect(multiFixture.componentInstance.select.panelOpen)
+            .toBe(false, 'Expected panel to stay closed.');
+      });
+
+      it('should prevent the default action when pressing space', () => {
+        let event = dispatchKeyboardEvent(select, 'keydown', SPACE);
+
+        expect(event.defaultPrevented).toBe(true);
       });
 
     });


### PR DESCRIPTION
* Fixes pressing tab (or any other key, except arrows) opening `md-select` in `multiple` mode.
* Fixes the page getting scrolled down when opening a select by pressing space.
* Adds missing test coverage for opening a multiple select with the arrow keys.