### PR TITLE
fix(menu): incorrect panel max height

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -11,9 +11,7 @@ $mat-menu-vertical-padding: 8px !default;
 .mat-menu-panel {
   @include mat-menu-base();
   @include mat-menu-positions();
-
-  // max height must be 100% of the viewport height + one row height
-  max-height: calc(100vh + 48px);
+  max-height: calc(100vh - #{$mat-menu-item-height});
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Fixes the menu panel having a wrong `max-height` and uses a variables to reduce it, instead of a hardcoded value.

Relates to #2725.