### PR TITLE
docs(slider): correct typo in MdSliderChange description (#4216)

### DIFF
--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -55,7 +55,7 @@ export class MdSliderChange {
   /** The MdSlider that changed. */
   source: MdSlider;
 
-  /** Thew new value of the source slider. */
+  /** The new value of the source slider. */
   value: number;
 }
 


### PR DESCRIPTION
- corrects typo in MdSliderChange `value` property description
Original: "_Thew_ new value of the source slider."
New: "_The_ new value of the source slider."