### PR TITLE
docs(ripple): add section about global options

### DIFF
--- a/src/lib/core/ripple/README.md
+++ b/src/lib/core/ripple/README.md
@@ -6,10 +6,33 @@ By default, a ripple is activated when the host element of the `md-ripple` direc
 
 Ripples can also be triggered programmatically by getting a reference to the MdRipple directive and calling its `start` and `end` methods.
 
+### Global options
 
-### Upcoming work
+Developers are able to specify options for all ripples inside of their application.
 
-Ripples will be added to the `md-button`, `md-radio-button`, `md-checkbox`, and `md-nav-list` components.
+The speed of the ripples can be adjusted and the ripples can be disabled globally as well.
+
+Global ripple options can be specified by setting the `MD_RIPPLE_GLOBAL_OPTIONS` provider.
+
+```ts
+const globalRippleConfig: RippleGlobalOptions = {
+  disabled: true,
+  baseSpeedFactor: 1.5 // Ripples will animate 50% faster than before.
+}
+
+@NgModule({
+  providers: [
+    {provide: MD_RIPPLE_GLOBAL_OPTIONS, useValue: globalRippleConfig} 
+  ]
+})
+```
+
+Here are all available global options listed:
+
+| Name            | Type    | Description                               |
+| --------------- | ------- | ----------------------------------------- |
+| disabled        | boolean | Whether ripples should show or not.       |
+| baseSpeedFactor | number  | Factor to adjust duration of the ripples. |
 
 ### API Summary
 

--- a/src/lib/core/ripple/README.md
+++ b/src/lib/core/ripple/README.md
@@ -32,7 +32,7 @@ Here are all available global options listed:
 | Name            | Type    | Description                               |
 | --------------- | ------- | ----------------------------------------- |
 | disabled        | boolean | Whether ripples should show or not.       |
-| baseSpeedFactor | number  | Factor to adjust duration of the ripples. |
+| baseSpeedFactor | number  | Factor to adjust ripple speed.            |
 
 ### API Summary
 


### PR DESCRIPTION
* Adds a new section about global ripple options to the `README.md` file of the ripple directive.

@mmalerba Not sure if the documentation for the `baseSpeedFactor` is good. I had hard times to explain that the factor is like a "percentage". Value `1.5` makes ripples animate 50% faster than normal.

Closes #4226