### PR TITLE
fix(connected-overlay): better handling of dynamic content

### DIFF
--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -18,8 +18,6 @@ import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Subscription} from 'rxjs/Subscription';
 import {ENTER, DOWN_ARROW, SPACE, UP_ARROW, HOME, END} from '../core/keyboard/keycodes';
 import {MdOption} from '../core/option/option';
-import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
-import {FakeViewportRuler} from '../core/overlay/position/fake-viewport-ruler';
 import {MdAutocomplete} from './autocomplete';
 import {MdInputContainer} from '../input/input-container';
 import {Observable} from 'rxjs/Observable';
@@ -65,10 +63,7 @@ describe('MdAutocomplete', () => {
 
           return {getContainerElement: () => overlayContainerElement};
         }},
-        {provide: Dir, useFactory: () => {
-          return {value: dir};
-        }},
-        {provide: ViewportRuler, useClass: FakeViewportRuler},
+        {provide: Dir, useFactory: () => ({value: dir})},
         {provide: ScrollDispatcher, useFactory: () => {
           return {scrolled: (delay: number, callback: () => any) => {
             return scrolledSubject.asObservable().subscribe(callback);
@@ -929,8 +924,8 @@ describe('MdAutocomplete', () => {
       const panelTop = panel.getBoundingClientRect().top;
 
       // Panel is offset by 6px in styles so that the underline has room to display.
-      expect((inputBottom + 6).toFixed(1))
-          .toEqual(panelTop.toFixed(1), `Expected panel top to match input bottom by default.`);
+      expect(Math.floor(inputBottom + 6))
+          .toEqual(Math.floor(panelTop), `Expected panel top to match input bottom by default.`);
       expect(fixture.componentInstance.trigger.autocomplete.positionY)
           .toEqual('below', `Expected autocomplete positionY to default to below.`);
     });
@@ -952,7 +947,7 @@ describe('MdAutocomplete', () => {
       const panel = overlayContainerElement.querySelector('.mat-autocomplete-panel');
       const panelTop = panel.getBoundingClientRect().top;
 
-      expect((inputBottom + 6).toFixed(1)).toEqual(panelTop.toFixed(1),
+      expect(Math.floor(inputBottom + 6)).toEqual(Math.floor(panelTop),
           'Expected panel top to match input bottom after scrolling.');
 
       document.body.removeChild(spacer);
@@ -971,8 +966,8 @@ describe('MdAutocomplete', () => {
       const panelBottom = panel.getBoundingClientRect().bottom;
 
       // Panel is offset by 24px in styles so that the label has room to display.
-      expect((inputTop - 24).toFixed(1))
-          .toEqual(panelBottom.toFixed(1), `Expected panel to fall back to above position.`);
+      expect(Math.floor(inputTop - 24))
+          .toEqual(Math.floor(panelBottom), `Expected panel to fall back to above position.`);
       expect(fixture.componentInstance.trigger.autocomplete.positionY)
           .toEqual('above', `Expected autocomplete positionY to be "above" if panel won't fit.`);
     });
@@ -994,8 +989,8 @@ describe('MdAutocomplete', () => {
         const panelBottom = panel.getBoundingClientRect().bottom;
 
         // Panel is offset by 24px in styles so that the label has room to display.
-        expect((inputTop - 24).toFixed(1))
-            .toEqual(panelBottom.toFixed(1), `Expected panel to stay aligned after filtering.`);
+        expect(Math.floor(inputTop - 24))
+            .toEqual(Math.floor(panelBottom), `Expected panel to stay aligned after filtering.`);
         expect(fixture.componentInstance.trigger.autocomplete.positionY)
             .toEqual('above', `Expected autocomplete positionY to be "above" if panel won't fit.`);
       });

--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -9,8 +9,10 @@
     // The container should be the size of the viewport.
     top: 0;
     left: 0;
-    height: 100%;
-    width: 100%;
+
+    // Note: we prefer viewport units, because they aren't being offset by the global scrollbar.
+    height: 100vh;
+    width: 100vw;
   }
 
   // The overlay-container is an invisible element which contains all individual overlays.

--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -41,7 +41,6 @@ describe('ConnectedPositionStrategy', () => {
     let overlayContainerElement: HTMLElement;
     let strategy: ConnectedPositionStrategy;
     let fakeElementRef: ElementRef;
-    let fakeViewportRuler: FakeViewportRuler;
     let positionBuilder: OverlayPositionBuilder;
 
     let originRect: ClientRect;
@@ -49,11 +48,9 @@ describe('ConnectedPositionStrategy', () => {
     let originCenterY: number;
 
     beforeEach(() => {
-      fakeViewportRuler = new FakeViewportRuler();
-
       // The origin and overlay elements need to be in the document body in order to have geometry.
       originElement = createPositionedBlockElement();
-      overlayContainerElement = createFixedElement();
+      overlayContainerElement = createOverlayContainer();
       overlayElement = createPositionedBlockElement();
       document.body.appendChild(originElement);
       document.body.appendChild(overlayContainerElement);
@@ -148,8 +145,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.left).toBe(originRect.left);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
       });
 
       it('should reposition the overlay if it would go off the left of the screen', () => {
@@ -172,18 +169,14 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originCenterY - (OVERLAY_HEIGHT / 2));
-        expect(overlayRect.left).toBe(originRect.right);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originCenterY - (OVERLAY_HEIGHT / 2)));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.right));
       });
 
       it('should reposition the overlay if it would go off the bottom of the screen', () => {
-        // Use the fake viewport ruler because we don't know *exactly* how big the viewport is.
-        fakeViewportRuler.fakeRect = {
-          top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-        };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(viewportRuler);
 
-        originElement.style.top = '475px';
+        originElement.style.bottom = '25px';
         originElement.style.left = '200px';
         originRect = originElement.getBoundingClientRect();
 
@@ -198,19 +191,15 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.bottom).toBe(originRect.top);
-        expect(overlayRect.right).toBe(originRect.right);
+        expect(Math.floor(overlayRect.bottom)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect.right));
       });
 
       it('should reposition the overlay if it would go off the right of the screen', () => {
-        // Use the fake viewport ruler because we don't know *exactly* how big the viewport is.
-        fakeViewportRuler.fakeRect = {
-          top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-        };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(viewportRuler);
 
         originElement.style.top = '200px';
-        originElement.style.left = '475px';
+        originElement.style.right = '25px';
         originRect = originElement.getBoundingClientRect();
 
         strategy = positionBuilder.connectedTo(
@@ -224,19 +213,16 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.right).toBe(originRect.left);
+
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect.left));
       });
 
       it('should recalculate and set the last position with recalculateLastPosition()', () => {
-        // Use the fake viewport ruler because we don't know *exactly* how big the viewport is.
-        fakeViewportRuler.fakeRect = {
-          top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-        };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(viewportRuler);
 
         // Push the trigger down so the overlay doesn't have room to open on the bottom.
-        originElement.style.top = '475px';
+        originElement.style.bottom = '25px';
         originRect = originElement.getBoundingClientRect();
 
         strategy = positionBuilder.connectedTo(
@@ -257,16 +243,12 @@ describe('ConnectedPositionStrategy', () => {
         strategy.recalculateLastPosition();
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.bottom).toBe(originRect.top,
+        expect(Math.floor(overlayRect.bottom)).toBe(Math.floor(originRect.top),
             'Expected overlay to be re-aligned to the trigger in the previous position.');
       });
 
       it('should default to the initial position, if no positions fit in the viewport', () => {
-        // Use the fake viewport ruler because we don't know *exactly* how big the viewport is.
-        fakeViewportRuler.fakeRect = {
-          top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-        };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(viewportRuler);
 
         // Make the origin element taller than the viewport.
         originElement.style.height = '1000px';
@@ -283,7 +265,7 @@ describe('ConnectedPositionStrategy', () => {
 
         let overlayRect = overlayElement.getBoundingClientRect();
 
-        expect(overlayRect.bottom).toBe(originRect.top,
+        expect(Math.floor(overlayRect.bottom)).toBe(Math.floor(originRect.top),
             'Expected overlay to be re-aligned to the trigger in the initial position.');
       });
 
@@ -300,8 +282,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.right).toBe(originRect.right);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect.right));
       });
 
       it('should position a panel with the x offset provided', () => {
@@ -315,8 +297,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.top);
-        expect(overlayRect.left).toBe(originRect.left + 10);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left + 10));
       });
 
       it('should position a panel with the y offset provided', () => {
@@ -330,20 +312,16 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.top + 50);
-        expect(overlayRect.left).toBe(originRect.left);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top + 50));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
       });
 
     });
 
     it('should emit onPositionChange event when position changes', () => {
-      // force the overlay to open in a fallback position
-      fakeViewportRuler.fakeRect = {
-        top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-      };
-      positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+      positionBuilder = new OverlayPositionBuilder(viewportRuler);
       originElement.style.top = '200px';
-      originElement.style.left = '475px';
+      originElement.style.right = '25px';
 
       strategy = positionBuilder.connectedTo(
           fakeElementRef,
@@ -363,14 +341,10 @@ describe('ConnectedPositionStrategy', () => {
               `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
 
       it('should pick the fallback position that shows the largest area of the element', () => {
-        // Use the fake viewport ruler because we don't know *exactly* how big the viewport is.
-        fakeViewportRuler.fakeRect = {
-          top: 0, left: 0, width: 500, height: 500, right: 500, bottom: 500
-        };
-        positionBuilder = new OverlayPositionBuilder(fakeViewportRuler);
+        positionBuilder = new OverlayPositionBuilder(viewportRuler);
 
         originElement.style.top = '200px';
-        originElement.style.left = '475px';
+        originElement.style.right = '25px';
         originRect = originElement.getBoundingClientRect();
 
         strategy = positionBuilder.connectedTo(
@@ -388,8 +362,8 @@ describe('ConnectedPositionStrategy', () => {
 
         let overlayRect = overlayElement.getBoundingClientRect();
 
-        expect(overlayRect.top).toBe(originRect.top);
-        expect(overlayRect.left).toBe(originRect.left);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
       });
 
       it('should position a panel properly when rtl', () => {
@@ -430,8 +404,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.left).toBe(originRect.left);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
       });
 
       it('should position to the right, center aligned vertically', () => {
@@ -443,8 +417,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originCenterY - (OVERLAY_HEIGHT / 2));
-        expect(overlayRect.left).toBe(originRect.right);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originCenterY - (OVERLAY_HEIGHT / 2)));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.right));
       });
 
       it('should position to the left, below', () => {
@@ -456,8 +430,9 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.right).toBe(originRect.left);
+
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect.left));
       });
 
       it('should position above, right aligned', () => {
@@ -469,8 +444,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.bottom).toBe(originRect.top);
-        expect(overlayRect.right).toBe(originRect.right);
+        expect(Math.floor(overlayRect.bottom)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect.right));
       });
 
       it('should position below, centered', () => {
@@ -482,8 +457,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.bottom);
-        expect(overlayRect.left).toBe(originCenterX - (OVERLAY_WIDTH / 2));
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originCenterX - (OVERLAY_WIDTH / 2)));
       });
 
       it('should center the overlay on the origin', () => {
@@ -495,8 +470,8 @@ describe('ConnectedPositionStrategy', () => {
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
-        expect(overlayRect.top).toBe(originRect.top);
-        expect(overlayRect.left).toBe(originRect.left);
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
       });
     }
   });
@@ -513,7 +488,7 @@ describe('ConnectedPositionStrategy', () => {
 
     beforeEach(() => {
       // Set up the overlay
-      overlayContainerElement = createFixedElement();
+      overlayContainerElement = createOverlayContainer();
       overlayElement = createPositionedBlockElement();
       document.body.appendChild(overlayContainerElement);
       overlayContainerElement.appendChild(overlayElement);
@@ -603,14 +578,114 @@ describe('ConnectedPositionStrategy', () => {
       });
     });
   });
+
+  describe('positioning properties', () => {
+    let originElement: HTMLElement;
+    let overlayElement: HTMLElement;
+    let overlayContainerElement: HTMLElement;
+    let strategy: ConnectedPositionStrategy;
+    let fakeElementRef: ElementRef;
+    let positionBuilder: OverlayPositionBuilder;
+
+    beforeEach(() => {
+      // The origin and overlay elements need to be in the document body in order to have geometry.
+      originElement = createPositionedBlockElement();
+      overlayContainerElement = createOverlayContainer();
+      overlayElement = createPositionedBlockElement();
+      document.body.appendChild(originElement);
+      document.body.appendChild(overlayContainerElement);
+      overlayContainerElement.appendChild(overlayElement);
+
+      fakeElementRef = new FakeElementRef(originElement);
+      positionBuilder = new OverlayPositionBuilder(viewportRuler);
+    });
+
+    describe('in ltr', () => {
+      it('should use `left` when positioning an element at the start', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'start', originY: 'top'},
+            {overlayX: 'start', overlayY: 'top'});
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.left).toBeTruthy();
+        expect(overlayElement.style.right).toBeFalsy();
+      });
+
+      it('should use `right` when positioning an element at the end', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'end', originY: 'top'},
+            {overlayX: 'end', overlayY: 'top'});
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.right).toBeTruthy();
+        expect(overlayElement.style.left).toBeFalsy();
+      });
+
+    });
+
+    describe('in rtl', () => {
+      it('should use `right` when positioning an element at the start', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'start', originY: 'top'},
+            {overlayX: 'start', overlayY: 'top'}
+        )
+        .withDirection('rtl');
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.right).toBeTruthy();
+        expect(overlayElement.style.left).toBeFalsy();
+      });
+
+      it('should use `left` when positioning an element at the end', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'end', originY: 'top'},
+            {overlayX: 'end', overlayY: 'top'}
+        ).withDirection('rtl');
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.left).toBeTruthy();
+        expect(overlayElement.style.right).toBeFalsy();
+      });
+    });
+
+    describe('vertical', () => {
+      it('should use `top` when positioning at element along the top', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'start', originY: 'top'},
+            {overlayX: 'start', overlayY: 'top'}
+        );
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.top).toBeTruthy();
+        expect(overlayElement.style.bottom).toBeFalsy();
+      });
+
+      it('should use `bottom` when positioning at element along the bottom', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'start', originY: 'bottom'},
+            {overlayX: 'start', overlayY: 'bottom'}
+        );
+
+        strategy.apply(overlayElement);
+        expect(overlayElement.style.bottom).toBeTruthy();
+        expect(overlayElement.style.top).toBeFalsy();
+      });
+    });
+
+  });
+
 });
 
 /** Creates an absolutely positioned, display: block element with a default size. */
 function createPositionedBlockElement() {
   let element = createBlockElement();
   element.style.position = 'absolute';
-  element.style.top = '0';
-  element.style.left = '0';
   return element;
 }
 
@@ -624,15 +699,10 @@ function createBlockElement() {
   return element;
 }
 
-/** Creates an position: fixed element that spans the screen size. */
-function createFixedElement() {
+/** Creates the wrapper for all of the overlays. */
+function createOverlayContainer() {
   let element = document.createElement('div');
-  element.style.position = 'fixed';
-  element.style.top = '0';
-  element.style.left = '0';
-  element.style.width = `100%`;
-  element.style.height = `100%`;
-  element.style.zIndex = '100';
+  element.classList.add('cdk-overlay-container');
   return element;
 }
 
@@ -648,23 +718,7 @@ function createOverflowContainerElement() {
 }
 
 
-/** Fake implementation of ViewportRuler that just returns the previously given ClientRect. */
-class FakeViewportRuler implements ViewportRuler {
-  fakeRect: ClientRect = {left: 0, top: 0, width: 1014, height: 686, bottom: 686, right: 1014};
-  fakeScrollPos: {top: number, left: number} = {top: 0, left: 0};
-
-  getViewportRect() {
-    return this.fakeRect;
-  }
-
-  getViewportScrollPosition(documentRect?: ClientRect): {top: number; left: number} {
-    return this.fakeScrollPos;
-  }
-}
-
-
 /** Fake implementation of ElementRef that is just a simple container for nativeElement. */
 class FakeElementRef implements ElementRef {
-  constructor(public nativeElement: HTMLElement) {
-  }
+  constructor(public nativeElement: HTMLElement) { }
 }

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -34,9 +34,7 @@ describe('MdMenu', () => {
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
-          overlayContainerElement.style.position = 'fixed';
-          overlayContainerElement.style.top = '0';
-          overlayContainerElement.style.left = '0';
+          overlayContainerElement.classList.add('cdk-overlay-container');
           document.body.appendChild(overlayContainerElement);
 
           // remove body padding to keep consistent cross-browser
@@ -46,8 +44,7 @@ describe('MdMenu', () => {
         }},
         {provide: Dir, useFactory: () => {
           return {value: dir};
-        }},
-        {provide: ViewportRuler, useClass: FakeViewportRuler}
+        }}
       ]
     });
 
@@ -118,7 +115,7 @@ describe('MdMenu', () => {
       const trigger = fixture.componentInstance.triggerEl.nativeElement;
 
       // Push trigger to the bottom edge of viewport,so it has space to open "above"
-      trigger.style.position = 'relative';
+      trigger.style.position = 'fixed';
       trigger.style.top = '600px';
 
       // Push trigger to the right, so it has space to open "before"
@@ -176,8 +173,9 @@ describe('MdMenu', () => {
 
       // Push trigger to the right side of viewport, so it doesn't have space to open
       // in its default "after" position on the right side.
-      trigger.style.position = 'relative';
-      trigger.style.left = '950px';
+      trigger.style.position = 'fixed';
+      trigger.style.right = '-50px';
+      trigger.style.top = '200px';
 
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
@@ -188,13 +186,13 @@ describe('MdMenu', () => {
       // In "before" position, the right sides of the overlay and the origin are aligned.
       // To find the overlay left, subtract the menu width from the origin's right side.
       const expectedLeft = triggerRect.right - overlayRect.width;
-      expect(Math.round(overlayRect.left))
-          .toBe(Math.round(expectedLeft),
+      expect(Math.floor(overlayRect.left))
+          .toBe(Math.floor(expectedLeft),
               `Expected menu to open in "before" position if "after" position wouldn't fit.`);
 
       // The y-position of the overlay should be unaffected, as it can already fit vertically
-      expect(Math.round(overlayRect.top))
-          .toBe(Math.round(triggerRect.top),
+      expect(Math.floor(overlayRect.top))
+          .toBe(Math.floor(triggerRect.top),
               `Expected menu top position to be unchanged if it can fit in the viewport.`);
     });
 
@@ -205,8 +203,8 @@ describe('MdMenu', () => {
 
       // Push trigger to the bottom part of viewport, so it doesn't have space to open
       // in its default "below" position below the trigger.
-      trigger.style.position = 'relative';
-      trigger.style.top = '600px';
+      trigger.style.position = 'fixed';
+      trigger.style.bottom = '65px';
 
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
@@ -217,13 +215,13 @@ describe('MdMenu', () => {
       // In "above" position, the bottom edges of the overlay and the origin are aligned.
       // To find the overlay top, subtract the menu height from the origin's bottom edge.
       const expectedTop = triggerRect.bottom - overlayRect.height;
-      expect(Math.round(overlayRect.top))
-          .toBe(Math.round(expectedTop),
+      expect(Math.floor(overlayRect.top))
+          .toBe(Math.floor(expectedTop),
               `Expected menu to open in "above" position if "below" position wouldn't fit.`);
 
-      // The xPosition of the overlay should be unaffected, as it can already fit horizontally
-      expect(Math.round(overlayRect.left))
-          .toBe(Math.round(triggerRect.left),
+      // The x-position of the overlay should be unaffected, as it can already fit horizontally
+      expect(Math.floor(overlayRect.left))
+          .toBe(Math.floor(triggerRect.left),
               `Expected menu x position to be unchanged if it can fit in the viewport.`);
     });
 
@@ -234,9 +232,9 @@ describe('MdMenu', () => {
 
       // push trigger to the bottom, right part of viewport, so it doesn't have space to open
       // in its default "after below" position.
-      trigger.style.position = 'relative';
-      trigger.style.left = '950px';
-      trigger.style.top = '600px';
+      trigger.style.position = 'fixed';
+      trigger.style.right = '-50px';
+      trigger.style.bottom = '65px';
 
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
@@ -247,12 +245,12 @@ describe('MdMenu', () => {
       const expectedLeft = triggerRect.right - overlayRect.width;
       const expectedTop = triggerRect.bottom - overlayRect.height;
 
-      expect(Math.round(overlayRect.left))
-          .toBe(Math.round(expectedLeft),
+      expect(Math.floor(overlayRect.left))
+          .toBe(Math.floor(expectedLeft),
               `Expected menu to open in "before" position if "after" position wouldn't fit.`);
 
-      expect(Math.round(overlayRect.top))
-          .toBe(Math.round(expectedTop),
+      expect(Math.floor(overlayRect.top))
+          .toBe(Math.floor(expectedTop),
               `Expected menu to open in "above" position if "below" position wouldn't fit.`);
     });
 
@@ -269,14 +267,14 @@ describe('MdMenu', () => {
 
       // As designated "before" position won't fit on screen, the menu should fall back
       // to "after" mode, where the left sides of the overlay and trigger are aligned.
-      expect(Math.round(overlayRect.left))
-          .toBe(Math.round(triggerRect.left),
+      expect(Math.floor(overlayRect.left))
+          .toBe(Math.floor(triggerRect.left),
               `Expected menu to open in "after" position if "before" position wouldn't fit.`);
 
       // As designated "above" position won't fit on screen, the menu should fall back
       // to "below" mode, where the top edges of the overlay and trigger are aligned.
-      expect(Math.round(overlayRect.top))
-          .toBe(Math.round(triggerRect.top),
+      expect(Math.floor(overlayRect.top))
+          .toBe(Math.floor(triggerRect.top),
               `Expected menu to open in "below" position if "above" position wouldn't fit.`);
     });
 
@@ -343,8 +341,8 @@ describe('MdMenu', () => {
         subject.openMenu();
 
         // Since the menu is overlaying the trigger, the overlay top should be the trigger top.
-        expect(Math.round(subject.overlayRect.top))
-            .toBe(Math.round(subject.triggerRect.top),
+        expect(Math.floor(subject.overlayRect.top))
+            .toBe(Math.floor(subject.triggerRect.top),
                 `Expected menu to open in default "below" position.`);
       });
     });
@@ -358,20 +356,20 @@ describe('MdMenu', () => {
         subject.openMenu();
 
         // Since the menu is below the trigger, the overlay top should be the trigger bottom.
-        expect(Math.round(subject.overlayRect.top))
-            .toBe(Math.round(subject.triggerRect.bottom),
+        expect(Math.floor(subject.overlayRect.top))
+            .toBe(Math.floor(subject.triggerRect.bottom),
                 `Expected menu to open directly below the trigger.`);
       });
 
       it('supports above position fall back', () => {
         // Push trigger to the bottom part of viewport, so it doesn't have space to open
         // in its default "below" position below the trigger.
-        subject.updateTriggerStyle({position: 'relative', top: '650px'});
+        subject.updateTriggerStyle({position: 'fixed', bottom: '0'});
         subject.openMenu();
 
         // Since the menu is above the trigger, the overlay bottom should be the trigger top.
-        expect(Math.round(subject.overlayRect.bottom))
-            .toBe(Math.round(subject.triggerRect.top),
+        expect(Math.floor(subject.overlayRect.bottom))
+            .toBe(Math.floor(subject.triggerRect.top),
                 `Expected menu to open in "above" position if "below" position wouldn't fit.`);
       });
 
@@ -529,16 +527,4 @@ class CustomMenuPanel implements MdMenuPanel {
 })
 class CustomMenu {
   @ViewChild(MdMenuTrigger) trigger: MdMenuTrigger;
-}
-
-class FakeViewportRuler {
-  getViewportRect() {
-    return {
-      left: 0, top: 0, width: 1014, height: 686, bottom: 686, right: 1014
-    };
-  }
-
-  getViewportScrollPosition() {
-    return {top: 0, left: 0};
-  }
 }


### PR DESCRIPTION
* Refactors the `ConnectedPositionStrategy` to be able to use `right` and `bottom` to position the panel. This will allow the element to keep its position automatically, even if the element's size changes.
* Removes the uses of the `FakeViewportRuler` in some of the unit tests since it doesn't work very well when the element is positioned relatively to the right edge of the screen.
* Rounds down the values when testing positioning. This is necessary, because some browsers (particularly Chrome on Windows) can have some subpixel deviations.

Fixes #4155.