### PR TITLE
docs(core/portal): fix TemplatePortalDirective spelling

### DIFF
--- a/src/lib/core/portal/README.md
+++ b/src/lib/core/portal/README.md
@@ -51,7 +51,7 @@ Usage:
 ```
 
 A component can use `@ViewChild` or `@ViewChildren` to get a reference to a
-`TemplatePortalDiective`.
+`TemplatePortalDirective`.
 
 ##### `ComponentPortal`
 Used to create a portal from a component type.


### PR DESCRIPTION
It was missing an `r`