### PR TITLE
fix(core): export MdOptionSelectionChange

### DIFF
--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -16,7 +16,7 @@ export {Dir, LayoutDirection, RtlModule} from './rtl/dir';
 // Mutation Observer
 export {ObserveContentModule, ObserveContent} from './observe-content/observe-content';
 
-export {MdOptionModule, MdOption} from './option/option';
+export {MdOptionModule, MdOption, MdOptionSelectionChange} from './option/option';
 
 // Portals
 export {


### PR DESCRIPTION
This exports `MdOptionSelectionChange` in `@angular/material`. It makes it easier to import if you are making a custom component which uses `mdOption` and needs to handle selection changes itself(ie a custom search bar).

I couldn't find any guidelines on when or why certain things are exported but not exposed in the main `@angular/material` package.

~~Feel free to close if we should just import from `@angular/material/core/option` instead.~~ It seems importing from `@angular/material/core/option` doesn't work even though there are type files.