### PR TITLE
chore(autocomplete): remove unused startWith import

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -27,7 +27,6 @@ import {Subscription} from 'rxjs/Subscription';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/switchMap';
 
 /**


### PR DESCRIPTION
I do not believe `startWith`'s side effects are required since it is not used in `autocomplete-trigger.ts`.