### PR TITLE
fix(a11y): export `ActiveDescendantKeyManager`

### DIFF
--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -68,6 +68,7 @@ export {
   LIVE_ANNOUNCER_ELEMENT_TOKEN,
   LIVE_ANNOUNCER_PROVIDER,
 } from './a11y/live-announcer';
+export {ActiveDescendantKeyManager} from './a11y/activedescendant-key-manager';
 
 // Selection
 export * from './selection/selection';


### PR DESCRIPTION
Follow up from https://github.com/angular/material2/pull/4285#issuecomment-297807895 for exporting `ActiveDescendantKeyManager`.


Still not sure on guidelines but it seems to be approved and this is very useful for custom overlays(easy a11y ftw).