### PR TITLE
chore: added @angular/forms as peer dependency

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -24,6 +24,7 @@
   "peerDependencies": {
     "@angular/core": "^4.0.0",
     "@angular/common": "^4.0.0",
+    "@angular/forms": "^4.0.0",
     "@angular/http": "^4.0.0"
   }
 }


### PR DESCRIPTION
I just created a blank app with `@angular/cli@1.0.1`, and removed `forms` dependency (since I was not planning to use any forms). When serving up the app and adding `@angular/material` I got this error:

![image](https://cloud.githubusercontent.com/assets/8770194/25556475/61dae32c-2cfd-11e7-8a22-d8014e645956.png)

Seems to me that `@angular/forms` should be a peer dependency if material be imported without errors with no `forms` module. 