### PR TITLE
feat: disabled fieldset support

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -7,10 +7,13 @@ import {
   Input,
   OnDestroy,
   Renderer2,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Optional,
+  SkipSelf,
 } from '@angular/core';
 import {coerceBooleanProperty, FocusOriginMonitor} from '../core';
-import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
+import {mixinDisabled, CanDisable} from '../core/common-behaviors/mixin-disabled';
+import {MdDisabled} from '../core/common-behaviors/disabled';
 
 
 // TODO(kara): Convert attribute selectors to classes when attr maps become available
@@ -121,8 +124,10 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
   set disableRipple(v) { this._disableRipple = coerceBooleanProperty(v); }
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer2,
-              private _focusOriginMonitor: FocusOriginMonitor) {
+              private _focusOriginMonitor: FocusOriginMonitor,
+              @SkipSelf() @Optional() disabledParent?: MdDisabled) {
     super();
+    this.withDisabledParent(disabledParent);
     this._focusOriginMonitor.monitor(this._elementRef.nativeElement, this._renderer, true);
   }
 
@@ -195,8 +200,9 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
   encapsulation: ViewEncapsulation.None
 })
 export class MdAnchor extends MdButton {
-  constructor(elementRef: ElementRef, renderer: Renderer2, focusOriginMonitor: FocusOriginMonitor) {
-    super(elementRef, renderer, focusOriginMonitor);
+  constructor(elementRef: ElementRef, renderer: Renderer2, focusOriginMonitor: FocusOriginMonitor,
+    @SkipSelf() @Optional() disabledParent?: MdDisabled) {
+    super(elementRef, renderer, focusOriginMonitor, disabledParent);
   }
 
   /** @docs-private */

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -12,11 +12,14 @@ import {
   Renderer2,
   ViewChild,
   ViewEncapsulation,
+  Optional,
+  SkipSelf,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {coerceBooleanProperty} from '../core/coercion/boolean-property';
 import {FocusOrigin, FocusOriginMonitor, MdRipple, RippleRef} from '../core';
-import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
+import {mixinDisabled, CanDisable} from '../core/common-behaviors/mixin-disabled';
+import {MdDisabled} from '../core/common-behaviors/disabled';
 
 
 /** Monotonically increasing integer used to auto-generate unique ids for checkbox components. */
@@ -193,8 +196,10 @@ export class MdCheckbox extends _MdCheckboxMixinBase
   constructor(private _renderer: Renderer2,
               private _elementRef: ElementRef,
               private _changeDetectorRef: ChangeDetectorRef,
-              private _focusOriginMonitor: FocusOriginMonitor) {
+              private _focusOriginMonitor: FocusOriginMonitor,
+              @SkipSelf() @Optional() disabledParent?: MdDisabled) {
     super();
+    this.withDisabledParent(disabledParent);
     this.color = 'accent';
   }
 

--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from '@angular/core';
 import {CompatibilityModule} from '../compatibility/compatibility';
+import {MdDisabled} from './disabled';
 
 
 /**
@@ -10,6 +11,7 @@ import {CompatibilityModule} from '../compatibility/compatibility';
  */
 @NgModule({
   imports: [CompatibilityModule],
-  exports: [CompatibilityModule],
+  exports: [CompatibilityModule, MdDisabled],
+  declarations: [MdDisabled]
 })
 export class MdCommonModule { }

--- a/src/lib/core/common-behaviors/disabled.spec.ts
+++ b/src/lib/core/common-behaviors/disabled.spec.ts
@@ -1,18 +1,95 @@
-import {mixinDisabled} from './disabled';
+import {Component, ViewChild, ViewChildren, QueryList} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {MdDisabled} from './disabled';
+import {MdCommonModule} from './common-module';
 
 
-describe('MixinDisabled', () => {
-  it('should augment an existing class with a disabled property', () => {
-    class EmptyClass { }
+describe('MdDisabled', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MdCommonModule],
+      declarations: [SimpleDisabled, OneLevelNestedDisabled, MultiLevelNestedDisabled]
+    }).compileComponents();
+  }));
 
-    let classWithDisabled = mixinDisabled(EmptyClass);
-    let instance = new classWithDisabled();
+  it('should be able to be disabled on its own', async(() => {
+    let fixture = TestBed.createComponent(SimpleDisabled);
+    fixture.detectChanges();
 
-    expect(instance.disabled)
-        .toBe(false, 'Expected the mixed-into class to have a disabled property');
+    expect(fixture.componentInstance.disabledInstance.disabled).toBe(true,
+        'Expected instance to be disabled.');
+  }));
 
-    instance.disabled = true;
-    expect(instance.disabled)
-        .toBe(true, 'Expected the mixed-into class to have an updated disabled property');
-  });
+  it('should inherit its disabled state from a direct ancestor', async(() => {
+    let fixture = TestBed.createComponent(OneLevelNestedDisabled);
+    fixture.detectChanges();
+
+    let [parent, child] = fixture.componentInstance.disabledInstances.toArray();
+
+    expect(child.disabled).toBe(false, 'Expected the child to be enabled.');
+    expect(parent.disabled).toBe(false, 'Expected the parent to be enabled.');
+
+    fixture.componentInstance.isParentDisabled = true;
+    fixture.detectChanges();
+
+    expect(child.disabled).toBe(true, 'Expected the child to be disabled.');
+    expect(parent.disabled).toBe(true, 'Expected the parent to be disabled.');
+  }));
+
+  it('should inherit its disabled state from an upper-level ancestor', async(() => {
+    let fixture = TestBed.createComponent(MultiLevelNestedDisabled);
+    fixture.detectChanges();
+
+    let [grandparent, parent, child] = fixture.componentInstance.disabledInstances.toArray();
+
+    expect(child.disabled).toBe(false, 'Expected the child to be enabled.');
+    expect(parent.disabled).toBe(false, 'Expected the parent to be enabled.');
+    expect(grandparent.disabled).toBe(false, 'Expected the grandparent to be enabled.');
+
+    fixture.componentInstance.isGrandparentDisabled = true;
+    fixture.detectChanges();
+
+    expect(child.disabled).toBe(true, 'Expected the child to be disabled.');
+    expect(parent.disabled).toBe(true, 'Expected the parent to be disabled.');
+    expect(grandparent.disabled).toBe(true, 'Expected the grandparent to be disabled.');
+  }));
 });
+
+
+@Component({
+  selector: 'simple-disabled',
+  template: `<fieldset disabled></fieldset>`
+})
+class SimpleDisabled {
+  @ViewChild(MdDisabled) disabledInstance: MdDisabled;
+}
+
+
+@Component({
+  selector: 'one-level-nested-disabled',
+  template: `
+    <fieldset [disabled]="isParentDisabled">
+      <fieldset [disabled]="false"></fieldset>
+    </fieldset>
+  `
+})
+class OneLevelNestedDisabled {
+  @ViewChildren(MdDisabled) disabledInstances: QueryList<MdDisabled>;
+  isParentDisabled = false;
+}
+
+
+@Component({
+  selector: 'multi-level-nested-disabled',
+  template: `
+    <fieldset [disabled]="isGrandparentDisabled">
+      <fieldset [disabled]="false">
+        <fieldset [disabled]="false"></fieldset>
+      </fieldset>
+    </fieldset>
+  `
+})
+class MultiLevelNestedDisabled {
+  @ViewChildren(MdDisabled) disabledInstances: QueryList<MdDisabled>;
+  isGrandparentDisabled = false;
+}

--- a/src/lib/core/common-behaviors/disabled.ts
+++ b/src/lib/core/common-behaviors/disabled.ts
@@ -1,22 +1,26 @@
-import {coerceBooleanProperty} from '../coercion/boolean-property';
-
-
-/** @docs-private */
-export type Constructor<T> = new(...args: any[]) => T;
+import {Directive, SkipSelf, Optional} from '@angular/core';
+import {mixinDisabled, CanDisable} from './mixin-disabled';
 
 /** @docs-private */
-export interface CanDisable {
-  disabled: boolean;
-}
+export class MdDisabledBase { }
+export const _MdDisabledMixinBase = mixinDisabled(MdDisabledBase);
 
-/** Mixin to augment a directive with a `disabled` property. */
-export function mixinDisabled<T extends Constructor<{}>>(base: T): Constructor<CanDisable> & T {
-  return class extends base {
-    private _disabled: boolean = false;
-
-    get disabled() { return this._disabled; }
-    set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
-
-    constructor(...args: any[]) { super(...args); }
-  };
+/**
+ * Wrapper around the native `disabled` attribute.
+ * Used to set up the `disabled` fieldset inheritance.
+ * @docs-private
+ */
+@Directive({
+  selector: '[disabled]',
+  inputs: ['disabled'],
+  host: {
+    '[attr.disabled]': 'disabled || null',
+    '[attr.aria-disabled]': 'disabled',
+  }
+})
+export class MdDisabled extends _MdDisabledMixinBase implements CanDisable {
+  constructor(@SkipSelf() @Optional() parent?: MdDisabled) {
+    super();
+    this.withDisabledParent(parent);
+  }
 }

--- a/src/lib/core/common-behaviors/mixin-disabled.spec.ts
+++ b/src/lib/core/common-behaviors/mixin-disabled.spec.ts
@@ -1,0 +1,35 @@
+import {mixinDisabled, CanDisable} from './mixin-disabled';
+
+
+describe('MixinDisabled', () => {
+  it('should augment an existing class with a disabled property', () => {
+    class EmptyClass { }
+
+    let classWithDisabled = mixinDisabled(EmptyClass);
+    let instance = new classWithDisabled();
+
+    expect(instance.disabled)
+        .toBe(false, 'Expected the mixed-into class to have a disabled property');
+
+    instance.disabled = true;
+    expect(instance.disabled)
+        .toBe(true, 'Expected the mixed-into class to have an updated disabled property');
+  });
+
+  it('should inherit the disabled state from the parent', () => {
+    class EmptyParentClass { }
+    class EmptyClass { }
+
+    let parentWithDisabled = mixinDisabled(EmptyParentClass);
+    let childWithDisabled = mixinDisabled(EmptyClass);
+
+    let parentInstance = new parentWithDisabled();
+    let instance = new childWithDisabled();
+
+    instance.withDisabledParent(parentInstance);
+
+    expect(instance.disabled).toBe(false);
+    parentInstance.disabled = true;
+    expect(instance.disabled).toBe(true);
+  });
+});

--- a/src/lib/core/common-behaviors/mixin-disabled.ts
+++ b/src/lib/core/common-behaviors/mixin-disabled.ts
@@ -1,0 +1,39 @@
+import {coerceBooleanProperty} from '../coercion/boolean-property';
+
+
+/** @docs-private */
+export type Constructor<T> = new(...args: any[]) => T;
+
+/** @docs-private */
+export interface CanDisable {
+  disabled: boolean;
+  withDisabledParent: (parent: CanDisable) => CanDisable;
+}
+
+/** Mixin to augment a directive with a `disabled` property. */
+export function mixinDisabled<T extends Constructor<{}>>(base: T): Constructor<CanDisable> & T {
+  return class extends base {
+    private _parent: CanDisable = null;
+    private _disabled: boolean = false;
+
+    get disabled() {
+      return (this._parent && this._parent.disabled) || this._disabled;
+    }
+    set disabled(value: any) {
+      this._disabled = coerceBooleanProperty(value);
+    }
+
+    /**
+     * Sets the parent from which to inherit the disabled state.
+     * @param parent Parent to inherit from.
+    */
+    withDisabledParent(parent: CanDisable): this {
+      this._parent = parent;
+      return this;
+    }
+
+    constructor(...args: any[]) {
+      super(...args);
+    }
+  };
+}

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -16,6 +16,7 @@ import {
   ViewChild,
   OnDestroy,
   AfterViewInit,
+  SkipSelf,
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {
@@ -26,7 +27,8 @@ import {
   FocusOrigin,
 } from '../core';
 import {coerceBooleanProperty} from '../core/coercion/boolean-property';
-import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
+import {mixinDisabled, CanDisable} from '../core/common-behaviors/mixin-disabled';
+import {MdDisabled} from '../core/common-behaviors/disabled';
 
 
 /**
@@ -158,6 +160,11 @@ export class MdRadioGroup extends _MdRadioGroupMixinBase
     this._selected = selected;
     this.value = selected ? selected.value : null;
     this._checkSelectedRadioButton();
+  }
+
+  constructor(@SkipSelf() @Optional() disabledParent?: MdDisabled) {
+    super();
+    this.withDisabledParent(disabledParent);
   }
 
   /**

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -10,7 +10,9 @@ import {
   Output,
   Renderer2,
   ViewChild,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Optional,
+  SkipSelf,
 } from '@angular/core';
 import {
   applyCssTransform,
@@ -22,7 +24,8 @@ import {
   RippleRef
 } from '../core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
+import {mixinDisabled, CanDisable} from '../core/common-behaviors/mixin-disabled';
+import {MdDisabled} from '../core/common-behaviors/disabled';
 
 
 export const MD_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
@@ -121,8 +124,10 @@ export class MdSlideToggle extends _MdSlideToggleMixinBase
 
   constructor(private _elementRef: ElementRef,
               private _renderer: Renderer2,
-              private _focusOriginMonitor: FocusOriginMonitor) {
+              private _focusOriginMonitor: FocusOriginMonitor,
+              @SkipSelf() @Optional() disabledParent?: MdDisabled) {
     super();
+    this.withDisabledParent(disabledParent);
   }
 
   ngAfterContentInit() {

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -8,7 +8,8 @@ import {
   Optional,
   Output,
   Renderer2,
-  ViewEncapsulation
+  ViewEncapsulation,
+  SkipSelf,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {coerceBooleanProperty, coerceNumberProperty, HammerInput} from '../core';
@@ -24,7 +25,8 @@ import {
   UP_ARROW
 } from '../core/keyboard/keycodes';
 import {FocusOrigin, FocusOriginMonitor} from '../core/style/focus-origin-monitor';
-import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
+import {mixinDisabled, CanDisable} from '../core/common-behaviors/mixin-disabled';
+import {MdDisabled} from '../core/common-behaviors/disabled';
 
 
 /**
@@ -381,8 +383,10 @@ export class MdSlider extends _MdSliderMixinBase
   }
 
   constructor(renderer: Renderer2, private _elementRef: ElementRef,
-              private _focusOriginMonitor: FocusOriginMonitor, @Optional() private _dir: Dir) {
+              private _focusOriginMonitor: FocusOriginMonitor, @Optional() private _dir: Dir,
+              @SkipSelf() @Optional() disabledParent?: MdDisabled) {
     super();
+    this.withDisabledParent(disabledParent);
     this._focusOriginMonitor.monitor(this._elementRef.nativeElement, renderer, true)
         .subscribe((origin: FocusOrigin) => this._isActive = !!origin && origin !== 'keyboard');
     this._renderer = new SliderRenderer(this._elementRef);


### PR DESCRIPTION
Adds support for disabling Material components by disabling their parent fieldset in a similar way to the native fieldsets. Example:

```html
<fieldset disabled>
  <button md-button>Some button</button>
</fieldset>
```