### PR TITLE
build: combine multiple stylelint tasks

### DIFF
--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -2,23 +2,23 @@ import gulp = require('gulp');
 import {execNodeTask} from '../util/task_helpers';
 import {DIST_MATERIAL} from '../constants';
 
-gulp.task('lint', ['tslint', 'stylelint', 'madge', 'dashboardlint']);
+/** Glob that matches all SCSS or CSS files that should be linted. */
+const stylesGlob = '+(tools|src)/**/*.+(css|scss)';
+
+/** List of flags that will passed to the different TSLint tasks. */
+const tsLintBaseFlags = [
+  '-c', 'tslint.json', '+(src|e2e|tools)/**/*.ts', '--exclude', '**/node_modules/**/*'
+];
+
+gulp.task('lint', ['tslint', 'stylelint', 'madge']);
 
 /** Task that runs madge to detect circular dependencies. */
 gulp.task('madge', ['material:clean-build'], execNodeTask('madge', ['--circular', DIST_MATERIAL]));
 
 /** Task to lint Angular Material's scss stylesheets. */
 gulp.task('stylelint', execNodeTask(
-  'stylelint', ['src/**/*.scss', '--config', 'stylelint-config.json', '--syntax', 'scss']
+  'stylelint', [stylesGlob, '--config', 'stylelint-config.json', '--syntax', 'scss']
 ));
-
-gulp.task('dashboardlint', execNodeTask(
-  'stylelint', ['tools/screenshot-test/**/*.css', '--config', 'stylelint-config.json',
-    '--syntax', 'scss']
-));
-
-const tsLintBaseFlags = ['-c', 'tslint.json', '+(src|e2e|tools)/**/*.ts', '--exclude',
-    '**/node_modules/**/*'];
 
 /** Task to run TSLint against the e2e/ and src/ directories. */
 gulp.task('tslint', execNodeTask('tslint', tsLintBaseFlags));


### PR DESCRIPTION
* Combines the multiple stylelint tasks into a single one. Stylelint supports globs using `globby`.