### PR TITLE
fix(datepicker): require actual date objects for min, max, etc

### DIFF
--- a/src/lib/datepicker/calendar-body.html
+++ b/src/lib/datepicker/calendar-body.html
@@ -24,6 +24,7 @@
       [class.mat-calendar-body-disabled]="!item.enabled"
       [class.mat-calendar-body-active]="_isActiveCell(rowIndex, colIndex)"
       [attr.aria-label]="item.ariaLabel"
+      [attr.aria-disabled]="!item.enabled || null"
       (click)="_cellClicked(item)">
     <div class="mat-calendar-body-cell-content"
          [class.mat-calendar-body-selected]="selectedValue === item.value"

--- a/src/lib/datepicker/calendar.spec.ts
+++ b/src/lib/datepicker/calendar.spec.ts
@@ -586,28 +586,35 @@ describe('MdCalendar', () => {
 
 
 @Component({
-  template: `<md-calendar startAt="1/31/2017" [(selected)]="selected"></md-calendar>`
+  template: `<md-calendar [startAt]="startDate" [(selected)]="selected"></md-calendar>`
 })
 class StandardCalendar {
   selected: Date = null;
-}
-
-
-@Component({
-  template: `<md-calendar [startAt]="startAt" minDate="1/1/2016" maxDate="1/1/2018"></md-calendar>`
-})
-class CalendarWithMinMax {
-  startAt: Date;
+  startDate = new Date(2017, JAN, 31);
 }
 
 
 @Component({
   template: `
-    <md-calendar startAt="1/1/2017" [(selected)]="selected" [dateFilter]="dateFilter"></md-calendar>
+    <md-calendar [startAt]="startAt" [minDate]="minDate" [maxDate]="maxDate"></md-calendar>
+  `
+})
+class CalendarWithMinMax {
+  startAt: Date;
+  minDate = new Date(2016, JAN, 1);
+  maxDate = new Date(2018, JAN, 1);
+}
+
+
+@Component({
+  template: `
+    <md-calendar [startAt]="startDate" [(selected)]="selected" [dateFilter]="dateFilter">
+    </md-calendar>
   `
 })
 class CalendarWithDateFilter {
   selected: Date = null;
+  startDate = new Date(2017, JAN, 1);
 
   dateFilter (date: Date) {
     return date.getDate() % 2 == 0 && date.getMonth() != NOV;

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -45,39 +45,19 @@ import {MD_DATE_FORMATS, MdDateFormats} from '../core/datetime/date-formats';
 })
 export class MdCalendar<D> implements AfterContentInit {
   /** A date representing the period (month or year) to start the calendar in. */
-  @Input()
-  get startAt(): D { return this._startAt; }
-  set startAt(value: D) {
-    this._startAt = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-  }
-  private _startAt: D;
+  @Input() startAt: D;
 
   /** Whether the calendar should be started in month or year view. */
   @Input() startView: 'month' | 'year' = 'month';
 
   /** The currently selected date. */
-  @Input()
-  get selected(): D { return this._selected; }
-  set selected(value: D) {
-    this._selected = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-  }
-  private _selected: D;
+  @Input() selected: D;
 
   /** The minimum selectable date. */
-  @Input()
-  get minDate(): D { return this._minDate; }
-  set minDate(date: D) {
-    this._minDate = this._dateAdapter.parse(date, this._dateFormats.parse.dateInput);
-  }
-  private _minDate: D;
+  @Input() minDate: D;
 
   /** The maximum selectable date. */
-  @Input()
-  get maxDate(): D { return this._maxDate; }
-  set maxDate(date: D) {
-    this._maxDate = this._dateAdapter.parse(date, this._dateFormats.parse.dateInput);
-  }
-  private _maxDate: D;
+  @Input() maxDate: D;
 
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter: (date: D) => boolean;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -73,20 +73,10 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   }
 
   /** The minimum valid date. */
-  @Input()
-  get min(): D { return this._min; }
-  set min(value: D) {
-    this._min = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-  }
-  private _min: D;
+  @Input() min: D;
 
   /** The maximum valid date. */
-  @Input()
-  get max(): D { return this._max; }
-  set max(value: D) {
-    this._max = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-  }
-  private _max: D;
+  @Input() max: D;
 
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D>();

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -466,12 +466,13 @@ describe('MdDatepicker', () => {
 
 @Component({
   template: `
-    <input [mdDatepicker]="d" value="1/1/2020">
+    <input [mdDatepicker]="d" [value]="date">
     <md-datepicker #d [touchUi]="touch"></md-datepicker>
   `,
 })
 class StandardDatepicker {
   touch = false;
+  date = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
   @ViewChild(MdDatepickerInput) datepickerInput: MdDatepickerInput<Date>;
 }
@@ -495,11 +496,13 @@ class NoInputDatepicker {
 
 @Component({
   template: `
-    <input [mdDatepicker]="d" value="1/1/2020">
-    <md-datepicker #d [startAt]="'1/1/2010'"></md-datepicker>
+    <input [mdDatepicker]="d" [value]="date">
+    <md-datepicker #d [startAt]="startDate"></md-datepicker>
   `,
 })
 class DatepickerWithStartAt {
+  date = new Date(2020, JAN, 1);
+  startDate = new Date(2010, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
 }
 
@@ -555,10 +558,12 @@ class InputContainerDatepicker {
 
 @Component({
   template: `
-    <input [mdDatepicker]="d" min="1/1/2010" max="1/1/2020">
+    <input [mdDatepicker]="d" [min]="minDate" [max]="maxDate">
     <md-datepicker #d></md-datepicker>
   `,
 })
 class DatepickerWithMinAndMax {
+  minDate = new Date(2010, JAN, 1);
+  maxDate = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -4,7 +4,6 @@ import {
   Component,
   ComponentRef,
   EventEmitter,
-  Inject,
   Input,
   OnDestroy,
   Optional,
@@ -32,7 +31,6 @@ import {Subscription} from 'rxjs/Subscription';
 import {MdDialogConfig} from '../dialog/dialog-config';
 import {DateAdapter} from '../core/datetime/index';
 import {createMissingDateImplError} from './datepicker-errors';
-import {MD_DATE_FORMATS, MdDateFormats} from '../core/datetime/date-formats';
 import {ESCAPE} from '../core/keyboard/keycodes';
 import {MdCalendar} from './calendar';
 
@@ -106,24 +104,20 @@ export class MdDatepicker<D> implements OnDestroy {
     // selected value is.
     return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D) {
-    this._startAt = this._dateAdapter.parse(date, this._dateFormats.parse.dateInput);
-  }
+  set startAt(date: D) { this._startAt = date; }
   private _startAt: D;
 
-  @Input()
-  startView: 'month' | 'year' = 'month';
+  /** The view that the calendar should start in. */
+  @Input() startView: 'month' | 'year' = 'month';
 
   /**
    * Whether the calendar UI is in touch mode. In touch mode the calendar opens in a dialog rather
    * than a popup and elements have more padding to allow for bigger touch targets.
    */
-  @Input()
-  touchUi = false;
+  @Input() touchUi = false;
 
   /** A function used to filter which dates are selectable. */
-  @Input()
-  dateFilter: (date: D) => boolean;
+  @Input() dateFilter: (date: D) => boolean;
 
   /** Emits new selected date when selected date changes. */
   @Output() selectedChanged = new EventEmitter<D>();
@@ -164,14 +158,11 @@ export class MdDatepicker<D> implements OnDestroy {
   constructor(private _dialog: MdDialog, private _overlay: Overlay,
               private _viewContainerRef: ViewContainerRef,
               @Optional() private _dateAdapter: DateAdapter<D>,
-              @Optional() @Inject(MD_DATE_FORMATS) private _dateFormats: MdDateFormats,
               @Optional() private _dir: Dir) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }
-    if (!this._dateFormats) {
-      throw createMissingDateImplError('MD_DATE_FORMATS');
-    }
+
   }
 
   ngOnDestroy() {

--- a/src/lib/datepicker/month-view.spec.ts
+++ b/src/lib/datepicker/month-view.spec.ts
@@ -117,9 +117,10 @@ class StandardMonthView {
 
 
 @Component({
-  template: `<md-month-view activeDate="1/1/2017" [dateFilter]="dateFilter"></md-month-view>`
+  template: `<md-month-view [activeDate]="activeDate" [dateFilter]="dateFilter"></md-month-view>`
 })
 class MonthViewWithDateFilter {
+  activeDate = new Date(2017, JAN, 1);
   dateFilter(date: Date) {
     return date.getDate() % 2 == 0;
   }

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -37,8 +37,7 @@ export class MdMonthView<D> implements AfterContentInit {
   get activeDate(): D { return this._activeDate; }
   set activeDate(value: D) {
     let oldActiveDate = this._activeDate;
-    this._activeDate = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput) ||
-        this._dateAdapter.today();
+    this._activeDate = value || this._dateAdapter.today();
     if (!this._hasSameMonthAndYear(oldActiveDate, this._activeDate)) {
       this._init();
     }
@@ -49,7 +48,7 @@ export class MdMonthView<D> implements AfterContentInit {
   @Input()
   get selected(): D { return this._selected; }
   set selected(value: D) {
-    this._selected = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+    this._selected = value;
     this._selectedDate = this._getDateInCurrentMonth(this.selected);
   }
   private _selected: D;

--- a/src/lib/datepicker/year-view.spec.ts
+++ b/src/lib/datepicker/year-view.spec.ts
@@ -118,9 +118,10 @@ class StandardYearView {
 
 
 @Component({
-  template: `<md-year-view date="1/1/2017" [dateFilter]="dateFilter"></md-year-view>`
+  template: `<md-year-view [activeDate]="activeDate" [dateFilter]="dateFilter"></md-year-view>`
 })
 class YearViewWithDateFilter {
+  activeDate = new Date(2017, JAN, 1);
   dateFilter(date: Date) {
     if (date.getMonth() == JAN) {
       return date.getDate() == 10;

--- a/src/lib/datepicker/year-view.ts
+++ b/src/lib/datepicker/year-view.ts
@@ -32,8 +32,7 @@ export class MdYearView<D> implements AfterContentInit {
   get activeDate(): D { return this._activeDate; }
   set activeDate(value: D) {
     let oldActiveDate = this._activeDate;
-    this._activeDate = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput) ||
-        this._dateAdapter.today();
+    this._activeDate = value || this._dateAdapter.today();
     if (this._dateAdapter.getYear(oldActiveDate) != this._dateAdapter.getYear(this._activeDate)) {
       this._init();
     }
@@ -44,7 +43,7 @@ export class MdYearView<D> implements AfterContentInit {
   @Input()
   get selected(): D { return this._selected; }
   set selected(value: D) {
-    this._selected = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+    this._selected = value;
     this._selectedMonth = this._getMonthInCurrentYear(this.selected);
   }
   private _selected: D;


### PR DESCRIPTION
string dates might not be correct across different locales, so we just require an actual object. also adds aria-disabled for disabled dates