### PR TITLE
fix(overlay): no longer export internal type

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -16,7 +16,7 @@ import {Scrollable} from '../scroll/scrollable';
  * where top and bottom are the y-axis coordinates of the bounding rectangle and left and right are
  * the x-axis coordinates.
  */
-export type ElementBoundingPositions = {
+type ElementBoundingPositions = {
   top: number;
   right: number;
   bottom: number;


### PR DESCRIPTION
* Currently the `ElementBoundingsPosition` type is only used internally by the `ConnectedPositionStrategy` and the export is unnecessary.
* Doesn't make any sense to export this type to the public while it's just internally used.