### PR TITLE
fix(focus-trap): import rxjs first operator

### DIFF
--- a/src/lib/core/a11y/focus-trap.ts
+++ b/src/lib/core/a11y/focus-trap.ts
@@ -10,6 +10,7 @@ import {
 import {InteractivityChecker} from './interactivity-checker';
 import {coerceBooleanProperty} from '../coercion/boolean-property';
 
+import 'rxjs/add/operator/first';
 
 /**
  * Class that allows for trapping focus within a DOM element.


### PR DESCRIPTION
* The `first` operator from RxJS is being used by the FocusTrap to subscribe to a NgZone EventEmitter. The `first` operator isn't imported and compiling & using core as a standalone would fail.

<img width="562" alt="screen shot 2017-05-05 at 19 26 18" src="https://cloud.githubusercontent.com/assets/4987015/25757028/37ffbab6-31c9-11e7-9a3d-afcab422f68a.png">

**Note**: More PR's like that to expect. Recognizable when doing the new packaging.
