### PR TITLE
feat(autocomplete): allow the ability to select an option on pressing…

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -19,7 +19,7 @@ import {PositionStrategy} from '../core/overlay/position/position-strategy';
 import {ConnectedPositionStrategy} from '../core/overlay/position/connected-position-strategy';
 import {Observable} from 'rxjs/Observable';
 import {MdOptionSelectionChange, MdOption} from '../core/option/option';
-import {ENTER, UP_ARROW, DOWN_ARROW} from '../core/keyboard/keycodes';
+import {ENTER, UP_ARROW, DOWN_ARROW, TAB} from '../core/keyboard/keycodes';
 import {Dir} from '../core/rtl/dir';
 import {MdInputContainer} from '../input/input-container';
 import {ScrollDispatcher} from '../core/overlay/scroll/scroll-dispatcher';
@@ -226,7 +226,8 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   _handleKeydown(event: KeyboardEvent): void {
-    if (this.activeOption && event.keyCode === ENTER) {
+    if (this.activeOption && (event.keyCode === ENTER ||
+      (event.keyCode == TAB && this._matAutocomplete.selectOptionOnTab && this.panelOpen))) {
       this.activeOption._selectViaInteraction();
       event.preventDefault();
     } else {

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -16,7 +16,7 @@ import {MdInputModule} from '../input/index';
 import {Dir, LayoutDirection} from '../core/rtl/dir';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Subscription} from 'rxjs/Subscription';
-import {ENTER, DOWN_ARROW, SPACE, UP_ARROW, HOME, END} from '../core/keyboard/keycodes';
+import {ENTER, DOWN_ARROW, SPACE, UP_ARROW, HOME, END, TAB} from '../core/keyboard/keycodes';
 import {MdOption} from '../core/option/option';
 import {MdAutocomplete} from './autocomplete';
 import {MdInputContainer} from '../input/input-container';
@@ -48,7 +48,8 @@ describe('MdAutocomplete', () => {
         AutocompleteWithoutForms,
         NgIfAutocomplete,
         AutocompleteWithNgModel,
-        AutocompleteWithOnPushDelay
+        AutocompleteWithOnPushDelay,
+        AutocompleteWithSelectOptionOnTab
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -528,6 +529,7 @@ describe('MdAutocomplete', () => {
     let input: HTMLInputElement;
     let DOWN_ARROW_EVENT: KeyboardEvent;
     let ENTER_EVENT: KeyboardEvent;
+    let TAB_EVENT: KeyboardEvent;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleAutocomplete);
@@ -536,6 +538,7 @@ describe('MdAutocomplete', () => {
       input = fixture.debugElement.query(By.css('input')).nativeElement;
       DOWN_ARROW_EVENT = new MockKeyboardEvent(DOWN_ARROW) as KeyboardEvent;
       ENTER_EVENT = new MockKeyboardEvent(ENTER) as KeyboardEvent;
+      TAB_EVENT = new MockKeyboardEvent(TAB) as KeyboardEvent;
 
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
@@ -644,6 +647,21 @@ describe('MdAutocomplete', () => {
           fixture.detectChanges();
           expect(input.value)
               .toContain('Alabama', `Expected text field to fill with selected value on ENTER.`);
+        });
+      });
+    }));
+
+    it('text field should be empty when TAB is pressed', async(() => {
+      fixture.whenStable().then(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+
+          fixture.componentInstance.trigger._handleKeydown(TAB_EVENT);
+          fixture.detectChanges();
+          expect(input.value)
+            .toBe('',`Expected text field to be empty when TAB is pressed.`);
         });
       });
     }));
@@ -788,6 +806,40 @@ describe('MdAutocomplete', () => {
 
   });
 
+  describe('tab keyboard event', () => {
+    let fixture: ComponentFixture<AutocompleteWithSelectOptionOnTab>;
+    let input: HTMLInputElement;
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let TAB_EVENT: KeyboardEvent;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(AutocompleteWithSelectOptionOnTab);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      DOWN_ARROW_EVENT = new MockKeyboardEvent(DOWN_ARROW) as KeyboardEvent;
+      TAB_EVENT = new MockKeyboardEvent(TAB) as KeyboardEvent;
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+    });
+
+    it('should fill the text field when an option is selected with TAB', async(() => {
+      fixture.whenStable().then(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+
+          fixture.componentInstance.trigger._handleKeydown(TAB_EVENT);
+          fixture.detectChanges();
+          expect(input.value)
+            .toContain('Alabama', `Expected text field to fill with selected value on TAB.`);
+        });
+      });
+    }));
+  });
+
   describe('aria', () => {
     let fixture: ComponentFixture<SimpleAutocomplete>;
     let input: HTMLInputElement;
@@ -929,7 +981,7 @@ describe('MdAutocomplete', () => {
 
       // Panel is offset by 6px in styles so that the underline has room to display.
       expect(Math.floor(inputBottom + 6))
-          .toEqual(Math.floor(panelTop), `Expected panel top to match input bottom by default.`);
+        .toEqual(Math.floor(panelTop), `Expected panel top to match input bottom by default.`);
       expect(fixture.componentInstance.trigger.autocomplete.positionY)
           .toEqual('below', `Expected autocomplete positionY to default to below.`);
     });
@@ -971,7 +1023,7 @@ describe('MdAutocomplete', () => {
 
       // Panel is offset by 24px in styles so that the label has room to display.
       expect(Math.floor(inputTop - 24))
-          .toEqual(Math.floor(panelBottom), `Expected panel to fall back to above position.`);
+        .toEqual(Math.floor(panelBottom), `Expected panel to fall back to above position.`);
       expect(fixture.componentInstance.trigger.autocomplete.positionY)
           .toEqual('above', `Expected autocomplete positionY to be "above" if panel won't fit.`);
     });
@@ -994,7 +1046,7 @@ describe('MdAutocomplete', () => {
 
         // Panel is offset by 24px in styles so that the label has room to display.
         expect(Math.floor(inputTop - 24))
-            .toEqual(Math.floor(panelBottom), `Expected panel to stay aligned after filtering.`);
+          .toEqual(Math.floor(panelBottom), `Expected panel to stay aligned after filtering.`);
         expect(fixture.componentInstance.trigger.autocomplete.positionY)
             .toEqual('above', `Expected autocomplete positionY to be "above" if panel won't fit.`);
       });
@@ -1348,6 +1400,51 @@ class AutocompleteWithOnPushDelay implements OnInit {
       this.options = ['One'];
     }, 1000);
   }
+}
+
+
+@Component({
+    template: `
+    <md-input-container [floatPlaceholder]="placeholder" [style.width.px]="width">
+      <input mdInput placeholder="State" [mdAutocomplete]="auto" [formControl]="stateCtrl">
+    </md-input-container>
+
+    <md-autocomplete #auto="mdAutocomplete" selectOptionOnTab="true">
+      <md-option *ngFor="let state of filteredStates" [value]="state.name">
+        <span> {{ state.code }}: {{ state.name }}  </span>
+      </md-option>
+    </md-autocomplete>
+  `
+})
+class AutocompleteWithSelectOptionOnTab implements OnDestroy {
+    stateCtrl = new FormControl();
+    filteredStates: any[];
+    valueSub: Subscription;
+    placeholder = 'auto';
+    width: number;
+
+    @ViewChild(MdAutocompleteTrigger) trigger: MdAutocompleteTrigger;
+    @ViewChild(MdAutocomplete) panel: MdAutocomplete;
+    @ViewChild(MdInputContainer) inputContainer: MdInputContainer;
+    @ViewChildren(MdOption) options: QueryList<MdOption>;
+
+    states = [
+        { code: 'AL', name: 'Alabama' },
+        { code: 'CA', name: 'California' },
+    ];
+
+    constructor() {
+        this.filteredStates = this.states;
+        this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
+            this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
+                : this.states;
+        });
+    }
+
+    ngOnDestroy() {
+        this.valueSub.unsubscribe();
+    }
+
 }
 
 

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -661,7 +661,7 @@ describe('MdAutocomplete', () => {
           fixture.componentInstance.trigger._handleKeydown(TAB_EVENT);
           fixture.detectChanges();
           expect(input.value)
-            .toBe('',`Expected text field to be empty when TAB is pressed.`);
+            .toBe('', `Expected text field to be empty when TAB is pressed.`);
         });
       });
     }));
@@ -1404,47 +1404,45 @@ class AutocompleteWithOnPushDelay implements OnInit {
 
 
 @Component({
-    template: `
-    <md-input-container [floatPlaceholder]="placeholder" [style.width.px]="width">
-      <input mdInput placeholder="State" [mdAutocomplete]="auto" [formControl]="stateCtrl">
-    </md-input-container>
+  template: `
+  <md-input-container [floatPlaceholder]="placeholder" [style.width.px]="width">
+    <input mdInput placeholder="State" [mdAutocomplete]="auto" [formControl]="stateCtrl">
+  </md-input-container>
 
-    <md-autocomplete #auto="mdAutocomplete" selectOptionOnTab="true">
-      <md-option *ngFor="let state of filteredStates" [value]="state.name">
-        <span> {{ state.code }}: {{ state.name }}  </span>
-      </md-option>
-    </md-autocomplete>
+  <md-autocomplete #auto="mdAutocomplete" selectOptionOnTab="true">
+    <md-option *ngFor="let state of filteredStates" [value]="state.name">
+      <span> {{ state.code }}: {{ state.name }}  </span>
+    </md-option>
+  </md-autocomplete>
   `
 })
 class AutocompleteWithSelectOptionOnTab implements OnDestroy {
-    stateCtrl = new FormControl();
-    filteredStates: any[];
-    valueSub: Subscription;
-    placeholder = 'auto';
-    width: number;
+  stateCtrl = new FormControl();
+  filteredStates: any[];
+  valueSub: Subscription;
+  placeholder = 'auto';
+  width: number;
 
-    @ViewChild(MdAutocompleteTrigger) trigger: MdAutocompleteTrigger;
-    @ViewChild(MdAutocomplete) panel: MdAutocomplete;
-    @ViewChild(MdInputContainer) inputContainer: MdInputContainer;
-    @ViewChildren(MdOption) options: QueryList<MdOption>;
+  @ViewChild(MdAutocompleteTrigger) trigger: MdAutocompleteTrigger;
+  @ViewChild(MdAutocomplete) panel: MdAutocomplete;
+  @ViewChild(MdInputContainer) inputContainer: MdInputContainer;
+  @ViewChildren(MdOption) options: QueryList<MdOption>;
 
-    states = [
-        { code: 'AL', name: 'Alabama' },
-        { code: 'CA', name: 'California' },
-    ];
+  states = [
+    { code: 'AL', name: 'Alabama' },
+    { code: 'CA', name: 'California' },
+  ];
 
-    constructor() {
+  constructor() {
+    this.filteredStates = this.states;
+    this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
         this.filteredStates = this.states;
-        this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
-            this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
-                : this.states;
-        });
-    }
+    });
+  }
 
-    ngOnDestroy() {
-        this.valueSub.unsubscribe();
-    }
-
+  ngOnDestroy() {
+    this.valueSub.unsubscribe();
+  }
 }
 
 

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -10,7 +10,7 @@ import {
   ViewEncapsulation,
   ChangeDetectorRef,
 } from '@angular/core';
-import {MdOption} from '../core';
+import {MdOption, coerceBooleanProperty} from '../core';
 import {ActiveDescendantKeyManager} from '../core/a11y/activedescendant-key-manager';
 
 /**
@@ -49,6 +49,16 @@ export class MdAutocomplete implements AfterContentInit {
 
   /** Function that maps an option's control value to its display value in the trigger. */
   @Input() displayWith: (value: any) => string;
+
+  private _selectOptionOnTab: boolean = false;
+  /** Whether to select an option when the 'TAB' key is pressed and an option is selected */
+  @Input()
+  get selectOptionOnTab() {
+    return this._selectOptionOnTab;
+  }
+  set selectOptionOnTab(val: any) {
+    this._selectOptionOnTab = coerceBooleanProperty(val);
+  }
 
   /** Unique ID to be used by autocomplete trigger's "aria-owns" property. */
   id: string = `md-autocomplete-${_uniqueAutocompleteIdCounter++}`;


### PR DESCRIPTION
… the 'TAB' key

Currently you can only select an option by pressing the 'ENTER' key when using the keyboard.  Many users expect to be able to use the 'TAB' key to select an option as well.