### PR TITLE
fix(input): placeholder not rendering in Chrome under certain conditions

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -14,7 +14,7 @@ $mat-input-underline-disabled-background-image:
 // Applies a floating placeholder above the input itself.
 @mixin mat-input-placeholder-floating {
   display: block;
-  transform: translateY(-1.35em) scale($mat-input-floating-placeholder-scale-factor);
+  transform: translate3d(0, -1.35em, 0) scale($mat-input-floating-placeholder-scale-factor);
   width: 100% / $mat-input-floating-placeholder-scale-factor;
 }
 
@@ -143,7 +143,7 @@ $mat-input-underline-disabled-background-image:
   text-overflow: ellipsis;
   overflow: hidden;
 
-  transform: translateY(0);
+  transform: translate3d(0, 0, 0);
   transform-origin: bottom left;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
               color $swift-ease-out-duration $swift-ease-out-timing-function,


### PR DESCRIPTION
Fixes Chrome not rendering the input placeholder, if it is placed inside a container that has a `column-count` and a wrapper with `overflow: auto`.

Fixes #4402.