### PR TITLE
fix(select): missing rxjs filter import

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -30,8 +30,10 @@ import {ConnectedOverlayDirective} from '../core/overlay/overlay-directives';
 import {ViewportRuler} from '../core/overlay/position/viewport-ruler';
 import {SelectionModel} from '../core/selection/selection';
 import {MdSelectDynamicMultipleError, MdSelectNonArrayValueError} from './select-errors';
+
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/operator/startWith';
+import 'rxjs/add/operator/filter';
 
 
 /**


### PR DESCRIPTION
* The `filter` RxJs operator is being used inside of the select.  Building the select package on its own would not work because the `filter` operator is not present.

* The failures just don't show up because in some other packages we import the `filter` operator and it will be applied to the global Observable prototype.

**Note**: This appears when building the different secondary entry-points on its own. 

Related to #4400 