### PR TITLE
build: properly publish examples package

### DIFF
--- a/scripts/release/publish-docs-content.sh
+++ b/scripts/release/publish-docs-content.sh
@@ -11,7 +11,7 @@ repoPath="/tmp/material2-docs-content"
 repoUrl="https://github.com/angular/material2-docs-content"
 examplesSource="./dist/docs/examples"
 
-$(npm bin)/gulp examples:build-release:clean
+$(npm bin)/gulp material-examples:build-release:clean
 $(npm bin)/gulp docs
 
 # Get git meta info for commit


### PR DESCRIPTION
* Due to a renaming of the gulp task for building an release of the examples, the docs examples didn't update anymore.