### PR TITLE
fix(tooltip): not using trigger's text direction

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -353,6 +353,19 @@ describe('MdTooltip', () => {
         tooltipDirective.show();
       }).toThrowError('Tooltip position "everywhere" is invalid.');
     });
+
+    it('should pass the layout direction to the tooltip', fakeAsync(() => {
+      dir.value = 'rtl';
+
+      tooltipDirective.show();
+      tick(0);
+      fixture.detectChanges();
+
+      const tooltipWrapper = overlayContainerElement.querySelector('.cdk-overlay-pane');
+
+      expect(tooltipWrapper).toBeTruthy('Expected tooltip to be shown.');
+      expect(tooltipWrapper.getAttribute('dir')).toBe('rtl', 'Expected tooltip to be in RTL mode.');
+    }));
   });
 
   describe('scrollable usage', () => {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -231,7 +231,9 @@ export class MdTooltip implements OnDestroy {
         this.hide(0);
       }
     });
+
     let config = new OverlayState();
+    config.direction = this._dir ? this._dir.value : 'ltr';
     config.positionStrategy = strategy;
     config.scrollStrategy =
         new RepositionScrollStrategy(this._scrollDispatcher, SCROLL_THROTTLE_MS);


### PR DESCRIPTION
Passes the trigger's layout direction along to the tooltip element.

Fixes #4411.