### PR TITLE
feat(list): allow ripples for normal lists

### DIFF
--- a/src/lib/list/index.ts
+++ b/src/lib/list/index.ts
@@ -2,12 +2,12 @@ import {NgModule} from '@angular/core';
 import {MdLineModule, MdRippleModule, MdCommonModule} from '../core';
 import {
   MdList,
+  MdNavList,
   MdListItem,
   MdListDivider,
   MdListAvatarCssMatStyler,
   MdListIconCssMatStyler,
   MdListCssMatStyler,
-  MdNavListCssMatStyler,
   MdDividerCssMatStyler,
   MdListSubheaderCssMatStyler,
 } from './list';
@@ -17,6 +17,7 @@ import {
   imports: [MdLineModule, MdRippleModule, MdCommonModule],
   exports: [
     MdList,
+    MdNavList,
     MdListItem,
     MdListDivider,
     MdListAvatarCssMatStyler,
@@ -24,18 +25,17 @@ import {
     MdCommonModule,
     MdListIconCssMatStyler,
     MdListCssMatStyler,
-    MdNavListCssMatStyler,
     MdDividerCssMatStyler,
     MdListSubheaderCssMatStyler,
   ],
   declarations: [
     MdList,
+    MdNavList,
     MdListItem,
     MdListDivider,
     MdListAvatarCssMatStyler,
     MdListIconCssMatStyler,
     MdListCssMatStyler,
-    MdNavListCssMatStyler,
     MdDividerCssMatStyler,
     MdListSubheaderCssMatStyler,
   ],

--- a/src/lib/list/list-item.html
+++ b/src/lib/list/list-item.html
@@ -1,5 +1,5 @@
 <div class="mat-list-item-content" [class.mat-list-item-focus]="_hasFocus"
-    md-ripple [mdRippleDisabled]="!isRippleEnabled()">
+    md-ripple [mdRippleDisabled]="isRippleDisabled()">
   <ng-content
       select="[md-list-avatar],[md-list-icon], [mat-list-avatar], [mat-list-icon]"></ng-content>
   <div class="mat-list-text"><ng-content select="[md-line], [mat-line]"></ng-content></div>

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -1,7 +1,7 @@
 import {async, TestBed} from '@angular/core/testing';
 import {Component, QueryList, ViewChildren} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MdListItem, MdListModule} from './index';
+import {MdList, MdListItem, MdListModule} from './index';
 
 
 describe('MdList', () => {
@@ -156,6 +156,49 @@ describe('MdList', () => {
 
     items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
   });
+
+  it('should allow enabling ripples for a normal list', () => {
+    const fixture = TestBed.createComponent(ListWithOneAnchorItem);
+    const list = fixture.debugElement.query(By.directive(MdList)).componentInstance;
+
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
+
+    // Ripples should be disabled by default, and can be enabled with a binding.
+    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+
+    list.disableRipple = false;
+    fixture.detectChanges();
+
+    items.forEach(item => expect(item.isRippleEnabled()).toBe(true));
+  });
+
+  it('should allow disabling ripples for specific normal list items', () => {
+    const fixture = TestBed.createComponent(ListWithOneAnchorItem);
+    const list = fixture.debugElement.query(By.directive(MdList)).componentInstance;
+
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
+
+    // Ripples should be disabled by default, and can be enabled with a binding.
+    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+
+    list.disableRipple = false;
+
+    items.forEach(item => item.disableRipple = true);
+    fixture.detectChanges();
+
+    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+  });
+
 });
 
 

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -122,7 +122,7 @@ describe('MdList', () => {
 
     const items: QueryList<MdListItem> = fixture.debugElement.componentInstance.listItems;
     expect(items.length).toBeGreaterThan(0);
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
   });
 
   it('should allow disabling ripples for specific nav-list items', () => {
@@ -133,12 +133,12 @@ describe('MdList', () => {
     expect(items.length).toBeGreaterThan(0);
 
     // Ripples should be enabled by default, and can be disabled with a binding.
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(false);
 
     fixture.componentInstance.disableItemRipple = true;
     fixture.detectChanges();
 
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
   });
 
   it('should allow disabling ripples for the whole nav-list', () => {
@@ -149,12 +149,12 @@ describe('MdList', () => {
     expect(items.length).toBeGreaterThan(0);
 
     // Ripples should be enabled by default, and can be disabled with a binding.
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(false);
 
     fixture.componentInstance.disableListRipple = true;
     fixture.detectChanges();
 
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
   });
 
   it('should allow enabling ripples for a normal list', () => {
@@ -169,12 +169,12 @@ describe('MdList', () => {
     expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
 
     // Ripples should be disabled by default, and can be enabled with a binding.
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
 
     list.disableRipple = false;
     fixture.detectChanges();
 
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(false);
   });
 
   it('should allow disabling ripples for specific normal list items', () => {
@@ -189,14 +189,14 @@ describe('MdList', () => {
     expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
 
     // Ripples should be disabled by default, and can be enabled with a binding.
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
 
     list.disableRipple = false;
 
     items.forEach(item => item.disableRipple = true);
     fixture.detectChanges();
 
-    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
+    expect(items.toArray().every(item => item.isRippleDisabled())).toBe(true);
   });
 
 });

--- a/src/lib/list/list.spec.ts
+++ b/src/lib/list/list.spec.ts
@@ -122,7 +122,7 @@ describe('MdList', () => {
 
     const items: QueryList<MdListItem> = fixture.debugElement.componentInstance.listItems;
     expect(items.length).toBeGreaterThan(0);
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
   });
 
   it('should allow disabling ripples for specific nav-list items', () => {
@@ -133,12 +133,12 @@ describe('MdList', () => {
     expect(items.length).toBeGreaterThan(0);
 
     // Ripples should be enabled by default, and can be disabled with a binding.
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(true));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
 
     fixture.componentInstance.disableItemRipple = true;
     fixture.detectChanges();
 
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
   });
 
   it('should allow disabling ripples for the whole nav-list', () => {
@@ -149,12 +149,12 @@ describe('MdList', () => {
     expect(items.length).toBeGreaterThan(0);
 
     // Ripples should be enabled by default, and can be disabled with a binding.
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(true));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
 
     fixture.componentInstance.disableListRipple = true;
     fixture.detectChanges();
 
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
   });
 
   it('should allow enabling ripples for a normal list', () => {
@@ -169,12 +169,12 @@ describe('MdList', () => {
     expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
 
     // Ripples should be disabled by default, and can be enabled with a binding.
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
 
     list.disableRipple = false;
     fixture.detectChanges();
 
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(true));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(true);
   });
 
   it('should allow disabling ripples for specific normal list items', () => {
@@ -189,14 +189,14 @@ describe('MdList', () => {
     expect(list.disableRipple).toBe(true, 'Ripples should be disabled for normal lists.');
 
     // Ripples should be disabled by default, and can be enabled with a binding.
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
 
     list.disableRipple = false;
 
     items.forEach(item => item.disableRipple = true);
     fixture.detectChanges();
 
-    items.forEach(item => expect(item.isRippleEnabled()).toBe(false));
+    expect(items.toArray().every(item => item.isRippleEnabled())).toBe(false);
   });
 
 });

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -10,6 +10,7 @@ import {
   Optional,
   Renderer2,
   AfterContentInit,
+  Self,
 } from '@angular/core';
 import {MdLine, MdLineSetter, coerceBooleanProperty} from '../core';
 
@@ -22,17 +23,19 @@ export class MdListDivider {}
   moduleId: module.id,
   selector: 'md-list, mat-list, md-nav-list, mat-nav-list',
   host: {
-    'role': 'list'},
+    'role': 'list'
+  },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None
 })
 export class MdList {
-  private _disableRipple: boolean = false;
+  // By default ripples are disabled for all lists. For nav-lists the ripples will be enabled later.
+  private _disableRipple: boolean = true;
 
   /**
    * Whether the ripple effect should be disabled on the list-items or not.
-   * This flag only has an effect for `md-nav-list` components.
+   * Ripples are disabled for normal lists by default.
    */
   @Input()
   get disableRipple() { return this._disableRipple; }
@@ -61,7 +64,12 @@ export class MdListCssMatStyler {}
     '[class.mat-nav-list]': 'true'
   }
 })
-export class MdNavListCssMatStyler {}
+export class MdNavList {
+  constructor(@Self() list: MdList) {
+    // For nav lists the ripples are enabled by default.
+    list.disableRipple = false;
+  }
+}
 
 /**
  * Directive whose purpose is to add the mat- CSS styling to this selector.
@@ -126,13 +134,12 @@ export class MdListSubheaderCssMatStyler {}
 export class MdListItem implements AfterContentInit {
   private _lineSetter: MdLineSetter;
   private _disableRipple: boolean = false;
-  private _isNavList: boolean = false;
 
   _hasFocus: boolean = false;
 
   /**
-   * Whether the ripple effect on click should be disabled. This applies only to list items that are
-   * part of a nav list. The value of `disableRipple` on the `md-nav-list` overrides this flag.
+   * Whether the ripple effect on click should be disabled.
+   * Ripples must be enabled on the list. By default nav lists have ripples enabled.
    */
   @Input()
   get disableRipple() { return this._disableRipple; }
@@ -151,10 +158,7 @@ export class MdListItem implements AfterContentInit {
 
   constructor(private _renderer: Renderer2,
               private _element: ElementRef,
-              @Optional() private _list: MdList,
-              @Optional() navList: MdNavListCssMatStyler) {
-    this._isNavList = !!navList;
-  }
+              @Optional() private _list: MdList) {}
 
   ngAfterContentInit() {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
@@ -162,7 +166,7 @@ export class MdListItem implements AfterContentInit {
 
   /** Whether this list item should show a ripple effect when clicked.  */
   isRippleEnabled() {
-    return !this.disableRipple && this._isNavList && !this._list.disableRipple;
+    return !this.disableRipple && !this._list.disableRipple;
   }
 
   _handleFocus() {

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -164,9 +164,9 @@ export class MdListItem implements AfterContentInit {
     this._lineSetter = new MdLineSetter(this._lines, this._renderer, this._element);
   }
 
-  /** Whether this list item should show a ripple effect when clicked.  */
-  isRippleEnabled() {
-    return !this.disableRipple && !this._list.disableRipple;
+  /** Whether this list item should not show any ripple effect on click. */
+  isRippleDisabled() {
+    return this.disableRipple || (this._list && this._list.disableRipple);
   }
 
   _handleFocus() {


### PR DESCRIPTION
* Allow enabling ripples for normal `md-list` elements.