### PR TITLE
docs(sidenav): escape pipes in markdown table

### DIFF
--- a/src/lib/sidenav/README.md
+++ b/src/lib/sidenav/README.md
@@ -23,8 +23,8 @@ The sidenav panel.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `align` | `"start"|"end"` | The alignment of this sidenav. In LTR direction, `"start"` will be shown on the left, `"end"` on the right. In RTL, it is reversed. `"start"` is used by default. If there is more than 1 sidenav on either side the container will be considered invalid and none of the sidenavs will be visible or toggleable until the container is valid again. |
-| `mode` | `"over"|"push"|"side"` | The mode or styling of the sidenav, default being `"over"`. With `"over"` the sidenav will appear above the content, and a backdrop will be shown. With `"push"` the sidenav will push the content of the `<md-sidenav-container>` to the side, and show a backdrop over it. `"side"` will resize the content and keep the sidenav opened. Clicking the backdrop will close sidenavs that do not have `mode="side"`. |
+| `align` | `"start"\|"end"` | The alignment of this sidenav. In LTR direction, `"start"` will be shown on the left, `"end"` on the right. In RTL, it is reversed. `"start"` is used by default. If there is more than 1 sidenav on either side the container will be considered invalid and none of the sidenavs will be visible or toggleable until the container is valid again. |
+| `mode` | `"over"\|"push"\|"side"` | The mode or styling of the sidenav, default being `"over"`. With `"over"` the sidenav will appear above the content, and a backdrop will be shown. With `"push"` the sidenav will push the content of the `<md-sidenav-container>` to the side, and show a backdrop over it. `"side"` will resize the content and keep the sidenav opened. Clicking the backdrop will close sidenavs that do not have `mode="side"`. |
 | `opened` | `boolean` | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. |
 
 ### Events


### PR DESCRIPTION
replace pipe "|" in markdown tables for correct rendering in a table cell in GitHub

The table in the sidenav readme looks currently like this:
![table_error](https://cloud.githubusercontent.com/assets/10274404/25785049/96bbed5e-3377-11e7-9393-9fd86461a99e.PNG)

With the fix, it looks like this:
![table_fixed](https://cloud.githubusercontent.com/assets/10274404/25785050/9ebab1de-3377-11e7-8b1e-524fce37136f.PNG)

This [seems to be an old but unresolved issue](https://github.com/gitlabhq/gitlabhq/issues/1238) with how GitHub renders MarkDown files / tables.