### PR TITLE
fix(list): remove overflow hidden from content

### DIFF
--- a/src/lib/list/list-item.html
+++ b/src/lib/list/list-item.html
@@ -1,5 +1,5 @@
-<div class="mat-list-item-content" [class.mat-list-item-focus]="_hasFocus"
-    md-ripple [mdRippleDisabled]="!isRippleEnabled()">
+<div class="mat-list-item-content" [class.mat-list-item-focus]="_hasFocus">
+  <div class="mat-list-item-ripple" md-ripple [mdRippleDisabled]="!isRippleEnabled()"></div>
   <ng-content
       select="[md-list-avatar],[md-list-icon], [mat-list-avatar], [mat-list-icon]"></ng-content>
   <div class="mat-list-text"><ng-content select="[md-line], [mat-line]"></ng-content></div>

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -48,6 +48,14 @@ $mat-dense-list-icon-size: 20px;
     position: relative;
   }
 
+  .mat-list-item-ripple {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+  }
+
   &.mat-list-item-avatar .mat-list-item-content {
     height: $avatar-height;
   }


### PR DESCRIPTION
* Removes the `overflow: hidden` on the list-items by moving the ripples into a child element that overlays the content.

Fixes #4156