### PR TITLE
feat(dialog): value for md-dialog-close button

### DIFF
--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -8,14 +8,20 @@ import {MdDialogRef} from './dialog-ref';
 @Directive({
   selector: 'button[md-dialog-close], button[mat-dialog-close]',
   host: {
-    '(click)': 'dialogRef.close()',
+    '(click)': 'dialogRef.close(dialogResult)',
     '[attr.aria-label]': 'ariaLabel',
     'type': 'button', // Prevents accidental form submits.
   }
 })
 export class MdDialogClose {
+  /** Result that will be returned to the dialog opener. */
+  @Input('md-dialog-close') dialogResult: any;
+
   /** Screenreader label for the button. */
   @Input('aria-label') ariaLabel: string = 'Close dialog';
+
+  /** Dialog close input for compatibility mode. */
+  @Input('mat-dialog-close') _matDialogClose(value: any) { this.dialogResult = value; }
 
   constructor(public dialogRef: MdDialogRef<any>) { }
 }


### PR DESCRIPTION
* Values can be bound to the md-dialog-close directive and the value will be returned automatically to the `DialogRef`.

Closes #4421