### PR TITLE
build(ci): skip tests on CI when only markdown files have changed

### DIFF
--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -10,6 +10,19 @@ cd $(dirname $0)/../..
 source scripts/ci/sources/mode.sh
 source scripts/ci/sources/tunnel.sh
 
+# Get commit diff
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  fileDiff=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+else
+  fileDiff=$(git diff --name-only $TRAVIS_BRANCH...HEAD)
+fi
+
+# Check if tests can be skipped
+if [[ ${fileDiff} =~ ^(.*\.md\s*)*$ ]] && (is_e2e || is_unit); then
+  echo "Skipping e2e and unit tests since only markdown files changed"
+  exit 0
+fi
+
 start_tunnel
 wait_for_tunnel
 
@@ -23,7 +36,7 @@ elif is_payload; then
   $(npm bin)/gulp ci:payload
 elif is_closure_compiler; then
   ./scripts/closure-compiler/build-devapp-bundle.sh
-else
+elif is_unit; then
   $(npm bin)/gulp ci:test
 fi
 

--- a/scripts/ci/sources/mode.sh
+++ b/scripts/ci/sources/mode.sh
@@ -20,3 +20,7 @@ is_closure_compiler() {
 is_payload() {
   [[ "$MODE" = payload ]]
 }
+
+is_unit() {
+  [[ "$MODE" = saucelabs_required || "$MODE" = browserstack_required ]]
+}


### PR DESCRIPTION
Skip both unit tests and e2e tests on CI when commits contain only markdown files (``*.md``)
solves #3967 