### PR TITLE
fix(checkbox): set pointer cursor for checkbox

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -192,9 +192,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   // Animation
   transition: background $swift-ease-out-duration $swift-ease-out-timing-function,
               mat-elevation-transition-property-value();
-}
 
-.mat-checkbox-label {
   cursor: pointer;
 }
 


### PR DESCRIPTION
* Adds the pointer cursor to the whole checkbox layout to also indicate that you can also click on the checkbox container and not only on the label.

Fixes #4185