### PR TITLE
fix(input): input placeholder not being hidden in IE under certain conditions

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -117,7 +117,9 @@ $mat-input-underline-disabled-background-image:
   // display: none, because IE ends up preventing the user from
   // focusing the input altogether.
   @include input-placeholder {
-    color: transparent;
+    // Needs to be !important, because the placeholder will end up inheriting the
+    // input color in IE, if the consumer overrides it with a higher specificity.
+    color: transparent !important;
   }
 }
 


### PR DESCRIPTION
Fixes cases where the input's native placeholder won't be hidden on IE, if the consumer was using a higher specificity selector to override the input color.

Fixes #4464.