### PR TITLE
fix(list): fix padding for list items

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -80,7 +80,11 @@ $mat-dense-list-icon-size: 20px;
     @include mat-line-wrapper-base();
     padding: 0 $mat-list-side-padding;
 
-    &:first-child {
+    // We only want to override the padding if there isn't
+    // an avatar or icon before the element. Since the ripple
+    // will always be the first child in the container, we
+    // check whether this element is the second child.
+    &:nth-child(2) {
       padding: 0;
     }
   }


### PR DESCRIPTION
Now that ripples are always the first children of the list content div, the selector overriding the padding needs to be updated.