### PR TITLE
fix(focus-origin): missing rxjs of operator

### DIFF
--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -14,6 +14,8 @@ import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {Platform} from '../platform/platform';
 
+import 'rxjs/add/observable/of';
+
 
 // This is the value used by AngularJS Material. Through trial and error (on iPhone 6S) they found
 // that a value of around 650ms seems appropriate.


### PR DESCRIPTION
Recently in SHA f27df86 the `Observable.of` operator has been introduced. This operator hasn't been imported explicitly.

The build doesn't fail if the whole library is built together because other files import the operator.

But when compiling the `core/` package on its own it will start failing.