### PR TITLE
feat(core): expose ScrollDispatchModule

### DIFF
--- a/src/lib/core/overlay/index.ts
+++ b/src/lib/core/overlay/index.ts
@@ -4,19 +4,12 @@ export {FullscreenOverlayContainer} from './fullscreen-overlay-container';
 export {OverlayRef} from './overlay-ref';
 export {OverlayState} from './overlay-state';
 export {ConnectedOverlayDirective, OverlayOrigin, OverlayModule} from './overlay-directives';
-export {ScrollDispatcher} from './scroll/scroll-dispatcher';
 export {ViewportRuler} from './position/viewport-ruler';
 
 export * from './position/connected-position';
+export * from './scroll/index';
 
 // Export pre-defined position strategies and interface to build custom ones.
 export {PositionStrategy} from './position/position-strategy';
 export {GlobalPositionStrategy} from './position/global-position-strategy';
 export {ConnectedPositionStrategy} from './position/connected-position-strategy';
-
-// Export pre-defined scroll strategies and interface to build custom ones.
-export {ScrollStrategy} from './scroll/scroll-strategy';
-export {RepositionScrollStrategy} from './scroll/reposition-scroll-strategy';
-export {CloseScrollStrategy} from './scroll/close-scroll-strategy';
-export {NoopScrollStrategy} from './scroll/noop-scroll-strategy';
-export {BlockScrollStrategy} from './scroll/block-scroll-strategy';

--- a/src/lib/core/overlay/scroll/index.ts
+++ b/src/lib/core/overlay/scroll/index.ts
@@ -6,6 +6,13 @@ import {PlatformModule} from '../../platform/index';
 export {Scrollable} from './scrollable';
 export {ScrollDispatcher} from './scroll-dispatcher';
 
+// Export pre-defined scroll strategies and interface to build custom ones.
+export {ScrollStrategy} from './scroll-strategy';
+export {RepositionScrollStrategy} from './reposition-scroll-strategy';
+export {CloseScrollStrategy} from './close-scroll-strategy';
+export {NoopScrollStrategy} from './noop-scroll-strategy';
+export {BlockScrollStrategy} from './block-scroll-strategy';
+
 @NgModule({
   imports: [PlatformModule],
   exports: [Scrollable],


### PR DESCRIPTION
With #4251 the `ScrollDispatchModule` has been created and it is used by a lot of different components.

The NgModule is already exported inside of the file but the core package doesn't export it to the public.

**Note**: Modules like that (that can be also part of the CDK at some point) should be exposed. Also it is necessary to get the secondary entry-points working.