### PR TITLE
build: include commit sha in build artifacts

### DIFF
--- a/scripts/release/publish-build-artifacts.sh
+++ b/scripts/release/publish-build-artifacts.sh
@@ -37,6 +37,9 @@ cp -r $buildDir/* $repoDir
 # Create the build commit and push the changes to the repository.
 cd $repoDir
 
+# Update the package.json version to include the current commit SHA.
+sed -i "s/$buildVersion/$buildVersion-$commitSha/g" package.json
+
 # Prepare Git for pushing the artifacts to the repository.
 git config user.name "$commitAuthorName"
 git config user.email "$commitAuthorEmail"


### PR DESCRIPTION
The package.json of the `material2-builds` repository will always have the same version as in the `material2` repository.

Now the build artifacts will have package.json files that include the according Git SHA in the version property.

Fixes #4502