### PR TITLE
build: faster building of tests

### DIFF
--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -11,6 +11,5 @@
   },
   "include": [
     "**/*.spec.ts"
-  ],
-  "files": null
+  ]
 }

--- a/src/lib/tsconfig-tests.json
+++ b/src/lib/tsconfig-tests.json
@@ -11,6 +11,5 @@
   },
   "include": [
     "**/*.spec.ts"
-  ],
-  "files": null
+  ]
 }

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -42,8 +42,8 @@ System.config({
       'node:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
 
     // Path mappings for local packages that can be imported inside of tests.
-    '@angular/material': 'dist/bundles/material.umd.js',
-    '@angular/cdk': 'dist/bundles/cdk.umd.js',
+    '@angular/material': 'dist/packages/material/index.js',
+    '@angular/cdk': 'dist/packages/cdk/index.js',
   },
   packages: {
     // Thirdparty barrels.

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -38,7 +38,6 @@ module.exports = (config) => {
       // Includes all package tests and source files into karma. Those files will be watched.
       // This pattern also matches all all sourcemap files and TypeScript files for debugging.
       {pattern: 'dist/packages/**/*', included: false, watched: true},
-      {pattern: 'dist/bundles/*.umd.js', included: false, watched: true},
     ],
 
     customLaunchers: customLaunchers,

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -9,10 +9,8 @@ const runSequence = require('run-sequence');
 /** Builds everything that is necessary for karma. */
 task(':test:build', sequenceTask(
   'clean',
-  // Build the material bundles without any test files. (CDK will be also built)
-  'material:build',
-  // Additionally build the test files for material and the CDK.
-  ['material:build:esm:tests', 'cdk:build:esm:tests']
+  // Build ESM output of Material that also includes all test files.
+  'material:build-tests',
 ));
 
 /**

--- a/tools/gulp/util/package-tasks.ts
+++ b/tools/gulp/util/package-tasks.ts
@@ -44,6 +44,15 @@ export function createPackageBuildTasks(packageName: string, requiredPackages: s
     `${packageName}:build:bundles`,
   ));
 
+  task(`${packageName}:build-tests`, sequenceTask(
+    // Build all required tests before building.
+    ...requiredPackages.map(pkgName => `${pkgName}:build-tests`),
+    // Build the ESM output that includes all test files. Also build assets for the package.
+    [`${packageName}:build:esm:tests`, `${packageName}:assets`],
+    // Inline assets into ESM output.
+    `${packageName}:assets:inline`
+  ));
+
   /**
    * Release tasks for the package. Tasks compose the release output for the package.
    */


### PR DESCRIPTION
Currently when running the tests, the library is built and afterwards the spec files are built.

TypeScript then re-builds the whole library again because the spec files reference the source files (templates no longer inlined + longer building)

This also fixes that the CDK isn't built with ES5 target.

**Note**: Building tests took for me 21 seconds and now it takes 13 seconds. Also the inlined templates should make the CI jobs run **more stable**. 