### PR TITLE
fix(tabs): dynamic tab scrollbar showing while animating

### DIFF
--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,4 +1,8 @@
 .mat-tab-body-content {
   height: 100%;
   overflow: auto;
+
+  .mat-tab-group-dynamic-height & {
+    overflow: hidden;
+  }
 }

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -8,6 +8,7 @@ import {
   ElementRef,
   Optional,
   AfterViewChecked,
+  ViewEncapsulation,
 } from '@angular/core';
 import {
   trigger,
@@ -50,6 +51,7 @@ export type MdTabBodyOriginState = 'left' | 'right';
   selector: 'md-tab-body, mat-tab-body',
   templateUrl: 'tab-body.html',
   styleUrls: ['tab-body.css'],
+  encapsulation: ViewEncapsulation.None,
   host: {
     '[class.mat-tab-body]': 'true',
   },


### PR DESCRIPTION
Fixes an issue that caused a scrollbar to be shown only while a tab inside a dynamic height tab group is animating.

Relates to #4035.

For reference:
![ref](https://cloud.githubusercontent.com/assets/4450522/26023581/9de69d08-37bf-11e7-941c-b04b9a173c44.gif)
