### PR TITLE
fix(progress-bar): buffer animation not working on user-generated themes

### DIFF
--- a/src/lib/progress-bar/_progress-bar-theme.scss
+++ b/src/lib/progress-bar/_progress-bar-theme.scss
@@ -8,7 +8,7 @@
   $warn: map-get($theme, warn);
 
   .mat-progress-bar-background {
-    background: #{_mat-progress-bar-buffer($primary, lighter)};
+    background-image: #{_mat-progress-bar-buffer($primary, lighter)};
   }
 
   .mat-progress-bar-buffer {
@@ -21,12 +21,13 @@
 
   .mat-progress-bar.mat-accent {
     .mat-progress-bar-background {
-      background: #{_mat-progress-bar-buffer($accent, lighter)};
+      background-image: #{_mat-progress-bar-buffer($accent, lighter)};
     }
 
     .mat-progress-bar-buffer {
       background-color: mat-color($accent, lighter);
     }
+
     .mat-progress-bar-fill::after {
       background-color: mat-color($accent);
     }
@@ -34,12 +35,13 @@
 
   .mat-progress-bar.mat-warn {
     .mat-progress-bar-background {
-      background: #{_mat-progress-bar-buffer($warn, lighter)};
+      background-image: #{_mat-progress-bar-buffer($warn, lighter)};
     }
 
     .mat-progress-bar-buffer {
       background-color: mat-color($warn, lighter);
     }
+
     .mat-progress-bar-fill::after {
       background-color: mat-color($warn);
     }


### PR DESCRIPTION
Fixes the progress bar buffer animation not working on user-generated themes (e.g. the dark theme in the demo app).