### PR TITLE
chore: remove unused vendors variable

### DIFF
--- a/tools/gulp/constants.ts
+++ b/tools/gulp/constants.ts
@@ -35,9 +35,4 @@ export const LICENSE_BANNER = `/**
   * License: MIT
   */`;
 
-export const NPM_VENDOR_FILES = [
-  '@angular', 'core-js/client', 'hammerjs', 'rxjs', 'systemjs/dist',
-  'zone.js/dist', 'web-animations-js'
-];
-
 export const COMPONENTS_DIR = join(SOURCE_ROOT, 'lib');


### PR DESCRIPTION
* Removes the unused `NPM_VENDOR_FILES` variable because the vendors aren't copied anymore.