### PR TITLE
fix(datepicker): calendar toggle submitting parent form

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -9,6 +9,7 @@ import {MdDatepickerIntl} from './datepicker-intl';
   template: '',
   styleUrls: ['datepicker-toggle.css'],
   host: {
+    '[attr.type]': 'type',
     '[class.mat-datepicker-toggle]': 'true',
     '[attr.aria-label]': '_intl.openCalendarLabel',
     '(click)': '_open($event)',
@@ -17,7 +18,11 @@ import {MdDatepickerIntl} from './datepicker-intl';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdDatepickerToggle<D> {
+  /** Datepicker instance that the button will toggle. */
   @Input('mdDatepickerToggle') datepicker: MdDatepicker<D>;
+
+  /** Type of the button. */
+  @Input() type: string = 'button';
 
   @Input('matDatepickerToggle')
   get _datepicker() { return this.datepicker; }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -374,7 +374,7 @@ describe('MdDatepicker', () => {
         fixture.detectChanges();
       }));
 
-      it('should open calendar when toggle clicked', async(() => {
+      it('should open calendar when toggle clicked', () => {
         expect(document.querySelector('md-dialog-container')).toBeNull();
 
         let toggle = fixture.debugElement.query(By.css('button'));
@@ -382,7 +382,12 @@ describe('MdDatepicker', () => {
         fixture.detectChanges();
 
         expect(document.querySelector('md-dialog-container')).not.toBeNull();
-      }));
+      });
+
+      it('should set the `button` type on the trigger to prevent form submissions', () => {
+        let toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+        expect(toggle.getAttribute('type')).toBe('button');
+      });
     });
 
     describe('datepicker inside input-container', () => {


### PR DESCRIPTION
Prevents the toggle for the datepicker's calendar from submitting its parent form.

Fixes #4530.