### PR TITLE
docs(dialog): remove mentioning of MaterialModule

### DIFF
--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -84,7 +84,7 @@ that the AOT compiler knows to create the `ComponentFactory` for it.
 @NgModule({
   imports: [
     // ...
-    MaterialModule
+    MdDialogModule
   ],
 
   declarations: [


### PR DESCRIPTION
* Since the `MaterialModule` is officially deprecated we should not mention it in our docs anymore.

**Note**: Holding off with updating the `demo-app` and `e2e-app` because maybe we'll keep the array of available modules (which would make testing & demos easier)

References #4532