### PR TITLE
fix(datepicker): set cursor on clickable elements

### DIFF
--- a/src/lib/datepicker/calendar-body.scss
+++ b/src/lib/datepicker/calendar-body.scss
@@ -36,6 +36,11 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
   padding: $mat-calendar-body-cell-padding 0;
   text-align: center;
   outline: none;
+  cursor: pointer;
+}
+
+.mat-calendar-body-disabled {
+  cursor: default;
 }
 
 .mat-calendar-body-cell-content {

--- a/src/lib/datepicker/datepicker-toggle.scss
+++ b/src/lib/datepicker/datepicker-toggle.scss
@@ -11,4 +11,5 @@ $mat-datepicker-toggle-icon-size: 24px !default;
   border: none;
   outline: none;
   vertical-align: middle;
+  cursor: pointer;
 }


### PR DESCRIPTION
* Adds the `pointer` cursor to the calendar toggle and date cells, indicating that they're clickable.
* Sets the `default` cursor on the disabled states, instead of the `text` cursor.

Fixes #4533.