### PR TITLE
build: fix deploy script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tslint": "gulp lint",
     "stylelint": "gulp lint",
     "e2e": "gulp e2e",
-    "deploy": "firebase deploy",
+    "deploy": "gulp deploy:devapp",
     "webdriver-manager": "webdriver-manager",
     "docs": "gulp docs",
     "api": "gulp api-docs"


### PR DESCRIPTION
* Recently we introduced a task that deploys the devapp to firebase. This task should be used inside of the NPM scripts.