### PR TITLE
fix(select): option text color blending in with background on dark theme

### DIFF
--- a/src/lib/core/option/_option-theme.scss
+++ b/src/lib/core/option/_option-theme.scss
@@ -9,6 +9,8 @@
   $warn: map-get($theme, warn);
 
   .mat-option {
+    color: mat-color($foreground, text);
+
     &:hover:not(.mat-option-disabled), &:focus:not(.mat-option-disabled) {
       background: mat-color($background, hover);
     }


### PR DESCRIPTION
Sets the proper color on the `md-option`, avoiding color contrast issues in dark themes.

Fixes #4560.