### PR TITLE
demos: invisible radios and buttons in dark mode

### DIFF
--- a/src/demo-app/button/button-demo.scss
+++ b/src/demo-app/button/button-demo.scss
@@ -8,12 +8,11 @@
   section {
     display: flex;
     align-items: center;
-    background-color: #f7f7f7;
     margin: 8px;
   }
 
   p {
-    padding:5px 15px;
+    padding: 5px 15px;
   }
 }
 

--- a/src/demo-app/radio/radio-demo.scss
+++ b/src/demo-app/radio/radio-demo.scss
@@ -4,7 +4,6 @@
 }
 
 .demo-section {
-  background-color: #f7f7f7;
   margin: 8px;
   padding: 16px;
 


### PR DESCRIPTION
Due to a hard-coded background in our button and radio demo the buttons and radios were invisible in dark mode.

This is not really helpful when testing buttons or radios against dark themes.