### PR TITLE
fix(dialog): enable smooth scrolling on md-dialog-content

### DIFF
--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -32,6 +32,7 @@ $mat-dialog-max-height: 65vh !default;
   padding: 0 $mat-dialog-padding;
   max-height: $mat-dialog-max-height;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .mat-dialog-title {


### PR DESCRIPTION
Enables the smooth native scrolling on `md-dialog-content`.