### PR TITLE
fix(block-scroll-strategy): collapsing root node when enabled

### DIFF
--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -72,8 +72,10 @@
   .cdk-global-scrollblock {
     position: fixed;
 
-    // Necessary for iOS not to expand past the viewport.
-    max-width: 100vw;
+    // Necessary for the content not to lose its width. Note that we're using 100%, instead of
+    // 100vw, because 100vw includes the width plus the scrollbar, whereas 100% is the width
+    // that the element had before we made it `fixed`.
+    width: 100%;
 
     // Note: this will always add a scrollbar to whatever element it is on, which can
     // potentially result in double scrollbars. It shouldn't be an issue, because we won't

--- a/src/lib/core/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/block-scroll-strategy.spec.ts
@@ -23,6 +23,7 @@ describe('BlockScrollStrategy', () => {
   }));
 
   afterEach(() => {
+    strategy.disable();
     document.body.removeChild(forceScrollElement);
     setScrollPosition(0, 0);
   });
@@ -109,6 +110,16 @@ describe('BlockScrollStrategy', () => {
     expect(document.documentElement.classList).not.toContain('cdk-global-scrollblock');
   }));
 
+
+  it('should keep the content width', () => {
+    forceScrollElement.style.width = '100px';
+
+    const previousContentWidth = document.documentElement.getBoundingClientRect().width;
+
+    strategy.enable();
+
+    expect(document.documentElement.getBoundingClientRect().width).toBe(previousContentWidth);
+  });
 
   /**
    * Skips the specified test, if it is being executed on iOS. This is necessary, because


### PR DESCRIPTION
* Prevents the `html` tag from collapsing when the `BlockScrollStrategy` is enabled.
* Fixes the scroll strategy not being disabled properly in tests.

Fixes https://github.com/angular/material2/issues/4646.