### PR TITLE
fix(select): deselect old options when programmatically setting value

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -321,12 +321,12 @@ describe('MdSelect', () => {
 
       options =
         overlayContainerElement.querySelectorAll('md-option') as NodeListOf<HTMLElement>;
-      expect(options[0].classList).not.toContain('mat-selected');
-      expect(options[1].classList).toContain('mat-selected');
+      expect(options[0].classList).not.toContain('mat-selected', 'Expected first option to no longer be selected');
+      expect(options[1].classList).toContain('mat-selected', 'Expected second option to be selected');
 
       const optionInstances = fixture.componentInstance.options.toArray();
-      expect(optionInstances[0].selected).toBe(false);
-      expect(optionInstances[1].selected).toBe(true);
+      expect(optionInstances[0].selected).toBe(false, 'Expected first option to no longer be selected');
+      expect(optionInstances[1].selected).toBe(true, 'Expected second option to be selected');
     });
 
     it('should remove selection if option has been removed', async(() => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -300,6 +300,35 @@ describe('MdSelect', () => {
       expect(optionInstances[2].selected).toBe(false);
     });
 
+    it('should deselect other options when one is programmatically selected', () => {
+      let control = fixture.componentInstance.control;
+      let foods = fixture.componentInstance.foods;
+
+      trigger.click();
+      fixture.detectChanges();
+
+      let options =
+        overlayContainerElement.querySelectorAll('md-option') as NodeListOf<HTMLElement>;
+
+      options[0].click();
+      fixture.detectChanges();
+
+      control.setValue(foods[1].value);
+      fixture.detectChanges();
+
+      trigger.click();
+      fixture.detectChanges();
+
+      options =
+        overlayContainerElement.querySelectorAll('md-option') as NodeListOf<HTMLElement>;
+      expect(options[0].classList).not.toContain('mat-selected');
+      expect(options[1].classList).toContain('mat-selected');
+
+      const optionInstances = fixture.componentInstance.options.toArray();
+      expect(optionInstances[0].selected).toBe(false);
+      expect(optionInstances[1].selected).toBe(true);
+    });
+
     it('should remove selection if option has been removed', async(() => {
       let select = fixture.componentInstance.select;
 

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -321,12 +321,18 @@ describe('MdSelect', () => {
 
       options =
         overlayContainerElement.querySelectorAll('md-option') as NodeListOf<HTMLElement>;
-      expect(options[0].classList).not.toContain('mat-selected', 'Expected first option to no longer be selected');
-      expect(options[1].classList).toContain('mat-selected', 'Expected second option to be selected');
+
+      expect(options[0].classList)
+        .not.toContain('mat-selected', 'Expected first option to no longer be selected');
+      expect(options[1].classList)
+        .toContain('mat-selected', 'Expected second option to be selected');
 
       const optionInstances = fixture.componentInstance.options.toArray();
-      expect(optionInstances[0].selected).toBe(false, 'Expected first option to no longer be selected');
-      expect(optionInstances[1].selected).toBe(true, 'Expected second option to be selected');
+
+      expect(optionInstances[0].selected)
+        .toBe(false, 'Expected first option to no longer be selected');
+      expect(optionInstances[1].selected)
+        .toBe(true, 'Expected second option to be selected');
     });
 
     it('should remove selection if option has been removed', async(() => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -544,12 +544,12 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
       throw getMdSelectNonArrayValueError();
     }
 
+    this._clearSelection();
     if (isArray) {
-      this._clearSelection();
       value.forEach((currentValue: any) => this._selectValue(currentValue));
       this._sortValues();
-    } else if (!this._selectValue(value)) {
-      this._clearSelection();
+    } else {
+      this._selectValue(value);
     }
 
     this._setValueWidth();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -545,6 +545,7 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
     }
 
     this._clearSelection();
+
     if (isArray) {
       value.forEach((currentValue: any) => this._selectValue(currentValue));
       this._sortValues();


### PR DESCRIPTION
Fixes #4476

This may be naive regarding selection change events, but existing tests pass and it fixes the issue.

cc @crisbeto 