### PR TITLE
test: fix infinite loop in tests

### DIFF
--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -77,7 +77,7 @@ describe('Overlay directives', () => {
 
     let strategy =
         <ConnectedPositionStrategy> overlayDirective.overlayRef.getState().positionStrategy;
-    expect(strategy).toEqual(jasmine.any(ConnectedPositionStrategy));
+    expect(strategy instanceof ConnectedPositionStrategy).toBe(true);
 
     let positions = strategy.positions;
     expect(positions.length).toBeGreaterThan(0);
@@ -266,9 +266,11 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.positionChangeHandler).toHaveBeenCalled();
-      expect(fixture.componentInstance.positionChangeHandler.calls.mostRecent().args[0])
-          .toEqual(jasmine.any(ConnectedOverlayPositionChange),
-              `Expected directive to emit an instance of ConnectedOverlayPositionChange.`);
+
+      const latestCall = fixture.componentInstance.positionChangeHandler.calls.mostRecent();
+
+      expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
+          .toBe(true, `Expected directive to emit an instance of ConnectedOverlayPositionChange.`);
     });
 
     it('should emit attach and detach appropriately', () => {
@@ -278,9 +280,8 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.attachHandler).toHaveBeenCalled();
-      expect(fixture.componentInstance.attachResult)
-          .toEqual(jasmine.any(HTMLElement),
-              `Expected pane to be populated with HTML elements when attach was called.`);
+      expect(fixture.componentInstance.attachResult instanceof HTMLElement)
+          .toBe(true, `Expected pane to be populated with HTML elements when attach was called.`);
       expect(fixture.componentInstance.detachHandler).not.toHaveBeenCalled();
 
       fixture.componentInstance.isOpen = false;

--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -336,10 +336,12 @@ describe('ConnectedPositionStrategy', () => {
       const subscription = strategy.onPositionChange.subscribe(positionChangeHandler);
 
       strategy.apply(overlayElement);
+
+      const latestCall = positionChangeHandler.calls.mostRecent();
+
       expect(positionChangeHandler).toHaveBeenCalled();
-      expect(positionChangeHandler.calls.mostRecent().args[0])
-          .toEqual(jasmine.any(ConnectedOverlayPositionChange),
-              `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
+      expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
+          .toBe(true, `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
 
       it('should pick the fallback position that shows the largest area of the element', () => {
         positionBuilder = new OverlayPositionBuilder(viewportRuler);

--- a/src/lib/core/portal/portal.spec.ts
+++ b/src/lib/core/portal/portal.spec.ts
@@ -244,7 +244,7 @@ describe('Portals', () => {
 
       let componentInstance: PizzaMsg = portal.attach(host).instance;
 
-      expect(componentInstance).toEqual(jasmine.any(PizzaMsg));
+      expect(componentInstance instanceof PizzaMsg).toBe(true);
       expect(someDomElement.textContent).toContain('Pizza');
 
       host.detach();
@@ -263,7 +263,7 @@ describe('Portals', () => {
       let componentInstance: PizzaMsg = portal.attach(host).instance;
       fixture.detectChanges();
 
-      expect(componentInstance).toEqual(jasmine.any(PizzaMsg));
+      expect(componentInstance instanceof PizzaMsg).toBe(true);
       expect(someDomElement.textContent).toContain('Pizza');
       expect(someDomElement.textContent).toContain('Chocolate');
 
@@ -342,8 +342,8 @@ describe('Portals', () => {
 
       let componentInstance: PizzaMsg = portal.attach(host).instance;
 
-      expect(componentInstance)
-          .toEqual(jasmine.any(PizzaMsg), 'Expected a PizzaMsg component to be created');
+      expect(componentInstance instanceof PizzaMsg)
+          .toBe(true, 'Expected a PizzaMsg component to be created');
       expect(someDomElement.textContent)
           .toContain('Pizza', 'Expected the static string "Pizza" in the DomPortalHost.');
 

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -72,7 +72,7 @@ describe('MdDialog', () => {
     viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.textContent).toContain('Pizza');
-    expect(dialogRef.componentInstance).toEqual(jasmine.any(PizzaMsg));
+    expect(dialogRef.componentInstance instanceof PizzaMsg).toBe(true);
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();
@@ -101,7 +101,7 @@ describe('MdDialog', () => {
     viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.textContent).toContain('Pizza');
-    expect(dialogRef.componentInstance).toEqual(jasmine.any(PizzaMsg));
+    expect(dialogRef.componentInstance instanceof PizzaMsg).toBe(true);
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -89,9 +89,8 @@ describe('MdSnackBar', () => {
 
     viewContainerFixture.detectChanges();
 
-    expect(snackBarRef.instance)
-      .toEqual(jasmine.any(SimpleSnackBar),
-               'Expected the snack bar content component to be SimpleSnackBar');
+    expect(snackBarRef.instance instanceof SimpleSnackBar)
+      .toBe(true, 'Expected the snack bar content component to be SimpleSnackBar');
     expect(snackBarRef.instance.snackBarRef)
       .toBe(snackBarRef, 'Expected the snack bar reference to be placed in the component instance');
 
@@ -113,9 +112,8 @@ describe('MdSnackBar', () => {
 
     viewContainerFixture.detectChanges();
 
-    expect(snackBarRef.instance)
-      .toEqual(jasmine.any(SimpleSnackBar),
-               'Expected the snack bar content component to be SimpleSnackBar');
+    expect(snackBarRef.instance instanceof SimpleSnackBar)
+      .toBe(true, 'Expected the snack bar content component to be SimpleSnackBar');
     expect(snackBarRef.instance.snackBarRef)
       .toBe(snackBarRef, 'Expected the snack bar reference to be placed in the component instance');
 
@@ -180,9 +178,8 @@ describe('MdSnackBar', () => {
     let config = {viewContainerRef: testViewContainerRef};
     let snackBarRef = snackBar.openFromComponent(BurritosNotification, config);
 
-    expect(snackBarRef.instance)
-      .toEqual(jasmine.any(BurritosNotification),
-               'Expected the snack bar content component to be BurritosNotification');
+    expect(snackBarRef.instance instanceof BurritosNotification)
+      .toBe(true, 'Expected the snack bar content component to be BurritosNotification');
     expect(overlayContainerElement.textContent.trim())
         .toBe('Burritos are on the way.',
               `Expected the overlay text content to be 'Burritos are on the way'`);


### PR DESCRIPTION
Fixes some unit tests going into an infinite loop by using the `jasmine.any` matcher. Not exactly sure what is going on, but it was most likely introduced in Jasmine 2.6.2. For now I've replaced those matches with `instanceof` checks which accomplish the same.

Fixes #4654.