### PR TITLE
fix(icon): remove automatic aria labelling and add a11y guidance

### DIFF
--- a/e2e/components/icon/icon.e2e.ts
+++ b/e2e/components/icon/icon.e2e.ts
@@ -11,11 +11,6 @@ describe('icon', () => {
       testIcon = element(by.id('test-icon'));
     });
 
-    it('should have the correct aria-label when used', () => {
-      expect(testIcon.getAttribute('aria-label')).toBe('favorite');
-      screenshot();
-    });
-
     it('should have the correct class when used', async () => {
       const attr = await testIcon.getAttribute('class');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,9 +226,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-3.0.2.tgz",
-      "integrity": "sha1-AMv0hWPzd/nOXPJCN7IbPZd54FU=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-3.0.3.tgz",
+      "integrity": "sha512-o2qkg/J2LWK+sr007+KFBBOrxzxpr9kiP0gMFC75gQJXhUn/E3pQA0kSVdxrQ3lf+rOwsRnuH0wnR5MNTotEKg==",
       "dev": true
     },
     "@types/glob": {
@@ -274,9 +274,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.22.tgz",
-      "integrity": "sha1-RZP02Ci91hKSlHjqQMZ7T0A8olU=",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.28.tgz",
+      "integrity": "sha512-9rLhvgupMpC7Yh24yB8zj+4L6SZ9BYUwqknEC8+R7gqCg3KL65UHg7yu9X6J8mSmmtVr1Hbey564yZ3C9nXqtQ==",
       "dev": true
     },
     "@types/orchestrator": {
@@ -438,9 +438,9 @@
       "dev": true
     },
     "aproba": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
     },
     "archiver": {
@@ -696,9 +696,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.2.2.tgz",
-      "integrity": "sha1-BNc+u+zJeoImVFc6DNR/qc8aR40=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.2.3.tgz",
+      "integrity": "sha512-wQMmUT9sKWe0D29zR+7IMahQSs9Ty3kQlcT4IXvlCOHEcrLm//EOz98fOwU0PFeDgBfDqhBK+c70ku+okdCJRQ==",
       "dev": true
     },
     "axe-webdriverjs": {
@@ -714,9 +714,9 @@
       "dev": true
     },
     "babylon": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
-      "integrity": "sha1-F/FP3fNhtpWYH+Z5OF5PHAHr2G8=",
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
+      "integrity": "sha1-IB0l71+JLEG65JSIsI2w3Udun1w=",
       "dev": true
     },
     "backo2": {
@@ -930,12 +930,6 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "buffered-spawn": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffered-spawn/-/buffered-spawn-1.1.2.tgz",
@@ -998,9 +992,9 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000676",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000676.tgz",
-      "integrity": "sha1-gupXgjdjfI/zSiisqt43O2JMTqg=",
+      "version": "1.0.30000679",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000679.tgz",
+      "integrity": "sha1-3XvhLxZXfl1q5tuIDG1hnnfco2U=",
       "dev": true
     },
     "canonical-path": {
@@ -2392,9 +2386,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.21",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.21.tgz",
-      "integrity": "sha1-Gacl+eUdAwC7wejoIRCf2dr1WSU=",
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
       "dev": true
     },
     "es6-iterator": {
@@ -2862,9 +2856,9 @@
       "dev": true
     },
     "firebase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.1.0.tgz",
-      "integrity": "sha1-L8q7f4T1Uilfn1H8OPETjrhfOeI=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.1.1.tgz",
+      "integrity": "sha1-LGoHxVDhO5QE44ZmtkY5Wxr215I=",
       "dev": true,
       "dependencies": {
         "base64url": {
@@ -3088,9 +3082,9 @@
       }
     },
     "firebase-tools": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.9.0.tgz",
-      "integrity": "sha1-FdurCKIFZxTgpufHvIyZC/3tFzo=",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.9.1.tgz",
+      "integrity": "sha1-tivitFZBile/Goz4sBprj3j2wbA=",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3344,688 +3338,688 @@
       "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "version": "2.2.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
-          "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asn1": {
-          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "version": "0.2.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "version": "0.2.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
-          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "version": "0.4.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
-          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "version": "0.6.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
-          "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "version": "1.6.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "version": "0.4.2",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
-          "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "block-stream": {
-          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "version": "0.0.9",
+          "bundled": true,
           "dev": true
         },
         "boom": {
-          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "version": "2.10.1",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+          "version": "1.1.6",
+          "bundled": true,
           "dev": true
         },
         "buffer-shims": {
-          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
-          "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "version": "0.11.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "1.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "version": "2.9.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "version": "0.0.1",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
-          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
-          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
-          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "version": "2.0.5",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "dashdash": {
-          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "version": "1.14.1",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.2.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "deep-extend": {
-          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+          "version": "0.4.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
-          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
-          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extend": {
-          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
-          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
-          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "version": "0.6.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
-          "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+          "version": "2.1.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
-          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+          "version": "1.0.10",
+          "bundled": true,
           "dev": true
         },
         "fstream-ignore": {
-          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
-          "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-          "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
+          "version": "2.7.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "generate-function": {
-          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "generate-object-property": {
-          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+          "version": "1.2.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "getpass": {
-          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+          "version": "0.1.6",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.1",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "version": "4.1.11",
+          "bundled": true,
           "dev": true
         },
         "graceful-readlink": {
-          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
-          "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "version": "2.0.6",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "has-unicode": {
-          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
-          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "version": "3.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "version": "2.16.3",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
-          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "version": "1.0.6",
+          "bundled": true,
           "dev": true
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "version": "2.0.3",
+          "bundled": true,
           "dev": true
         },
         "ini": {
-          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "version": "1.3.4",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-my-json-valid": {
-          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+          "version": "2.15.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-property": {
-          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-typedarray": {
-          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
-          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "version": "0.1.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
-          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsbn": {
-          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
-          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "version": "0.2.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
-          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "version": "5.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonpointer": {
-          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+          "version": "4.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
-          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-          "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-          "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
+          "version": "1.26.0",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-          "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
+          "version": "2.1.14",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.0.8",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "version": "0.7.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
-          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
+          "version": "0.6.33",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "3.0.6",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npmlog": {
-          "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
-          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "version": "0.8.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "version": "1.4.0",
+          "bundled": true,
           "dev": true
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
-          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "version": "2.0.4",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "pinkie-promise": {
-          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
-          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "version": "1.0.7",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
-          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "version": "1.4.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
-          "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
+          "version": "6.3.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "version": "1.2.0",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+          "version": "2.2.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "version": "2.79.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "version": "2.5.4",
+          "bundled": true,
           "dev": true
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.3.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
-          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
-          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "version": "1.0.9",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sshpk": {
-          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-          "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
+          "version": "1.10.2",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "version": "1.0.0",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "version": "0.10.31",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "stringstream": {
-          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "version": "0.0.5",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true
         },
         "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
-          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "2.2.1",
+          "bundled": true,
           "dev": true
         },
         "tar-pack": {
-          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+          "version": "3.3.0",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "once": {
-              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "version": "1.3.3",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+              "version": "2.1.5",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "tough-cookie": {
-          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "version": "2.3.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tunnel-agent": {
-          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "version": "0.4.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tweetnacl": {
-          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "version": "0.14.5",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
-          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "version": "0.0.6",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
-          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
-          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "version": "1.3.6",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
-          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "version": "4.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         }
@@ -4471,57 +4465,49 @@
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.6.34",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz",
-          "integrity": "sha1-lK0ceYoR1/xnOBtQ1H+MwY2Xmfc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-                  "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-                  "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "os-tmpdir": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4531,77 +4517,66 @@
             },
             "npmlog": {
               "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-              "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "readable-stream": {
                       "version": "2.2.9",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                          "bundled": true,
                           "dev": true
                         },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "string_decoder": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -4611,67 +4586,57 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                  "bundled": true,
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-                  "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "aproba": {
                       "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-                      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "has-unicode": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "object-assign": {
                       "version": "4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "bundled": true,
                           "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -4680,22 +4645,19 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4703,8 +4665,7 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -4712,36 +4673,31 @@
             },
             "rc": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -4749,71 +4705,61 @@
             },
             "request": {
               "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4821,36 +4767,31 @@
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.6",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz",
-                      "integrity": "sha1-lH6TBJeQlCsqLWCoKJsokk05+Yc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -4860,8 +4801,7 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4869,34 +4809,29 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4904,49 +4839,42 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "bundled": true,
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -4954,70 +4882,60 @@
                     },
                     "sshpk": {
                       "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-                      "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -5027,84 +4945,72 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "safe-buffer": {
                   "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                  "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+                  "bundled": true,
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5112,15 +5018,13 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "uuid": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                  "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -5128,64 +5032,54 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                  "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                          "bundled": true,
                           "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -5194,22 +5088,19 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -5218,63 +5109,54 @@
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "tar-pack": {
               "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "debug": {
                   "version": "2.6.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-                  "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ms": {
                       "version": "0.7.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5282,63 +5164,54 @@
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -5350,15 +5223,13 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5366,56 +5237,48 @@
                 },
                 "readable-stream": {
                   "version": "2.2.9",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                  "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                      "bundled": true,
                       "dev": true
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "string_decoder": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5423,8 +5286,7 @@
                 },
                 "uid-number": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -5587,9 +5449,9 @@
       }
     },
     "gulp-clean-css": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.4.0.tgz",
-      "integrity": "sha1-y0wcdGVFty98FQyN2Qam7nOf2E8=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.4.1.tgz",
+      "integrity": "sha1-thpEnqBWwDi43NyFcEGyOCsJsNU=",
       "dev": true
     },
     "gulp-cli": {
@@ -6129,9 +5991,9 @@
       "dev": true,
       "dependencies": {
         "uglify-js": {
-          "version": "3.0.14",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.14.tgz",
-          "integrity": "sha1-JpevEm/SFarFVvrLHt+xeHUgR2A=",
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.15.tgz",
+          "integrity": "sha1-qssyOoRrI0YCJw3q2KMkQaiAb0I=",
           "dev": true
         }
       }
@@ -7458,9 +7320,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
+      "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ==",
       "dev": true
     },
     "madge": {
@@ -7972,9 +7834,9 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz",
-      "integrity": "sha1-GVYQZ/8YVGSt7UeCEmgfR/1XjLw=",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true
     },
     "node-html-encoder": {
@@ -8417,9 +8279,9 @@
       "dev": true,
       "dependencies": {
         "@types/node": {
-          "version": "6.0.73",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.73.tgz",
-          "integrity": "sha1-hdxLtvElN3x13dJRmh7rY/Ck7XA=",
+          "version": "6.0.78",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
+          "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg==",
           "dev": true
         }
       }
@@ -8773,9 +8635,9 @@
       "dev": true,
       "dependencies": {
         "@types/node": {
-          "version": "6.0.73",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.73.tgz",
-          "integrity": "sha1-hdxLtvElN3x13dJRmh7rY/Ck7XA=",
+          "version": "6.0.78",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
+          "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg==",
           "dev": true
         },
         "@types/q": {
@@ -8967,9 +8829,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
       "dev": true
     },
     "readdirp": {
@@ -9959,9 +9821,9 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
       "dev": true
     },
     "string-format-obj": {
@@ -10313,9 +10175,9 @@
       "dev": true
     },
     "text-extensions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz",
-      "integrity": "sha1-w4XS6Ah5/m75eJPhcJ2I2UU3Juk=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.5.0.tgz",
+      "integrity": "sha1-0cstFLXQvEW/3Kigikc/aMfrDLw=",
       "dev": true
     },
     "text-table": {
@@ -10526,9 +10388,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.0.4.tgz",
-      "integrity": "sha1-oUdevyT9Ti7i+6ixqhYFuXe95QY=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.0.6.tgz",
+      "integrity": "sha1-VRJ/95DH7r9rpowebd6UsJqqIeA=",
       "dev": true
     },
     "tsconfig": {
@@ -10571,9 +10433,9 @@
       "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tslint": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.3.2.tgz",
-      "integrity": "sha1-5WRZ+wlacwfxA7hAUhdPXju+9u0=",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
+      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
       "dev": true,
       "dependencies": {
         "colors": {
@@ -10634,9 +10496,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
-      "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+      "version": "2.8.28",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
+      "integrity": "sha512-WqKNbmNJKzIdIEQu/U2ytgGBbhCy2PVks94GoetczOAJ/zCgVu2CuO7gguI5KPFGPtUtI1dmPQl6h0D4cPzypA==",
       "dev": true
     },
     "uglify-to-browserify": {
@@ -11418,18 +11280,10 @@
       "dev": true
     },
     "yn": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-1.3.0.tgz",
-      "integrity": "sha1-GwgSq7jYBdSJZvjfOF3J2syaGdg=",
-      "dev": true,
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     },
     "zip-stream": {
       "version": "0.6.0",

--- a/src/e2e-app/button/button-e2e.html
+++ b/src/e2e-app/button/button-e2e.html
@@ -26,11 +26,11 @@
     off
   </button>
 
-  <button md-mini-fab [disabled]="isDisabled">
+  <button md-mini-fab [disabled]="isDisabled" aria-label="Check">
     <md-icon class="md-24">check</md-icon>
   </button>
 
-  <button md-icon-button color="accent" [disabled]="isDisabled">
+  <button md-icon-button color="accent" [disabled]="isDisabled" aria-label="Check">
     <md-icon class="md-24">favorite</md-icon>
   </button>
 </section>

--- a/src/lib/icon/icon.md
+++ b/src/lib/icon/icon.md
@@ -15,8 +15,8 @@ Some fonts are designed to show icons by using
 "home" as a home image. To use a ligature icon, put its text in the content of the `md-icon`
 component.
 
-By default the
-[Material icons font](http://google.github.io/material-design-icons/#icon-font-for-the-web) is used.
+By default, `<md-icon>` expects the
+[Material icons font](http://google.github.io/material-design-icons/#icon-font-for-the-web).
 (You will still need to include the HTML to load the font and its CSS, as described in the link).
 You can specify a different font by setting the `fontSet` input to either the CSS class to apply to
 use the desired font, or to an alias previously registered with
@@ -80,9 +80,34 @@ match the current theme's colors using the `color` attribute. This can be change
 
 ### Accessibility
 
-If an `aria-label` attribute is set on the `md-icon` element, its value will be used as-is. If not,
-the md-icon component will attempt to set the aria-label value from one of these sources:
-* The `alt` attribute
-* The `fontIcon` input
-* The name of the icon from the `svgIcon` input (not including any namespace)
-* The text content of the component (for ligature icons)
+Similar to an `<img>` element, an icon alone does not convey any useful information for a
+screen-reader user. The user of `<md-icon>` must provide additional information pertaining to how
+the icon is used. Based on the use-cases described below, `md-icon` is marked as
+`aria-hidden="true"` by default, but this can be overriden by adding `aria-hidden="false"` to the
+element.
+
+In thinking about accessibility, it is useful to place icon use into one of three categories:
+1. **Decorative**: the icon conveys no real semantic meaning and is purely cosmetic.
+2. **Interactive**: a user will click or otherwise interact with the icon to perform some action.
+3. **Indicator**: the icon is not interactive, but it conveys some information, such as a status.
+
+#### Decorative icons
+When the icon is puely cosmetic and conveys no real semantic meaning, the `<md-icon>` element
+should be marked with `aria-hidden="true"`.
+
+#### Interactive icons
+Icons alone are not interactive elements for screen-reader users; when the user would interact with
+some icon on the page, a more appropriate  element should "own" the interaction:
+* The `<md-icon>` element should be a child of a `<button>` or `<a>` element.
+* The `<md-icon>` element should be marked with `aria-hidden="true"`.
+* The parent `<button>` or `<a>` should either have a meaningful label provided either through
+direct text content, `aria-label`, or `aria-labelledby`.
+
+#### Indicator icons
+When the presence of an icon communicates some information to the user, that information must also
+be made available to screen-readers. The most straightforward way to do this is to
+1. Mark the `<md-icon>` as `aria-hidden="true"`
+2. Add a `<span>` as an adjacent sibling to the `<md-icon>` element with text that conveys the same
+information as the icon.
+3. Add the `cdk-visually-hidden` class to the `<span>`. This will make the message invisible
+on-screen but still available to screen-reader users.

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -42,11 +42,11 @@ describe('MdIcon', () => {
     TestBed.configureTestingModule({
       imports: [HttpModule, MdIconModule],
       declarations: [
-        MdIconColorTestApp,
-        MdIconLigatureTestApp,
-        MdIconLigatureWithAriaBindingTestApp,
-        MdIconCustomFontCssTestApp,
-        MdIconFromSvgNameTestApp,
+        IconWithColor,
+        IconWithLigature,
+        IconWithCustomFontCss,
+        IconFromSvgName,
+        IconWithAriaHiddenFalse,
       ],
       providers: [
         MockBackend,
@@ -76,7 +76,7 @@ describe('MdIcon', () => {
   }));
 
   it('should apply class based on color attribute', () => {
-    let fixture = TestBed.createComponent(MdIconColorTestApp);
+    let fixture = TestBed.createComponent(IconWithColor);
 
     const testComponent = fixture.componentInstance;
     const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -86,9 +86,23 @@ describe('MdIcon', () => {
     expect(sortedClassNames(mdIconElement)).toEqual(['mat-icon', 'mat-primary', 'material-icons']);
   });
 
+  it('should mark md-icon as aria-hidden by default', () => {
+    const fixture = TestBed.createComponent(IconWithLigature);
+    const iconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+    expect(iconElement.getAttribute('aria-hidden'))
+        .toBe('true', 'Expected the md-icon element has aria-hidden="true" by default');
+  });
+
+  it('should not override a user-provided aria-hidden attribute', () => {
+    const fixture = TestBed.createComponent(IconWithAriaHiddenFalse);
+    const iconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
+    expect(iconElement.getAttribute('aria-hidden'))
+        .toBe('false', 'Expected the md-icon element has the user-provided aria-hidden value');
+  });
+
   describe('Ligature icons', () => {
     it('should add material-icons class by default', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+      let fixture = TestBed.createComponent(IconWithLigature);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -100,7 +114,7 @@ describe('MdIcon', () => {
     it('should use alternate icon font if set', () => {
       mdIconRegistry.setDefaultFontSetClass('myfont');
 
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
+      let fixture = TestBed.createComponent(IconWithLigature);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -115,7 +129,7 @@ describe('MdIcon', () => {
       mdIconRegistry.addSvgIcon('fluffy', trust('cat.svg'));
       mdIconRegistry.addSvgIcon('fido', trust('dog.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
       let svgElement: SVGElement;
@@ -124,15 +138,12 @@ describe('MdIcon', () => {
       fixture.detectChanges();
       svgElement = verifyAndGetSingleSvgChild(mdIconElement);
       verifyPathChildElement(svgElement, 'woof');
-      // The aria label should be taken from the icon name.
-      expect(mdIconElement.getAttribute('aria-label')).toBe('fido');
 
       // Change the icon, and the SVG element should be replaced.
       testComponent.iconName = 'fluffy';
       fixture.detectChanges();
       svgElement = verifyAndGetSingleSvgChild(mdIconElement);
       verifyPathChildElement(svgElement, 'meow');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('fluffy');
 
       expect(httpRequestUrls).toEqual(['dog.svg', 'cat.svg']);
       // Using an icon from a previously loaded URL should not cause another HTTP request.
@@ -147,7 +158,7 @@ describe('MdIcon', () => {
       mdIconRegistry.addSvgIcon('fluffy', 'farm-set-1.svg');
 
       expect(() => {
-        let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+        let fixture = TestBed.createComponent(IconFromSvgName);
         fixture.componentInstance.iconName = 'fluffy';
         fixture.detectChanges();
       }).toThrowError(/unsafe value used in a resource URL context/);
@@ -157,7 +168,7 @@ describe('MdIcon', () => {
       mdIconRegistry.addSvgIconSetInNamespace('farm', 'farm-set-1.svg');
 
       expect(() => {
-        let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+        let fixture = TestBed.createComponent(IconFromSvgName);
         fixture.componentInstance.iconName = 'farm:pig';
         fixture.detectChanges();
       }).toThrowError(/unsafe value used in a resource URL context/);
@@ -166,7 +177,7 @@ describe('MdIcon', () => {
     it('should extract icon from SVG icon set', () => {
       mdIconRegistry.addSvgIconSetInNamespace('farm', trust('farm-set-1.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -184,8 +195,6 @@ describe('MdIcon', () => {
       expect(svgChild.tagName.toLowerCase()).toBe('g');
       expect(svgChild.getAttribute('id')).toBe('pig');
       verifyPathChildElement(svgChild, 'oink');
-      // The aria label should be taken from the icon name (without the icon set portion).
-      expect(mdIconElement.getAttribute('aria-label')).toBe('pig');
 
       // Change the icon, and the SVG element should be replaced.
       testComponent.iconName = 'farm:cow';
@@ -196,7 +205,6 @@ describe('MdIcon', () => {
       expect(svgChild.tagName.toLowerCase()).toBe('g');
       expect(svgChild.getAttribute('id')).toBe('cow');
       verifyPathChildElement(svgChild, 'moo');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('cow');
     });
 
     it('should allow multiple icon sets in a namespace', () => {
@@ -204,7 +212,7 @@ describe('MdIcon', () => {
       mdIconRegistry.addSvgIconSetInNamespace('farm', trust('farm-set-2.svg'));
       mdIconRegistry.addSvgIconSetInNamespace('arrows', trust('arrow-set.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -221,8 +229,6 @@ describe('MdIcon', () => {
       expect(svgChild.getAttribute('id')).toBe('pig');
       expect(svgChild.childNodes.length).toBe(1);
       verifyPathChildElement(svgChild, 'oink');
-      // The aria label should be taken from the icon name (without the namespace).
-      expect(mdIconElement.getAttribute('aria-label')).toBe('pig');
 
       // Both icon sets registered in the 'farm' namespace should have been fetched.
       expect(httpRequestUrls.sort()).toEqual(['farm-set-1.svg', 'farm-set-2.svg']);
@@ -239,14 +245,13 @@ describe('MdIcon', () => {
       expect(svgChild.getAttribute('id')).toBe('cow');
       expect(svgChild.childNodes.length).toBe(1);
       verifyPathChildElement(svgChild, 'moo moo');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('cow');
       expect(httpRequestUrls.sort()).toEqual(['farm-set-1.svg', 'farm-set-2.svg']);
     });
 
     it('should unwrap <symbol> nodes', () => {
       mdIconRegistry.addSvgIconSetInNamespace('farm', trust('farm-set-3.svg'));
 
-      const fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
 
@@ -265,7 +270,7 @@ describe('MdIcon', () => {
     it('should not wrap <svg> elements in icon sets in another svg tag', () => {
       mdIconRegistry.addSvgIconSet(trust('arrow-set.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -277,13 +282,12 @@ describe('MdIcon', () => {
       // directly and not wrapped in an outer <svg> tag like the <g> elements in other sets.
       svgElement = verifyAndGetSingleSvgChild(mdIconElement);
       verifyPathChildElement(svgElement, 'left');
-      expect(mdIconElement.getAttribute('aria-label')).toBe('left-arrow');
     });
 
     it('should return unmodified copies of icons from icon sets', () => {
       mdIconRegistry.addSvgIconSet(trust('arrow-set.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -316,7 +320,7 @@ describe('MdIcon', () => {
       mdIconRegistry.registerFontClassAlias('f1', 'font1');
       mdIconRegistry.registerFontClassAlias('f2');
 
-      let fixture = TestBed.createComponent(MdIconCustomFontCssTestApp);
+      let fixture = TestBed.createComponent(IconWithCustomFontCss);
 
       const testComponent = fixture.componentInstance;
       const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
@@ -324,89 +328,16 @@ describe('MdIcon', () => {
       testComponent.fontIcon = 'house';
       fixture.detectChanges();
       expect(sortedClassNames(mdIconElement)).toEqual(['font1', 'house', 'mat-icon']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
 
       testComponent.fontSet = 'f2';
       testComponent.fontIcon = 'igloo';
       fixture.detectChanges();
       expect(sortedClassNames(mdIconElement)).toEqual(['f2', 'igloo', 'mat-icon']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('igloo');
 
       testComponent.fontSet = 'f3';
       testComponent.fontIcon = 'tent';
       fixture.detectChanges();
       expect(sortedClassNames(mdIconElement)).toEqual(['f3', 'mat-icon', 'tent']);
-      expect(mdIconElement.getAttribute('aria-label')).toBe('tent');
-    });
-  });
-
-  describe('aria label', () => {
-    it('should set aria label from text content if not specified', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
-
-      const testComponent = fixture.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
-      testComponent.iconName = 'home';
-
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
-
-      testComponent.iconName = 'hand';
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('hand');
-    });
-
-    it('should not set aria label unless it actually changed', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureTestApp);
-
-      const testComponent = fixture.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
-      testComponent.iconName = 'home';
-
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
-
-      mdIconElement.removeAttribute('aria-label');
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBeFalsy();
-    });
-
-    it('should use alt tag if aria label is not specified', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureWithAriaBindingTestApp);
-
-      const testComponent = fixture.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
-      testComponent.iconName = 'home';
-      testComponent.altText = 'castle';
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('castle');
-
-      testComponent.ariaLabel = 'house';
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
-    });
-
-    it('should use provided aria label rather than icon name', () => {
-      let fixture = TestBed.createComponent(MdIconLigatureWithAriaBindingTestApp);
-
-      const testComponent = fixture.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
-      testComponent.iconName = 'home';
-      testComponent.ariaLabel = 'house';
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('house');
-    });
-
-    it('should use provided aria label rather than font icon', () => {
-      let fixture = TestBed.createComponent(MdIconCustomFontCssTestApp);
-
-      const testComponent = fixture.componentInstance;
-      const mdIconElement = fixture.debugElement.nativeElement.querySelector('md-icon');
-      testComponent.fontSet = 'f1';
-      testComponent.fontIcon = 'house';
-      testComponent.ariaLabel = 'home';
-      fixture.detectChanges();
-      expect(mdIconElement.getAttribute('aria-label')).toBe('home');
     });
   });
 
@@ -424,7 +355,7 @@ describe('MdIcon without HttpModule', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MdIconModule],
-      declarations: [MdIconFromSvgNameTestApp],
+      declarations: [IconFromSvgName],
     });
 
     TestBed.compileComponents();
@@ -441,7 +372,7 @@ describe('MdIcon without HttpModule', () => {
     expect(() => {
       mdIconRegistry.addSvgIcon('fido', sanitizer.bypassSecurityTrustResourceUrl('dog.svg'));
 
-      let fixture = TestBed.createComponent(MdIconFromSvgNameTestApp);
+      let fixture = TestBed.createComponent(IconFromSvgName);
 
       fixture.componentInstance.iconName = 'fido';
       fixture.detectChanges();
@@ -450,38 +381,27 @@ describe('MdIcon without HttpModule', () => {
 });
 
 
-/** Test components that contain an MdIcon. */
 @Component({template: `<md-icon>{{iconName}}</md-icon>`})
-class MdIconLigatureTestApp {
-  ariaLabel: string = null;
+class IconWithLigature {
   iconName = '';
 }
 
 @Component({template: `<md-icon [color]="iconColor">{{iconName}}</md-icon>`})
-class MdIconColorTestApp {
-  ariaLabel: string = null;
+class IconWithColor {
   iconName = '';
   iconColor = 'primary';
 }
 
-@Component({template: `<md-icon [aria-label]="ariaLabel" [alt]="altText">{{iconName}}</md-icon>`})
-class MdIconLigatureWithAriaBindingTestApp {
-  altText: string = '';
-  ariaLabel: string = null;
-  iconName = '';
-}
-
-@Component({
-  template: `<md-icon [fontSet]="fontSet" [fontIcon]="fontIcon" [aria-label]="ariaLabel"></md-icon>`
-})
-class MdIconCustomFontCssTestApp {
-  ariaLabel: string = null;
+@Component({template: `<md-icon [fontSet]="fontSet" [fontIcon]="fontIcon"></md-icon>`})
+class IconWithCustomFontCss {
   fontSet = '';
   fontIcon = '';
 }
 
-@Component({template: `<md-icon [svgIcon]="iconName" [aria-label]="ariaLabel"></md-icon>`})
-class MdIconFromSvgNameTestApp {
-  ariaLabel: string = null;
+@Component({template: `<md-icon [svgIcon]="iconName"></md-icon>`})
+class IconFromSvgName {
   iconName = '';
 }
+
+@Component({template: '<md-icon aria-hidden="false">face</md-icon>'})
+class IconWithAriaHiddenFalse { }


### PR DESCRIPTION
The automatic application of aria-label for md-icon, in hindsight, was
not a great idea. Neither the ligature string nor the SVG filename are
likely to be meaningful descriptions. Even in cases where they *are*,
the icon may be used in such a way that the application of a label is
still the wrong thing. On top of that, adding `role="img"` is usually
not the right approach for an icon, as that role typically refers to
*content* images, rather than icons that are part of the UI.

Ultimately, it is up to the application developer to add the appropriate
meaning for icons based on how they're used. To this end, we add
guidance to the documentation for what to do in different situations.