### PR TITLE
build: fix umd module names

### DIFF
--- a/tools/gulp/util/package-build.ts
+++ b/tools/gulp/util/package-build.ts
@@ -43,7 +43,7 @@ export function composeRelease(packageName: string) {
 
 /** Builds the bundles for the specified package. */
 export async function buildPackageBundles(entryFile: string, packageName: string) {
-  let moduleName = `ng.material.${packageName}`;
+  let moduleName = `ng.${packageName}`;
 
   // List of paths to the package bundles.
   let fesm2015File = join(DIST_BUNDLES, `${packageName}.js`);


### PR DESCRIPTION
* Fixes that the UMD module names are invalid. Currently they look like `ng.material.material` while it should be just `ng.material`.