### PR TITLE
chore(examples): fix color binding for progress-spinner

### DIFF
--- a/src/material-examples/progress-spinner-configurable/progress-spinner-configurable-example.html
+++ b/src/material-examples/progress-spinner-configurable/progress-spinner-configurable-example.html
@@ -41,7 +41,7 @@
 
     <md-progress-spinner
         class="example-margin"
-        [attr.color]="color"
+        [color]="color"
         [mode]="mode"
         [value]="value">
     </md-progress-spinner>


### PR DESCRIPTION
* Replaces the invalid `attr.color` with a property binding. This fixes the progress-spinner demo on the docs.

Fixes #4617