### PR TITLE
build(docs): markdown for api descriptions

### DIFF
--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -1,7 +1,7 @@
 <h4 class="docs-api-h4 docs-api-class-name">
   <code>{$ class.name $}</code>
 </h4>
-<p class="docs-api-class-description">{$ class.description $}</p>
+<p class="docs-api-class-description">{$ class.description | marked | safe $}</p>
 
 {%- if class.directiveSelectors -%}
 <div class="docs-api-directive-selectors">

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -10,7 +10,9 @@
     </tr>
   </thead>
   <tr class="docs-api-method-description-row">
-    <td colspan="2" class="docs-api-method-description-cell">{$ method.description $}</td>
+    <td colspan="2" class="docs-api-method-description-cell">
+      {$ method.description | marked | safe $}
+    </td>
   </tr>
 
   {%- if method.params.length -%}
@@ -31,7 +33,9 @@
       <code class="docs-api-method-parameter-type">{$ parameter.type $}</code>
     </td>
     <td class="docs-api-method-parameter-description-cell">
-      <p class="docs-api-method-parameter-description">{$ parameter.description $}</p>
+      <p class="docs-api-method-parameter-description">
+        {$ parameter.description | marked | safe $}
+      </p>
     </td>
   </tr>
   {% endfor %}
@@ -48,7 +52,9 @@
       <code class="docs-api-method-returns-type">{$ method.returnType $}</code>
     </td>
     <td class="docs-api-method-returns-description-cell">
-      <p class="docs-api-method-returns-description">{$ method.returns.description $}</p>
+      <p class="docs-api-method-returns-description">
+        {$ method.returns.description | marked | safe $}
+      </p>
     </td>
   </tr>
   {%- endif -%}

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -27,5 +27,5 @@
     </p>
     <code class="docs-api-property-type">{$ property.type $}</code>
   </td>
-  <td class="docs-api-property-description">{$ property.description $}</td>
+  <td class="docs-api-property-description">{$ property.description | marked | safe $}</td>
 </tr>


### PR DESCRIPTION
* Parses Class, Property and Method descriptions using a markdown filter from Dgeni.

**Important**: Markdown adds `<p>` elements around text and those have margins by default. The styles on `material.angular.io` would need to be revised too.

But still a big benefit because backticks are rendered as code snippets. Same would happen if there would be multi line code-snippets.

Closes #3924