### PR TITLE
fix(autocomplete): restore focus to input when clicking on an option

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -339,6 +339,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
       this._clearPreviousSelectedOption(event.source);
       this._setTriggerValue(event.source.value);
       this._onChange(event.source.value);
+      this._element.nativeElement.focus();
     }
 
     this.closePanel();

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -907,6 +907,22 @@ describe('MdAutocomplete', () => {
 
     });
 
+    it('should restore focus to the input when clicking to select a value', async(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        const option = overlayContainerElement.querySelector('md-option') as HTMLElement;
+
+        // Focus the option manually since the synthetic click may not do it.
+        option.focus();
+        option.click();
+        fixture.detectChanges();
+
+        expect(document.activeElement).toBe(input, 'Expected focus to be restored to the input.');
+      });
+    }));
+
   });
 
   describe('Fallback positions', () => {


### PR DESCRIPTION
Restores focus to the autocomplete input when an option is clicked, instead of dumping it into the body.

**Note:** The CI failures seem to be due to an unrelated issue with our build.

Fixes #4645.