### PR TITLE
build(ci): run CI with most recent LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - '6.10.2'
+  - '--lts'
 
 addons:
   jwt:


### PR DESCRIPTION
* Runs Travis with the most up-to-date LTS version.

**Note**: Tests are failing due to infinite loops in the latest Jasmine version (#4662) and the broken RxJS configuration (#4709)