### PR TITLE
build: fix rxjs building error for closure

### DIFF
--- a/scripts/closure-compiler/tsconfig-rxjs.json
+++ b/scripts/closure-compiler/tsconfig-rxjs.json
@@ -3,7 +3,8 @@
     "module": "es2015",
     "outDir": "../../dist/packages/rxjs",
     "target": "es5",
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    "types": []
   },
   "files": [
     "../../node_modules/rxjs/src/Rx.ts"


### PR DESCRIPTION
When testing against closure, RxJS will be re-compiled to target ES2015 modules.

The RxJS tsconfig file takes all `@types` that are installed and due to a recent update of the gulp types, building RxJS fails now.

**Note**: Tests are failing due to infinite loops in the latest Jasmine version (#4662)