### PR TITLE
build: bump typescript to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/minimist": "^1.2.0",
     "@types/node": "^7.0.5",
     "@types/run-sequence": "^0.0.28",
-    "@types/rx": "2.5.33",
+    "@types/rx": "4.1.1",
     "autoprefixer": "^6.7.6",
     "axe-core": "^2.1.7",
     "axe-webdriverjs": "^0.5.0",
@@ -113,7 +113,7 @@
     "travis-after-modes": "0.0.7",
     "ts-node": "^3.0.0",
     "tslint": "^5.1.0",
-    "typescript": "~2.2.1",
+    "typescript": "~2.3.2",
     "uglify-js": "^2.8.14",
     "web-animations-js": "^2.2.2"
   }


### PR DESCRIPTION
Bumps TypeScript to 2.3.2 to match `@angular/angular`.