### PR TITLE
fix(autocomplete): show hover style on selected options

### DIFF
--- a/src/lib/autocomplete/_autocomplete-theme.scss
+++ b/src/lib/autocomplete/_autocomplete-theme.scss
@@ -9,7 +9,12 @@
     color: mat-color($foreground, text);
 
     .mat-option {
-      &.mat-selected:not(.mat-active) {
+      // Selected options in autocompletes should not be gray, but we
+      // only want to override the background for selected options if
+      // they are *not* in hover or focus state. This change has to be
+      // made here because base option styles are shared between the
+      // autocomplete and the select.
+      &.mat-selected:not(.mat-active):not(:hover) {
         background: mat-color($background, card);
         color: mat-color($foreground, text);
       }


### PR DESCRIPTION
Hover styles on previously selected options were being suppressed.  To replicate:

1. Go to [docs site example](https://material.angular.io/components/component/autocomplete).
2. Click on 'Alabama'.
3. Delete text until you have 'A'.
4. Try to hover over 'Alabama' - no hover style appears.

