### PR TITLE
Add "menu" role to md-menu-panel/mat-menu-content

### DIFF
--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -1,7 +1,7 @@
 <ng-template>
   <div class="mat-menu-panel" [ngClass]="_classList" (keydown)="_handleKeydown($event)"
     (click)="_emitCloseEvent()" [@transformMenu]="'showing'">
-    <div class="mat-menu-content" [@fadeInItems]="'showing'">
+    <div class="mat-menu-content" [@fadeInItems]="'showing'" role="menu">
       <ng-content></ng-content>
     </div>
   </div>


### PR DESCRIPTION
Hi. I think this role is necessary.
In Aria, "md-menu-item" should be inside "menu".
https://www.w3.org/TR/wai-aria/roles#menuitem