### PR TITLE
build: better naming for firebase token

### DIFF
--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -15,7 +15,7 @@ export function openFirebaseDashboardDatabase() {
       client_email: 'firebase-adminsdk-ch1ob@material2-dashboard.iam.gserviceaccount.com',
       // In Travis CI the private key will be incorrect because the line-breaks are escaped.
       // The line-breaks need to persist in the service account private key.
-      private_key: decode(process.env['MATERIAL2_FIREBASE_PRIVATE_KEY'])
+      private_key: decode(process.env['MATERIAL2_DASHBOARD_FIREBASE_KEY'])
     }),
     databaseURL: 'https://material2-dashboard.firebaseio.com'
   });


### PR DESCRIPTION
Changes the `MATERIAL2_FIREBASE_PRIVATE_KEY` to `MATERIAL2_DASHBOARD_FIREBASE_KEY` because it's confusing to just say that its for firebase.

Giving it a more explicit token as same as with the screenshots ensures that we have a structured & clean list of tokens in our CI settings.

@jelbourn I added the token already to the CI and kept the old one so that nothing breaks for now.

In a follow-up PR we should also switch away from the `MATERIAL2_DOCS_CONTENT_TOKEN` and just use the `MATERIAL2_BUILDS_TOKEN`. @jelbourn can you confirm that the @titanium-octobot has permission to the docs content repository as well?