### PR TITLE
fix(datepicker): generate api docs

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -9,8 +9,8 @@ import {MdDatepickerIntl} from './datepicker-intl';
   template: '',
   styleUrls: ['datepicker-toggle.css'],
   host: {
-    '[attr.type]': 'type',
-    '[class.mat-datepicker-toggle]': 'true',
+    'type': 'button',
+    'class': 'mat-datepicker-toggle',
     '[attr.aria-label]': '_intl.openCalendarLabel',
     '(click)': '_open($event)',
   },
@@ -20,9 +20,6 @@ import {MdDatepickerIntl} from './datepicker-intl';
 export class MdDatepickerToggle<D> {
   /** Datepicker instance that the button will toggle. */
   @Input('mdDatepickerToggle') datepicker: MdDatepicker<D>;
-
-  /** Type of the button. */
-  @Input() type: string = 'button';
 
   @Input('matDatepickerToggle')
   get _datepicker() { return this.datepicker; }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -43,7 +43,7 @@ let datepickerUid = 0;
  * MdCalendar directly as the content so we can control the initial focus. This also gives us a
  * place to put additional features of the popup that are not part of the calendar itself in the
  * future. (e.g. confirmation buttons).
- * @docs-internal
+ * @docs-private
  */
 @Component({
   moduleId: module.id,

--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -91,6 +91,7 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
     'checkbox/index.ts',
     'chips/index.ts',
     'core/index.ts',
+    'datepicker/index.ts',
     'dialog/index.ts',
     'grid-list/index.ts',
     'icon/index.ts',

--- a/tools/dgeni/processors/categorizer.js
+++ b/tools/dgeni/processors/categorizer.js
@@ -90,9 +90,9 @@ module.exports = function categorizer() {
   }
 };
 
-/** Function that walks through all inherited docs and collects public methods. */
+/** Walks through all inherited docs and collects public methods. */
 function resolveMethods(classDoc) {
-  let methods = classDoc.members.filter(member => member.hasOwnProperty('parameters'));
+  let methods = classDoc.members.filter(isMethod);
 
   if (classDoc.inheritedDoc) {
     methods = methods.concat(resolveMethods(classDoc.inheritedDoc));
@@ -101,9 +101,9 @@ function resolveMethods(classDoc) {
   return methods;
 }
 
-/** Function that walks through all inherited docs and collects public properties. */
+/** Walks through all inherited docs and collects public properties. */
 function resolveProperties(classDoc) {
-  let properties = classDoc.members.filter(member => !member.hasOwnProperty('parameters'));
+  let properties = classDoc.members.filter(isProperty);
 
   if (classDoc.inheritedDoc) {
     properties = properties.concat(resolveProperties(classDoc.inheritedDoc));
@@ -151,6 +151,18 @@ function normalizeMethodParameters(method) {
       jsDocParam.isOptional = isOptional;
     });
   }
+}
+
+function isMethod(doc) {
+  return doc.hasOwnProperty('parameters');
+}
+
+function isGenericTypeParameter(doc) {
+  return doc.classDoc.typeParams && `<${doc.name}>` === doc.classDoc.typeParams;
+}
+
+function isProperty(doc) {
+  return doc.docType === 'member' && !isMethod(doc) && !isGenericTypeParameter(doc);
 }
 
 function isDirective(doc) {


### PR DESCRIPTION
This also adds handling for directives with generics, which we have not had before. Dgeni treats this as "members" and they need to be disambiguated from properties.

Fixes #4554