### PR TITLE
build: silence build and test script

### DIFF
--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -1,7 +1,10 @@
-#!/usr/bin/env bash
-set -ex
+#!/bin/bash
 
-echo "=======  Starting build-and-test.sh  ========================================"
+set -e
+
+echo ""
+echo "Building sources and running tests. Running mode: ${MODE}"
+echo ""
 
 # Go to project dir
 cd $(dirname $0)/../..


### PR DESCRIPTION
Currently the CI logs everything that runs inside of the bash script.

This might have been useful when creating the script but now it really pollutes the CI output which should be clean and structured.

Disabling tracing for the build and test script because the errors will still show up and the CI will look more clean.