### PR TITLE
build: fix screenshot functions export

### DIFF
--- a/tools/screenshot-test/functions/index.js
+++ b/tools/screenshot-test/functions/index.js
@@ -14,4 +14,9 @@ require('ts-node').register({
   project: path.join(__dirname, 'tsconfig.json')
 });
 
-require('./screenshot-functions');
+const functionExports = require('./screenshot-functions');
+
+// Re-export every firebase function from TypeScript
+Object.keys(functionExports).forEach(fnName => {
+  module.exports[fnName] = functionExports[fnName];
+});


### PR DESCRIPTION
* The Firebase CLI is not able to properly detect the Firebase functions for the screenshot project. This is because the functions are not re-exported.