### PR TITLE
fix(dialog): blurry content and slow animation in IE

### DIFF
--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -45,8 +45,12 @@ export function throwMdDialogContentAlreadyAttachedError() {
   encapsulation: ViewEncapsulation.None,
   animations: [
     trigger('slideDialog', [
+      // Note: The `enter` animation doesn't transition to something like `translate3d(0, 0, 0)
+      // scale(1)`, because for some reason specifying the transform explicitly, causes IE both
+      // to blur the dialog content and decimate the animation performance. Leaving it blank
+      // solves both issues.
+      state('enter', style({ opacity: 1 })),
       state('void', style({ transform: 'translate3d(0, 25%, 0) scale(0.9)', opacity: 0 })),
-      state('enter', style({ transform: 'translate3d(0, 0, 0) scale(1)', opacity: 1 })),
       state('exit', style({ transform: 'translate3d(0, 25%, 0)', opacity: 0 })),
       transition('* => *', animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)')),
     ])


### PR DESCRIPTION
Fixes the dialog content being blurry and the animation being really janky in IE11.