### PR TITLE
build: missing cdk release output

### DIFF
--- a/scripts/ci/publish-artifacts.sh
+++ b/scripts/ci/publish-artifacts.sh
@@ -15,7 +15,8 @@ echo "Starting to publish the build artifacts and docs content..."
 echo ""
 
 # Build Material, CDK and the docs before publishing artifacts
-$(npm bin)/gulp material:build-release:clean
+$(npm bin)/gulp cdk:build-release:clean
+$(npm bin)/gulp material:build-release
 $(npm bin)/gulp material-examples:build-release
 $(npm bin)/gulp docs
 


### PR DESCRIPTION
For the publish artifacts script the CDK release output didn't build. The CDK release output is necessary since it will be also published to cdk-builds.