### PR TITLE
fix(dialog): componentInstance unavailable in afterClose

### DIFF
--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -27,12 +27,10 @@ export class MdDialogRef<T> {
   constructor(private _overlayRef: OverlayRef, public _containerInstance: MdDialogContainer) {
     _containerInstance._onAnimationStateChange
       .filter((event: AnimationEvent) => event.toState === 'exit')
-      .subscribe(() => {
-        this._overlayRef.dispose();
-        this.componentInstance = null;
-      }, null, () => {
+      .subscribe(() => this._overlayRef.dispose(), null, () => {
         this._afterClosed.next(this._result);
         this._afterClosed.complete();
+        this.componentInstance = null;
       });
   }
 

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -367,6 +367,18 @@ describe('MdDialog', () => {
     });
   }));
 
+  it('should have the componentInstance available in the afterClosed callback', fakeAsync(() => {
+    let dialogRef = dialog.open(PizzaMsg);
+
+    dialogRef.afterClosed().subscribe(() => {
+      expect(dialogRef.componentInstance).toBeTruthy('Expected component instance to be defined.');
+    });
+
+    dialogRef.close();
+    tick(500);
+    viewContainerFixture.detectChanges();
+  }));
+
   describe('passing in data', () => {
     it('should be able to pass in data', () => {
       let config = {


### PR DESCRIPTION
Fixes the `dialogRef.componentInstance` being cleaned up too early, causing it to be unavailable in the `afterClosed` callback.

Fixes #4815.