### PR TITLE
build: invalid tsconfig for screenshot functions

### DIFF
--- a/tools/screenshot-test/functions/tsconfig.json
+++ b/tools/screenshot-test/functions/tsconfig.json
@@ -11,6 +11,6 @@
     "outDir": "../../../dist/screenshot-functions/"
   },
   "files": [
-    "./index.ts"
+    "./screenshot-functions.ts"
   ]
 }


### PR DESCRIPTION
The tsconfig for the Screenshot function specifies a non existing `index.ts` file. This leads to errors in the TypeScript project because the source files are not being loaded with the ES2015 library (e.g Promise is undefined)