### PR TITLE
Add flex wrap to dialog.scss

### DIFF
--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -45,6 +45,7 @@ $mat-dialog-max-height: 65vh !default;
 .mat-dialog-actions {
   padding: $mat-dialog-padding / 2 0;
   display: flex;
+  flex-wrap: wrap;
 
   &:last-child {
     // If the actions are the last element in a dialog, we need to pull them down


### PR DESCRIPTION
Adding flex-wrap: wrap; would decrease the likelihood of hiding buttons on small screens.