### PR TITLE
Documenting action buttons align

### DIFF
--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -61,13 +61,14 @@ Several directives are available to make it easier to structure your dialog cont
 | `md-dialog-title`     | \[Attr] Dialog title, applied to a heading element (e.g., `<h1>`, `<h2>`)                                     |
 | `<md-dialog-content>` | Primary scrollable content of the dialog                                                                      |
 | `<md-dialog-actions>` | Container for action buttons at the bottom of the dialog                                                      |
+| `align`               | \[Attr] for action buttons aligment end or center                                                             |
 | `md-dialog-close`     | \[Attr] Added to a `<button>`, makes the button close the dialog with an optional result from the bound value.|
 
 For example:
 ```html
 <h2 md-dialog-title>Delete all</h2>
 <md-dialog-content>Are you sure?</md-dialog-content>
-<md-dialog-actions>
+<md-dialog-actions align="end">
   <button md-button md-dialog-close>No</button>
   <!-- Can optionally provide a result for the closing dialog. -->
   <button md-button [md-dialog-close]="true">Yes</button>


### PR DESCRIPTION
Documentation for the action buttons alignments was missing. Also I would suggest to add by default the align="end" property to be more compliment with the Material design guidelines.