### PR TITLE
fix(dialog): invalid text color in dark themes

### DIFF
--- a/src/lib/dialog/_dialog-theme.scss
+++ b/src/lib/dialog/_dialog-theme.scss
@@ -4,8 +4,10 @@
 
 @mixin mat-dialog-theme($theme) {
   $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
 
   .mat-dialog-container {
     background: mat-color($background, dialog);
+    color: mat-color($foreground, text);
   }
 }

--- a/tools/gulp/packaging/build-tasks-gulp.ts
+++ b/tools/gulp/packaging/build-tasks-gulp.ts
@@ -14,7 +14,7 @@ const inlineResources = require('../../../scripts/release/inline-resources');
  * @param packageName Name of the package. Needs to be similar to the directory name in `src/`.
  * @param requiredPackages Required packages that will be built before building the current package.
  */
-export function createPackageBuildTasks(packageName: string, requiredPackages: string[] = [], ) {
+export function createPackageBuildTasks(packageName: string, requiredPackages: string[] = []) {
   // To avoid refactoring of the project the package material will map to the source path `lib/`.
   const packageRoot = join(SOURCE_ROOT, packageName === 'material' ? 'lib' : packageName);
   const packageOut = join(DIST_ROOT, 'packages', packageName);


### PR DESCRIPTION
In dark themes the dialog container will have a dark background and the text should therefore have a light text color.

Currently the text color is still dark on a dark background which causes the dialog to look bad in dark themes.