### PR TITLE
build: duplicate theme styles in demo-app

### DIFF
--- a/src/demo-app/index.html
+++ b/src/demo-app/index.html
@@ -8,7 +8,6 @@
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="dist/packages/material/core/theming/prebuilt/indigo-pink.css" rel="stylesheet">
   <link href="theme.css" rel="stylesheet">
 
   <!-- FontAwesome for md-icon demo. -->


### PR DESCRIPTION
* Recently the `theme.scss` file was added in favor of the dark theme button for our demo-app. The import for the prebuilt theme was still there and caused the theme styles to exist twice (overlapping)