### PR TITLE
build: suppress logging of sauce-connect

### DIFF
--- a/scripts/browserstack/start-tunnel.sh
+++ b/scripts/browserstack/start-tunnel.sh
@@ -4,52 +4,49 @@ set -e -o pipefail
 
 # Workaround for Travis CI cookbook https://github.com/travis-ci/travis-ci/issues/4862,
 # where $PATH will be extended with relative paths to the NPM binaries.
-PATH=`echo $PATH | sed -e 's/:\.\/node_modules\/\.bin//'`
+PATH=`echo ${PATH} | sed -e 's/:\.\/node_modules\/\.bin//'`
 
 TUNNEL_FILE="BrowserStackLocal-linux-x64.zip"
-TUNNEL_URL="https://www.browserstack.com/browserstack-local/$TUNNEL_FILE"
+TUNNEL_URL="https://www.browserstack.com/browserstack-local/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/browserstack-tunnel"
-TUNNEL_LOG="$LOGS_DIR/browserstack-tunnel.log"
+TUNNEL_LOG="${LOGS_DIR}/browserstack-tunnel.log"
 
-BROWSER_STACK_ACCESS_KEY=`echo $BROWSER_STACK_ACCESS_KEY | rev`
+BROWSER_STACK_ACCESS_KEY=`echo ${BROWSER_STACK_ACCESS_KEY} | rev`
 
 # Cleanup and create the folder structure for the tunnel connector.
-rm -rf $TUNNEL_DIR $BROWSER_PROVIDER_READY_FILE
-mkdir -p $TUNNEL_DIR
-touch $TUNNEL_LOG
+rm -rf ${TUNNEL_DIR} ${BROWSER_PROVIDER_READY_FILE}
+mkdir -p ${TUNNEL_DIR}
+touch ${TUNNEL_LOG}
 
-cd $TUNNEL_DIR
+cd ${TUNNEL_DIR}
 
 # Download the browserstack local binaries.
-curl $TUNNEL_URL -o $TUNNEL_FILE 2> /dev/null 1> /dev/null
+curl ${TUNNEL_URL} -o ${TUNNEL_FILE} 2> /dev/null 1> /dev/null
 
 # Extract the browserstack local binaries from the tarball.
 mkdir -p browserstack-tunnel
-unzip -q $TUNNEL_FILE -d browserstack-tunnel
+unzip -q ${TUNNEL_FILE} -d browserstack-tunnel
 
 # Cleanup the download directory.
-rm $TUNNEL_FILE
+rm ${TUNNEL_FILE}
 
 ARGS=""
 
 # Set tunnel-id only on Travis, to make local testing easier.
-if [ ! -z "$TRAVIS_JOB_ID" ]; then
-  ARGS="$ARGS --local-identifier $TRAVIS_JOB_ID"
+if [ ! -z "${TRAVIS_JOB_ID}" ]; then
+  ARGS="${ARGS} --local-identifier ${TRAVIS_JOB_ID}"
 fi
 
-echo "Starting Browserstack Local in the background, logging into:"
-echo "  $TUNNEL_LOG"
-echo "  ---"
-echo "  $ARGS"
+echo "Starting Browserstack Local in the background, logging into: ${TUNNEL_LOG}"
 
 # Extension to the BrowserStackLocal binaries, because those can't create a readyfile.
 function create_ready_file {
 
   # To be able to exit the tail properly we need to have a sub shell spawned, which is
   # used to track the state of tail.
-  { sleep 120; touch $BROWSER_PROVIDER_ERROR_FILE; } &
+  { sleep 120; touch ${BROWSER_PROVIDER_ERROR_FILE}; } &
 
-  TIMER_PID=$!
+  TIMER_PID=${!}
 
   # Disown the background process, because we don't want to show any messages when killing
   # the timer.
@@ -57,16 +54,16 @@ function create_ready_file {
 
   # When the tail recognizes the `Ctrl-C` log message the BrowserStack Tunnel is up.
   {
-    tail -n0 -f $TUNNEL_LOG --pid $TIMER_PID | { sed '/Ctrl/q' && kill -9 $TIMER_PID; };
+    tail -n0 -f ${TUNNEL_LOG} --pid ${TIMER_PID} | { sed '/Ctrl/q' && kill -9 ${TIMER_PID}; };
   } &> /dev/null
 
   echo
   echo "BrowserStack Tunnel ready"
 
-  touch $BROWSER_PROVIDER_READY_FILE
+  touch ${BROWSER_PROVIDER_READY_FILE}
 }
 
-browserstack-tunnel/BrowserStackLocal -k $BROWSER_STACK_ACCESS_KEY $ARGS &>> $TUNNEL_LOG &
+browserstack-tunnel/BrowserStackLocal -k ${BROWSER_STACK_ACCESS_KEY} ${ARGS} 2>&1 >> ${TUNNEL_LOG} &
 
 # Wait for the tunnel to be ready and create the readyfile with the Browserstack PID
 create_ready_file &

--- a/scripts/browserstack/wait-tunnel.sh
+++ b/scripts/browserstack/wait-tunnel.sh
@@ -26,3 +26,6 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   printf "."
   sleep .5
 done
+
+echo ""
+echo "Connected to Browserstack"

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -3,42 +3,39 @@
 set -e -o pipefail
 
 TUNNEL_FILE="sc-4.4.6-linux.tar.gz"
-TUNNEL_URL="https://saucelabs.com/downloads/$TUNNEL_FILE"
+TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 
-TUNNEL_LOG="$LOGS_DIR/sauce-connect"
+TUNNEL_LOG="${LOGS_DIR}/sauce-connect"
 
-SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+SAUCE_ACCESS_KEY=`echo ${SAUCE_ACCESS_KEY} | rev`
 
 # Cleanup and create the folder structure for the tunnel connector.
-rm -rf $TUNNEL_DIR $BROWSER_PROVIDER_READY_FILE
-mkdir -p $TUNNEL_DIR
+rm -rf ${TUNNEL_DIR} ${BROWSER_PROVIDER_READY_FILE}
+mkdir -p ${TUNNEL_DIR}
 
-cd $TUNNEL_DIR
+cd ${TUNNEL_DIR}
 
 # Download the saucelabs connect binaries.
-curl $TUNNEL_URL -o $TUNNEL_FILE 2> /dev/null 1> /dev/null
+curl ${TUNNEL_URL} -o ${TUNNEL_FILE} 2> /dev/null 1> /dev/null
 
 # Extract the saucelabs connect binaries from the tarball.
 mkdir -p sauce-connect
-tar --extract --file=$TUNNEL_FILE --strip-components=1 --directory=sauce-connect > /dev/null
+tar --extract --file=${TUNNEL_FILE} --strip-components=1 --directory=sauce-connect > /dev/null
 
 # Cleanup the download directory.
-rm $TUNNEL_FILE
+rm ${TUNNEL_FILE}
 
 ARGS=""
 
 # Set tunnel-id only on Travis, to make local testing easier.
-if [ ! -z "$TRAVIS_JOB_ID" ]; then
-  ARGS="$ARGS --tunnel-identifier $TRAVIS_JOB_ID"
+if [ ! -z "${TRAVIS_JOB_ID}" ]; then
+  ARGS="${ARGS} --tunnel-identifier ${TRAVIS_JOB_ID}"
 fi
-if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
-  ARGS="$ARGS --readyfile $BROWSER_PROVIDER_READY_FILE"
+if [ ! -z "${BROWSER_PROVIDER_READY_FILE}" ]; then
+  ARGS="${ARGS} --readyfile ${BROWSER_PROVIDER_READY_FILE}"
 fi
 
-echo "Starting Sauce Connect in the background, logging into:"
-echo "  $TUNNEL_LOG"
-echo "  ---"
-echo "  $ARGS"
+echo "Starting Sauce Connect in the background, logging into: ${TUNNEL_LOG}"
 
-sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS --logfile $TUNNEL_LOG &
+sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${ARGS} 2>&1 >> ${TUNNEL_LOG} &

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Wait for Connect to be ready before exiting
-echo "Connecting to Sauce Labs"
-
-
 # Wait for Saucelabs Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
 let "counter=0"
@@ -12,7 +8,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
 
   if [ $counter -gt 240 ]; then
-    echo
+    echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
     exit 5
   fi
@@ -21,5 +17,5 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   sleep .5
 done
 
-echo
-echo "Connected"
+echo ""
+echo "Connected to Saucelabs"


### PR DESCRIPTION
* Suppresses normal log messages from Saucelabs Conect. Error messages will still show up
* No longer suppresses the whole Browserstack Tunnel execution. Stderr output will be printed if present.
* Switches to best-practice variable referencing in Bash

**Note**: In a follow-up PR the normal stdout will be printed together with the stdout on CI failures (finally using the `$LOG_DIR` variable in the CI)
