### PR TITLE
fix(select): unable to programmatically select falsy values

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -56,7 +56,8 @@ describe('MdSelect', () => {
         BasicSelectInitiallyHidden,
         BasicSelectNoPlaceholder,
         BasicSelectWithTheming,
-        ResetValuesSelect
+        ResetValuesSelect,
+        FalsyValueSelect
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -619,6 +620,22 @@ describe('MdSelect', () => {
       fixture.detectChanges();
       expect(getComputedStyle(placeholder, '::after').getPropertyValue('content'))
         .toContain('*', `Expected placeholder to have an asterisk, as control was required.`);
+    });
+
+    it('should be able to programmatically select a falsy option', () => {
+      fixture.destroy();
+
+      const falsyFixture = TestBed.createComponent(FalsyValueSelect);
+
+      falsyFixture.detectChanges();
+      falsyFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      falsyFixture.componentInstance.control.setValue(0);
+      falsyFixture.detectChanges();
+
+      expect(falsyFixture.componentInstance.options.first.selected)
+        .toBe(true, 'Expected first option to be selected');
+      expect(overlayContainerElement.querySelectorAll('md-option')[0].classList)
+        .toContain('mat-selected', 'Expected first option to be selected');
     });
 
   });
@@ -2503,4 +2520,21 @@ class ResetValuesSelect {
   control = new FormControl();
 
   @ViewChild(MdSelect) select: MdSelect;
+}
+
+
+@Component({
+  template: `
+    <md-select [formControl]="control">
+      <md-option *ngFor="let food of foods" [value]="food.value">{{ food.viewValue }}</md-option>
+    </md-select>
+  `
+})
+class FalsyValueSelect {
+  foods: any[] = [
+    { value: 0, viewValue: 'Steak' },
+    { value: 1, viewValue: 'Pizza' },
+  ];
+  control = new FormControl();
+  @ViewChildren(MdOption) options: QueryList<MdOption>;
 }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -579,7 +579,9 @@ export class MdSelect implements AfterContentInit, OnDestroy, OnInit, ControlVal
    */
   private _selectValue(value: any): MdOption {
     let optionsArray = this.options.toArray();
-    let correspondingOption = optionsArray.find(option => option.value && option.value === value);
+    let correspondingOption = optionsArray.find(option => {
+      return option.value != null && option.value === value;
+    });
 
     if (correspondingOption) {
       correspondingOption.select();


### PR DESCRIPTION
Fixes not being able to set falsy values progammatically in `md-select`.

Fixes #4854.