### PR TITLE
build: minify html before inlining resources

### DIFF
--- a/tools/gulp/packaging/build-tasks-gulp.ts
+++ b/tools/gulp/packaging/build-tasks-gulp.ts
@@ -26,8 +26,8 @@ export function createPackageBuildTasks(packageName: string, requiredPackages: s
   // Paths to the different output files and directories.
   const esmMainFile = join(packageOut, 'index.js');
 
-  // Glob that matches all assets that should be copied to the package.
-  const assetsGlob = join(packageRoot, '**/*.+(scss|css)');
+  // Glob that matches all style files that need to be copied to the package output.
+  const stylesGlob = join(packageRoot, '**/*.+(scss|css)');
 
   // Glob that matches every HTML file in the current package.
   const htmlGlob = join(packageRoot, '**/*.html');
@@ -75,11 +75,11 @@ export function createPackageBuildTasks(packageName: string, requiredPackages: s
    * Asset tasks. Building SASS files and inlining CSS, HTML files into the ESM output.
    */
   task(`${packageName}:assets`, [
-    `${packageName}:assets:scss`, `${packageName}:assets:copy`, `${packageName}:assets:html`
+    `${packageName}:assets:scss`, `${packageName}:assets:copy-styles`, `${packageName}:assets:html`
   ]);
 
   task(`${packageName}:assets:scss`, sassBuildTask(packageOut, packageRoot, true));
-  task(`${packageName}:assets:copy`, copyTask(assetsGlob, packageOut));
+  task(`${packageName}:assets:copy-styles`, copyTask(stylesGlob, packageOut));
   task(`${packageName}:assets:html`, () => {
     return src(htmlGlob).pipe(htmlmin(HTML_MINIFIER_OPTIONS)).pipe(dest(packageOut));
   });


### PR DESCRIPTION
* Now minifies the HTML files before inlining the resources. This drops unnecessary whitespace due to previous line breaks and developers can easily test with Material components.

**Note**: The minifying could be done in another utility file as well but all our utility files should be done without gulp (because we want to have a standalone packaging tool). Only the `build-tasks-gulp` should contain gulp-related stuff. 

Fixes #1596