### PR TITLE
fix(overlay): emit attach and detach at appropriate times

### DIFF
--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -44,7 +44,6 @@ export class OverlayRef implements PortalHost {
     this.updateSize();
     this.updateDirection();
     this.updatePosition();
-    this._attachments.next();
     this._scrollStrategy.enable();
 
     // Enable pointer events for the overlay pane element.
@@ -57,6 +56,9 @@ export class OverlayRef implements PortalHost {
     if (this._state.panelClass) {
       this._pane.classList.add(this._state.panelClass);
     }
+
+    // Only emit the `attachments` event once all other setup is done.
+    this._attachments.next();
 
     return attachResult;
   }
@@ -73,9 +75,13 @@ export class OverlayRef implements PortalHost {
     // pointer events therefore. Depends on the position strategy and the applied pane boundaries.
     this._togglePointerEvents(false);
     this._scrollStrategy.disable();
+
+    let detachmentResult = this._portalHost.detach();
+
+    // Only emit after everything is detached.
     this._detachments.next();
 
-    return this._portalHost.detach();
+    return detachmentResult;
   }
 
   /**
@@ -93,9 +99,9 @@ export class OverlayRef implements PortalHost {
 
     this.detachBackdrop();
     this._portalHost.dispose();
+    this._attachments.complete();
     this._detachments.next();
     this._detachments.complete();
-    this._attachments.complete();
   }
 
   /**


### PR DESCRIPTION
* Emits the `attachments` when everything has been attached.
* Emits the `detachments` when everything has been detached.
* Completes the `attachments` observable before the `detachments`.

Fixes #4871.