### PR TITLE
feat(menu): coercing overlapTrigger attribute

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -73,7 +73,7 @@
       </button>
     </md-toolbar>
 
-    <md-menu [overlapTrigger]="false" #menuOverlay="mdMenu">
+    <md-menu overlapTrigger="false" #menuOverlay="mdMenu">
       <button md-menu-item *ngFor="let item of items" [disabled]="item.disabled">
         {{ item.text }}
       </button>
@@ -89,7 +89,7 @@
       </button>
     </md-toolbar>
 
-    <md-menu xPosition="before" [overlapTrigger]="false" #posXMenuOverlay="mdMenu" class="before">
+    <md-menu xPosition="before" overlapTrigger="false" #posXMenuOverlay="mdMenu" class="before">
       <button md-menu-item *ngFor="let item of iconItems" [disabled]="item.disabled">
         <md-icon>{{ item.icon }}</md-icon>
         {{ item.text }}
@@ -106,7 +106,7 @@
       </button>
     </md-toolbar>
 
-    <md-menu yPosition="above" [overlapTrigger]="false" #posYMenuOverlay="mdMenu">
+    <md-menu yPosition="above" overlapTrigger="false" #posYMenuOverlay="mdMenu">
       <button md-menu-item *ngFor="let item of items" [disabled]="item.disabled">
         {{ item.text }}
       </button>

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -21,7 +21,7 @@ import {MdMenuPanel} from './menu-panel';
 import {Subscription} from 'rxjs/Subscription';
 import {transformMenu, fadeInItems} from './menu-animations';
 import {ESCAPE} from '../core/keyboard/keycodes';
-
+import {coerceBooleanProperty} from '../core';
 
 @Component({
   moduleId: module.id,
@@ -75,7 +75,10 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   @ContentChildren(MdMenuItem) items: QueryList<MdMenuItem>;
 
   /** Whether the menu should overlap its trigger. */
-  @Input() overlapTrigger = true;
+  @Input()
+  get overlapTrigger(): boolean { return this._overlapTrigger; }
+  set overlapTrigger(value: boolean) { this._overlapTrigger = coerceBooleanProperty(value); }
+  private _overlapTrigger = true;
 
   /**
    * This method takes classes set on the host md-menu element and applies them on the

--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -54,7 +54,7 @@ Menus support displaying `md-icon` elements before the menu item text.
 
 By default, the menu will display below (y-axis), after (x-axis), and overlapping its trigger.  The position can be changed
 using the `xPosition` (`before | after`) and `yPosition` (`above | below`) attributes.
-The menu can be be forced to not overlap the trigger using `[overlapTrigger]="false"` attribute.
+The menu can be be forced to not overlap the trigger using `overlapTrigger="false"` attribute.
 
 ```html
 <md-menu #appMenu="mdMenu" yPosition="above">


### PR DESCRIPTION
Uses coerceBooleanProperty for `overlapTrigger` attribute.
```
<md-menu overlapTrigger="false"></md-menu>
```