### PR TITLE
fix(navbar): update ink bar when links change

### DIFF
--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -1,5 +1,9 @@
 <h1>Tab Nav Bar</h1>
 
+<button md-button (click)="tabLinks.push({label: 'New', link: 'sunny-tab'})">Add tab</button>
+<button md-button (click)="tabLinks.shift()">Remove tab</button>
+<button md-button (click)="swapTabLinks()">Swap first two</button>
+
 <div class="demo-nav-bar">
   <nav md-tab-nav-bar aria-label="weather navigation links">
     <a md-tab-link

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -2,7 +2,7 @@
 
 <button md-button (click)="tabLinks.shift()">Remove tab</button>
 <button md-button (click)="swapTabLinks()">Swap first two</button>
-<button md-button (click)="scrambleLabels()">Change labels</button>
+<button md-button (click)="addToLabel()">Add to labels</button>
 
 <div class="demo-nav-bar">
   <nav md-tab-nav-bar aria-label="weather navigation links">

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -1,6 +1,5 @@
 <h1>Tab Nav Bar</h1>
 
-<button md-button (click)="tabLinks.push({label: 'New', link: 'sunny-tab'})">Add tab</button>
 <button md-button (click)="tabLinks.shift()">Remove tab</button>
 <button md-button (click)="swapTabLinks()">Swap first two</button>
 

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -2,6 +2,7 @@
 
 <button md-button (click)="tabLinks.shift()">Remove tab</button>
 <button md-button (click)="swapTabLinks()">Swap first two</button>
+<button md-button (click)="scrambleLabels()">Change labels</button>
 
 <div class="demo-nav-bar">
   <nav md-tab-nav-bar aria-label="weather navigation links">

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -89,6 +89,10 @@ export class TabsDemo {
     this.tabLinks[0] = this.tabLinks[1];
     this.tabLinks[1] = temp;
   }
+
+  scrambleLabels() {
+    this.tabLinks.forEach(link => link.label += 'a');
+  }
 }
 
 

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -90,8 +90,8 @@ export class TabsDemo {
     this.tabLinks[1] = temp;
   }
 
-  scrambleLabels() {
-    this.tabLinks.forEach(link => link.label += 'a');
+  addToLabel() {
+    this.tabLinks.forEach(link => link.label += 'extracontent');
   }
 }
 

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -83,6 +83,12 @@ export class TabsDemo {
   deleteTab(tab: any) {
     this.dynamicTabs.splice(this.dynamicTabs.indexOf(tab), 1);
   }
+
+  swapTabLinks() {
+    const temp = this.tabLinks[0];
+    this.tabLinks[0] = this.tabLinks[1];
+    this.tabLinks[1] = temp;
+  }
 }
 
 

--- a/src/lib/tabs/tab-header.html
+++ b/src/lib/tabs/tab-header.html
@@ -8,7 +8,7 @@
 
 <div class="mat-tab-label-container" #tabListContainer
      (keydown)="_handleKeydown($event)">
-  <div class="mat-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges($event)">
+  <div class="mat-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges()">
     <div class="mat-tab-labels">
       <ng-content></ng-content>
     </div>

--- a/src/lib/tabs/tab-header.html
+++ b/src/lib/tabs/tab-header.html
@@ -8,7 +8,7 @@
 
 <div class="mat-tab-label-container" #tabListContainer
      (keydown)="_handleKeydown($event)">
-  <div class="mat-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges()">
+  <div class="mat-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges($event)">
     <div class="mat-tab-labels">
       <ng-content></ng-content>
     </div>

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.html
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.html
@@ -1,4 +1,4 @@
-<div class="mat-tab-links">
+<div class="mat-tab-links" (cdkObserveContent)="_alignInkBar()">
   <ng-content></ng-content>
   <md-ink-bar></md-ink-bar>
 </div>

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -10,7 +10,7 @@ import {LayoutDirection, Dir} from '../../core/rtl/dir';
 import {Subject} from 'rxjs/Subject';
 
 
-fdescribe('MdTabNavBar', () => {
+describe('MdTabNavBar', () => {
   let dir: LayoutDirection = 'ltr';
   let dirChange = new Subject();
 

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -10,7 +10,7 @@ import {LayoutDirection, Dir} from '../../core/rtl/dir';
 import {Subject} from 'rxjs/Subject';
 
 
-describe('MdTabNavBar', () => {
+fdescribe('MdTabNavBar', () => {
   let dir: LayoutDirection = 'ltr';
   let dirChange = new Subject();
 
@@ -37,20 +37,19 @@ describe('MdTabNavBar', () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.detectChanges();
     });
 
     it('should change active index on click', () => {
-      let component = fixture.debugElement.componentInstance;
-
       // select the second link
       let tabLink = fixture.debugElement.queryAll(By.css('a'))[1];
       tabLink.nativeElement.click();
-      expect(component.activeIndex).toBe(1);
+      expect(fixture.componentInstance.activeIndex).toBe(1);
 
       // select the third link
       tabLink = fixture.debugElement.queryAll(By.css('a'))[2];
       tabLink.nativeElement.click();
-      expect(component.activeIndex).toBe(2);
+      expect(fixture.componentInstance.activeIndex).toBe(2);
     });
 
     it('should re-align the ink bar when the direction changes', () => {
@@ -59,6 +58,17 @@ describe('MdTabNavBar', () => {
       spyOn(inkBar, 'alignToElement');
 
       dirChange.next();
+      fixture.detectChanges();
+
+      expect(inkBar.alignToElement).toHaveBeenCalled();
+    });
+
+    it('should re-align the ink bar when the tabs change', () => {
+      const inkBar = fixture.componentInstance.tabNavBar._inkBar;
+
+      spyOn(inkBar, 'alignToElement');
+
+      fixture.componentInstance.tabs = [1, 2, 3, 4];
       fixture.detectChanges();
 
       expect(inkBar.alignToElement).toHaveBeenCalled();
@@ -97,14 +107,19 @@ describe('MdTabNavBar', () => {
   selector: 'test-app',
   template: `
     <nav md-tab-nav-bar>
-      <a md-tab-link [active]="activeIndex === 0" (click)="activeIndex = 0">Tab One</a>
-      <a md-tab-link [active]="activeIndex === 1" (click)="activeIndex = 1">Tab Two</a>
-      <a md-tab-link [active]="activeIndex === 2" (click)="activeIndex = 2">Tab Three</a>
+      <a md-tab-link
+         *ngFor="let tab of tabs; let index = index"
+         [active]="activeIndex === index"
+         (click)="activeIndex = index">
+        Tab link
+      </a>
     </nav>
   `
 })
 class SimpleTabNavBarTestApp {
   @ViewChild(MdTabNavBar) tabNavBar: MdTabNavBar;
+
+  tabs = [0, 1, 2];
 
   activeIndex = 0;
 }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -1,12 +1,12 @@
-import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MdTabsModule} from '../index';
 import {MdTabNavBar} from './tab-nav-bar';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {ViewportRuler} from '../../core/overlay/position/viewport-ruler';
 import {FakeViewportRuler} from '../../core/overlay/position/fake-viewport-ruler';
-import {dispatchMouseEvent, dispatchFakeEvent} from '../../core/testing/dispatch-events';
-import {LayoutDirection, Dir} from '../../core/rtl/dir';
+import {dispatchFakeEvent, dispatchMouseEvent} from '../../core/testing/dispatch-events';
+import {Dir, LayoutDirection} from '../../core/rtl/dir';
 import {Subject} from 'rxjs/Subject';
 
 
@@ -63,7 +63,7 @@ describe('MdTabNavBar', () => {
       expect(inkBar.alignToElement).toHaveBeenCalled();
     });
 
-    it('should re-align the ink bar when the tabs change', () => {
+    it('should re-align the ink bar when the tabs list change', () => {
       const inkBar = fixture.componentInstance.tabNavBar._inkBar;
 
       spyOn(inkBar, 'alignToElement');
@@ -72,6 +72,20 @@ describe('MdTabNavBar', () => {
       fixture.detectChanges();
 
       expect(inkBar.alignToElement).toHaveBeenCalled();
+    });
+
+    it('should re-align the ink bar when the tab labels change the width', done => {
+      const inkBar = fixture.componentInstance.tabNavBar._inkBar;
+
+      const spy = spyOn(inkBar, 'alignToElement').and.callFake(() => {
+        expect(spy.calls.any()).toBe(true);
+        done();
+      });
+
+      fixture.componentInstance.label = 'label change';
+      fixture.detectChanges();
+
+      expect(spy.calls.any()).toBe(false);
     });
 
     it('should re-align the ink bar when the window is resized', fakeAsync(() => {
@@ -111,7 +125,7 @@ describe('MdTabNavBar', () => {
          *ngFor="let tab of tabs; let index = index"
          [active]="activeIndex === index"
          (click)="activeIndex = index">
-        Tab link
+        Tab link {{label}}
       </a>
     </nav>
   `
@@ -119,6 +133,7 @@ describe('MdTabNavBar', () => {
 class SimpleTabNavBarTestApp {
   @ViewChild(MdTabNavBar) tabNavBar: MdTabNavBar;
 
+  label = '';
   tabs = [0, 1, 2];
 
   activeIndex = 0;

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -38,9 +38,6 @@ import {Subject} from 'rxjs/Subject';
   encapsulation: ViewEncapsulation.None,
 })
 export class MdTabNavBar implements AfterContentInit, OnDestroy {
-  /** Combines listeners that will re-align the ink bar whenever they're invoked. */
-  private _realignInkBar: Subscription = null;
-
   /** Subject that emits when the component has been destroyed. */
   private _onDestroy = new Subject<void>();
 
@@ -48,7 +45,6 @@ export class MdTabNavBar implements AfterContentInit, OnDestroy {
   _activeLinkElement: ElementRef;
 
   @ViewChild(MdInkBar) _inkBar: MdInkBar;
-  @ContentChildren(forwardRef(() => MdTabLink)) _tabLinks: QueryList<MdTabLink>;
 
   constructor(@Optional() private _dir: Dir, private _ngZone: NgZone) { }
 
@@ -59,12 +55,7 @@ export class MdTabNavBar implements AfterContentInit, OnDestroy {
   }
 
   ngAfterContentInit(): void {
-    /** Realign the ink bar if the list of tab links have been added, removed, or moved. */
-    this._tabLinks.changes
-        .takeUntil(this._onDestroy)
-        .subscribe(() => this._alignInkBar());
-
-    this._realignInkBar = this._ngZone.runOutsideAngular(() => {
+    this._ngZone.runOutsideAngular(() => {
       let dirChange = this._dir ? this._dir.dirChange : Observable.of(null);
       let resize = typeof window !== 'undefined' ?
           Observable.fromEvent(window, 'resize').auditTime(10) :
@@ -89,7 +80,7 @@ export class MdTabNavBar implements AfterContentInit, OnDestroy {
   }
 
   /** Aligns the ink bar to the active link. */
-  private _alignInkBar(): void {
+  _alignInkBar(): void {
     if (this._activeLinkElement) {
       this._inkBar.alignToElement(this._activeLinkElement.nativeElement);
     }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -1,15 +1,13 @@
 import {
   AfterContentInit,
   Component,
-  ContentChildren,
   Directive,
-  ElementRef, forwardRef,
+  ElementRef,
   Inject,
   Input,
   NgZone,
   OnDestroy,
   Optional,
-  QueryList,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
@@ -18,7 +16,6 @@ import {MdRipple} from '../../core/ripple/index';
 import {ViewportRuler} from '../../core/overlay/position/viewport-ruler';
 import {Dir, MD_RIPPLE_GLOBAL_OPTIONS, Platform, RippleGlobalOptions} from '../../core';
 import {Observable} from 'rxjs/Observable';
-import {Subscription} from 'rxjs/Subscription';
 import 'rxjs/add/operator/auditTime';
 import 'rxjs/add/operator/takeUntil';
 import 'rxjs/add/observable/of';

--- a/tools/gulp/packaging/rollup-helpers.ts
+++ b/tools/gulp/packaging/rollup-helpers.ts
@@ -42,6 +42,7 @@ const ROLLUP_GLOBALS = {
   'rxjs/add/operator/share': 'Rx.Observable.prototype',
   'rxjs/add/operator/startWith': 'Rx.Observable.prototype',
   'rxjs/add/operator/switchMap': 'Rx.Observable.prototype',
+  'rxjs/add/operator/takeUntil': 'Rx.Observable.prototype',
   'rxjs/add/operator/toPromise': 'Rx.Observable.prototype',
   'rxjs/BehaviorSubject': 'Rx',
   'rxjs/Observable': 'Rx',


### PR DESCRIPTION
Fixes #4737, #4738

When the list of tab links change, the ink bar should adjust to make sure it's positioned under the right element. E.g. tabs are added/removed/moved/content changed