### PR TITLE
fix(button-toggle): dirty on load when used with ngModel

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -90,7 +90,8 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
   _buttonToggles: QueryList<MdButtonToggle> = null;
 
   ngAfterViewInit() {
-    this._isInitialized = true;
+    // Defer until the next tick to avoid the value accessor's initial value.
+    Promise.resolve().then(() => this._isInitialized = true);
   }
 
   /** `name` attribute for the underlying `input` element. */


### PR DESCRIPTION
Fixes the button toggle group being marked as dirty on load, if it has a ControlValueAccessor and an initial value.

Fixes #4888.