### PR TITLE
build: switch to NPM v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 
 before_install:
   - source ./scripts/ci/env.sh
-  - npm i -g npm@latest
+  - npm i -g npm@^5.0.1
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
 
 before_install:
   - source ./scripts/ci/env.sh
+  - npm i -g npm@latest
 
 install:
   - npm install
@@ -51,5 +52,4 @@ script:
 
 cache:
   directories:
-    - node_modules
-    - tools/screenshot-test/functions/node_modules
+    - $HOME/.npm


### PR DESCRIPTION
* Switches to NPM v5 that should use the packages from the `$HOME/.npm` cache.
* Now caches the dashboard functions `node_modules` by using the shared cache in `$HOME/.npm`