### PR TITLE
build: properly inline multiple styles

### DIFF
--- a/tools/gulp/packaging/inline-resources.ts
+++ b/tools/gulp/packaging/inline-resources.ts
@@ -40,7 +40,7 @@ function inlineStyles(fileContent: string, filePath: string) {
       .map(url => join(dirname(filePath), url))
       .map(path => loadResourceFile(path));
 
-    return `styles: ["${styleContents.join(',')}"]`;
+    return `styles: ["${styleContents.join(' ')}"]`;
   });
 }
 


### PR DESCRIPTION
* Recently we moved the inline script to the packaging directory and we cleaned up some logic. At this point the multiple style files inlining broke accidentally.
* We joined the different styles using a comma inside of the inlined stylesheet (while we were trying to create a array). Instead it would be just easier to concatenate the styles using a space.

Before (incorrect)

```ts
styleUrls: ["AAA,  BBB"] // Note the incorrect comma between the different stylesheets
```

Now (correct)

```ts
styleUrls: ["AAA BBB"] // This is a simpler solution than creating a real array and it also works the same
```

Fixes #4910 