### PR TITLE
fix(button,tabs): potential clash with typography styles

### DIFF
--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -120,6 +120,10 @@
 
 @mixin mat-button-typography($config) {
   .mat-button, .mat-raised-button, .mat-icon-button {
-    @include mat-typography-level-to-styles($config, button);
+    font: {
+      family: mat-font-family($config);
+      size: mat-font-size($config, button);
+      weight: mat-font-weight($config, button);
+    }
   }
 }

--- a/src/lib/tabs/_tabs-theme.scss
+++ b/src/lib/tabs/_tabs-theme.scss
@@ -46,6 +46,10 @@
   }
 
   .mat-tab-label, .mat-tab-link {
-    @include mat-typography-level-to-styles($config, button);
+    font: {
+      family: mat-font-family($config);
+      size: mat-font-size($config, button);
+      weight: mat-font-weight($config, button);
+    }
   }
 }


### PR DESCRIPTION
Since the buttons and tabs depend on their `line-height` for sizing, we shouldn't override it via the typography styles. This fix removes the `line-height` that is set from the typography, in order to prevent potential issues.