### PR TITLE
fix(input): IE always adding scrollbar to textarea

### DIFF
--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -26,7 +26,6 @@
       <div class="demo-toolbar">
         <h1>Angular Material Demos</h1>
         <div>
-          <button md-button (click)="dark = !dark">{{dark ? 'Light' : 'Dark'}} theme</button>
           <button md-button (click)="toggleChangeDetection()" title="Toggle change detection">
             Change detection: {{changeDetectionStrategy}}
           </button>

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -143,6 +143,11 @@ $mat-input-underline-height: 1px !default;
   pointer-events: none;  // We shouldn't catch mouse events (let them through).
 }
 
+// Prevents IE from always adding a scrollbar by default.
+textarea.mat-input-element {
+  overflow: auto;
+}
+
 // The placeholder label. This is invisible unless it is. The logic to show it is
 // basically `empty || (float && (!empty || focused))`. Float is dependent on the
 // `floatingPlaceholder` input.


### PR DESCRIPTION
* Fixes IE always adding a scrollbar to Material textareas, even if they don't overflow.
* Removes a double theme toggle from the demo app. It was probably the result of a bad merge.