### PR TITLE
fix(autocomplete example): regex metacharacter escape

### DIFF
--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -72,9 +72,16 @@ export class AutocompleteOverviewExample {
         .map(name => this.filterStates(name));
   }
 
+  escapeSpecChars(val: string) {
+    return val ? val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+               : val;
+  }
+
   filterStates(val: string) {
-    return val ? this.states.filter(s => new RegExp(`^${val}`, 'gi').test(s))
+    let escVal: string = this.escapeSpecChars(val);
+    return val ? this.states.filter(s => new RegExp(`^${escVal}`, 'gi').test(s))
                : this.states;
   }
 
 }
+

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -73,7 +73,7 @@ export class AutocompleteOverviewExample {
   }
 
   escapeSpecChars(val: string) {
-    return val ? val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+    return val ? val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
                : val;
   }
 

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -73,7 +73,7 @@ export class AutocompleteOverviewExample {
   }
 
   filterStates(val: string) {
-    return val ? this.states.filter(s => s.toLowerCase().includes(val.toLowerCase()))
+    return val ? this.states.filter(s => s.toLowerCase().indexOf(val.toLowerCase()) === 0)
                : this.states;
   }
 

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -78,4 +78,3 @@ export class AutocompleteOverviewExample {
   }
 
 }
-

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -72,14 +72,8 @@ export class AutocompleteOverviewExample {
         .map(name => this.filterStates(name));
   }
 
-  escapeSpecChars(val: string) {
-    return val ? val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
-               : val;
-  }
-
   filterStates(val: string) {
-    let escVal: string = this.escapeSpecChars(val);
-    return val ? this.states.filter(s => new RegExp(`^${escVal}`, 'gi').test(s))
+    return val ? this.states.filter(s => s.toLowerCase().includes(val.toLowerCase()))
                : this.states;
   }
 


### PR DESCRIPTION
autocomplete material example fails if regex metacharacters (ie *) are provided. Fixed by adding escapeSpecChars function