### PR TITLE
build: fix universal prerendering task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,26 +219,6 @@
       "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
       "dev": true
     },
-    "@gulp-sourcemaps/identity-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
-      "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
-      "dev": true,
-      "dependencies": {
-        "acorn": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-          "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
-          "dev": true
-        }
-      }
-    },
-    "@gulp-sourcemaps/map-sources": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
-      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
-      "dev": true
-    },
     "@types/chalk": {
       "version": "0.4.31",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
@@ -695,12 +675,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "atob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
       "dev": true
     },
     "autoprefixer": {
@@ -1574,12 +1548,6 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true
     },
-    "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-      "dev": true
-    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -1719,20 +1687,6 @@
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
       "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
       "dev": true
-    },
-    "css": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
-      "dev": true,
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
-        }
-      }
     },
     "css-color-names": {
       "version": "0.0.3",
@@ -1926,20 +1880,6 @@
       "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
       "dev": true
     },
-    "debug-fabulous": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.1.0.tgz",
-      "integrity": "sha1-rQ6gel1RkyT7VYQqjzTuWcf4/2w=",
-      "dev": true,
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true
-        }
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2051,12 +1991,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
-    },
-    "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "detective-amd": {
@@ -5996,20 +5930,6 @@
       "integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
       "dev": true
     },
-    "gulp-sourcemaps": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.0.tgz",
-      "integrity": "sha1-fMzomaijv8oVk6M0jQ+/Qd0/UeU=",
-      "dev": true,
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
     "gulp-transform": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-transform/-/gulp-transform-2.0.0.tgz",
@@ -9286,12 +9206,6 @@
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
-    },
     "response-time": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
@@ -9890,22 +9804,10 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
-    "source-map-resolve": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
-      "dev": true
-    },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
-    },
-    "source-map-url": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
       "dev": true
     },
     "sourcemap-codec": {
@@ -10115,12 +10017,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
-    },
-    "strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true
     },
     "strip-eof": {
@@ -10649,6 +10545,20 @@
         }
       }
     },
+    "tsconfig-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-2.2.0.tgz",
+      "integrity": "sha1-x2rOfyxFTNMcpvcsM4dtuuAgAOg=",
+      "dev": true,
+      "dependencies": {
+        "tsconfig": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz",
+          "integrity": "sha1-X0J45wGACWeo/Dg/0ZZIh48qbjo=",
+          "dev": true
+        }
+      }
+    },
     "tsickle": {
       "version": "0.21.6",
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
@@ -10941,12 +10851,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "dev": true
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url-join": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "sorcery": "^0.10.0",
     "stylelint": "^7.10.1",
     "ts-node": "^3.0.4",
+    "tsconfig-paths": "^2.2.0",
     "tslint": "^5.2.0",
     "typescript": "~2.2.1",
     "uglify-js": "^2.8.14",

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -1,4 +1,5 @@
-// TypeScript config file that is used to compile the universal-app.
+// TypeScript config file that is used to compile the Universal App. All sources are compiled
+// inside of the output folder and therefore all paths can be relative to the output folder.
 {
   "compilerOptions": {
     "declaration": true,
@@ -6,7 +7,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "../../dist/packages/universal-app",
+    "outDir": ".",
     "rootDir": ".",
     "sourceMap": true,
     "target": "es2015",
@@ -23,7 +24,6 @@
     "main.ts"
   ],
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
-    "genDir": "../../dist/packages/universal-app"
+    "annotateForClosureCompiler": true
   }
 }

--- a/tools/gulp/tasks/universal.ts
+++ b/tools/gulp/tasks/universal.ts
@@ -7,34 +7,39 @@ import {copySync} from 'fs-extra';
 const appDir = join(SOURCE_ROOT, 'universal-app');
 const outDir = join(DIST_ROOT, 'packages', 'universal-app');
 
-/** Path to the universal-app tsconfig files. */
-const tsconfigAppPath = join(appDir, 'tsconfig-build.json');
+// Paths to the different tsconfig files of the Universal app.
+// Building the sources in the output directory is part of the workaround for
+// https://github.com/angular/angular/issues/12249
+const tsconfigAppPath = join(outDir, 'tsconfig-build.json');
 const tsconfigPrerenderPath = join(outDir, 'tsconfig-prerender.json');
-
-/** Glob that matches all assets that need to copied to the dist. */
-const assetsGlob = join(appDir, '**/*.+(html|css|json)');
-
-/** Path to the file that prerenders the universal app using platform-server. */
-const prerenderFile = join(appDir, 'prerender.ts');
 
 /** Path to the compiled prerender file. Running this file just dumps the HTML output for now. */
 const prerenderOutFile = join(outDir, 'prerender.js');
 
-task('universal:test-prerender', ['universal:build'], execTask('node', [prerenderOutFile]));
+/** Task that builds the universal-app and runs the prerender script. */
+task('universal:test-prerender', ['universal:build'], execTask(
+  // Runs node with the tsconfig-paths module to alias the @angular/material dependency.
+  'node', ['-r', 'tsconfig-paths/register', prerenderOutFile], {
+    env: {TS_NODE_PROJECT: tsconfigPrerenderPath}
+  }
+));
 
 task('universal:build', sequenceTask(
   'clean',
   ['material:build-release', 'cdk:build-release'],
-  'universal:copy-release',
-  ['universal:build-app-ts', 'universal:copy-app-assets', 'universal:copy-prerender-source'],
+  ['universal:copy-release', 'universal:copy-files'],
+  'universal:build-app-ts',
   'universal:build-prerender-ts'
 ));
 
+/** Task that builds the universal app in the output directory. */
 task('universal:build-app-ts', ngcBuildTask(tsconfigAppPath));
-task('universal:copy-app-assets', copyTask(assetsGlob, outDir));
 
+/** Task that copies all files to the output directory. */
+task('universal:copy-files', copyTask(appDir, outDir));
+
+/** Task that builds the prerender script in the output directory. */
 task('universal:build-prerender-ts', tsBuildTask(tsconfigPrerenderPath));
-task('universal:copy-prerender-source', copyTask(prerenderFile, outDir));
 
 // As a workaround for https://github.com/angular/angular/issues/12249, we need to
 // copy the Material and CDK ESM output inside of the universal-app output.

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -61,12 +61,15 @@ export interface ExecTaskOptions {
   silentStdout?: boolean;
   // If an error happens, this will replace the standard error.
   errMessage?: string;
+  // Environment variables being passed to the child process.
+  env?: any;
 }
 
 /** Create a task that executes a binary as if from the command line. */
 export function execTask(binPath: string, args: string[], options: ExecTaskOptions = {}) {
   return (done: (err?: string) => void) => {
-    const childProcess = child_process.spawn(binPath, args);
+    const env = Object.assign({}, process.env, options.env);
+    const childProcess = child_process.spawn(binPath, args, {env});
 
     if (!options.silentStdout && !options.silent) {
       childProcess.stdout.on('data', (data: string) => process.stdout.write(data));


### PR DESCRIPTION
Fixes the Universal Prerendering task by using the same workaround as for the AOT job (building sources in the output directory already)

Building the sources in the output directory (similar as for the AOT task) is the only known workaround for https://github.com/angular/angular/issues/12249

---

When building the files the TypeScript path mapping functionality is used to map `@angular/material` to the correct path. But when running the `prerender` script this is not working and it won't find the package.

Using the `tsconfig-paths` npm module can handle such path mapping at runtime. It also uses the TSConfig file which helps us not duplicating the mapping. 

Copying the different packages to the `node_modules/` may work too, but it's more elegant to just use the `tsconfig-paths` module since it uses the tsconfig file already.

