### PR TITLE
fix(tooltip): not rendering in IE and Edge without web animations polyfill

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -337,6 +337,9 @@ export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
     ])
   ],
   host: {
+    // Forces the element to have a layout in IE and Edge. This fixes issues where the element
+    // won't be rendered if the animations are disabled or there is no web animations polyfill.
+    '[style.zoom]': '_visibility === "visible" ? 1 : null',
     '(body:click)': 'this._handleBodyInteraction()'
   }
 })


### PR DESCRIPTION
Fixes the tooltip not being rendered in IE and Edge, if there is no web animations polyfill. When we don't animate the element, for some reason IE and Edge decide not to lay it out at all. We force the element to be shown by using the `zoom: 1` hack.

Fixes #4935.