### PR TITLE
fix: make material work with noUnusedParameters

### DIFF
--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -38,7 +38,7 @@ export class DialogDemo {
     // Possible useful example for the open and closeAll events.
     // Adding a class to the body if a dialog opens and
     // removing it after all open dialogs are closed
-    dialog.afterOpen.subscribe((ref: MdDialogRef<any>) => {
+    dialog.afterOpen.subscribe(() => {
       if (!doc.body.classList.contains('no-scroll')) {
         doc.body.classList.add('no-scroll');
       }

--- a/src/demo-app/style/style-demo.ts
+++ b/src/demo-app/style/style-demo.ts
@@ -1,4 +1,4 @@
-import {Component, Renderer2} from '@angular/core';
+import {Component} from '@angular/core';
 import {FocusOriginMonitor} from '@angular/material';
 
 
@@ -9,5 +9,5 @@ import {FocusOriginMonitor} from '@angular/material';
   styleUrls: ['style-demo.css'],
 })
 export class StyleDemo {
-  constructor(public renderer: Renderer2, public fom: FocusOriginMonitor) {}
+  constructor(public fom: FocusOriginMonitor) {}
 }

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -92,7 +92,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   private _manuallyFloatingPlaceholder = false;
 
   /** View -> model callback called when value changes */
-  _onChange = (value: any) => {};
+  _onChange: (value: any) => void = () => {};
 
   /** View -> model callback called when autocomplete has been touched */
   _onTouched = () => {};

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -72,7 +72,7 @@ describe('MdAutocomplete', () => {
         }},
         {provide: Dir, useFactory: () => ({value: dir})},
         {provide: ScrollDispatcher, useFactory: () => {
-          return {scrolled: (delay: number, callback: () => any) => {
+          return {scrolled: (_delay: number, callback: () => any) => {
             return scrolledSubject.asObservable().subscribe(callback);
           }};
         }}

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -80,7 +80,7 @@ export class MdButtonToggleGroup implements AfterViewInit, ControlValueAccessor 
    * The method to be called in order to update ngModel.
    * Now `ngModel` binding is not supported in multiple selection mode.
    */
-  private _controlValueAccessorChangeFn: (value: any) => void = (value) => {};
+  private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
   /** onTouch function registered via registerOnTouch (ControlValueAccessor). */
   onTouched: () => any = () => {};

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -814,8 +814,8 @@ class SingleCheckbox {
   checkboxColor: string = 'primary';
   checkboxValue: string = 'single_checkbox';
 
-  onCheckboxClick(event: Event) {}
-  onCheckboxChange(event: MdCheckboxChange) {}
+  onCheckboxClick: (event?: Event) => void = () => {};
+  onCheckboxChange: (event?: MdCheckboxChange) => void = () => {};
 }
 
 /** Simple component for testing an MdCheckbox with ngModel. */

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -186,7 +186,7 @@ export class MdCheckbox extends _MdCheckboxMixinBase
 
   private _indeterminate: boolean = false;
 
-  private _controlValueAccessorChangeFn: (value: any) => void = (value) => {};
+  private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
   /** Reference to the focused state ripple. */
   private _focusRipple: RippleRef;

--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -236,11 +236,8 @@ describe('MdChipList', () => {
 class StaticChipList {
   name: string = 'Test';
   selectable: boolean = true;
-  remove: Number;
+  remove: number;
 
-  chipSelect(index: Number) {
-  }
-
-  chipDeselect(index: Number) {
-  }
+  chipSelect: (index?: number) => void = () => {};
+  chipDeselect: (index?: number) => void = () => {};
 }

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -135,17 +135,10 @@ class SingleChip {
   selected: boolean = false;
   shouldShow: boolean = true;
 
-  chipFocus(event: MdChipEvent) {
-  }
-
-  chipDestroy(event: MdChipEvent) {
-  }
-
-  chipSelect(event: MdChipEvent) {
-  }
-
-  chipDeselect(event: MdChipEvent) {
-  }
+  chipFocus: (event?: MdChipEvent) => void = () => {};
+  chipDestroy: (event?: MdChipEvent) => void = () => {};
+  chipSelect: (event?: MdChipEvent) => void = () => {};
+  chipDeselect: (event?: MdChipEvent) => void = () => {};
 }
 
 @Component({

--- a/src/lib/core/data-table/data-table.spec.ts
+++ b/src/lib/core/data-table/data-table.spec.ts
@@ -275,7 +275,7 @@ function getHeaderCells(tableElement: Element): Element[] {
 }
 
 const tableCustomMatchers: jasmine.CustomMatcherFactories = {
-  toMatchTableContent: function(util, customEqualityTesters) {
+  toMatchTableContent: () => {
     return {
       compare: function (tableElement: Element, expectedTableContent: any[]) {
         const missedExpectations = [];

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -31,7 +31,11 @@ const DEFAULT_DAY_OF_WEEK_NAMES = {
 
 /** Creates an array and fills it with values. */
 function range<T>(length: number, valueFunction: (index: number) => T): T[] {
-  return Array.apply(null, Array(length)).map((v: undefined, i: number) => valueFunction(i));
+  const valuesArray = Array(length);
+  for (let i = 0; i < length; i++) {
+    valuesArray[i] = valueFunction(i);
+  }
+  return valuesArray;
 }
 
 
@@ -123,7 +127,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     return new Date();
   }
 
-  parse(value: any, parseFormat: Object): Date | null {
+  parse(value: any): Date | null {
     // We have no way using the native JS Date to set the parse format or locale, so we ignore these
     // parameters.
     let timestamp = typeof value == 'number' ? value : Date.parse(value);

--- a/src/lib/core/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/close-scroll-strategy.spec.ts
@@ -8,7 +8,6 @@ import {
   OverlayState,
   OverlayRef,
   OverlayModule,
-  ScrollStrategy,
   ScrollDispatcher,
 } from '../../core';
 
@@ -23,7 +22,7 @@ describe('CloseScrollStrategy', () => {
       imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [
         {provide: ScrollDispatcher, useFactory: () => {
-          return {scrolled: (delay: number, callback: () => any) => {
+          return {scrolled: (_delay: number, callback: () => any) => {
             return scrolledSubject.asObservable().subscribe(callback);
           }};
         }}

--- a/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -8,7 +8,6 @@ import {
   OverlayState,
   OverlayRef,
   OverlayModule,
-  ScrollStrategy,
   ScrollDispatcher,
 } from '../../core';
 
@@ -23,7 +22,7 @@ describe('RepositionScrollStrategy', () => {
       imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [
         {provide: ScrollDispatcher, useFactory: () => {
-          return {scrolled: (delay: number, callback: () => any) => {
+          return {scrolled: (_delay: number, callback: () => any) => {
             return scrolledSubject.asObservable().subscribe(callback);
           }};
         }}

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -105,7 +105,7 @@ export class ScrollDispatcher {
   getScrollContainers(elementRef: ElementRef): Scrollable[] {
     const scrollingContainers: Scrollable[] = [];
 
-    this.scrollableReferences.forEach((subscription: Subscription, scrollable: Scrollable) => {
+    this.scrollableReferences.forEach((_subscription: Subscription, scrollable: Scrollable) => {
       if (this.scrollableContainsElement(scrollable, elementRef)) {
         scrollingContainers.push(scrollable);
       }

--- a/src/lib/core/style/focus-origin-monitor.spec.ts
+++ b/src/lib/core/style/focus-origin-monitor.spec.ts
@@ -464,7 +464,7 @@ class PlainButton {
   template: `<button cdkMonitorElementFocus (cdkFocusChange)="focusChanged($event)"></button>`
 })
 class ButtonWithFocusClasses {
-  focusChanged(origin: FocusOrigin) {}
+  focusChanged(_origin: FocusOrigin) {}
 }
 
 

--- a/src/lib/core/testing/jasmine-matchers.ts
+++ b/src/lib/core/testing/jasmine-matchers.ts
@@ -2,8 +2,7 @@
  * Collection of useful custom jasmine matchers for tests.
  */
 export const customMatchers: jasmine.CustomMatcherFactories = {
-  toBeRole: function(util: jasmine.MatchersUtil,
-                     customEqualityTesters: jasmine.CustomEqualityTester[]) {
+  toBeRole: () => {
     return {
       compare: function (element: Element, expectedRole: string) {
         const result: jasmine.CustomMatcherResult = {pass: false};

--- a/src/lib/core/testing/type-in-element.ts
+++ b/src/lib/core/testing/type-in-element.ts
@@ -6,7 +6,7 @@ import {dispatchFakeEvent} from './dispatch-events';
  * @param value Value to be set on the input.
  * @param element Element onto which to set the value.
  */
-export function typeInElement(value: string, element: HTMLInputElement, autoFocus = true) {
+export function typeInElement(value: string, element: HTMLInputElement) {
   element.focus();
   element.value = value;
   dispatchFakeEvent(element, 'input');

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -121,7 +121,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
 
   _onTouched = () => {};
 
-  private _cvaOnChange = (value: any) => {};
+  private _cvaOnChange: (value: any) => void = () => {};
 
   private _validatorOnChange = () => {};
 

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -6,7 +6,7 @@ import {TileCoordinator} from './tile-coordinator';
  * Tile Coordinator.
  * @docs-private
  */
-export class TileStyler {
+export abstract class TileStyler {
   _gutterSize: string;
   _rows: number = 0;
   _rowspan: number = 0;
@@ -122,11 +122,12 @@ export class TileStyler {
    * This method will be implemented by each type of TileStyler.
    * @docs-private
    */
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number, gutterWidth: number) {}
+  abstract setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
+                        gutterWidth: number);
 
   /**
    * Calculates the computed height and returns the correct style property to set.
-   * This method will be implemented by each type of TileStyler.
+   * This method can be implemented by each type of TileStyler.
    * @docs-private
    */
   getComputedHeight(): [string, string] { return null; }
@@ -147,8 +148,7 @@ export class FixedTileStyler extends TileStyler {
     this.fixedRowHeight = normalizeUnits(this.fixedRowHeight);
   }
 
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
-               gutterWidth: number): void {
+  setRowStyles(tile: MdGridTile, rowIndex: number): void {
     tile._setStyle('top', this.getTilePosition(this.fixedRowHeight, rowIndex));
     tile._setStyle('height', calc(this.getTileSize(this.fixedRowHeight, tile.rowspan)));
   }
@@ -215,8 +215,7 @@ export class RatioTileStyler extends TileStyler {
  */
 export class FitTileStyler extends TileStyler {
 
-  setRowStyles(tile: MdGridTile, rowIndex: number, percentWidth: number,
-               gutterWidth: number): void {
+  setRowStyles(tile: MdGridTile, rowIndex: number): void {
     // Percent of the available vertical space that one row takes up.
     let percentHeightPerTile = 100 / this._rowspan;
 
@@ -229,6 +228,7 @@ export class FitTileStyler extends TileStyler {
     tile._setStyle('top', this.getTilePosition(baseTileHeight, rowIndex));
     tile._setStyle('height', calc(this.getTileSize(baseTileHeight, tile.rowspan)));
   }
+
 }
 
 

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -245,7 +245,7 @@ export class MdIconRegistry {
         .filter(iconSetConfig => !iconSetConfig.svgElement)
         .map(iconSetConfig =>
             this._loadSvgIconSetFromConfig(iconSetConfig)
-                .catch((err: any, caught: Observable<SVGElement>): Observable<SVGElement> => {
+                .catch((err: any): Observable<SVGElement> => {
                   let url =
                       this._sanitizer.sanitize(SecurityContext.RESOURCE_URL, iconSetConfig.url);
 
@@ -263,7 +263,7 @@ export class MdIconRegistry {
     // Fetch all the icon set URLs. When the requests complete, every IconSet should have a
     // cached SVG element (unless the request failed), and we can check again for the icon.
     return Observable.forkJoin(iconSetFetchRequests)
-        .map((ignoredResults: any) => {
+        .map(() => {
           const foundIcon = this._extractIconWithNameFromAnySet(name, iconSetConfigs);
           if (!foundIcon) {
             throw getMdIconNameNotFoundError(name);

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -143,7 +143,7 @@ describe('MdRadio', () => {
       expect(radioInstances[0].checked).toBe(false);
 
       let spies = radioInstances
-        .map((value, index) => jasmine.createSpy(`onChangeSpy ${index}`));
+        .map((radio, index) => jasmine.createSpy(`onChangeSpy ${index} for ${radio.name}`));
 
       spies.forEach((spy, index) => radioInstances[index].change.subscribe(spy));
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -95,7 +95,7 @@ export class MdRadioGroup extends _MdRadioGroupMixinBase
   private _disabled: boolean = false;
 
   /** The method to be called in order to update ngModel */
-  _controlValueAccessorChangeFn: (value: any) => void = (value) => {};
+  _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
   /**
    * onTouch function registered via registerOnTouch (ControlValueAccessor).

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -74,7 +74,7 @@ describe('MdSelect', () => {
         }},
         {provide: Dir, useFactory: () => dir = { value: 'ltr' }},
         {provide: ScrollDispatcher, useFactory: () => {
-          return {scrolled: (delay: number, callback: () => any) => {
+          return {scrolled: (_delay: number, callback: () => any) => {
             return scrolledSubject.asObservable().subscribe(callback);
           }};
         }}
@@ -2324,9 +2324,9 @@ class SelectInitWithoutOptions {
 class CustomSelectAccessor implements ControlValueAccessor {
   @ViewChild(MdSelect) select: MdSelect;
 
-  writeValue(val: any): void {}
-  registerOnChange(fn: (val: any) => void): void {}
-  registerOnTouched(fn: Function): void {}
+  writeValue: (value?: any) => void = () => {};
+  registerOnChange: (changeFn?: (value: any) => void) => void = () => {};
+  registerOnTouched: (touchedFn?: () => void) => void = () => {};
 }
 
 @Component({

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -186,7 +186,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   _selectedValueWidth: number;
 
   /** View -> model callback called when value changes */
-  _onChange = (value: any) => {};
+  _onChange: (value: any) => void = () => {};
 
   /** View -> model callback called when select has been touched */
   _onTouched = () => {};

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -685,10 +685,8 @@ class SlideToggleTestApp {
   lastEvent: MdSlideToggleChange;
   labelPosition: string;
 
-  onSlideClick(event: Event) {}
-  onSlideChange(event: MdSlideToggleChange) {
-    this.lastEvent = event;
-  }
+  onSlideClick: (event?: Event) => void = () => {};
+  onSlideChange = (event: MdSlideToggleChange) => this.lastEvent = event;
 }
 
 

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -99,7 +99,7 @@ export class MdSnackBarContainer extends BasePortalHost implements OnDestroy {
   }
 
   /** Attach a template portal as content to this snack bar container. */
-  attachTemplatePortal(portal: TemplatePortal): Map<string, any> {
+  attachTemplatePortal(): Map<string, any> {
     throw new Error('Not yet implemented');
   }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,6 +5,7 @@
     "experimentalDecorators": true,
     "module": "es2015",
     "moduleResolution": "node",
+    "noUnusedParameters": true,
     "outDir": "../dist/packages/all",
     "sourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
* Recently Angular core fixed most of their `noUnusedParameters` warnings in https://github.com/angular/angular/issues/15532 (this one is still left - https://github.com/angular/angular/issues/17131)
* When using Angular with Material and the users has `noUnusedParameters` enabled the library will be checked and will throw right now.

**Note**: I don't plan to add the `noUnusedParameters` to any build tsconfig files yet, because it would make the watching & live-reloading extremely bad. The `noUnusedParameters` should / can be tested on the CI in a follow-up.

Fixes #4443