### PR TITLE
fix(button-toggle): remove redundant blocking touchstart listener

### DIFF
--- a/src/lib/button-toggle/button-toggle.html
+++ b/src/lib/button-toggle/button-toggle.html
@@ -12,5 +12,4 @@
     <ng-content></ng-content>
   </div>
 </label>
-<!-- the touchstart handler prevents the overlay from capturing the initial tap on touch devices -->
-<div class="mat-button-toggle-focus-overlay" (touchstart)="$event.preventDefault()"></div>
+<div class="mat-button-toggle-focus-overlay"></div>

--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -55,11 +55,11 @@ $mat-button-toggle-border-radius: 2px !default;
   vertical-align: middle;
 }
 
-// Overlay to be used as a tint. Note that the same effect can be achieved by using a pseudo
-// element, however we use a proper DOM element in order to be able to disable the default
-// touch action. This makes the buttons more responsive on touch devices.
+// Overlay to be used as a tint.
 .mat-button-toggle-focus-overlay {
   border-radius: inherit;
+
+  // Disable pointer events to prevent it from hijacking user events.
   pointer-events: none;
   opacity: 0;
   @include mat-fill;


### PR DESCRIPTION
Removes an unnecessary `touchstart` listener on the button toggle. It was initially added to prevent it from capturing user events, however it's no longer necessary, because we have `pointer-events: none` on the element. This also fixes a warning that is being logged by Chrome.

Fixes #4221.