### PR TITLE
fix(button): remove webkit tap highlight

### DIFF
--- a/src/lib/core/style/_button-common.scss
+++ b/src/lib/core/style/_button-common.scss
@@ -6,4 +6,5 @@
   cursor: pointer;
   outline: none;
   border: none;
+  -webkit-tap-highlight-color: transparent;
 }


### PR DESCRIPTION
Removes the overlay that gets added when tapping on something on a mobile Webkit browser. It is unnecessary in our case, because we render a ripple and we have an overlay that darkens focused buttons.