### PR TITLE
build: ambiguous imports in IDEs

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -16,5 +16,10 @@
       "@angular/material": ["./lib/public_api.ts"],
       "@angular/cdk": ["./cdk/public_api.ts"]
     }
-  }
+  },
+  "exclude": [
+    // Exclude files that depend on Node APIs because those depend on the Node types and therefore
+    // cause ambiguous imports. For example `setTimeout()` will return a Timer instead of a number.
+    "universal-app/prerender.ts"
+  ]
 }


### PR DESCRIPTION
Recently the Universal App has been added to the repository. The universal-app contains a script that runs inside of Node and therefore uses Node APIs.

The global tsconfig file that is used to provide proper autocompletion in IDEs includes every TS file inside of `src/` and therefore the `prerender.ts` file is also included.

This is problematic because now the NodeJS @types are being loaded as well and ambiguous imports appear in editors. Causing for example `setTimeout` calls to return a `Timer` instead of a number (error in your IDEs)

**Example**

![](https://i.gyazo.com/f57245aae3538be837edfb12f018cc98.png)

You can also test this by running `$(npm bin)/tsc -p src/tsconfig.json`