### PR TITLE
build: fix 404s when debugging unit tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -25,10 +25,11 @@ module.exports = (config) => {
       {pattern: 'node_modules/zone.js/dist/async-test.js', included: true, watched: false},
       {pattern: 'node_modules/zone.js/dist/fake-async-test.js', included: true, watched: false},
       {pattern: 'node_modules/hammerjs/hammer.min.js', included: true, watched: false},
+      {pattern: 'node_modules/hammerjs/hammer.min.js.map', included: false, watched: false},
 
       // Include all Angular dependencies
       {pattern: 'node_modules/@angular/**/*', included: false, watched: false},
-      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false},
+      {pattern: 'node_modules/rxjs/**/*', included: false, watched: false},
 
       {pattern: 'test/karma-test-shim.js', included: true, watched: false},
 
@@ -47,10 +48,6 @@ module.exports = (config) => {
     },
 
     reporters: ['dots'],
-
-    port: 9876,
-    colors: true,
-    logLevel: config.LOG_INFO,
     autoWatch: false,
 
     coverageReporter: {


### PR DESCRIPTION
* Fixes a bunch of 404s that were being logged when debugging unit tests through the dev tools. It was because we're not serving the source maps for RxJS and Hammer.
* Removes a few redundant options from the Karma config, because they're the same as the defaults.