### PR TITLE
test(slide-toggle): verify that NgControl stays pristine if initial value is set

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -631,6 +631,21 @@ describe('MdSlideToggle with forms', () => {
       expect(slideToggle.checked)
         .toBe(false, 'Expected slide-toggle to be no longer checked after label click.');
     }));
+
+    it('should be pristine if initial value is set from NgModel', fakeAsync(() => {
+      fixture = TestBed.createComponent(SlideToggleWithModel);
+
+      fixture.componentInstance.modelValue = true;
+      fixture.detectChanges();
+
+      const debugElement = fixture.debugElement.query(By.directive(MdSlideToggle));
+      const modelInstance = debugElement.injector.get<NgModel>(NgModel);
+
+      // Flush the microtasks because the forms module updates the model state asynchronously.
+      flushMicrotasks();
+
+      expect(modelInstance.pristine).toBe(true);
+    }));
   });
 
   describe('with a FormControl', () => {


### PR DESCRIPTION
* If a developer sets an initial value for the slide-toggle the NgControl of the slide-toggle can turn dirty. The slide-toggle should only turn dirty if the value changed after initialization. This adds a test to confirm that this is not the case.

Blocked by #4220 