### PR TITLE
fix(slide-toggle): switch typography level to body-1

### DIFF
--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -90,6 +90,6 @@
 
 @mixin mat-slide-toggle-typography($config) {
   .mat-slide-toggle-content {
-    @include mat-typography-level-to-styles($config, button);
+    @include mat-typography-level-to-styles($config, body-1);
   }
 }


### PR DESCRIPTION
* With the typography the slide-toggle was switched accidentally from a font-weight of 500 to a font-weight of 400.
* The slide-toggle label should not be treated as a button because it's basically a normal body text.

Per the specs a `switch` does not have any text by default and if text will be added to it will be a normal text(view) that just is aligned next to the switch (and therefore uses the body styles)