### PR TITLE
fix(dialog): partial keyframes animation error

### DIFF
--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -47,9 +47,9 @@ export function throwMdDialogContentAlreadyAttachedError() {
     trigger('slideDialog', [
       // Note: The `enter` animation doesn't transition to something like `translate3d(0, 0, 0)
       // scale(1)`, because for some reason specifying the transform explicitly, causes IE both
-      // to blur the dialog content and decimate the animation performance. Leaving it blank
+      // to blur the dialog content and decimate the animation performance. Leaving it as `none`
       // solves both issues.
-      state('enter', style({ opacity: 1 })),
+      state('enter', style({ transform: 'none', opacity: 1 })),
       state('void', style({ transform: 'translate3d(0, 25%, 0) scale(0.9)', opacity: 0 })),
       state('exit', style({ transform: 'translate3d(0, 25%, 0)', opacity: 0 })),
       transition('* => *', animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)')),


### PR DESCRIPTION
Fixes an error being thrown by the dialog animations. It looks like it was triggered as a result of the changes from 28d2ddd098dd0e6fec70d149ce8e3dc144caf1e4.

Fixes #5019.