### PR TITLE
Allow using 0 as a key in MdSelect

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -583,7 +583,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   private _selectValue(value: any): MdOption {
     let optionsArray = this.options.toArray();
     let correspondingOption = optionsArray.find(option => {
-      return option.value != null && option.value === value;
+      return option.value !== null && option.value !== '' && option.value !== undefined && option.value === value;
     });
 
     if (correspondingOption) {


### PR DESCRIPTION
fix(select): allow using 0 as a key

when using integers as keys, the value 0 is evaluated as an empty selection, because of the falsey condition instead, we should be explicitly checking for null, empty string or undefined.