### PR TITLE
build: include roboto font in e2e-app

### DIFF
--- a/src/e2e-app/index.html
+++ b/src/e2e-app/index.html
@@ -8,6 +8,7 @@
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <link href="dist/packages/material/core/theming/prebuilt/indigo-pink.css" rel="stylesheet">
 
   <!-- FontAwesome for md-icon demo. -->


### PR DESCRIPTION
* Includes the Roboto font in the e2e-app. This should help comparing font-weights of typography for the screendiffs.