### PR TITLE
build: explicitly add tsc-wrapped to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,23 +75,16 @@
       "dev": true
     },
     "@google-cloud/functions-emulator": {
-      "version": "1.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.19.tgz",
-      "integrity": "sha1-7qwC+b0APEOWJHxzcu0lUjs5jTI=",
+      "version": "1.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.20.tgz",
+      "integrity": "sha512-1JBNSP+3F30pTpsNx0V89mv6ZJYioQcB6GsBXxC+7wa+cnrZicQM261PFwHrQn2GbUCVt37N6mU12ZynLf8p1Q==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@google-cloud/storage": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.0.tgz",
-          "integrity": "sha1-XpBaGu1MGW1c513NteTNfOKaCGA=",
-          "dev": true,
-          "optional": true
-        },
         "ajv": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.0.1.tgz",
-          "integrity": "sha1-X9Go9cySs3GqhkRbEVL9TeyESsk=",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
+          "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g=",
           "dev": true,
           "optional": true
         },
@@ -274,9 +267,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.28.tgz",
-      "integrity": "sha512-9rLhvgupMpC7Yh24yB8zj+4L6SZ9BYUwqknEC8+R7gqCg3KL65UHg7yu9X6J8mSmmtVr1Hbey564yZ3C9nXqtQ==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",
+      "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ==",
       "dev": true
     },
     "@types/orchestrator": {
@@ -835,9 +828,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha1-dbO8mN3W5+DY/+dQ36ylxmmT+kc=",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "dev": true,
       "dependencies": {
         "qs": {
@@ -992,9 +985,9 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000679",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000679.tgz",
-      "integrity": "sha1-3XvhLxZXfl1q5tuIDG1hnnfco2U=",
+      "version": "1.0.30000680",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000680.tgz",
+      "integrity": "sha1-126+quuC49mVK/3FwjHE+DzUgUQ=",
       "dev": true
     },
     "canonical-path": {
@@ -1365,21 +1358,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
       "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -1869,9 +1848,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-      "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
       "dev": true
     },
     "decamelize": {
@@ -1879,6 +1858,13 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "optional": true
     },
     "deep-equal": {
       "version": "0.2.2",
@@ -2312,6 +2298,12 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
         }
       }
     },
@@ -2325,6 +2317,12 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
@@ -2602,9 +2600,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.2.tgz",
-      "integrity": "sha1-rxB/wUhQRFfy3Kmm8lcdcSm5ezU=",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2803,21 +2801,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "find": {
       "version": "0.2.6",
@@ -2856,9 +2840,9 @@
       "dev": true
     },
     "firebase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.1.1.tgz",
-      "integrity": "sha1-LGoHxVDhO5QE44ZmtkY5Wxr215I=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.1.2.tgz",
+      "integrity": "sha1-shOrIp62XjG9vR0mIFmxux7frB8=",
       "dev": true,
       "dependencies": {
         "base64url": {
@@ -2937,8 +2921,8 @@
           "dev": true
         },
         "safe-buffer": {
-          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+          "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
           "dev": true
         },
         "topo": {
@@ -3146,6 +3130,12 @@
           "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
           "dev": true
         },
+        "ms": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+          "dev": true
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3338,688 +3328,688 @@
       "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true,
           "optional": true
         },
         "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
           "dev": true,
           "optional": true
         },
         "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true
         },
         "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true
         },
         "boom": {
-          "version": "2.10.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
           "dev": true
         },
         "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
-          "version": "0.11.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true,
           "optional": true
         },
         "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true
         },
         "commander": {
-          "version": "2.9.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "optional": true
         },
         "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "debug": {
-          "version": "2.2.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "optional": true
         },
         "deep-extend": {
-          "version": "0.4.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true,
           "optional": true
         },
         "extend": {
-          "version": "3.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
-          "version": "2.1.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
           "dev": true,
           "optional": true
         },
         "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
-          "version": "1.0.10",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
           "dev": true
         },
         "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true
         },
         "gauge": {
-          "version": "2.7.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+          "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
           "dev": true,
           "optional": true
         },
         "generate-function": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
           "dev": true,
           "optional": true
         },
         "generate-object-property": {
-          "version": "1.2.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
           "dev": true,
           "optional": true
         },
         "getpass": {
-          "version": "0.1.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
-          "version": "2.0.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "optional": true
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "optional": true
         },
         "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "optional": true
         },
         "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true
         },
         "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true
         },
         "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
-          "version": "1.3.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true
         },
         "is-my-json-valid": {
-          "version": "2.15.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
           "dev": true,
           "optional": true
         },
         "is-property": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
           "dev": true,
           "optional": true
         },
         "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true
         },
         "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
-          "version": "1.3.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+          "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
           "dev": true,
           "optional": true
         },
         "mime-db": {
-          "version": "1.26.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+          "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.14",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+          "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true
         },
         "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true
         },
         "ms": {
-          "version": "0.7.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.33",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
           "dev": true,
           "optional": true
         },
         "nopt": {
-          "version": "3.0.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "optional": true
         },
         "npmlog": {
-          "version": "4.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
           "dev": true,
           "optional": true
         },
         "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
-          "version": "1.4.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true
         },
         "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true,
           "optional": true
         },
         "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
-          "version": "6.3.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
+          "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
           "dev": true,
           "optional": true
         },
         "request": {
-          "version": "2.79.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "optional": true
         },
         "rimraf": {
-          "version": "2.5.4",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true
         },
         "semver": {
-          "version": "5.3.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "optional": true
         },
         "sshpk": {
-          "version": "1.10.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+          "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true
         },
         "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true
         },
         "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true,
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true
         },
         "tar-pack": {
-          "version": "3.3.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "once": {
-              "version": "1.3.3",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "optional": true
             },
             "readable-stream": {
-              "version": "2.1.5",
-              "bundled": true,
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
               "dev": true,
               "optional": true
             }
           }
         },
         "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true
         },
         "tunnel-agent": {
-          "version": "0.4.3",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true,
           "optional": true
         },
         "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
-          "version": "1.3.6",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.0",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
           "dev": true,
           "optional": true
         },
         "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true,
           "optional": true
         }
@@ -4409,9 +4399,9 @@
       "dev": true
     },
     "google-proto-files": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.11.1.tgz",
-      "integrity": "sha1-zDrqsnlzaq4LEvHOLAWH21W+7T0=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.0.tgz",
+      "integrity": "sha1-pJB1wfzCvYpIAYaDHCl2Bbl3Sys=",
       "dev": true,
       "optional": true
     },
@@ -4432,9 +4422,9 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.0.0.tgz",
+      "integrity": "sha1-gtQ59nY82xyIIbejquJ4TIjDuNM=",
       "dev": true,
       "optional": true
     },
@@ -4457,57 +4447,65 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.2.4.tgz",
-      "integrity": "sha1-7wyMcIJF2Px5fjmqMw3OQJs90Dw=",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.3.8.tgz",
+      "integrity": "sha1-N9ETwaxAKtFO3KfTjc+QYkwueeQ=",
       "dev": true,
       "optional": true,
       "dependencies": {
         "node-pre-gyp": {
-          "version": "0.6.34",
-          "bundled": true,
+          "version": "0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                  "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                  "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                       "dev": true,
                       "optional": true
                     },
                     "os-tmpdir": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                       "dev": true,
                       "optional": true
                     }
@@ -4516,67 +4514,78 @@
               }
             },
             "npmlog": {
-              "version": "4.0.2",
-              "bundled": true,
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU=",
               "dev": true,
               "optional": true,
               "dependencies": {
                 "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "bundled": true,
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true,
                       "optional": true
                     },
                     "readable-stream": {
-                      "version": "2.2.9",
-                      "bundled": true,
+                      "version": "2.2.10",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+                      "integrity": "sha1-7/5yu3yITA3TNeI3nVJhltnQEe4=",
                       "dev": true,
                       "optional": true,
                       "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true,
                           "optional": true
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                           "dev": true,
                           "optional": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                           "dev": true,
                           "optional": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                           "dev": true,
                           "optional": true
                         },
+                        "safe-buffer": {
+                          "version": "5.1.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+                          "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
+                          "dev": true
+                        },
                         "string_decoder": {
-                          "version": "1.0.0",
-                          "bundled": true,
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                           "dev": true,
                           "optional": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                           "dev": true,
                           "optional": true
                         }
@@ -4586,57 +4595,67 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true
                 },
                 "gauge": {
-                  "version": "2.7.3",
-                  "bundled": true,
+                  "version": "2.7.4",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "aproba": {
-                      "version": "1.1.1",
-                      "bundled": true,
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+                      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
                       "dev": true,
                       "optional": true
                     },
                     "has-unicode": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                       "dev": true,
                       "optional": true
                     },
                     "object-assign": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                       "dev": true,
                       "optional": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                       "dev": true,
                       "optional": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -4645,19 +4664,22 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
-                      "version": "1.1.0",
-                      "bundled": true,
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
                       "dev": true,
                       "optional": true
                     }
@@ -4665,7 +4687,8 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true,
                   "optional": true
                 }
@@ -4673,31 +4696,36 @@
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "dev": true,
               "optional": true,
               "dependencies": {
                 "deep-extend": {
-                  "version": "0.4.1",
-                  "bundled": true,
+                  "version": "0.4.2",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
                   "dev": true,
                   "optional": true
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "dev": true,
                   "optional": true
                 }
@@ -4705,61 +4733,71 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "optional": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true,
                   "optional": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                   "dev": true,
                   "optional": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                   "dev": true,
                   "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
                 "extend": {
-                  "version": "3.0.0",
-                  "bundled": true,
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                   "dev": true,
                   "optional": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true,
                   "optional": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "dev": true,
                       "optional": true
                     }
@@ -4767,31 +4805,36 @@
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ajv": {
-                      "version": "4.11.6",
-                      "bundled": true,
+                      "version": "4.11.8",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                           "dev": true,
                           "optional": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                               "dev": true,
                               "optional": true
                             }
@@ -4801,7 +4844,8 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                       "dev": true,
                       "optional": true
                     }
@@ -4809,29 +4853,34 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "optional": true
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "optional": true
                     }
@@ -4839,103 +4888,120 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true,
                       "optional": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true,
                           "optional": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "dev": true,
                           "optional": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true,
                           "optional": true
                         }
                       }
                     },
                     "sshpk": {
-                      "version": "1.11.0",
-                      "bundled": true,
+                      "version": "1.13.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true,
                           "optional": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "dev": true,
                           "optional": true
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "dev": true,
                           "optional": true
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true
                         },
                         "getpass": {
-                          "version": "0.1.6",
-                          "bundled": true,
+                          "version": "0.1.7",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "dev": true,
                           "optional": true
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                           "dev": true,
                           "optional": true
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "dev": true,
                           "optional": true
                         }
@@ -4945,72 +5011,84 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true,
                   "optional": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true,
                   "optional": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true,
                   "optional": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true,
                   "optional": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                   "dev": true,
                   "optional": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                   "dev": true,
                   "optional": true
                 },
                 "safe-buffer": {
-                  "version": "5.0.1",
-                  "bundled": true,
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+                  "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true,
                   "optional": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                       "dev": true,
                       "optional": true
                     }
@@ -5018,13 +5096,15 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "dev": true,
                   "optional": true
                 },
                 "uuid": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                  "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
                   "dev": true,
                   "optional": true
                 }
@@ -5032,54 +5112,64 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "dependencies": {
                 "glob": {
-                  "version": "7.1.1",
-                  "bundled": true,
+                  "version": "7.1.2",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                  "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
                   "dev": true,
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                       "dev": true
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                       "dev": true
                     },
                     "minimatch": {
-                      "version": "3.0.3",
-                      "bundled": true,
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
                       "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                           "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -5088,19 +5178,22 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                           "dev": true
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                       "dev": true
                     }
                   }
@@ -5109,54 +5202,63 @@
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                       "dev": true
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "dev": true
                 }
               }
             },
             "tar-pack": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "dev": true,
               "optional": true,
               "dependencies": {
                 "debug": {
-                  "version": "2.6.3",
-                  "bundled": true,
+                  "version": "2.6.8",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.2",
-                      "bundled": true,
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                       "dev": true,
                       "optional": true
                     }
@@ -5164,54 +5266,63 @@
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                       "dev": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                       "dev": true
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                       "dev": true,
                       "optional": true
                     },
                     "minimatch": {
-                      "version": "3.0.3",
-                      "bundled": true,
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true,
                               "optional": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true,
                               "optional": true
                             }
@@ -5223,62 +5334,72 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                       "dev": true,
                       "optional": true
                     }
                   }
                 },
                 "readable-stream": {
-                  "version": "2.2.9",
-                  "bundled": true,
+                  "version": "2.2.10",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+                  "integrity": "sha1-7/5yu3yITA3TNeI3nVJhltnQEe4=",
                   "dev": true,
                   "optional": true,
                   "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true,
                       "optional": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                       "dev": true,
                       "optional": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true,
                       "optional": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true,
                       "optional": true
                     },
+                    "safe-buffer": {
+                      "version": "5.1.0",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+                      "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
+                      "dev": true
+                    },
                     "string_decoder": {
-                      "version": "1.0.0",
-                      "bundled": true,
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                       "dev": true,
                       "optional": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true,
                       "optional": true
                     }
@@ -5286,7 +5407,8 @@
                 },
                 "uid-number": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
                   "dev": true,
                   "optional": true
                 }
@@ -6290,6 +6412,13 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true,
+      "optional": true
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -6307,6 +6436,13 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true,
+      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.3",
@@ -6522,6 +6658,13 @@
         }
       }
     },
+    "isurl": {
+      "version": "1.0.0-alpha5",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0-alpha5.tgz",
+      "integrity": "sha1-d/oSL/8fMb4ntvFXZh+IWCuhzTY=",
+      "dev": true,
+      "optional": true
+    },
     "jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
@@ -6529,9 +6672,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
-      "integrity": "sha1-dOoffPQoaRryARB9YxI0AnoJ2qs=",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.3.tgz",
+      "integrity": "sha1-RQcpUOSkKx4yL+VcABEApGXXeBU=",
       "dev": true
     },
     "jasminewd2": {
@@ -6545,13 +6688,6 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
       "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
       "dev": true
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "dev": true,
-      "optional": true
     },
     "joi": {
       "version": "6.10.1",
@@ -6732,15 +6868,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.1.tgz",
       "integrity": "sha1-fKMk9SFfi+A5zTWmxFu4y3SkSPs=",
-      "dev": true,
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.0",
@@ -7526,12 +7654,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -7570,6 +7692,13 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+      "dev": true,
+      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7658,19 +7787,13 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multimatch": {
@@ -8177,6 +8300,13 @@
       "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.2.0.tgz",
+      "integrity": "sha1-MVL08wvnYGtg6/6LuTs/32kIXkY=",
+      "dev": true,
+      "optional": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -8195,6 +8325,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "optional": true
+    },
+    "p-timeout": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.1.1.tgz",
+      "integrity": "sha1-0o6f35bjKIhvv/B4+IatFYxTv20=",
       "dev": true,
       "optional": true
     },
@@ -8220,12 +8357,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
           "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
           "dev": true
         }
       }
@@ -8897,9 +9028,9 @@
       "dev": true
     },
     "remove-trailing-separator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-      "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
       "dev": true
     },
     "repeat-element": {
@@ -9140,12 +9271,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -9385,9 +9510,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.1.tgz",
-      "integrity": "sha1-igI1TCbm9cynAAZfXwzeupDse18=",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
       "dev": true,
       "dependencies": {
         "mime": {
@@ -9434,6 +9559,12 @@
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
           "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
           "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
         }
       }
     },
@@ -9476,9 +9607,9 @@
       }
     },
     "serve-static": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz",
-      "integrity": "sha1-dEOpZePO1kes61Y5+ga/TRu+ADk=",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
       "dev": true,
       "optional": true
     },
@@ -9507,9 +9638,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true
     },
     "sigmund": {
@@ -9586,6 +9717,12 @@
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true
         },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
         "object-assign": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
@@ -9605,6 +9742,12 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
           "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
         }
       }
     },
@@ -9618,6 +9761,12 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         }
       }
@@ -9739,9 +9888,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "dependencies": {
         "assert-plus": {
@@ -10627,11 +10776,10 @@
       }
     },
     "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true,
-      "optional": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
     },
     "update-notifier": {
       "version": "0.5.0",
@@ -11318,9 +11466,9 @@
       }
     },
     "zone.js": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.11.tgz",
-      "integrity": "sha1-dCvvsX+8SaVxcSuMfYfljKJv2IY="
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.12.tgz",
+      "integrity": "sha1-hv9QU8mK7CkaC/S7rFAdaUoFz7s="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/platform-server": "^4.0.0",
     "@angular/router": "^4.0.0",
+    "@angular/tsc-wrapped": "^4.0.0",
     "@google-cloud/storage": "^1.1.1",
     "@types/chalk": "^0.4.31",
     "@types/fs-extra": "^3.0.1",


### PR DESCRIPTION
The dependency on `tsc-wrapped` should be added explicitly. Our tooling uses the `@angular/tsc-wrapped` package directly and it currently only works because the `@angular/compiler-cli` has a dependency on it.

If not specified explicitly, the `@angular/tsc-wrapped` dependency might be a local dependency of the compiler-cli and our tooling won't be able to access it anymore.