### PR TITLE
fix(datepicker): use toggle color from theme

### DIFF
--- a/src/lib/core/style/_escape-color.scss
+++ b/src/lib/core/style/_escape-color.scss
@@ -1,0 +1,10 @@
+// URL-encodes a hex color. Useful when concatenating a color into a URL-encoded SVG.
+@function escape-color($color) {
+  $stringified: $color + '';
+
+  @if str-index($stringified, '#') == 1 {
+    @return '%23' + str-slice($stringified, 2);
+  }
+
+  @return $stringified;
+}

--- a/src/lib/datepicker/_datepicker-theme.scss
+++ b/src/lib/datepicker/_datepicker-theme.scss
@@ -1,5 +1,6 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/style/escape-color';
 @import '../core/typography/typography-utils';
 
 
@@ -82,6 +83,10 @@ $mat-calendar-weekday-table-font-size: 11px !default;
   .mat-calendar-body-disabled > .mat-calendar-body-today:not(.mat-calendar-body-selected) {
     border-color: fade-out(mat-color($foreground, hint-text), $mat-datepicker-today-fade-amount);
   }
+
+  .mat-datepicker-toggle {
+    background-image: _mat-datepicker-toggle-icon($foreground, icon);
+  }
 }
 
 @mixin mat-datepicker-typography($config) {
@@ -107,4 +112,25 @@ $mat-calendar-weekday-table-font-size: 11px !default;
       weight: mat-font-weight($config, body-1);
     }
   }
+}
+
+
+// Returns the URL-encoded version of the following:
+// <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24"
+//  fill="{INJECTED_COLOR}">
+//  <path d="M0 0h24v24H0z" fill="none"/>
+//  <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2
+//  2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
+//</svg>
+@function _mat-datepicker-toggle-icon($palette, $hue) {
+  $result: '' +
+    'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000' +
+    '%2Fsvg%22%20width%3D%2224px%22%20height%3D%2224px%22%20viewBox%3D%220%200%2024%2024' +
+    '%22%20fill%3D%22' + escape-color(mat-color($palette, $hue)) + '%22%3E%0A%20%20%3Cpa' +
+    'th%20d%3D%22M0%200h24v24H0z%22%20fill%3D%22none%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M' +
+    '19%203h-1V1h-2v2H8V1H6v2H5c-1.11%200-1.99.9-1.99%202L3%2019c0%201.1.89%202%202%202h' +
+    '14c1.1%200%202-.9%202-2V5c0-1.1-.9-2-2-2zm0%2016H5V8h14v11zM7%2010h5v5H7z%22%2F%3E%' +
+    '0A%3C%2Fsvg%3E';
+
+  @return url($result);
 }

--- a/src/lib/datepicker/datepicker-toggle.scss
+++ b/src/lib/datepicker/datepicker-toggle.scss
@@ -3,9 +3,9 @@ $mat-datepicker-toggle-icon-size: 24px !default;
 
 .mat-datepicker-toggle {
   display: inline-block;
-  // Note: SVG needs to be base64 encoded or it will not work on IE11.
-  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE5IDNoLTFWMWgtMnYySDhWMUg2djJINWMtMS4xMSAwLTEuOTkuOS0xLjk5IDJMMyAxOWMwIDEuMS44OSAyIDIgMmgxNGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDVWOGgxNHYxMXpNNyAxMGg1djVIN3oiLz48L3N2Zz4=') no-repeat;
   background-size: contain;
+  background-color: transparent;
+  background-repeat: no-repeat;
   height: $mat-datepicker-toggle-icon-size;
   width: $mat-datepicker-toggle-icon-size;
   border: none;

--- a/src/lib/progress-bar/_progress-bar-theme.scss
+++ b/src/lib/progress-bar/_progress-bar-theme.scss
@@ -1,5 +1,6 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/style/escape-color';
 
 
 @mixin mat-progress-bar-theme($theme) {
@@ -62,21 +63,13 @@
 //   <circle cx="1" cy="1" r="1" fill="{INJECTED_COLOR}"/>
 // </svg>
 @function _mat-progress-bar-buffer($palette, $hue) {
-  $color: mat-color($palette, $hue) + '';
-
-  // We also need to escape the hash in hex colors,
-  // otherwise IE will throw an XML error.
-  @if str-index($color, '#') == 1 {
-    $color: '%23' + str-slice($color, 2);
-  }
-
   $result: '' +
     'data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%271.1%27%20xmlns%3D%27http%3A%2F%2F' +
     'www.w3.org%2F2000%2Fsvg%27%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%2' +
     '7%20x%3D%270px%27%20y%3D%270px%27%20enable-background%3D%27new%200%200%205%202%27%20xml%' +
     '3Aspace%3D%27preserve%27%20viewBox%3D%270%200%205%202%27%20preserveAspectRatio%3D%27none' +
     '%20slice%27%3E%3Ccircle%20cx%3D%271%27%20cy%3D%271%27%20r%3D%271%27%20fill%3D%27' +
-    $color + '%27%2F%3E%3C%2Fsvg%3E';
+    escape-color(mat-color($palette, $hue)) + '%27%2F%3E%3C%2Fsvg%3E';
 
   @return url($result);
 }


### PR DESCRIPTION
Fixes the datepicker toggle being black, instead of taking its color from the theme.

**Note:** Overriding this might be a bit simpler if we had the SVG inside the toggle's `template`.