### PR TITLE
build: fix missing prebuilt themes

### DIFF
--- a/tools/gulp/tasks/validate-release.ts
+++ b/tools/gulp/tasks/validate-release.ts
@@ -64,7 +64,7 @@ function checkMaterialPackage(): string[] {
   const themingFilePath = join(packagePath, '_theming.scss');
   const failures = [];
 
-  if (!existsSync(prebuiltThemesPath) || glob('*.css', {cwd: prebuiltThemesPath}).length === 0) {
+  if (glob('*.css', {cwd: prebuiltThemesPath}).length === 0) {
     failures.push('Prebuilt themes are not present in the Material release output.');
   }
 

--- a/tools/gulp/tasks/validate-release.ts
+++ b/tools/gulp/tasks/validate-release.ts
@@ -1,9 +1,10 @@
 import {task} from 'gulp';
-import {readFileSync} from 'fs';
+import {readFileSync, existsSync} from 'fs';
 import {join} from 'path';
 import {green, red} from 'chalk';
 import {sequenceTask} from '../util/task_helpers';
 import {releasePackages} from './publish';
+import {sync as glob} from 'glob';
 import {buildConfig} from '../packaging/build-config';
 
 /** Path to the directory where all releases are created. */
@@ -19,27 +20,27 @@ task('validate-release', sequenceTask(':publish:build-releases', 'validate-relea
 
 /** Task that checks the release bundles for any common mistakes before releasing to the public. */
 task('validate-release:check-bundles', () => {
-  const bundleFailures = releasePackages
-    .map(packageName => join(releasesDir, packageName, '@angular', `${packageName}.js`))
-    .map(packageBundle => checkPackageBundle(packageBundle))
+  const releaseFailures = releasePackages
+    .map(packageName => checkReleasePackage(packageName))
     .map((failures, index) => ({failures, packageName: releasePackages[index]}));
 
-  bundleFailures.forEach(({failures, packageName}) => {
+  releaseFailures.forEach(({failures, packageName}) => {
     failures.forEach(failure => console.error(red(`Failure (${packageName}): ${failure}`)));
   });
 
-  if (bundleFailures.some(({failures}) => failures.length > 0)) {
+  if (releaseFailures.some(({failures}) => failures.length > 0)) {
     // Throw an error to notify Gulp about the failures that have been detected.
-    throw 'Release bundles are not valid and ready for being released.';
+    throw 'Release output is not valid and not ready for being released.';
   } else {
-    console.log(green('Release bundles have been checked and are looking fine.'));
+    console.log(green('Release output has been checked and everything looks fine.'));
   }
 });
 
-/** Task that checks the given release bundle for common mistakes. */
-function checkPackageBundle(bundlePath: string): string[] {
+/** Task that validates the given release package before releasing. */
+function checkReleasePackage(packageName: string): string[] {
+  const bundlePath = join(releasesDir, packageName, '@angular', `${packageName}.js`);
   const bundleContent = readFileSync(bundlePath, 'utf8');
-  const failures = [];
+  let failures = [];
 
   if (inlineStylesSourcemapRegex.exec(bundleContent) !== null) {
     failures.push('Bundles contain sourcemap references in component styles.');
@@ -47,6 +48,28 @@ function checkPackageBundle(bundlePath: string): string[] {
 
   if (externalReferencesRegex.exec(bundleContent) !== null) {
     failures.push('Bundles are including references to external resources (templates or styles)');
+  }
+
+  if (packageName === 'material') {
+    failures = failures.concat(checkMaterialPackage());
+  }
+
+  return failures;
+}
+
+/** Function that includes special checks for the Material package. */
+function checkMaterialPackage(): string[] {
+  const packagePath = join(releasesDir, 'material');
+  const prebuiltThemesPath = join(packagePath, 'prebuilt-themes');
+  const themingFilePath = join(packagePath, '_theming.scss');
+  const failures = [];
+
+  if (!existsSync(prebuiltThemesPath) || glob('*.css', {cwd: prebuiltThemesPath}).length === 0) {
+    failures.push('Prebuilt themes are not present in the Material release output.');
+  }
+
+  if (!existsSync(themingFilePath)) {
+    failures.push('The theming SCSS file is not present in the Material release output.');
   }
 
   return failures;


### PR DESCRIPTION
* Fixes that the prebuilt themes are not copied over to the release output.
* Introduces two more checks (specifc for material) in the validate-release task
* Fixes that the generation of the theming SCSS bundle happens outside of gulp.

Fixes #5038