### PR TITLE
build: run fewer browsers on saucelabs

### DIFF
--- a/src/lib/core/platform/platform.ts
+++ b/src/lib/core/platform/platform.ts
@@ -37,4 +37,9 @@ export class Platform {
 
   // Trident on mobile adds the android platform to the userAgent to trick detections.
   ANDROID = this.isBrowser && /android/i.test(navigator.userAgent) && !this.TRIDENT;
+
+  // Safari browsers will include the Safari keyword in their userAgent. Some browsers may fake
+  // this and just place the Safari keyword in the userAgent. To be more safe about Safari every
+  // Safari browser should also use Webkit as its layout engine.
+  SAFARI = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 }

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -24,7 +24,6 @@ import {
 } from './input-container-errors';
 import {MD_PLACEHOLDER_GLOBAL_OPTIONS} from '../core/placeholder/placeholder-options';
 
-
 describe('MdInputContainer', function () {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -108,7 +107,7 @@ describe('MdInputContainer', function () {
 
   it('should not be treated as empty if type is date',
       inject([Platform], (platform: Platform) => {
-        if (!(platform.TRIDENT || platform.FIREFOX)) {
+        if (!(platform.TRIDENT || platform.FIREFOX || (platform.SAFARI && !platform.IOS))) {
           let fixture = TestBed.createComponent(MdInputContainerDateTestController);
           fixture.detectChanges();
 
@@ -118,10 +117,10 @@ describe('MdInputContainer', function () {
         }
       }));
 
-  // Firefox and IE don't support type="date" and fallback to type="text".
+  // Firefox, Safari Desktop and IE don't support type="date" and fallback to type="text".
   it('should be treated as empty if type is date on Firefox and IE',
       inject([Platform], (platform: Platform) => {
-        if (platform.TRIDENT || platform.FIREFOX) {
+        if (platform.TRIDENT || platform.FIREFOX || (platform.SAFARI && !platform.IOS)) {
           let fixture = TestBed.createComponent(MdInputContainerDateTestController);
           fixture.detectChanges();
 

--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -5,9 +5,9 @@
  * Target can be either: BS (Browserstack) | SL (Saucelabs) | null (To not run at all)
  */
 const browserConfig = {
-  'Chrome':       { unitTest: {target: 'SL', required: true  }},
-  'Firefox':      { unitTest: {target: 'SL', required: true  }},
-  'ChromeBeta':   { unitTest: {target: 'SL', required: false }},
+  'Chrome':       { unitTest: {target: 'BS', required: true  }},
+  'Firefox':      { unitTest: {target: 'BS', required: true  }},
+  'ChromeBeta':   { unitTest: {target: null, required: false }},
   'FirefoxBeta':  { unitTest: {target: null, required: false }},
   'ChromeDev':    { unitTest: {target: null, required: true  }},
   'FirefoxDev':   { unitTest: {target: null, required: true  }},
@@ -19,15 +19,15 @@ const browserConfig = {
   'Android4.2':   { unitTest: {target: null, required: false }},
   'Android4.3':   { unitTest: {target: null, required: false }},
   'Android4.4':   { unitTest: {target: null, required: false }},
-  'Android5':     { unitTest: {target: 'SL', required: false }},
+  'Android5':     { unitTest: {target: null, required: false }},
   'Safari7':      { unitTest: {target: null, required: false }},
   'Safari8':      { unitTest: {target: null, required: false }},
-  'Safari9':      { unitTest: {target: 'BS', required: false }},
-  'Safari10':     { unitTest: {target: 'SL', required: false }},
+  'Safari9':      { unitTest: {target: 'SL', required: true }},
+  'Safari10':     { unitTest: {target: 'BS', required: true }},
   'iOS7':         { unitTest: {target: null, required: false }},
   'iOS8':         { unitTest: {target: null, required: false }},
   'iOS9':         { unitTest: {target: 'BS', required: true  }},
-  'WindowsPhone': { unitTest: {target: 'BS', required: false }}
+  'WindowsPhone': { unitTest: {target: null, required: false }}
 };
 
 /** Exports all available remote browsers. */

--- a/test/remote_browsers.json
+++ b/test/remote_browsers.json
@@ -167,6 +167,13 @@
     "os": "OS X",
     "os_version": "El Capitan"
   },
+  "BS_SAFARI10": {
+    "base": "BrowserStack",
+    "browser": "safari",
+    "browser_version": "10.1",
+    "os": "OS X",
+    "os_version": "Sierra"
+  },
   "BS_IOS7": {
     "base": "BrowserStack",
     "device": "iPhone 5S",


### PR DESCRIPTION
* Better balance between Saucelabs and Browserstack because Browserstack runs more stable. Considering that e2e tests also run on Saucelabs it's only fair running more on Browserstack.
* Sets browsers that are optional and don't run at all to `null`. Just to have a nice overview which browsers are running or not.
* Runs tests against Safari 9 and 10. 

