### PR TITLE
fix(snack-bar): test error in IE

### DIFF
--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -329,10 +329,8 @@ describe('MdSnackBar', () => {
   }));
 
   it('should add extra classes to the container', () => {
-    snackBar.open(simpleMessage, simpleActionLabel, {
-      viewContainerRef: testViewContainerRef,
-      extraClasses: ['one', 'two']
-    });
+    snackBar.open(simpleMessage, simpleActionLabel, { extraClasses: ['one', 'two'] });
+    viewContainerFixture.detectChanges();
 
     let containerClasses = overlayContainerElement.querySelector('snack-bar-container').classList;
 
@@ -342,6 +340,7 @@ describe('MdSnackBar', () => {
 
   it('should set the layout direction', () => {
     snackBar.open(simpleMessage, simpleActionLabel, { direction: 'rtl' });
+    viewContainerFixture.detectChanges();
 
     let pane = overlayContainerElement.querySelector('.cdk-overlay-pane');
 


### PR DESCRIPTION
Fixes a silent error that was being logged by IE when running the snack bar tests. It seems to be due to the specific test case not triggering change detection and not passing in a `viewContainerRef` so it could be triggered automatically.