### PR TITLE
test(datepicker): set locale to en-US

### DIFF
--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -8,7 +8,7 @@ import {By} from '@angular/platform-browser';
 import {dispatchFakeEvent, dispatchMouseEvent} from '../core/testing/dispatch-events';
 import {MdInputModule} from '../input/index';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MdNativeDateModule} from '../core/datetime/index';
+import {MdNativeDateModule, DateAdapter, NativeDateAdapter} from '../core/datetime/index';
 
 
 // When constructing a Date, the month is zero-based. This can be confusing, since people are
@@ -28,6 +28,13 @@ describe('MdDatepicker', () => {
           MdNativeDateModule,
           NoopAnimationsModule,
           ReactiveFormsModule,
+        ],
+        providers: [
+          {provide: DateAdapter, useFactory: () => {
+            let adapter = new NativeDateAdapter();
+            adapter.setLocale('en-US');
+            return adapter;
+          }}
         ],
         declarations: [
           DatepickerWithFilterAndValidation,

--- a/src/lib/datepicker/month-view.spec.ts
+++ b/src/lib/datepicker/month-view.spec.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MdMonthView} from './month-view';
 import {MdCalendarBody} from './calendar-body';
-import {MdNativeDateModule} from '../core/datetime/index';
+import {MdNativeDateModule, DateAdapter, NativeDateAdapter} from '../core/datetime/index';
 
 
 // When constructing a Date, the month is zero-based. This can be confusing, since people are
@@ -17,6 +17,13 @@ describe('MdMonthView', () => {
     TestBed.configureTestingModule({
       imports: [
         MdNativeDateModule,
+      ],
+      providers: [
+        {provide: DateAdapter, useFactory: () => {
+          let adapter = new NativeDateAdapter();
+          adapter.setLocale('en-US');
+          return adapter;
+        }}
       ],
       declarations: [
         MdCalendarBody,

--- a/src/lib/datepicker/year-view.spec.ts
+++ b/src/lib/datepicker/year-view.spec.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MdYearView} from './year-view';
 import {MdCalendarBody} from './calendar-body';
-import {MdNativeDateModule} from '../core/datetime/index';
+import {MdNativeDateModule, DateAdapter, NativeDateAdapter} from '../core/datetime/index';
 
 
 // When constructing a Date, the month is zero-based. This can be confusing, since people are
@@ -17,6 +17,13 @@ describe('MdYearView', () => {
     TestBed.configureTestingModule({
       imports: [
         MdNativeDateModule,
+      ],
+      providers: [
+        {provide: DateAdapter, useFactory: () => {
+          let adapter = new NativeDateAdapter();
+          adapter.setLocale('en-US');
+          return adapter;
+        }}
       ],
       declarations: [
         MdCalendarBody,


### PR DESCRIPTION
Currently, some of the datepicker tests will fail if the browser's locale is different from en-US. These changes set the locale to en-US in order to avoid potential issues in the future.