### PR TITLE
build: generate docs for expansion

### DIFF
--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -91,6 +91,7 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
     'core/index.ts',
     'datepicker/index.ts',
     'dialog/index.ts',
+    'expansion/index.ts',
     'grid-list/index.ts',
     'icon/index.ts',
     'input/index.ts',


### PR DESCRIPTION
* Recently the expansion component has been introduced but not added to the Dgeni docs generation yet.

**Note**: We may be able to replace the static list of files we want to generate docs for with a `glob` in the future.