### PR TITLE
build: fix payload function invalid diff

### DIFF
--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -15,7 +15,7 @@ export const payloadGithubStatus = https.onRequest(async (request, response) => 
     return response.status(404).json({message: 'No commit has been specified'});
   }
 
-  if (!payloadDiff || isNaN(payloadDiff)) {
+  if (isNaN(payloadDiff)) {
     return response.status(400).json({message: 'No valid payload diff has been specified.'});
   }
 


### PR DESCRIPTION
* Currently when the payload difference is zero, the Github status won't be set because the falsy check is invalid and declares the payload diff as not valid.