### PR TITLE
build: fix deploying of screenshot functions

### DIFF
--- a/scripts/deploy/deploy-screenshot-functions.sh
+++ b/scripts/deploy/deploy-screenshot-functions.sh
@@ -3,18 +3,25 @@
 # The script should immediately exit if any command in the script fails.
 set -e
 
-# Go to the project root directory
-cd $(dirname ${0})/../..
-
-# Install node modules for screenshot functions. Firebase CLI needs to execute the functions
-# before it can collect all functions and deploy them.
-(cd tools/screenshot-test/functions; npm install)
-
-if [ -z ${MATERIAL2_SCREENSHOT_ACCESS_TOKEN} ]; then
+if [ -z ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} ]; then
   echo "Error: No access token for firebase specified." \
-       "Please set the environment variable 'MATERIAL2_SCREENSHOT_ACCESS_TOKEN'."
+       "Please set the environment variable 'MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN'."
   exit 1
 fi
 
+# Go to the project root directory
+cd $(dirname ${0})/../..
+
+# Paths to the screenshot-test directory that also contains the function directory.
+screenshotTestFolder=tools/screenshot-test
+
+# Go to the screenshot-test folder because otherwise Firebase tries to deploy the wrong project.
+cd ${screenshotTestFolder}
+
+# Install node modules for the screenshot functions. Firebase CLI needs to execute the functions
+# before it can collect all functions and deploy them.
+(cd functions; npm install)
+
 # Deploy the screenshot functions to Firebase
-$(npm bin)/firebase deploy --only functions --token ${MATERIAL2_SCREENSHOT_ACCESS_TOKEN}
+$(npm bin)/firebase deploy --only functions --token ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} \
+  --project material2-screenshots

--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -38,7 +38,7 @@ export function openScreenshotsBucket() {
     projectId: 'material2-screenshots',
     credentials: {
       client_email: 'firebase-adminsdk-t4209@material2-screenshots.iam.gserviceaccount.com',
-      private_key: decode(process.env['MATERIAL2_SCREENSHOT_FIREBASE_KEY'])
+      private_key: decode(process.env['MATERIAL2_SCREENSHOT_FIREBASE_SERVICE_KEY'])
     },
   });
 


### PR DESCRIPTION
* Updates the dashboard and screenshot deploy script to exit the process immediately if the Firebase token is not set.
* Fixes that the error message of the dashboard still shows the old name of the token variable
* Renames the screenshot variables to follow the dashboard environment variables
* Explicitly specifies the project that will be uploaded in the screenshot deploy script (same as for dashboard)

@jelbourn You already renamed the dashboard variables a few days ago. Can you rename the screenshot variables too? So we have those variables consistent and it's clear what every variable does.

* `MATERIAL2_SCREENSHOT_ACCESS_TOKEN` -> `MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN`
* `MATERIAL2_SCREENSHOT_FIREBASE_KEY`  -> `MATERIAL2_SCREENSHOT_FIREBASE_SERVICE_KEY`