### PR TITLE
chore: fix focus origin demo

### DIFF
--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -73,7 +73,8 @@ import {
   MdTabsModule,
   MdToolbarModule,
   MdTooltipModule,
-  OverlayContainer
+  OverlayContainer,
+  StyleModule
 } from '@angular/material';
 import {TableHeaderDemo} from './data-table/table-header-demo';
 
@@ -111,6 +112,7 @@ import {TableHeaderDemo} from './data-table/table-header-demo';
     MdTooltipModule,
     MdNativeDateModule,
     CdkDataTableModule,
+    StyleModule
   ]
 })
 export class DemoMaterialModule {}


### PR DESCRIPTION
* Fixes the style demo (or FocusOriginMonitor demo) by including the missing `StyleModule` in the demo-app.

**Note**: We are not going to add the `StyleModule` to the `MdCoreModule` because those things will be moved to the cdk soon.