### PR TITLE
build: enable noUnusedParameters check

### DIFF
--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "importHelpers": true,
     "module": "es2015",
     "moduleResolution": "node",

--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -5,6 +5,8 @@
   "extends": "./tsconfig-build",
   "compilerOptions": {
     "experimentalDecorators": true,
+    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
+    "noUnusedParameters": false,
     "outDir": ".",
     "paths": {
       "@angular/material": ["./material"],

--- a/src/demo-app/tsconfig-build.json
+++ b/src/demo-app/tsconfig-build.json
@@ -5,6 +5,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "lib": ["es6", "es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/src/e2e-app/tsconfig-build.json
+++ b/src/e2e-app/tsconfig-build.json
@@ -5,6 +5,8 @@
     "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
+    "noUnusedParameters": false,
     "lib": ["es6", "es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -56,7 +56,7 @@ export class MdExpansionPanelHeader {
   constructor(@Host() public panel: MdExpansionPanel) {}
 
   /** Toggles the expanded state of the panel. */
-  _toggle(event?: KeyboardEvent): void {
+  _toggle(): void {
     this.panel.toggle();
   }
 

--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "importHelpers": true,
     "module": "es2015",
     "moduleResolution": "node",

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "importHelpers": true,
     "module": "es2015",
     "moduleResolution": "node",

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": ".",

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -4,6 +4,8 @@
     "declaration": false,
     "stripInternal": false,
     "experimentalDecorators": true,
+    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
+    "noUnusedParameters": false,
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": ".",

--- a/tools/gulp/packaging/inline-resources.ts
+++ b/tools/gulp/packaging/inline-resources.ts
@@ -22,7 +22,7 @@ export function inlineResources(filePath: string) {
 
 /** Inlines the templates of Angular components for a specified source file. */
 function inlineTemplate(fileContent: string, filePath: string) {
-  return fileContent.replace(/templateUrl:\s*'([^']+?\.html)'/g, (match, templateUrl) => {
+  return fileContent.replace(/templateUrl:\s*'([^']+?\.html)'/g, (_match, templateUrl) => {
     const templatePath = join(dirname(filePath), templateUrl);
     const templateContent = loadResourceFile(templatePath);
     return `template: "${templateContent}"`;
@@ -31,7 +31,7 @@ function inlineTemplate(fileContent: string, filePath: string) {
 
 /** Inlines the external styles of Angular components for a specified source file. */
 function inlineStyles(fileContent: string, filePath: string) {
-  return fileContent.replace(/styleUrls:\s*(\[[\s\S]*?])/gm, (match, styleUrlsValue) => {
+  return fileContent.replace(/styleUrls:\s*(\[[\s\S]*?])/gm, (_match, styleUrlsValue) => {
     // The RegExp matches the array of external style files. This is a string right now and
     // can to be parsed using the `eval` method. The value looks like "['AAA.css', 'BBB.css']"
     const styleUrls = eval(styleUrlsValue) as string[];

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -130,12 +130,12 @@ function transformMarkdownFiles(buffer: Buffer, file: any): string {
   let content = buffer.toString('utf-8');
 
   // Replace <!-- example(..) --> comments with HTML elements.
-  content = content.replace(EXAMPLE_PATTERN, (match: string, name: string) =>
+  content = content.replace(EXAMPLE_PATTERN, (_match: string, name: string) =>
     `<div material-docs-example="${name}"></div>`
   );
 
   // Replace the URL in anchor elements inside of compiled markdown files.
-  content = content.replace(LINK_PATTERN, (match: string, head: string, link: string) =>
+  content = content.replace(LINK_PATTERN, (_match: string, head: string, link: string) =>
     // The head is the first match of the RegExp and is necessary to ensure that the RegExp matches
     // an anchor element. The head will be then used to re-create the existing anchor element.
     // If the head is not prepended to the replaced value, then the first match will be lost.

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compilerOptions": {
     "experimentalDecorators": true,
+    "noUnusedParameters": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -9,7 +9,7 @@ const screenshotFirebaseConfig = require('../../screenshot-test/functions/config
 const dashboardDatabaseUrl = 'https://material2-board.firebaseio.com';
 
 /** Opens a connection to the Firebase dashboard app using a service account. */
-export function openFirebaseDashboardApp(asGuest = false) {
+export function openFirebaseDashboardApp() {
   // Initialize the Firebase application with firebaseAdmin credentials.
   // Credentials need to be for a Service Account, which can be created in the Firebase console.
   return firebaseAdmin.initializeApp({


### PR DESCRIPTION
* This enables the "noUnusedParameters" TypeScript option in all tsconfig files. This ensures that every package that will be published can be used together with "noUnusedParameters".
* Added the "noUnusedParameters" option in unrelated tsconfig files as well (gulp tsconfig). This also helps avoiding unused / unnecessary code.
* Skipped setting "noUnusedParameters" for the e2e spec files because those are served in AOT mode and the current Angular version of the project does not support "noUnusedParameters" yet.

@jelbourn I initially was against adding it to the tsconfig files because I expected issues with the livereloading (when serving the app) but I tested it and it works fine like that.

**Note**: I thought about having a global tsconfig that will be extended by all other child tsconfig files. But this would mean that we need *another* tsconfig (again). Maybe a longer discussion for the future.