### PR TITLE
build: remove url from payload status

### DIFF
--- a/tools/dashboard/functions/github/github-status.ts
+++ b/tools/dashboard/functions/github/github-status.ts
@@ -11,7 +11,7 @@ export type GithubStatusData = {
   result: boolean;
   name: string;
   description: string;
-  url: string;
+  url?: string;
 };
 
 /** Function that sets a Github commit status */

--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -5,7 +5,7 @@ import {setGithubStatus} from './github/github-status';
 export const payloadGithubStatus = https.onRequest(async (request, response) => {
   const authToken = request.header('auth-token');
   const commitSha = request.header('commit-sha');
-  const payloadDiff = parseInt(request.header('commit-payload-diff'));
+  const payloadDiff = parseFloat(request.header('commit-payload-diff'));
 
   if (!verifyToken(authToken)) {
     return response.status(403).json({message: 'Auth token is not valid'});

--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -22,7 +22,7 @@ export const payloadGithubStatus = https.onRequest(async (request, response) => 
   await setGithubStatus(commitSha, {
     result: true,
     name: 'Library Payload',
-    description: `${payloadDiff >= 0 ? `+` : ''} ${payloadDiff.toFixed(2)}KB`
+    description: `${payloadDiff >= 0 ? `+` : ''}${payloadDiff.toFixed(2)}KB`
   });
 
   response.json({message: 'Payload Github status successfully set.'});

--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -22,8 +22,7 @@ export const payloadGithubStatus = https.onRequest(async (request, response) => 
   await setGithubStatus(commitSha, {
     result: true,
     name: 'Library Payload',
-    url: `https://travis-ci.org/angular/material2/jobs/${process.env['TRAVIS_JOB_ID']}`,
-    description: `${payloadDiff > 0 ? `+` : ''} ${payloadDiff.toFixed(2)}KB`
+    description: `${payloadDiff >= 0 ? `+` : ''} ${payloadDiff.toFixed(2)}KB`
   });
 
   response.json({message: 'Payload Github status successfully set.'});


### PR DESCRIPTION
* Removes the invalid URL that will be shown in the payload status
* If the payload difference is zero there should be a plus instead of the plain number (Keeping the message simple for now. No need to construct complex descriptions)