### PR TITLE
build: separate payload diffs for packages

### DIFF
--- a/tools/dashboard/functions/github/github-status.ts
+++ b/tools/dashboard/functions/github/github-status.ts
@@ -18,26 +18,25 @@ export type GithubStatusData = {
 export function setGithubStatus(commitSHA: string, data: GithubStatusData) {
   const state = data.result ? 'success' : 'failure';
 
-  const requestData = JSON.stringify({
+  const requestData = {
     state: state,
     target_url: data.url,
     context: data.name,
     description: data.description
-  });
+  };
 
   const headers = {
     'Authorization': `token ${repoToken}`,
-    'User-Agent': `${name}/${version}`,
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(requestData)
+    'User-Agent': `${name}/${version}`
   };
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     request({
       url: `https://api.github.com/repos/angular/material2/statuses/${commitSHA}`,
       method: 'POST',
-      form: requestData,
-      headers: headers
-    }, (error: any, response: any) => resolve(response.statusCode));
+      body: requestData,
+      headers: headers,
+      json: true
+    }, (error: any, response: any) => error ? reject(error) : resolve(response.statusCode));
   });
 }

--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -5,7 +5,9 @@ import {setGithubStatus} from './github/github-status';
 export const payloadGithubStatus = https.onRequest(async (request, response) => {
   const authToken = request.header('auth-token');
   const commitSha = request.header('commit-sha');
-  const payloadDiff = parseFloat(request.header('commit-payload-diff'));
+  const packageName = request.header('package-name');
+  const packageSize = parseFloat(request.header('package-full-size'));
+  const packageDiff = parseFloat(request.header('package-size-diff'));
 
   if (!verifyToken(authToken)) {
     return response.status(403).json({message: 'Auth token is not valid'});
@@ -15,15 +17,36 @@ export const payloadGithubStatus = https.onRequest(async (request, response) => 
     return response.status(404).json({message: 'No commit has been specified'});
   }
 
-  if (isNaN(payloadDiff)) {
-    return response.status(400).json({message: 'No valid payload diff has been specified.'});
+  if (isNaN(packageDiff)) {
+    return response.status(400).json({message: 'No valid package difference has been specified.'});
   }
+
+  if (isNaN(packageSize)) {
+    return response.status(400).json({message: 'No full size of the package has been specified.'});
+  }
+
+  if (!packageName) {
+    return response.status(400).json({message: 'No package name has been specified.'});
+  }
+
+  if (packageDiff === 0) {
+    return response.status(400).json({message: `The difference equals zero. Status won't be set.`});
+  }
+
+  // Better message about the diff that shows whether the payload increased or decreased.
+  const diffMessage = packageDiff < 0 ? 'decrease' : 'increase';
+  const diffFormatted = Math.abs(packageDiff).toFixed(2);
 
   await setGithubStatus(commitSha, {
     result: true,
-    name: 'Library Payload',
-    description: `${payloadDiff >= 0 ? `+` : ''}${payloadDiff.toFixed(2)}KB`
+    name: `${capitalizeFirstLetter(packageName)} Payload Size`,
+    description: `${packageSize}kb / ${diffFormatted}kb ${diffMessage} (ES2015 bundle)`
   });
 
   response.json({message: 'Payload Github status successfully set.'});
 });
+
+/** Capitalizes the first letter of a string. */
+function capitalizeFirstLetter(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}


### PR DESCRIPTION
* Now shows separate payload github statuses for the CDK and Material.
* No longer shows the Github status if the difference equals zero.
* Now shows errors if something fails within the Github request (in the functions)
* Better message for statuses (including full-size of the given package)

**Note**: The extra check for the `packageDiff === 0` is intentionally separate. There should be a different message if the packageDiff is a "valid" but zero.