### PR TITLE
build: get previous payload by querying git

### DIFF
--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -142,7 +142,7 @@ async function uploadPayloadResults(database: firebaseAdmin.database.Database, c
   }
 }
 
-/** Gets the last payload uploaded from previous Travis builds. */
+/** Gets payload results of the specified commit sha. */
 async function getPayloadResults(database: firebaseAdmin.database.Database, commitSha: string) {
   const snapshot = await database.ref('payloads').child(commitSha).once('value');
 

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -157,18 +157,18 @@ async function getPayloadResults(database: firebaseAdmin.database.Database, comm
 function getCommitFromPreviousPayloadUpload(): string {
   if (isTravisMasterBuild()) {
     const commitRange = process.env['TRAVIS_COMMIT_RANGE'];
-    // In some situations Travis will include multiple commits in a single Travis Job. This means
+    // In some situations, Travis will include multiple commits in a single Travis Job. This means
     // that we can't just resolve the previous commit by using the parent commit of HEAD.
-    // By resolving the amount of commits inside of the current Travis Job we can figure out
+    // By resolving the amount of commits inside of the current Travis Job, we can figure out
     // how many commits before HEAD the last Travis Job ran.
     const commitCount = spawnSync('git', ['rev-list', '--count', commitRange]).stdout
       .toString().trim();
-    // With the amount of commits inside of the current Travis Job we can query Git to print
+    // With the amount of commits inside of the current Travis Job, we can query Git to print
     // the SHA of the commit that ran before this Travis Job was created.
     return spawnSync('git', ['rev-parse', `HEAD~${commitCount}`]).stdout.toString().trim();
   } else {
     // Travis applies the changes of Pull Requests in new branches. This means that resolving
-    // the commit, that previously ran on the target branch (mostly "master"), can be done
+    // the commit that previously ran on the target branch (mostly "master") can be done
     // by just loading the SHA of the most recent commit in the target branch.
     return spawnSync('git', ['rev-parse', process.env['TRAVIS_BRANCH']]).stdout.toString().trim();
   }

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -4,6 +4,7 @@ import {statSync} from 'fs';
 import {isTravisBuild, isTravisMasterBuild} from '../util/travis-ci';
 import {buildConfig} from '../packaging/build-config';
 import {openFirebaseDashboardApp, openFirebaseDashboardAppAsGuest} from '../util/firebase';
+import {spawnSync} from 'child_process';
 import * as firebaseAdmin from 'firebase-admin';
 
 
@@ -78,13 +79,16 @@ async function calculatePayloadDiff(database: firebaseAdmin.database.Database, c
     return;
   }
 
-  const previousPayload = await getLastPayloadResults(database);
+  const previousSha = getCommitFromPreviousPayloadUpload();
+  const previousPayload = await getPayloadResults(database, previousSha);
 
   if (!previousPayload) {
     console.warn('There are no previous payload results uploaded. Cannot calculate payload ' +
       'difference for this job');
     return;
   }
+
+  console.log(`Comparing payload against payload results from SHA ${previousSha}`);
 
   // Calculate the payload diffs by subtracting the previous size of the FESM ES2015 bundles.
   const cdkFullSize = currentPayload.cdk_fesm_2015;
@@ -139,15 +143,24 @@ async function uploadPayloadResults(database: firebaseAdmin.database.Database, c
 }
 
 /** Gets the last payload uploaded from previous Travis builds. */
-async function getLastPayloadResults(database: firebaseAdmin.database.Database) {
-  const snapshot = await database.ref('payloads')
-    .orderByChild('timestamp')
-    .limitToLast(1)
-    .once('value');
+async function getPayloadResults(database: firebaseAdmin.database.Database, commitSha: string) {
+  const snapshot = await database.ref('payloads').child(commitSha).once('value');
 
-  // The value of the DataSnapshot is an object with the SHA as a key. Later only the
-  // first value of the object will be returned because the SHA is unnecessary.
-  const results = snapshot.val();
+  if (!snapshot.exists()) {
+    throw `There is no payload data uploaded for SHA ${commitSha}`;
+  }
 
-  return snapshot.hasChildren() ? results[Object.keys(results)[0]] : null;
+  return snapshot.val();
+}
+
+/** Gets the SHA of the commit where the payload was uploaded before this Travis Job started. */
+function getCommitFromPreviousPayloadUpload(): string {
+  if (isTravisMasterBuild()) {
+    const commitRange = process.env['TRAVIS_COMMIT_RANGE'];
+    const commitCount = spawnSync('git', ['rev-list', '--count', commitRange]).stdout
+      .toString().trim();
+    return spawnSync('git', ['rev-parse', `HEAD~${commitCount}`]).stdout.toString().trim();
+  } else {
+    return spawnSync('git', ['rev-parse', process.env['TRAVIS_BRANCH']]).stdout.toString().trim();
+  }
 }


### PR DESCRIPTION
Currently the previous payload is just the latest uploaded payload result on Firebase. This is problematic because it can happen that the current payload is uploaded "too fast" and the payload task is comparing against itself.

Just calculating before uploading could work most of the time, but there it would still fail if another Travis Job uploades payload results at the same time.

The safest solution would be resolving the parent commit of the current Travis job. This way the payload diff would be always correct (even if multiple Jobs are running).