### PR TITLE
Revert "fix(portal): detect changes for portal hostview  while before attaching. (#4370)"

### DIFF
--- a/src/lib/core/portal/dom-portal-host.ts
+++ b/src/lib/core/portal/dom-portal-host.ts
@@ -29,17 +29,21 @@ export class DomPortalHost extends BasePortalHost {
    */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     let componentFactory = this._componentFactoryResolver.resolveComponentFactory(portal.component);
-    let componentRef = componentFactory.create(portal.injector || this._defaultInjector);
-    componentRef.hostView.detectChanges();
+    let componentRef: ComponentRef<T>;
 
     // If the portal specifies a ViewContainerRef, we will use that as the attachment point
     // for the component (in terms of Angular's component tree, not rendering).
     // When the ViewContainerRef is missing, we use the factory to create the component directly
     // and then manually attach the view to the application.
     if (portal.viewContainerRef) {
-      portal.viewContainerRef.insert(componentRef.hostView);
+      componentRef = portal.viewContainerRef.createComponent(
+          componentFactory,
+          portal.viewContainerRef.length,
+          portal.injector || portal.viewContainerRef.parentInjector);
+
       this.setDisposeFn(() => componentRef.destroy());
     } else {
+      componentRef = componentFactory.create(portal.injector || this._defaultInjector);
       this._appRef.attachView(componentRef.hostView);
       this.setDisposeFn(() => {
         this._appRef.detachView(componentRef.hostView);

--- a/src/lib/core/portal/portal.spec.ts
+++ b/src/lib/core/portal/portal.spec.ts
@@ -368,12 +368,6 @@ describe('Portals', () => {
 
       expect(spy).toHaveBeenCalled();
     });
-
-    it('should run change detection in the created component when a ComponentPortal is attached',
-      () => {
-        host.attach(new ComponentPortal(ComponentWithBoundVariable, someViewContainerRef));
-        expect(someDomElement.textContent).toContain('initial value');
-      });
   });
 });
 
@@ -408,15 +402,6 @@ class PizzaMsg {
 })
 class ArbitraryViewContainerRefComponent {
   constructor(public viewContainerRef: ViewContainerRef, public injector: Injector) { }
-}
-
-/** Simple component with a bound variable in the template */
-@Component({
-  selector: 'bound-text',
-  template: '<p>{{text}}</p>'
-})
-class ComponentWithBoundVariable {
-  text: string = 'initial value';
 }
 
 
@@ -468,12 +453,7 @@ class PortalTestApp {
 
 // Create a real (non-test) NgModule as a workaround for
 // https://github.com/angular/angular/issues/10760
-const TEST_COMPONENTS = [
-  PortalTestApp,
-  ArbitraryViewContainerRefComponent,
-  PizzaMsg,
-  ComponentWithBoundVariable
-];
+const TEST_COMPONENTS = [PortalTestApp, ArbitraryViewContainerRefComponent, PizzaMsg];
 @NgModule({
   imports: [CommonModule, PortalModule],
   exports: TEST_COMPONENTS,

--- a/src/lib/datepicker/datepicker-content.html
+++ b/src/lib/datepicker/datepicker-content.html
@@ -1,10 +1,10 @@
 <md-calendar cdkTrapFocus
-    [id]="datepicker?.id"
-    [startAt]="datepicker?.startAt"
-    [startView]="datepicker?.startView"
-    [minDate]="datepicker?._minDate"
-    [maxDate]="datepicker?._maxDate"
-    [dateFilter]="datepicker?._dateFilter"
-    [selected]="datepicker?._selected"
-    (selectedChange)="datepicker?._selectAndClose($event)">
+    [id]="datepicker.id"
+    [startAt]="datepicker.startAt"
+    [startView]="datepicker.startView"
+    [minDate]="datepicker._minDate"
+    [maxDate]="datepicker._maxDate"
+    [dateFilter]="datepicker._dateFilter"
+    [selected]="datepicker._selected"
+    (selectedChange)="datepicker._selectAndClose($event)">
 </md-calendar>

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -34,7 +34,7 @@ describe('MdDatepicker', () => {
             let adapter = new NativeDateAdapter();
             adapter.setLocale('en-US');
             return adapter;
-          }}
+          }},
         ],
         declarations: [
           DatepickerWithFilterAndValidation,
@@ -42,6 +42,7 @@ describe('MdDatepicker', () => {
           DatepickerWithMinAndMaxValidation,
           DatepickerWithNgModel,
           DatepickerWithStartAt,
+          DatepickerWithStartView,
           DatepickerWithToggle,
           InputContainerDatepicker,
           MultiInputDatepicker,
@@ -200,6 +201,35 @@ describe('MdDatepicker', () => {
 
       it('explicit startAt should override input value', () => {
         expect(testComponent.datepicker.startAt).toEqual(new Date(2010, JAN, 1));
+      });
+    });
+
+    describe('datepicker with startView', () => {
+      let fixture: ComponentFixture<DatepickerWithStartView>;
+      let testComponent: DatepickerWithStartView;
+
+      beforeEach(async(() => {
+        fixture = TestBed.createComponent(DatepickerWithStartView);
+        fixture.detectChanges();
+
+        testComponent = fixture.componentInstance;
+      }));
+
+      afterEach(async(() => {
+        testComponent.datepicker.close();
+        fixture.detectChanges();
+      }));
+
+      it('should start at the specified view', () => {
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+
+        const firstCalendarCell = document.querySelector('.mat-calendar-body-cell');
+
+        // When the calendar is in year view, the first cell should be for a month rather than
+        // for a date.
+        expect(firstCalendarCell.textContent)
+            .toBe('JAN', 'Expected the calendar to be in year-view');
       });
     });
 
@@ -694,6 +724,18 @@ class NoInputDatepicker {
 class DatepickerWithStartAt {
   date = new Date(2020, JAN, 1);
   startDate = new Date(2010, JAN, 1);
+  @ViewChild('d') datepicker: MdDatepicker<Date>;
+}
+
+
+@Component({
+  template: `
+    <input [mdDatepicker]="d" [value]="date">
+    <md-datepicker #d startView="year"></md-datepicker>
+  `,
+})
+class DatepickerWithStartView {
+  date = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
 }
 

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -49,7 +49,7 @@ let datepickerUid = 0;
   styleUrls: ['datepicker-content.css'],
   host: {
     'class': 'mat-datepicker-content',
-    '[class.mat-datepicker-content-touch]': 'datepicker?.touchUi',
+    '[class.mat-datepicker-content-touch]': 'datepicker.touchUi',
     '(keydown)': '_handleKeydown($event)',
   },
   encapsulation: ViewEncapsulation.None,

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -123,6 +123,11 @@ export class MdSnackBar {
     let containerRef: ComponentRef<MdSnackBarContainer> = overlayRef.attach(containerPortal);
     containerRef.instance.snackBarConfig = config;
 
+    // The snackbar animation needs the content to be resolved in order to transform the bar
+    // out of the view initially (so it can slide in). To make the content resolve, we manually
+    // detect changes.
+    containerRef.changeDetectorRef.detectChanges();
+
     return containerRef.instance;
   }
 


### PR DESCRIPTION
This reverts a change where `attachComponentPortal` in `DomPortalHost` would run `detectChanges` before attaching the embedded view to the view container. 

This revert came about because it broke some datepicker features, but ultimately brought to light that having a call to `detectChanges` here prevents the user from initializing anything on the portal component before change detection runs, which means that any kind of one-time initialization will no longer work. 

This also:
* Adds a test for the datepicker which would have caught this regression. 
* Fixes the original snackbar issue (#4318) by calling detectChanges in the snackbar code

Fixes #5065