### PR TITLE
refactor: shorter error constructors

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -62,7 +62,7 @@ export const MD_AUTOCOMPLETE_VALUE_ACCESSOR: any = {
  * Creates an error to be thrown when attempting to use an autocomplete trigger without a panel.
  */
 export function getMdAutocompleteMissingPanelError(): Error {
-  return new Error('Attempting to open an undefined instance of `md-autocomplete`. ' +
+  return Error('Attempting to open an undefined instance of `md-autocomplete`. ' +
                    'Make sure that the id passed to the `mdAutocomplete` is correct and that ' +
                    'you\'re attempting to open it after the ngAfterContentInit hook.');
 }

--- a/src/lib/core/compatibility/compatibility.ts
+++ b/src/lib/core/compatibility/compatibility.ts
@@ -16,7 +16,7 @@ export const MATERIAL_COMPATIBILITY_MODE = new InjectionToken<boolean>('md-compa
  * @docs-private
  */
 export function getMdCompatibilityInvalidPrefixError(prefix: string, nodeName: string) {
-  return new Error(`The "${prefix}-" prefix cannot be used in ng-material v1 compatibility mode. ` +
+  return Error(`The "${prefix}-" prefix cannot be used in ng-material v1 compatibility mode. ` +
                    `It was used on an "${nodeName.toLowerCase()}" element.`);
 }
 

--- a/src/lib/core/portal/portal-errors.ts
+++ b/src/lib/core/portal/portal-errors.ts
@@ -11,7 +11,7 @@
  * @docs-private
  */
 export function throwNullPortalError() {
-  throw new Error('Must provide a portal to attach');
+  throw Error('Must provide a portal to attach');
 }
 
 /**
@@ -19,7 +19,7 @@ export function throwNullPortalError() {
  * @docs-private
  */
 export function throwPortalAlreadyAttachedError() {
-  throw new Error('Host already has a portal attached');
+  throw Error('Host already has a portal attached');
 }
 
 /**
@@ -27,7 +27,7 @@ export function throwPortalAlreadyAttachedError() {
  * @docs-private
  */
 export function throwPortalHostAlreadyDisposedError() {
-  throw new Error('This PortalHost has already been disposed');
+  throw Error('This PortalHost has already been disposed');
 }
 
 /**
@@ -35,7 +35,7 @@ export function throwPortalHostAlreadyDisposedError() {
  * @docs-private
  */
 export function throwUnknownPortalTypeError() {
-  throw new Error('Attempting to attach an unknown Portal type. BasePortalHost accepts either' +
+  throw Error('Attempting to attach an unknown Portal type. BasePortalHost accepts either' +
                   'a ComponentPortal or a TemplatePortal.');
 }
 
@@ -44,7 +44,7 @@ export function throwUnknownPortalTypeError() {
  * @docs-private
  */
 export function throwNullPortalHostError() {
-  throw new Error('Attempting to attach a portal to a null PortalHost');
+  throw Error('Attempting to attach a portal to a null PortalHost');
 }
 
 /**
@@ -52,5 +52,5 @@ export function throwNullPortalHostError() {
  * @docs-privatew
  */
 export function throwNoPortalAttachedError() {
-  throw new Error('Attempting to detach a portal that is not attached to a host');
+  throw Error('Attempting to detach a portal that is not attached to a host');
 }

--- a/src/lib/datepicker/datepicker-errors.ts
+++ b/src/lib/datepicker/datepicker-errors.ts
@@ -8,7 +8,7 @@
 
 /** @docs-private */
 export function createMissingDateImplError(provider: string) {
-  return new Error(
+  return Error(
       `MdDatepicker: No provider found for ${provider}. You must import one of the following` +
       `modules at your application root: MdNativeDateModule, or provide a custom implementation.`);
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -198,7 +198,7 @@ export class MdDatepicker<D> implements OnDestroy {
    */
   _registerInput(input: MdDatepickerInput<D>): void {
     if (this._datepickerInput) {
-      throw new Error('An MdDatepicker can only be associated with a single input.');
+      throw Error('An MdDatepicker can only be associated with a single input.');
     }
     this._datepickerInput = input;
     this._inputSubscription =
@@ -211,7 +211,7 @@ export class MdDatepicker<D> implements OnDestroy {
       return;
     }
     if (!this._datepickerInput) {
-      throw new Error('Attempted to open an MdDatepicker with no associated input.');
+      throw Error('Attempted to open an MdDatepicker with no associated input.');
     }
 
     this.touchUi ? this._openAsDialog() : this._openAsPopup();

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -37,7 +37,7 @@ import {FocusTrapFactory, FocusTrap} from '../core/a11y/focus-trap';
  * @docs-private
  */
 export function throwMdDialogContentAlreadyAttachedError() {
-  throw new Error('Attempting to attach dialog content after content is already attached');
+  throw Error('Attempting to attach dialog content after content is already attached');
 }
 
 /**

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -104,7 +104,7 @@ export class MdGridList implements OnInit, AfterContentChecked {
   /** Throw a friendly error if cols property is missing */
   private _checkCols() {
     if (!this.cols) {
-      throw new Error(`md-grid-list: must pass in number of columns. ` +
+      throw Error(`md-grid-list: must pass in number of columns. ` +
                       `Example: <md-grid-list cols="3">`);
     }
   }

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -76,7 +76,7 @@ export class TileCoordinator {
   /** Finds the next available space large enough to fit the tile. */
   private _findMatchingGap(tileCols: number): number {
     if (tileCols > this.tracker.length) {
-      throw new Error(`md-grid-list: tile with colspan ${tileCols} is wider than ` +
+      throw Error(`md-grid-list: tile with colspan ${tileCols} is wider than ` +
                       `grid with cols="${this.tracker.length}".`);
     }
 

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -207,7 +207,7 @@ export class RatioTileStyler extends TileStyler {
     let ratioParts = value.split(':');
 
     if (ratioParts.length !== 2) {
-      throw new Error(`md-grid-list: invalid ratio given for row-height: "${value}"`);
+      throw Error(`md-grid-list: invalid ratio given for row-height: "${value}"`);
     }
 
     this.rowHeightRatio = parseFloat(ratioParts[0]) / parseFloat(ratioParts[1]);

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -27,7 +27,7 @@ import 'rxjs/add/observable/throw';
  * @docs-private
  */
 export function getMdIconNameNotFoundError(iconName: string): Error {
-  return new Error(`Unable to find icon with the name "${iconName}"`);
+  return Error(`Unable to find icon with the name "${iconName}"`);
 }
 
 
@@ -37,7 +37,7 @@ export function getMdIconNameNotFoundError(iconName: string): Error {
  * @docs-private
  */
 export function getMdIconNoHttpProviderError(): Error {
-  return new Error('Could not find Http provider for use with Angular Material icons. ' +
+  return Error('Could not find Http provider for use with Angular Material icons. ' +
                    'Please include the HttpModule from @angular/http in your app imports.');
 }
 
@@ -375,7 +375,7 @@ export class MdIconRegistry {
     div.innerHTML = str;
     const svg = div.querySelector('svg') as SVGElement;
     if (!svg) {
-      throw new Error('<svg> tag not found');
+      throw Error('<svg> tag not found');
     }
     return svg;
   }

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -128,7 +128,7 @@ export class MdIcon extends _MdIconMixinBase implements OnChanges, OnInit, CanCo
       case 2:
         return <[string, string]>parts;
       default:
-        throw new Error(`Invalid icon name: "${iconName}"`);
+        throw Error(`Invalid icon name: "${iconName}"`);
     }
   }
 

--- a/src/lib/input/input-container-errors.ts
+++ b/src/lib/input/input-container-errors.ts
@@ -8,21 +8,21 @@
 
 /** @docs-private */
 export function getMdInputContainerPlaceholderConflictError(): Error {
-  return new Error('Placeholder attribute and child element were both specified.');
+  return Error('Placeholder attribute and child element were both specified.');
 }
 
 /** @docs-private */
 export function getMdInputContainerUnsupportedTypeError(type: string): Error {
-  return new Error(`Input type "${type}" isn't supported by md-input-container.`);
+  return Error(`Input type "${type}" isn't supported by md-input-container.`);
 }
 
 /** @docs-private */
 export function getMdInputContainerDuplicatedHintError(align: string): Error {
-  return new Error(`A hint was already declared for 'align="${align}"'.`);
+  return Error(`A hint was already declared for 'align="${align}"'.`);
 }
 
 /** @docs-private */
 export function getMdInputContainerMissingMdInputError(): Error {
-  return new Error('md-input-container must contain an mdInput directive. ' +
+  return Error('md-input-container must contain an mdInput directive. ' +
                    'Did you forget to add mdInput to the native input or textarea element?');
 }

--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -11,7 +11,7 @@
  * @docs-private
  */
 export function throwMdMenuMissingError() {
-  throw new Error(`md-menu-trigger: must pass in an md-menu instance.
+  throw Error(`md-menu-trigger: must pass in an md-menu instance.
 
     Example:
       <md-menu #menu="mdMenu"></md-menu>
@@ -24,7 +24,7 @@ export function throwMdMenuMissingError() {
  * @docs-private
  */
 export function throwMdMenuInvalidPositionX() {
-  throw new Error(`x-position value must be either 'before' or after'.
+  throw Error(`x-position value must be either 'before' or after'.
       Example: <md-menu x-position="before" #menu="mdMenu"></md-menu>`);
 }
 
@@ -34,6 +34,6 @@ export function throwMdMenuInvalidPositionX() {
  * @docs-private
  */
 export function throwMdMenuInvalidPositionY() {
-  throw new Error(`y-position value must be either 'above' or below'.
+  throw Error(`y-position value must be either 'above' or below'.
       Example: <md-menu y-position="above" #menu="mdMenu"></md-menu>`);
 }

--- a/src/lib/select/select-errors.ts
+++ b/src/lib/select/select-errors.ts
@@ -12,7 +12,7 @@
  * @docs-private
  */
 export function getMdSelectDynamicMultipleError(): Error {
-  return new Error('Cannot change `multiple` mode of select after initialization.');
+  return Error('Cannot change `multiple` mode of select after initialization.');
 }
 
 /**
@@ -22,5 +22,5 @@ export function getMdSelectDynamicMultipleError(): Error {
  * @docs-private
  */
 export function getMdSelectNonArrayValueError(): Error {
-  return new Error('Cannot assign truthy non-array value to select in `multiple` mode.');
+  return Error('Cannot assign truthy non-array value to select in `multiple` mode.');
 }

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2556,7 +2556,7 @@ class SelectWithErrorSibling {
 })
 export class ThrowsErrorOnInit implements OnInit {
   ngOnInit() {
-    throw new Error('Oh no!');
+    throw Error('Oh no!');
   }
 }
 

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -31,7 +31,7 @@ import {DOCUMENT} from '@angular/platform-browser';
 
 /** Throws an exception when two MdSidenav are matching the same side. */
 export function throwMdDuplicatedSidenavError(align: string) {
-  throw new Error(`A sidenav was already declared for 'align="${align}"'`);
+  throw Error(`A sidenav was already declared for 'align="${align}"'`);
 }
 
 

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -92,7 +92,7 @@ export class MdSnackBarContainer extends BasePortalHost implements OnDestroy {
   /** Attach a component portal as content to this snack bar container. */
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
     if (this._portalHost.hasAttached()) {
-      throw new Error('Attempting to attach snack bar content after content is already attached');
+      throw Error('Attempting to attach snack bar content after content is already attached');
     }
 
     if (this.snackBarConfig.extraClasses) {
@@ -108,7 +108,7 @@ export class MdSnackBarContainer extends BasePortalHost implements OnDestroy {
 
   /** Attach a template portal as content to this snack bar container. */
   attachTemplatePortal(): Map<string, any> {
-    throw new Error('Not yet implemented');
+    throw Error('Not yet implemented');
   }
 
   /** Handle end of animations, updating the state of the snackbar. */

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -52,7 +52,7 @@ export const SCROLL_THROTTLE_MS = 20;
 
 /** Throws an error if the user supplied an invalid tooltip position. */
 export function throwMdTooltipInvalidPositionError(position: string) {
-  throw new Error(`Tooltip position "${position}" is invalid.`);
+  throw Error(`Tooltip position "${position}" is invalid.`);
 }
 
 /**


### PR DESCRIPTION
Uses the shorter `throw Error` syntax to throw errors, instead of `throw new Error`.