### PR TITLE
style(button-toggle, slider, expansion): remove base colors in themes

### DIFF
--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -25,7 +25,7 @@
 
   .mat-button-toggle-checked {
     background-color: mat-color($background, selected-button);
-    color: mat-color($foreground, base);
+    color: mat-color($foreground, secondary-text);
   }
 
   .mat-button-toggle-disabled {

--- a/src/lib/core/theming/_palette.scss
+++ b/src/lib/core/theming/_palette.scss
@@ -690,6 +690,7 @@ $mat-light-theme-foreground: (
   icon:              rgba(black, 0.54),
   icons:             rgba(black, 0.54),
   text:              rgba(black, 0.87),
+  slider-min:        rgba(black, 0.87),
   slider-off:        rgba(black, 0.26),
   slider-off-active: rgba(black, 0.38),
 );
@@ -707,6 +708,7 @@ $mat-dark-theme-foreground: (
   icon:              white,
   icons:             white,
   text:              white,
+  slider-min:        white,
   slider-off:        rgba(white, 0.3),
   slider-off-active: rgba(white, 0.3),
 );

--- a/src/lib/expansion/_expansion-theme.scss
+++ b/src/lib/expansion/_expansion-theme.scss
@@ -7,14 +7,14 @@
 
   .mat-expansion-panel {
     background: mat-color($background, card);
-    color: mat-color($foreground, base);
+    color: mat-color($foreground, text);
   }
 
   .mat-action-row {
     border-top-color: mat-color($foreground, divider);
   }
 
-  .mat-expansion-panel-header:focus, 
+  .mat-expansion-panel-header:focus,
   .mat-expansion-panel-header:hover {
     background: mat-color($background, hover);
   }

--- a/src/lib/slider/_slider-theme.scss
+++ b/src/lib/slider/_slider-theme.scss
@@ -24,7 +24,7 @@
   $mat-slider-off-color: mat-color($foreground, slider-off);
   $mat-slider-off-focused-color: mat-color($foreground, slider-off-active);
   $mat-slider-disabled-color: mat-color($foreground, slider-off);
-  $mat-slider-labeled-min-value-thumb-color: mat-color($foreground, base);
+  $mat-slider-labeled-min-value-thumb-color: mat-color($foreground, slider-min);
   $mat-slider-labeled-min-value-thumb-label-color: mat-color($foreground, slider-off);
   $mat-slider-focus-ring-color: mat-color($accent, default, 0.2);
   $mat-slider-focus-ring-min-value-color: mat-color($foreground, base, 0.12);


### PR DESCRIPTION
Removes use of `base` color in theme mixins

**Checked button toggle**
 - Light theme: black -> black 54%
 - Dark theme: white -> white 70%

**Slider min thumb**
 - Light theme: black -> black 87%

**Expansion panel**
 - Light theme: black -> black 87%
  