### PR TITLE
build: faster artifacts deploy script

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -42,8 +42,8 @@ publishPackage() {
   rm -rf ${repoDir}
   mkdir -p ${repoDir}
 
-  # Clone the repository
-  git clone ${repoUrl} ${repoDir}
+  # Clone the repository and only fetch the last commit to download less unused data.
+  git clone ${repoUrl} ${repoDir} --depth 1
 
   # Copy the build files to the repository
   rm -rf ${repoDir}/*

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -25,7 +25,7 @@ commitMessage="$(git log --oneline -n 1)"
 # create directory and clone test repo
 rm -rf $repoPath
 mkdir -p $repoPath
-git clone $repoUrl $repoPath
+git clone $repoUrl $repoPath --depth 1
 
 # Clean out repo directory and copy contents of dist/docs into it
 rm -rf $repoPath/*

--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -146,11 +146,11 @@ async function uploadPayloadResults(database: firebaseAdmin.database.Database, c
 async function getPayloadResults(database: firebaseAdmin.database.Database, commitSha: string) {
   const snapshot = await database.ref('payloads').child(commitSha).once('value');
 
-  if (!snapshot.exists()) {
-    throw `There is no payload data uploaded for SHA ${commitSha}`;
+  if (snapshot.exists()) {
+    return snapshot.val();
+  } else {
+    console.error(`There is no payload data uploaded for SHA ${commitSha}`);
   }
-
-  return snapshot.val();
 }
 
 /** Gets the SHA of the commit where the payload was uploaded before this Travis Job started. */


### PR DESCRIPTION
* Improves the artifacts deploy script by not cloning the whole history of the build repositories (all tags, commits).
* Less aggressive failing of the payload task if the previous payload is not uploaded (yet)