### PR TITLE
fix(input): invalid font declaration

### DIFF
--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -26,7 +26,7 @@
   $caption:       mat-typography-level(12px, 20px, 400),
   $button:        mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:         mat-typography-level(inherit, 1.125, 400)
+  $input:         mat-typography-level(16px, 1.125, 400)
 ) {
   @return (
     font-family:    $font-family,

--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -142,7 +142,10 @@
   }
 
   .mat-input-container {
-    @include mat-typography-level-to-styles($config, input);
+    font-family: mat-font-family($config);
+    font-size: inherit;
+    font-weight: mat-font-weight($config, input);
+    line-height: mat-line-height($config, input);
   }
 
   .mat-input-wrapper {


### PR DESCRIPTION
Fixes the `font` declaration on the `md-input-container` being ignored, because it was invalid.

Note: I updated the font size to the correct value from [the spec](https://material.io/guidelines/components/text-fields.html#text-fields-states), however I'm not using it, in order to avoid any breaking changes. Also note that since the line height wasn't being used before, the baseline is now slightly off when next to a select.

Fixes #5262.