### PR TITLE
fix(memory leak): memory leaking in UniqueSelectionDispatcher

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -376,11 +376,12 @@ export class MdButtonToggle implements OnInit, OnDestroy {
     this.buttonToggleGroupMultiple = toggleGroupMultiple;
 
     if (this.buttonToggleGroup) {
-      this._buttonToggleDispatcherListener = _buttonToggleDispatcher.listen((id: string, name: string) => {
-        if (id != this.id && name == this.name) {
-          this.checked = false;
-        }
-      });
+      this._buttonToggleDispatcherListener = _buttonToggleDispatcher.listen(
+        (id: string, name: string) => {
+          if (id != this.id && name == this.name) {
+            this.checked = false;
+          }
+        });
 
       this._type = 'radio';
       this.name = this.buttonToggleGroup.name;

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -16,6 +16,7 @@ import {
   HostBinding,
   Input,
   OnInit,
+  OnDestroy,
   Optional,
   Output,
   QueryList,
@@ -271,7 +272,7 @@ export class MdButtonToggleGroupMultiple extends _MdButtonToggleGroupMixinBase
     'class': 'mat-button-toggle'
   }
 })
-export class MdButtonToggle implements OnInit {
+export class MdButtonToggle implements OnInit, OnDestroy {
   /** Whether or not this button toggle is checked. */
   private _checked: boolean = false;
 
@@ -286,6 +287,9 @@ export class MdButtonToggle implements OnInit {
 
   /** Whether or not the button toggle is a single selection. */
   private _isSingleSelector: boolean = null;
+
+  /** Unregister function for _buttonToggleDispatcherListener **/
+  private _buttonToggleDispatcherListener: Function;
 
   @ViewChild('input') _inputElement: ElementRef;
 
@@ -372,7 +376,7 @@ export class MdButtonToggle implements OnInit {
     this.buttonToggleGroupMultiple = toggleGroupMultiple;
 
     if (this.buttonToggleGroup) {
-      _buttonToggleDispatcher.listen((id: string, name: string) => {
+      this._buttonToggleDispatcherListener = _buttonToggleDispatcher.listen((id: string, name: string) => {
         if (id != this.id && name == this.name) {
           this.checked = false;
         }
@@ -445,5 +449,12 @@ export class MdButtonToggle implements OnInit {
     event.source = this;
     event.value = this._value;
     this.change.emit(event);
+  }
+
+  // Unregister buttonToggleDispatcherListener on destroy
+  ngOnDestroy(): void {
+    if(this._buttonToggleDispatcherListener) {
+      this._buttonToggleDispatcherListener();
+    }
   }
 }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -454,7 +454,7 @@ export class MdButtonToggle implements OnInit, OnDestroy {
 
   // Unregister buttonToggleDispatcherListener on destroy
   ngOnDestroy(): void {
-    if(this._buttonToggleDispatcherListener) {
+    if (this._buttonToggleDispatcherListener) {
       this._buttonToggleDispatcherListener();
     }
   }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -288,8 +288,8 @@ export class MdButtonToggle implements OnInit, OnDestroy {
   /** Whether or not the button toggle is a single selection. */
   private _isSingleSelector: boolean = null;
 
-  /** Unregister function for _buttonToggleDispatcherListener **/
-  private _buttonToggleDispatcherListener: Function;
+  /** Unregister function for _buttonToggleDispatcher **/
+  private _removeUniqueSelectionListener: () => void = () => {};
 
   @ViewChild('input') _inputElement: ElementRef;
 
@@ -376,8 +376,8 @@ export class MdButtonToggle implements OnInit, OnDestroy {
     this.buttonToggleGroupMultiple = toggleGroupMultiple;
 
     if (this.buttonToggleGroup) {
-      this._buttonToggleDispatcherListener = _buttonToggleDispatcher.listen(
-        (id: string, name: string) => {
+      this._removeUniqueSelectionListener =
+        _buttonToggleDispatcher.listen((id: string, name: string) => {
           if (id != this.id && name == this.name) {
             this.checked = false;
           }
@@ -454,8 +454,6 @@ export class MdButtonToggle implements OnInit, OnDestroy {
 
   // Unregister buttonToggleDispatcherListener on destroy
   ngOnDestroy(): void {
-    if (this._buttonToggleDispatcherListener) {
-      this._buttonToggleDispatcherListener();
-    }
+    this._removeUniqueSelectionListener();
   }
 }

--- a/src/lib/core/coordination/unique-selection-dispatcher.spec.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.spec.ts
@@ -1,0 +1,32 @@
+import {UniqueSelectionDispatcher} from './unique-selection-dispatcher';
+
+
+describe('Unique selection dispatcher', () => {
+
+  describe('register', () => {
+    it('once unregistered the listener must not be called on notify', (done) => {
+      let dispatcher: UniqueSelectionDispatcher = new UniqueSelectionDispatcher();
+      let called = false;
+
+      // Register first listener
+      dispatcher.listen(() => {
+        called = true;
+      });
+
+      // Register a listener
+      let deregisterFn = dispatcher.listen(() => {
+        done.fail('Should not be called');
+      });
+
+      // Unregister
+      deregisterFn();
+
+      // Call registered listeners
+      dispatcher.notify('testId', 'testName');
+
+      expect(called).toBeTruthy('Registered listener must be called.');
+
+      done();
+    });
+  });
+});

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -36,9 +36,17 @@ export class UniqueSelectionDispatcher {
     }
   }
 
-  /** Listen for future changes to item selection. */
-  listen(listener: UniqueSelectionDispatcherListener) {
+  /**
+   * Listen for future changes to item selection.
+   * @return Function used to unregister listener
+   **/
+  listen(listener: UniqueSelectionDispatcherListener): Function {
     this._listeners.push(listener);
+    return () => {
+      this._listeners = this._listeners.filter((registered: UniqueSelectionDispatcherListener) => {
+        return listener !== registered;
+      });
+    }
   }
 }
 

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -40,7 +40,7 @@ export class UniqueSelectionDispatcher {
    * Listen for future changes to item selection.
    * @return Function used to unregister listener
    **/
-  listen(listener: UniqueSelectionDispatcherListener): Function {
+  listen(listener: UniqueSelectionDispatcherListener): () => void {
     this._listeners.push(listener);
     return () => {
       this._listeners = this._listeners.filter((registered: UniqueSelectionDispatcherListener) => {

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -46,7 +46,7 @@ export class UniqueSelectionDispatcher {
       this._listeners = this._listeners.filter((registered: UniqueSelectionDispatcherListener) => {
         return listener !== registered;
       });
-    }
+    };
   }
 }
 

--- a/src/lib/expansion/accordion-item.ts
+++ b/src/lib/expansion/accordion-item.ts
@@ -48,9 +48,12 @@ export class AccordionItem implements OnDestroy {
   }
   private _expanded: boolean;
 
+  /** Unregister function for _expansionDispatcherListener **/
+  private _expansionDispatcherListener: Function;
+
   constructor(@Optional() public accordion: CdkAccordion,
               protected _expansionDispatcher: UniqueSelectionDispatcher) {
-     _expansionDispatcher.listen((id: string, accordionId: string) => {
+     this._expansionDispatcherListener = _expansionDispatcher.listen((id: string, accordionId: string) => {
        if (this.accordion && !this.accordion.multi &&
            this.accordion.id === accordionId && this.id !== id) {
          this.expanded = false;
@@ -61,6 +64,7 @@ export class AccordionItem implements OnDestroy {
   /** Emits an event for the accordion item being destroyed. */
   ngOnDestroy() {
     this.destroyed.emit();
+    this._expansionDispatcherListener();
   }
 
   /** Toggles the expanded state of the accordion item. */

--- a/src/lib/expansion/accordion-item.ts
+++ b/src/lib/expansion/accordion-item.ts
@@ -48,13 +48,13 @@ export class AccordionItem implements OnDestroy {
   }
   private _expanded: boolean;
 
-  /** Unregister function for _expansionDispatcherListener **/
-  private _expansionDispatcherListener: Function;
+  /** Unregister function for _expansionDispatcher **/
+  private _removeUniqueSelectionListener: () => void = () => {};
 
   constructor(@Optional() public accordion: CdkAccordion,
               protected _expansionDispatcher: UniqueSelectionDispatcher) {
-     this._expansionDispatcherListener = _expansionDispatcher.listen(
-       (id: string, accordionId: string) => {
+     this._removeUniqueSelectionListener =
+       _expansionDispatcher.listen((id: string, accordionId: string) => {
          if (this.accordion && !this.accordion.multi &&
              this.accordion.id === accordionId && this.id !== id) {
            this.expanded = false;
@@ -65,7 +65,7 @@ export class AccordionItem implements OnDestroy {
   /** Emits an event for the accordion item being destroyed. */
   ngOnDestroy() {
     this.destroyed.emit();
-    this._expansionDispatcherListener();
+    this._removeUniqueSelectionListener();
   }
 
   /** Toggles the expanded state of the accordion item. */

--- a/src/lib/expansion/accordion-item.ts
+++ b/src/lib/expansion/accordion-item.ts
@@ -53,12 +53,13 @@ export class AccordionItem implements OnDestroy {
 
   constructor(@Optional() public accordion: CdkAccordion,
               protected _expansionDispatcher: UniqueSelectionDispatcher) {
-     this._expansionDispatcherListener = _expansionDispatcher.listen((id: string, accordionId: string) => {
-       if (this.accordion && !this.accordion.multi &&
-           this.accordion.id === accordionId && this.id !== id) {
-         this.expanded = false;
-       }
-     });
+     this._expansionDispatcherListener = _expansionDispatcher.listen(
+       (id: string, accordionId: string) => {
+         if (this.accordion && !this.accordion.multi &&
+             this.accordion.id === accordionId && this.id !== id) {
+           this.expanded = false;
+         }
+       });
     }
 
   /** Emits an event for the accordion item being destroyed. */

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -459,7 +459,7 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
   private _focusRipple: RippleRef;
 
   /** Unregister function for _radioDispatcher **/
-  private _radioDispatcherListener: Function;
+  private _removeUniqueSelectionListener: () => void = () => {};
 
   /** The native `<input type=radio>` element */
   @ViewChild('input') _inputElement: ElementRef;
@@ -476,11 +476,12 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.
     this.radioGroup = radioGroup;
 
-    this._radioDispatcherListener = _radioDispatcher.listen((id: string, name: string) => {
-      if (id != this.id && name == this.name) {
-        this.checked = false;
-      }
-    });
+    this._removeUniqueSelectionListener =
+      _radioDispatcher.listen((id: string, name: string) => {
+        if (id != this.id && name == this.name) {
+          this.checked = false;
+        }
+      });
   }
 
   /** Focuses the radio button. */
@@ -516,7 +517,7 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
 
   ngOnDestroy() {
     this._focusOriginMonitor.stopMonitoring(this._inputElement.nativeElement);
-    this._radioDispatcherListener();
+    this._removeUniqueSelectionListener();
   }
 
   /** Dispatch change event with current value. */

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -458,6 +458,9 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
   /** Reference to the current focus ripple. */
   private _focusRipple: RippleRef;
 
+  /** Unregister function for _radioDispatcher **/
+  private _radioDispatcherListener: Function;
+
   /** The native `<input type=radio>` element */
   @ViewChild('input') _inputElement: ElementRef;
 
@@ -473,7 +476,7 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.
     this.radioGroup = radioGroup;
 
-    _radioDispatcher.listen((id: string, name: string) => {
+    this._radioDispatcherListener = _radioDispatcher.listen((id: string, name: string) => {
       if (id != this.id && name == this.name) {
         this.checked = false;
       }
@@ -513,6 +516,7 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
 
   ngOnDestroy() {
     this._focusOriginMonitor.stopMonitoring(this._inputElement.nativeElement);
+    this._radioDispatcherListener();
   }
 
   /** Dispatch change event with current value. */


### PR DESCRIPTION
Listeners are only registered inside of `UniqueSelectionDispatcher`. But there were never removed causing in my case a small memory leak when using `MdButtonToggle`.

In this fix `UniqueSelectionDispatcher.listen` returns a function that removes the listener once called.