### PR TITLE
fix(dialog): set aria-labelledby based on the md-dialog-title

### DIFF
--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -66,6 +66,7 @@ export function throwMdDialogContentAlreadyAttachedError() {
   host: {
     'class': 'mat-dialog-container',
     '[attr.role]': '_config?.role',
+    '[attr.aria-labelledby]': '_ariaLabelledBy',
     '[@slideDialog]': '_state',
     '(@slideDialog.done)': '_onAnimationDone($event)',
   },
@@ -91,6 +92,9 @@ export class MdDialogContainer extends BasePortalHost {
 
   /** Emits the current animation state whenever it changes. */
   _onAnimationStateChange = new EventEmitter<AnimationEvent>();
+
+  /** ID of the element that should be considered as the dialog's label. */
+  _ariaLabelledBy: string | null = null;
 
   constructor(
     private _ngZone: NgZone,

--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, Optional, OnInit} from '@angular/core';
 import {MdDialogRef} from './dialog-ref';
+import {MdDialogContainer} from './dialog-container';
 
+/** Counter used to generate unique IDs for dialog elements. */
+let dialogElementUid = 0;
 
 /**
  * Button that will close the current dialog.
@@ -40,9 +43,22 @@ export class MdDialogClose {
  */
 @Directive({
   selector: '[md-dialog-title], [mat-dialog-title], [mdDialogTitle], [matDialogTitle]',
-  host: {'class': 'mat-dialog-title'},
+  host: {
+    'class': 'mat-dialog-title',
+    '[id]': 'id',
+  },
 })
-export class MdDialogTitle { }
+export class MdDialogTitle implements OnInit {
+  @Input() id = `md-dialog-title-${dialogElementUid++}`;
+
+  constructor(@Optional() private _container: MdDialogContainer) { }
+
+  ngOnInit() {
+    if (this._container && !this._container._ariaLabelledBy) {
+      Promise.resolve().then(() => this._container._ariaLabelledBy = this.id);
+    }
+  }
+}
 
 
 /**

--- a/src/lib/dialog/dialog-injector.ts
+++ b/src/lib/dialog/dialog-injector.ts
@@ -6,25 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, InjectionToken} from '@angular/core';
+import {Injector} from '@angular/core';
 import {MdDialogRef} from './dialog-ref';
-
-export const MD_DIALOG_DATA = new InjectionToken<any>('MdDialogData');
+import {MdDialogContainer} from './dialog-container';
 
 /** Custom injector type specifically for instantiating components with a dialog. */
 export class DialogInjector implements Injector {
   constructor(
     private _parentInjector: Injector,
-    private _dialogRef: MdDialogRef<any>,
-    private _data: any) { }
+    private _customTokens: WeakMap<any, any>) { }
 
   get(token: any, notFoundValue?: any): any {
-    if (token === MdDialogRef) {
-      return this._dialogRef;
-    }
+    const value = this._customTokens.get(token);
 
-    if (token === MD_DIALOG_DATA) {
-      return this._data;
+    if (typeof value !== 'undefined') {
+      return value;
     }
 
     return this._parentInjector.get<any>(token, notFoundValue);

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -21,11 +21,10 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {MdDialogModule} from './index';
-import {MdDialog} from './dialog';
+import {MdDialog, MD_DIALOG_DATA} from './dialog';
 import {MdDialogContainer} from './dialog-container';
 import {OverlayContainer, ESCAPE} from '../core';
 import {MdDialogRef} from './dialog-ref';
-import {MD_DIALOG_DATA} from './dialog-injector';
 import {dispatchKeyboardEvent} from '../core/testing/dispatch-events';
 
 
@@ -666,6 +665,17 @@ describe('MdDialog', () => {
 
       viewContainerFixture.whenStable().then(() => {
         expect(afterCloseCallback).toHaveBeenCalledWith(true);
+      });
+    }));
+
+    it('should set the aria-labelled by attribute to the id of the title', async(() => {
+      let title = overlayContainerElement.querySelector('[md-dialog-title]');
+      let container = overlayContainerElement.querySelector('md-dialog-container');
+
+      viewContainerFixture.whenStable().then(() => {
+        expect(title.id).toBeTruthy('Expected title element to have an id.');
+        expect(container.getAttribute('aria-labelledby'))
+            .toBe(title.id, 'Expected the aria-labelledby to match the title id.');
       });
     }));
 

--- a/src/lib/dialog/index.ts
+++ b/src/lib/dialog/index.ts
@@ -59,4 +59,3 @@ export * from './dialog-container';
 export * from './dialog-content-directives';
 export * from './dialog-config';
 export * from './dialog-ref';
-export {MD_DIALOG_DATA} from './dialog-injector';


### PR DESCRIPTION
* [Based on the accessibility guidelines](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal), these changes add the `aria-labelledby` to dialogs that use `md-dialog-title`, which causes the screen reader to read out the title. E.g. before NVDA would read out "Dialog", but now it reads out "Neptune dialog".
* Adds the MdDialogContainer instance to the dialog injector.
* Slight refactor of the dialog injector to make it a little easier to add more tokens.