### PR TITLE
chore: move OverlayModule and related providers into index file

### DIFF
--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -12,7 +12,7 @@ import {BidiModule} from './bidi/index';
 import {ObserveContentModule} from './observe-content/observe-content';
 import {MdOptionModule} from './option/index';
 import {PortalModule} from './portal/portal-directives';
-import {OverlayModule} from './overlay/overlay-directives';
+import {OverlayModule} from './overlay/index';
 import {A11yModule} from './a11y/index';
 import {MdSelectionModule} from './selection/index';
 import {MdRippleModule} from './ripple/index';

--- a/src/lib/core/overlay/index.ts
+++ b/src/lib/core/overlay/index.ts
@@ -5,13 +5,38 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {NgModule, Provider} from '@angular/core';
+import {Overlay} from './overlay';
+import {ScrollDispatchModule} from './scroll/index';
+import {PortalModule} from '../portal/portal-directives';
+import {ConnectedOverlayDirective, OverlayOrigin} from './overlay-directives';
+import {OverlayPositionBuilder} from './position/overlay-position-builder';
+import {VIEWPORT_RULER_PROVIDER} from './position/viewport-ruler';
+import {OVERLAY_CONTAINER_PROVIDER} from './overlay-container';
 
-export {Overlay, OVERLAY_PROVIDERS} from './overlay';
+
+export const OVERLAY_PROVIDERS: Provider[] = [
+  Overlay,
+  OverlayPositionBuilder,
+  VIEWPORT_RULER_PROVIDER,
+  OVERLAY_CONTAINER_PROVIDER,
+];
+
+@NgModule({
+  imports: [PortalModule, ScrollDispatchModule],
+  exports: [ConnectedOverlayDirective, OverlayOrigin, ScrollDispatchModule],
+  declarations: [ConnectedOverlayDirective, OverlayOrigin],
+  providers: [OVERLAY_PROVIDERS],
+})
+export class OverlayModule {}
+
+
+export {Overlay} from './overlay';
 export {OverlayContainer} from './overlay-container';
 export {FullscreenOverlayContainer} from './fullscreen-overlay-container';
 export {OverlayRef} from './overlay-ref';
 export {OverlayState} from './overlay-state';
-export {ConnectedOverlayDirective, OverlayOrigin, OverlayModule} from './overlay-directives';
+export {ConnectedOverlayDirective, OverlayOrigin} from './overlay-directives';
 export {ViewportRuler} from './position/viewport-ruler';
 
 export * from './position/connected-position';

--- a/src/lib/core/overlay/overlay-directives.spec.ts
+++ b/src/lib/core/overlay/overlay-directives.spec.ts
@@ -1,7 +1,7 @@
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {ConnectedOverlayDirective, OverlayModule, OverlayOrigin} from './overlay-directives';
+import {ConnectedOverlayDirective, OverlayModule, OverlayOrigin} from './index';
 import {OverlayContainer} from './overlay-container';
 import {ConnectedPositionStrategy} from './position/connected-position-strategy';
 import {ConnectedOverlayPositionChange} from './position/connected-position';

--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-    NgModule,
     Directive,
     EventEmitter,
     TemplateRef,
@@ -21,7 +20,7 @@ import {
     OnChanges,
     SimpleChanges,
 } from '@angular/core';
-import {Overlay, OVERLAY_PROVIDERS} from './overlay';
+import {Overlay} from './overlay';
 import {OverlayRef} from './overlay-ref';
 import {TemplatePortal} from '../portal/portal';
 import {OverlayState} from './overlay-state';
@@ -29,7 +28,6 @@ import {
     ConnectionPositionPair,
     ConnectedOverlayPositionChange
 } from './position/connected-position';
-import {PortalModule} from '../portal/portal-directives';
 import {ConnectedPositionStrategy} from './position/connected-position-strategy';
 import {Directionality, Direction} from '../bidi/index';
 import {Scrollable} from './scroll/scrollable';
@@ -37,7 +35,6 @@ import {ScrollStrategy} from './scroll/scroll-strategy';
 import {coerceBooleanProperty} from '../coercion/boolean-property';
 import {ESCAPE} from '../keyboard/keycodes';
 import {Subscription} from 'rxjs/Subscription';
-import {ScrollDispatchModule} from './scroll/index';
 
 
 /** Default set of positions for the overlay. Follows the behavior of a dropdown. */
@@ -326,12 +323,3 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
     });
   }
 }
-
-
-@NgModule({
-  imports: [PortalModule, ScrollDispatchModule],
-  exports: [ConnectedOverlayDirective, OverlayOrigin, ScrollDispatchModule],
-  declarations: [ConnectedOverlayDirective, OverlayOrigin],
-  providers: [OVERLAY_PROVIDERS],
-})
-export class OverlayModule {}

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -2,14 +2,17 @@ import {inject, TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {NgModule, Component, ViewChild, ViewContainerRef} from '@angular/core';
 import {TemplatePortalDirective, PortalModule} from '../portal/portal-directives';
 import {TemplatePortal, ComponentPortal} from '../portal/portal';
-import {Overlay} from './overlay';
-import {OverlayContainer} from './overlay-container';
-import {OverlayState} from './overlay-state';
-import {OverlayRef} from './overlay-ref';
-import {PositionStrategy} from './position/position-strategy';
-import {OverlayModule} from './overlay-directives';
-import {ViewportRuler} from './position/viewport-ruler';
-import {ScrollStrategy, ScrollDispatcher} from './scroll/index';
+import {
+  OverlayModule,
+  OverlayRef,
+  OverlayState,
+  OverlayContainer,
+  Overlay,
+  PositionStrategy,
+  ViewportRuler,
+  ScrollStrategy,
+  ScrollDispatcher,
+} from './index';
 
 
 describe('Overlay', () => {

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -12,14 +12,12 @@ import {
   ApplicationRef,
   Injector,
   NgZone,
-  Provider,
 } from '@angular/core';
 import {OverlayState} from './overlay-state';
 import {DomPortalHost} from '../portal/dom-portal-host';
 import {OverlayRef} from './overlay-ref';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
-import {VIEWPORT_RULER_PROVIDER} from './position/viewport-ruler';
-import {OverlayContainer, OVERLAY_CONTAINER_PROVIDER} from './overlay-container';
+import {OverlayContainer} from './overlay-container';
 import {ScrollStrategy, ScrollStrategyOptions} from './scroll/index';
 
 
@@ -99,11 +97,3 @@ export class Overlay {
     return new OverlayRef(portalHost, pane, state, scrollStrategy, this._ngZone);
   }
 }
-
-/** Providers for Overlay and its related injectables. */
-export const OVERLAY_PROVIDERS: Provider[] = [
-  Overlay,
-  OverlayPositionBuilder,
-  VIEWPORT_RULER_PROVIDER,
-  OVERLAY_CONTAINER_PROVIDER,
-];

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.spec.ts
@@ -1,8 +1,6 @@
 import {inject, TestBed, async, fakeAsync, ComponentFixture, tick} from '@angular/core/testing';
 import {NgModule, Component, ViewChild, ElementRef} from '@angular/core';
-import {ScrollDispatcher} from './scroll-dispatcher';
-import {OverlayModule} from '../overlay-directives';
-import {Scrollable} from './scrollable';
+import {OverlayModule, Scrollable, ScrollDispatcher} from '../index';
 import {dispatchFakeEvent} from '../../testing/dispatch-events';
 
 describe('Scroll Dispatcher', () => {

--- a/src/lib/sidenav/index.ts
+++ b/src/lib/sidenav/index.ts
@@ -10,7 +10,7 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MdCommonModule} from '../core';
 import {A11yModule} from '../core/a11y/index';
-import {OverlayModule} from '../core/overlay/overlay-directives';
+import {OverlayModule} from '../core/overlay/index';
 import {MdSidenav, MdSidenavContainer} from './sidenav';
 
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -16,11 +16,9 @@ import {AnimationEvent} from '@angular/animations';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {TooltipPosition, MdTooltip, MdTooltipModule, SCROLL_THROTTLE_MS} from './index';
-import {OverlayContainer} from '../core';
 import {Directionality, Direction} from '../core/bidi/index';
-import {OverlayModule} from '../core/overlay/overlay-directives';
+import {OverlayModule, Scrollable, OverlayContainer} from '../core/overlay/index';
 import {Platform} from '../core/platform/platform';
-import {Scrollable} from '../core/overlay/scroll/scrollable';
 import {dispatchFakeEvent} from '../core/testing/dispatch-events';
 
 


### PR DESCRIPTION
Moves the `OverlayModule` and the `OVERLAY_PROVIDERS` into the `index.ts`, as opposed to the `overlay-directives.ts`, in order to match the setup in the rest of the modules.