### PR TITLE
fix(select): md-optgroup not using typography styles

### DIFF
--- a/src/lib/core/option/_optgroup-theme.scss
+++ b/src/lib/core/option/_optgroup-theme.scss
@@ -1,5 +1,6 @@
 @import '../theming/palette';
 @import '../theming/theming';
+@import '../typography/typography-utils';
 
 @mixin mat-optgroup-theme($theme) {
   $foreground: map-get($theme, foreground);
@@ -10,5 +11,11 @@
 
   .mat-optgroup-disabled .mat-optgroup-label {
     color: mat-color($foreground, hint-text);
+  }
+}
+
+@mixin mat-optgroup-typography($config) {
+  .mat-optgroup-label {
+    @include mat-typography-level-to-styles($config, body-2);
   }
 }

--- a/src/lib/core/option/_optgroup.scss
+++ b/src/lib/core/option/_optgroup.scss
@@ -6,9 +6,5 @@
     @include mat-menu-item-base();
     @include user-select(none);
     cursor: default;
-
-    // TODO(crisbeto): should use the typography functions once #4375 is in.
-    font-weight: bold;
-    font-size: 14px;
   }
 }

--- a/src/lib/core/typography/_all-typography.scss
+++ b/src/lib/core/typography/_all-typography.scss
@@ -24,6 +24,7 @@
 @import '../../tooltip/tooltip-theme';
 @import '../../snack-bar/simple-snack-bar-theme';
 @import '../option/option-theme';
+@import '../option/optgroup-theme';
 
 
 // Includes all of the typographic styles.
@@ -53,5 +54,6 @@
   @include mat-tooltip-typography($config);
   @include mat-list-typography($config);
   @include mat-option-typography($config);
+  @include mat-optgroup-typography($config);
   @include mat-simple-snack-bar-typography($config);
 }


### PR DESCRIPTION
Resolves a TODO from a while ago to set up the `md-optgroup` to use the typography API. This wasn't done initially since the typography PR and the option group PR got in around the same time.