### PR TITLE
fix(overlay-container): overlay container throws an error if its wasn't set initially 

### DIFF
--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -25,7 +25,10 @@ export class OverlayContainer {
   get themeClass(): string { return this._themeClass; }
   set themeClass(value: string) {
     if (this._containerElement) {
-      this._containerElement.classList.remove(this._themeClass);
+
+      if (this._safeClassDefiner(this._themeClass)) {
+        this._containerElement.classList.remove(this._themeClass);
+      }
 
       if (value) {
         this._containerElement.classList.add(value);
@@ -60,6 +63,20 @@ export class OverlayContainer {
 
     document.body.appendChild(container);
     this._containerElement = container;
+  }
+
+  /***
+   * @description classList.contains throw error if get checked for empty string in classList
+   * @param className
+   * @return {boolean}
+   * @private
+   */
+  private _safeClassDefiner(className: string): boolean {
+    try {
+      return this._containerElement.classList.contains(className);
+    } catch (e) {
+      return false;
+    }
   }
 }
 

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -476,6 +476,14 @@ describe('OverlayContainer theming', () => {
     expect(overlayContainerElement.classList).not.toContain('initial-theme');
     expect(overlayContainerElement.classList).toContain('new-theme');
   });
+
+  it('should not throw error if previously-set theme initialy was not set', () => {
+    overlayContainer.themeClass = 'new-theme';
+    expect(overlayContainerElement.classList).toContain('new-theme');
+
+    expect( function(){ overlayContainer.themeClass = ''; }).not.toThrow();
+    expect(overlayContainerElement.classList).not.toContain('new-theme');
+  });
 });
 
 /** Simple component for testing ComponentPortal. */


### PR DESCRIPTION
fix(overlay-container): if initial theme overlay container was not set after toggle the class error occurred

We're using `ngrx` and we have themes in store, our initial state is empty (''), when we try switch (e.g to dark and back to empty error occurs `Uncaught DOMException: Failed to execute 'contains' on 'DOMTokenList': The token provided must not be empty.` this PR able to fix it

test(overlay): test for safe toggle theme of theme wasn't initialized