### PR TITLE
build: remove duplicate licenses in bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7491,6 +7491,12 @@
         }
       }
     },
+    "magic-string": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.21.3.tgz",
+      "integrity": "sha1-h+IBAJ6/3m9G3FdXMFpwr3HjFiQ=",
+      "dev": true
+    },
     "make-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "karma-sauce-launcher": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "madge": "^1.6.0",
+    "magic-string": "^0.21.3",
     "merge2": "^1.0.3",
     "minimist": "^1.2.0",
     "node-sass": "^4.5.3",

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "noUnusedParameters": true,
     "importHelpers": true,
+    "newLine": "lf",
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "../../dist/packages/cdk",

--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "noUnusedParameters": true,
     "importHelpers": true,
+    "newLine": "lf",
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "../../dist/packages/material",

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {ScriptTarget, ModuleKind} from 'typescript';
+import {ScriptTarget, ModuleKind, NewLineKind} from 'typescript';
 import {uglifyJsFile} from './minify-sources';
 import {createRollupBundle} from './rollup-helpers';
 import {remapSourcemap} from './sourcemap-remap';
@@ -38,7 +38,8 @@ export async function buildPackageBundles(entryFile: string, packageName: string
     importHelpers: true,
     target: ScriptTarget.ES5,
     module: ModuleKind.ES2015,
-    allowJs: true
+    allowJs: true,
+    newLine: NewLineKind.LineFeed
   });
 
   await remapSourcemap(fesm2014File);

--- a/tools/package-tools/rollup-helpers.ts
+++ b/tools/package-tools/rollup-helpers.ts
@@ -1,4 +1,5 @@
 import {buildConfig} from './build-config';
+import {rollupRemoveLicensesPlugin} from './rollup-remove-licenses';
 
 // There are no type definitions available for these imports.
 const rollup = require('rollup');
@@ -59,10 +60,11 @@ export type BundleConfig = {
 
 /** Creates a rollup bundle of a specified JavaScript file.*/
 export function createRollupBundle(config: BundleConfig): Promise<any> {
-  const bundleOptions: any = {
+  const bundleOptions = {
     context: 'this',
     external: Object.keys(ROLLUP_GLOBALS),
     entry: config.entry,
+    plugins: [rollupRemoveLicensesPlugin]
   };
 
   const writeOptions = {
@@ -79,7 +81,7 @@ export function createRollupBundle(config: BundleConfig): Promise<any> {
   // When creating a UMD, we want to exclude tslib from the `external` bundle option so that it
   // is inlined into the bundle.
   if (config.format === 'umd') {
-    bundleOptions.plugins = [rollupNodeResolutionPlugin()];
+    bundleOptions.plugins.push(rollupNodeResolutionPlugin());
 
     const external = Object.keys(ROLLUP_GLOBALS);
     external.splice(external.indexOf('tslib'), 1);

--- a/tools/package-tools/rollup-remove-licenses.ts
+++ b/tools/package-tools/rollup-remove-licenses.ts
@@ -1,0 +1,26 @@
+import {buildConfig} from './build-config';
+import MagicString from 'magic-string';
+
+/** License banner from the build config that will be removed in all source files. */
+const licenseBanner = buildConfig.licenseBanner;
+
+/**
+ * Rollup plugin that removes all license banners of source files.
+ * This is necessary to avoid having the license comment repeated in the output.
+ */
+export const rollupRemoveLicensesPlugin = {
+  name: 'rollup-clean-duplicate-licenses',
+  transform: (code: string) => {
+    const newContent = new MagicString(code);
+
+    // Walks through every occurrence of a license comment and overwrites it with an empty string.
+    for (let pos = -1; (pos = code.indexOf(licenseBanner, pos + 1)) !== -1; null) {
+      newContent.overwrite(pos, pos + licenseBanner.length, '');
+    }
+
+    return {
+      code: newContent.toString(),
+      map:  newContent.generateMap({ hires: true })
+    };
+  }
+};


### PR DESCRIPTION
* No longer includes the license comments from every source file in the different FESM and UMD bundles.
* Build packages are now emitted with explicit `LF` line endings instead of platform dependent line endings.