### PR TITLE
build: keep license comment in minified umd

### DIFF
--- a/tools/package-tools/minify-sources.ts
+++ b/tools/package-tools/minify-sources.ts
@@ -7,8 +7,10 @@ const uglify = require('uglify-js');
 export function uglifyJsFile(inputPath: string, outputPath: string) {
   const sourcemapOut = `${outputPath}.map`;
   const result = uglify.minify(inputPath, {
-    preserveComments: 'license',
-    outSourceMap: sourcemapOut
+    outSourceMap: sourcemapOut,
+    output: {
+      comments: 'some'
+    }
   });
 
   writeFileSync(outputPath, result.code);


### PR DESCRIPTION
* The `preserveComments` option from the old uglify gulp plugin is not valid for the programmatic API. Setting the `comments` option `some` means that license commens will be preserved.
