### PR TITLE
chore: fix error when searching for special characters in the autocomplete demo

### DIFF
--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -88,8 +88,11 @@ export class AutocompleteDemo {
   }
 
   filterStates(val: string) {
-    return val ? this.states.filter(s => new RegExp(`^${val}`, 'gi').test(s.name))
-               : this.states;
-  }
+    if (val) {
+      const filterValue = val.toLowerCase();
+      return this.states.filter(state => state.name.toLowerCase().startsWith(filterValue));
+    }
 
+    return this.states;
+  }
 }


### PR DESCRIPTION
Fixes regex special characters causing the autocomplete in the demo app to throw.

Relates to #3373.