### PR TITLE
build: payload task fails if functions are down

### DIFF
--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -127,7 +127,7 @@ async function updateGithubStatus(commitSha: string, packageName: string, packag
       if (err) {
         reject(`Dashboard Error ${err.toString()}`);
       } else {
-        console.info('Dashboard Response:', JSON.parse(body).message);
+        console.info(`Dashboard Response (${response.statusCode}): ${body}`);
         resolve(response.statusCode);
       }
     });


### PR DESCRIPTION
It can happen that the firebase `payloadGithubStatus` function is temporary disabled because a deploy failed (for example due to deploying while function executes).

This leads to a failure inside of the payload CI task because the task is trying to parse the body using JSON (which is not always a JSON response)

It's not worth trying to parse the JSON value since it's only used for debugging and to give an insight what's going on in the functions.

**Note**: As mentioned we can also try to parse the JSON if it's a json, but this doesn't really have any big benefits and it feels nicer to print the whole JSON which is readable already.