### PR TITLE
fix(list-demo) list images not found

### DIFF
--- a/src/demo-app/list/list-demo.ts
+++ b/src/demo-app/list/list-demo.ts
@@ -25,19 +25,19 @@ export class ListDemo {
       from: 'Nancy',
       subject: 'Brunch?',
       message: 'Did you want to go on Sunday? I was thinking that might work.',
-      image: 'https://angular.io/resources/images/bios/julie-ralph.jpg'
+      image: 'https://angular.io/generated/images/bios/julie-ralph.jpg'
     },
     {
       from: 'Mary',
       subject: 'Summer BBQ',
       message: 'Wish I could come, but I have some prior obligations.',
-      image: 'https://angular.io/resources/images/bios/juleskremer.jpg'
+      image: 'https://angular.io/generated/images/bios/juleskremer.jpg'
     },
     {
       from: 'Bobby',
       subject: 'Oui oui',
       message: 'Do you have Paris reservations for the 15th? I just booked!',
-      image: 'https://angular.io/resources/images/bios/jelbourn.jpg'
+      image: 'https://angular.io/generated/images/bios/jelbourn.jpg'
     }
   ];
 


### PR DESCRIPTION
Fixes the paths of the images in the list-demo example
from
`https://angular.io/resources/images/…`
to
`https://angular.io/generated/images/…`

![screen shot 2017-06-20 at 14 11 45](https://user-images.githubusercontent.com/4140990/27333940-ea13ac54-55c7-11e7-9aec-04ee2851b9e5.png)
