### PR TITLE
fix(select): expose focus method

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1688,6 +1688,14 @@ describe('MdSelect', () => {
         subscription.unsubscribe();
       });
 
+      it('should be able to focus the select trigger', () => {
+        document.body.focus(); // ensure that focus isn't on the trigger already
+
+        fixture.componentInstance.select.focus();
+
+        expect(document.activeElement).toBe(select, 'Expected select element to be focused.');
+      });
+
     });
 
     describe('for options', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -397,7 +397,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
         this._placeholderState = '';
       }
 
-      this._focusHost();
+      this.focus();
     }
   }
 
@@ -752,8 +752,8 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
     }
   }
 
-  /** Focuses the host element when the panel closes. */
-  private _focusHost(): void {
+  /** Focuses the select element. */
+  focus(): void {
     this._elementRef.nativeElement.focus();
   }
 


### PR DESCRIPTION
Exposes the `focus` method from `md-select` for consistency with `md-input-container`.

Fixes #5251.