### PR TITLE
fix(overlay): remove webkit tap highlight from backdrop

### DIFF
--- a/src/lib/core/overlay/_overlay.scss
+++ b/src/lib/core/overlay/_overlay.scss
@@ -47,6 +47,7 @@
 
     z-index: $cdk-z-index-overlay-backdrop;
     pointer-events: auto;
+    -webkit-tap-highlight-color: transparent;
 
     // TODO(jelbourn): figure out if there are actually spec'ed colors for both light and dark
     // themes here. Currently using the values from AngularJS Material.


### PR DESCRIPTION
Removes the native Webkit tap highlight from the overlay backdrop. This prevents a dark tint from being added when tapping away from an overlay.