### PR TITLE
refactor(button, chips): use toString method for aria-disabled

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -193,7 +193,7 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
              a[mat-button], a[mat-raised-button], a[mat-icon-button], a[mat-fab], a[mat-mini-fab]`,
   host: {
     '[attr.disabled]': 'disabled || null',
-    '[attr.aria-disabled]': '_isAriaDisabled',
+    '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_haltDisabledEvents($event)',
   },
   inputs: ['disabled', 'color'],
@@ -214,10 +214,6 @@ export class MdAnchor extends MdButton {
   @HostBinding('tabIndex')
   get tabIndex(): number {
     return this.disabled ? -1 : 0;
-  }
-
-  get _isAriaDisabled(): string {
-    return this.disabled ? 'true' : 'false';
   }
 
   _haltDisabledEvents(event: Event) {

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -55,7 +55,7 @@ export class MdBasicChip { }
     'role': 'option',
     '[class.mat-chip-selected]': 'selected',
     '[attr.disabled]': 'disabled || null',
-    '[attr.aria-disabled]': '_isAriaDisabled()',
+    '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_handleClick($event)',
     '(focus)': '_hasFocus = true',
     '(blur)': '_hasFocus = false',
@@ -107,11 +107,6 @@ export class MdChip extends _MdChipMixinBase implements Focusable, OnDestroy, Ca
   focus(): void {
     this._elementRef.nativeElement.focus();
     this.onFocus.emit({chip: this});
-  }
-
-  /** The aria-disabled state for the chip */
-  _isAriaDisabled(): string {
-    return String(this.disabled);
   }
 
   /** Ensures events fire properly upon click. */


### PR DESCRIPTION
For buttons and chips the value of the aria-disabled host binding is resolved from an extra method on the class instance.

As already done in other components, the button and chips should just use `boolean.toString()` which is less payload and also makes the code more readable.