### PR TITLE
build: print logs if tunnel times out

### DIFF
--- a/scripts/browserstack/wait-tunnel.sh
+++ b/scripts/browserstack/wait-tunnel.sh
@@ -2,6 +2,13 @@
 
 TUNNEL_LOG="$LOGS_DIR/browserstack-tunnel.log"
 
+# Method that prints the logfile output of the browserstack tunnel.
+printLog() {
+  echo "Logfile output of Browserstack tunnel (${TUNNEL_LOG}):"
+  echo ""
+  cat ${TUNNEL_LOG}
+}
+
 # Wait for Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
 let "counter=0"
@@ -10,7 +17,7 @@ let "counter=0"
 if [ -f $BROWSER_PROVIDER_ERROR_FILE ]; then
   echo
   echo "An error occurred while starting the tunnel. See error:"
-  cat $TUNNEL_LOG
+  printLog
   exit 5
 fi
 
@@ -20,6 +27,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   if [ $counter -gt 240 ]; then
     echo
     echo "Timed out after 2 minutes waiting for tunnel ready file"
+    printLog
     exit 5
   fi
 

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -6,7 +6,7 @@ TUNNEL_FILE="sc-4.4.7-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 
-TUNNEL_LOG="${LOGS_DIR}/sauce-connect"
+TUNNEL_LOG="${LOGS_DIR}/saucelabs-tunnel.log"
 
 SAUCE_ACCESS_KEY=`echo ${SAUCE_ACCESS_KEY} | rev`
 

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+TUNNEL_LOG="$LOGS_DIR/saucelabs-tunnel.log"
+
+# Method that prints the logfile output of the saucelabs tunnel.
+printLog() {
+  echo "Logfile output of Saucelabs tunnel (${TUNNEL_LOG}):"
+  echo ""
+  cat ${TUNNEL_LOG}
+}
+
 # Wait for Saucelabs Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
 let "counter=0"
@@ -10,6 +19,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   if [ $counter -gt 240 ]; then
     echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
+    printLog
     exit 5
   fi
 


### PR DESCRIPTION
* The logfile output should be printed if the tunnel connection can't be established. The logging is also useful to see the update message from Saucelabs for example.