### PR TITLE
fix(input): underline showing at end if text-align is set

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -206,6 +206,7 @@ textarea.mat-input-element {
     position: absolute;
     height: $mat-input-underline-height * 2;
     top: 0;
+    left: 0;
     width: 100%;
     transform-origin: 50%;
     transform: scaleX(0.5);


### PR DESCRIPTION
Recently the `align` input binding has been removed in favor of the CSS property `text-align`.

If a developer sets the `text-align` property to `end` the text will start from the end and also the input underline will show incorrectly start from the end.

Setting the absolute positioned underline to `left: 0` ensures that the underline always shows-up correctly (because the `mat-input-underline` is inside of a relative container)


![](https://i.gyazo.com/361fa2fa95e316c6bc43f8c026db1da7.png)

**Note**: This still works with RTL because the `mat-input-underline` container is inside of a relative container and it uses a width of `100%`)

Fixes #5272