### PR TITLE
feat(dialog): 8px margin between dialog action buttons

### DIFF
--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -65,6 +65,6 @@ $mat-dialog-max-height: 65vh !default;
   }
 
   :last-child {
-    margin-right: 0px;
+    margin-right: 0;
   }
 }

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -59,4 +59,12 @@ $mat-dialog-max-height: 65vh !default;
   &[align='center'] {
     justify-content: center;
   }
+
+  :not(:last-child) {
+    margin-right: 8px;
+  }
+
+  :last-child {
+    margin-right: 0px;
+  }
 }


### PR DESCRIPTION
According to https://material.io/guidelines/components/dialogs.html#dialogs-specs there should be a margin of 8px between action buttons.