### PR TITLE
fix(select): enable hiding the asterisk even when required

### DIFF
--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -6,8 +6,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
   <md-card>
     <md-card-subtitle>ngModel</md-card-subtitle>
 
-    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired && !hideRequiredMarker"
-      [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder" #drinkControl="ngModel">
+    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired"
+      [hideRequiredMarker]="hideRequiredMarker" [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder"
+      #drinkControl="ngModel">
       <md-option>None</md-option>
       <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
         {{ drink.viewValue }}

--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -6,7 +6,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
   <md-card>
     <md-card-subtitle>ngModel</md-card-subtitle>
 
-    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired"
+    <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired && !hideRequiredMarker"
       [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder" #drinkControl="ngModel">
       <md-option>None</md-option>
       <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
@@ -36,6 +36,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <button md-button (click)="drinksRequired=!drinksRequired">TOGGLE REQUIRED</button>
     <button md-button (click)="drinksDisabled=!drinksDisabled">TOGGLE DISABLED</button>
     <button md-button (click)="drinkControl.reset()">RESET</button>
+    <button md-button (click)="hideRequiredMarker=!hideRequiredMarker">HIDE REQUIRED MARKER</button>
   </md-card>
 
   <md-card>

--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -7,8 +7,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <md-card-subtitle>ngModel</md-card-subtitle>
 
     <md-select placeholder="Drink" [color]="drinksTheme" [(ngModel)]="currentDrink" [required]="drinksRequired"
-      [hideRequiredMarker]="hideRequiredMarker" [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder"
-      #drinkControl="ngModel">
+        [hideRequiredMarker]="hideRequiredMarker" [disabled]="drinksDisabled" [floatPlaceholder]="floatPlaceholder"
+        #drinkControl="ngModel">
       <md-option>None</md-option>
       <md-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
         {{ drink.viewValue }}

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -11,6 +11,7 @@ import {MdSelectChange} from '@angular/material';
 export class SelectDemo {
   drinksRequired = false;
   pokemonRequired = false;
+  hideRequiredMarker: boolean = false;
   drinksDisabled = false;
   pokemonDisabled = false;
   showSelect = false;

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -72,7 +72,7 @@ $mat-select-panel-max-height: 256px !default;
   }
 
   // TODO: Double-check accessibility of this style
-  [aria-required=true] &::after {
+  .mat-select-show-required-marker[aria-required=true] &::after {
     content: '*';
   }
 }

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -693,8 +693,9 @@ describe('MdSelect', () => {
 
       fixture.componentInstance.hideRequiredMarker = true;
       fixture.detectChanges();
-      expect(initialContent === 'none' || initialContent === '')
-          .toBe(true, `Expected not to have an asterisk, as required marker was hidden.`);
+      const newContent = getComputedStyle(placeholder, '::after').getPropertyValue('content');
+      expect(newContent === 'none' || newContent === '')
+          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.`);
     });
 
     it('should be able to programmatically select a falsy option', () => {
@@ -2423,8 +2424,9 @@ describe('MdSelect', () => {
   template: `
     <div [style.height.px]="heightAbove"></div>
     <md-select placeholder="Food" [formControl]="control"
-      [required]="isRequired && !hideRequiredMarker" [tabIndex]="tabIndexOverride"
-      [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby" [panelClass]="panelClass">
+      [required]="isRequired" [hideRequiredMarker]="hideRequiredMarker"
+      [tabIndex]="tabIndexOverride" [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby"
+      [panelClass]="panelClass">
       <md-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
         {{ food.viewValue }}
       </md-option>

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -696,7 +696,7 @@ describe('MdSelect', () => {
       fixture.detectChanges();
       content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
       expect(content === 'none' || content === '')
-          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.' + content);
+          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.` + content);
     });
 
     it('should be able to programmatically select a falsy option', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -680,21 +680,22 @@ describe('MdSelect', () => {
     it('hide asterisk after the placeholder when set to hide the required marker', () => {
       const placeholder =
           fixture.debugElement.query(By.css('.mat-select-placeholder')).nativeElement;
-      const initialContent =  getComputedStyle(placeholder, '::after').getPropertyValue('content');
+      let content =  getComputedStyle(placeholder, '::after').getPropertyValue('content');
 
       // must support both default cases to work in all browsers in Saucelabs
-      expect(initialContent === 'none' || initialContent === '')
+      expect(content === 'none' || content === '')
           .toBe(true, `Expected placeholder not to have an asterisk, as control was not required.`);
 
       fixture.componentInstance.isRequired = true;
       fixture.detectChanges();
-      expect(getComputedStyle(placeholder, '::after').getPropertyValue('content'))
+      content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
+      expect(content)
           .toContain('*', `Expected placeholder to have an asterisk, as control was required.`);
 
       fixture.componentInstance.hideRequiredMarker = true;
       fixture.detectChanges();
-      const newContent = getComputedStyle(placeholder, '::after').getPropertyValue('content');
-      expect(newContent === 'none' || newContent === '')
+      content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
+      expect(content === 'none' || content === '')
           .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.`);
     });
 
@@ -2424,9 +2425,9 @@ describe('MdSelect', () => {
   template: `
     <div [style.height.px]="heightAbove"></div>
     <md-select placeholder="Food" [formControl]="control"
-      [required]="isRequired" [hideRequiredMarker]="hideRequiredMarker"
-      [tabIndex]="tabIndexOverride" [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby"
-      [panelClass]="panelClass">
+        [required]="isRequired" [hideRequiredMarker]="hideRequiredMarker"
+        [tabIndex]="tabIndexOverride" [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby"
+        [panelClass]="panelClass">
       <md-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
         {{ food.viewValue }}
       </md-option>

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -696,7 +696,7 @@ describe('MdSelect', () => {
       fixture.detectChanges();
       content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
       expect(content === 'none' || content === '')
-          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.`);
+          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.' + content);
     });
 
     it('should be able to programmatically select a falsy option', () => {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -695,6 +695,7 @@ describe('MdSelect', () => {
       fixture.componentInstance.hideRequiredMarker = true;
       fixture.detectChanges();
       content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
+      console.error(`test file error` + content);
       expect(content === 'none' || content === '')
           .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.`);
     });

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -677,6 +677,26 @@ describe('MdSelect', () => {
         .toContain('*', `Expected placeholder to have an asterisk, as control was required.`);
     });
 
+    it('hide asterisk after the placeholder when set to hide the required marker', () => {
+      const placeholder =
+          fixture.debugElement.query(By.css('.mat-select-placeholder')).nativeElement;
+      const initialContent =  getComputedStyle(placeholder, '::after').getPropertyValue('content');
+
+      // must support both default cases to work in all browsers in Saucelabs
+      expect(initialContent === 'none' || initialContent === '')
+          .toBe(true, `Expected placeholder not to have an asterisk, as control was not required.`);
+
+      fixture.componentInstance.isRequired = true;
+      fixture.detectChanges();
+      expect(getComputedStyle(placeholder, '::after').getPropertyValue('content'))
+          .toContain('*', `Expected placeholder to have an asterisk, as control was required.`);
+
+      fixture.componentInstance.hideRequiredMarker = true;
+      fixture.detectChanges();
+      expect(initialContent === 'none' || initialContent === '')
+          .toBe(true, `Expected not to have an asterisk, as required marker was hidden.`);
+    });
+
     it('should be able to programmatically select a falsy option', () => {
       fixture.destroy();
 
@@ -2402,9 +2422,9 @@ describe('MdSelect', () => {
   selector: 'basic-select',
   template: `
     <div [style.height.px]="heightAbove"></div>
-    <md-select placeholder="Food" [formControl]="control" [required]="isRequired"
-      [tabIndex]="tabIndexOverride" [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby"
-      [panelClass]="panelClass">
+    <md-select placeholder="Food" [formControl]="control"
+      [required]="isRequired && !hideRequiredMarker" [tabIndex]="tabIndexOverride"
+      [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby" [panelClass]="panelClass">
       <md-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
         {{ food.viewValue }}
       </md-option>
@@ -2425,6 +2445,7 @@ class BasicSelect {
   ];
   control = new FormControl();
   isRequired: boolean;
+  hideRequiredMarker: boolean;
   heightAbove = 0;
   heightBelow = 0;
   tabIndexOverride: number;

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -696,7 +696,7 @@ describe('MdSelect', () => {
       fixture.detectChanges();
       content = getComputedStyle(placeholder, '::after').getPropertyValue('content');
       expect(content === 'none' || content === '')
-          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.` + content);
+          .toBe(true, `Expected to hide the asterisk, as required marker was set to hidden.`);
     });
 
     it('should be able to programmatically select a falsy option', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -189,7 +189,6 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
    * The width of the trigger. Must be saved to set the min width of the overlay panel
    * and the width of the selected value.
    */
-
   _triggerWidth: number;
 
   /** Manages keyboard events for options in the panel. */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -132,6 +132,7 @@ export const _MdSelectMixinBase = mixinColor(mixinDisabled(MdSelectBase), 'prima
     '[attr.aria-invalid]': '_control?.invalid || "false"',
     '[attr.aria-owns]': '_optionIds',
     '[class.mat-select-disabled]': 'disabled',
+    '[class.mat-select-show-required-marker]': '!hideRequiredMarker',
     'class': 'mat-select',
     '(keydown)': '_handleClosedKeydown($event)',
     '(blur)': '_onBlur()',
@@ -160,6 +161,9 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   /** Whether filling out the select is required in the form.  */
   private _required: boolean = false;
 
+  /** Whether required marker is hidden in the placeholder.  */
+  private _hideRequiredMarker: boolean = false;
+
   /** The scroll position of the overlay panel, calculated to center the selected option. */
   private _scrollTop = 0;
 
@@ -185,6 +189,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
    * The width of the trigger. Must be saved to set the min width of the overlay panel
    * and the width of the selected value.
    */
+
   _triggerWidth: number;
 
   /** Manages keyboard events for options in the panel. */
@@ -268,6 +273,11 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   @Input()
   get required() { return this._required; }
   set required(value: any) { this._required = coerceBooleanProperty(value); }
+
+  /** Whether we should hide the required marker. */
+  @Input()
+  get hideRequiredMarker() { return this._hideRequiredMarker; }
+  set hideRequiredMarker(value: any) { this._hideRequiredMarker = coerceBooleanProperty(value); }
 
   /** Whether the user should be allowed to select multiple options. */
   @Input()

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -276,7 +276,9 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   /** Whether we should hide the required marker. */
   @Input()
   get hideRequiredMarker() { return this._hideRequiredMarker; }
-  set hideRequiredMarker(value: any) { this._hideRequiredMarker = coerceBooleanProperty(value); }
+  set hideRequiredMarker(value: any) {
+    console.error('required mark error' + value);
+    this._hideRequiredMarker = coerceBooleanProperty(value); }
 
   /** Whether the user should be allowed to select multiple options. */
   @Input()


### PR DESCRIPTION
This allows the user to hide the required marker (asterisk) from mdSelect even when the selection is required.

Fixes #4745 