### PR TITLE
refactor: make mixin base classes docs private

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -32,6 +32,7 @@ import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 export type ToggleType = 'checkbox' | 'radio';
 
 // Boilerplate for applying mixins to MdButtonToggleGroup and MdButtonToggleGroupMultiple
+/** @docs-private */
 export class MdButtonToggleGroupBase {}
 export const _MdButtonToggleGroupMixinBase = mixinDisabled(MdButtonToggleGroupBase);
 

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -100,6 +100,7 @@ export class MdMiniFab {
 
 
 // Boilerplate for applying mixins to MdButton.
+/** @docs-private */
 export class MdButtonBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -66,6 +66,7 @@ export class MdCheckboxChange {
 }
 
 // Boilerplate for applying mixins to MdCheckbox.
+/** @docs-private */
 export class MdCheckboxBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -26,6 +26,7 @@ export interface MdChipEvent {
 }
 
 // Boilerplate for applying mixins to MdChip.
+/** @docs-private */
 export class MdChipBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/core/option/optgroup.ts
+++ b/src/lib/core/option/optgroup.ts
@@ -10,6 +10,7 @@ import {Component, ViewEncapsulation, ContentChildren, QueryList, Input} from '@
 import {mixinDisabled, CanDisable} from '../common-behaviors/disabled';
 
 // Boilerplate for applying mixins to MdOptgroup.
+/** @docs-private */
 export class MdOptgroupBase { }
 export const _MdOptgroupMixinBase = mixinDisabled(MdOptgroupBase);
 

--- a/src/lib/core/selection/pseudo-checkbox/pseudo-checkbox.ts
+++ b/src/lib/core/selection/pseudo-checkbox/pseudo-checkbox.ts
@@ -19,6 +19,7 @@ export type MdPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
 
 // Boilerplate for applying mixins to MdChip.
+/** @docs-private */
 export class MdPseudoCheckboxBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -23,6 +23,7 @@ import {CanColor, mixinColor} from '../core/common-behaviors/color';
 
 
 // Boilerplate for applying mixins to MdIcon.
+/** @docs-private */
 export class MdIconBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -11,6 +11,7 @@ import {Focusable} from '../core/a11y/focus-key-manager';
 import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 
 // Boilerplate for applying mixins to MdMenuItem.
+/** @docs-private */
 export class MdMenuItemBase {}
 export const _MdMenuItemMixinBase = mixinDisabled(MdMenuItemBase);
 

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -57,6 +57,7 @@ type EasingFn = (currentTime: number, startValue: number,
 export class MdProgressSpinnerCssMatStyler {}
 
 // Boilerplate for applying mixins to MdProgressSpinner.
+/** @docs-private */
 export class MdProgressSpinnerBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -63,6 +63,7 @@ export class MdRadioChange {
 
 
 // Boilerplate for applying mixins to MdRadioGroup.
+/** @docs-private */
 export class MdRadioGroupBase { }
 export const _MdRadioGroupMixinBase = mixinDisabled(MdRadioGroupBase);
 
@@ -297,6 +298,7 @@ export class MdRadioGroup extends _MdRadioGroupMixinBase
 }
 
 // Boilerplate for applying mixins to MdRadioButton.
+/** @docs-private */
 export class MdRadioButtonBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -110,6 +110,7 @@ export class MdSelectChange {
 }
 
 // Boilerplate for applying mixins to MdSelect.
+/** @docs-private */
 export class MdSelectBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -54,6 +54,7 @@ let nextId = 0;
 
 
 // Boilerplate for applying mixins to MdSlideToggle.
+/** @docs-private */
 export class MdSlideToggleBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -71,6 +71,7 @@ export class MdSliderChange {
 
 
 // Boilerplate for applying mixins to MdSlider.
+/** @docs-private */
 export class MdSliderBase { }
 export const _MdSliderMixinBase = mixinDisabled(MdSliderBase);
 

--- a/src/lib/tabs/tab-label-wrapper.ts
+++ b/src/lib/tabs/tab-label-wrapper.ts
@@ -10,6 +10,7 @@ import {Directive, ElementRef} from '@angular/core';
 import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 
 // Boilerplate for applying mixins to MdTabLabelWrapper.
+/** @docs-private */
 export class MdTabLabelWrapperBase {}
 export const _MdTabLabelWrapperMixinBase = mixinDisabled(MdTabLabelWrapperBase);
 

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -15,6 +15,7 @@ import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 import {MdTabLabel} from './tab-label';
 
 // Boilerplate for applying mixins to MdTab.
+/** @docs-private */
 export class MdTabBase {}
 export const _MdTabMixinBase = mixinDisabled(MdTabBase);
 

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -24,6 +24,7 @@ import {CanColor, mixinColor} from '../core/common-behaviors/color';
 export class MdToolbarRow {}
 
 // Boilerplate for applying mixins to MdToolbar.
+/** @docs-private */
 export class MdToolbarBase {
   constructor(public _renderer: Renderer2, public _elementRef: ElementRef) {}
 }


### PR DESCRIPTION
* The base classes that are used to apply mixins should not be show up in the generated docs