### PR TITLE
fix(datepicker): allow disabling calendar popup

### DIFF
--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -3,25 +3,26 @@
   <md-checkbox [(ngModel)]="touch">Use touch UI</md-checkbox>
   <md-checkbox [(ngModel)]="filterOdd">Filter odd months and dates</md-checkbox>
   <md-checkbox [(ngModel)]="yearView">Start in year view</md-checkbox>
+  <md-checkbox [(ngModel)]="readOnly">Read-only mode</md-checkbox>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
     <button mdSuffix [mdDatepickerToggle]="minDatePicker"></button>
   </md-input-container>
-  <md-datepicker #minDatePicker [touchUi]="touch"></md-datepicker>
+  <md-datepicker #minDatePicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
   <md-input-container>
     <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
     <button mdSuffix [mdDatepickerToggle]="maxDatePicker"></button>
   </md-input-container>
-  <md-datepicker #maxDatePicker [touchUi]="touch"></md-datepicker>
+  <md-datepicker #maxDatePicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
     <button mdSuffix [mdDatepickerToggle]="startAtPicker"></button>
   </md-input-container>
-  <md-datepicker #startAtPicker [touchUi]="touch"></md-datepicker>
+  <md-datepicker #startAtPicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
 </p>
 
 <h2>Result</h2>
@@ -44,6 +45,7 @@
   <md-datepicker
       #resultPicker
       [touchUi]="touch"
+      [readOnly]="readOnly"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>
@@ -59,6 +61,7 @@
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"
+      [readOnly]="readOnly"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -28,7 +28,7 @@
 <h2>Result</h2>
 
 <p>
-  <button [mdDatepickerToggle]="resultPicker" [disabled]="resultPickerModel.disabled"></button>
+  <button [mdDatepickerToggle]="resultPicker"></button>
   <md-input-container>
     <input mdInput
            #resultPickerModel="ngModel"
@@ -84,8 +84,8 @@
 <p>
   <button [mdDatepickerToggle]="datePicker2"></button>
   <md-input-container>
-    <input mdInput [mdDatepicker]="datePicker2" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
-           [mdDatepickerFilter]="filterOdd ? dateFilter : null" [disabled]="true"
+    <input mdInput disabled [mdDatepicker]="datePicker2" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
+           [mdDatepickerFilter]="filterOdd ? dateFilter : null"
            placeholder="Input disabled, datepicker enabled">
   </md-input-container>
   <md-datepicker #datePicker2 [touchUi]="touch" [disabled]="false" [startAt]="startAt"

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -3,28 +3,24 @@
   <md-checkbox [(ngModel)]="touch">Use touch UI</md-checkbox>
   <md-checkbox [(ngModel)]="filterOdd">Filter odd months and dates</md-checkbox>
   <md-checkbox [(ngModel)]="yearView">Start in year view</md-checkbox>
-  <md-checkbox [(ngModel)]="inputDisabled">Disable input</md-checkbox>
   <md-checkbox [(ngModel)]="datepickerDisabled">Disable datepicker</md-checkbox>
 </p>
 <p>
   <md-input-container>
-    <input mdInput #mdInput1 [mdDatepicker]="minDatePicker" [(ngModel)]="minDate"
-        [disabled]="inputDisabled" placeholder="Min date">
-    <button mdSuffix [mdDatepickerToggle]="minDatePicker" [disabled]="mdInput1.disabled"></button>
+    <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
+    <button mdSuffix [mdDatepickerToggle]="minDatePicker"></button>
   </md-input-container>
   <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
   <md-input-container>
-    <input mdInput #mdInput2 [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate"
-        [disabled]="inputDisabled" placeholder="Max date">
-    <button mdSuffix [mdDatepickerToggle]="maxDatePicker" [disabled]="mdInput2.disabled"></button>
+    <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
+    <button mdSuffix [mdDatepickerToggle]="maxDatePicker"></button>
   </md-input-container>
   <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
-    <input mdInput #mdInput3 [mdDatepicker]="startAtPicker" [(ngModel)]="startAt"
-        [disabled]="inputDisabled" placeholder="Start at date">
-    <button mdSuffix [mdDatepickerToggle]="startAtPicker" [disabled]="mdInput3.disabled"></button>
+    <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
+    <button mdSuffix [mdDatepickerToggle]="startAtPicker"></button>
   </md-input-container>
   <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
@@ -41,7 +37,6 @@
            [min]="minDate"
            [max]="maxDate"
            [mdDatepickerFilter]="filterOdd ? dateFilter : null"
-           [disabled]="inputDisabled"
            placeholder="Pick a date">
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMin')">Too early!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMax')">Too late!</md-error>
@@ -62,9 +57,8 @@
          [min]="minDate"
          [max]="maxDate"
          [mdDatepickerFilter]="filterOdd ? dateFilter : null"
-         [disabled]="inputDisabled"
          placeholder="Pick a date">
-  <button [mdDatepickerToggle]="resultPicker2" [disabled]="resultPickerModel2.disabled"></button>
+  <button [mdDatepickerToggle]="resultPicker2"></button>
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"
@@ -72,4 +66,28 @@
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>
+</p>
+
+<h2>Input disabled datepicker</h2>
+<p>
+  <button [mdDatepickerToggle]="datePicker1"></button>
+  <md-input-container>
+    <input mdInput [mdDatepicker]="datePicker1" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
+           [mdDatepickerFilter]="filterOdd ? dateFilter : null" [disabled]="true"
+           placeholder="Input disabled">
+  </md-input-container>
+  <md-datepicker #datePicker1 [touchUi]="touch" [startAt]="startAt"
+                   [startView]="yearView ? 'year' : 'month'"></md-datepicker>
+</p>
+
+<h2>Input disabled, datepicker popup enabled</h2>
+<p>
+  <button [mdDatepickerToggle]="datePicker2"></button>
+  <md-input-container>
+    <input mdInput [mdDatepicker]="datePicker2" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
+           [mdDatepickerFilter]="filterOdd ? dateFilter : null" [disabled]="true"
+           placeholder="Input disabled, datepicker enabled">
+  </md-input-container>
+  <md-datepicker #datePicker2 [touchUi]="touch" [disabled]="false" [startAt]="startAt"
+                 [startView]="yearView ? 'year' : 'month'"></md-datepicker>
 </p>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -3,32 +3,33 @@
   <md-checkbox [(ngModel)]="touch">Use touch UI</md-checkbox>
   <md-checkbox [(ngModel)]="filterOdd">Filter odd months and dates</md-checkbox>
   <md-checkbox [(ngModel)]="yearView">Start in year view</md-checkbox>
-  <md-checkbox [(ngModel)]="disabled">Read-only mode</md-checkbox>
+  <md-checkbox [(ngModel)]="inputDisabled">Disable input</md-checkbox>
+  <md-checkbox [(ngModel)]="datepickerDisabled">Disable datepicker</md-checkbox>
 </p>
 <p>
   <md-input-container>
-    <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
-    <button mdSuffix [mdDatepickerToggle]="minDatePicker"></button>
+    <input mdInput #mdInput1 [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" [disabled]="inputDisabled" placeholder="Min date">
+    <button mdSuffix [mdDatepickerToggle]="minDatePicker" [disabled]="mdInput1.disabled"></button>
   </md-input-container>
-  <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
+  <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
   <md-input-container>
-    <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
-    <button mdSuffix [mdDatepickerToggle]="maxDatePicker"></button>
+    <input mdInput #mdInput2 [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" [disabled]="inputDisabled" placeholder="Max date">
+    <button mdSuffix [mdDatepickerToggle]="maxDatePicker" [disabled]="mdInput2.disabled"></button>
   </md-input-container>
-  <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
+  <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
-    <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
-    <button mdSuffix [mdDatepickerToggle]="startAtPicker"></button>
+    <input mdInput #mdInput3 [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" [disabled]="inputDisabled" placeholder="Start at date">
+    <button mdSuffix [mdDatepickerToggle]="startAtPicker" [disabled]="mdInput3.disabled"></button>
   </md-input-container>
-  <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
+  <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 
 <h2>Result</h2>
 
 <p>
-  <button [mdDatepickerToggle]="resultPicker"></button>
+  <button [mdDatepickerToggle]="resultPicker" [disabled]="resultPickerModel.disabled"></button>
   <md-input-container>
     <input mdInput
            #resultPickerModel="ngModel"
@@ -37,6 +38,7 @@
            [min]="minDate"
            [max]="maxDate"
            [mdDatepickerFilter]="filterOdd ? dateFilter : null"
+           [disabled]="inputDisabled"
            placeholder="Pick a date">
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMin')">Too early!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMax')">Too late!</md-error>
@@ -45,23 +47,25 @@
   <md-datepicker
       #resultPicker
       [touchUi]="touch"
-      [disabled]="disabled"
+      [disabled]="datepickerDisabled"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>
 </p>
 <p>
-  <input [mdDatepicker]="resultPicker2"
+  <input #resultPickerModel2
+         [mdDatepicker]="resultPicker2"
          [(ngModel)]="date"
          [min]="minDate"
          [max]="maxDate"
          [mdDatepickerFilter]="filterOdd ? dateFilter : null"
+         [disabled]="inputDisabled"
          placeholder="Pick a date">
-  <button [mdDatepickerToggle]="resultPicker2"></button>
+  <button [mdDatepickerToggle]="resultPicker2" [disabled]="resultPickerModel2.disabled"></button>
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"
-      [disabled]="disabled"
+      [disabled]="datepickerDisabled"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -8,19 +8,22 @@
 </p>
 <p>
   <md-input-container>
-    <input mdInput #mdInput1 [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" [disabled]="inputDisabled" placeholder="Min date">
+    <input mdInput #mdInput1 [mdDatepicker]="minDatePicker" [(ngModel)]="minDate"
+        [disabled]="inputDisabled" placeholder="Min date">
     <button mdSuffix [mdDatepickerToggle]="minDatePicker" [disabled]="mdInput1.disabled"></button>
   </md-input-container>
   <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
   <md-input-container>
-    <input mdInput #mdInput2 [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" [disabled]="inputDisabled" placeholder="Max date">
+    <input mdInput #mdInput2 [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate"
+        [disabled]="inputDisabled" placeholder="Max date">
     <button mdSuffix [mdDatepickerToggle]="maxDatePicker" [disabled]="mdInput2.disabled"></button>
   </md-input-container>
   <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
-    <input mdInput #mdInput3 [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" [disabled]="inputDisabled" placeholder="Start at date">
+    <input mdInput #mdInput3 [mdDatepicker]="startAtPicker" [(ngModel)]="startAt"
+        [disabled]="inputDisabled" placeholder="Start at date">
     <button mdSuffix [mdDatepickerToggle]="startAtPicker" [disabled]="mdInput3.disabled"></button>
   </md-input-container>
   <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -3,26 +3,26 @@
   <md-checkbox [(ngModel)]="touch">Use touch UI</md-checkbox>
   <md-checkbox [(ngModel)]="filterOdd">Filter odd months and dates</md-checkbox>
   <md-checkbox [(ngModel)]="yearView">Start in year view</md-checkbox>
-  <md-checkbox [(ngModel)]="readOnly">Read-only mode</md-checkbox>
+  <md-checkbox [(ngModel)]="disabled">Read-only mode</md-checkbox>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
     <button mdSuffix [mdDatepickerToggle]="minDatePicker"></button>
   </md-input-container>
-  <md-datepicker #minDatePicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
+  <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
   <md-input-container>
     <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
     <button mdSuffix [mdDatepickerToggle]="maxDatePicker"></button>
   </md-input-container>
-  <md-datepicker #maxDatePicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
+  <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
     <button mdSuffix [mdDatepickerToggle]="startAtPicker"></button>
   </md-input-container>
-  <md-datepicker #startAtPicker [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
+  <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="disabled"></md-datepicker>
 </p>
 
 <h2>Result</h2>
@@ -45,7 +45,7 @@
   <md-datepicker
       #resultPicker
       [touchUi]="touch"
-      [readOnly]="readOnly"
+      [disabled]="disabled"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>
@@ -61,7 +61,7 @@
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"
-      [readOnly]="readOnly"
+      [disabled]="disabled"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
   </md-datepicker>

--- a/src/demo-app/datepicker/datepicker-demo.ts
+++ b/src/demo-app/datepicker/datepicker-demo.ts
@@ -11,6 +11,8 @@ export class DatepickerDemo {
   touch: boolean;
   filterOdd: boolean;
   yearView: boolean;
+  inputDisabled: boolean;
+  datepickerDisabled: boolean;
   minDate: Date;
   maxDate: Date;
   startAt: Date;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -35,6 +35,7 @@ import {DOWN_ARROW} from '../core/keyboard/keycodes';
 import {DateAdapter} from '../core/datetime/index';
 import {createMissingDateImplError} from './datepicker-errors';
 import {MD_DATE_FORMATS, MdDateFormats} from '../core/datetime/date-formats';
+import {coerceBooleanProperty} from '@angular/cdk';
 
 
 export const MD_DATEPICKER_VALUE_ACCESSOR: any = {
@@ -123,6 +124,16 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
     this._validatorOnChange();
   }
   private _max: D;
+
+  @Input()
+  get disabled() { return this._disabled; }
+  set disabled(value: any) {
+    this._disabled = coerceBooleanProperty(value);
+    if (this._datepicker.disabled === undefined) {
+      this._datepicker.disabled = this._disabled;
+    }
+  }
+  private _disabled: boolean;
 
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D|null>();

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -125,6 +125,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   }
   private _max: D;
 
+  /** Whether the datepicker-input is disabled. */
   @Input()
   get disabled() { return this._disabled; }
   set disabled(value: any) {

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -62,6 +62,7 @@ export const MD_DATEPICKER_VALIDATORS: any = {
     '[attr.aria-owns]': '_datepicker?.id',
     '[attr.min]': 'min ? _dateAdapter.getISODateString(min) : null',
     '[attr.max]': 'max ? _dateAdapter.getISODateString(max) : null',
+    '[disabled]': 'disabled',
     '(input)': '_onInput($event.target.value)',
     '(blur)': '_onTouched()',
     '(keydown)': '_onKeydown($event)',
@@ -130,9 +131,6 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   get disabled() { return this._disabled; }
   set disabled(value: any) {
     this._disabled = coerceBooleanProperty(value);
-    if (this._datepicker.disabled === undefined) {
-      this._datepicker.disabled = this._disabled;
-    }
   }
   private _disabled: boolean;
 

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -9,6 +9,7 @@
 import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 import {MdDatepicker} from './datepicker';
 import {MdDatepickerIntl} from './datepicker-intl';
+import {coerceBooleanProperty} from '@angular/cdk';
 
 
 @Component({
@@ -20,6 +21,7 @@ import {MdDatepickerIntl} from './datepicker-intl';
     'type': 'button',
     'class': 'mat-datepicker-toggle',
     '[attr.aria-label]': '_intl.openCalendarLabel',
+    '[disabled]': 'disabled',
     '(click)': '_open($event)',
   },
   encapsulation: ViewEncapsulation.None,
@@ -33,10 +35,20 @@ export class MdDatepickerToggle<D> {
   get _datepicker() { return this.datepicker; }
   set _datepicker(v: MdDatepicker<D>) { this.datepicker = v; }
 
+  /** Whether the toggle button is disabled. */
+  @Input()
+  get disabled() {
+    return this._disabled === undefined ? this.datepicker.disabled : this._disabled;
+  }
+  set disabled(value) {
+    this._disabled = coerceBooleanProperty(value);
+  }
+  private _disabled: boolean;
+
   constructor(public _intl: MdDatepickerIntl) {}
 
   _open(event: Event): void {
-    if (this.datepicker && !this.datepicker.disabled) {
+    if (this.datepicker && !this._disabled) {
       this.datepicker.open();
       event.stopPropagation();
     }

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -48,7 +48,7 @@ export class MdDatepickerToggle<D> {
   constructor(public _intl: MdDatepickerIntl) {}
 
   _open(event: Event): void {
-    if (this.datepicker && !this._disabled) {
+    if (this.datepicker && !this.disabled) {
       this.datepicker.open();
       event.stopPropagation();
     }

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -36,7 +36,7 @@ export class MdDatepickerToggle<D> {
   constructor(public _intl: MdDatepickerIntl) {}
 
   _open(event: Event): void {
-    if (this.datepicker) {
+    if (this.datepicker && !this.datepicker.disabled) {
       this.datepicker.open();
       event.stopPropagation();
     }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -96,6 +96,20 @@ describe('MdDatepicker', () => {
         expect(document.querySelector('md-dialog-container')).not.toBeNull();
       }));
 
+      it('open in read only mode should not open the calendar', async(() => {
+        testComponent.readOnly = true;
+        fixture.detectChanges();
+
+        expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
+        expect(document.querySelector('md-dialog-container')).toBeNull();
+
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+
+        expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
+        expect(document.querySelector('md-dialog-container')).toBeNull();
+      }));
+
       it('close should close popup', async(() => {
         testComponent.datepicker.open();
         fixture.detectChanges();
@@ -734,11 +748,12 @@ describe('MdDatepicker', () => {
 @Component({
   template: `
     <input [mdDatepicker]="d" [value]="date">
-    <md-datepicker #d [touchUi]="touch"></md-datepicker>
+    <md-datepicker #d [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
   `,
 })
 class StandardDatepicker {
   touch = false;
+  readOnly = false;
   date = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
   @ViewChild(MdDatepickerInput) datepickerInput: MdDatepickerInput<Date>;

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -75,27 +75,28 @@ describe('MdDatepicker', () => {
         fixture.detectChanges();
       }));
 
-      it('open non-touch should open popup', async(() => {
+      it('open non-touch should open popup', () => {
         expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
 
         testComponent.datepicker.open();
         fixture.detectChanges();
 
         expect(document.querySelector('.cdk-overlay-pane')).not.toBeNull();
-      }));
+      });
 
-      it('open touch should open dialog', async(() => {
+      it('open touch should open dialog', () => {
         testComponent.touch = true;
         fixture.detectChanges();
+
         expect(document.querySelector('md-dialog-container')).toBeNull();
 
         testComponent.datepicker.open();
         fixture.detectChanges();
 
         expect(document.querySelector('md-dialog-container')).not.toBeNull();
-      }));
+      });
 
-      it('open in disabled mode should not open the calendar', async(() => {
+      it('open in disabled mode should not open the calendar', () => {
         testComponent.disabled = true;
         fixture.detectChanges();
 
@@ -107,9 +108,22 @@ describe('MdDatepicker', () => {
 
         expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
         expect(document.querySelector('md-dialog-container')).toBeNull();
-      }));
+      });
 
-      it('close should close popup', async(() => {
+      it('disabled datepicker input should open the calendar if datepicker is enabled', () => {
+        testComponent.datepicker.disabled = false;
+        testComponent.datepickerInput.disabled = true;
+        fixture.detectChanges();
+
+        expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
+
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+
+        expect(document.querySelector('.cdk-overlay-pane')).not.toBeNull();
+      });
+
+      it('close should close popup', () => {
         testComponent.datepicker.open();
         fixture.detectChanges();
 
@@ -123,7 +137,7 @@ describe('MdDatepicker', () => {
         fixture.whenStable().then(() => {
           expect(parseInt(getComputedStyle(popup).height as string)).toBe(0);
         });
-      }));
+      });
 
       it('should close the popup when pressing ESCAPE', () => {
         testComponent.datepicker.open();
@@ -142,7 +156,7 @@ describe('MdDatepicker', () => {
             .toBe(true, 'Expected default ESCAPE action to be prevented.');
       });
 
-      it('close should close dialog', async(() => {
+      it('close should close dialog', () => {
         testComponent.touch = true;
         fixture.detectChanges();
 
@@ -157,9 +171,9 @@ describe('MdDatepicker', () => {
         fixture.whenStable().then(() => {
           expect(document.querySelector('md-dialog-container')).toBeNull();
         });
-      }));
+      });
 
-      it('setting selected should update input and close calendar', async(() => {
+      it('setting selected should update input and close calendar', () => {
         testComponent.touch = true;
         fixture.detectChanges();
 
@@ -177,7 +191,7 @@ describe('MdDatepicker', () => {
           expect(document.querySelector('md-dialog-container')).toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
         });
-      }));
+      });
 
       it('startAt should fallback to input value', () => {
         expect(testComponent.datepicker.startAt).toEqual(new Date(2020, JAN, 1));
@@ -454,6 +468,19 @@ describe('MdDatepicker', () => {
         fixture.detectChanges();
 
         expect(document.querySelector('md-dialog-container')).not.toBeNull();
+      });
+
+      it('should not open calendar when toggle clicked if datepicker is disabled', () => {
+        testComponent.datepicker.disabled = true;
+        fixture.detectChanges();
+
+        expect(document.querySelector('md-dialog-container')).toBeNull();
+
+        let toggle = fixture.debugElement.query(By.css('button'));
+        dispatchMouseEvent(toggle.nativeElement, 'click');
+        fixture.detectChanges();
+
+        expect(document.querySelector('md-dialog-container')).toBeNull();
       });
 
       it('should set the `button` type on the trigger to prevent form submissions', () => {

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -87,7 +87,6 @@ describe('MdDatepicker', () => {
       it('open touch should open dialog', async(() => {
         testComponent.touch = true;
         fixture.detectChanges();
-
         expect(document.querySelector('md-dialog-container')).toBeNull();
 
         testComponent.datepicker.open();

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -96,7 +96,7 @@ describe('MdDatepicker', () => {
         expect(document.querySelector('md-dialog-container')).not.toBeNull();
       }));
 
-      it('open in read only mode should not open the calendar', async(() => {
+      it('open in disabled mode should not open the calendar', async(() => {
         testComponent.disabled = true;
         fixture.detectChanges();
 

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -97,7 +97,7 @@ describe('MdDatepicker', () => {
       }));
 
       it('open in read only mode should not open the calendar', async(() => {
-        testComponent.readOnly = true;
+        testComponent.disabled = true;
         fixture.detectChanges();
 
         expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
@@ -748,12 +748,12 @@ describe('MdDatepicker', () => {
 @Component({
   template: `
     <input [mdDatepicker]="d" [value]="date">
-    <md-datepicker #d [touchUi]="touch" [readOnly]="readOnly"></md-datepicker>
+    <md-datepicker #d [touchUi]="touch" [disabled]="disabled"></md-datepicker>
   `,
 })
 class StandardDatepicker {
   touch = false;
-  readOnly = false;
+  disabled = false;
   date = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
   @ViewChild(MdDatepickerInput) datepickerInput: MdDatepickerInput<Date>;

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -116,6 +116,9 @@ export class MdDatepicker<D> implements OnDestroy {
    */
   @Input() touchUi = false;
 
+  /** Whether the datepicker pop-up should be disabled for read-only mode. */
+  @Input() readOnly = false;
+
   /** Emits new selected date when selected date changes. */
   @Output() selectedChanged = new EventEmitter<D>();
 
@@ -207,6 +210,9 @@ export class MdDatepicker<D> implements OnDestroy {
   /** Open the calendar. */
   open(): void {
     if (this.opened) {
+      return;
+    }
+    if (this.readOnly) {
       return;
     }
     if (!this._datepickerInput) {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -119,12 +119,11 @@ export class MdDatepicker<D> implements OnDestroy {
 
   /** Whether the datepicker pop-up should be disabled. */
   @Input()
-  get disabled() { return this._disabled; }
+  get disabled() {
+    return this._disabled === undefined ? this._datepickerInput.disabled : this._disabled;
+  }
   set disabled(value: any) {
     this._disabled = coerceBooleanProperty(value);
-    if (this._disabled === undefined) {
-      this._disabled = this._datepickerInput.disabled;
-    }
   }
   private _disabled: boolean;
 

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -217,10 +217,7 @@ export class MdDatepicker<D> implements OnDestroy {
 
   /** Open the calendar. */
   open(): void {
-    if (this.opened) {
-      return;
-    }
-    if (this.disabled) {
+    if (this.opened || this.disabled) {
       return;
     }
     if (!this._datepickerInput) {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -117,7 +117,7 @@ export class MdDatepicker<D> implements OnDestroy {
   @Input() touchUi = false;
 
   /** Whether the datepicker pop-up should be disabled for read-only mode. */
-  @Input() readOnly = false;
+  @Input() disabled = false;
 
   /** Emits new selected date when selected date changes. */
   @Output() selectedChanged = new EventEmitter<D>();
@@ -212,7 +212,7 @@ export class MdDatepicker<D> implements OnDestroy {
     if (this.opened) {
       return;
     }
-    if (this.readOnly) {
+    if (this.disabled) {
       return;
     }
     if (!this._datepickerInput) {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -39,6 +39,8 @@ import {createMissingDateImplError} from './datepicker-errors';
 import {ESCAPE} from '../core/keyboard/keycodes';
 import {MdCalendar} from './calendar';
 import {first} from '../core/rxjs/index';
+import 'rxjs/add/operator/first';
+import {coerceBooleanProperty} from '@angular/cdk';
 
 
 /** Used to generate a unique ID for each datepicker instance. */
@@ -116,8 +118,16 @@ export class MdDatepicker<D> implements OnDestroy {
    */
   @Input() touchUi = false;
 
-  /** Whether the datepicker pop-up should be disabled for read-only mode. */
-  @Input() disabled = false;
+  /** Whether the datepicker pop-up should be disabled. */
+  @Input()
+  get disabled() { return this._disabled; }
+  set disabled(value: any) {
+    this._disabled = coerceBooleanProperty(value);
+    if (this._disabled === undefined) {
+      this._disabled = this._datepickerInput.disabled;
+    }
+  }
+  private _disabled: boolean;
 
   /** Emits new selected date when selected date changes. */
   @Output() selectedChanged = new EventEmitter<D>();

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -39,7 +39,6 @@ import {createMissingDateImplError} from './datepicker-errors';
 import {ESCAPE} from '../core/keyboard/keycodes';
 import {MdCalendar} from './calendar';
 import {first} from '../core/rxjs/index';
-import 'rxjs/add/operator/first';
 import {coerceBooleanProperty} from '@angular/cdk';
 
 


### PR DESCRIPTION
This adds ability to disable datepicker pop-up in read-only mode.

Fixes #5017 