### PR TITLE
fix(datepicker): refactor datepicker toggle to support theming

### DIFF
--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -8,25 +8,19 @@
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
-    <button md-icon-button mdSuffix [mdDatepickerToggle]="minDatePicker">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle mdSuffix [for]="minDatePicker"></md-datepicker-toggle>
   </md-input-container>
   <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
   <md-input-container>
     <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
-    <button md-icon-button mdSuffix [mdDatepickerToggle]="maxDatePicker">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle mdSuffix [for]="maxDatePicker"></md-datepicker-toggle>
   </md-input-container>
   <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
-    <button md-icon-button mdSuffix [mdDatepickerToggle]="startAtPicker">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle mdSuffix [for]="startAtPicker"></md-datepicker-toggle>
   </md-input-container>
   <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
@@ -34,9 +28,7 @@
 <h2>Result</h2>
 
 <p>
-  <button md-icon-button [mdDatepickerToggle]="resultPicker">
-    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-  </button>
+  <md-datepicker-toggle [for]="resultPicker"></md-datepicker-toggle>
   <md-input-container>
     <input mdInput
            #resultPickerModel="ngModel"
@@ -71,9 +63,7 @@
          [max]="maxDate"
          [mdDatepickerFilter]="filterOdd ? dateFilter : null"
          placeholder="Pick a date">
-  <button md-icon-button [mdDatepickerToggle]="resultPicker2">
-    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-  </button>
+  <md-datepicker-toggle [for]="resultPicker2"></md-datepicker-toggle>
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -8,19 +8,25 @@
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date">
-    <button mdSuffix [mdDatepickerToggle]="minDatePicker"></button>
+    <button md-icon-button mdSuffix [mdDatepickerToggle]="minDatePicker">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
   </md-input-container>
   <md-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
   <md-input-container>
     <input mdInput [mdDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date">
-    <button mdSuffix [mdDatepickerToggle]="maxDatePicker"></button>
+    <button md-icon-button mdSuffix [mdDatepickerToggle]="maxDatePicker">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
   </md-input-container>
   <md-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
 <p>
   <md-input-container>
     <input mdInput [mdDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date">
-    <button mdSuffix [mdDatepickerToggle]="startAtPicker"></button>
+    <button md-icon-button mdSuffix [mdDatepickerToggle]="startAtPicker">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
   </md-input-container>
   <md-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></md-datepicker>
 </p>
@@ -28,7 +34,9 @@
 <h2>Result</h2>
 
 <p>
-  <button [mdDatepickerToggle]="resultPicker"></button>
+  <button md-icon-button [mdDatepickerToggle]="resultPicker">
+    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+  </button>
   <md-input-container>
     <input mdInput
            #resultPickerModel="ngModel"
@@ -63,7 +71,9 @@
          [max]="maxDate"
          [mdDatepickerFilter]="filterOdd ? dateFilter : null"
          placeholder="Pick a date">
-  <button [mdDatepickerToggle]="resultPicker2"></button>
+  <button md-icon-button [mdDatepickerToggle]="resultPicker2">
+    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+  </button>
   <md-datepicker
       #resultPicker2
       [touchUi]="touch"

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -75,7 +75,7 @@
 
 <h2>Input disabled datepicker</h2>
 <p>
-  <button [mdDatepickerToggle]="datePicker1"></button>
+  <md-datepicker-toggle [for]="datePicker1"></md-datepicker-toggle>
   <md-input-container>
     <input mdInput [mdDatepicker]="datePicker1" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
            [mdDatepickerFilter]="filterOdd ? dateFilter : null" [disabled]="true"
@@ -87,10 +87,10 @@
 
 <h2>Input disabled, datepicker popup enabled</h2>
 <p>
-  <button [mdDatepickerToggle]="datePicker2"></button>
+  <md-datepicker-toggle [for]="datePicker2"></md-datepicker-toggle>
   <md-input-container>
-    <input mdInput disabled [mdDatepicker]="datePicker2" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
-           [mdDatepickerFilter]="filterOdd ? dateFilter : null"
+    <input mdInput disabled [mdDatepicker]="datePicker2" [(ngModel)]="date" [min]="minDate"
+           [max]="maxDate" [mdDatepickerFilter]="filterOdd ? dateFilter : null"
            placeholder="Input disabled, datepicker enabled">
   </md-input-container>
   <md-datepicker #datePicker2 [touchUi]="touch" [disabled]="false" [startAt]="startAt"

--- a/src/lib/datepicker/datepicker-toggle.html
+++ b/src/lib/datepicker/datepicker-toggle.html
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%"
+     fill="currentColor" style="vertical-align: top">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
+</svg>

--- a/src/lib/datepicker/datepicker-toggle.html
+++ b/src/lib/datepicker/datepicker-toggle.html
@@ -1,5 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%"
-     fill="currentColor" style="vertical-align: top">
-  <path d="M0 0h24v24H0z" fill="none"/>
-  <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
-</svg>
+<button md-icon-button type="button" [attr.aria-label]="_intl.openCalendarLabel"
+        [disabled]="disabled" (click)="_open($event)">
+  <md-icon>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%"
+         fill="currentColor" style="vertical-align: top">
+      <path d="M0 0h24v24H0z" fill="none"/>
+      <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
+    </svg>
+  </md-icon>
+</button>

--- a/src/lib/datepicker/datepicker-toggle.scss
+++ b/src/lib/datepicker/datepicker-toggle.scss
@@ -1,8 +1,0 @@
-// The width/height of the icon element.
-$mat-datepicker-toggle-icon-size: 24px !default;
-
-.mat-datepicker-toggle-icon {
-  display: inline-block;
-  height: $mat-datepicker-toggle-icon-size;
-  width: $mat-datepicker-toggle-icon-size;
-}

--- a/src/lib/datepicker/datepicker-toggle.scss
+++ b/src/lib/datepicker/datepicker-toggle.scss
@@ -1,18 +1,8 @@
+// The width/height of the icon element.
 $mat-datepicker-toggle-icon-size: 24px !default;
 
-
-.mat-datepicker-toggle {
+.mat-datepicker-toggle-icon {
   display: inline-block;
-  // Note: SVG needs to be base64 encoded or it will not work on IE11.
-  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE5IDNoLTFWMWgtMnYySDhWMUg2djJINWMtMS4xMSAwLTEuOTkuOS0xLjk5IDJMMyAxOWMwIDEuMS44OSAyIDIgMmgxNGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDVWOGgxNHYxMXpNNyAxMGg1djVIN3oiLz48L3N2Zz4=') no-repeat;
-  background-size: contain;
   height: $mat-datepicker-toggle-icon-size;
   width: $mat-datepicker-toggle-icon-size;
-  border: none;
-  outline: none;
-  vertical-align: middle;
-
-  &:not([disabled]) {
-    cursor: pointer;
-  }
 }

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -9,8 +9,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Directive,
-  ElementRef,
   Input,
   ViewEncapsulation,
   OnDestroy,
@@ -22,27 +20,21 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
 
 
-@Directive({
-  selector: '[mdDatepickerToggle], [matDatepickerToggle]',
+@Component({
+  moduleId: module.id,
+  selector: 'md-datepicker-toggle, mat-datepicker-toggle',
+  templateUrl: 'datepicker-toggle.html',
   host: {
-    '[type]': '_isButton ? "button" : undefined',
-    '[attr.aria-label]': '_intl.openCalendarLabel',
-    '[disabled]': 'disabled',
-    '(click)': '_open($event)',
+    'class': 'mat-datepicker-toggle',
   },
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdDatepickerToggle<D> implements OnDestroy {
   private _intlChanges: Subscription;
 
   /** Datepicker instance that the button will toggle. */
-  @Input('mdDatepickerToggle') datepicker: MdDatepicker<D>;
-
-  @Input('matDatepickerToggle')
-  get _datepicker() { return this.datepicker; }
-  set _datepicker(v: MdDatepicker<D>) { this.datepicker = v; }
-
-  /** Whether the host element is an HTML button. */
-  _isButton = false;
+  @Input('for') datepicker: MdDatepicker<D>;
 
   /** Whether the toggle button is disabled. */
   @Input()
@@ -54,8 +46,7 @@ export class MdDatepickerToggle<D> implements OnDestroy {
   }
   private _disabled: boolean;
 
-  constructor(elementRef: ElementRef, public _intl: MdDatepickerIntl, changeDetectorRef: ChangeDetectorRef) {
-    this._isButton = elementRef.nativeElement.tagName.toLowerCase() === 'button';
+  constructor(public _intl: MdDatepickerIntl, changeDetectorRef: ChangeDetectorRef) {
     this._intlChanges = _intl.changes.subscribe(() => changeDetectorRef.markForCheck());
   }
 
@@ -70,17 +61,3 @@ export class MdDatepickerToggle<D> implements OnDestroy {
     }
   }
 }
-
-
-@Component({
-  moduleId: module.id,
-  selector: 'md-datepicker-toggle-icon, mat-datepicker-toggle-icon',
-  templateUrl: 'datepicker-toggle.html',
-  styleUrls: ['datepicker-toggle.css'],
-  host: {
-    'class': 'mat-datepicker-toggle-icon',
-  },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class MdDatepickerToggleIcon {}

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -9,6 +9,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  Directive,
+  ElementRef,
   Input,
   ViewEncapsulation,
   OnDestroy,
@@ -20,20 +22,14 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
 
 
-@Component({
-  moduleId: module.id,
-  selector: 'button[mdDatepickerToggle], button[matDatepickerToggle]',
-  template: '',
-  styleUrls: ['datepicker-toggle.css'],
+@Directive({
+  selector: '[mdDatepickerToggle], [matDatepickerToggle]',
   host: {
-    'type': 'button',
-    'class': 'mat-datepicker-toggle',
+    '[type]': '_isButton ? "button" : undefined',
     '[attr.aria-label]': '_intl.openCalendarLabel',
     '[disabled]': 'disabled',
     '(click)': '_open($event)',
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdDatepickerToggle<D> implements OnDestroy {
   private _intlChanges: Subscription;
@@ -45,6 +41,9 @@ export class MdDatepickerToggle<D> implements OnDestroy {
   get _datepicker() { return this.datepicker; }
   set _datepicker(v: MdDatepicker<D>) { this.datepicker = v; }
 
+  /** Whether the host element is an HTML button. */
+  _isButton = false;
+
   /** Whether the toggle button is disabled. */
   @Input()
   get disabled() {
@@ -55,7 +54,8 @@ export class MdDatepickerToggle<D> implements OnDestroy {
   }
   private _disabled: boolean;
 
-  constructor(public _intl: MdDatepickerIntl, changeDetectorRef: ChangeDetectorRef) {
+  constructor(elementRef: ElementRef, public _intl: MdDatepickerIntl, changeDetectorRef: ChangeDetectorRef) {
+    this._isButton = elementRef.nativeElement.tagName.toLowerCase() === 'button';
     this._intlChanges = _intl.changes.subscribe(() => changeDetectorRef.markForCheck());
   }
 
@@ -70,3 +70,17 @@ export class MdDatepickerToggle<D> implements OnDestroy {
     }
   }
 }
+
+
+@Component({
+  moduleId: module.id,
+  selector: 'md-datepicker-toggle-icon, mat-datepicker-toggle-icon',
+  templateUrl: 'datepicker-toggle.html',
+  styleUrls: ['datepicker-toggle.css'],
+  host: {
+    'class': 'mat-datepicker-toggle-icon',
+  },
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MdDatepickerToggleIcon {}

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -25,9 +25,7 @@ An optional datepicker toggle button is available. A toggle can be added to the 
 
 ```html
 <input [mdDatepicker]="myDatepicker">
-<button md-icon-button [mdDatepickerToggle]="myDatepicker">
-  <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-</button>
+<md-datepicker-toggle [for]="myDatepicker"></md-datepicker-toggle>
 <md-datepicker #myDatepicker></md-datepicker>
 ```
 
@@ -37,9 +35,7 @@ can easily be used as a prefix or suffix on the material input:
 ```html
 <md-input-container>
   <input mdInput [mdDatepicker]="myDatepicker">
-  <button md-icon-button mdSuffix [mdDatepickerToggle]="myDatepicker">
-    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-  </button>
+  <md-datepicker-toggle mdSuffix [for]="myDatepicker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker #myDatepicker></md-datepicker>
 ```

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -25,7 +25,9 @@ An optional datepicker toggle button is available. A toggle can be added to the 
 
 ```html
 <input [mdDatepicker]="myDatepicker">
-<button [mdDatepickerToggle]="myDatepicker"></button>
+<button md-icon-button [mdDatepickerToggle]="myDatepicker">
+  <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+</button>
 <md-datepicker #myDatepicker></md-datepicker>
 ```
 
@@ -35,7 +37,9 @@ can easily be used as a prefix or suffix on the material input:
 ```html
 <md-input-container>
   <input mdInput [mdDatepicker]="myDatepicker">
-  <button mdSuffix [mdDatepickerToggle]="myDatepicker"></button>
+  <button md-icon-button mdSuffix [mdDatepickerToggle]="myDatepicker">
+    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+  </button>
 </md-input-container>
 <md-datepicker #myDatepicker></md-datepicker>
 ```

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -960,7 +960,9 @@ class DatepickerWithFormControl {
 @Component({
   template: `
     <input [mdDatepicker]="d">
-    <button [mdDatepickerToggle]="d"></button>
+    <button [mdDatepickerToggle]="d">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
     <md-datepicker #d [touchUi]="touchUI"></md-datepicker>
   `,
 })
@@ -987,7 +989,9 @@ class InputContainerDatepicker {
 @Component({
   template: `
     <input [mdDatepicker]="d" [(ngModel)]="date" [min]="minDate" [max]="maxDate">
-    <button [mdDatepickerToggle]="d"></button>
+    <button [mdDatepickerToggle]="d">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
     <md-datepicker #d></md-datepicker>
   `,
 })
@@ -1002,7 +1006,9 @@ class DatepickerWithMinAndMaxValidation {
 @Component({
   template: `
     <input [mdDatepicker]="d" [(ngModel)]="date" [mdDatepickerFilter]="filter">
-    <button [mdDatepickerToggle]="d"></button>
+    <button [mdDatepickerToggle]="d">
+      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+    </button>
     <md-datepicker #d [touchUi]="true"></md-datepicker>
   `,
 })

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -465,7 +465,7 @@ describe('MdDatepicker', () => {
       });
     });
 
-    describe('datepicker with mdDatepickerToggle', () => {
+    describe('datepicker with md-datepicker-toggle', () => {
       let fixture: ComponentFixture<DatepickerWithToggle>;
       let testComponent: DatepickerWithToggle;
 

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -960,9 +960,7 @@ class DatepickerWithFormControl {
 @Component({
   template: `
     <input [mdDatepicker]="d">
-    <button [mdDatepickerToggle]="d">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle [for]="d"></md-datepicker-toggle>
     <md-datepicker #d [touchUi]="touchUI"></md-datepicker>
   `,
 })
@@ -989,9 +987,7 @@ class InputContainerDatepicker {
 @Component({
   template: `
     <input [mdDatepicker]="d" [(ngModel)]="date" [min]="minDate" [max]="maxDate">
-    <button [mdDatepickerToggle]="d">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle [for]="d"></md-datepicker-toggle>
     <md-datepicker #d></md-datepicker>
   `,
 })
@@ -1006,9 +1002,7 @@ class DatepickerWithMinAndMaxValidation {
 @Component({
   template: `
     <input [mdDatepicker]="d" [(ngModel)]="date" [mdDatepickerFilter]="filter">
-    <button [mdDatepickerToggle]="d">
-      <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-    </button>
+    <md-datepicker-toggle [for]="d"></md-datepicker-toggle>
     <md-datepicker #d [touchUi]="true"></md-datepicker>
   `,
 })

--- a/src/lib/datepicker/index.ts
+++ b/src/lib/datepicker/index.ts
@@ -20,9 +20,10 @@ import {
 import {MdDatepickerInput} from './datepicker-input';
 import {MdDialogModule} from '../dialog/index';
 import {MdCalendar} from './calendar';
-import {MdDatepickerToggle, MdDatepickerToggleIcon} from './datepicker-toggle';
+import {MdDatepickerToggle} from './datepicker-toggle';
 import {MdButtonModule} from '../button/index';
 import {MdDatepickerIntl} from './datepicker-intl';
+import {MdIconModule} from '../icon/index';
 
 
 export * from './calendar';
@@ -40,6 +41,7 @@ export * from './year-view';
     CommonModule,
     MdButtonModule,
     MdDialogModule,
+    MdIconModule,
     OverlayModule,
     StyleModule,
     A11yModule,
@@ -49,7 +51,6 @@ export * from './year-view';
     MdDatepickerContent,
     MdDatepickerInput,
     MdDatepickerToggle,
-    MdDatepickerToggleIcon,
   ],
   declarations: [
     MdCalendar,
@@ -58,7 +59,6 @@ export * from './year-view';
     MdDatepickerContent,
     MdDatepickerInput,
     MdDatepickerToggle,
-    MdDatepickerToggleIcon,
     MdMonthView,
     MdYearView,
   ],

--- a/src/lib/datepicker/index.ts
+++ b/src/lib/datepicker/index.ts
@@ -20,7 +20,7 @@ import {
 import {MdDatepickerInput} from './datepicker-input';
 import {MdDialogModule} from '../dialog/index';
 import {MdCalendar} from './calendar';
-import {MdDatepickerToggle} from './datepicker-toggle';
+import {MdDatepickerToggle, MdDatepickerToggleIcon} from './datepicker-toggle';
 import {MdButtonModule} from '../button/index';
 import {MdDatepickerIntl} from './datepicker-intl';
 
@@ -49,6 +49,7 @@ export * from './year-view';
     MdDatepickerContent,
     MdDatepickerInput,
     MdDatepickerToggle,
+    MdDatepickerToggleIcon,
   ],
   declarations: [
     MdCalendar,
@@ -57,6 +58,7 @@ export * from './year-view';
     MdDatepickerContent,
     MdDatepickerInput,
     MdDatepickerToggle,
+    MdDatepickerToggleIcon,
     MdMonthView,
     MdYearView,
   ],

--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -164,8 +164,9 @@
   .mat-input-suffix {
     // Allow icons in a prefix or suffix to adapt to the correct size.
     .mat-icon,
-    .mat-datepicker-toggle {
+    .mat-datepicker-toggle-icon {
       font-size: $prefix-suffix-icon-font-size;
+      line-height: $line-height;
     }
 
     // Allow icon buttons in a prefix or suffix to adapt to the correct size.
@@ -173,8 +174,10 @@
       height: $prefix-suffix-icon-font-scale * 1em;
       width: $prefix-suffix-icon-font-scale * 1em;
 
-      .mat-icon {
-        line-height: $prefix-suffix-icon-font-scale;
+      .mat-icon,
+      .mat-datepicker-toggle-icon {
+        height: $line-height * 1em;
+        line-height: $line-height;
       }
     }
   }

--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -163,8 +163,7 @@
   .mat-input-prefix,
   .mat-input-suffix {
     // Allow icons in a prefix or suffix to adapt to the correct size.
-    .mat-icon,
-    .mat-datepicker-toggle-icon {
+    .mat-icon {
       font-size: $prefix-suffix-icon-font-size;
       line-height: $line-height;
     }
@@ -174,8 +173,7 @@
       height: $prefix-suffix-icon-font-scale * 1em;
       width: $prefix-suffix-icon-font-scale * 1em;
 
-      .mat-icon,
-      .mat-datepicker-toggle-icon {
+      .mat-icon {
         height: $line-height * 1em;
         line-height: $line-height;
       }

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -41,8 +41,7 @@ $mat-input-underline-height: 1px !default;
   flex: none;
 
   // Allow icons in a prefix or suffix to adapt to the correct size.
-  .mat-icon,
-  .mat-datepicker-toggle-icon {
+  .mat-icon {
     width: 1em;
   }
 
@@ -51,8 +50,7 @@ $mat-input-underline-height: 1px !default;
     font: inherit;
     vertical-align: baseline;
 
-    .mat-icon,
-    .mat-datepicker-toggle-icon {
+    .mat-icon {
       font-size: inherit;
     }
   }
@@ -232,8 +230,7 @@ textarea.mat-input-element {
 // Scale down icons in the placeholder and hint to be the same size as the text.
 .mat-input-subscript-wrapper,
 .mat-input-placeholder-wrapper {
-  .mat-icon,
-  .mat-datepicker-toggle-icon {
+  .mat-icon {
     width: 1em;
     height: 1em;
     font-size: inherit;

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -42,10 +42,8 @@ $mat-input-underline-height: 1px !default;
 
   // Allow icons in a prefix or suffix to adapt to the correct size.
   .mat-icon,
-  .mat-datepicker-toggle {
+  .mat-datepicker-toggle-icon {
     width: 1em;
-    height: 1em;
-    vertical-align: text-bottom;
   }
 
   // Allow icon buttons in a prefix or suffix to adapt to the correct size.
@@ -53,11 +51,9 @@ $mat-input-underline-height: 1px !default;
     font: inherit;
     vertical-align: baseline;
 
-    .mat-icon {
+    .mat-icon,
+    .mat-datepicker-toggle-icon {
       font-size: inherit;
-      width: 1em;
-      height: 1em;
-      vertical-align: baseline;
     }
   }
 }
@@ -237,7 +233,7 @@ textarea.mat-input-element {
 .mat-input-subscript-wrapper,
 .mat-input-placeholder-wrapper {
   .mat-icon,
-  .mat-datepicker-toggle {
+  .mat-datepicker-toggle-icon {
     width: 1em;
     height: 1em;
     font-size: inherit;

--- a/src/material-examples/datepicker-filter/datepicker-filter-example.html
+++ b/src/material-examples/datepicker-filter/datepicker-filter-example.html
@@ -1,5 +1,5 @@
 <md-input-container class="example-full-width">
   <input mdInput [mdDatepickerFilter]="myFilter" [mdDatepicker]="picker" placeholder="Choose a date">
-  <button mdSuffix [mdDatepickerToggle]="picker"></button>
+  <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker #picker></md-datepicker>

--- a/src/material-examples/datepicker-min-max/datepicker-min-max-example.html
+++ b/src/material-examples/datepicker-min-max/datepicker-min-max-example.html
@@ -1,5 +1,5 @@
 <md-input-container class="example-full-width">
   <input mdInput [min]="minDate" [max]="maxDate" [mdDatepicker]="picker" placeholder="Choose a date">
-  <button mdSuffix [mdDatepickerToggle]="picker"></button>
+  <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker #picker></md-datepicker>

--- a/src/material-examples/datepicker-overview/datepicker-overview-example.html
+++ b/src/material-examples/datepicker-overview/datepicker-overview-example.html
@@ -1,7 +1,5 @@
 <md-input-container>
   <input mdInput [mdDatepicker]="picker" placeholder="Choose a date">
-  <button md-icon-button mdSuffix [mdDatepickerToggle]="picker">
-    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-  </button>
+  <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker #picker></md-datepicker>

--- a/src/material-examples/datepicker-overview/datepicker-overview-example.html
+++ b/src/material-examples/datepicker-overview/datepicker-overview-example.html
@@ -1,5 +1,7 @@
 <md-input-container>
   <input mdInput [mdDatepicker]="picker" placeholder="Choose a date">
-  <button mdSuffix [mdDatepickerToggle]="picker"></button>
+  <button md-icon-button mdSuffix [mdDatepickerToggle]="picker">
+    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+  </button>
 </md-input-container>
 <md-datepicker #picker></md-datepicker>

--- a/src/material-examples/datepicker-start-view/datepicker-start-view-example.html
+++ b/src/material-examples/datepicker-start-view/datepicker-start-view-example.html
@@ -1,5 +1,5 @@
 <md-input-container>
   <input mdInput [mdDatepicker]="picker" placeholder="Choose a date">
-  <button mdSuffix [mdDatepickerToggle]="picker"></button>
+  <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker #picker startView="year" [startAt]="startDate"></md-datepicker>

--- a/src/material-examples/datepicker-touch/datepicker-touch-example.html
+++ b/src/material-examples/datepicker-touch/datepicker-touch-example.html
@@ -1,5 +1,5 @@
 <md-input-container class="example-full-width">
   <input mdInput [mdDatepicker]="picker" placeholder="Choose a date">
-  <button mdSuffix [mdDatepickerToggle]="picker"></button>
+  <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
 </md-input-container>
 <md-datepicker touchUi="true" #picker></md-datepicker>

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -85,9 +85,7 @@
 
 <md-input-container>
   <input type="text" mdInput [mdDatepicker]="birthday" placeholder="Birthday">
-  <button md-icon-button mdSuffix [mdDatepickerToggle]="birthday">
-    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
-  </button>
+  <md-datepicker-toggle mdSuffix [for]="birthday"></md-datepicker-toggle>
   <md-datepicker #birthday></md-datepicker>
 </md-input-container>
 

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -85,7 +85,9 @@
 
 <md-input-container>
   <input type="text" mdInput [mdDatepicker]="birthday" placeholder="Birthday">
-  <button mdSuffix [mdDatepickerToggle]="birthday"></button>
+  <button md-icon-button mdSuffix [mdDatepickerToggle]="birthday">
+    <md-datepicker-toggle-icon></md-datepicker-toggle-icon>
+  </button>
   <md-datepicker #birthday></md-datepicker>
 </md-input-container>
 


### PR DESCRIPTION
@jelbourn The `md-datepicker-toggle-icon` could easily be replaced with an `md-icon` the only reason it's separate is so users don't need to load a font to use it. Would it be better to have datepicker module register an svg set with just a `'material:datepicker:toggle'` icon for now? Other components could create similar sets if they need to include icons.

BREAKING CHANGE: `[mdDatepickerToggle]` attribute has been changed to `md-datepicker-toggle` element 

fixes #5224
fixes #4934
fixes #4684