### PR TITLE
build: replace cdk version placeholder for build artifacts

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -55,6 +55,10 @@ publishPackage() {
   # Update the package.json version to include the current commit SHA.
   sed -i "s/${buildVersion}/${buildVersion}-${commitSha}/g" package.json
 
+  # For build artifacts the different Angular packages that refer to the 0.0.0-PLACEHOLDER should
+  # be replaced with the Github builds that are published at the same time.
+  sed -i "s/0.0.0-PLACEHOLDER/${buildVersion}-${commitSha}/g" package.json
+
   # Prepare Git for pushing the artifacts to the repository.
   git config user.name "${commitAuthorName}"
   git config user.email "${commitAuthorEmail}"


### PR DESCRIPTION
* Currently the `0.0.0-PLACEHOLDER` is still inside of the `package.json` of the material2-builds. Similar as for every other Angular package the version placeholder should be replaced with the version of the current "build commit".

**Note**: Issue #5320 is not really an issue we can solve. It more likely needs some documentation about how to install the CDK builds as well (follow-up PR)

Closes #5320