### PR TITLE
docs: explain that material2-builds depends on cdk-builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The latest release of Angular Material can be installed from npm
 `npm install @angular/material`
 
 A snapshot build with the latest changes from
-[master](https://github.com/angular/material2/tree/master) is also available. Note that this
-snapshot build should not be considered stable and may break between releases.
+[master](https://github.com/angular/material2/tree/master) is also available.
+Note that this snapshot build should not be considered stable and may break between releases.
 
-`npm install --save https://github.com/angular/material2-builds.git`
+`npm install --save angular/material2-builds angular/cdk-builds`
 
 ### Getting started
 


### PR DESCRIPTION
* Recently the coercing has been moved to the cdk package and now the `material2-builds` repository has a peer dependency on the `cdk-builds`. The readme should be updated to also include the `cdk-builds` installation.

**Note**: I'm not sure whether it's worth explaining what the CDk is already. It would confuse people and they would think that they need to install the `CDK` right now as well (while it's not released yet)

References #5320 