### PR TITLE
fix(input): prevent textarea from resizing beyond input container

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -85,6 +85,10 @@ $mat-input-underline-height: 1px !default;
   padding: 0;
   width: 100%;
 
+  // Prevent textareas from being resized outside the container.
+  max-width: 100%;
+  resize: vertical;
+
   // Needed to make last line of the textarea line up with the baseline.
   vertical-align: bottom;
 


### PR DESCRIPTION
Prevents `textarea` instances from resizing beyond their `md-input-container`.