### PR TITLE
fix(chips): not visible in high contrast mode

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -1,3 +1,5 @@
+@import '../core/a11y/a11y';
+
 $mat-chip-vertical-padding: 8px;
 $mat-chip-horizontal-padding: 12px;
 
@@ -22,6 +24,10 @@ $mat-chips-chip-margin: $mat-chip-horizontal-padding / 4;
     [dir='rtl'] & {
       margin: 0 $mat-chips-chip-margin 0 0;
     }
+  }
+
+  @include cdk-high-contrast {
+    outline: solid 1px;
   }
 }
 


### PR DESCRIPTION
Fixes `md-chip` instances not being visible for users running high contrast mode.