### PR TITLE
build: add rule to prevent rxjs patch imports

### DIFF
--- a/tools/tslint-rules/noRxjsPatchImportsRule.js
+++ b/tools/tslint-rules/noRxjsPatchImportsRule.js
@@ -1,0 +1,35 @@
+const Lint = require('tslint');
+const ERROR_MESSAGE = 'Uses of RxJS patch imports are forbidden.';
+
+/**
+ * Rule that prevents uses of RxJS patch imports (e.g. `import 'rxjs/add/operator/map').
+ * Supports whitelisting via `"no-patch-imports": [true, "\.spec\.ts$"]`.
+ */
+class Rule extends Lint.Rules.AbstractRule {
+  apply(file) {
+    return this.applyWithWalker(new Walker(file, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  constructor(file, options) {
+    super(...arguments);
+
+    // Whitelist with regular expressions to use when determining which files to lint.
+    const whitelist = options.ruleArguments;
+
+    // Whether the file should be checked at all.
+    this._enabled = !whitelist.length || whitelist.some(p => new RegExp(p).test(file.fileName));
+  }
+
+  visitImportDeclaration(node) {
+    // Walk through the imports and check if they start with `rxjs/add`.
+    if (this._enabled && node.moduleSpecifier.getText().startsWith('rxjs/add', 1)) {
+      this.addFailureAtNode(node, ERROR_MESSAGE);
+    }
+
+    super.visitImportDeclaration(node);
+  }
+}
+
+exports.Rule = Rule;

--- a/tslint.json
+++ b/tslint.json
@@ -29,6 +29,11 @@
     "no-var-keyword": true,
     "no-exposed-todo": true,
     "no-debugger": true,
+    "no-rxjs-patch-imports": [
+      true,
+      "src/lib",
+      "src/cdk"
+    ],
     "one-line": [
       true,
       "check-catch",


### PR DESCRIPTION
Adds a rule that will ensure that we don't use patch imports in the library and cdk files.