### PR TITLE
chore: fix paginator example not added to module

### DIFF
--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -261,6 +261,7 @@ export const EXAMPLE_LIST = [
   MenuIconsExample,
   MenuOverviewExample,
   PaginatorOverviewExample,
+  PaginatorConfigurableExample,
   ProgressBarConfigurableExample,
   ProgressBarOverviewExample,
   ProgressSpinnerConfigurableExample,


### PR DESCRIPTION
* The PaginatorConfigurableExample is not added to the examples module and therefore using the latest docs-content inside of `material.angular.io` does not work.