### PR TITLE
fix(position): emit position change when no fallbacks are in viewport

### DIFF
--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -343,53 +343,76 @@ describe('ConnectedPositionStrategy', () => {
       expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
           .toBe(true, `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
 
-      it('should pick the fallback position that shows the largest area of the element', () => {
-        positionBuilder = new OverlayPositionBuilder(viewportRuler);
-
-        originElement.style.top = '200px';
-        originElement.style.right = '25px';
-        originRect = originElement.getBoundingClientRect();
-
-        strategy = positionBuilder.connectedTo(
-            fakeElementRef,
-            {originX: 'end', originY: 'center'},
-            {overlayX: 'start', overlayY: 'center'})
-            .withFallbackPosition(
-                {originX: 'end', originY: 'top'},
-                {overlayX: 'start', overlayY: 'bottom'})
-            .withFallbackPosition(
-                {originX: 'end', originY: 'top'},
-                {overlayX: 'end', overlayY: 'top'});
-
-        strategy.apply(overlayElement);
-
-        let overlayRect = overlayElement.getBoundingClientRect();
-
-        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
-        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
-      });
-
-      it('should position a panel properly when rtl', () => {
-        // must make the overlay longer than the origin to properly test attachment
-        overlayElement.style.width = `500px`;
-        originRect = originElement.getBoundingClientRect();
-        strategy = positionBuilder.connectedTo(
-            fakeElementRef,
-            {originX: 'start', originY: 'bottom'},
-            {overlayX: 'start', overlayY: 'top'})
-            .withDirection('rtl');
-        originElement.style.top = '0';
-        originElement.style.left = '0';
-
-        // If the strategy is re-applied and the initial position would now fit,
-        // the position change event should be emitted again.
-        strategy.apply(overlayElement);
-        expect(positionChangeHandler).toHaveBeenCalledTimes(2);
-
-        subscription.unsubscribe();
-      });
+      subscription.unsubscribe();
     });
 
+    it('should emit onPositionChange event when no fallbacks are in viewport', () => {
+      positionBuilder = new OverlayPositionBuilder(viewportRuler);
+      originElement.style.top = '200px';
+      originElement.style.right = '25px';
+
+      strategy = positionBuilder.connectedTo(
+          fakeElementRef,
+          {originX: 'end', originY: 'center'},
+          {overlayX: 'start', overlayY: 'center'});
+
+      const positionChangeHandler = jasmine.createSpy('positionChangeHandler');
+      const subscription = strategy.onPositionChange.subscribe(positionChangeHandler);
+
+      strategy.apply(overlayElement);
+
+      expect(positionChangeHandler).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
+
+    it('should pick the fallback position that shows the largest area of the element', () => {
+      positionBuilder = new OverlayPositionBuilder(viewportRuler);
+
+      originElement.style.top = '200px';
+      originElement.style.right = '25px';
+      originRect = originElement.getBoundingClientRect();
+
+      strategy = positionBuilder.connectedTo(
+          fakeElementRef,
+          {originX: 'end', originY: 'center'},
+          {overlayX: 'start', overlayY: 'center'})
+          .withFallbackPosition(
+              {originX: 'end', originY: 'top'},
+              {overlayX: 'start', overlayY: 'bottom'})
+          .withFallbackPosition(
+              {originX: 'end', originY: 'top'},
+              {overlayX: 'end', overlayY: 'top'});
+
+      strategy.apply(overlayElement);
+
+      let overlayRect = overlayElement.getBoundingClientRect();
+
+      expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+      expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
+    });
+
+    it('should position a panel properly when rtl', () => {
+      // must make the overlay longer than the origin to properly test attachment
+      overlayElement.style.width = `500px`;
+      originRect = originElement.getBoundingClientRect();
+
+      strategy = positionBuilder.connectedTo(
+          fakeElementRef,
+          {originX: 'start', originY: 'bottom'},
+          {overlayX: 'start', overlayY: 'top'})
+          .withDirection('rtl');
+      originElement.style.top = '0';
+      originElement.style.left = '0';
+
+      const positionChangeHandler = jasmine.createSpy('positionChangeHandler');
+      const subscription = strategy.onPositionChange.subscribe(positionChangeHandler);
+
+      strategy.apply(overlayElement);
+      expect(positionChangeHandler).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
 
     /**
      * Run all tests for connecting the overlay to the origin such that first preferred

--- a/src/lib/core/overlay/position/connected-position-strategy.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.ts
@@ -129,14 +129,10 @@ export class ConnectedPositionStrategy implements PositionStrategy {
       // If the overlay in the calculated position fits on-screen, put it there and we're done.
       if (overlayPoint.fitsInViewport) {
         this._setElementPosition(element, overlayRect, overlayPoint, pos);
+        this._notifyPositionChange(element, pos);
 
         // Save the last connected position in case the position needs to be re-calculated.
         this._lastConnectedPosition = pos;
-
-        // Notify that the position has been changed along with its change properties.
-        const scrollableViewProperties = this.getScrollableViewProperties(element);
-        const positionChange = new ConnectedOverlayPositionChange(pos, scrollableViewProperties);
-        this._onPositionChange.next(positionChange);
 
         return;
       } else if (!fallbackPoint || fallbackPoint.visibleArea < overlayPoint.visibleArea) {
@@ -148,6 +144,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     // If none of the preferred positions were in the viewport, take the one
     // with the largest visible area.
     this._setElementPosition(element, overlayRect, fallbackPoint!, fallbackPosition!);
+    this._notifyPositionChange(element, fallbackPosition!);
   }
 
   /**
@@ -352,6 +349,13 @@ export class ConnectedPositionStrategy implements PositionStrategy {
 
       return clippedAbove || clippedBelow || clippedLeft || clippedRight;
     });
+  }
+
+  /** Notify that the position has been changed along with its change properties. */
+  private _notifyPositionChange(element: HTMLElement, pos: ConnectionPositionPair) {
+    const scrollableViewProperties = this.getScrollableViewProperties(element);
+    const positionChange = new ConnectedOverlayPositionChange(pos, scrollableViewProperties);
+    this._onPositionChange.next(positionChange);
   }
 
   /** Physically positions the overlay element to the given coordinate. */


### PR DESCRIPTION
This also cleans up where two nested `it` blocks weren't being run. One of those tests (`should position a panel properly when rtl`) failed when "de-nesting" it, so I did my best to match the original intention of the test.