### PR TITLE
fix(menu): complete close stream on destroy

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -116,6 +116,9 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
     if (this._tabSubscription) {
       this._tabSubscription.unsubscribe();
     }
+
+    this._emitCloseEvent();
+    this.close.complete();
   }
 
   /** Handle a keyboard event from the menu, delegating to the appropriate action. */

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -15,7 +15,8 @@ import {
   MdMenuTrigger,
   MdMenuPanel,
   MenuPositionX,
-  MenuPositionY
+  MenuPositionY,
+  MdMenu
 } from './index';
 import {OverlayContainer} from '../core/overlay/overlay-container';
 import {Directionality, Direction} from '../core/bidi/index';
@@ -477,6 +478,17 @@ describe('MdMenu', () => {
 
       expect(fixture.componentInstance.closeCallback).toHaveBeenCalled();
     });
+
+    it('should complete the callback when the menu is destroyed', () => {
+      let emitCallback = jasmine.createSpy('emit callback');
+      let completeCallback = jasmine.createSpy('complete callback');
+
+      fixture.componentInstance.menu.close.subscribe(emitCallback, null, completeCallback);
+      fixture.destroy();
+
+      expect(emitCallback).toHaveBeenCalled();
+      expect(completeCallback).toHaveBeenCalled();
+    });
   });
 
   describe('destroy', () => {
@@ -499,6 +511,7 @@ describe('MdMenu', () => {
 class SimpleMenu {
   @ViewChild(MdMenuTrigger) trigger: MdMenuTrigger;
   @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild(MdMenu) menu: MdMenu;
   closeCallback = jasmine.createSpy('menu closed callback');
 }
 


### PR DESCRIPTION
This is something I noticed while working on the nested menus: We're subscribing to the `close` event internally inside the menu trigger, but we're never unsubscribing. These changes complete the observable so we don't have to unsubscribe manually.