### PR TITLE
chore: build cdk and material in npm build task

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/angular/material2.git"
   },
   "scripts": {
-    "build": "gulp material:build-release:clean",
+    "build": "gulp :publish:build-releases",
     "demo-app": "gulp serve:devapp",
     "test": "gulp test",
     "tslint": "gulp lint",


### PR DESCRIPTION
Apparently developers that clone the Material repository to get their own version of Material are running the `npm run build` command and are expecting the CDK and Material release output to be inside of the `dist/` folder.

Currently only the Material package will be built and the CDK isn't built at all. This commit changes the npm build task so that it builds every release package of the publish task.

Closes #5372