### PR TITLE
chore: dashboard depends on cdk builds

### DIFF
--- a/tools/dashboard/package.json
+++ b/tools/dashboard/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^4.2.2",
+    "@angular/cdk": "github:angular/cdk-builds",
     "@angular/common": "^4.2.2",
     "@angular/compiler": "^4.2.2",
     "@angular/core": "^4.2.2",


### PR DESCRIPTION
Recently stuff has been moved to the CDK and the `material2-builds` repository now depends on the `@angular/cdk`.

Since the dashboard uses the latest version of Material (material2-builds) the CDK dependency needs to be added.