### PR TITLE
build: better error reporting of bash scripts

### DIFF
--- a/scripts/ci/build-and-test.sh
+++ b/scripts/ci/build-and-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# The script should immediately exit if any command in the script fails.
 set -e
 
 echo ""

--- a/scripts/ci/publish-artifacts.sh
+++ b/scripts/ci/publish-artifacts.sh
@@ -3,6 +3,9 @@
 # Script that runs after the testing stage of Travis passed.
 # Build artifacts and docs content will be published to different repositories.
 
+# The script should immediately exit if any command in the script fails.
+set -e
+
 # Go to the project root directory
 cd $(dirname $0)/../..
 

--- a/scripts/deploy/deploy-dashboard.sh
+++ b/scripts/deploy/deploy-dashboard.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# The script should immediately exit if any command in the script fails.
+set -e
+
 # This script deploys the Dashboard App and their Cloud Functions to Firebase.
 # Before the script installs all dependencies and builds the dashboard app in production.
 

--- a/scripts/deploy/deploy-screenshot-functions.sh
+++ b/scripts/deploy/deploy-screenshot-functions.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# The script should immediately exit if any command in the script fails.
+set -e
+
 # Go to the project root directory
 cd $(dirname ${0})/../..
 

--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -3,7 +3,8 @@
 # Script to publish the build artifacts to a GitHub repository.
 # Builds will be automatically published once new changes are made to the repository.
 
-set -e -o pipefail
+# The script should immediately exit if any command in the script fails.
+set -e
 
 # Go to the project root directory
 cd $(dirname ${0})/../..

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -3,6 +3,9 @@
 # Publish material2 docs assets to the material2-docs-content repo
 # material.angular.io will pull from this assets repo to get the latest docs
 
+# The script should immediately exit if any command in the script fails.
+set -e
+
 cd "$(dirname $0)/../../"
 
 docsPath="./dist/docs"


### PR DESCRIPTION
Currently whenever something fails in the deploy script it will likely not cause the CI to show the failure. This is because Bash by default doesn't exit the process with the proper error code (for example: #5395)