### PR TITLE
chore: enforce whitespace before the opening brace of a block

### DIFF
--- a/tools/screenshot-test/src/app/firebase.service.ts
+++ b/tools/screenshot-test/src/app/firebase.service.ts
@@ -45,7 +45,7 @@ export class FirebaseService {
   /** Set pull request number. All test information and pull request information will be retrived
    * from database
    */
-  set prNumber(prNumber: string){
+  set prNumber(prNumber: string) {
     this.screenshotResultSummary = new ScreenshotResultSummary();
     this.screenshotResultSummary.prNumber = prNumber;
     this._readPullRequestScreenshotReport();

--- a/tslint.json
+++ b/tslint.json
@@ -70,7 +70,8 @@
       "check-decl",
       "check-operator",
       "check-separator",
-      "check-type"
+      "check-type",
+      "check-preblock"
     ],
     // Bans jasmine helper functions that will prevent the CI from properly running tests.
     "ban": [true, ["fit"], ["fdescribe"], ["xit"], ["xdescribe"]],


### PR DESCRIPTION
* Enforces whitespace before the opening brace of a block. This makes sure that the code is consistent is everywhere (https://palantir.github.io/tslint/rules/whitespace/)