### PR TITLE
docs(paginator): change heading level for page event

### DIFF
--- a/src/material-examples/paginator-configurable/paginator-configurable-example.html
+++ b/src/material-examples/paginator-configurable/paginator-configurable-example.html
@@ -21,7 +21,7 @@
 </md-paginator>
 
 <div *ngIf="pageEvent">
-  <h2>Page Change Event Properties</h2>
+  <h5>Page Change Event Properties</h5>
   <div>List length: {{pageEvent.length}}</div>
   <div>Page size: {{pageEvent.pageSize}}</div>
   <div>Page index: {{pageEvent.pageIndex}}</div>


### PR DESCRIPTION
`<h2>` is too low for where this content lives