### PR TITLE
feat(tooltip): add support for custom HTML inside tooltip

### DIFF
--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -14,6 +14,19 @@
       Mouse over to see the tooltip
     </button>
     <div>Scroll down while tooltip is open to see it hide automatically</div>
+
+    <button #tooltip="mdTooltip"
+            md-raised-button
+            color="primary"
+            [mdTooltip]="messageHTML"
+            [mdTooltipPosition]="'below'"
+            [mdIsHTML]="isHtml"
+            [mdTooltipDisabled]="disabled"
+            [mdTooltipShowDelay]="showDelay"
+            [mdTooltipHideDelay]="hideDelay"
+            [mdTooltipClass]="'cust-tooltip'">
+      Mouse over to see the html tooltip below
+    </button>
     <div style="height: 400px;"></div>
   </div>
 

--- a/src/demo-app/tooltip/tooltip-demo.scss
+++ b/src/demo-app/tooltip/tooltip-demo.scss
@@ -1,18 +1,18 @@
-@mixin cust-tooltip($position: 'top', $bg: #3F434F, $color: #FFFFFF){
+@mixin cust-tooltip($position: 'top', $bg: #3F434F, $color: #FFFFFF) {
     border-radius: 3px;
     background-color: $bg;
     color: $color;
-    box-shadow: 0 2px 3px 0 rgba(0,0,0,0.1);
+    box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1);
     text-align: center;
     font-size: 11px;
     font-weight: 200;
     padding: 8px 16px;
-    &:after{
+    &::after {
         bottom: 100%;
         border-bottom-color: $bg !important;
         left: 50%;
         border: solid transparent;
-        content: " ";
+        content: ' ';
         height: 0;
         width: 0;
         position: absolute;
@@ -23,7 +23,7 @@
     }
 }
 
-.cust-tooltip{
+.cust-tooltip {
   @include cust-tooltip();
 }
 
@@ -47,24 +47,24 @@
   color: black;
 }
 
-.cust-tt-container{
+.cust-tt-container {
   padding: 0 10px;
-  .tt-heading{
-    color: #FFFFFF;
+  .tt-heading {
+    color: #ffffff;
     font-size: 14px;
     letter-spacing: 4px;
   }
 
-  .tt-items{
+  .tt-items {
     padding-top: 10px;
-    .tt-item{
-      color: #FFFFFF;
+    .tt-item {
+      color: #ffffff;
       font-size: 13px;
       text-align: left;
       margin-bottom: 8px;
     }
   }
 }
-.upvote-items{
+.upvote-items {
   padding: 16px 8px;
 }

--- a/src/demo-app/tooltip/tooltip-demo.scss
+++ b/src/demo-app/tooltip/tooltip-demo.scss
@@ -1,3 +1,32 @@
+@mixin cust-tooltip($position: 'top', $bg: #3F434F, $color: #FFFFFF){
+    border-radius: 3px;
+    background-color: $bg;
+    color: $color;
+    box-shadow: 0 2px 3px 0 rgba(0,0,0,0.1);
+    text-align: center;
+    font-size: 11px;
+    font-weight: 200;
+    padding: 8px 16px;
+    &:after{
+        bottom: 100%;
+        border-bottom-color: $bg !important;
+        left: 50%;
+        border: solid transparent;
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        pointer-events: none;
+        border-color: rgba(55, 207, 189, 0);
+        border-width: 8px;
+        margin-left: -8px;
+    }
+}
+
+.cust-tooltip{
+  @include cust-tooltip();
+}
+
 .demo-tooltip {
   .centered {
     text-align: center;
@@ -16,4 +45,26 @@
 .red-tooltip {
   background-color: rgb(255, 128, 128);
   color: black;
+}
+
+.cust-tt-container{
+  padding: 0 10px;
+  .tt-heading{
+    color: #FFFFFF;
+    font-size: 14px;
+    letter-spacing: 4px;
+  }
+
+  .tt-items{
+    padding-top: 10px;
+    .tt-item{
+      color: #FFFFFF;
+      font-size: 13px;
+      text-align: left;
+      margin-bottom: 8px;
+    }
+  }
+}
+.upvote-items{
+  padding: 16px 8px;
 }

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -12,8 +12,20 @@ import {TooltipPosition} from '@angular/material';
 export class TooltipDemo {
   position: TooltipPosition = 'below';
   message: string = 'Here is the tooltip';
+  messageHTML: string = `<div class="cust-tt-container">
+                          <div class="tt-heading">Likes</div>
+                          <div class="tt-items">
+                            <div class="tt-item">Michael Stern</div>
+                            <div class="tt-item">John Wick</div>
+                            <div class="tt-item">Siraj Ul Haq</div>
+                            <div class="tt-item">Ahsan Ayaz</div>
+                            <div class="tt-item">Barry Allen</div>
+                            <div class="tt-item">+ 3 more</div>
+                          </div>
+                        </div>`;
   disabled = false;
   showDelay = 0;
   hideDelay = 1000;
+  isHtml = true;
   showExtraClass = false;
 }

--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -1,7 +1,15 @@
 <div class="mat-tooltip"
-     [ngClass]="tooltipClass"
-     [style.transform-origin]="_transformOrigin"
-     [@state]="_visibility"
-     (@state.done)="_afterVisibilityAnimation($event)">
-  {{message}}
+    [ngClass]="tooltipClass"
+    [style.transform-origin]="_transformOrigin"
+    [@state]="_visibility"
+    (@state.done)="_afterVisibilityAnimation($event)">
+
+    <div class="tooltip-html" 
+        [innerHTML]="message" 
+        *ngIf="isHTML; else messageString;">
+    </div>
+    <ng-template #messageString>
+      {{message}}
+    </ng-template>
+
 </div>

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -125,6 +125,8 @@ export class MdTooltip implements OnDestroy {
     this._setTooltipMessage(this._message);
   }
 
+  @Input('mdIsHTML') isHTML = false;
+
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */
   @Input('mdTooltipClass')
   get tooltipClass() { return this._tooltipClass; }
@@ -337,6 +339,7 @@ export class MdTooltip implements OnDestroy {
     // calculate the correct positioning based on the size of the text.
     if (this._tooltipInstance) {
       this._tooltipInstance.message = message;
+      this._tooltipInstance.isHTML = this.isHTML;
       this._tooltipInstance._markForCheck();
 
       first.call(this._ngZone.onMicrotaskEmpty).subscribe(() => {
@@ -388,6 +391,8 @@ export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
 export class TooltipComponent {
   /** Message to display in the tooltip */
   message: string;
+
+  isHTML: boolean;
 
   /** Classes to be added to the tooltip. Supports the same syntax as `ngClass`. */
   tooltipClass: string|string[]|Set<string>|{[key: string]: any};


### PR DESCRIPTION
add support for custom html inside tooltip. in some projects it is necessary to have custom tooltips and when using angular-material, it’ll be hard to follow. so for flexibility, we should add it.

closes #5440 