### PR TITLE
build: use node to resolve build version

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -9,6 +9,12 @@ set -e
 # Go to the project root directory
 cd $(dirname ${0})/../..
 
+if [ -z ${MATERIAL2_BUILDS_TOKEN} ]; then
+  echo "Error: No access token for GitHub could be found." \
+       "Please set the environment variable 'MATERIAL2_BUILDS_TOKEN'."
+  exit 1
+fi
+
 # Material packages that need to published.
 PACKAGES=(cdk material)
 REPOSITORIES=(cdk-builds material2-builds)
@@ -24,7 +30,7 @@ publishPackage() {
   packageRepo=${2}
 
   buildDir="dist/releases/${packageName}"
-  buildVersion=$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)
+  buildVersion=$(node -pe "require('./package.json').version")
 
   commitSha=$(git rev-parse --short HEAD)
   commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
@@ -72,7 +78,7 @@ publishPackage() {
   git tag "${buildVersion}-${commitSha}"
   git push origin master --tags
 
-  echo "Published artifacts for ${packageName} package."
+  echo "Published package artifacts for ${packageName}#${commitSha}."
 }
 
 for ((i = 0; i < ${#PACKAGES[@]}; i++)); do

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -8,6 +8,12 @@ set -e
 
 cd "$(dirname $0)/../../"
 
+if [ -z ${MATERIAL2_DOCS_CONTENT_TOKEN} ]; then
+  echo "Error: No access token for GitHub could be found." \
+       "Please set the environment variable 'MATERIAL2_DOCS_CONTENT_TOKEN'."
+  exit 1
+fi
+
 docsPath="./dist/docs"
 packagePath="./dist/releases/material-examples"
 repoPath="/tmp/material2-docs-content"


### PR DESCRIPTION
* Instead of using a complex RegExp that will likely break at some point in the future, we are switching to a single-line NodeJS script to resolve the version.