### PR TITLE
fix(checkbox): server-side rendering error when checking textContent

### DIFF
--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -1,6 +1,6 @@
 <label [attr.for]="inputId" class="mat-checkbox-layout" #label>
   <div class="mat-checkbox-inner-container"
-       [class.mat-checkbox-inner-container-no-side-margin]="!checkboxLabel.textContent.trim()">
+       [class.mat-checkbox-inner-container-no-side-margin]="!checkboxLabel.textContent || !checkboxLabel.textContent.trim()">
     <input #input
            class="mat-checkbox-input cdk-visually-hidden" type="checkbox"
            [id]="inputId"


### PR DESCRIPTION
Adds an extra null check when trimming the checkbox `textContent`. This avoids issues in Universal where the `textContent` will be undefined.

Fixes #5453.