### PR TITLE
fix(reposition-scroll-strategy): use last calculated position to re-align the overlay

### DIFF
--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -150,6 +150,13 @@ export class OverlayRef implements PortalHost {
     }
   }
 
+  /** Re-positions the overlay based on its last calculated position. */
+  recalculateLastPosition() {
+    if (this._state.positionStrategy) {
+      this._state.positionStrategy.recalculateLastPosition();
+    }
+  }
+
   /** Updates the text direction of the overlay panel. */
   private updateDirection() {
     this._pane.setAttribute('dir', this._state.direction!);

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -520,6 +520,7 @@ class FakePositionStrategy implements PositionStrategy {
     return Promise.resolve(null);
   }
 
+  recalculateLastPosition() { }
   dispose() {}
 }
 

--- a/src/lib/core/overlay/position/global-position-strategy.ts
+++ b/src/lib/core/overlay/position/global-position-strategy.ts
@@ -168,4 +168,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
       this._wrapper = null;
     }
   }
+
+  recalculateLastPosition() {
+    // noop since the automatic positioning is handled by CSS.
+  }
 }

--- a/src/lib/core/overlay/position/position-strategy.ts
+++ b/src/lib/core/overlay/position/position-strategy.ts
@@ -12,6 +12,9 @@ export interface PositionStrategy {
   /** Updates the position of the overlay element. */
   apply(element: Element): void;
 
+  /** Re-positions the overlay element based on its last calculated position. */
+  recalculateLastPosition(): void;
+
   /** Cleans up any DOM modifications made by the position strategy, if necessary. */
   dispose(): void;
 }

--- a/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -45,33 +45,33 @@ describe('RepositionScrollStrategy', () => {
 
   it('should update the overlay position when the page is scrolled', () => {
     overlayRef.attach(componentPortal);
-    spyOn(overlayRef, 'updatePosition');
+    spyOn(overlayRef, 'recalculateLastPosition');
 
     scrolledSubject.next();
-    expect(overlayRef.updatePosition).toHaveBeenCalledTimes(1);
+    expect(overlayRef.recalculateLastPosition).toHaveBeenCalledTimes(1);
 
     scrolledSubject.next();
-    expect(overlayRef.updatePosition).toHaveBeenCalledTimes(2);
+    expect(overlayRef.recalculateLastPosition).toHaveBeenCalledTimes(2);
   });
 
   it('should not be updating the position after the overlay is detached', () => {
     overlayRef.attach(componentPortal);
-    spyOn(overlayRef, 'updatePosition');
+    spyOn(overlayRef, 'recalculateLastPosition');
 
     overlayRef.detach();
     scrolledSubject.next();
 
-    expect(overlayRef.updatePosition).not.toHaveBeenCalled();
+    expect(overlayRef.recalculateLastPosition).not.toHaveBeenCalled();
   });
 
   it('should not be updating the position after the overlay is destroyed', () => {
     overlayRef.attach(componentPortal);
-    spyOn(overlayRef, 'updatePosition');
+    spyOn(overlayRef, 'recalculateLastPosition');
 
     overlayRef.dispose();
     scrolledSubject.next();
 
-    expect(overlayRef.updatePosition).not.toHaveBeenCalled();
+    expect(overlayRef.recalculateLastPosition).not.toHaveBeenCalled();
   });
 
 });

--- a/src/lib/core/overlay/scroll/reposition-scroll-strategy.ts
+++ b/src/lib/core/overlay/scroll/reposition-scroll-strategy.ts
@@ -42,7 +42,7 @@ export class RepositionScrollStrategy implements ScrollStrategy {
       let throttle = this._config ? this._config.scrollThrottle : 0;
 
       this._scrollSubscription = this._scrollDispatcher.scrolled(throttle, () => {
-        this._overlayRef.updatePosition();
+        this._overlayRef.recalculateLastPosition();
       });
     }
   }


### PR DESCRIPTION
Uses the element's last calculated position to re-align it, instead of recomputing the position completely. This prevents the overlay from jumping into the viewport when the user scrolls away.