### PR TITLE
feat(menu): add nested menu functionality

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -15,7 +15,61 @@
     </md-menu>
   </div>
   <div class="menu-section">
-    <p> Clicking these will navigate:</p>
+    <p>Nested menu</p>
+
+    <md-toolbar>
+      <button md-icon-button [mdMenuTriggerFor]="animals">
+        <md-icon>more_vert</md-icon>
+      </button>
+    </md-toolbar>
+
+    <md-menu #animals="mdMenu">
+      <button md-menu-item [mdMenuTriggerFor]="vertebrates">Vertebrates</button>
+      <button md-menu-item [mdMenuTriggerFor]="invertebrates">Invertebrates</button>
+    </md-menu>
+
+    <md-menu #vertebrates="mdMenu">
+      <button md-menu-item [mdMenuTriggerFor]="fish">Fishes</button>
+      <button md-menu-item [mdMenuTriggerFor]="amphibians">Amphibians</button>
+      <button md-menu-item [mdMenuTriggerFor]="reptiles">Reptiles</button>
+      <button md-menu-item>Birds</button>
+      <button md-menu-item>Mammals</button>
+    </md-menu>
+
+    <md-menu #invertebrates="mdMenu">
+      <button md-menu-item>Insects</button>
+      <button md-menu-item>Molluscs</button>
+      <button md-menu-item>Crustaceans</button>
+      <button md-menu-item>Corals</button>
+      <button md-menu-item>Arachnids</button>
+      <button md-menu-item>Velvet worms</button>
+      <button md-menu-item>Horseshoe crabs</button>
+    </md-menu>
+
+    <md-menu #fish="mdMenu">
+      <button md-menu-item>Baikal oilfish</button>
+      <button md-menu-item>Bala shark</button>
+      <button md-menu-item>Ballan wrasse</button>
+      <button md-menu-item>Bamboo shark</button>
+      <button md-menu-item>Banded killifish</button>
+    </md-menu>
+
+    <md-menu #amphibians="mdMenu">
+      <button md-menu-item>Sonoran desert toad</button>
+      <button md-menu-item>Western toad</button>
+      <button md-menu-item>Arroyo toad</button>
+      <button md-menu-item>Yosemite toad</button>
+    </md-menu>
+
+    <md-menu #reptiles="mdMenu">
+      <button md-menu-item>Banded Day Gecko</button>
+      <button md-menu-item>Banded Gila Monster</button>
+      <button md-menu-item>Black Tree Monitor</button>
+      <button md-menu-item>Blue Spiny Lizard</button>
+    </md-menu>
+  </div>
+  <div class="menu-section">
+    <p>Clicking these will navigate:</p>
     <md-toolbar>
       <button md-icon-button [mdMenuTriggerFor]="anchorMenu" aria-label="Open anchor menu">
         <md-icon>more_vert</md-icon>

--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -24,7 +24,12 @@
       vertical-align: middle;
     }
 
-    &:hover:not([disabled]), &:focus:not([disabled]) {
+  }
+
+  .mat-menu-item:hover,
+  .mat-menu-item:focus,
+  .mat-menu-item-highlighted {
+    &:not([disabled]) {
       background: mat-color($background, 'hover');
     }
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -20,7 +20,6 @@ import {
   ViewEncapsulation,
   ElementRef,
   ChangeDetectionStrategy,
-  Directive,
 } from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {MenuPositionX, MenuPositionY} from './menu-positions';

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -118,13 +118,13 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   }
 
   /** Event emitted when the menu is closed. */
-  @Output() close = new EventEmitter<void>();
+  @Output() close = new EventEmitter<void | 'click' | 'keydown'>();
 
   constructor(private _elementRef: ElementRef) { }
 
   ngAfterContentInit() {
     this._keyManager = new FocusKeyManager(this.items).withWrap();
-    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.close.emit());
+    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.close.emit('keydown'));
   }
 
   ngOnDestroy() {
@@ -145,16 +145,16 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   _handleKeydown(event: KeyboardEvent) {
     switch (event.keyCode) {
       case ESCAPE:
-        this.close.emit();
+        this.close.emit('keydown');
       break;
       case LEFT_ARROW:
         if (this.isSubmenu && this.direction === 'ltr') {
-          this.close.emit();
+          this.close.emit('keydown');
         }
       break;
       case RIGHT_ARROW:
         if (this.isSubmenu && this.direction === 'rtl') {
-          this.close.emit();
+          this.close.emit('keydown');
         }
       break;
       default:

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, ChangeDetectionStrategy} from '@angular/core';
+import {Component, ElementRef, OnDestroy, ChangeDetectionStrategy} from '@angular/core';
 import {Focusable} from '../core/a11y/focus-key-manager';
 import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
+import {Subject} from 'rxjs/Subject';
 
 // Boilerplate for applying mixins to MdMenuItem.
 /** @docs-private */
@@ -26,16 +27,23 @@ export const _MdMenuItemMixinBase = mixinDisabled(MdMenuItemBase);
   host: {
     'role': 'menuitem',
     'class': 'mat-menu-item',
+    '[class.mat-menu-item-highlighted]': '_highlighted',
     '[attr.tabindex]': '_getTabIndex()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.disabled]': 'disabled || null',
     '(click)': '_checkDisabled($event)',
+    '(mouseenter)': '_emitHoverEvent()',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: 'menu-item.html',
   exportAs: 'mdMenuItem',
 })
-export class MdMenuItem extends _MdMenuItemMixinBase implements Focusable, CanDisable {
+export class MdMenuItem extends _MdMenuItemMixinBase implements Focusable, CanDisable, OnDestroy {
+  /** Stream that emits when the menu item is hovered. */
+  hover: Subject<MdMenuItem> = new Subject();
+
+  /** Whether the menu item is highlighted. */
+  _highlighted: boolean = false;
 
   constructor(private _elementRef: ElementRef) {
     super();
@@ -44,6 +52,10 @@ export class MdMenuItem extends _MdMenuItemMixinBase implements Focusable, CanDi
   /** Focuses the menu item. */
   focus(): void {
     this._getHostElement().focus();
+  }
+
+  ngOnDestroy() {
+    this.hover.complete();
   }
 
   /** Used to set the `tabindex`. */
@@ -63,5 +75,13 @@ export class MdMenuItem extends _MdMenuItemMixinBase implements Focusable, CanDi
       event.stopPropagation();
     }
   }
+
+  /** Emits to the hover stream. */
+  _emitHoverEvent() {
+    if (!this.disabled) {
+      this.hover.next(this);
+    }
+  }
+
 }
 

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -15,7 +15,7 @@ export interface MdMenuPanel {
   yPosition: MenuPositionY;
   overlapTrigger: boolean;
   templateRef: TemplateRef<any>;
-  close: EventEmitter<void>;
+  close: EventEmitter<void | 'click' | 'keydown'>;
   isSubmenu: boolean;
   direction: Direction;
   focusFirstItem: () => void;

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -17,7 +17,7 @@ export interface MdMenuPanel {
   templateRef: TemplateRef<any>;
   close: EventEmitter<void | 'click' | 'keydown'>;
   isSubmenu?: boolean;
-  direction: Direction;
+  direction?: Direction;
   focusFirstItem: () => void;
   setPositionClasses: (x: MenuPositionX, y: MenuPositionY) => void;
 }

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -16,7 +16,7 @@ export interface MdMenuPanel {
   overlapTrigger: boolean;
   templateRef: TemplateRef<any>;
   close: EventEmitter<void | 'click' | 'keydown'>;
-  isSubmenu: boolean;
+  isSubmenu?: boolean;
   direction: Direction;
   focusFirstItem: () => void;
   setPositionClasses: (x: MenuPositionX, y: MenuPositionY) => void;

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -8,6 +8,7 @@
 
 import {EventEmitter, TemplateRef} from '@angular/core';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
+import {Direction} from '../core';
 
 export interface MdMenuPanel {
   xPosition: MenuPositionX;
@@ -15,7 +16,8 @@ export interface MdMenuPanel {
   overlapTrigger: boolean;
   templateRef: TemplateRef<any>;
   close: EventEmitter<void>;
+  isSubmenu: boolean;
+  direction: Direction;
   focusFirstItem: () => void;
   setPositionClasses: (x: MenuPositionX, y: MenuPositionY) => void;
-  _emitCloseEvent: () => void;
 }

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -3,7 +3,7 @@
     class="mat-menu-panel"
     [ngClass]="_classList"
     (keydown)="_handleKeydown($event)"
-    (click)="_emitCloseEvent()"
+    (click)="close.emit()"
     [@transformMenu]="_panelAnimationState"
     (@transformMenu.done)="_onAnimationDone($event)"
     role="menu">

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -3,7 +3,7 @@
     class="mat-menu-panel"
     [ngClass]="_classList"
     (keydown)="_handleKeydown($event)"
-    (click)="close.emit()"
+    (click)="close.emit('click')"
     [@transformMenu]="_panelAnimationState"
     (@transformMenu.done)="_onAnimationDone($event)"
     role="menu">

--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -70,7 +70,7 @@ The position can be changed using the `xPosition` (`before | after`) and `yPosit
 
 ### Nested menu
 
-Material supports the ability for a `md-menu-item` to open a sub-menu. To do so, you have to define
+Material supports the ability for an `md-menu-item` to open a sub-menu. To do so, you have to define
 your root menu and sub-menus, in addition to setting the `[mdMenuTriggerFor]` on the `md-menu-item`
 that should trigger the sub-menu:
 

--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -1,8 +1,8 @@
-`<md-menu>` is a floating panel containing list of options. 
+`<md-menu>` is a floating panel containing list of options.
 
 <!-- example(menu-overview) -->
 
-By itself, the `<md-menu>` element does not render anything. The menu is attached to and opened 
+By itself, the `<md-menu>` element does not render anything. The menu is attached to and opened
 via application of the `mdMenuTriggerFor` directive:
 ```html
 <md-menu #appMenu="mdMenu">
@@ -16,7 +16,7 @@ via application of the `mdMenuTriggerFor` directive:
 ```
 
 ### Toggling the menu programmatically
-The menu exposes an API to open/close programmatically. Please note that in this case, an 
+The menu exposes an API to open/close programmatically. Please note that in this case, an
 `mdMenuTriggerFor` directive is still necessary to attach the menu to a trigger element in the DOM.
 
 ```ts
@@ -52,9 +52,10 @@ Menus support displaying `md-icon` elements before the menu item text.
 
 ### Customizing menu position
 
-By default, the menu will display below (y-axis), after (x-axis), and overlapping its trigger.  The position can be changed
-using the `xPosition` (`before | after`) and `yPosition` (`above | below`) attributes.
-The menu can be be forced to not overlap the trigger using `[overlapTrigger]="false"` attribute.
+By default, the menu will display below (y-axis), after (x-axis), and overlapping its trigger.
+The position can be changed using the `xPosition` (`before | after`) and `yPosition`
+(`above | below`) attributes. The menu can be be forced to not overlap the trigger using
+`[overlapTrigger]="false"` attribute.
 
 ```html
 <md-menu #appMenu="mdMenu" yPosition="above">
@@ -63,7 +64,30 @@ The menu can be be forced to not overlap the trigger using `[overlapTrigger]="fa
 </md-menu>
 
 <button md-icon-button [mdMenuTriggerFor]="appMenu">
-   <md-icon>more_vert</md-icon>
+  <md-icon>more_vert</md-icon>
+</button>
+```
+
+### Nested menu
+
+Material supports the ability for a `md-menu-item` to open a sub-menu. To do so, you have to define
+your root menu and sub-menus, in addition to setting the `[mdMenuTriggerFor]` on the `md-menu-item`
+that should trigger the sub-menu:
+
+```html
+<md-menu #rootMenu="mdMenu">
+  <button md-menu-item [mdMenuTriggerFor]="subMenu">Power</button>
+  <button md-menu-item>System settings</button>
+</md-menu>
+
+<md-menu #subMenu="mdMenu">
+  <button md-menu-item>Shut down</button>
+  <button md-menu-item>Restart</button>
+  <button md-menu-item>Hibernate</button>
+</md-menu>
+
+<button md-icon-button [mdMenuTriggerFor]="rootMenu">
+  <md-icon>more_vert</md-icon>
 </button>
 ```
 
@@ -71,4 +95,6 @@ The menu can be be forced to not overlap the trigger using `[overlapTrigger]="fa
 ### Keyboard interaction
 - <kbd>DOWN_ARROW</kbd>: Focuses the next menu item
 - <kbd>UP_ARROW</kbd>: Focuses previous menu item
+- <kbd>RIGHT_ARROW</kbd>: Opens the menu item's sub-menu
+- <kbd>LEFT_ARROW</kbd>: Closes the current menu, if it is a sub-menu.
 - <kbd>ENTER</kbd>: Activates the focused menu item

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -11,18 +11,24 @@ import {
   ViewChild
 } from '@angular/core';
 import {
+  OverlayContainer,
+  Directionality,
+  Direction,
+  ESCAPE,
+  RIGHT_ARROW,
+  LEFT_ARROW,
+} from '../core';
+import {
   MdMenuModule,
   MdMenuTrigger,
   MdMenuPanel,
   MenuPositionX,
   MenuPositionY,
-  MdMenu
+  MdMenu,
 } from './index';
-import {OverlayContainer} from '../core/overlay/overlay-container';
-import {Directionality, Direction} from '../core/bidi/index';
+import {MENU_PANEL_TOP_PADDING} from './menu-trigger';
 import {extendObject} from '../core/util/object-extend';
-import {ESCAPE} from '../core/keyboard/keycodes';
-import {dispatchKeyboardEvent} from '@angular/cdk/testing';
+import {dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing';
 
 
 describe('MdMenu', () => {
@@ -33,7 +39,14 @@ describe('MdMenu', () => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [MdMenuModule, NoopAnimationsModule],
-      declarations: [SimpleMenu, PositionedMenu, OverlapMenu, CustomMenuPanel, CustomMenu],
+      declarations: [
+        SimpleMenu,
+        PositionedMenu,
+        OverlapMenu,
+        CustomMenuPanel,
+        CustomMenu,
+        NestedMenu
+      ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
           overlayContainerElement = document.createElement('div');
@@ -145,6 +158,11 @@ describe('MdMenu', () => {
 
     const role = menuPanel ? menuPanel.getAttribute('role') : '';
     expect(role).toBe('menu', 'Expected panel to have the "menu" role.');
+  });
+
+  it('should not throw an error on destroy', () => {
+    const fixture = TestBed.createComponent(SimpleMenu);
+    expect(fixture.destroy.bind(fixture)).not.toThrow();
   });
 
   describe('positions', () => {
@@ -491,12 +509,349 @@ describe('MdMenu', () => {
     });
   });
 
-  describe('destroy', () => {
-    it('does not throw an error on destroy', () => {
-      const fixture = TestBed.createComponent(SimpleMenu);
-      expect(fixture.destroy.bind(fixture)).not.toThrow();
+  describe('nested menu', () => {
+    let fixture: ComponentFixture<NestedMenu>;
+    let instance: NestedMenu;
+    let overlay: HTMLElement;
+    let compileTestComponent = () => {
+      fixture = TestBed.createComponent(NestedMenu);
+      fixture.detectChanges();
+      instance = fixture.componentInstance;
+      overlay = overlayContainerElement;
+    };
+
+    it('should set the `triggersSubmenu` flags on the triggers', () => {
+      compileTestComponent();
+      expect(instance.rootTrigger.triggersSubmenu()).toBe(false);
+      expect(instance.levelOneTrigger.triggersSubmenu()).toBe(true);
+      expect(instance.levelTwoTrigger.triggersSubmenu()).toBe(true);
     });
+
+    it('should set the `isSubmenu` flag on the menu instances', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(instance.rootMenu.isSubmenu).toBe(false);
+      expect(instance.levelOneMenu.isSubmenu).toBe(true);
+      expect(instance.levelTwoMenu.isSubmenu).toBe(true);
+    });
+
+    it('should pass the layout direction the nested menus', () => {
+      dir = 'rtl';
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(instance.rootMenu.direction).toBe('rtl');
+      expect(instance.levelOneMenu.direction).toBe('rtl');
+      expect(instance.levelTwoMenu.direction).toBe('rtl');
+    });
+
+    it('should emit an event when the hover state of the menu items changes', () => {
+      compileTestComponent();
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      const spy = jasmine.createSpy('hover spy');
+      const subscription = instance.rootMenu.hover.subscribe(spy);
+      const menuItems = overlay.querySelectorAll('[md-menu-item]');
+
+      dispatchMouseEvent(menuItems[0], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      dispatchMouseEvent(menuItems[1], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      subscription.unsubscribe();
+    });
+
+    it('should toggle a nested menu when its trigger is hovered', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+
+      const items = Array.from(overlay.querySelectorAll('.mat-menu-panel [md-menu-item]'));
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')!;
+
+      dispatchMouseEvent(levelOneTrigger, 'mouseenter');
+      fixture.detectChanges();
+      expect(levelOneTrigger.classList)
+          .toContain('mat-menu-item-highlighted', 'Expected the trigger to be highlighted');
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(2, 'Expected two open menus');
+
+      dispatchMouseEvent(items[items.indexOf(levelOneTrigger) + 1], 'mouseenter');
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+      expect(levelOneTrigger.classList)
+          .not.toContain('mat-menu-item-highlighted', 'Expected the trigger to not be highlighted');
+    });
+
+    it('should close all the open sub-menus when the hover state is changed at the root', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      const items = Array.from(overlay.querySelectorAll('.mat-menu-panel [md-menu-item]'));
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')!;
+
+      dispatchMouseEvent(levelOneTrigger, 'mouseenter');
+      fixture.detectChanges();
+
+      const levelTwoTrigger = overlay.querySelector('#level-two-trigger')! as HTMLElement;
+      dispatchMouseEvent(levelTwoTrigger, 'mouseenter');
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length)
+          .toBe(3, 'Expected three open menus');
+
+      dispatchMouseEvent(items[items.indexOf(levelOneTrigger) + 1], 'mouseenter');
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+    });
+
+    it('should open a nested menu when its trigger is clicked', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+
+      levelOneTrigger.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(2, 'Expected two open menus');
+
+      levelOneTrigger.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length)
+          .toBe(2, 'Expected repeat clicks not to close the menu.');
+    });
+
+    it('should open and close a nested menu with arrow keys in ltr', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+
+      dispatchKeyboardEvent(levelOneTrigger, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      const panels = overlay.querySelectorAll('.mat-menu-panel');
+
+      expect(panels.length).toBe(2, 'Expected two open menus');
+      dispatchKeyboardEvent(panels[1], 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1);
+    });
+
+    it('should open and close a nested menu with the arrow keys in rtl', () => {
+      dir = 'rtl';
+      fixture.destroy();
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+
+      dispatchKeyboardEvent(levelOneTrigger, 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+
+      const panels = overlay.querySelectorAll('.mat-menu-panel');
+
+      expect(panels.length).toBe(2, 'Expected two open menus');
+      dispatchKeyboardEvent(panels[1], 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1);
+    });
+
+    it('should not do anything with the arrow keys for a top-level menu', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      const menu = overlay.querySelector('.mat-menu-panel')!;
+
+      dispatchKeyboardEvent(menu, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length)
+          .toBe(1, 'Expected one menu to remain open');
+
+      dispatchKeyboardEvent(menu, 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length)
+          .toBe(1, 'Expected one menu to remain open');
+    });
+
+    it('should close all of the menus when the backdrop is clicked', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length)
+          .toBe(3, 'Expected three open menus');
+      expect(overlay.querySelectorAll('.cdk-overlay-backdrop').length)
+          .toBe(1, 'Expected one backdrop element');
+      expect(overlay.querySelectorAll('.mat-menu-panel, .cdk-overlay-backdrop')[0].classList)
+          .toContain('cdk-overlay-backdrop', 'Expected backdrop to be beneath all of the menus');
+
+      (overlay.querySelector('.cdk-overlay-backdrop')! as HTMLElement).click();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(0, 'Expected no open menus');
+    });
+
+    it('should shift focus between the sub-menus', () => {
+      compileTestComponent();
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelector('.mat-menu-panel')!.contains(document.activeElement))
+          .toBe(true, 'Expected focus to be inside the root menu');
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel')[1].contains(document.activeElement))
+          .toBe(true, 'Expected focus to be inside the first nested menu');
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel')[2].contains(document.activeElement))
+          .toBe(true, 'Expected focus to be inside the second nested menu');
+
+      instance.levelTwoTrigger.closeMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel')[1].contains(document.activeElement))
+          .toBe(true, 'Expected focus to be back inside the first nested menu');
+
+      instance.levelOneTrigger.closeMenu();
+      fixture.detectChanges();
+
+      expect(overlay.querySelector('.mat-menu-panel')!.contains(document.activeElement))
+          .toBe(true, 'Expected focus to be back inside the root menu');
+    });
+
+    it('should not shift focus to the sub-menu when it was opened by hover', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+
+      dispatchMouseEvent(levelOneTrigger, 'mouseenter');
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel')[1].contains(document.activeElement))
+          .toBe(false, 'Expected focus to not be inside the nested menu');
+    });
+
+    it('should position the sub-menu to the right edge of the trigger in ltr', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.style.position = 'fixed';
+      instance.rootTriggerEl.nativeElement.style.left = '50%';
+      instance.rootTriggerEl.nativeElement.style.top = '50%';
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      const triggerRect = overlay.querySelector('#level-one-trigger')!.getBoundingClientRect();
+      const panelRect = overlay.querySelectorAll('.mat-menu-panel')[1].getBoundingClientRect();
+
+      expect(Math.round(triggerRect.right)).toBe(Math.round(panelRect.left));
+      expect(Math.round(triggerRect.top)).toBe(Math.round(panelRect.top) + MENU_PANEL_TOP_PADDING);
+    });
+
+    it('should fall back to aligning to the left edge of the trigger in ltr', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.style.position = 'fixed';
+      instance.rootTriggerEl.nativeElement.style.right = '10px';
+      instance.rootTriggerEl.nativeElement.style.top = '50%';
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      const triggerRect = overlay.querySelector('#level-one-trigger')!.getBoundingClientRect();
+      const panelRect = overlay.querySelectorAll('.mat-menu-panel')[1].getBoundingClientRect();
+
+      expect(Math.round(triggerRect.left)).toBe(Math.round(panelRect.right));
+      expect(Math.round(triggerRect.top)).toBe(Math.round(panelRect.top) + MENU_PANEL_TOP_PADDING);
+    });
+
+    it('should position the sub-menu to the left edge of the trigger in rtl', () => {
+      dir = 'rtl';
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.style.position = 'fixed';
+      instance.rootTriggerEl.nativeElement.style.left = '50%';
+      instance.rootTriggerEl.nativeElement.style.top = '50%';
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      const triggerRect = overlay.querySelector('#level-one-trigger')!.getBoundingClientRect();
+      const panelRect = overlay.querySelectorAll('.mat-menu-panel')[1].getBoundingClientRect();
+
+      expect(Math.round(triggerRect.left)).toBe(Math.round(panelRect.right));
+      expect(Math.round(triggerRect.top)).toBe(Math.round(panelRect.top) + MENU_PANEL_TOP_PADDING);
+    });
+
+    it('should fall back to aligning to the right edge of the trigger in rtl', () => {
+      dir = 'rtl';
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.style.position = 'fixed';
+      instance.rootTriggerEl.nativeElement.style.left = '10px';
+      instance.rootTriggerEl.nativeElement.style.top = '50%';
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      const triggerRect = overlay.querySelector('#level-one-trigger')!.getBoundingClientRect();
+      const panelRect = overlay.querySelectorAll('.mat-menu-panel')[1].getBoundingClientRect();
+
+      expect(Math.round(triggerRect.right)).toBe(Math.round(panelRect.left));
+      expect(Math.round(triggerRect.top)).toBe(Math.round(panelRect.top) + MENU_PANEL_TOP_PADDING);
+    });
+
   });
+
 });
 
 @Component({
@@ -559,17 +914,16 @@ class OverlapMenu implements TestableMenu {
   exportAs: 'mdCustomMenu'
 })
 class CustomMenuPanel implements MdMenuPanel {
+  direction: Direction;
   xPosition: MenuPositionX = 'after';
   yPosition: MenuPositionY = 'below';
-  overlapTrigger: true;
+  overlapTrigger = true;
+  isSubmenu = false;
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
   @Output() close = new EventEmitter<void>();
   focusFirstItem = () => {};
   setPositionClasses = () => {};
-  _emitCloseEvent() {
-    this.close.emit();
-  }
 }
 
 @Component({
@@ -582,4 +936,49 @@ class CustomMenuPanel implements MdMenuPanel {
 })
 class CustomMenu {
   @ViewChild(MdMenuTrigger) trigger: MdMenuTrigger;
+}
+
+
+@Component({
+  template: `
+    <button
+      [mdMenuTriggerFor]="root"
+      #rootTrigger="mdMenuTrigger"
+      #rootTriggerEl>Toggle menu</button>
+
+    <md-menu #root="mdMenu">
+      <button md-menu-item
+        id="level-one-trigger"
+        [mdMenuTriggerFor]="levelOne"
+        #levelOneTrigger="mdMenuTrigger">One</button>
+      <button md-menu-item>Two</button>
+      <button md-menu-item>Three</button>
+    </md-menu>
+
+    <md-menu #levelOne="mdMenu">
+      <button md-menu-item>Four</button>
+      <button md-menu-item
+        id="level-two-trigger"
+        [mdMenuTriggerFor]="levelTwo"
+        #levelTwoTrigger="mdMenuTrigger">Five</button>
+      <button md-menu-item>Six</button>
+    </md-menu>
+
+    <md-menu #levelTwo="mdMenu">
+      <button md-menu-item>Seven</button>
+      <button md-menu-item>Eight</button>
+      <button md-menu-item>Nine</button>
+    </md-menu>
+  `
+})
+class NestedMenu {
+  @ViewChild('root') rootMenu: MdMenu;
+  @ViewChild('rootTrigger') rootTrigger: MdMenuTrigger;
+  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef;
+
+  @ViewChild('levelOne') levelOneMenu: MdMenu;
+  @ViewChild('levelOneTrigger') levelOneTrigger: MdMenuTrigger;
+
+  @ViewChild('levelTwo') levelTwoMenu: MdMenu;
+  @ViewChild('levelTwoTrigger') levelTwoTrigger: MdMenuTrigger;
 }

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -850,6 +850,27 @@ describe('MdMenu', () => {
       expect(Math.round(triggerRect.top)).toBe(Math.round(panelRect.top) + MENU_PANEL_TOP_PADDING);
     });
 
+    it('should close all of the menus when an item is clicked', () => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      const menus = overlay.querySelectorAll('.mat-menu-panel');
+
+      expect(menus.length).toBe(3, 'Expected three open menus');
+
+      (menus[2].querySelector('.mat-menu-item')! as HTMLElement).click();
+      fixture.detectChanges();
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(0, 'Expected no open menus');
+    });
+
   });
 
 });
@@ -921,7 +942,7 @@ class CustomMenuPanel implements MdMenuPanel {
   isSubmenu = false;
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
-  @Output() close = new EventEmitter<void>();
+  @Output() close = new EventEmitter<void | 'click' | 'keydown'>();
   focusFirstItem = () => {};
   setPositionClasses = () => {};
 }

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -566,7 +566,7 @@ describe('MdMenu', () => {
       fixture.detectChanges();
 
       const spy = jasmine.createSpy('hover spy');
-      const subscription = instance.rootMenu.hover.subscribe(spy);
+      const subscription = instance.rootMenu.hover().subscribe(spy);
       const menuItems = overlay.querySelectorAll('[md-menu-item]');
 
       dispatchMouseEvent(menuItems[0], 'mouseenter');

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -779,8 +779,8 @@ describe('MdMenu', () => {
     it('should position the sub-menu to the right edge of the trigger in ltr', () => {
       compileTestComponent();
       instance.rootTriggerEl.nativeElement.style.position = 'fixed';
-      instance.rootTriggerEl.nativeElement.style.left = '50%';
-      instance.rootTriggerEl.nativeElement.style.top = '50%';
+      instance.rootTriggerEl.nativeElement.style.left = '50px';
+      instance.rootTriggerEl.nativeElement.style.top = '50px';
       instance.rootTrigger.openMenu();
       fixture.detectChanges();
 


### PR DESCRIPTION
Adds the ability for an `md-menu-item` inside of a `md-menu` to trigger another `md-menu`. This is a first step towards a `md-toolbar` component.

Demo: https://material-cb7ec.firebaseapp.com/menu

Fixes #1429.