### PR TITLE
docs(ripple): remove outdated createRipple method in docs

### DIFF
--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -57,8 +57,8 @@ export class MdRipple implements OnChanges, OnDestroy {
   @Input('mdRippleCentered') centered: boolean;
 
   /**
-   * Whether click events will not trigger the ripple. It can still be triggered by manually
-   * calling createRipple()
+   * Whether click events will not trigger the ripple. Ripples can be still launched manually
+   * by using the `launch()` method.
    */
   @Input('mdRippleDisabled') disabled: boolean;
 


### PR DESCRIPTION
* Replaces the outdated `createRipple()` method with the new `launch()` method in the docs.

Fixes #5480