### PR TITLE
chore(menu): switch to OnPush change detection

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -19,6 +19,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   ElementRef,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
 import {throwMdMenuInvalidPositionX, throwMdMenuInvalidPositionY} from './menu-errors';
@@ -35,6 +36,7 @@ import {ESCAPE} from '../core/keyboard/keycodes';
   selector: 'md-menu, mat-menu',
   templateUrl: 'menu.html',
   styleUrls: ['menu.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   animations: [
     transformMenu,

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef} from '@angular/core';
+import {Component, ElementRef, ChangeDetectionStrategy} from '@angular/core';
 import {Focusable} from '../core/a11y/focus-key-manager';
 import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 
@@ -31,8 +31,9 @@ export const _MdMenuItemMixinBase = mixinDisabled(MdMenuItemBase);
     '[attr.disabled]': 'disabled || null',
     '(click)': '_checkDisabled($event)',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: 'menu-item.html',
-  exportAs: 'mdMenuItem'
+  exportAs: 'mdMenuItem',
 })
 export class MdMenuItem extends _MdMenuItemMixinBase implements Focusable, CanDisable {
 


### PR DESCRIPTION
Switches the `md-menu` and `md-menu-item` components to `OnPush` change detection.

Relates to #5035.