### PR TITLE
fix(slide-toggle): slide-toggle module depends on forms module

### DIFF
--- a/src/lib/slide-toggle/index.ts
+++ b/src/lib/slide-toggle/index.ts
@@ -7,7 +7,6 @@
  */
 
 import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {MdSlideToggle} from './slide-toggle';
 import {
@@ -19,7 +18,7 @@ import {
 } from '../core';
 
 @NgModule({
-  imports: [FormsModule, MdRippleModule, MdCommonModule, PlatformModule],
+  imports: [MdRippleModule, MdCommonModule, PlatformModule],
   exports: [MdSlideToggle, MdCommonModule],
   declarations: [MdSlideToggle],
   providers: [

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -23,6 +23,53 @@ describe('MdSlideToggle', () => {
     TestBed.compileComponents();
   }));
 
+  describe('without form modules', () => {
+    let fixture: ComponentFixture<SlideToggleWithoutForms>;
+    let slideToggleInstance: MdSlideToggle;
+    let labelElement: HTMLLabelElement;
+
+    beforeEach(async(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MdSlideToggleModule],
+        declarations: [SlideToggleWithoutForms]
+      });
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SlideToggleWithoutForms);
+      fixture.detectChanges();
+
+      const slideToggleDebug = fixture.debugElement.query(By.directive(MdSlideToggle));
+
+      slideToggleInstance = slideToggleDebug.componentInstance;
+      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+    });
+
+    it('should update the checked state on click', () => {
+      expect(slideToggleInstance.checked)
+        .toBe(false, 'Expected the slide-toggle not to be checked initially.');
+
+      labelElement.click();
+      fixture.detectChanges();
+
+      expect(slideToggleInstance.checked)
+        .toBe(true, 'Expected the slide-toggle to be checked after click.');
+    });
+
+    it('should update the checked state from binding', () => {
+      expect(slideToggleInstance.checked)
+        .toBe(false, 'Expected the slide-toggle not to be checked initially.');
+
+      fixture.componentInstance.isChecked = true;
+      fixture.detectChanges();
+
+      expect(slideToggleInstance.checked)
+        .toBe(true, 'Expected the slide-toggle to be checked after click.');
+    });
+
+  });
+
   describe('basic behavior', () => {
     let fixture: ComponentFixture<any>;
 
@@ -712,4 +759,11 @@ class SlideToggleFormsTestApp {
 })
 class SlideToggleWithFormControl {
   formControl = new FormControl();
+}
+
+@Component({
+  template: `<md-slide-toggle [checked]="isChecked"></md-slide-toggle>`
+})
+class SlideToggleWithoutForms {
+  isChecked = false;
 }


### PR DESCRIPTION
* Currently the slide-toggle module always imports the `FormsModule` and therefore when treeshaking the `FormsModule` would be always included (even if FormsModule is not used at all)

**Note**: I'm working on similar PRs for the *button-toggle*  and *slider* (need to check first)