### PR TITLE
docs(table): add missing table JsDoc

### DIFF
--- a/guides/cdk-table.md
+++ b/guides/cdk-table.md
@@ -6,8 +6,9 @@ The table provides a foundation upon which other features, such as sorting and p
 built. Because it enforces no opinions on these matters, developers have full control over the
 interaction patterns associated with the table.
 
-For a Material Design styled table, see the documentation for `<md-table>` which builds on top of
-the CDK data-table.
+For a Material Design styled table, see the
+[documentation for `<md-table>`](https://material.angular.io/components/table) which builds on
+top of the CDK data-table.
 
 <!-- example(cdk-table-basic) -->
 
@@ -117,12 +118,9 @@ sorting and pagination.
 
 ##### `trackBy`
 To improve performance, a trackBy function can be provided to the table similar to Angular’s
-(`ngFor` trackBy)[trackBy]. This informs the table how to uniquely identify rows to track how the
-data changes with each update.
+[`ngFor` trackBy](https://angular.io/api/common/NgForOf#change-propagation). This informs the
+table how to uniquely identify rows to track how the data changes with each update.
 
 ```html
 <cdk-table [dataSource]="dataSource" [trackBy]="myTrackById">
 ```
-
-
-[trackBy][https://angular.io/api/common/NgForOf#change-propagation]

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,9 +69,9 @@
       "dev": true
     },
     "@google-cloud/common": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.3.tgz",
-      "integrity": "sha1-1z7j+lEfKf+8xEZniYaFcJ6f7Iw=",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.4.tgz",
+      "integrity": "sha1-dbt/YJMc/J2U2gtdQIlQ0Lvw6Xk=",
       "dev": true
     },
     "@google-cloud/functions-emulator": {
@@ -81,6 +81,13 @@
       "dev": true,
       "optional": true,
       "dependencies": {
+        "@google-cloud/storage": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.1.tgz",
+          "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
+          "dev": true,
+          "optional": true
+        },
         "ajv": {
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
@@ -88,10 +95,24 @@
           "dev": true,
           "optional": true
         },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true,
+          "optional": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true,
           "optional": true
         },
@@ -125,6 +146,34 @@
           "dev": true,
           "optional": true
         },
+        "gcp-metadata": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
+          "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
+          "dev": true,
+          "optional": true
+        },
+        "gcs-resumable-upload": {
+          "version": "0.7.7",
+          "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.7.tgz",
+          "integrity": "sha1-2clyWvlwu8hsvwr+8kBtwizpGGQ=",
+          "dev": true,
+          "optional": true
+        },
+        "google-auto-auth": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
+          "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "optional": true
+        },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -146,6 +195,13 @@
           "dev": true,
           "optional": true
         },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true,
+          "optional": true
+        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -160,10 +216,33 @@
           "dev": true,
           "optional": true
         },
+        "retry-request": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
+          "integrity": "sha1-Wa0k5x+K4/MS1fe0vPRnpeWle9Y=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.8",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+              "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+              "dev": true,
+              "optional": true
+            },
+            "request": {
+              "version": "2.76.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
           "dev": true,
           "optional": true,
           "dependencies": {
@@ -171,6 +250,13 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "optional": true
             }
@@ -187,6 +273,13 @@
           "version": "0.0.31",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
           "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true,
           "optional": true
         },
@@ -207,9 +300,9 @@
       }
     },
     "@google-cloud/storage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.1.tgz",
-      "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.2.0.tgz",
+      "integrity": "sha1-dO6TaJbaXkU8NBzygEQ0LBqazrc=",
       "dev": true
     },
     "@types/chalk": {
@@ -267,9 +360,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.32.tgz",
-      "integrity": "sha512-7+0Ai8r8Xt6NNVM0Eo+XSqiZsBUYXg2yrCwyBhQzSfFHTGQWzFv/pk9106vPR8HWjKmGK+zzUj244POs4xfO2g==",
+      "version": "7.0.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz",
+      "integrity": "sha512-8fVvl6Yyk3jZvSYxRMS9/AmZJ5RXCOP9N4xSlykyBViVESu751pxHYTN14Embn1Fem78YwEHdC7p7KGQQpwunw==",
       "dev": true
     },
     "@types/orchestrator": {
@@ -520,9 +613,9 @@
       "dev": true
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-differ": {
@@ -647,9 +740,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "dev": true
     },
     "async-each": {
@@ -695,9 +788,9 @@
       "dev": true
     },
     "axe-webdriverjs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-1.1.2.tgz",
-      "integrity": "sha1-YURZFaM6D2lkzSNl34FUbOlKtBs=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-1.1.3.tgz",
+      "integrity": "sha1-lIqXLk0OJSa0HGCptEBkkyu24G8=",
       "dev": true
     },
     "babel-code-frame": {
@@ -831,15 +924,7 @@
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
-      "dev": true,
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "boom": {
       "version": "2.10.1",
@@ -900,9 +985,9 @@
       "dev": true
     },
     "browserstacktunnel-wrapper": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz",
-      "integrity": "sha1-ZZj7fXhLb/NI4998EEsNnCfqUnU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-2.0.1.tgz",
+      "integrity": "sha1-/+GRDW45/oZhgYPoJmkAQa9T7a4=",
       "dev": true
     },
     "buffer-crc32": {
@@ -985,9 +1070,9 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000693",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000693.tgz",
-      "integrity": "sha1-hRDnqasErcyiOl3O+jTfnSjBziA=",
+      "version": "1.0.30000697",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000697.tgz",
+      "integrity": "sha1-IM5qnO7vTvShXcjoDy6PuQSejXc=",
       "dev": true
     },
     "canonical-path": {
@@ -1003,9 +1088,9 @@
       "dev": true
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "catharsis": {
@@ -1165,10 +1250,22 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true
+    },
     "color-diff": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
       "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
       "dev": true
     },
     "colorguard": {
@@ -1229,9 +1326,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "commondir": {
@@ -2262,9 +2359,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
-      "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M=",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz",
+      "integrity": "sha1-CDl5NIkcvPrrvRi4KpW1pIETg2k=",
       "dev": true
     },
     "encodeurl": {
@@ -2610,16 +2707,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
-      "optional": true,
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
     "express-session": {
       "version": "1.11.3",
@@ -3207,12 +3295,6 @@
           "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
           "dev": true
         },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        },
         "winston": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/winston/-/winston-1.1.2.tgz",
@@ -3366,9 +3448,9 @@
       "dev": true,
       "dependencies": {
         "jsonfile": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
-          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true
         }
       }
@@ -3388,172 +3470,146 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -3561,102 +3617,87 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -3664,155 +3705,132 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -3820,153 +3838,130 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -3974,68 +3969,58 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4043,108 +4028,92 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -4188,30 +4157,74 @@
       "dev": true
     },
     "gcp-metadata": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
-      "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.2.0.tgz",
+      "integrity": "sha1-Ytr8pl86YxvIzi7Dt3Zh9fk4ego=",
+      "dev": true
+    },
+    "gcs-resumable-upload": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.8.0.tgz",
+      "integrity": "sha1-023swVIzRGCC249J4hAndE80+CQ=",
       "dev": true,
       "dependencies": {
-        "request": {
-          "version": "2.76.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-          "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "gcp-metadata": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
+          "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
+          "dev": true
+        },
+        "google-auto-auth": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
+          "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
           "dev": true
         },
         "retry-request": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
           "integrity": "sha1-Wa0k5x+K4/MS1fe0vPRnpeWle9Y=",
+          "dev": true,
+          "dependencies": {
+            "request": {
+              "version": "2.76.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "dev": true
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
       }
-    },
-    "gcs-resumable-upload": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.7.tgz",
-      "integrity": "sha1-2clyWvlwu8hsvwr+8kBtwizpGGQ=",
-      "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
@@ -4303,7 +4316,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true
     },
     "glob-base": {
@@ -4515,9 +4528,9 @@
       "dev": true
     },
     "google-auto-auth": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
-      "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.1.tgz",
+      "integrity": "sha1-yCYERJEt2M7szYOHYdVvRik3vQI=",
       "dev": true
     },
     "google-closure-compiler": {
@@ -4589,57 +4602,49 @@
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-                  "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "osenv": {
                   "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-                  "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "os-tmpdir": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4649,77 +4654,66 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-              "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "readable-stream": {
                       "version": "2.2.10",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-                      "integrity": "sha1-7/5yu3yITA3TNeI3nVJhltnQEe4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "safe-buffer": {
                           "version": "5.1.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-                          "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
+                          "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-                          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -4729,67 +4723,57 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                  "bundled": true,
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "aproba": {
                       "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-                      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "has-unicode": {
                       "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "object-assign": {
                       "version": "4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                          "bundled": true,
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "bundled": true,
                           "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -4798,22 +4782,19 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-                      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4821,8 +4802,7 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -4830,36 +4810,31 @@
             },
             "rc": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -4867,71 +4842,61 @@
             },
             "request": {
               "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4939,36 +4904,31 @@
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -4978,8 +4938,7 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -4987,34 +4946,29 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "bundled": true,
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5022,49 +4976,42 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "bundled": true,
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -5072,70 +5019,60 @@
                     },
                     "sshpk": {
                       "version": "1.13.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-                      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "bundled": true,
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true
                         }
@@ -5145,84 +5082,72 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "safe-buffer": {
                   "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-                  "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5230,15 +5155,13 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 },
                 "uuid": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                  "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -5246,64 +5169,54 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "glob": {
                   "version": "7.1.2",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "minimatch": {
                       "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                          "bundled": true,
                           "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -5312,22 +5225,19 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "bundled": true,
                       "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -5336,63 +5246,54 @@
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "bundled": true,
               "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "bundled": true,
                   "dev": true
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "tar-pack": {
               "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "dependencies": {
                 "debug": {
                   "version": "2.6.8",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5400,63 +5301,54 @@
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                  "bundled": true,
                   "dev": true,
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                      "bundled": true,
                       "dev": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "minimatch": {
                       "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                          "bundled": true,
                           "dev": true,
                           "optional": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "bundled": true,
                               "dev": true,
                               "optional": true
                             }
@@ -5468,15 +5360,13 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5484,56 +5374,48 @@
                 },
                 "readable-stream": {
                   "version": "2.2.10",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-                  "integrity": "sha1-7/5yu3yITA3TNeI3nVJhltnQEe4=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "safe-buffer": {
                       "version": "5.1.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-                      "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-                      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -5541,8 +5423,7 @@
                 },
                 "uid-number": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -6131,9 +6012,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true
     },
     "has-ansi": {
@@ -6175,16 +6056,16 @@
       "dev": true
     },
     "has-symbol-support-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.2.0.tgz",
-      "integrity": "sha1-5iTq1RkMNbNOTimTRN/2Q32wLOI=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.3.0.tgz",
+      "integrity": "sha512-kLtS+N9qwz+Buc6TUfcW5iGb59hLLr5qfxTACi/0uGpH1u5NMNWsdU57KoYRBywvPykeRmu5qfB5x0chpDSWlg==",
       "dev": true,
       "optional": true
     },
     "has-to-string-tag-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.2.0.tgz",
-      "integrity": "sha1-xTbcTbvr4b6dKPYk/TIPeTEp/VM=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.3.0.tgz",
+      "integrity": "sha512-Fu9Nwv8/VNJMvKjkldzXHO+yeX+TCelwUQ9dGW2LrAfHfHi6zVqQt+Qjilf0qGHvpl6Fap6o8aDhWhMt5hY/1g==",
       "dev": true,
       "optional": true
     },
@@ -6243,9 +6124,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -6260,18 +6141,24 @@
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
       "dev": true,
       "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true
+        },
         "uglify-js": {
-          "version": "3.0.22",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.22.tgz",
-          "integrity": "sha512-VEC+Qdr615ZEbmf8xV+F9gKpX8mEJpB+lnYgNBkIgRkogz8eGzzZM1TbrS+FOqIvISdOrnQICQIBzt/fMlwUEQ==",
+          "version": "3.0.23",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.23.tgz",
+          "integrity": "sha512-miLHbO2QcdQGxL/q1wLcUr6TGIRHhMnpKyywUbAdZRkJMqCeZCDmBsgYu1Wlj26xHBXN+sU5tHaWh38QsN208g==",
           "dev": true
         }
       }
     },
     "html-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
-      "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
       "dev": true
     },
     "htmlparser2": {
@@ -6339,6 +6226,12 @@
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "mkdirp": {
@@ -6435,9 +6328,9 @@
       "optional": true
     },
     "irregular-plurals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
-      "integrity": "sha1-OPKZg0uowAwwvpxVThNyaXUv86w=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
+      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
       "dev": true
     },
     "is": {
@@ -6599,9 +6492,9 @@
       "dev": true,
       "dependencies": {
         "isobject": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz",
-          "integrity": "sha1-OVZSF/NmF4nooKDAgNX35rxG4aA=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
@@ -6807,9 +6700,9 @@
       }
     },
     "isurl": {
-      "version": "1.0.0-alpha6",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0-alpha6.tgz",
-      "integrity": "sha1-nfC4R3hmqkJdBGvo+7Qp5ktbiRU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "optional": true
     },
@@ -6856,9 +6749,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
@@ -6909,9 +6802,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz",
-      "integrity": "sha1-ABbAscoe/kbUTTdUG838Gdz64Ns=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true,
       "optional": true
     },
@@ -7078,23 +6971,15 @@
       }
     },
     "karma-browserstack-launcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.2.0.tgz",
-      "integrity": "sha1-rPpTSDW6WQBB7vAJwRaaIZEgu1s=",
-      "dev": true,
-      "dependencies": {
-        "q": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-          "dev": true
-        }
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.3.0.tgz",
+      "integrity": "sha512-LrPf5sU/GISkEElWyoy06J8x0c8BcOjjOwf61Wqu6M0aWQu0Eoqm9yh3xON64/ByST/CEr0GsWiREQ/EIEMd4Q==",
+      "dev": true
     },
     "karma-chrome-launcher": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz",
-      "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
+      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true
     },
     "karma-coverage": {
@@ -7729,9 +7614,9 @@
       }
     },
     "mathml-tag-names": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.0.tgz",
-      "integrity": "sha1-7uYVESorEn5w9VjWnJ6+FAdlA9c=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+      "integrity": "sha1-jUEmgWi/htEQK5gQnijlMeejRXg=",
       "dev": true
     },
     "media-typer": {
@@ -7781,9 +7666,9 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.0.3.tgz",
-      "integrity": "sha1-+kT4siYmFaty8ICKQB1HinDjlNs=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.1.0.tgz",
+      "integrity": "sha1-mfsys16frYQBRgBOE6VrdUmlJNs=",
       "dev": true
     },
     "methmeth": {
@@ -8161,12 +8046,6 @@
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -8174,9 +8053,9 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true
     },
     "normalize-path": {
@@ -8205,9 +8084,9 @@
       "optional": true
     },
     "npmlog": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true
     },
     "null-check": {
@@ -8297,9 +8176,9 @@
           "dev": true
         },
         "isobject": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz",
-          "integrity": "sha1-OVZSF/NmF4nooKDAgNX35rxG4aA=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }
@@ -8480,8 +8359,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "p-limit": {
       "version": "1.1.0",
@@ -8498,9 +8376,9 @@
       "optional": true
     },
     "p-timeout": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.1.1.tgz",
-      "integrity": "sha1-0o6f35bjKIhvv/B4+IatFYxTv20=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz",
+      "integrity": "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w=",
       "dev": true,
       "optional": true
     },
@@ -8579,9 +8457,9 @@
       "dev": true,
       "dependencies": {
         "@types/node": {
-          "version": "6.0.78",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
-          "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg==",
+          "version": "6.0.79",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
+          "integrity": "sha512-7F3/P6MkTPA0QxOstRqfcnoReCUy5V/QG92cyBoZSPnqdX44L8TtNELSVfN56gAttm3YWj9cEi8FRIPVq0WmeQ==",
           "dev": true
         }
       }
@@ -8935,9 +8813,9 @@
       "dev": true,
       "dependencies": {
         "@types/node": {
-          "version": "6.0.78",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
-          "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg==",
+          "version": "6.0.79",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
+          "integrity": "sha512-7F3/P6MkTPA0QxOstRqfcnoReCUy5V/QG92cyBoZSPnqdX44L8TtNELSVfN56gAttm3YWj9cEi8FRIPVq0WmeQ==",
           "dev": true
         },
         "@types/q": {
@@ -9062,9 +8940,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
       "dev": true
     },
     "random-bytes": {
@@ -9151,9 +9029,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true
     },
     "readdirp": {
@@ -9252,39 +9130,7 @@
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
-      "dependencies": {
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -9466,9 +9312,9 @@
       }
     },
     "rsvp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.5.0.tgz",
-      "integrity": "sha1-pixXOkrk4d/QaX68YkLnnGgeqjQ=",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.1.tgz",
+      "integrity": "sha1-NPSnrChZ97rMj0l4nFYE8eJq5wI=",
       "dev": true
     },
     "run-async": {
@@ -9490,9 +9336,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.1.tgz",
-      "integrity": "sha1-ti91fyeURdJloYpY+wpw3JDpFiY="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -10049,9 +9895,9 @@
       "dev": true
     },
     "specificity": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.0.tgz",
-      "integrity": "sha1-MyRy1OXrWvIIIRcZM5mKa8Oxzm8=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.1.tgz",
+      "integrity": "sha1-8bBoQkzjF64HR42V3jwhz4Xo1Wc=",
       "dev": true
     },
     "split": {
@@ -10273,11 +10119,17 @@
       }
     },
     "stylelint": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-7.11.1.tgz",
-      "integrity": "sha1-yBbGWLr32eXRZ9gic/6tN8l65J0=",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-7.12.0.tgz",
+      "integrity": "sha512-DpEYhVZnjrNIFmX7IkigvwoR0F5NLBqHOF3+ovJeKhnv+qCEOC5CI+tZ8FOCdQGytfnIa6hUItSYbwg1Dbipfw==",
       "dev": true,
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "balanced-match": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -10309,9 +10161,15 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true
         }
       }
@@ -10409,6 +10267,12 @@
           "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
           "dev": true
         },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        },
         "write-file-atomic": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
@@ -10476,6 +10340,12 @@
       "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
       "dev": true,
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -10483,9 +10353,15 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true
         }
       }
@@ -10734,10 +10610,36 @@
       "dev": true
     },
     "ts-node": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.1.0.tgz",
-      "integrity": "sha1-p17FrrSPMFixuUXbp2XxFQuoj4w=",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.2.0.tgz",
+      "integrity": "sha1-mBTwwBQXhJAM8S/vEZetS39NI9E=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
+          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.1.0.tgz",
+          "integrity": "sha1-kswUuz2tiSjKVlbDPhmhnyCvXHo=",
+          "dev": true
+        }
+      }
     },
     "tsconfig": {
       "version": "6.0.0",
@@ -10799,15 +10701,15 @@
       "dev": true
     },
     "tsutils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.4.0.tgz",
-      "integrity": "sha1-rUzm26Dlo+2934Ymt8oEB4IYn+o=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.5.1.tgz",
+      "integrity": "sha1-wgATkMee7Bpcz6esEtWZY5aD4M8=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true
     },
     "tweetnacl": {
@@ -10918,6 +10820,12 @@
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
           "dev": true
         }
       }
@@ -11034,6 +10942,12 @@
           "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
           "dev": true
         },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        },
         "write-file-atomic": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
@@ -11079,9 +10993,9 @@
       "dev": true
     },
     "useragent": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
-      "integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.0.tgz",
+      "integrity": "sha1-74X0GQPP0F4rqMEa5hJJx6a79mM=",
       "dev": true,
       "dependencies": {
         "lru-cache": {
@@ -11121,9 +11035,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
     "v8flags": {
@@ -11286,6 +11200,12 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true
         },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
         "compress-commons": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
@@ -11304,6 +11224,12 @@
           "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
           "dev": true
         },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.16.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
@@ -11314,6 +11240,12 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
           "dev": true
         },
         "request": {
@@ -11328,10 +11260,10 @@
           "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
           "dev": true
         },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         },
         "zip-stream": {
@@ -11445,7 +11377,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true
     },
     "widest-line": {
@@ -11507,7 +11439,7 @@
     "write-file-atomic": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha1-F2n0tVHu3OQZ8FBd6uLiZ2NULTc=",
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true
     },
     "write-file-stdout": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "stylelint": "^7.10.1",
     "ts-node": "^3.0.4",
     "tsconfig-paths": "^2.2.0",
-    "tslint": "^5.2.0",
+    "tslint": "~5.4.3",
     "typescript": "~2.2.1",
     "uglify-js": "^2.8.14",
     "web-animations-js": "^2.2.5"

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -32,9 +32,13 @@ export class CdkHeaderCellDef {
  */
 @Directive({selector: '[cdkColumnDef]'})
 export class CdkColumnDef {
+  /** Unique name for this column. */
   @Input('cdkColumnDef') name: string;
 
+  /** @docs-private */
   @ContentChild(CdkCellDef) cell: CdkCellDef;
+
+  /** @docs-private */
   @ContentChild(CdkHeaderCellDef) headerCell: CdkHeaderCellDef;
 }
 

--- a/src/cdk/table/data-source.ts
+++ b/src/cdk/table/data-source.ts
@@ -13,6 +13,20 @@ export interface CollectionViewer {
 }
 
 export abstract class DataSource<T> {
+  /**
+   * Connects a collection viewer (such as a data-table) to this data source.
+   * @param collectionViewer The component that exposes a view over the data provided by this
+   *     data source.
+   * @returns Observable that emits a new value when the data changes.
+   */
   abstract connect(collectionViewer: CollectionViewer): Observable<T[]>;
+
+  /**
+   * Disconnects a collection viewer (such as a data-table) from this data source. Can be used
+   * to perform any clean-up or tear-down operations when a view is being destroyed.
+   *
+   * @param collectionViewer The component that exposes a view over the data provided by this
+   *     data source.
+   */
   abstract disconnect(collectionViewer: CollectionViewer): void;
 }

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -39,6 +39,7 @@ import {Subscription} from 'rxjs/Subscription';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdSortHeader implements MdSortable {
+  /** @docs-private  */
   sortSubscription: Subscription;
 
   /**

--- a/src/lib/table/table.md
+++ b/src/lib/table/table.md
@@ -10,7 +10,8 @@ instead of `cdk-`.
 Note that the column definition directives (`cdkColumnDef` and `cdkHeaderCellDef`) are still
 prefixed with `cdk-`.
 
-For more information on the interface and how it works, see the guide covering the CDK data-table.
+For more information on the interface and how it works, see the
+[guide covering the CDK data-table](https://material.angular.io/guides/cdk-table).
 
 ### Features
 

--- a/src/material-examples/input-clearable/input-clearable-example.html
+++ b/src/material-examples/input-clearable/input-clearable-example.html
@@ -1,6 +1,6 @@
 <md-input-container class="example-input-container">
   <input mdInput type="text" placeholder="Clearable input" [(ngModel)]="value"/>
-  <md-button *ngIf="value" mdSuffix md-icon-button aria-label="Clear" (click)="value=''">
+  <button md-button *ngIf="value" mdSuffix md-icon-button aria-label="Clear" (click)="value=''">
     <md-icon>close</md-icon>
-  </md-button>
+  </button>
 </md-input-container>

--- a/src/material-examples/table-basic/table-basic-example.css
+++ b/src/material-examples/table-basic/table-basic-example.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   max-height: 500px;
-  background: white;
   min-width: 300px;
 }
 

--- a/src/material-examples/table-basic/table-basic-example.html
+++ b/src/material-examples/table-basic/table-basic-example.html
@@ -1,6 +1,4 @@
 <div class="example-container mat-elevation-z8">
-  <div class="example-header"> Users </div>
-
   <md-table #table [dataSource]="dataSource">
 
     <!--- Note that these columns can be defined in any order.

--- a/src/material-examples/table-filtering/table-filtering-example.css
+++ b/src/material-examples/table-filtering/table-filtering-example.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   max-height: 500px;
-  background: white;
   min-width: 300px;
 }
 

--- a/src/material-examples/table-filtering/table-filtering-example.html
+++ b/src/material-examples/table-filtering/table-filtering-example.html
@@ -1,7 +1,5 @@
 <div class="example-container mat-elevation-z8">
   <div class="example-header">
-    Users
-
     <md-input-container floatPlaceholder="never">
       <input mdInput #filter placeholder="Filter users">
     </md-input-container>

--- a/src/material-examples/table-overview/table-overview-example.css
+++ b/src/material-examples/table-overview/table-overview-example.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   max-height: 500px;
-  background: white;
   min-width: 300px;
 }
 

--- a/src/material-examples/table-overview/table-overview-example.html
+++ b/src/material-examples/table-overview/table-overview-example.html
@@ -1,7 +1,5 @@
 <div class="example-container mat-elevation-z8">
   <div class="example-header" [style.display]="selection.isEmpty() ? '' : 'none'">
-    Users
-
     <md-input-container floatPlaceholder="never">
       <input mdInput #filter placeholder="Filter users">
     </md-input-container>

--- a/src/material-examples/table-pagination/table-pagination-example.css
+++ b/src/material-examples/table-pagination/table-pagination-example.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   max-height: 500px;
-  background: white;
   min-width: 300px;
 }
 

--- a/src/material-examples/table-pagination/table-pagination-example.html
+++ b/src/material-examples/table-pagination/table-pagination-example.html
@@ -1,5 +1,4 @@
 <div class="example-container mat-elevation-z8">
-  <div class="example-header"> Users </div>
 
   <md-table #table [dataSource]="dataSource">
 

--- a/src/material-examples/table-sorting/table-sorting-example.css
+++ b/src/material-examples/table-sorting/table-sorting-example.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   max-height: 500px;
-  background: white;
   min-width: 300px;
 }
 

--- a/src/material-examples/table-sorting/table-sorting-example.html
+++ b/src/material-examples/table-sorting/table-sorting-example.html
@@ -1,6 +1,4 @@
 <div class="example-container mat-elevation-z8">
-  <div class="example-header"> Users </div>
-
   <md-table #table [dataSource]="dataSource" mdSort>
 
     <!--- Note that these columns can be defined in any order.

--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -115,6 +115,8 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
     'lib/slide-toggle/index.ts',
     'lib/slider/index.ts',
     'lib/snack-bar/index.ts',
+    'lib/sort/index.ts',
+    'lib/table/index.ts',
     'lib/tabs/index.ts',
     'lib/toolbar/index.ts',
     'lib/tooltip/index.ts',


### PR DESCRIPTION
Also 
* Adds links to table overview/guide
* Fixes missing package.json dep for our own build tools
* Removes header from table examples that had a problematic background color for dark themes
* Configure dgeni to output API docs for table and sort-header