### PR TITLE
build: dgeni is building docs twice

### DIFF
--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -156,7 +156,3 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
 
 
 module.exports = apiDocsPackage;
-
-
-  const docs = new Dgeni([apiDocsPackage]);
-  docs.generate();


### PR DESCRIPTION
* With #5429 dgeni runs twice when running the `gulp docs` command. This is because the dgeni generate function has been added to the `dgeni/index.js` file.