### PR TITLE
fix(button-toggle): button-toggle module depends on forms module

### DIFF
--- a/src/lib/button-toggle/index.ts
+++ b/src/lib/button-toggle/index.ts
@@ -7,7 +7,6 @@
  */
 
 import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
 import {MdButtonToggleGroup, MdButtonToggleGroupMultiple, MdButtonToggle} from './button-toggle';
 import {
   UNIQUE_SELECTION_DISPATCHER_PROVIDER,
@@ -17,7 +16,7 @@ import {
 
 
 @NgModule({
-  imports: [FormsModule, MdCommonModule, StyleModule],
+  imports: [MdCommonModule, StyleModule],
   exports: [
     MdButtonToggleGroup,
     MdButtonToggleGroupMultiple,


### PR DESCRIPTION
* Fixes that the button-toggle module depends on the forms module.
* Tests with forms and without forms have been separated to ensure that button-toggle works without forms as expected.

**Note**: It's clear to me that there is the question whether we should do this or not, but I finished most of this yesterday so I'm still pushing the PR.