### PR TITLE
feat(table): support dynamic column definitions

### DIFF
--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -9,7 +9,8 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Directive, IterableChanges,
+  Directive,
+  IterableChanges,
   IterableDiffer,
   IterableDiffers,
   SimpleChanges,
@@ -17,7 +18,6 @@ import {
   ViewContainerRef
 } from '@angular/core';
 import {CdkCellDef} from './cell';
-import {Subject} from 'rxjs/Subject';
 
 /**
  * The row template that can be used by the md-table. Should not be used outside of the
@@ -34,7 +34,7 @@ export abstract class BaseRowDef {
   columns: string[];
 
   /** Differ used to check if any changes were made to the columns. */
-  columnsDiffer: IterableDiffer<any>;
+  protected _columnsDiffer: IterableDiffer<any>;
 
   constructor(public template: TemplateRef<any>,
               protected _differs: IterableDiffers) { }
@@ -43,8 +43,8 @@ export abstract class BaseRowDef {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
     // of the columns property.
     const columns = changes['columns'].currentValue;
-    if (!this.columnsDiffer && columns) {
-      this.columnsDiffer = this._differs.find(columns).create();
+    if (!this._columnsDiffer && columns) {
+      this._columnsDiffer = this._differs.find(columns).create();
       this._columnsDiffer.diff(columns);
     }
   }
@@ -54,7 +54,7 @@ export abstract class BaseRowDef {
    * if there is no difference.
    */
   getColumnsDiff(): IterableChanges<any> | null {
-    return this.columnsDiffer.diff(this.columns);
+    return this._columnsDiffer.diff(this.columns);
   }
 }
 

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -50,7 +50,7 @@ export abstract class BaseRowDef {
   }
 
   /**
-   * Returns the difference between the current columns and the collumns from the last diff, or null
+   * Returns the difference between the current columns and the columns from the last diff, or null
    * if there is no difference.
    */
   getColumnsDiff(): IterableChanges<any> | null {

--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -1,4 +1,12 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
  * Returns an error to be thrown when attempting to find an unexisting column.
  * @param id Id whose lookup failed.
  * @docs-private

--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns an error to be thrown when attempting to find an unexisting column.
+ * @param id Id whose lookup failed.
+ * @docs-private
+ */
+export function getTableUnknownColumnError(id: string) {
+  return Error(`cdk-table: Could not find column with id "${id}".`);
+}
+
+/**
+ * Returns an error to be thrown when two column definitions have the same name.
+ * @docs-private
+ */
+export function getTableDuplicateColumnNameError(name: string) {
+  return Error(`cdk-table: Duplicate column definition name provided: "${name}".`);
+}

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -9,7 +9,7 @@ import {CdkTableModule} from './index';
 import {map} from 'rxjs/operator/map';
 import {getTableDuplicateColumnNameError, getTableUnknownColumnError} from './table-errors';
 
-describe('CdkTable', () => {
+fdescribe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
 
   let component: SimpleCdkTableApp;

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -9,7 +9,7 @@ import {CdkTableModule} from './index';
 import {map} from 'rxjs/operator/map';
 import {getTableDuplicateColumnNameError, getTableUnknownColumnError} from './table-errors';
 
-fdescribe('CdkTable', () => {
+describe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
 
   let component: SimpleCdkTableApp;

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -8,7 +8,7 @@ import {combineLatest} from 'rxjs/observable/combineLatest';
 import {CdkTableModule} from './index';
 import {map} from 'rxjs/operator/map';
 
-fdescribe('CdkTable', () => {
+describe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
 
   let component: SimpleCdkTableApp;
@@ -108,14 +108,45 @@ fdescribe('CdkTable', () => {
     expect(fixture.nativeElement.querySelector('cdk-table').getAttribute('role')).toBe('treegrid');
   });
 
-  fit('should be able to dynamically add/remove column definitions', () => {
+  it('should be able to dynamically add/remove column definitions', () => {
     const dynamicColumnDefFixture = TestBed.createComponent(DynamicColumnDefinitionsCdkTableApp);
     dynamicColumnDefFixture.detectChanges();
-
-    const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
-    expect(dynamicColumnDefComp.dynamicColumns.push('columnA'));
-
     dynamicColumnDefFixture.detectChanges();
+
+    const dynamicColumnDefTableEl = dynamicColumnDefFixture.nativeElement.querySelector('cdk-table');
+    const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
+
+    // Add a new column and expect it to show up in the table
+    let columnA = 'columnA';
+    dynamicColumnDefComp.dynamicColumns.push(columnA);
+    dynamicColumnDefFixture.detectChanges();
+    expectTableToMatchContent(dynamicColumnDefTableEl, [
+      [columnA], // Header row
+      [columnA], // Data rows
+      [columnA],
+      [columnA],
+    ]);
+
+    // Add another new column and expect it to show up in the table
+    let columnB = 'columnB';
+    dynamicColumnDefComp.dynamicColumns.push(columnB);
+    dynamicColumnDefFixture.detectChanges();
+    expectTableToMatchContent(dynamicColumnDefTableEl, [
+      [columnA, columnB], // Header row
+      [columnA, columnB], // Data rows
+      [columnA, columnB],
+      [columnA, columnB],
+    ]);
+
+    // Remove column A expect only column B to be rendered
+    dynamicColumnDefComp.dynamicColumns.shift();
+    dynamicColumnDefFixture.detectChanges();
+    expectTableToMatchContent(dynamicColumnDefTableEl, [
+      [columnB], // Header row
+      [columnB], // Data rows
+      [columnB],
+      [columnB],
+    ]);
   });
 
   it('should re-render the rows when the data changes', () => {
@@ -602,8 +633,8 @@ class TrackByCdkTableApp {
   template: `
     <cdk-table [dataSource]="dataSource">
       <ng-container [cdkColumnDef]="column" *ngFor="let column of dynamicColumns">
-        <cdk-header-cell *cdkHeaderCellDef> {{column}}</cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row"> {{column}}</cdk-cell>
+        <cdk-header-cell *cdkHeaderCellDef> {{column}} </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{column}} </cdk-cell>
       </ng-container>
 
       <cdk-header-row *cdkHeaderRowDef="dynamicColumns"></cdk-header-row>
@@ -613,14 +644,9 @@ class TrackByCdkTableApp {
 })
 class DynamicColumnDefinitionsCdkTableApp {
   dynamicColumns: any[] = [];
-
   dataSource: FakeDataSource = new FakeDataSource();
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
-
-  addDynamicColumnDef() {
-    this.dynamicColumns.push(this.dynamicColumns.length);
-  }
 }
 
 @Component({

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -113,14 +113,14 @@ describe('CdkTable', () => {
     dynamicColumnDefFixture.detectChanges();
     dynamicColumnDefFixture.detectChanges();
 
-    const dynamicColumnDefTableEl = dynamicColumnDefFixture.nativeElement.querySelector('cdk-table');
+    const dynamicColumnDefTable = dynamicColumnDefFixture.nativeElement.querySelector('cdk-table');
     const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
 
     // Add a new column and expect it to show up in the table
     let columnA = 'columnA';
     dynamicColumnDefComp.dynamicColumns.push(columnA);
     dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTableEl, [
+    expectTableToMatchContent(dynamicColumnDefTable, [
       [columnA], // Header row
       [columnA], // Data rows
       [columnA],
@@ -131,7 +131,7 @@ describe('CdkTable', () => {
     let columnB = 'columnB';
     dynamicColumnDefComp.dynamicColumns.push(columnB);
     dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTableEl, [
+    expectTableToMatchContent(dynamicColumnDefTable, [
       [columnA, columnB], // Header row
       [columnA, columnB], // Data rows
       [columnA, columnB],
@@ -141,7 +141,7 @@ describe('CdkTable', () => {
     // Remove column A expect only column B to be rendered
     dynamicColumnDefComp.dynamicColumns.shift();
     dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTableEl, [
+    expectTableToMatchContent(dynamicColumnDefTable, [
       [columnB], // Header row
       [columnB], // Data rows
       [columnB],

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -8,7 +8,7 @@ import {combineLatest} from 'rxjs/observable/combineLatest';
 import {CdkTableModule} from './index';
 import {map} from 'rxjs/operator/map';
 
-describe('CdkTable', () => {
+fdescribe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
 
   let component: SimpleCdkTableApp;
@@ -584,6 +584,40 @@ class TrackByCdkTableApp {
       case 'propertyA': return item.a;
       case 'index': return index;
     }
+  }
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumnDefs">
+        <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="dynamicColumnIds"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: dynamicColumnIds;"></cdk-row>
+    </cdk-table>
+  `
+})
+class DynamicColumnDefinitionsCdkTableApp {
+  dynamicColumnDefs: any[] = [];
+  dynamicColumnIds: string[] = [];
+
+  dataSource: FakeDataSource = new FakeDataSource();
+  columnsToRender = ['column_a', 'column_b'];
+
+  @ViewChild(CdkTable) table: CdkTable<TestData>;
+
+  addDynamicColumnDef() {
+    const nextProperty = this.dynamicColumnDefs.length;
+    this.dynamicColumnDefs.push({
+      id: nextProperty,
+      property: nextProperty,
+      headerText: nextProperty
+    });
+
+    this.dynamicColumnIds = this.dynamicColumnDefs.map(columnDef => columnDef.id);
   }
 }
 

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -24,6 +24,7 @@ fdescribe('CdkTable', () => {
         DynamicDataSourceCdkTableApp,
         CustomRoleCdkTableApp,
         TrackByCdkTableApp,
+        DynamicColumnDefinitionsCdkTableApp,
         RowContextCdkTableApp,
       ],
     }).compileComponents();
@@ -105,6 +106,16 @@ fdescribe('CdkTable', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('cdk-table').getAttribute('role')).toBe('treegrid');
+  });
+
+  fit('should be able to dynamically add/remove column definitions', () => {
+    const dynamicColumnDefFixture = TestBed.createComponent(DynamicColumnDefinitionsCdkTableApp);
+    dynamicColumnDefFixture.detectChanges();
+
+    const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
+    expect(dynamicColumnDefComp.dynamicColumns.push('columnA'));
+
+    dynamicColumnDefFixture.detectChanges();
   });
 
   it('should re-render the rows when the data changes', () => {
@@ -590,34 +601,25 @@ class TrackByCdkTableApp {
 @Component({
   template: `
     <cdk-table [dataSource]="dataSource">
-      <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumnDefs">
-        <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
+      <ng-container [cdkColumnDef]="column" *ngFor="let column of dynamicColumns">
+        <cdk-header-cell *cdkHeaderCellDef> {{column}}</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{column}}</cdk-cell>
       </ng-container>
 
-      <cdk-header-row *cdkHeaderRowDef="dynamicColumnIds"></cdk-header-row>
-      <cdk-row *cdkRowDef="let row; columns: dynamicColumnIds;"></cdk-row>
+      <cdk-header-row *cdkHeaderRowDef="dynamicColumns"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: dynamicColumns;"></cdk-row>
     </cdk-table>
   `
 })
 class DynamicColumnDefinitionsCdkTableApp {
-  dynamicColumnDefs: any[] = [];
-  dynamicColumnIds: string[] = [];
+  dynamicColumns: any[] = [];
 
   dataSource: FakeDataSource = new FakeDataSource();
-  columnsToRender = ['column_a', 'column_b'];
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
 
   addDynamicColumnDef() {
-    const nextProperty = this.dynamicColumnDefs.length;
-    this.dynamicColumnDefs.push({
-      id: nextProperty,
-      property: nextProperty,
-      headerText: nextProperty
-    });
-
-    this.dynamicColumnIds = this.dynamicColumnDefs.map(columnDef => columnDef.id);
+    this.dynamicColumns.push(this.dynamicColumns.length);
   }
 }
 

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -7,6 +7,7 @@ import {Observable} from 'rxjs/Observable';
 import {combineLatest} from 'rxjs/observable/combineLatest';
 import {CdkTableModule} from './index';
 import {map} from 'rxjs/operator/map';
+import {getTableDuplicateColumnNameError, getTableUnknownColumnError} from './table-errors';
 
 describe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
@@ -26,6 +27,8 @@ describe('CdkTable', () => {
         TrackByCdkTableApp,
         DynamicColumnDefinitionsCdkTableApp,
         RowContextCdkTableApp,
+        DuplicateColumnDefNameCdkTableApp,
+        MissingColumnDefCdkTableApp,
       ],
     }).compileComponents();
   }));
@@ -106,6 +109,16 @@ describe('CdkTable', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('cdk-table').getAttribute('role')).toBe('treegrid');
+  });
+
+  it('should throw an error if two column definitions have the same name', () => {
+    expect(() => TestBed.createComponent(DuplicateColumnDefNameCdkTableApp).detectChanges())
+        .toThrowError(getTableDuplicateColumnNameError('column_a').message);
+  });
+
+  it('should throw an error if a column definition is requested but not defined', () => {
+    expect(() => TestBed.createComponent(MissingColumnDefCdkTableApp).detectChanges())
+        .toThrowError(getTableUnknownColumnError('column_a').message);
   });
 
   it('should be able to dynamically add/remove column definitions', () => {
@@ -667,6 +680,45 @@ class CustomRoleCdkTableApp {
   columnsToRender = ['column_a'];
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+    </cdk-table>
+  `
+})
+class DuplicateColumnDefNameCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_b">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+    </cdk-table>
+  `
+})
+class MissingColumnDefCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
 }
 
 @Component({

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -194,6 +194,10 @@ export class CdkTable<T> implements CollectionViewer {
       this._columnDefinitionsByName.set(columnDef.name, columnDef);
     });
 
+    this._columnDefinitions.changes.subscribe(() => {
+      console.log('Column def change');
+    });
+
     // Re-render the rows if any of their columns change.
     // TODO(andrewseguin): Determine how to only re-render the rows that have their columns changed.
     const columnChangeEvents = this._rowDefinitions.map(rowDef => rowDef.columnsChange);
@@ -207,6 +211,7 @@ export class CdkTable<T> implements CollectionViewer {
 
     // Re-render the header row if the columns change
     takeUntil.call(this._headerDefinition.columnsChange, this._onDestroy).subscribe(() => {
+      console.log('Header columns changed');
       this._headerRowPlaceholder.viewContainer.clear();
       this._renderHeaderRow();
     });

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -22,7 +22,6 @@ import {
   IterableDiffer,
   IterableDiffers,
   NgIterable,
-  NgZone,
   QueryList,
   Renderer2,
   TrackByFunction,
@@ -168,6 +167,7 @@ export class CdkTable<T> implements CollectionViewer {
   ngAfterContentInit() {
     this._cacheColumnDefinitionsByName();
     this._columnDefinitions.changes.subscribe(() => this._cacheColumnDefinitionsByName());
+    this._renderHeaderRow();
   }
 
   ngAfterContentChecked() {
@@ -221,8 +221,6 @@ export class CdkTable<T> implements CollectionViewer {
       this._headerRowPlaceholder.viewContainer.clear();
       this._renderHeaderRow();
     }
-
-    this._renderHeaderRow();
   }
 
   /**

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -152,7 +152,6 @@ export class CdkTable<T> implements CollectionViewer {
 
   constructor(private readonly _differs: IterableDiffers,
               private readonly _changeDetectorRef: ChangeDetectorRef,
-              private readonly _ngZone: NgZone,
               elementRef: ElementRef,
               renderer: Renderer2,
               @Attribute('role') role: string) {
@@ -166,15 +165,6 @@ export class CdkTable<T> implements CollectionViewer {
     this._dataDiffer = this._differs.find([]).create(this._trackByFn);
   }
 
-  ngDoCheck() {
-    // After the the content and view have been initialized and checked then we can connect
-    // to the data source and render data rows. This cannot be done from within change detection,
-    // so the table must wait until the next change detection cycle before rendering.
-    if (this._isViewInitialized && this.dataSource && !this._renderChangeSubscription) {
-      this._observeRenderChanges();
-    }
-  }
-
   ngAfterContentInit() {
     this._cacheColumnDefinitionsByName();
     this._columnDefinitions.changes.subscribe(() => this._cacheColumnDefinitionsByName());
@@ -182,10 +172,6 @@ export class CdkTable<T> implements CollectionViewer {
 
   ngAfterContentChecked() {
     this._renderUpdatedColumns();
-    this._cacheColumnDefinitionsByName();
-  }
-
-  ngAfterViewInit() {
     if (this.dataSource && !this._renderChangeSubscription) {
       this._observeRenderChanges();
     }
@@ -199,17 +185,6 @@ export class CdkTable<T> implements CollectionViewer {
 
     if (this.dataSource) {
       this.dataSource.disconnect(this);
-    }
-  }
-
-  ngAfterContentInit() {
-    // TODO(andrewseguin): Throw an error if two columns share the same name
-    this._columnDefinitions.forEach(columnDef => {
-      this._columnDefinitionsByName.set(columnDef.name, columnDef);
-    });
-
-    if (this.dataSource && !this._renderChangeSubscription) {
-      this._observeRenderChanges();
     }
   }
 
@@ -231,8 +206,8 @@ export class CdkTable<T> implements CollectionViewer {
    */
   private _renderUpdatedColumns() {
     // Re-render the rows when the row definition columns change.
-    this._rowDefinitions.forEach(def => {
-      if (!!def.getColumnsDiff()) {
+    this._rowDefinitions.forEach(rowDefinition => {
+      if (!!rowDefinition.getColumnsDiff()) {
         // Reset the data to an empty array so that renderRowChanges will re-render all new rows.
         this._dataDiffer.diff([]);
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -190,6 +190,7 @@ export class CdkTable<T> implements CollectionViewer {
   }
 
   ngAfterContentChecked() {
+    console.log('Content checked');
     this._updateColumnDefinitions();
   }
 
@@ -224,6 +225,7 @@ export class CdkTable<T> implements CollectionViewer {
 
   /** Update the map containing the content's column definitions. */
   private _updateColumnDefinitions() {
+    console.log('Updating columns');
     this._columnDefinitionsByName.clear();
     this._columnDefinitions.forEach(columnDef => {
       if (this._columnDefinitionsByName.has(columnDef.name)) {

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -36,7 +36,6 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Subscription} from 'rxjs/Subscription';
 import {Subject} from 'rxjs/Subject';
 import {CdkCellDef, CdkColumnDef, CdkHeaderCellDef} from './cell';
-import {startWith} from 'rxjs/operator/startWith';
 
 /**
  * Returns an error to be thrown when attempting to find an unexisting column.

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -36,23 +36,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Subscription} from 'rxjs/Subscription';
 import {Subject} from 'rxjs/Subject';
 import {CdkCellDef, CdkColumnDef, CdkHeaderCellDef} from './cell';
-
-/**
- * Returns an error to be thrown when attempting to find an unexisting column.
- * @param id Id whose lookup failed.
- * @docs-private
- */
-export function getTableUnknownColumnError(id: string) {
-  return new Error(`cdk-table: Could not find column with id "${id}".`);
-}
-
-/**
- * Returns an error to be thrown when attempting to find an unexisting column.
- * @docs-private
- */
-export function getTableDuplicateColumnNameError(name: string) {
-  return new Error(`cdk-table: Duplicate column definition name provided: "${name}".`);
-}
+import {getTableDuplicateColumnNameError, getTableUnknownColumnError} from './table-errors';
 
 /**
  * Provides a handle for the table to grab the view container's ng-container to insert data rows.

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -21,7 +21,8 @@ import {
   IterableChangeRecord,
   IterableDiffer,
   IterableDiffers,
-  NgIterable, NgZone,
+  NgIterable,
+  NgZone,
   QueryList,
   Renderer2,
   TrackByFunction,
@@ -37,7 +38,6 @@ import {Subscription} from 'rxjs/Subscription';
 import {Subject} from 'rxjs/Subject';
 import {CdkCellDef, CdkColumnDef, CdkHeaderCellDef} from './cell';
 import {getTableDuplicateColumnNameError, getTableUnknownColumnError} from './table-errors';
-import {first} from '../rxjs/rx-operators';
 
 /**
  * Provides a handle for the table to grab the view container's ng-container to insert data rows.

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -88,7 +88,7 @@ export class CdkTable<T> implements CollectionViewer {
   private _renderChangeSubscription: Subscription | null;
 
   /** Map of all the user's defined columns (header and data cell template) identified by name. */
-  private _columnDefinitionsMap = new Map<string,  CdkColumnDef>();
+  private _columnDefinitionsByName = new Map<string,  CdkColumnDef>();
 
   /** Differ used to find the changes in the data provided by the data source. */
   private _dataDiffer: IterableDiffer<T>;
@@ -170,6 +170,7 @@ export class CdkTable<T> implements CollectionViewer {
   }
 
   ngAfterContentChecked() {
+    this._renderUpdatedColumns();
     this._cacheColumnDefinitionsByName();
   }
 
@@ -204,12 +205,12 @@ export class CdkTable<T> implements CollectionViewer {
 
   /** Update the map containing the content's column definitions. */
   private _cacheColumnDefinitionsByName() {
-    this._columnDefinitionsMap.clear();
+    this._columnDefinitionsByName.clear();
     this._columnDefinitions.forEach(columnDef => {
-      if (this._columnDefinitionsMap.has(columnDef.name)) {
+      if (this._columnDefinitionsByName.has(columnDef.name)) {
         throw getTableDuplicateColumnNameError(columnDef.name);
       }
-      this._columnDefinitionsMap.set(columnDef.name, columnDef);
+      this._columnDefinitionsByName.set(columnDef.name, columnDef);
     });
   }
 
@@ -217,7 +218,7 @@ export class CdkTable<T> implements CollectionViewer {
    * Check if the header or rows have changed what columns they want to display. If there is a diff,
    * then re-render that section.
    */
-  private _checkColumnsChange() {
+  private _renderUpdatedColumns() {
     // Re-render the rows when the row definition columns change.
     this._rowDefinitions.forEach(def => {
       if (!!def.getColumnsDiff()) {
@@ -366,7 +367,7 @@ export class CdkTable<T> implements CollectionViewer {
   private _getHeaderCellTemplatesForRow(headerDef: CdkHeaderRowDef): CdkHeaderCellDef[] {
     if (!headerDef.columns) { return []; }
     return headerDef.columns.map(columnId => {
-      const column = this._columnDefinitionsMap.get(columnId);
+      const column = this._columnDefinitionsByName.get(columnId);
 
       if (!column) {
         throw getTableUnknownColumnError(columnId);
@@ -383,7 +384,7 @@ export class CdkTable<T> implements CollectionViewer {
   private _getCellTemplatesForRow(rowDef: CdkRowDef): CdkCellDef[] {
     if (!rowDef.columns) { return []; }
     return rowDef.columns.map(columnId => {
-      const column = this._columnDefinitionsMap.get(columnId);
+      const column = this._columnDefinitionsByName.get(columnId);
 
       if (!column) {
         throw getTableUnknownColumnError(columnId);

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -19,7 +19,7 @@
   </div>
 </div>
 
-<md-card>
+<md-card class="demo-table-card">
   <h3>
     CdkTable With Dynamic Column Def
     <div>
@@ -47,7 +47,7 @@
   </cdk-table>
 </md-card>
 
-<md-card>
+<md-card class="demo-table-card">
   <h3>CdkTable Example</h3>
 
   <div class="demo-highlighter">

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -36,7 +36,7 @@
 <h3>CdkTable With Dynamic Column Def</h3>
 
 <cdk-table [dataSource]="dataSource">
-  <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumnDefs">
+  <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumns">
     <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
     <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
   </ng-container>

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -25,7 +25,23 @@
     <md-checkbox (change)="toggleHighlight('even', $event.checked)">Even Rows</md-checkbox>
     <md-checkbox (change)="toggleHighlight('odd', $event.checked)">Odd Rows</md-checkbox>
   </div>
+
+  <div>
+    <button md-raised-button (click)="addDynamicColumnDef()">Add Dynamic Column Def</button>
+  </div>
 </div>
+
+<h3>CdkTable With Dynamic Column Def</h3>
+
+<cdk-table [dataSource]="dataSource">
+  <ng-container cdkColumnDef="column.id" *ngFor="let column of dynamicColumns">
+    <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
+    <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
+  </ng-container>
+
+  <cdk-header-row *cdkHeaderRowDef="dynamicColumnIds"></cdk-header-row>
+  <cdk-row *cdkRowDef="let row; columns: dynamicColumnIds;"></cdk-row>
+</cdk-table>
 
 <h3>CdkTable Example</h3>
 

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -17,6 +17,38 @@
       <md-radio-button [value]="'index'">Index</md-radio-button>
     </md-radio-group>
   </div>
+</div>
+
+<md-card>
+  <h3>
+    CdkTable With Dynamic Column Def
+    <div>
+      <button md-raised-button
+              (click)="addDynamicColumnDef()"
+              [disabled]="dynamicColumnIds.length >= 4">
+        Add Column Def
+      </button>
+      <button md-raised-button
+              (click)="removeDynamicColumnDef()"
+              [disabled]="dynamicColumnIds.length == 0">
+        Remove Column Def
+      </button>
+    </div>
+  </h3>
+
+  <cdk-table [dataSource]="dataSource">
+    <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumnDefs">
+      <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
+    </ng-container>
+
+    <cdk-header-row *cdkHeaderRowDef="dynamicColumnIds"></cdk-header-row>
+    <cdk-row *cdkRowDef="let row; columns: dynamicColumnIds;"></cdk-row>
+  </cdk-table>
+</md-card>
+
+<md-card>
+  <h3>CdkTable Example</h3>
 
   <div class="demo-highlighter">
     Highlight:
@@ -26,85 +58,65 @@
     <md-checkbox (change)="toggleHighlight('odd', $event.checked)">Odd Rows</md-checkbox>
   </div>
 
-  <div>
-    <button md-raised-button (click)="addDynamicColumnDef()" [disabled]="dynamicColumnIds.length >= 4">
-      Add Dynamic Column Def
-    </button>
-  </div>
-</div>
+  <cdk-table #table mdSort
+               [dataSource]="dataSource"
+               [trackBy]="userTrackBy">
 
-<h3>CdkTable With Dynamic Column Def</h3>
+    <!-- Column Definition: ID -->
+    <ng-container cdkColumnDef="userId">
+      <cdk-header-cell *cdkHeaderCellDef
+                       md-sort-header arrowPosition="before">
+          ID
+        </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let row"> {{row.id}} </cdk-cell>
+    </ng-container>
 
-<cdk-table [dataSource]="dataSource">
-  <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumns">
-    <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
-  </ng-container>
+    <!-- Column Definition: Progress -->
+    <ng-container cdkColumnDef="progress">
+      <cdk-header-cell *cdkHeaderCellDef
+                         md-sort-header start="desc">
+          Progress
+        </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let row">
+        <div class="demo-progress-stat">{{row.progress}}%</div>
+        <div class="demo-progress-indicator-container">
+          <div class="demo-progress-indicator"
+               [style.background]="row.progress > 50 ? 'green' : 'red'"
+               [style.opacity]="getOpacity(row.progress)"
+               [style.width.%]="row.progress"></div>
+        </div>
+      </cdk-cell>
+    </ng-container>
 
-  <cdk-header-row *cdkHeaderRowDef="dynamicColumnIds"></cdk-header-row>
-  <cdk-row *cdkRowDef="let row; columns: dynamicColumnIds;"></cdk-row>
-</cdk-table>
+    <!-- Column Definition: Name -->
+    <ng-container cdkColumnDef="userName">
+      <cdk-header-cell *cdkHeaderCellDef md-sort-header>
+          Name
+        </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let row"> {{row.name}} </cdk-cell>
+    </ng-container>
 
-<h3>CdkTable Example</h3>
+    <!-- Column Definition: Color -->
+    <ng-container cdkColumnDef="color">
+      <cdk-header-cell *cdkHeaderCellDef
+                         md-sort-header disableClear>
+          Color
+        </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let row" [style.color]="row.color"> {{row.color}} </cdk-cell>
+    </ng-container>
 
-<cdk-table #table mdSort
-             [dataSource]="dataSource"
-             [trackBy]="userTrackBy">
-
-  <!-- Column Definition: ID -->
-  <ng-container cdkColumnDef="userId">
-    <cdk-header-cell *cdkHeaderCellDef
-                     md-sort-header arrowPosition="before">
-        ID
-      </cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row"> {{row.id}} </cdk-cell>
-  </ng-container>
-
-  <!-- Column Definition: Progress -->
-  <ng-container cdkColumnDef="progress">
-    <cdk-header-cell *cdkHeaderCellDef
-                       md-sort-header start="desc">
-        Progress
-      </cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row">
-      <div class="demo-progress-stat">{{row.progress}}%</div>
-      <div class="demo-progress-indicator-container">
-        <div class="demo-progress-indicator"
-             [style.background]="row.progress > 50 ? 'green' : 'red'"
-             [style.opacity]="getOpacity(row.progress)"
-             [style.width.%]="row.progress"></div>
-      </div>
-    </cdk-cell>
-  </ng-container>
-
-  <!-- Column Definition: Name -->
-  <ng-container cdkColumnDef="userName">
-    <cdk-header-cell *cdkHeaderCellDef md-sort-header>
-        Name
-      </cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row"> {{row.name}} </cdk-cell>
-  </ng-container>
-
-  <!-- Column Definition: Color -->
-  <ng-container cdkColumnDef="color">
-    <cdk-header-cell *cdkHeaderCellDef
-                       md-sort-header disableClear>
-        Color
-      </cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row" [style.color]="row.color"> {{row.color}} </cdk-cell>
-  </ng-container>
-
-  <cdk-header-row *cdkHeaderRowDef="displayedColumns"></cdk-header-row>
-  <cdk-row *cdkRowDef="let row; columns: displayedColumns;
-                         let first = first; let last = last; let even = even; let odd = odd"
-             [ngClass]="{
-               'demo-row-highlight-first': highlights.has('first') && first,
-               'demo-row-highlight-last': highlights.has('last') && last,
-               'demo-row-highlight-even': highlights.has('even') && even,
-               'demo-row-highlight-odd': highlights.has('odd') && odd
-             }">
-    </cdk-row>
-</cdk-table>
+    <cdk-header-row *cdkHeaderRowDef="displayedColumns"></cdk-header-row>
+    <cdk-row *cdkRowDef="let row; columns: displayedColumns;
+                           let first = first; let last = last; let even = even; let odd = odd"
+               [ngClass]="{
+                 'demo-row-highlight-first': highlights.has('first') && first,
+                 'demo-row-highlight-last': highlights.has('last') && last,
+                 'demo-row-highlight-even': highlights.has('even') && even,
+                 'demo-row-highlight-odd': highlights.has('odd') && odd
+               }">
+      </cdk-row>
+  </cdk-table>
+</md-card>
 
 <h3>MdTable Example</h3>
 

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -27,14 +27,16 @@
   </div>
 
   <div>
-    <button md-raised-button (click)="addDynamicColumnDef()">Add Dynamic Column Def</button>
+    <button md-raised-button (click)="addDynamicColumnDef()" [disabled]="dynamicColumnIds.length >= 4">
+      Add Dynamic Column Def
+    </button>
   </div>
 </div>
 
 <h3>CdkTable With Dynamic Column Def</h3>
 
 <cdk-table [dataSource]="dataSource">
-  <ng-container cdkColumnDef="column.id" *ngFor="let column of dynamicColumns">
+  <ng-container [cdkColumnDef]="column.id" *ngFor="let column of dynamicColumnDefs">
     <cdk-header-cell *cdkHeaderCellDef> {{column.headerText}} </cdk-header-cell>
     <cdk-cell *cdkCellDef="let row"> {{row[column.property]}} </cdk-cell>
   </ng-container>

--- a/src/demo-app/table/table-demo.scss
+++ b/src/demo-app/table/table-demo.scss
@@ -22,7 +22,7 @@
 .demo-row-highlight-even { background: #ff0099; }
 .demo-row-highlight-odd { background: #83f52c; }
 
-.mat-card {
+.demo-table-card {
   margin: 24px 0;
   max-height: 200px;
   overflow: auto;

--- a/src/demo-app/table/table-demo.scss
+++ b/src/demo-app/table/table-demo.scss
@@ -22,6 +22,18 @@
 .demo-row-highlight-even { background: #ff0099; }
 .demo-row-highlight-odd { background: #83f52c; }
 
+.mat-card {
+  margin: 24px 0;
+  max-height: 200px;
+  overflow: auto;
+
+  h3 {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
 /** Styles so that the CDK Table columns have width and font size. */
 .cdk-table {
   font-size: 12px;

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -21,6 +21,9 @@ export class TableDemo {
   changeReferences = false;
   highlights = new Set<string>();
 
+  dynamicColumns: any[] = [];
+  dynamicColumnIds: string[] = [];
+
   @ViewChild(MdPaginator) _paginator: MdPaginator;
 
   @ViewChild(MdSort) sort: MdSort;
@@ -29,6 +32,18 @@ export class TableDemo {
 
   ngOnInit() {
     this.connect();
+  }
+
+  addDynamicColumnDef() {
+    const properties = ['userId', 'userName', 'progress', 'color'];
+    const nextProperty = properties[this.dynamicColumns.length];
+    this.dynamicColumns.push({
+      id: nextProperty,
+      property: nextProperty,
+      headerText: nextProperty
+    });
+
+    this.dynamicColumnIds.push(nextProperty);
   }
 
   connect() {

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -1,12 +1,18 @@
-import {Component, ViewChild} from '@angular/core';
+import {
+  ChangeDetectorRef, Component, ContentChildren, QueryList, ViewChild,
+  ViewChildren
+} from '@angular/core';
 import {PeopleDatabase, UserData} from './people-database';
 import {PersonDataSource} from './person-data-source';
 import {MdPaginator} from '@angular/material';
 import {MdSort} from '@angular/material';
+import {CdkColumnDef} from '@angular/cdk';
 
 export type UserProperties = 'userId' | 'userName' | 'progress' | 'color' | undefined;
 
 export type TrackByStrategy = 'id' | 'reference' | 'index';
+
+const properties = ['id', 'name', 'progress', 'color'];
 
 @Component({
   moduleId: module.id,
@@ -21,7 +27,7 @@ export class TableDemo {
   changeReferences = false;
   highlights = new Set<string>();
 
-  dynamicColumns: any[] = [];
+  dynamicColumnDefs: any[] = [];
   dynamicColumnIds: string[] = [];
 
   @ViewChild(MdPaginator) _paginator: MdPaginator;
@@ -35,15 +41,13 @@ export class TableDemo {
   }
 
   addDynamicColumnDef() {
-    const properties = ['userId', 'userName', 'progress', 'color'];
-    const nextProperty = properties[this.dynamicColumns.length];
-    this.dynamicColumns.push({
-      id: nextProperty,
+    const nextProperty = properties[this.dynamicColumnDefs.length];
+    this.dynamicColumnDefs.push({
+      id: nextProperty.toUpperCase(),
       property: nextProperty,
       headerText: nextProperty
     });
-
-    this.dynamicColumnIds.push(nextProperty);
+    this.dynamicColumnIds = this.dynamicColumnDefs.map(columnDef => columnDef.id);
   }
 
   connect() {

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -47,6 +47,7 @@ export class TableDemo {
       property: nextProperty,
       headerText: nextProperty
     });
+
     this.dynamicColumnIds = this.dynamicColumnDefs.map(columnDef => columnDef.id);
   }
 

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -51,6 +51,11 @@ export class TableDemo {
     this.dynamicColumnIds = this.dynamicColumnDefs.map(columnDef => columnDef.id);
   }
 
+  removeDynamicColumnDef() {
+    this.dynamicColumnDefs.pop();
+    this.dynamicColumnIds.pop();
+  }
+
   connect() {
     this.displayedColumns = ['userId', 'userName', 'progress', 'color'];
     this.dataSource = new PersonDataSource(this._peopleDatabase,

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -1,12 +1,7 @@
-import {
-  ChangeDetectorRef, Component, ContentChildren, QueryList, ViewChild,
-  ViewChildren
-} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {PeopleDatabase, UserData} from './people-database';
 import {PersonDataSource} from './person-data-source';
-import {MdPaginator} from '@angular/material';
-import {MdSort} from '@angular/material';
-import {CdkColumnDef} from '@angular/cdk';
+import {MdPaginator, MdSort} from '@angular/material';
 
 export type UserProperties = 'userId' | 'userName' | 'progress' | 'color' | undefined;
 


### PR DESCRIPTION
Move the base row's column diff check to the table's change detection to control timing better. The table should have its content checked before reviewing the header/data row columns in case column definitions have been added/removed.