### PR TITLE
chore(tooltip): switch to OnPush change detection

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -17,6 +17,7 @@ import {
   OnDestroy,
   Renderer2,
   ChangeDetectorRef,
+  ChangeDetectionStrategy,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -368,6 +369,7 @@ export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
   templateUrl: 'tooltip.html',
   styleUrls: ['tooltip.css'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('state', [
       state('void', style({transform: 'scale(0)'})),


### PR DESCRIPTION
Switches `md-tooltip` to `OnPush` change detection.

Relates to #5035.