### PR TITLE
chore(button): switch MdAnchor to OnPush change detection

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -12,14 +12,13 @@ import {
   Directive,
   ElementRef,
   forwardRef,
-  HostBinding,
   Input,
   OnDestroy,
   Optional,
   Renderer2,
   Self,
   ViewEncapsulation,
-  Inject
+  Inject,
 } from '@angular/core';
 import {coerceBooleanProperty, FocusOriginMonitor, Platform} from '../core';
 import {mixinDisabled, CanDisable} from '../core/common-behaviors/disabled';
@@ -193,6 +192,7 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
   selector: `a[md-button], a[md-raised-button], a[md-icon-button], a[md-fab], a[md-mini-fab],
              a[mat-button], a[mat-raised-button], a[mat-icon-button], a[mat-fab], a[mat-mini-fab]`,
   host: {
+    '[attr.tabindex]': 'disabled ? -1 : 0',
     '[attr.disabled]': 'disabled || null',
     '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_haltDisabledEvents($event)',
@@ -200,7 +200,8 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
   inputs: ['disabled', 'color'],
   templateUrl: 'button.html',
   styleUrls: ['button.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdAnchor extends MdButton {
   constructor(
@@ -209,12 +210,6 @@ export class MdAnchor extends MdButton {
       elementRef: ElementRef,
       renderer: Renderer2) {
     super(renderer, elementRef, platform, focusOriginMonitor);
-  }
-
-  /** @docs-private */
-  @HostBinding('tabIndex')
-  get tabIndex(): number {
-    return this.disabled ? -1 : 0;
   }
 
   _haltDisabledEvents(event: Event) {


### PR DESCRIPTION
* Switches the `MdAnchor` component to `OnPush` change detection.
* Gets rid of a `@HostBinding` in favor of using the `host`.

Relates to #5035.