### PR TITLE
build: incorrect path mapping in editor tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "@angular/material": ["./src/lib/public_api.ts"],
       "@angular/cdk": ["./src/cdk/public_api.ts"],
-      "@angular/cdk/testing": ["./cdk/testing"]
+      "@angular/cdk/testing": ["./src/cdk/testing"]
     }
   },
   "include": [


### PR DESCRIPTION
* The root tsconfig file used to have proper autocompletion in editors like WebStorm is currently not working correctly. The path to the `@angular/cdk/testing` package is mapped to a non-existing folder.