### PR TITLE
refactor: fix tests leaking overlay containers

### DIFF
--- a/src/lib/core/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/block-scroll-strategy.spec.ts
@@ -9,6 +9,7 @@ import {
   OverlayState,
   Overlay,
   OverlayRef,
+  OverlayContainer,
 } from '../../core';
 
 
@@ -26,24 +27,26 @@ describe('BlockScrollStrategy', () => {
   }));
 
   beforeEach(inject([Overlay, ViewportRuler], (overlay: Overlay, viewportRuler: ViewportRuler) => {
-      let overlayState = new OverlayState();
+    let overlayState = new OverlayState();
 
-      overlayState.scrollStrategy = overlay.scrollStrategies.block();
-      overlayRef = overlay.create(overlayState);
-      componentPortal = new ComponentPortal(FocacciaMsg);
+    overlayState.scrollStrategy = overlay.scrollStrategies.block();
+    overlayRef = overlay.create(overlayState);
+    componentPortal = new ComponentPortal(FocacciaMsg);
 
-      viewport = viewportRuler;
-      forceScrollElement = document.createElement('div');
-      document.body.appendChild(forceScrollElement);
-      forceScrollElement.style.width = '100px';
-      forceScrollElement.style.height = '3000px';
-    }));
+    viewport = viewportRuler;
+    forceScrollElement = document.createElement('div');
+    document.body.appendChild(forceScrollElement);
+    forceScrollElement.style.width = '100px';
+    forceScrollElement.style.height = '3000px';
+    forceScrollElement.style.background = 'rebeccapurple';
+  }));
 
-  afterEach(() => {
+  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
     document.body.removeChild(forceScrollElement);
     setScrollPosition(0, 0);
-  });
+    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+  }));
 
   it('should toggle scroll blocking along the y axis', skipIOS(() => {
     setScrollPosition(0, 100);

--- a/src/lib/core/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/close-scroll-strategy.spec.ts
@@ -9,6 +9,7 @@ import {
   OverlayRef,
   OverlayModule,
   ScrollDispatcher,
+  OverlayContainer,
 } from '../../core';
 
 
@@ -39,9 +40,10 @@ describe('CloseScrollStrategy', () => {
     componentPortal = new ComponentPortal(MozarellaMsg);
   }));
 
-  afterEach(() => {
+  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
-  });
+    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+  }));
 
   it('should detach the overlay as soon as the user scrolls', () => {
     overlayRef.attach(componentPortal);

--- a/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/lib/core/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -8,6 +8,7 @@ import {
   OverlayState,
   OverlayRef,
   OverlayModule,
+  OverlayContainer,
   ScrollDispatcher,
 } from '../../core';
 
@@ -39,9 +40,10 @@ describe('RepositionScrollStrategy', () => {
     componentPortal = new ComponentPortal(PastaMsg);
   }));
 
-  afterEach(() => {
+  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
-  });
+    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+  }));
 
   it('should update the overlay position when the page is scrolled', () => {
     overlayRef.attach(componentPortal);

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -8,11 +8,15 @@ import {MdDatepicker} from './datepicker';
 import {MdDatepickerInput} from './datepicker-input';
 import {MdInputModule} from '../input/index';
 import {MdNativeDateModule, DateAdapter, NativeDateAdapter} from '../core/datetime/index';
-import {ESCAPE} from '../core';
+import {ESCAPE, OverlayContainer} from '../core';
 import {dispatchFakeEvent, dispatchMouseEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {DEC, JAN} from '../core/testing/month-constants';
 
 describe('MdDatepicker', () => {
+  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
+    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+  }));
+
   describe('with MdNativeDateModule', () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({


### PR DESCRIPTION
Fixes a few test suites that were leaking `.cdk-overlay-container` instances.