### PR TITLE
build: fix rollup globals for examples package

### DIFF
--- a/tools/package-tools/rollup-helpers.ts
+++ b/tools/package-tools/rollup-helpers.ts
@@ -24,7 +24,7 @@ const ROLLUP_GLOBALS = {
   '@angular/material': 'ng.material',
   '@angular/cdk': 'ng.cdk',
 
-  // Rxjs dependencies
+  // RxJS dependencies
   'rxjs/BehaviorSubject': 'Rx',
   'rxjs/Observable': 'Rx',
   'rxjs/Subject': 'Rx',
@@ -49,6 +49,14 @@ const ROLLUP_GLOBALS = {
   'rxjs/operator/switchMap': 'Rx.Observable.prototype',
   'rxjs/operator/takeUntil': 'Rx.Observable.prototype',
   'rxjs/operator/toPromise': 'Rx.Observable.prototype',
+
+  // RxJS imports for the examples package
+  'rxjs/add/observable/merge': 'Rx.Observable',
+  'rxjs/add/observable/fromEvent': 'Rx.Observable',
+  'rxjs/add/operator/startWith': 'Rx.Observable.prototype',
+  'rxjs/add/operator/map': 'Rx.Observable.prototype',
+  'rxjs/add/operator/debounceTime': 'Rx.Observable.prototype',
+  'rxjs/add/operator/distinctUntilChanged': 'Rx.Observable.prototype',
 };
 
 export type BundleConfig = {


### PR DESCRIPTION
Recently the rollup globals have been changed because the operators are no longer applied to the prototype (using `/add/` imports).

This now causes some warnigns and invalid id's in the bundles of the Material examples because those still use the `/add/` imports in some examples.

**Note**: In theory we can also generate this object automatically as well, but since those are less operator it should be fine.

@jelbourn In the future I think it would be better if we also have a `rollup-config.js` file for every package? (as in Angular core)