### PR TITLE
fix(radio): animation looking off on IE

### DIFF
--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -54,8 +54,11 @@ $mat-radio-ripple-size: $mat-radio-size * 0.75;
   position: absolute;
   top: 0;
   transition: transform ease 280ms, background-color ease 280ms;
-  transform: scale(0);
   width: $mat-radio-size;
+
+  // Note: This starts from 0.001 instead of 0, because transitioning from 0 to 0.5 causes
+  // IE to flash the entire circle for a couple of frames, throwing off the entire animation.
+  transform: scale(0.001);
 
   .mat-radio-checked & {
     transform: scale(0.5);


### PR DESCRIPTION
Fixes the radio button checked animation looking off on IE. The issue comes the fact that IE renders the entire circle for a couple of frames before starting the animation.

For reference, here's the slowed down animation and a green circle for better contrast:
![a](https://user-images.githubusercontent.com/4450522/27992825-2a5b34a6-649d-11e7-99c7-ac615b8f7224.gif)
