### PR TITLE
chore(tabs): switch to OnPush change detection

### DIFF
--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -17,6 +17,7 @@ import {
   Optional,
   AfterViewChecked,
   ViewEncapsulation,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {
   trigger,
@@ -59,6 +60,7 @@ export type MdTabBodyOriginState = 'left' | 'right';
   templateUrl: 'tab-body.html',
   styleUrls: ['tab-body.css'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'mat-tab-body',
   },

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -18,7 +18,9 @@ import {
   OnDestroy,
   Optional,
   ViewChild,
-  ViewEncapsulation
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {MdInkBar} from '../ink-bar';
 import {CanDisable, mixinDisabled} from '../../core/common-behaviors/disabled';
@@ -43,6 +45,7 @@ import {fromEvent} from 'rxjs/observable/fromEvent';
   styleUrls: ['tab-nav-bar.css'],
   host: {'class': 'mat-tab-nav-bar'},
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdTabNav implements AfterContentInit, OnDestroy {
   /** Subject that emits when the component has been destroyed. */
@@ -56,12 +59,19 @@ export class MdTabNav implements AfterContentInit, OnDestroy {
   /** Subscription for window.resize event **/
   private _resizeSubscription: Subscription;
 
-  constructor(@Optional() private _dir: Directionality, private _ngZone: NgZone) { }
+  constructor(
+    @Optional() private _dir: Directionality,
+    private _ngZone: NgZone,
+    private _changeDetectorRef: ChangeDetectorRef) { }
 
   /** Notifies the component that the active link has been changed. */
   updateActiveLink(element: ElementRef) {
     this._activeLinkChanged = this._activeLinkElement != element;
     this._activeLinkElement = element;
+
+    if (this._activeLinkChanged) {
+      this._changeDetectorRef.markForCheck();
+    }
   }
 
   ngAfterContentInit(): void {

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -9,10 +9,11 @@
 import {TemplatePortal} from '../core/portal/portal';
 import {
   ViewContainerRef, Input, TemplateRef, ViewChild, OnInit, ContentChild,
-  Component
+  Component, ChangeDetectionStrategy, OnDestroy, OnChanges, SimpleChanges,
 } from '@angular/core';
 import {CanDisable, mixinDisabled} from '../core/common-behaviors/disabled';
 import {MdTabLabel} from './tab-label';
+import {Subject} from 'rxjs/Subject';
 
 // Boilerplate for applying mixins to MdTab.
 /** @docs-private */
@@ -23,9 +24,10 @@ export const _MdTabMixinBase = mixinDisabled(MdTabBase);
   moduleId: module.id,
   selector: 'md-tab, mat-tab',
   templateUrl: 'tab.html',
-  inputs: ['disabled']
+  inputs: ['disabled'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MdTab extends _MdTabMixinBase implements OnInit, CanDisable {
+export class MdTab extends _MdTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
   /** Content for the tab label given by <ng-template md-tab-label>. */
   @ContentChild(MdTabLabel) templateLabel: MdTabLabel;
 
@@ -38,6 +40,9 @@ export class MdTab extends _MdTabMixinBase implements OnInit, CanDisable {
   /** The portal that will be the hosted content of the tab */
   private _contentPortal: TemplatePortal | null = null;
   get content(): TemplatePortal | null { return this._contentPortal; }
+
+  /** Emits whenever the label changes. */
+  _labelChange = new Subject<void>();
 
   /**
    * The relatively indexed position where 0 represents the center, negative is left, and positive
@@ -53,6 +58,16 @@ export class MdTab extends _MdTabMixinBase implements OnInit, CanDisable {
 
   constructor(private _viewContainerRef: ViewContainerRef) {
     super();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.hasOwnProperty('textLabel')) {
+      this._labelChange.next();
+    }
+  }
+
+  ngOnDestroy() {
+    this._labelChange.complete();
   }
 
   ngOnInit() {


### PR DESCRIPTION
Switches all of the tab-related components to OnPush change detection and sorts out the issues that come from the changes.

Relates to #5035.

**Note:** I'm not a fan of having to subscribe to changes in the tab labels just so we can trigger change detection, but if we want something more practical, we'll have to restructure the tabs so they don't have to reach into other components.