### PR TITLE
docs(README.md): removed empty table row between the tooltip and theming rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ High level stuff planned for Q3 2017 (July - September):
 | textarea         |                                                        |   [Docs][5]  |
 | toolbar          |                                                        |   [Docs][7]  |
 | tooltip          |                                                        |   [Docs][18] |
-|                                                                                          |
 | theming          |                                                        |  [Guide][20] |
 | typography       |                                                        |  [Guide][27] |
 | layout           |                      See [angular/flex-layout][lay_rp] |  [Wiki][0]   |


### PR DESCRIPTION
There was an empty row between the tooltip and theming row in the [Available features](https://github.com/angular/material2#available-features) table