### PR TITLE
refactor(input): remove dash-case selectors for mdPrefix and mdSuffix

### DIFF
--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -104,14 +104,14 @@ export class MdErrorDirective { }
 
 /** Prefix to be placed the the front of the input. */
 @Directive({
-  selector: '[mdPrefix], [matPrefix], [md-prefix]'
+  selector: '[mdPrefix], [matPrefix]'
 })
 export class MdPrefix {}
 
 
 /** Suffix to be placed at the end of the input. */
 @Directive({
-  selector: '[mdSuffix], [matSuffix], [md-suffix]'
+  selector: '[mdSuffix], [matSuffix]'
 })
 export class MdSuffix {}
 


### PR DESCRIPTION
Removes the `md-prefix` and `md-suffix` selectors from their respective directives.

BREAKING CHANGES: Any uses of `md-prefix` and `md-suffix` should be switched over to `mdPrefix` and `mdSuffix`.

Fixes #5643.
