### PR TITLE
fix(expansion-panel): toggle not being updated when set programmatically

### DIFF
--- a/src/lib/expansion/accordion-item.ts
+++ b/src/lib/expansion/accordion-item.ts
@@ -35,8 +35,10 @@ export class AccordionItem implements OnDestroy {
   @Output() destroyed = new EventEmitter<void>();
   /** The unique MdAccordionChild id. */
   readonly id = `cdk-accordion-child-${nextId++}`;
+
   /** Whether the MdAccordionChild is expanded. */
-  @Input() get expanded(): boolean { return this._expanded; }
+  @Input()
+  get expanded(): boolean { return this._expanded; }
   set expanded(expanded: boolean) {
     // Only emit events and update the internal value if the value changes.
     if (this._expanded !== expanded) {

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -16,6 +16,9 @@ import {
   forwardRef,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  SimpleChanges,
+  OnChanges,
+  OnDestroy,
 } from '@angular/core';
 import {
   trigger,
@@ -27,6 +30,7 @@ import {
 import {MdAccordion, MdAccordionDisplayMode} from './accordion';
 import {AccordionItem} from './accordion-item';
 import {UniqueSelectionDispatcher} from '../core';
+import {Subject} from 'rxjs/Subject';
 
 
 /** MdExpansionPanel's states. */
@@ -72,9 +76,12 @@ export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,
     ]),
   ],
 })
-export class MdExpansionPanel extends AccordionItem {
+export class MdExpansionPanel extends AccordionItem implements OnChanges, OnDestroy {
   /** Whether the toggle indicator should be hidden. */
   @Input() hideToggle: boolean = false;
+
+  /** Stream that emits for changes in `@Input` properties. */
+  _inputChanges = new Subject<SimpleChanges>();
 
   constructor(@Optional() @Host() accordion: MdAccordion,
               _changeDetectorRef: ChangeDetectorRef,
@@ -103,6 +110,14 @@ export class MdExpansionPanel extends AccordionItem {
   /** Gets the expanded state string. */
   _getExpandedState(): MdExpansionPanelState {
     return this.expanded ? 'expanded' : 'collapsed';
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this._inputChanges.next(changes);
+  }
+
+  ngOnDestroy() {
+    this._inputChanges.complete();
   }
 }
 

--- a/src/lib/expansion/expansion.spec.ts
+++ b/src/lib/expansion/expansion.spec.ts
@@ -103,12 +103,47 @@ describe('MdExpansionPanel', () => {
     expect(styles.marginLeft).toBe('37px');
     expect(styles.marginRight).toBe('37px');
   }));
+
+  it('should be able to hide the toggle', () => {
+    const fixture = TestBed.createComponent(PanelWithContent);
+    const header = fixture.debugElement.query(By.css('.mat-expansion-panel-header')).nativeElement;
+
+    fixture.detectChanges();
+
+    expect(header.querySelector('.mat-expansion-indicator'))
+        .toBeTruthy('Expected indicator to be shown.');
+
+    fixture.componentInstance.hideToggle = true;
+    fixture.detectChanges();
+
+    expect(header.querySelector('.mat-expansion-indicator'))
+        .toBeFalsy('Expected indicator to be hidden.');
+  });
+
+  it('should update the indicator rotation when the expanded state is toggled programmatically',
+    fakeAsync(() => {
+      const fixture = TestBed.createComponent(PanelWithContent);
+
+      fixture.detectChanges();
+      tick(250);
+
+      const arrow = fixture.debugElement.query(By.css('.mat-expansion-indicator')).nativeElement;
+
+      expect(arrow.style.transform).toBe('rotate(0deg)', 'Expected no rotation.');
+
+      fixture.componentInstance.expanded = true;
+      fixture.detectChanges();
+      tick(250);
+
+      expect(arrow.style.transform).toBe('rotate(180deg)', 'Expected 180 degree rotation.');
+    }));
 });
 
 
 @Component({
   template: `
   <md-expansion-panel [expanded]="expanded"
+                      [hideToggle]="hideToggle"
                       (opened)="openCallback()"
                       (closed)="closeCallback()">
     <md-expansion-panel-header>Panel Title</md-expansion-panel-header>
@@ -118,6 +153,7 @@ describe('MdExpansionPanel', () => {
 })
 class PanelWithContent {
   expanded: boolean = false;
+  hideToggle: boolean = false;
   openCallback = jasmine.createSpy('openCallback');
   closeCallback = jasmine.createSpy('closeCallback');
 }


### PR DESCRIPTION
Fixes the toggle arrow not being flipped when the `expanded` is set programmatically, in addition to the `hideToggle` input not working either. This is a regression from #5549 and is a consequence of the fact that the panel header reaches into the panel to determine what to do with the arrow.

Fixes #5623.

**Note:** Similarly to #5631, if we want something more practical, we'll have to re-think where the input for these properties should go.