### PR TITLE
fix(snackbar): make closeWithAction public method

### DIFF
--- a/src/lib/snack-bar/simple-snack-bar.html
+++ b/src/lib/snack-bar/simple-snack-bar.html
@@ -3,4 +3,4 @@
 <button
   class="mat-simple-snackbar-action"
   *ngIf="hasAction"
-  (click)="dismiss()">{{data.action}}</button>
+  (click)="action()">{{data.action}}</button>

--- a/src/lib/snack-bar/simple-snack-bar.ts
+++ b/src/lib/snack-bar/simple-snack-bar.ts
@@ -36,9 +36,9 @@ export class SimpleSnackBar {
     this.data = data;
   }
 
-  /** Dismisses the snack bar. */
-  dismiss(): void {
-    this.snackBarRef._action();
+  /** Performs the action on the snack bar. */
+  action(): void {
+    this.snackBarRef.closeWithAction();
   }
 
   /** If the action button should be shown. */

--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -25,13 +25,13 @@ export class MdSnackBarRef<T> {
   containerInstance: MdSnackBarContainer;
 
   /** Subject for notifying the user that the snack bar has closed. */
-  private _afterClosed: Subject<any> = new Subject();
+  private _afterClosed = new Subject<void>();
 
   /** Subject for notifying the user that the snack bar has opened and appeared. */
-  private _afterOpened: Subject<any>;
+  private _afterOpened = new Subject<void>();
 
   /** Subject for notifying the user that the snack bar action was called. */
-  private _onAction: Subject<any> = new Subject();
+  private _onAction = new Subject<void>();
 
   /**
    * Timeout ID for the duration setTimeout call. Used to clear the timeout if the snackbar is
@@ -55,17 +55,17 @@ export class MdSnackBarRef<T> {
     clearTimeout(this._durationTimeoutId);
   }
 
-  /** Dismisses the snack bar after some duration */
-  _dismissAfter(duration: number): void {
-    this._durationTimeoutId = setTimeout(() => this.dismiss(), duration);
-  }
-
   /** Marks the snackbar action clicked. */
-  _action(): void {
+  closeWithAction(): void {
     if (!this._onAction.closed) {
       this._onAction.next();
       this._onAction.complete();
     }
+  }
+
+  /** Dismisses the snack bar after some duration */
+  _dismissAfter(duration: number): void {
+    this._durationTimeoutId = setTimeout(() => this.dismiss(), duration);
   }
 
   /** Marks the snackbar as opened */

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -305,6 +305,29 @@ describe('MdSnackBar', () => {
       tick(500);
     }));
 
+  it('should allow manually closing with an action', fakeAsync(() => {
+    let dismissObservableCompleted = false;
+    let actionObservableCompleted = false;
+    let snackBarRef = snackBar.open('Some content');
+    viewContainerFixture.detectChanges();
+
+    snackBarRef.afterDismissed().subscribe(undefined, undefined, () => {
+      dismissObservableCompleted = true;
+    });
+    snackBarRef.onAction().subscribe(undefined, undefined, () => {
+      actionObservableCompleted = true;
+    });
+
+    snackBarRef.closeWithAction();
+    viewContainerFixture.detectChanges();
+    flushMicrotasks();
+
+    expect(dismissObservableCompleted).toBeTruthy('Expected the snack bar to be dismissed');
+    expect(actionObservableCompleted).toBeTruthy('Expected the snack bar to notify of action');
+
+    tick(500);
+  }));
+
   it('should dismiss automatically after a specified timeout', fakeAsync(() => {
     let dismissObservableCompleted = false;
     let config = new MdSnackBarConfig();
@@ -385,6 +408,29 @@ describe('MdSnackBar', () => {
       expect(snackBarRef.instance.data.burritoType)
         .toBe('Chimichanga', 'Expected the injected data object to be the one the user provided.');
     });
+
+    it('should allow manually closing with an action', fakeAsync(() => {
+      let dismissObservableCompleted = false;
+      let actionObservableCompleted = false;
+      const snackBarRef = snackBar.openFromComponent(BurritosNotification);
+      viewContainerFixture.detectChanges();
+
+      snackBarRef.afterDismissed().subscribe(undefined, undefined, () => {
+        dismissObservableCompleted = true;
+      });
+      snackBarRef.onAction().subscribe(undefined, undefined, () => {
+        actionObservableCompleted = true;
+      });
+
+      snackBarRef.closeWithAction();
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      expect(dismissObservableCompleted).toBeTruthy('Expected the snack bar to be dismissed');
+      expect(actionObservableCompleted).toBeTruthy('Expected the snack bar to notify of action');
+
+      tick(500);
+    }));
 
   });
 


### PR DESCRIPTION
Fixes #5657

This also changes the SimpleSnackBar's api from `dismiss()` to `action()` bc the previous naming was misleading.