### PR TITLE
fix(autocomplate): autocomplate menu in bellow position over input's underline #5709

### DIFF
--- a/src/lib/autocomplete/autocomplete.scss
+++ b/src/lib/autocomplete/autocomplete.scss
@@ -7,7 +7,7 @@
 $mat-autocomplete-panel-max-height: 256px !default;
 
 /** When in "below" position, the panel needs a slight y-offset to ensure the input underline displays. */
-$mat-autocomplete-panel-below-offset: 6px !default;
+$mat-autocomplete-panel-below-offset: 8px !default;
 
 /** When in "above" position, the panel needs a larger y-offset to ensure the label has room to display. */
 $mat-autocomplete-panel-above-offset: -24px !default;
@@ -15,7 +15,7 @@ $mat-autocomplete-panel-above-offset: -24px !default;
 .mat-autocomplete-panel {
   @include mat-menu-base();
   visibility: hidden;
-  
+
   max-width: none;
   max-height: $mat-autocomplete-panel-max-height;
   position: relative;


### PR DESCRIPTION
fix [#5709](https://github.com/angular/material2/issues/5709)

The [autocomplete](https://material.angular.io/components/autocomplete/overview) is a normal text input and it should follow inputs style and behavior. One of the input behaviors is their underline or input line which was going under the autocomplete container.

### Before
![Current behavior](https://i.stack.imgur.com/0lzrU.png)

### After
![Expected behavior](https://i.stack.imgur.com/K1n5s.png)