### PR TITLE
fix(datepicker): validate that input actually parses

### DIFF
--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -40,7 +40,9 @@
            placeholder="Pick a date"
            (dateInput)="onDateInput($event)"
            (dateChange)="onDateChange($event)">
-    <md-error *ngIf="resultPickerModel.hasError('mdDatepickerParse')">Not a valid date!</md-error>
+    <md-error *ngIf="resultPickerModel.hasError('mdDatepickerParse')">
+      "{{resultPickerModel.getError('mdDatepickerParse').text}}" is not a valid date!
+    </md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMin')">Too early!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMax')">Too late!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerFilter')">Date unavailable!</md-error>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -40,6 +40,7 @@
            placeholder="Pick a date"
            (dateInput)="onDateInput($event)"
            (dateChange)="onDateChange($event)">
+    <md-error *ngIf="resultPickerModel.hasError('mdDatepickerParse')">Not a valid date!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMin')">Too early!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerMax')">Too late!</md-error>
     <md-error *ngIf="resultPickerModel.hasError('mdDatepickerFilter')">Date unavailable!</md-error>

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -157,11 +157,26 @@ export abstract class DateAdapter<D> {
   abstract getISODateString(date: D): string;
 
   /**
-   * Checks whether the given value is a valid date object.
-   * @param value The value to check.
-   * @returns Whether the value is a valid date object.
+   * Checks whether the given object is considered a date instance by this DateAdapter.
+   * @param obj The object to check
+   * @returns Whether the object is a date instance.
    */
-  abstract isValidDate(value: any): boolean;
+  abstract isDateInstance(obj: any): boolean;
+
+  /**
+   * Checks whether the given date is valid.
+   * @param date The date to check.
+   * @returns Whether the date is valid.
+   */
+  abstract isValid(date: D): boolean;
+
+  /**
+   * @param {obj} The object to check.
+   * @returns The given object if it is both a date instance and valid, otherwise null.
+   */
+  getValidDateOrNull(obj: any): D | null {
+    return (this.isDateInstance(obj) && this.isValid(obj)) ? obj : null;
+  }
 
   /**
    * Sets the locale used for all dates.

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -157,6 +157,13 @@ export abstract class DateAdapter<D> {
   abstract getISODateString(date: D): string;
 
   /**
+   * Checks whether the given value is a date object of type `D`.
+   * @param value The value to check.
+   * @returns Whether the value is a date object of type `D`.
+   */
+  abstract isDateObject(value: any): boolean;
+
+  /**
    * Sets the locale used for all dates.
    * @param locale The new locale.
    */

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -107,15 +107,15 @@ export abstract class DateAdapter<D> {
    * @param value The value to parse.
    * @param parseFormat The expected format of the value being parsed
    *     (type is implementation-dependent).
-   * @returns The parsed date, or null if date could not be parsed.
+   * @returns The parsed date.
    */
   abstract parse(value: any, parseFormat: any): D | null;
 
   /**
    * Formats a date as a string.
-   * @param date The value to parse.
+   * @param date The value to format.
    * @param displayFormat The format to use to display the date as a string.
-   * @returns The parsed date, or null if date could not be parsed.
+   * @returns The formatted date string.
    */
   abstract format(date: D, displayFormat: any): string;
 
@@ -157,11 +157,11 @@ export abstract class DateAdapter<D> {
   abstract getISODateString(date: D): string;
 
   /**
-   * Checks whether the given value is a date object of type `D`.
+   * Checks whether the given value is a valid date object.
    * @param value The value to check.
-   * @returns Whether the value is a date object of type `D`.
+   * @returns Whether the value is a valid date object.
    */
-  abstract isDateObject(value: any): boolean;
+  abstract isValidDate(value: any): boolean;
 
   /**
    * Sets the locale used for all dates.

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -171,14 +171,6 @@ export abstract class DateAdapter<D> {
   abstract isValid(date: D): boolean;
 
   /**
-   * @param {obj} The object to check.
-   * @returns The given object if it is both a date instance and valid, otherwise null.
-   */
-  getValidDateOrNull(obj: any): D | null {
-    return (this.isDateInstance(obj) && this.isValid(obj)) ? obj : null;
-  }
-
-  /**
    * Sets the locale used for all dates.
    * @param locale The new locale.
    */

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -305,12 +305,16 @@ describe('NativeDateAdapter', () => {
     }
   });
 
-  it('should count a Date as a date object', () => {
-    expect(adapter.isDateObject(new Date())).toBe(true);
+  it('should count a Date as a valid date object', () => {
+    expect(adapter.isValidDate(new Date())).toBe(true);
   });
 
-  it('should not count a string as a date object', () => {
-    expect(adapter.isDateObject('1/1/2017')).toBe(false);
+  it('should not count a string as a valid date object', () => {
+    expect(adapter.isValidDate('1/1/2017')).toBe(false);
+  });
+
+  it('should not count InvalidDate as a valid date object', () => {
+    expect(adapter.isValidDate(new Date(NaN))).toBe(false);
   });
 });
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -304,6 +304,14 @@ describe('NativeDateAdapter', () => {
       expect(adapter.format(new Date(1800, 7, 14), {day: 'numeric'})).toBe('Thu Aug 14 1800');
     }
   });
+
+  it('should count a Date as a date object', () => {
+    expect(adapter.isDateObject(new Date())).toBe(true);
+  });
+
+  it('should not count a string as a date object', () => {
+    expect(adapter.isDateObject('1/1/2017')).toBe(false);
+  });
 });
 
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -306,15 +306,15 @@ describe('NativeDateAdapter', () => {
   });
 
   it('should count a Date as a valid date object', () => {
-    expect(adapter.isValidDate(new Date())).toBe(true);
+    expect(adapter.isValid(new Date())).toBe(true);
   });
 
   it('should not count a string as a valid date object', () => {
-    expect(adapter.isValidDate('1/1/2017')).toBe(false);
+    expect(adapter.isValid('1/1/2017')).toBe(false);
   });
 
   it('should not count InvalidDate as a valid date object', () => {
-    expect(adapter.isValidDate(new Date(NaN))).toBe(false);
+    expect(adapter.isValid(new Date(NaN))).toBe(false);
   });
 });
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -199,8 +199,10 @@ describe('NativeDateAdapter', () => {
   it('should parse invalid value as invalid', () => {
     let d = adapter.parse('hello');
     expect(d).not.toBeNull();
-    expect(adapter.isDateInstance(d)).toBe(true);
-    expect(adapter.isValid(d as Date)).toBe(false);
+    expect(adapter.isDateInstance(d))
+        .toBe(true, 'Expected string to have been fed through Date.parse');
+    expect(adapter.isValid(d as Date))
+        .toBe(false, 'Expected to parse as "invalid date" object');
   });
 
   it('should format', () => {
@@ -240,6 +242,11 @@ describe('NativeDateAdapter', () => {
       expect(adapter.format(new Date(2017, JAN, 1), {})).toEqual('Sun Jan 01 2017');
     }
   });
+
+  it('should throw when attempting to format invalid date', () => {
+    expect(() => adapter.format(new Date(NaN), {}))
+        .toThrowError(/NativeDateAdapter: Cannot format invalid date\./);
+  })
 
   it('should add years', () => {
     expect(adapter.addCalendarYears(new Date(2017, JAN, 1), 1)).toEqual(new Date(2018, JAN, 1));

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -312,20 +312,17 @@ describe('NativeDateAdapter', () => {
     let d = new Date();
     expect(adapter.isValid(d)).toBe(true);
     expect(adapter.isDateInstance(d)).toBe(true);
-    expect(adapter.getValidDateOrNull(d)).toBe(d);
   });
 
   it('should count an invalid date as an invalid date instance', () => {
     let d = new Date(NaN);
     expect(adapter.isValid(d)).toBe(false);
     expect(adapter.isDateInstance(d)).toBe(true);
-    expect(adapter.getValidDateOrNull(d)).toBeNull();
   });
 
   it('should count a string as not a date instance', () => {
     let d = '1/1/2017';
     expect(adapter.isDateInstance(d)).toBe(false);
-    expect(adapter.getValidDateOrNull(d)).toBeNull();
   });
 });
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -246,7 +246,7 @@ describe('NativeDateAdapter', () => {
   it('should throw when attempting to format invalid date', () => {
     expect(() => adapter.format(new Date(NaN), {}))
         .toThrowError(/NativeDateAdapter: Cannot format invalid date\./);
-  })
+  });
 
   it('should add years', () => {
     expect(adapter.addCalendarYears(new Date(2017, JAN, 1), 1)).toEqual(new Date(2018, JAN, 1));

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -196,8 +196,11 @@ describe('NativeDateAdapter', () => {
     expect(adapter.parse(date)).not.toBe(date);
   });
 
-  it('should parse invalid value as null', () => {
-    expect(adapter.parse('hello')).toBeNull();
+  it('should parse invalid value as invalid', () => {
+    let d = adapter.parse('hello');
+    expect(d).not.toBeNull();
+    expect(adapter.isDateInstance(d)).toBe(true);
+    expect(adapter.isValid(d as Date)).toBe(false);
   });
 
   it('should format', () => {
@@ -305,16 +308,24 @@ describe('NativeDateAdapter', () => {
     }
   });
 
-  it('should count a Date as a valid date object', () => {
-    expect(adapter.isValid(new Date())).toBe(true);
+  it('should count today as a valid date instance', () => {
+    let d = new Date();
+    expect(adapter.isValid(d)).toBe(true);
+    expect(adapter.isDateInstance(d)).toBe(true);
+    expect(adapter.getValidDateOrNull(d)).toBe(d);
   });
 
-  it('should not count a string as a valid date object', () => {
-    expect(adapter.isValid('1/1/2017')).toBe(false);
+  it('should count an invalid date as an invalid date instance', () => {
+    let d = new Date(NaN);
+    expect(adapter.isValid(d)).toBe(false);
+    expect(adapter.isDateInstance(d)).toBe(true);
+    expect(adapter.getValidDateOrNull(d)).toBeNull();
   });
 
-  it('should not count InvalidDate as a valid date object', () => {
-    expect(adapter.isValid(new Date(NaN))).toBe(false);
+  it('should count a string as not a date instance', () => {
+    let d = '1/1/2017';
+    expect(adapter.isDateInstance(d)).toBe(false);
+    expect(adapter.getValidDateOrNull(d)).toBeNull();
   });
 });
 

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -165,7 +165,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
 
   format(date: Date, displayFormat: Object): string {
     if (!this.isValid(date)) {
-      return 'INVALID DATE';
+      throw Error('NativeDateAdapter: Cannot format invalid date.');
     }
     if (SUPPORTS_INTL_API) {
       if (this.useUtcForDisplay) {

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -207,6 +207,10 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     ].join('-');
   }
 
+  isDateObject(value: any) {
+    return value instanceof Date;
+  }
+
   /** Creates a date but allows the month and date to overflow. */
   private _createDateWithOverflow(year: number, month: number, date: number) {
     let result = new Date(year, month, date);

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -157,11 +157,16 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   parse(value: any): Date | null {
     // We have no way using the native JS Date to set the parse format or locale, so we ignore these
     // parameters.
-    let timestamp = typeof value == 'number' ? value : Date.parse(value);
-    return isNaN(timestamp) ? null : new Date(timestamp);
+    if (typeof value == 'number') {
+      return new Date(value);
+    }
+    return value ? new Date(Date.parse(value)) : null;
   }
 
   format(date: Date, displayFormat: Object): string {
+    if (!this.isValidDate(date)) {
+      return 'INVALID DATE';
+    }
     if (SUPPORTS_INTL_API) {
       if (this.useUtcForDisplay) {
         date = new Date(Date.UTC(
@@ -207,8 +212,14 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     ].join('-');
   }
 
-  isDateObject(value: any) {
-    return value instanceof Date;
+  isValidDate(value: any) {
+    if (value == null) {
+      return true;
+    }
+    if (value instanceof Date) {
+      return !isNaN(value.getTime());
+    }
+    return false;
   }
 
   /** Creates a date but allows the month and date to overflow. */

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -164,7 +164,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   }
 
   format(date: Date, displayFormat: Object): string {
-    if (!this.isValidDate(date)) {
+    if (!this.isValid(date)) {
       return 'INVALID DATE';
     }
     if (SUPPORTS_INTL_API) {
@@ -212,14 +212,12 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     ].join('-');
   }
 
-  isValidDate(value: any) {
-    if (value == null) {
-      return true;
-    }
-    if (value instanceof Date) {
-      return !isNaN(value.getTime());
-    }
-    return false;
+  isDateInstance(obj: any) {
+    return obj instanceof Date;
+  }
+
+  isValid(date: Date) {
+    return !isNaN(date.getTime());
   }
 
   /** Creates a date but allows the month and date to overflow. */

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -66,13 +66,13 @@ export class MdCalendar<D> implements AfterContentInit, OnDestroy {
   @Input() startView: 'month' | 'year' = 'month';
 
   /** The currently selected date. */
-  @Input() selected: D;
+  @Input() selected: D | null;
 
   /** The minimum selectable date. */
-  @Input() minDate: D;
+  @Input() minDate: D | null;
 
   /** The maximum selectable date. */
-  @Input() maxDate: D;
+  @Input() maxDate: D | null;
 
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter: (date: D) => boolean;
@@ -154,6 +154,7 @@ export class MdCalendar<D> implements AfterContentInit, OnDestroy {
 
   /** Handles date selection in the month view. */
   _dateSelected(date: D): void {
+    console.log('date selected', date, this.selected);
     if (!this._dateAdapter.sameDate(date, this.selected)) {
       this.selectedChange.emit(date);
     }

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -154,7 +154,6 @@ export class MdCalendar<D> implements AfterContentInit, OnDestroy {
 
   /** Handles date selection in the month view. */
   _dateSelected(date: D): void {
-    console.log('date selected', date, this.selected);
     if (!this._dateAdapter.sameDate(date, this.selected)) {
       this.selectedChange.emit(date);
     }

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -112,15 +112,14 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   /** The value of the input. */
   @Input()
   get value(): D | null {
-    return this._dateAdapter.getValidDateOrNull(
-        this._dateAdapter.parse(
-            this._elementRef.nativeElement.value, this._dateFormats.parse.dateInput));
+    return this._getValidDateOrNull(this._dateAdapter.parse(
+        this._elementRef.nativeElement.value, this._dateFormats.parse.dateInput));
   }
   set value(value: D | null) {
     if (value != null && !this._dateAdapter.isDateInstance(value)) {
       throw Error('Datepicker: value not recognized as a date object by DateAdapter.');
     }
-    value = this._dateAdapter.getValidDateOrNull(value);
+    value = this._getValidDateOrNull(value);
 
     let oldDate = this.value;
     this._renderer.setProperty(this._elementRef.nativeElement, 'value',
@@ -134,7 +133,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   @Input()
   get min(): D | null { return this._min; }
   set min(value: D | null) {
-    this._min = this._dateAdapter.getValidDateOrNull(value);
+    this._min = this._getValidDateOrNull(value);
     this._validatorOnChange();
   }
   private _min: D | null;
@@ -143,7 +142,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   @Input()
   get max(): D | null { return this._max; }
   set max(value: D | null) {
-    this._max = this._dateAdapter.getValidDateOrNull(value);
+    this._max = this._getValidDateOrNull(value);
     this._validatorOnChange();
   }
   private _max: D | null;
@@ -288,5 +287,13 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
 
   _onChange() {
     this.dateChange.emit(new MdDatepickerInputEvent(this, this._elementRef.nativeElement));
+  }
+
+  /**
+   * @param obj The object to check.
+   * @returns The given object if it is both a date instance and valid, otherwise null.
+   */
+  private _getValidDateOrNull(obj: any): D | null {
+    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
 }

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -116,12 +116,14 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
         this._dateFormats.parse.dateInput);
   }
   set value(value: D | null) {
-    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+    if (value != null && !this._dateAdapter.isDateObject(value)) {
+      throw new Error('Datepicker: value not recognized as a date object by DateAdapter.');
+    }
     let oldDate = this.value;
     this._renderer.setProperty(this._elementRef.nativeElement, 'value',
-        date ? this._dateAdapter.format(date, this._dateFormats.display.dateInput) : '');
-    if (!this._dateAdapter.sameDate(oldDate, date)) {
-      this._valueChange.emit(date);
+        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '');
+    if (!this._dateAdapter.sameDate(oldDate, value)) {
+      this._valueChange.emit(value);
     }
   }
 

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -117,7 +117,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   }
   set value(value: D | null) {
     if (value != null && !this._dateAdapter.isDateObject(value)) {
-      throw new Error('Datepicker: value not recognized as a date object by DateAdapter.');
+      throw Error('Datepicker: value not recognized as a date object by DateAdapter.');
     }
     let oldDate = this.value;
     this._renderer.setProperty(this._elementRef.nativeElement, 'value',

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1001,7 +1001,7 @@ class InputContainerDatepicker {
 })
 class DatepickerWithMinAndMaxValidation {
   @ViewChild('d') datepicker: MdDatepicker<Date>;
-  date: Date;
+  date: Date | null;
   minDate = new Date(2010, JAN, 1);
   maxDate = new Date(2020, JAN, 1);
 }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -223,6 +223,14 @@ describe('MdDatepicker', () => {
         expect(ownedElement).not.toBeNull();
         expect((ownedElement as Element).tagName.toLowerCase()).toBe('md-calendar');
       });
+
+      it('should throw when given wrong data type', () => {
+        testComponent.date = '1/1/2017' as any;
+
+        expect(() => fixture.detectChanges()).toThrow();
+
+        testComponent.date = null;
+      });
     });
 
     describe('datepicker with too many inputs', () => {
@@ -887,7 +895,7 @@ describe('MdDatepicker', () => {
 class StandardDatepicker {
   touch = false;
   disabled = false;
-  date = new Date(2020, JAN, 1);
+  date: Date | null = new Date(2020, JAN, 1);
   @ViewChild('d') datepicker: MdDatepicker<Date>;
   @ViewChild(MdDatepickerInput) datepickerInput: MdDatepickerInput<Date>;
 }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -227,7 +227,8 @@ describe('MdDatepicker', () => {
       it('should throw when given wrong data type', () => {
         testComponent.date = '1/1/2017' as any;
 
-        expect(() => fixture.detectChanges()).toThrow();
+        expect(() => fixture.detectChanges())
+            .toThrowError(/Datepicker: value not recognized as a date object by DateAdapter\./);
 
         testComponent.date = null;
       });

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -129,7 +129,7 @@ export class MdDatepicker<D> implements OnDestroy {
     // selected value is.
     return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D | null) { this._startAt = this._dateAdapter.getValidDateOrNull(date); }
+  set startAt(date: D | null) { this._startAt = this._getValidDateOrNull(date); }
   private _startAt: D | null;
 
   /** The view that the calendar should start in. */
@@ -344,5 +344,13 @@ export class MdDatepicker<D> implements OnDestroy {
         { originX: 'end', originY: 'top' },
         { overlayX: 'end', overlayY: 'bottom' }
       );
+  }
+
+  /**
+   * @param obj The object to check.
+   * @returns The given object if it is both a date instance and valid, otherwise null.
+   */
+  private _getValidDateOrNull(obj: any): D | null {
+    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -127,7 +127,9 @@ export class MdDatepicker<D> implements OnDestroy {
   get startAt(): D {
     // If an explicit startAt is set we start there, otherwise we start at whatever the currently
     // selected value is.
-    return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
+    return this._startAt ||
+        (this._datepickerInput && this._dateAdapter.isValidDate(this._datepickerInput.value) ?
+            this._datepickerInput.value : null);
   }
   set startAt(date: D) { this._startAt = date; }
   private _startAt: D;
@@ -240,7 +242,8 @@ export class MdDatepicker<D> implements OnDestroy {
     }
     this._datepickerInput = input;
     this._inputSubscription =
-        this._datepickerInput._valueChange.subscribe((value: D) => this._selected = value);
+        this._datepickerInput._valueChange.subscribe((value: D) =>
+            this._selected = this._dateAdapter.isValidDate(value) ? value : null);
   }
 
   /** Open the calendar. */

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -164,7 +164,9 @@ export class MdDatepicker<D> implements OnDestroy {
   id = `md-datepicker-${datepickerUid++}`;
 
   /** The currently selected date. */
-  _selected: D | null = null;
+  get _selected(): D | null { return this._validSelected; }
+  set _selected(value: D | null) { this._validSelected = this._getValidDateOrNull(value); }
+  private _validSelected: D | null = null;
 
   /** The minimum selectable date. */
   get _minDate(): D | null {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -124,15 +124,13 @@ export class MdDatepickerContent<D> implements AfterContentInit {
 export class MdDatepicker<D> implements OnDestroy {
   /** The date to open the calendar to initially. */
   @Input()
-  get startAt(): D {
+  get startAt(): D | null {
     // If an explicit startAt is set we start there, otherwise we start at whatever the currently
     // selected value is.
-    return this._startAt ||
-        (this._datepickerInput && this._dateAdapter.isValidDate(this._datepickerInput.value) ?
-            this._datepickerInput.value : null);
+    return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D) { this._startAt = date; }
-  private _startAt: D;
+  set startAt(date: D | null) { this._startAt = this._dateAdapter.getValidDateOrNull(date); }
+  private _startAt: D | null;
 
   /** The view that the calendar should start in. */
   @Input() startView: 'month' | 'year' = 'month';
@@ -169,12 +167,12 @@ export class MdDatepicker<D> implements OnDestroy {
   _selected: D | null = null;
 
   /** The minimum selectable date. */
-  get _minDate(): D {
+  get _minDate(): D | null {
     return this._datepickerInput && this._datepickerInput.min;
   }
 
   /** The maximum selectable date. */
-  get _maxDate(): D {
+  get _maxDate(): D | null {
     return this._datepickerInput && this._datepickerInput.max;
   }
 
@@ -242,8 +240,7 @@ export class MdDatepicker<D> implements OnDestroy {
     }
     this._datepickerInput = input;
     this._inputSubscription =
-        this._datepickerInput._valueChange.subscribe((value: D) =>
-            this._selected = this._dateAdapter.isValidDate(value) ? value : null);
+        this._datepickerInput._valueChange.subscribe((value: D | null) => this._selected = value);
   }
 
   /** Open the calendar. */

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -129,7 +129,7 @@ export class MdDatepicker<D> implements OnDestroy {
     // selected value is.
     return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D | null) { this._startAt = this._getValidDateOrNull(date); }
+  set startAt(date: D | null) { this._startAt = date; }
   private _startAt: D | null;
 
   /** The view that the calendar should start in. */
@@ -165,7 +165,7 @@ export class MdDatepicker<D> implements OnDestroy {
 
   /** The currently selected date. */
   get _selected(): D | null { return this._validSelected; }
-  set _selected(value: D | null) { this._validSelected = this._getValidDateOrNull(value); }
+  set _selected(value: D | null) { this._validSelected = value; }
   private _validSelected: D | null = null;
 
   /** The minimum selectable date. */
@@ -346,13 +346,5 @@ export class MdDatepicker<D> implements OnDestroy {
         { originX: 'end', originY: 'top' },
         { overlayX: 'end', overlayY: 'bottom' }
       );
-  }
-
-  /**
-   * @param obj The object to check.
-   * @returns The given object if it is both a date instance and valid, otherwise null.
-   */
-  private _getValidDateOrNull(obj: any): D | null {
-    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: You must now use an actual Date object rather than a
string when setting the value of the datepicker programmatically
(through `value`, `ngModel`, or `formControl`).

BREAKING CHNAGE: `DateAdapter` subclasses must now provide an implementation for `isValidDate`

fixes #5417
fixes #4978