### PR TITLE
fix(dialog): default md-dialog-close result to null instead of ''

### DIFF
--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -30,7 +30,7 @@ export class MdDialogClose {
   @Input('aria-label') ariaLabel: string = 'Close dialog';
 
   /** Dialog close input. */
-  @Input('md-dialog-close') dialogResult: any;
+  @Input('md-dialog-close') dialogResult: any = null;
 
   /** Dialog close input for compatibility mode. */
   @Input('mat-dialog-close') set _matDialogClose(value: any) { this.dialogResult = value; }


### PR DESCRIPTION
fixes #5237