### PR TITLE
fix toggling OverlayContainer.themeClass

### DIFF
--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -25,7 +25,9 @@ export class OverlayContainer {
   get themeClass(): string { return this._themeClass; }
   set themeClass(value: string) {
     if (this._containerElement) {
-      this._containerElement.classList.remove(this._themeClass);
+      if (this._themeClass) {
+        this._containerElement.classList.remove(this._themeClass);
+      }
 
       if (value) {
         this._containerElement.classList.add(value);


### PR DESCRIPTION
when toggling `overlayContainer.themeClass`
```
overlayContainer.themeClass = 'some-class';
overlayContainer.themeClass = '';
overlayContainer.themeClass = 'some-class';
```
we get:
`Uncaught DOMException: Failed to execute 'remove' on 'DOMTokenList': The token provided must not be empty.`

`''` is allowed as input to themeClass so it should be checked for on remove from classList