### PR TITLE
Positively define input text color for dark themes

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -39,6 +39,10 @@
     }
   }
 
+  .mat-input-element {
+    color: mat-color($foreground, text);
+  }
+
   .mat-input-element:disabled {
     color: mat-color($foreground, disabled-text);
   }


### PR DESCRIPTION
Before this change, input text on dark themes was invisible due to having similar color to dark background.