### PR TITLE
fix(tooltip): a11y improvement, create overlay on init

### DIFF
--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -1,6 +1,14 @@
 <div class="demo-tooltip">
   <h1>Tooltip Demo</h1>
 
+  <div class="demo-icon-row">
+    <button md-icon-button><md-icon mdTooltip="Delete">delete</md-icon></button>
+    <button md-icon-button><md-icon mdTooltip="Make favorite">favorite</md-icon></button>
+    <button md-icon-button><md-icon mdTooltip="Get help">help</md-icon></button>
+    <button md-icon-button><md-icon mdTooltip="Ride">motorcycle</md-icon></button>
+    <button md-icon-button><md-icon [mdTooltip]="extensionTooltip">extension</md-icon></button>
+  </div>
+
   <div class="centered" cdk-scrollable>
     <button #tooltip="mdTooltip"
             md-raised-button

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -2,11 +2,11 @@
   <h1>Tooltip Demo</h1>
 
   <div class="demo-icon-row">
-    <button md-icon-button><md-icon mdTooltip="Delete">delete</md-icon></button>
-    <button md-icon-button><md-icon mdTooltip="Make favorite">favorite</md-icon></button>
-    <button md-icon-button><md-icon mdTooltip="Get help">help</md-icon></button>
-    <button md-icon-button><md-icon mdTooltip="Ride">motorcycle</md-icon></button>
-    <button md-icon-button><md-icon [mdTooltip]="extensionTooltip">extension</md-icon></button>
+    <button md-icon-button mdTooltip="Delete"><md-icon >delete</md-icon></button>
+    <button md-icon-button mdTooltip="Make favorite"><md-icon>favorite</md-icon></button>
+    <button md-icon-button mdTooltip="Get help"><md-icon>help</md-icon></button>
+    <button md-icon-button mdTooltip="Ride"><md-icon >motorcycle</md-icon></button>
+    <button md-icon-button [mdTooltip]="extensionTooltip"><md-icon>extension</md-icon></button>
   </div>
 
   <div class="centered" cdk-scrollable>

--- a/src/demo-app/tooltip/tooltip-demo.scss
+++ b/src/demo-app/tooltip/tooltip-demo.scss
@@ -1,4 +1,10 @@
 .demo-tooltip {
+  .demo-icon-row {
+    height: 64px;
+    display: flex;
+    align-items: center;
+  }
+
   .centered {
     text-align: center;
     height: 200px;

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -15,5 +15,7 @@ export class TooltipDemo {
   disabled = false;
   showDelay = 0;
   hideDelay = 1000;
+
+  extensionTooltip = 'Extension tooltip';
   showExtraClass = false;
 }

--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -1,4 +1,6 @@
 <div class="mat-tooltip"
+     role="tooltip"
+     [id]="id"
      [ngClass]="tooltipClass"
      [style.transform-origin]="_transformOrigin"
      [@state]="_visibility"

--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -4,7 +4,6 @@
      [ngClass]="tooltipClass"
      [style.transform-origin]="_transformOrigin"
      [@state]="_visibility"
-     (@state.start)="_whenVisibilityAnimation($event)"
      (@state.done)="_afterVisibilityAnimation($event)">
   {{message}}
 </div>

--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -4,6 +4,7 @@
      [ngClass]="tooltipClass"
      [style.transform-origin]="_transformOrigin"
      [@state]="_visibility"
+     (@state.start)="_whenVisibilityAnimation($event)"
      (@state.done)="_afterVisibilityAnimation($event)">
   {{message}}
 </div>

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -31,7 +31,7 @@ import {dispatchFakeEvent} from '@angular/cdk/testing';
 
 const initialTooltipMessage = 'initial tooltip message';
 
-fdescribe('MdTooltip', () => {
+describe('MdTooltip', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: Direction};
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -1,16 +1,17 @@
 import {
   async,
   ComponentFixture,
-  TestBed,
-  tick,
   fakeAsync,
-  flushMicrotasks
+  flushMicrotasks,
+  TestBed,
+  tick
 } from '@angular/core/testing';
 import {
+  ChangeDetectionStrategy,
   Component,
   DebugElement,
-  ViewChild,
-  ChangeDetectionStrategy, ContentChild, ElementRef
+  ElementRef,
+  ViewChild
 } from '@angular/core';
 import {
   TooltipPosition,
@@ -22,6 +23,7 @@ import {
 import {AnimationEvent} from '@angular/animations';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MdTooltip, MdTooltipModule, SCROLL_THROTTLE_MS, TooltipPosition} from './index';
 import {Directionality, Direction} from '../core/bidi/index';
 import {OverlayModule, Scrollable, OverlayContainer} from '../core/overlay/index';
 import {Platform} from '../core/platform/platform';

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -420,9 +420,9 @@ describe('MdTooltip', () => {
 
       // Tooltip is shown, check that the tooltip's id matches the aria-describedby
       fixture.detectChanges();
-      expect(tooltipDirective._getTooltipId()).toBe('md-tooltip-0');
-      expect(tooltipDirective._tooltipInstance.id).toBe('md-tooltip-0');
-      expect(trigger.getAttribute('aria-describedBy')).toBe('md-tooltip-0');
+      expect(tooltipDirective._getTooltipId()).toContain('md-tooltip-');
+      expect(tooltipDirective._tooltipInstance.id).toContain('md-tooltip-');
+      expect(trigger.getAttribute('aria-describedBy')).toContain('md-tooltip-');
 
       tooltipDirective.hide(0);
       tick(0); // Tick for the hide delay

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -413,7 +413,7 @@ describe('MdTooltip', () => {
     it('should associate trigger and tooltip through aria-describedby', fakeAsync(() => {
       // Expect that the trigger does not have an associated tooltip since there is no tooltip shown
       const trigger = fixture.componentInstance.trigger.nativeElement;
-      expect(trigger.getAttribute('aria-describedBy')).toBe('');
+      expect(trigger.getAttribute('aria-describedBy')).toBe(null);
 
       tooltipDirective.show(0);
       tick(0); // Tick for the show delay

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -7,22 +7,16 @@ import {
   ViewChild
 } from '@angular/core';
 import {
-  TooltipPosition,
   MdTooltip,
   MdTooltipModule,
   SCROLL_THROTTLE_MS,
-  TOOLTIP_PANEL_CLASS
+  TOOLTIP_PANEL_CLASS,
+  TooltipComponent,
+  TooltipPosition
 } from './index';
 import {AnimationEvent} from '@angular/animations';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {
-  MdTooltip,
-  MdTooltipModule,
-  SCROLL_THROTTLE_MS,
-  TooltipComponent,
-  TooltipPosition
-} from './index';
 import {Direction, Directionality} from '../core/bidi/index';
 import {OverlayContainer, OverlayModule, Scrollable} from '../core/overlay/index';
 import {Platform} from '../core/platform/platform';

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -10,7 +10,7 @@ import {
   Component,
   DebugElement,
   ViewChild,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy, ContentChild, ElementRef
 } from '@angular/core';
 import {
   TooltipPosition,
@@ -407,6 +407,30 @@ describe('MdTooltip', () => {
       expect(tooltipWrapper).toBeTruthy('Expected tooltip to be shown.');
       expect(tooltipWrapper.getAttribute('dir')).toBe('rtl', 'Expected tooltip to be in RTL mode.');
     }));
+
+    it('should associate trigger and tooltip through aria-describedby', fakeAsync(() => {
+      // Expect that the trigger does not have an associated tooltip since there is no tooltip shown
+      const trigger = fixture.componentInstance.trigger.nativeElement;
+      expect(trigger.getAttribute('aria-describedBy')).toBe('');
+
+      tooltipDirective.show(0);
+      tick(0); // Tick for the show delay
+
+      // Tooltip is shown, check that the tooltip's id matches the aria-describedby
+      fixture.detectChanges();
+      expect(tooltipDirective._getTooltipId()).toBe('md-tooltip-0');
+      expect(tooltipDirective._tooltipInstance.id).toBe('md-tooltip-0');
+      expect(trigger.getAttribute('aria-describedBy')).toBe('md-tooltip-0');
+
+      tooltipDirective.hide(0);
+      tick(0); // Tick for the hide delay
+      fixture.detectChanges();
+      flushMicrotasks();
+
+      // Tooltip is hidden again, check that the trigger does not have an aria-describedby
+      expect(tooltipDirective._getTooltipId()).toBe('');
+      expect(trigger.getAttribute('aria-describedBy')).toBe('');
+    }));
   });
 
   describe('scrollable usage', () => {
@@ -512,6 +536,7 @@ describe('MdTooltip', () => {
   selector: 'app',
   template: `
     <button *ngIf="showButton"
+            #trigger
             [mdTooltip]="message"
             [mdTooltipPosition]="position"
             [mdTooltipClass]="{'custom-one': showTooltipClass, 'custom-two': showTooltipClass }">
@@ -522,6 +547,7 @@ class BasicTooltipDemo {
   position: string = 'below';
   message: string = initialTooltipMessage;
   showButton: boolean = true;
+  @ViewChild('trigger') trigger: ElementRef;
   showTooltipClass = false;
   @ViewChild(MdTooltip) tooltip: MdTooltip;
 }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -4,14 +4,14 @@ import {
   fakeAsync,
   flushMicrotasks,
   TestBed,
-  tick
+  tick,
 } from '@angular/core/testing';
 import {
   ChangeDetectionStrategy,
   Component,
   DebugElement,
   ElementRef,
-  ViewChild
+  ViewChild,
 } from '@angular/core';
 import {
   TooltipPosition,

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -31,7 +31,7 @@ import {dispatchFakeEvent} from '@angular/cdk/testing';
 
 const initialTooltipMessage = 'initial tooltip message';
 
-describe('MdTooltip', () => {
+fdescribe('MdTooltip', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: Direction};
 
@@ -71,11 +71,6 @@ describe('MdTooltip', () => {
       buttonDebugElement = fixture.debugElement.query(By.css('button'));
       buttonElement = <HTMLButtonElement> buttonDebugElement.nativeElement;
       tooltipDirective = buttonDebugElement.injector.get<MdTooltip>(MdTooltip);
-    });
-
-    afterEach(() => {
-      fixture.detectChanges();
-      flushMicrotasks();
     });
 
     it('should show and hide the tooltip', fakeAsync(() => {
@@ -425,14 +420,17 @@ describe('MdTooltip', () => {
 
       // Tooltip is shown, check that the tooltip's id matches the aria-describedby
       fixture.detectChanges();
-      expect(tooltipDirective._getTooltipId()).toBe('md-tooltip-0');
-      expect(tooltipDirective._tooltipInstance.id).toBe('md-tooltip-0');
-      expect(trigger.getAttribute('aria-describedBy')).toBe('md-tooltip-0');
+      expect(tooltipDirective._getTooltipId()).toContain('md-tooltip-');
+      expect(tooltipDirective._tooltipInstance.id).toContain('md-tooltip-');
+      expect(trigger.getAttribute('aria-describedBy')).toContain('md-tooltip-');
 
       tooltipDirective.hide(0);
       tick(0); // Tick for the hide delay
       fixture.detectChanges();
+
+      // Let animation play out and resolve to remove the tooltip
       flushMicrotasks();
+      fixture.detectChanges();
 
       // Tooltip is hidden again, check that the trigger does not have an aria-describedby
       expect(tooltipDirective._getTooltipId()).toBe('');

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -73,6 +73,11 @@ describe('MdTooltip', () => {
       tooltipDirective = buttonDebugElement.injector.get<MdTooltip>(MdTooltip);
     });
 
+    afterEach(() => {
+      fixture.detectChanges();
+      flushMicrotasks();
+    });
+
     it('should show and hide the tooltip', fakeAsync(() => {
       expect(tooltipDirective._tooltipInstance).toBeUndefined();
 
@@ -420,9 +425,9 @@ describe('MdTooltip', () => {
 
       // Tooltip is shown, check that the tooltip's id matches the aria-describedby
       fixture.detectChanges();
-      expect(tooltipDirective._getTooltipId()).toContain('md-tooltip-');
-      expect(tooltipDirective._tooltipInstance.id).toContain('md-tooltip-');
-      expect(trigger.getAttribute('aria-describedBy')).toContain('md-tooltip-');
+      expect(tooltipDirective._getTooltipId()).toBe('md-tooltip-0');
+      expect(tooltipDirective._tooltipInstance.id).toBe('md-tooltip-0');
+      expect(trigger.getAttribute('aria-describedBy')).toBe('md-tooltip-0');
 
       tooltipDirective.hide(0);
       tick(0); // Tick for the hide delay

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -94,7 +94,11 @@ export const MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER = {
   selector: '[md-tooltip], [mdTooltip], [mat-tooltip], [matTooltip]',
   host: {
     '(longpress)': 'show()',
+    '(focus)': 'show()',
+    '(blur)': 'hide(0)',
+    '(keydown.esc)': 'hide(0)',
     '(touchend)': 'hide(' + TOUCHEND_HIDE_DELAY + ')',
+    '[attr.aria-describedby]': '_getTooltipId()'
   },
   exportAs: 'mdTooltip',
 })
@@ -261,6 +265,10 @@ export class MdTooltip implements OnDestroy {
     this._isTooltipVisible() ? this.hide() : this.show();
   }
 
+  _getTooltipId(): string {
+    return this._tooltipInstance ? this._tooltipInstance.id : '';
+  }
+
   /** Returns true if the tooltip is currently visible to the user */
   _isTooltipVisible(): boolean {
     return !!this._tooltipInstance && this._tooltipInstance.isVisible();
@@ -277,6 +285,7 @@ export class MdTooltip implements OnDestroy {
     this._tooltipInstance!.afterHidden().subscribe(() => {
       // Check first if the tooltip has already been removed through this components destroy.
       if (this._tooltipInstance) {
+        debugger;
         this._disposeTooltip();
       }
     });
@@ -396,6 +405,9 @@ export class MdTooltip implements OnDestroy {
 
 export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
 
+/** Tooltip IDs need to be unique, so this counter exists outside of the component definition. */
+let _uniqueTooltipIdCounter = 0;
+
 /**
  * Internal component that wraps the tooltip's content.
  * @docs-private
@@ -445,6 +457,9 @@ export class TooltipComponent {
 
   /** The transform origin used in the animation for showing and hiding the tooltip */
   _transformOrigin: string = 'bottom';
+
+  /** Unique ID to be used by the tooltip trigger's "aria-describedby" property. */
+  id: string = `md-tooltip-${_uniqueTooltipIdCounter++}`;
 
   /** Subject for notifying that the tooltip has been hidden from the view */
   private _onHide: Subject<any> = new Subject();

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -568,7 +568,7 @@ export class TooltipComponent {
 
   /** Whether the tooltip is being displayed */
   isVisible(): boolean {
-    return this._visibility === 'visible';\
+    return this._visibility === 'visible';
   }
 
   /** Sets the tooltip transform origin according to the tooltip position */

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -478,7 +478,7 @@ let _uniqueTooltipIdCounter = 0;
     // won't be rendered if the animations are disabled or there is no web animations polyfill.
     '[style.zoom]': '_visibility === "visible" ? 1 : null',
     '(body:click)': '_handleBodyInteraction()',
-    '[attr.aria-hidden]': "isVisible() ? '' : 'true'",
+    '[attr.aria-hidden]': 'isVisible()',
   }
 })
 export class TooltipComponent {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Directive,

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -285,7 +285,6 @@ export class MdTooltip implements OnDestroy {
     this._tooltipInstance!.afterHidden().subscribe(() => {
       // Check first if the tooltip has already been removed through this components destroy.
       if (this._tooltipInstance) {
-        debugger;
         this._disposeTooltip();
       }
     });

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -288,7 +288,10 @@ export class MdTooltip implements OnDestroy {
     this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', describedBy);
   }
 
-  /** Create the tooltip to display */
+  /**
+   * Create the tooltip to display. Uses the trigger's view container reference and should not be
+   * called within the change detection after the view has already been checked.
+   */
   private _createTooltip(): void {
     let portal = new ComponentPortal(TooltipComponent, this._viewContainerRef);
     this._overlayRef = this._createTooltipOverlay();

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -23,10 +23,6 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
-// Importing ScrollStrategy is only used to define a generic type.
-// The current TypeScript version incorrectly considers such imports as
-// unused (https://github.com/Microsoft/TypeScript/issues/14953)
-// tslint:disable-next-line:no-unused-variable
 import {
   ComponentPortal,
   OriginConnectionPosition,

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -341,7 +341,7 @@ export class MdTooltip implements OnDestroy {
     strategy.onPositionChange.subscribe(change => {
       if (change.scrollableViewProperties.isOverlayClipped && this._tooltipInstance &&
           this._tooltipInstance.isVisible()) {
-        this.hide(1000);
+        this.hide(0);
       }
     });
 
@@ -359,8 +359,10 @@ export class MdTooltip implements OnDestroy {
 
   /** Visually hides the overlay and disables the scrolling strategy. */
   private _hideOverlay(): void {
-    this._overlayRef.overlayElement.classList.add('cdk-visually-hidden');
-    this._scrollStrategy.disable();
+    if (this._overlayRef) {
+      this._overlayRef.overlayElement.classList.add('cdk-visually-hidden');
+      this._scrollStrategy.disable();
+    }
   }
 
   /** Disposes the current tooltip and the overlay it is attached to */
@@ -474,7 +476,9 @@ let _uniqueTooltipIdCounter = 0;
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('state', [
-      state('void, initial, hidden', style({transform: 'scale(0)'})),
+      state('void', style({transform: 'scale(0)'})),
+      state('initial', style({transform: 'scale(0)'})),
+      state('hidden', style({transform: 'scale(0)'})),
       state('visible', style({transform: 'scale(1)'})),
       transition('* => visible', animate('150ms cubic-bezier(0.0, 0.0, 0.2, 1)')),
       transition('* => hidden', animate('150ms cubic-bezier(0.4, 0.0, 1, 1)')),
@@ -538,6 +542,7 @@ export class TooltipComponent {
     this._setTransformOrigin(position);
     this._showTimeoutId = setTimeout(() => {
       this._visibility = 'visible';
+      console.log('Setting visibility to', this._visibility);
 
       // If this was set to true immediately, then a body click that triggers show() would
       // trigger interaction and close the tooltip right after it was displayed.
@@ -595,9 +600,14 @@ export class TooltipComponent {
   }
 
   _afterVisibilityAnimation(e: AnimationEvent): void {
+    console.log('Visibility set', e);
     if (e.toState === 'hidden' && !this.isVisible()) {
       this._onHide.next();
     }
+  }
+
+  _whenVisibilityAnimation(e: AnimationEvent): void {
+    console.log('Visibility animation started', e);
   }
 
   /**

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -238,7 +238,10 @@ export class MdTooltip implements OnDestroy {
    * screen readers immediately have a reference to the tooltip content.
    */
   ngOnInit() {
-    this._createTooltip();
+    // Only create the tooltip if we are on the browser platform
+    if (this._platform.isBrowser) {
+      this._createTooltip();
+    }
   }
 
   ngOnDestroy() {

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -12,6 +12,8 @@ import {
   Component,
   Directive,
   ElementRef,
+  Inject,
+  InjectionToken,
   Input,
   NgZone,
   OnDestroy,
@@ -19,27 +21,21 @@ import {
   Renderer2,
   ViewContainerRef,
   ViewEncapsulation
-  ViewContainerRef
-  ChangeDetectorRef,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  InjectionToken,
-  Inject,
 } from '@angular/core';
 import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
+// Importing ScrollStrategy is only used to define a generic type.
+// The current TypeScript version incorrectly considers such imports as
+// unused (https://github.com/Microsoft/TypeScript/issues/14953)
+// tslint:disable-next-line:no-unused-variable
 import {
   ComponentPortal,
   OriginConnectionPosition,
-  RepositionScrollStrategy,
-  // This import is only used to define a generic type. The current TypeScript version incorrectly
-  // considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
-  // tslint:disable-next-line:no-unused-variable
-  ScrollStrategy,
   Overlay,
   OverlayConnectionPosition,
   OverlayRef,
   OverlayState,
-  RepositionScrollStrategy
+  RepositionScrollStrategy,
+  ScrollStrategy
 } from '../core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
@@ -128,7 +124,6 @@ export class MdTooltip implements OnDestroy {
       }
     }
   }
-
 
   /** Disables the display of the tooltip. */
   @Input('mdTooltipDisabled')
@@ -221,8 +216,8 @@ export class MdTooltip implements OnDestroy {
       private _ngZone: NgZone,
       private _renderer: Renderer2,
       private _platform: Platform,
-      @Inject(MD_TOOLTIP_SCROLL_STRATEGY) private _scrollStrategy,
-    @Optional() private _dir: Directionality) {
+      @Optional() private _dir: Directionality,
+      @Inject(MD_TOOLTIP_SCROLL_STRATEGY) private _scrollStrategyProvider) {
     // The mouse events shouldn't be bound on iOS devices, because
     // they can prevent the first tap from firing its click event.
     if (!_platform.IOS) {
@@ -344,8 +339,8 @@ export class MdTooltip implements OnDestroy {
     config.positionStrategy = strategy;
     config.panelClass = TOOLTIP_PANEL_CLASS;
 
-    this._scrollStrategy = this._scrollStrategy();
-    config.scrollStrategy = this._scrollStrategy;
+    this._scrollStrategy = this._scrollStrategyProvider();
+    config.scrollStrategy = this._scrollStrategy!;
 
     return this._overlay.create(config);
   }


### PR DESCRIPTION
Problem: Screenreaders can't read out the tooltip since the overlay is created on `show`. 

This PR changes the tooltip so that the tooltip overlay is created in the DOM on init so that it is always available to screenreaders. 

Fixes #2334