### PR TITLE
fix(table): set font family

### DIFF
--- a/src/lib/table/_table-theme.scss
+++ b/src/lib/table/_table-theme.scss
@@ -24,7 +24,9 @@
 }
 
 @mixin mat-table-typography($config) {
-  $font-family: mat-font-family($config);
+  .mat-table {
+    font-family: mat-font-family($config);
+  }
 
   .mat-header-cell {
     font-size: mat-font-size($config, caption);


### PR DESCRIPTION
Fixes the font family not being set on the `md-table`.