### PR TITLE
fix(expansion): use correct expanded line-height

### DIFF
--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -57,7 +57,7 @@ import {MdExpansionPanel, EXPANSION_PANEL_ANIMATION_TIMING} from './expansion-pa
     ]),
     trigger('expansionHeight', [
       state('collapsed', style({height: '48px', 'line-height': '48px'})),
-      state('expanded', style({height: '64px', 'line-height': '68px'})),
+      state('expanded', style({height: '64px', 'line-height': '64px'})),
       transition('expanded <=> collapsed', animate(EXPANSION_PANEL_ANIMATION_TIMING)),
     ]),
   ],


### PR DESCRIPTION
Presumed typo in animation styles. It now matches the value from the component styles
```scss
$mat-expansion-panel-header-height-expanded: 64px;

...

&.mat-expanded {
  height: $mat-expansion-panel-header-height-expanded;
  line-height: $mat-expansion-panel-header-height-expanded;
}
```