### PR TITLE
docs(Portal): Fix broken link to core portal README.md

### DIFF
--- a/src/lib/core/portal/README.md
+++ b/src/lib/core/portal/README.md
@@ -1,1 +1,1 @@
-See [cdk/portal](../../../cdk/portal/README.md)
+See [cdk/portal](../../../cdk/portal/portal.md)


### PR DESCRIPTION
Fix broken link to core portal README.md
`src/lib/core/portal/README.md`