### PR TITLE
fix(OverlayContainer): themeClass only remove class if not empty

### DIFF
--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -25,7 +25,9 @@ export class OverlayContainer {
   get themeClass(): string { return this._themeClass; }
   set themeClass(value: string) {
     if (this._containerElement) {
-      this._containerElement.classList.remove(this._themeClass);
+      if (this._themeClass) {
+        this._containerElement.classList.remove(this._themeClass);
+      }
 
       if (value) {
         this._containerElement.classList.add(value);


### PR DESCRIPTION
If _themeClass is empty do not try and remove from the element classList.