### PR TITLE
fix(slider): set proper font family on label

### DIFF
--- a/src/lib/slider/_slider-theme.scss
+++ b/src/lib/slider/_slider-theme.scss
@@ -132,6 +132,7 @@
 @mixin mat-slider-typography($config) {
   .mat-slider-thumb-label-text {
     font: {
+      family: mat-font-family($config);
       size: mat-font-size($config, caption);
       weight: mat-font-weight($config, body-2);
     }


### PR DESCRIPTION
Sets the proper font family on the slider label. Currently it inherits from the body.