### PR TITLE
fix(chips): remove background from unstyled chip

### DIFF
--- a/src/lib/chips/_chips-theme.scss
+++ b/src/lib/chips/_chips-theme.scss
@@ -45,7 +45,7 @@ $mat-chip-line-height: 16px;
   $selected-background: if($is-dark-theme, mat-color($background, app-bar), #808080);
   $selected-foreground: if($is-dark-theme, mat-color($foreground, text), $light-selected-foreground);
 
-  .mat-chip {
+  .mat-chip:not(.mat-basic-chip) {
     @include mat-chips-color($unselected-foreground, $unselected-background);
   }
 


### PR DESCRIPTION
This seems like a regression from c82aca9f8decb9860501196abc7f5028c1187344. The basic chips aren't supposed to have a background color.