### PR TITLE
build: fix screenshot functions deploying

### DIFF
--- a/scripts/deploy/deploy-dashboard.sh
+++ b/scripts/deploy/deploy-dashboard.sh
@@ -4,7 +4,7 @@
 set -e
 
 # This script deploys the Dashboard App and their Cloud Functions to Firebase.
-# Before the script installs all dependencies and builds the dashboard app in production.
+# Before deploying, the script installs all dependencies and builds the dashboard app in production.
 
 # Go to the project root directory
 cd $(dirname ${0})/../..
@@ -17,6 +17,9 @@ fi
 
 # Paths to the dashboard and functions directories.
 dashboardFolder=tools/dashboard
+
+# Path to the firebase binary of the root package.json
+firebaseBin=$(npm bin)/firebase
 
 # Go to the dashboard folder because otherwise the Firebase CLI tries to deploy the wrong project.
 cd ${dashboardFolder}
@@ -34,5 +37,5 @@ wait
 
 # Deploy the dashboard to Firebase. Based on the current configuration hosting and functions
 # will be deployed.
-$(npm bin)/firebase deploy --token ${MATERIAL2_BOARD_FIREBASE_DEPLOY_KEY} \
+${firebaseBin} deploy --token ${MATERIAL2_BOARD_FIREBASE_DEPLOY_KEY} \
   --non-interactive --project material2-board

--- a/scripts/deploy/deploy-screenshot-functions.sh
+++ b/scripts/deploy/deploy-screenshot-functions.sh
@@ -3,25 +3,31 @@
 # The script should immediately exit if any command in the script fails.
 set -e
 
+# This script deploys the Cloud Functions of the screenshot tool to Firebase.
+# Before deploying, the script installs all dependencies of the functions.
+
+# Go to the project root directory
+cd $(dirname ${0})/../..
+
 if [ -z ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} ]; then
   echo "Error: No access token for firebase specified." \
        "Please set the environment variable 'MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN'."
   exit 1
 fi
 
-# Go to the project root directory
-cd $(dirname ${0})/../..
+# Path to the screenshot tool in the project.
+screenshotToolFolder="tools/dashboard"
 
-# Paths to the screenshot-test directory that also contains the function directory.
-screenshotTestFolder=tools/screenshot-test
+# Path to the firebase binary of the root package.json
+firebaseBin=$(npm bin)/firebase
 
 # Go to the screenshot-test folder because otherwise Firebase tries to deploy the wrong project.
-cd ${screenshotTestFolder}
+cd ${screenshotToolFolder}
 
 # Install node modules for the screenshot functions. Firebase CLI needs to execute the functions
-# before it can collect all functions and deploy them.
+# to collect all function names before it can deploy them.
 (cd functions; npm install)
 
 # Deploy the screenshot functions to Firebase
-$(npm bin)/firebase deploy --only functions --token ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} \
-  --project material2-screenshots
+${firebaseBin} deploy --only functions --token ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} \
+  --non-interactive --project material2-screenshots

--- a/tools/dashboard/package.json
+++ b/tools/dashboard/package.json
@@ -35,7 +35,6 @@
     "@angular/language-service": "^4.2.6",
     "@types/jasmine": "2.5.45",
     "@types/node": "~6.0.60",
-    "firebase-tools": "^3.9.1",
     "ts-node": "~3.0.4",
     "typescript": "^2.4.1"
   }


### PR DESCRIPTION
* Fixes the screenshot functions deploying by properly resolving the path to the Firebase CLI binary.
* Also cleans up the script to be aligned with the dashboard deployment script.
* Removes firebase-tools as dependency from the dashboard since it's not used there anymore