### PR TITLE
build: dashboard deploy bug in firebase

### DIFF
--- a/scripts/deploy/deploy-dashboard.sh
+++ b/scripts/deploy/deploy-dashboard.sh
@@ -34,4 +34,5 @@ wait
 
 # Deploy the dashboard to Firebase. Based on the current configuration hosting and functions
 # will be deployed.
-$(npm bin)/firebase deploy --token ${MATERIAL2_BOARD_FIREBASE_DEPLOY_KEY} --project material2-board
+$(npm bin)/firebase deploy --token ${MATERIAL2_BOARD_FIREBASE_DEPLOY_KEY} \
+  --non-interactive --project material2-board


### PR DESCRIPTION
* Workaround for a Firebase bug (https://github.com/firebase/firebase-tools/issues/382) that causes the deployment to not work in Travis CI.