### PR TITLE
build: fix es2015 entry point for cdk

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -4,7 +4,7 @@
   "description": "Angular Material Component Development Kit",
   "main": "./bundles/cdk.umd.js",
   "module": "./@angular/cdk.es5.js",
-  "es2015": "./@angular/cdkjs",
+  "es2015": "./@angular/cdk.js",
   "typings": "./cdk.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Currently the cdk package file does refer to a non existing file for the ES2015 entry point.

Fixes #5782