### PR TITLE
refactor(overlay): simplify overlay ref construction

### DIFF
--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -9,7 +9,6 @@
 import {NgZone} from '@angular/core';
 import {PortalHost, Portal} from '../portal/portal';
 import {OverlayState} from './overlay-state';
-import {ScrollStrategy} from './scroll/scroll-strategy';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
@@ -28,10 +27,9 @@ export class OverlayRef implements PortalHost {
       private _portalHost: PortalHost,
       private _pane: HTMLElement,
       private _state: OverlayState,
-      private _scrollStrategy: ScrollStrategy,
       private _ngZone: NgZone) {
 
-    _scrollStrategy.attach(this);
+    _state.scrollStrategy.attach(this);
   }
 
   /** The overlay's HTML element */
@@ -52,7 +50,7 @@ export class OverlayRef implements PortalHost {
     this.updateSize();
     this.updateDirection();
     this.updatePosition();
-    this._scrollStrategy.enable();
+    this._state.scrollStrategy.enable();
 
     // Enable pointer events for the overlay pane element.
     this._togglePointerEvents(true);
@@ -82,7 +80,7 @@ export class OverlayRef implements PortalHost {
     // This is necessary because otherwise the pane element will cover the page and disable
     // pointer events therefore. Depends on the position strategy and the applied pane boundaries.
     this._togglePointerEvents(false);
-    this._scrollStrategy.disable();
+    this._state.scrollStrategy.disable();
 
     let detachmentResult = this._portalHost.detach();
 
@@ -100,10 +98,7 @@ export class OverlayRef implements PortalHost {
       this._state.positionStrategy.dispose();
     }
 
-    if (this._scrollStrategy) {
-      this._scrollStrategy.disable();
-    }
-
+    this._state.scrollStrategy.disable();
     this.detachBackdrop();
     this._portalHost.dispose();
     this._attachments.complete();

--- a/src/lib/core/overlay/overlay-state.ts
+++ b/src/lib/core/overlay/overlay-state.ts
@@ -9,6 +9,7 @@
 import {PositionStrategy} from './position/position-strategy';
 import {Direction} from '../bidi/index';
 import {ScrollStrategy} from './scroll/scroll-strategy';
+import {NoopScrollStrategy} from './scroll/noop-scroll-strategy';
 
 
 /**
@@ -20,7 +21,7 @@ export class OverlayState {
   positionStrategy: PositionStrategy;
 
   /** Strategy to be used when handling scroll events while the overlay is open. */
-  scrollStrategy: ScrollStrategy;
+  scrollStrategy: ScrollStrategy = new NoopScrollStrategy();
 
   /** Custom class to add to the overlay pane. */
   panelClass?: string = '';

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -18,7 +18,7 @@ import {DomPortalHost} from '../portal/dom-portal-host';
 import {OverlayRef} from './overlay-ref';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
 import {OverlayContainer} from './overlay-container';
-import {ScrollStrategy, ScrollStrategyOptions} from './scroll/index';
+import {ScrollStrategyOptions} from './scroll/index';
 
 
 /** Next overlay unique ID. */
@@ -52,7 +52,9 @@ export class Overlay {
    * @returns Reference to the created overlay.
    */
   create(state: OverlayState = defaultState): OverlayRef {
-    return this._createOverlayRef(this._createPaneElement(), state);
+    const pane = this._createPaneElement();
+    const portalHost = this._createPortalHost(pane);
+    return new OverlayRef(portalHost, pane, state, this._ngZone);
   }
 
   /**
@@ -84,16 +86,5 @@ export class Overlay {
    */
   private _createPortalHost(pane: HTMLElement): DomPortalHost {
     return new DomPortalHost(pane, this._componentFactoryResolver, this._appRef, this._injector);
-  }
-
-  /**
-   * Creates an OverlayRef for an overlay in the given DOM element.
-   * @param pane DOM element for the overlay
-   * @param state
-   */
-  private _createOverlayRef(pane: HTMLElement, state: OverlayState): OverlayRef {
-    let scrollStrategy = state.scrollStrategy || this.scrollStrategies.noop();
-    let portalHost = this._createPortalHost(pane);
-    return new OverlayRef(portalHost, pane, state, scrollStrategy, this._ngZone);
   }
 }


### PR DESCRIPTION
Simplifies the construction of the `OverlayRef` by not passing in the `ScrollStrategy` via the constructor. Instead, the ref takes the scroll strategy from the `OverlayState` directly. This looks like it might be something that we overlooked while the scroll strategy API was in flux.