### PR TITLE
fix(connected-position-strategy): multiple places to specify direction

### DIFF
--- a/src/lib/core/overlay/overlay-directives.ts
+++ b/src/lib/core/overlay/overlay-directives.ts
@@ -264,7 +264,6 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
       this._createOverlay();
     }
 
-    this._position.withDirection(this.dir);
     this._overlayRef.getState().direction = this.dir;
     this._initEscapeListener();
 

--- a/src/lib/core/overlay/overlay-ref.ts
+++ b/src/lib/core/overlay/overlay-ref.ts
@@ -10,6 +10,7 @@ import {NgZone} from '@angular/core';
 import {PortalHost, Portal} from '../portal/portal';
 import {OverlayState} from './overlay-state';
 import {ScrollStrategy} from './scroll/scroll-strategy';
+import {ConnectedPositionStrategy} from './position/connected-position-strategy';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
@@ -146,6 +147,12 @@ export class OverlayRef implements PortalHost {
   /** Updates the position of the overlay based on the position strategy. */
   updatePosition() {
     if (this._state.positionStrategy) {
+      // Pass the state direction from here since we don't want to introduce a circular
+      // dependency between the OverlayState and the ConnectedPositionStrategy.
+      if (this._state.positionStrategy instanceof ConnectedPositionStrategy) {
+        this._state.positionStrategy.direction = this._state.direction!;
+      }
+
       this._state.positionStrategy.apply(this._pane);
     }
   }

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -219,6 +219,19 @@ describe('Overlay', () => {
     expect(callbackOrder).toEqual(['attach', 'detach']);
   });
 
+  it('should pass the layout direction to connected overlays', () => {
+    let state = new OverlayState();
+    let positionStrategy = overlay.position().connectedTo({ nativeElement: document.body },
+      {originX: 'end', originY: 'top'},
+      {overlayX: 'end', overlayY: 'bottom'});
+
+    state.direction = 'rtl';
+    state.positionStrategy = positionStrategy;
+    overlay.create(state).attach(componentPortal);
+
+    expect(positionStrategy.direction).toBe('rtl');
+  });
+
   describe('positioning', () => {
     let state: OverlayState;
 

--- a/src/lib/core/overlay/position/connected-position-strategy.spec.ts
+++ b/src/lib/core/overlay/position/connected-position-strategy.spec.ts
@@ -277,9 +277,9 @@ describe('ConnectedPositionStrategy', () => {
         strategy = positionBuilder.connectedTo(
             fakeElementRef,
             {originX: 'start', originY: 'bottom'},
-            {overlayX: 'start', overlayY: 'top'})
-            .withDirection('rtl');
+            {overlayX: 'start', overlayY: 'top'});
 
+        strategy.direction = 'rtl';
         strategy.apply(overlayElement);
 
         let overlayRect = overlayElement.getBoundingClientRect();
@@ -376,8 +376,9 @@ describe('ConnectedPositionStrategy', () => {
         strategy = positionBuilder.connectedTo(
             fakeElementRef,
             {originX: 'start', originY: 'bottom'},
-            {overlayX: 'start', overlayY: 'top'})
-            .withDirection('rtl');
+            {overlayX: 'start', overlayY: 'top'});
+
+        strategy.direction = 'rtl';
         originElement.style.top = '0';
         originElement.style.left = '0';
 
@@ -639,10 +640,11 @@ describe('ConnectedPositionStrategy', () => {
             fakeElementRef,
             {originX: 'start', originY: 'top'},
             {overlayX: 'start', overlayY: 'top'}
-        )
-        .withDirection('rtl');
+        );
 
+        strategy.direction = 'rtl';
         strategy.apply(overlayElement);
+
         expect(overlayElement.style.right).toBeTruthy();
         expect(overlayElement.style.left).toBeFalsy();
       });
@@ -652,8 +654,9 @@ describe('ConnectedPositionStrategy', () => {
             fakeElementRef,
             {originX: 'end', originY: 'top'},
             {overlayX: 'end', overlayY: 'top'}
-        ).withDirection('rtl');
+        );
 
+        strategy.direction = 'rtl';
         strategy.apply(overlayElement);
         expect(overlayElement.style.left).toBeTruthy();
         expect(overlayElement.style.right).toBeFalsy();

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -232,8 +232,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
    */
   private _getOverlayConfig(): OverlayState {
     const overlayState = new OverlayState();
-    overlayState.positionStrategy = this._getPosition()
-                                        .withDirection(this.dir);
+    overlayState.positionStrategy = this._getPosition();
     overlayState.hasBackdrop = true;
     overlayState.backdropClass = 'cdk-overlay-transparent-backdrop';
     overlayState.direction = this.dir;


### PR DESCRIPTION
* Currently, if the consumer wants to handle layout direction in a connected overlay, they have to specify it in two places: via the `OverlayState.direction` and the `ConnectedPositionStrategy.withDirection`. This can be confusing and easy to overlook. These changes remove the `ConnectedPositionStrategy.withDirection` method, in favor of passing in the overlay state direction.
* Makes a few underscored properties private since they weren't being used anywhere outside of the `ConnectedPositionStrategy` class.

BREAKING CHANGE: This will be a breaking change if somebody was using the `withDirection` method and the way to fix it is to only pass the direction to the `OverlayState`. If we want to be safer about it, I can put the method back in and mark it as deprecated.