### PR TITLE
perf(table): cell references not being cleaned up on destroy

### DIFF
--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -155,6 +155,19 @@ describe('CdkTable', () => {
     expect(changedRows[2].getAttribute('initialIndex')).toBe(null);
   });
 
+  it('should clear the row view containers on destroy', () => {
+    const rowPlaceholder = fixture.componentInstance.table._rowPlaceholder.viewContainer;
+    const headerPlaceholder = fixture.componentInstance.table._headerRowPlaceholder.viewContainer;
+
+    spyOn(rowPlaceholder, 'clear').and.callThrough();
+    spyOn(headerPlaceholder, 'clear').and.callThrough();
+
+    fixture.destroy();
+
+    expect(rowPlaceholder.clear).toHaveBeenCalled();
+    expect(headerPlaceholder.clear).toHaveBeenCalled();
+  });
+
   describe('with trackBy', () => {
 
     let trackByComponent: TrackByCdkTableApp;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -27,7 +27,7 @@ import {
   TrackByFunction,
   ViewChild,
   ViewContainerRef,
-  ViewEncapsulation
+  ViewEncapsulation,
 } from '@angular/core';
 import {CollectionViewer, DataSource} from './data-source';
 import {CdkCellOutlet, CdkCellOutletRowContext, CdkHeaderRowDef, CdkRowDef} from './row';
@@ -175,8 +175,11 @@ export class CdkTable<T> implements CollectionViewer {
   }
 
   ngOnDestroy() {
+    this._rowPlaceholder.viewContainer.clear();
+    this._headerRowPlaceholder.viewContainer.clear();
     this._onDestroy.next();
     this._onDestroy.complete();
+
     if (this.dataSource) {
       this.dataSource.disconnect(this);
     }
@@ -343,7 +346,7 @@ export class CdkTable<T> implements CollectionViewer {
       viewRef.context.first = index === 0;
       viewRef.context.last = index === count - 1;
       viewRef.context.even = index % 2 === 0;
-      viewRef.context.odd = index % 2 !== 0;
+      viewRef.context.odd = !viewRef.context.even;
     }
   }
 


### PR DESCRIPTION
Fixes the table cell references not being cleaned up when the table is destroyed, causing them to stay in memory forever.