### PR TITLE
docs(slide-toggle): show MdSlideToggleChange description in docs

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -44,7 +44,7 @@ export const MD_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
   multi: true
 };
 
-// A simple change event emitted by the MdSlideToggle component.
+/** Change event object emitted by a MdSlideToggle. */
 export class MdSlideToggleChange {
   source: MdSlideToggle;
   checked: boolean;


### PR DESCRIPTION
* Because of a single line comment the `MdSlideToggleChange` description does not show in the docs.