### PR TITLE
docs(icons): escape HTML tags in code comments

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -180,7 +180,7 @@ export class MdIconRegistry {
   }
 
   /**
-   * Returns an Observable that produces the icon (as an <svg> DOM element) from the given URL.
+   * Returns an Observable that produces the icon (as an `<svg>` DOM element) from the given URL.
    * The response from the URL may be cached so this will not always cause an HTTP request, but
    * the produced element will always be a new copy of the originally fetched icon. (That is,
    * it will not contain any modifications made to elements previously returned).
@@ -207,7 +207,7 @@ export class MdIconRegistry {
   }
 
   /**
-   * Returns an Observable that produces the icon (as an <svg> DOM element) with the given name
+   * Returns an Observable that produces the icon (as an `<svg>` DOM element) with the given name
    * and namespace. The icon must have been previously registered with addIcon or addIconSet;
    * if not, the Observable will throw an error.
    *


### PR DESCRIPTION
Fix #5793 

I supose that using backticks is enough to escape HTML tags in code multiline comments