### PR TITLE
build: tslint rule to enforce html tags escaping in comments

### DIFF
--- a/tools/tslint-rules/noUnscapedHtmlTagRule.js
+++ b/tools/tslint-rules/noUnscapedHtmlTagRule.js
@@ -1,0 +1,64 @@
+const ts = require('typescript');
+const utils = require('tsutils');
+const Lint = require('tslint');
+
+const ERROR_MESSAGE =
+    'A HTML tag may only appear if it is escaped. ' +
+    'This is meant to prevent failures in docs generation caused by a misinterpreted tag.';
+
+/**
+ * Rule that walks through all comments inside of the library and adds failures when it
+ * detects unescaped HTML tags inside of multi-line comments.
+ */
+class Rule extends Lint.Rules.AbstractRule {
+
+  apply(sourceFile) {
+    return this.applyWithWalker(new NoUnescapedHtmlTagWalker(sourceFile, this.getOptions()));
+  }
+}
+
+class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
+
+  visitSourceFile(sourceFile) {
+    utils.forEachComment(sourceFile, (fullText, commentRange) => {
+
+      let isEscapedHtmlTag = true;
+      while (true) {
+        const iOpenTag = fullText.indexOf('<');
+        const iCloseTag = fullText.indexOf('>');
+        if ((iOpenTag === -1) && (iCloseTag === -1)) {
+          break;
+        }
+        if ((iCloseTag < iOpenTag) || (iCloseTag === -1)) {
+          isEscapedHtmlTag = false;
+          break;
+        }
+        let iTestTag = fullText.indexOf('<', iOpenTag + 1);
+        if ((iTestTag > iOpenTag) && (iTestTag < iCloseTag)) {
+          isEscapedHtmlTag = false;
+          break;
+        }
+        iTestTag = fullText.indexOf('`<');
+        if (iTestTag !== (iOpenTag - 1)) {
+          isEscapedHtmlTag = false;
+          break;
+        }
+        iTestTag = fullText.indexOf('>`')
+        if (iTestTag !== iCloseTag) {
+          isEscapedHtmlTag = false;
+          break;
+        }
+        if ((iCloseTag + 2) > fullText.length) {
+          break;
+        }
+        fullText = fullText.substring(iCloseTag + 2, fullText.length)
+      }
+
+      if (commentRange.kind === ts.SyntaxKind.MultiLineCommentTrivia && !isEscapedHtmlTag) {
+        this.addFailureAt(commentRange.pos, commentRange.end - commentRange.pos, ERROR_MESSAGE);
+      }
+    });
+  }
+}
+
+exports.Rule = Rule;

--- a/tslint.json
+++ b/tslint.json
@@ -28,6 +28,7 @@
     "no-unused-expression": true,
     "no-var-keyword": true,
     "no-exposed-todo": true,
+	  "no-unescaped-html-tag": true,
     "no-debugger": true,
     "no-unused-variable": [true, {"ignore-pattern": "^_"}],
     "no-rxjs-patch-imports": [


### PR DESCRIPTION
The rule was built suposing that using backticks is enough to escape HTML tags in multiline code  comments. It should emit warnings when there is:

1 - Any HTML open tag (`<`) without a backtick (`)

```
/** 
 * The using of <svg>` is very good because...
 */
```

2 - Any HTML close tag (`>`) without a backtick (`):

```
/** 
 * The using of `<svg> is very good because...
 */
```

3 - Any HTML open or close tag without it's matching:

```
/** 
 * The using of `<svg is very good because...
 */
```

4 - Any HTML open following an open tag and before a closing tag:

```
/** 
 * The using of `<svg attr1="value1" < >` is very good because...
 */
```