### PR TITLE
style(table): table rows expand to fit content

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -10,7 +10,7 @@ $mat-row-horizontal-padding: 24px;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   align-items: center;
-  height: $mat-row-height;
+  min-height: $mat-row-height;
   padding: 0 $mat-row-horizontal-padding;
 }
 


### PR DESCRIPTION
Changing row height so a minimum rather than exact height in case the cell content is taller than row height.

Fixes #5827