### PR TITLE
build: artifact scripts should push empty commits

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -60,6 +60,8 @@ publishPackage() {
   cd ${repoDir}
 
   # Update the package.json version to include the current commit SHA.
+  # Normally this "sed" call would just replace the version placeholder, but the version in the
+  # package.json file is already replaced by the release task of the current package.
   sed -i "s/${buildVersion}/${buildVersion}-${commitSha}/g" package.json
 
   # For build artifacts the different Angular packages that refer to the 0.0.0-PLACEHOLDER should
@@ -74,7 +76,7 @@ publishPackage() {
   echo "https://${MATERIAL2_BUILDS_TOKEN}:@github.com" > .git/credentials
 
   git add -A
-  git commit -m "${commitMessage}"
+  git commit --allow-empty -m "${commitMessage}"
   git tag "${buildVersion}-${commitSha}"
   git push origin master --tags
 

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -90,6 +90,6 @@ git config credential.helper "store --file=.git/credentials"
 echo "https://${MATERIAL2_DOCS_CONTENT_TOKEN}:@github.com" > .git/credentials
 
 git add -A
-git commit -m "$commitMessage"
+git commit --allow-empty -m "$commitMessage"
 git tag "$commitSha"
 git push origin master --tags


### PR DESCRIPTION
When publishing build artifacts (cdk; material) there will be always a change (regardless if something changed in the package or not). This is because the version will be always appended with the current SHA.

But when publishing the docs content this is not the case. Sometimes there won't be any change and Git will exit with error code `1` because empty commits are not allowed.

In the future we might also just append the SHA to the version of the `material-examples` package, but I have a different solution in mind (which depends on #4962)