### PR TITLE
fix(radio-group): coerce disabled property

### DIFF
--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -67,11 +67,24 @@ describe('MdRadio', () => {
       }
     });
 
+    it('should coerce the disabled binding on the radio group', () => {
+      (groupInstance as any).disabled = '';
+      fixture.detectChanges();
+
+      radioLabelElements[0].click();
+      fixture.detectChanges();
+
+      expect(radioInstances[0].checked).toBe(false);
+      expect(groupInstance.disabled).toBe(true);
+    });
+
     it('should disable click interaction when the group is disabled', () => {
       testComponent.isGroupDisabled = true;
       fixture.detectChanges();
 
       radioLabelElements[0].click();
+      fixture.detectChanges();
+
       expect(radioInstances[0].checked).toBe(false);
     });
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -186,11 +186,11 @@ export class MdRadioGroup extends _MdRadioGroupMixinBase
     this._checkSelectedRadioButton();
   }
 
-  /** Whether the radio group is diabled */
+  /** Whether the radio group is disabled */
   @Input()
   get disabled() { return this._disabled; }
   set disabled(value) {
-    this._disabled = value;
+    this._disabled = coerceBooleanProperty(value);
     this._markRadiosForCheck();
   }
 


### PR DESCRIPTION
* Properly coerces the disabled property of the radio-group.
* Fixes a typo in the description of the disabled getter/setter.