### PR TITLE
refactor: use renderer in DOM-related services

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -11,7 +11,6 @@ import {
   ContentChildren,
   Directive,
   ElementRef,
-  Renderer2,
   EventEmitter,
   HostBinding,
   Input,
@@ -372,7 +371,6 @@ export class MdButtonToggle implements OnInit, OnDestroy {
               @Optional() toggleGroupMultiple: MdButtonToggleGroupMultiple,
               private _changeDetectorRef: ChangeDetectorRef,
               private _buttonToggleDispatcher: UniqueSelectionDispatcher,
-              private _renderer: Renderer2,
               private _elementRef: ElementRef,
               private _focusOriginMonitor: FocusOriginMonitor) {
 
@@ -407,7 +405,7 @@ export class MdButtonToggle implements OnInit, OnDestroy {
     if (this.buttonToggleGroup && this._value == this.buttonToggleGroup.value) {
       this._checked = true;
     }
-    this._focusOriginMonitor.monitor(this._elementRef.nativeElement, this._renderer, true);
+    this._focusOriginMonitor.monitor(this._elementRef.nativeElement, true);
   }
 
   /** Focuses the button. */

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -144,7 +144,7 @@ export class MdButton extends _MdButtonMixinBase implements OnDestroy, CanDisabl
               private _platform: Platform,
               private _focusOriginMonitor: FocusOriginMonitor) {
     super(renderer, elementRef);
-    this._focusOriginMonitor.monitor(this._elementRef.nativeElement, this._renderer, true);
+    this._focusOriginMonitor.monitor(this._elementRef.nativeElement, true);
   }
 
   ngOnDestroy() {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -201,7 +201,7 @@ export class MdCheckbox extends _MdCheckboxMixinBase
 
   ngAfterViewInit() {
     this._focusOriginMonitor
-      .monitor(this._inputElement.nativeElement, this._renderer, false)
+      .monitor(this._inputElement.nativeElement, false)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/core/overlay/overlay.ts
+++ b/src/lib/core/overlay/overlay.ts
@@ -12,6 +12,8 @@ import {
   ApplicationRef,
   Injector,
   NgZone,
+  Renderer2,
+  RendererFactory2,
 } from '@angular/core';
 import {OverlayState} from './overlay-state';
 import {DomPortalHost} from '../portal/dom-portal-host';
@@ -38,13 +40,19 @@ let defaultState = new OverlayState();
  */
 @Injectable()
 export class Overlay {
+  private _renderer: Renderer2;
+
   constructor(public scrollStrategies: ScrollStrategyOptions,
               private _overlayContainer: OverlayContainer,
               private _componentFactoryResolver: ComponentFactoryResolver,
               private _positionBuilder: OverlayPositionBuilder,
               private _appRef: ApplicationRef,
               private _injector: Injector,
-              private _ngZone: NgZone) { }
+              private _ngZone: NgZone,
+              rendererFactory: RendererFactory2) {
+
+    this._renderer = rendererFactory.createRenderer(null, null);
+  }
 
   /**
    * Creates an overlay.
@@ -68,11 +76,11 @@ export class Overlay {
    * @returns Newly-created pane element
    */
   private _createPaneElement(): HTMLElement {
-    let pane = document.createElement('div');
+    const pane = this._renderer.createElement('div');
 
-    pane.id = `cdk-overlay-${nextUniqueId++}`;
-    pane.classList.add('cdk-overlay-pane');
-    this._overlayContainer.getContainerElement().appendChild(pane);
+    this._renderer.setAttribute(pane, 'id', `cdk-overlay-${nextUniqueId++}`);
+    this._renderer.addClass(pane, 'cdk-overlay-pane');
+    this._renderer.appendChild(this._overlayContainer.getContainerElement(), pane);
 
     return pane;
   }

--- a/src/lib/core/style/focus-origin-monitor.spec.ts
+++ b/src/lib/core/style/focus-origin-monitor.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, inject, TestBed, fakeAsync, tick} from '@angular/core/testing';
-import {Component, Renderer2} from '@angular/core';
+import {Component} from '@angular/core';
 import {StyleModule} from './index';
 import {By} from '@angular/platform-browser';
 import {TAB} from '../keyboard/keycodes';
@@ -10,7 +10,6 @@ import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@ang
 describe('FocusOriginMonitor', () => {
   let fixture: ComponentFixture<PlainButton>;
   let buttonElement: HTMLElement;
-  let buttonRenderer: Renderer2;
   let focusOriginMonitor: FocusOriginMonitor;
   let changeHandler: (origin: FocusOrigin) => void;
 
@@ -28,11 +27,10 @@ describe('FocusOriginMonitor', () => {
     fixture.detectChanges();
 
     buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
-    buttonRenderer = fixture.componentInstance.renderer;
     focusOriginMonitor = fom;
 
     changeHandler = jasmine.createSpy('focus origin change handler');
-    focusOriginMonitor.monitor(buttonElement, buttonRenderer, false).subscribe(changeHandler);
+    focusOriginMonitor.monitor(buttonElement, false).subscribe(changeHandler);
     patchElementFocus(buttonElement);
   }));
 
@@ -380,9 +378,7 @@ describe('cdkMonitorFocus', () => {
 @Component({
   template: `<button>focus me!</button>`
 })
-class PlainButton {
-  constructor(public renderer: Renderer2) {}
-}
+class PlainButton {}
 
 
 @Component({

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -512,7 +512,7 @@ export class MdRadioButton extends _MdRadioButtonMixinBase
 
   ngAfterViewInit() {
     this._focusOriginMonitor
-      .monitor(this._inputElement.nativeElement, this._renderer, false)
+      .monitor(this._inputElement.nativeElement, false)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -141,7 +141,7 @@ export class MdSlideToggle extends _MdSlideToggleMixinBase
     this._slideRenderer = new SlideToggleRenderer(this._elementRef, this._platform);
 
     this._focusOriginMonitor
-      .monitor(this._inputElement.nativeElement, this._renderer, false)
+      .monitor(this._inputElement.nativeElement, false)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -15,7 +15,6 @@ import {
   OnDestroy,
   Optional,
   Output,
-  Renderer2,
   ViewEncapsulation,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -407,13 +406,13 @@ export class MdSlider extends _MdSliderMixinBase
     return (this._dir && this._dir.value == 'rtl') ? 'rtl' : 'ltr';
   }
 
-  constructor(renderer: Renderer2, private _elementRef: ElementRef,
+  constructor(private _elementRef: ElementRef,
               private _focusOriginMonitor: FocusOriginMonitor,
               private _changeDetectorRef: ChangeDetectorRef,
               @Optional() private _dir: Directionality) {
     super();
     this._focusOriginMonitor
-        .monitor(this._elementRef.nativeElement, renderer, true)
+        .monitor(this._elementRef.nativeElement, true)
         .subscribe((origin: FocusOrigin) => this._isActive = !!origin && origin !== 'keyboard');
     this._renderer = new SliderRenderer(this._elementRef);
   }


### PR DESCRIPTION
Since it's now possible to get a hold of a renderer inside of a service, these changes switch over as much DOM manipulation as possible to it. There are still a couple of more candidates (namely the `IconRegistry`), however the `Renderer2` doesn't have all of the necessary methods.