### PR TITLE
docs(table): add cdk module reference

### DIFF
--- a/src/lib/table/table.md
+++ b/src/lib/table/table.md
@@ -1,14 +1,14 @@
 The `md-table` provides a Material Design styled data-table that can be used to display rows of
 data.
-
-This table builds on the foundation of the CDK data-table and uses a similar interface for its
-data source input and template, except that its element selectors will be prefixed with `md-`
-instead of `cdk-`.
  
 <!-- example(table-basic) -->
 
-Note that the column definition directives (`cdkColumnDef` and `cdkHeaderCellDef`) are still
-prefixed with `cdk-`.
+This table builds on the foundation of the CDK data-table and uses a similar interface for its
+data source input and template, except that its element selectors will be prefixed with `md-`
+instead of `cdk-`. 
+
+Note that the column definition directives (`cdkColumnDef` and `cdkHeaderCellDef`) are from the CDK
+and are prefixed with `cdk`. Be sure to import `CdkTableModule` to use these directives.
 
 For more information on the interface and how it works, see the
 [guide covering the CDK data-table](https://material.angular.io/guide/cdk-table).


### PR DESCRIPTION
Would like to also get your opinion on creating `mdColumnDef` and `mdHeaderCellDef` to avoid having users import the `CdkTableModule`. Been hearing a lot of users say that they struggled to find out they needed to import both `MdTableModule` and `CdkTableModule` to make the table work.

Fixes #5819

