### PR TITLE
Placeholder overflow is hidden now

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -55,7 +55,14 @@ $mat-select-trigger-underline-height: 1px !default;
   padding: 0 2px;
   transform-origin: left top;
   flex-grow: 1;
-
+  
+  // If the placeholder is very long, the overflow should be hidden 
+  // and replaced with three dots instead. 
+  // Otherwise, a long placeholder will be displayed in two lines. 
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  
   // These values are duplicated from animation code in order to
   // allow placeholders to sometimes float without animating,
   // for example when the value is set programmatically.


### PR DESCRIPTION
 If the placeholder is very long, the overflow should be hidden and replaced with three dots instead. 
 Otherwise, a long placeholder will be displayed in two lines.