### PR TITLE
feat(select): support basic usage without @angular/forms

### DIFF
--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -66,6 +66,22 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
   </md-card>
 
   <md-card>
+    <md-card-subtitle>Without Angular forms</md-card-subtitle>
+
+    <md-select placeholder="Digimon" [(value)]="currentDigimon">
+      <md-option>None</md-option>
+      <md-option *ngFor="let creature of digimon" [value]="creature.value">
+        {{ creature.viewValue }}
+      </md-option>
+    </md-select>
+
+    <p>Value: {{ currentDigimon }}</p>
+
+    <button md-button (click)="currentDigimon='pajiramon-3'">SET VALUE</button>
+    <button md-button (click)="currentDigimon=null">RESET</button>
+  </md-card>
+
+  <md-card>
     <md-card-subtitle>Option groups</md-card-subtitle>
 
     <md-card-content>

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -17,6 +17,7 @@ export class SelectDemo {
   currentDrink: string;
   currentPokemon: string[];
   currentPokemonFromGroup: string;
+  currentDigimon: string;
   latestChangeEvent: MdSelectChange;
   floatPlaceholder: string = 'auto';
   foodControl = new FormControl('pizza-1');
@@ -92,6 +93,15 @@ export class SelectDemo {
         { value: 'mewtwo-10', viewValue: 'Mewtwo' },
       ]
     }
+  ];
+
+  digimon = [
+    { value: 'mihiramon-0', viewValue: 'Mihiramon' },
+    { value: 'sandiramon-1', viewValue: 'Sandiramon' },
+    { value: 'sinduramon-2', viewValue: 'Sinduramon' },
+    { value: 'pajiramon-3', viewValue: 'Pajiramon' },
+    { value: 'vajiramon-4', viewValue: 'Vajiramon' },
+    { value: 'indramon-5', viewValue: 'Indramon' }
   ];
 
   toggleDisabled() {


### PR DESCRIPTION
Currently `md-select` can only really be used together with `@angular/forms` which is overkill for simple usages where it only sets a value (for example, the only reason the paginator module brings in the `FormsModule` is the select). These changes introduce the `value` two-way binding that can be used to read/write the value without using `ngModel` or a `formControl`. This also aligns it with the input module.

Relates to #5717.