### PR TITLE
fix(menu): make it easier to override elevation

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -13,10 +13,14 @@ $mat-menu-side-padding: 16px !default;
 $mat-menu-icon-margin: 16px !default;
 
 
-@mixin mat-menu-base($elevation) {
-  @include mat-elevation($elevation);
+@mixin mat-menu-base($default-elevation) {
   min-width: $mat-menu-overlay-min-width;
   max-width: $mat-menu-overlay-max-width;
+
+  // Allow elevation to be overwritten.
+  &:not([class*='mat-elevation-z']) {
+    @include mat-elevation($default-elevation);
+  }
 
   overflow: auto;
   -webkit-overflow-scrolling: touch;   // for momentum scroll on mobile


### PR DESCRIPTION
Makes it a little easier to override the elevation of the `.mat-menu-panel`. Previously it wasn't possible to apply the `mat-elevation-z*` classes directly, because the elevation styles are defined earlier in the stylesheet than the menu styles.

Fixes #5870.