### PR TITLE
build: faster live-reload for theme changes

### DIFF
--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -33,9 +33,8 @@ task(':watch:devapp', () => {
   watchFiles(join(appDir, '**/*.html'), [':build:devapp:assets']);
 
   // The themes for the demo-app are built by the demo-app using the SCSS mixins from Material.
-  // Therefore when the CSS files have been changed the SCSS mixins have been refreshed and
-  // copied over. Rebuilt the theme CSS using the updated SCSS mixins.
-  watchFiles(join(materialOutPath, '**/*.css'), [':build:devapp:scss']);
+  // Therefore when SCSS files have been changed, the custom theme needs to be rebuilt.
+  watchFiles(join(materialOutPath, '**/*.scss'), [':build:devapp:scss']);
 });
 
 /** Path to the demo-app tsconfig file. */


### PR DESCRIPTION
Whenever something inside of a theme changes and the demo-app is served, the watch task waits for the CSS files to be built. This is superfluous because the custom theme only waits for the SCSS files to be copied over.

This changes the watcher to listen for changes in SCSS files instead of CSS files.