### PR TITLE
chore: make provider factories docs-private

### DIFF
--- a/src/cdk/a11y/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer.ts
@@ -77,11 +77,13 @@ export class LiveAnnouncer implements OnDestroy {
 
 }
 
+/** @docs-private */
 export function LIVE_ANNOUNCER_PROVIDER_FACTORY(
     parentDispatcher: LiveAnnouncer, liveElement: any, platform: Platform) {
   return parentDispatcher || new LiveAnnouncer(liveElement, platform);
 }
 
+/** @docs-private */
 export const LIVE_ANNOUNCER_PROVIDER = {
   // If there is already a LiveAnnouncer available, use that. Otherwise, provide a new one.
   provide: LiveAnnouncer,

--- a/src/cdk/bidi/directionality.ts
+++ b/src/cdk/bidi/directionality.ts
@@ -53,10 +53,12 @@ export class Directionality {
   }
 }
 
+/** @docs-private */
 export function DIRECTIONALITY_PROVIDER_FACTORY(parentDirectionality, _document) {
   return parentDirectionality || new Directionality(_document);
 }
 
+/** @docs-private */
 export const DIRECTIONALITY_PROVIDER = {
   // If there is already a Directionality available, use that. Otherwise, provide a new one.
   provide: Directionality,

--- a/src/lib/core/coordination/unique-selection-dispatcher.ts
+++ b/src/lib/core/coordination/unique-selection-dispatcher.ts
@@ -50,11 +50,13 @@ export class UniqueSelectionDispatcher {
   }
 }
 
+/** @docs-private */
 export function UNIQUE_SELECTION_DISPATCHER_PROVIDER_FACTORY(
     parentDispatcher: UniqueSelectionDispatcher) {
   return parentDispatcher || new UniqueSelectionDispatcher();
 }
 
+/** @docs-private */
 export const UNIQUE_SELECTION_DISPATCHER_PROVIDER = {
   // If there is already a dispatcher available, use that. Otherwise, provide a new one.
   provide: UniqueSelectionDispatcher,

--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -63,10 +63,12 @@ export class OverlayContainer {
   }
 }
 
+/** @docs-private */
 export function OVERLAY_CONTAINER_PROVIDER_FACTORY(parentContainer: OverlayContainer) {
   return parentContainer || new OverlayContainer();
 }
 
+/** @docs-private */
 export const OVERLAY_CONTAINER_PROVIDER = {
   // If there is already an OverlayContainer available, use that. Otherwise, provide a new one.
   provide: OverlayContainer,

--- a/src/lib/core/overlay/position/viewport-ruler.ts
+++ b/src/lib/core/overlay/position/viewport-ruler.ts
@@ -90,11 +90,13 @@ export class ViewportRuler {
 
 }
 
+/** @docs-private */
 export function VIEWPORT_RULER_PROVIDER_FACTORY(parentRuler: ViewportRuler,
                                                 scrollDispatcher: ScrollDispatcher) {
   return parentRuler || new ViewportRuler(scrollDispatcher);
 }
 
+/** @docs-private */
 export const VIEWPORT_RULER_PROVIDER = {
   // If there is already a ViewportRuler available, use that. Otherwise, provide a new one.
   provide: ViewportRuler,

--- a/src/lib/core/overlay/scroll/scroll-dispatcher.ts
+++ b/src/lib/core/overlay/scroll/scroll-dispatcher.ts
@@ -143,11 +143,13 @@ export class ScrollDispatcher {
   }
 }
 
+/** @docs-private */
 export function SCROLL_DISPATCHER_PROVIDER_FACTORY(
     parentDispatcher: ScrollDispatcher, ngZone: NgZone, platform: Platform) {
   return parentDispatcher || new ScrollDispatcher(ngZone, platform);
 }
 
+/** @docs-private */
 export const SCROLL_DISPATCHER_PROVIDER = {
   // If there is already a ScrollDispatcher available, use that. Otherwise, provide a new one.
   provide: ScrollDispatcher,

--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -334,13 +334,13 @@ export class CdkMonitorFocus implements OnDestroy {
   }
 }
 
-
+/** @docs-private */
 export function FOCUS_ORIGIN_MONITOR_PROVIDER_FACTORY(
     parentDispatcher: FocusOriginMonitor, ngZone: NgZone, platform: Platform) {
   return parentDispatcher || new FocusOriginMonitor(ngZone, platform);
 }
 
-
+/** @docs-private */
 export const FOCUS_ORIGIN_MONITOR_PROVIDER = {
   // If there is already a FocusOriginMonitor available, use that. Otherwise, provide a new one.
   provide: FocusOriginMonitor,

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -473,11 +473,13 @@ export class MdIconRegistry {
   }
 }
 
+/** @docs-private */
 export function ICON_REGISTRY_PROVIDER_FACTORY(
     parentRegistry: MdIconRegistry, http: Http, sanitizer: DomSanitizer) {
   return parentRegistry || new MdIconRegistry(http, sanitizer);
 }
 
+/** @docs-private */
 export const ICON_REGISTRY_PROVIDER = {
   // If there is already an MdIconRegistry available, use that. Otherwise, provide a new one.
   provide: MdIconRegistry,


### PR DESCRIPTION
Most of the provider factories are already marked as `@docs-private`. This adds the `@docs-private` JSDoc tag to the missing ones.

This is necessary to avoid that the provider factories show up in the docs (once we have docs for the CDK) or in general when functions are also shown as part of a docs entry.