### PR TITLE
fix(menu): improve menu open animation

### DIFF
--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -7,7 +7,7 @@
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
-  .mat-menu-content {
+  .mat-menu-panel {
     background: mat-color($background, 'card');
   }
 

--- a/src/lib/menu/menu-animations.ts
+++ b/src/lib/menu/menu-animations.ts
@@ -49,7 +49,7 @@ export const transformMenu: AnimationTriggerMetadata = trigger('transformMenu', 
 ]);
 
 /**
- * This animation fades in the background color and content of the menu panel
+ * This animation fades in the content of the menu panel
  * after its containing element is scaled in.
  */
 export const fadeInItems: AnimationTriggerMetadata = trigger('fadeInItems', [


### PR DESCRIPTION
## Description
The current open animation behavior for the menus does not look like to follow the Material spec, and it's not elegant. ([Material.io video demo](https://storage.googleapis.com/material-design/publish/material_v_11/assets/0Bzhp5Z4wHba3WVAwRkdSdURJZWc/Component-Menus-Usage_Appbar_Dropdown_xhdpi_004.webm)).

The menu seems to be somehow broken with the first look, because first you will get an empty (transparent) container which has shadow border, then the content appears inside the container.

You will see slow motion demos in bellow:

### The current behavior of the menu open animation:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/7496103/28423025-19ced206-6d7f-11e7-9bd3-fc896928cf2d.gif)

### The new open animation behavior (after the change):
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/7496103/28423043-2dbfbaaa-6d7f-11e7-97b0-bdb7fab7aef0.gif)

### Side by side view:
![animated](https://user-images.githubusercontent.com/7496103/28423202-a7d21176-6d7f-11e7-8bb9-576083691595.gif)

## What Changed?
The menu container did not have any background color, and instead of that the content of the menu (`mat-menu-content`) had a white background color, and as far as I know, we don't have any rules in the Material spec that the menu should be transparent until its content appeared.
There is also no need to set the background color for the content of the menu since by this change, we will see just the parent background color.

## Other Material Design Menus
[Material Design Lite](https://getmdl.io/components/index.html#menus-section)
[AngularJS Material](https://material.angularjs.org/latest/demo/menu)
[Material guidelines demos](https://material.io/guidelines/components/menus.html)