### PR TITLE
build: e2e failures and add missing rx operators to rollup config

### DIFF
--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -552,6 +552,7 @@ export const EXAMPLE_LIST = [
   SortOverviewExample,
   TableBasicExample,
   TableFilteringExample,
+  TableHttpExample,
   TableOverviewExample,
   TablePaginationExample,
   TableSortingExample,

--- a/tools/package-tools/rollup-helpers.ts
+++ b/tools/package-tools/rollup-helpers.ts
@@ -53,10 +53,15 @@ const ROLLUP_GLOBALS = {
   // RxJS imports for the examples package
   'rxjs/add/observable/merge': 'Rx.Observable',
   'rxjs/add/observable/fromEvent': 'Rx.Observable',
+  'rxjs/add/observable/of': 'Rx.Observable',
+  'rxjs/add/observable/interval': 'Rx.Observable',
   'rxjs/add/operator/startWith': 'Rx.Observable.prototype',
   'rxjs/add/operator/map': 'Rx.Observable.prototype',
   'rxjs/add/operator/debounceTime': 'Rx.Observable.prototype',
   'rxjs/add/operator/distinctUntilChanged': 'Rx.Observable.prototype',
+  'rxjs/add/operator/first': 'Rx.Observable.prototype',
+  'rxjs/add/operator/catch': 'Rx.Observable.prototype',
+  'rxjs/add/operator/switchMap': 'Rx.Observable.prototype',
 };
 
 export type BundleConfig = {


### PR DESCRIPTION
* Fixes a component not being added to the examples module, causing the E2E task to fail.
* Adds some operators that were missing from the Rollup config.
