### PR TITLE
chore: default gulp task should not list tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
 
 before_install:
   - source ./scripts/ci/env.sh
-  - npm i -g npm@^5.0.1
+  - npm i -g npm@^5.3.0
 
 install:
   - npm install

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ require('ts-node').register({
 // The gulp tsconfig file maps specific imports to relative paths. In combination with ts-node
 // this doesn't work because the JavaScript output will still refer to the imports instead of
 // to the relative path. Tsconfig-paths can be used to support path mapping inside of Node.
-require("tsconfig-paths").register({
+require('tsconfig-paths').register({
   baseUrl: path.dirname(tsconfigPath),
   paths: tsconfig.compilerOptions.paths
 });

--- a/tools/gulp/tasks/default.ts
+++ b/tools/gulp/tasks/default.ts
@@ -1,16 +1,12 @@
 import {task} from 'gulp';
-const gulp = require('gulp');
+import {yellow} from 'chalk';
 
 task('default', ['help']);
 
 task('help', function() {
-  const taskList = Object.keys(gulp.tasks)
-    .filter(taskName => !taskName.startsWith(':'))
-    .filter(taskName => !taskName.startsWith('ci:'))
-    .filter(taskName => taskName != 'default')
-    .sort();
-
-  console.log(`\nHere's a list of supported tasks:\n   `, taskList.join('\n    '));
-  console.log(`\nYou're probably looking for "test" or "serve:devapp".\n\n`);
+  console.log();
+  console.log('Please specify a gulp task you want to run.');
+  console.log(`You're probably looking for ${yellow('test')} or ${yellow('serve:devapp')}.`);
+  console.log();
 });
 


### PR DESCRIPTION
* The default gulp task should not list all gulp tasks. This a way too long list with all internal things as well.
* Addresses feedback from @jelbourn in Flex-Layout's tooling sync PR.

@jelbourn The change of the NPM version shouldn't really have any value, but it may re-validate the cache of NPM and it's also more explicit.