### PR TITLE
style(expansion): simplify vertical centering in header

### DIFF
--- a/src/lib/expansion/expansion-panel-header.scss
+++ b/src/lib/expansion/expansion-panel-header.scss
@@ -1,18 +1,10 @@
-$mat-expansion-panel-header-height: 48px;
-$mat-expansion-panel-header-height-expanded: 64px;
 
 .mat-expansion-panel-header {
   cursor: pointer;
   display: flex;
   flex-direction: row;
-  height: $mat-expansion-panel-header-height;
-  line-height: $mat-expansion-panel-header-height;
+  align-items: center;
   padding: 0 24px;
-
-  &.mat-expanded {
-    height: $mat-expansion-panel-header-height-expanded;
-    line-height: $mat-expansion-panel-header-height-expanded;
-  }
 
   &:focus,
   &:hover {

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -61,8 +61,8 @@ import {Subscription} from 'rxjs/Subscription';
       transition('expanded <=> collapsed', animate(EXPANSION_PANEL_ANIMATION_TIMING)),
     ]),
     trigger('expansionHeight', [
-      state('collapsed', style({height: '48px', 'line-height': '48px'})),
-      state('expanded', style({height: '64px', 'line-height': '64px'})),
+      state('collapsed', style({height: '48px'})),
+      state('expanded', style({height: '64px'})),
       transition('expanded <=> collapsed', animate(EXPANSION_PANEL_ANIMATION_TIMING)),
     ]),
   ],


### PR DESCRIPTION
Instead of animating height and line-height together, this just animates height and uses `align-items: center` for vertical alignment