### PR TITLE
chore: use list example component for e2e

### DIFF
--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -11,7 +11,6 @@ import {SimpleRadioButtons} from './radio/radio-e2e';
 import {BasicTabs} from './tabs/tabs-e2e';
 import {DialogE2E, TestDialog} from './dialog/dialog-e2e';
 import {GridListE2E} from './grid-list/grid-list-e2e';
-import {ListE2E} from './list/list-e2e';
 import {ProgressBarE2E} from './progress-bar/progress-bar-e2e';
 import {ProgressSpinnerE2E} from './progress-spinner/progress-spinner-e2e';
 import {FullscreenE2E, TestDialog as TestDialogFullScreen} from './fullscreen/fullscreen-e2e';
@@ -70,7 +69,6 @@ export class E2eMaterialModule {}
     Home,
     IconE2E,
     InputE2E,
-    ListE2E,
     MenuE2E,
     ProgressBarE2E,
     ProgressSpinnerE2E,

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -1,5 +1,5 @@
 import {Routes} from '@angular/router';
-import {CardFancyExample} from '@angular/material-examples';
+import {CardFancyExample, ListOverviewExample} from '@angular/material-examples';
 
 import {Home} from './e2e-app';
 import {ButtonE2E} from '../button/button-e2e';
@@ -10,7 +10,6 @@ import {SimpleRadioButtons} from '../radio/radio-e2e';
 import {SimpleCheckboxes} from '../checkbox/checkbox-e2e';
 import {DialogE2E} from '../dialog/dialog-e2e';
 import {GridListE2E} from '../grid-list/grid-list-e2e';
-import {ListE2E} from '../list/list-e2e';
 import {ProgressBarE2E} from '../progress-bar/progress-bar-e2e';
 import {ProgressSpinnerE2E} from '../progress-spinner/progress-spinner-e2e';
 import {SlideToggleE2E} from '../slide-toggle/slide-toggle-e2e';
@@ -29,7 +28,7 @@ export const E2E_APP_ROUTES: Routes = [
   {path: 'grid-list', component: GridListE2E},
   {path: 'icon', component: IconE2E},
   {path: 'input', component: InputE2E},
-  {path: 'list', component: ListE2E},
+  {path: 'list', component: ListOverviewExample},
   {path: 'menu', component: MenuE2E},
   {path: 'progress-bar', component: ProgressBarE2E},
   {path: 'progress-spinner', component: ProgressSpinnerE2E},

--- a/src/e2e-app/list/list-e2e.html
+++ b/src/e2e-app/list/list-e2e.html
@@ -1,5 +1,0 @@
-<md-list>
-  <h3 md-subheader>Items</h3>
-  <md-list-item>Item one</md-list-item>
-  <md-list-item>Item two</md-list-item>
-</md-list>

--- a/src/e2e-app/list/list-e2e.ts
+++ b/src/e2e-app/list/list-e2e.ts
@@ -1,9 +1,0 @@
-import {Component} from '@angular/core';
-
-
-@Component({
-  moduleId: module.id,
-  selector: 'list-e2e',
-  templateUrl: 'list-e2e.html',
-})
-export class ListE2E {}

--- a/src/material-examples/public_api.ts
+++ b/src/material-examples/public_api.ts
@@ -1,4 +1,6 @@
 export * from './example-data';
 export * from './example-module';
+
+export * from './list-overview/list-overview-example';
 export * from './datepicker-overview/datepicker-overview-example';
 export * from './card-fancy/card-fancy-example';


### PR DESCRIPTION
* The e2e app now uses the list overview example for the list e2e tests.