### PR TITLE
fix(autocomplete): don't prevent default enter action if panel is closed

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -299,7 +299,7 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   _handleKeydown(event: KeyboardEvent): void {
     if (event.keyCode === ESCAPE && this.panelOpen) {
       this.closePanel();
-    } else if (this.activeOption && event.keyCode === ENTER) {
+    } else if (this.activeOption && event.keyCode === ENTER && this.panelOpen) {
       this.activeOption._selectViaInteraction();
       event.preventDefault();
     } else {

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -688,14 +688,27 @@ describe('MdAutocomplete', () => {
         fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
 
         fixture.whenStable().then(() => {
-          spyOn(ENTER_EVENT, 'preventDefault');
-
           fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
 
-          expect(ENTER_EVENT.preventDefault).toHaveBeenCalled();
+          expect(ENTER_EVENT.defaultPrevented)
+              .toBe(true, 'Expected the default action to have been prevented.');
         });
       });
     }));
+
+    it('should not prevent the default enter action for a closed panel after a user interaction',
+      fakeAsync(() => {
+        tick();
+        fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+
+        fixture.componentInstance.trigger.closePanel();
+        fixture.detectChanges();
+        fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+
+        expect(ENTER_EVENT.defaultPrevented).toBe(false, 'Default action should not be prevented.');
+      }));
 
     it('should fill the text field, not select an option, when SPACE is entered', async(() => {
       fixture.whenStable().then(() => {


### PR DESCRIPTION
Currently the autocomplete will always prevent the default enter key action, even if the panel is closed, which goes against the native behavior.

Fixes #5976.