### PR TITLE
chore: scroll active link into view in the demo app

### DIFF
--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -4,6 +4,9 @@
       <a *ngFor="let navItem of navItems"
          md-list-item
          (click)="start.close()"
+         routerLinkActive
+         #routerLinkActiveInstance="routerLinkActive"
+         [attr.tabindex]="routerLinkActiveInstance.isActive ? 0 : -1"
          [routerLink]="[navItem.route]">
         {{navItem.name}}
       </a>


### PR DESCRIPTION
Scrolls to the active link in the demo app when the sidenav is opened. Previously it would jump back up to the first one. This isn't a huge issue, but is something that has been bugging me for a while.