### PR TITLE
fix(menu): prevent user from accidentally opening a sub-menu while animating

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -15,6 +15,13 @@ $mat-menu-border-radius: 2px !default;
   max-height: calc(100vh - #{$mat-menu-item-height});
   border-radius: $mat-menu-border-radius;
 
+  // Prevent the user from interacting while the panel is still animating.
+  // This avoids issues where the user could accidentally open a sub-menu,
+  // because of the `overlapTrigger` option.
+  &.ng-animating {
+    pointer-events: none;
+  }
+
   @include cdk-high-contrast {
     outline: solid 1px;
   }


### PR DESCRIPTION
Makes the menu panel non-interactive while it is animating, preventing the user from accidentally triggering a sub-menu.

For reference, here's what it used to look like if the user moved their cursor while animating:
![a](https://user-images.githubusercontent.com/4450522/28525173-01179490-708c-11e7-8b0b-d642b8cf8432.gif)
