### PR TITLE
chore: better logging for madge

### DIFF
--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -2,6 +2,10 @@ import {task} from 'gulp';
 import {execNodeTask} from '../util/task_helpers';
 import {join} from 'path';
 import {buildConfig} from 'material2-build-tools';
+import {red} from 'chalk';
+
+// These types lack of type definitions
+const madge = require('madge');
 
 /** Glob that matches all SCSS or CSS files that should be linted. */
 const stylesGlob = '+(tools|src)/**/!(*.bundle).+(css|scss)';
@@ -17,11 +21,6 @@ const cdkOutPath = join(buildConfig.outputDir, 'packages', 'cdk');
 
 task('lint', ['tslint', 'stylelint', 'madge']);
 
-/** Task that runs madge to detect circular dependencies. */
-task('madge', ['material:clean-build'], execNodeTask(
-  'madge', ['--circular', materialOutPath, cdkOutPath])
-);
-
 /** Task to lint Angular Material's scss stylesheets. */
 task('stylelint', execNodeTask(
   'stylelint', [stylesGlob, '--config', 'stylelint-config.json', '--syntax', 'scss']
@@ -32,3 +31,22 @@ task('tslint', execNodeTask('tslint', tsLintBaseFlags));
 
 /** Task that automatically fixes TSLint warnings. */
 task('tslint:fix', execNodeTask('tslint', [...tsLintBaseFlags, '--fix']));
+
+/** Task that runs madge to detect circular dependencies. */
+task('madge', ['material:clean-build'], () => {
+  madge([materialOutPath, cdkOutPath]).then((res: any) => {
+    const circularModules = res.circular();
+
+    if (circularModules.length) {
+      console.error();
+      console.error(red(`Madge found modules with circular dependencies.`));
+      console.error(formatMadgeCircularModules(circularModules));
+      console.error();
+    }
+  });
+});
+
+/** Returns a string that formats the graph of circular modules. */
+function formatMadgeCircularModules(circularModules: string[][]): string {
+  return circularModules.map((modulePaths: string[]) => `\n - ${modulePaths.join(' > ')}`).join('');
+}


### PR DESCRIPTION
* Switches madge to the programmatic API usage which also allows us to ignore warnings about the dependency on `@angular/cdk` which could not be found by Madge (since it's not a node module)
* This also allows us to reduce the amount of messages that Madge prints. Currently the CI output is not readable because the spinner of the Madge CLI spams everything.