### PR TITLE
fix(datepicker): deprecate selectedChanged output

### DIFF
--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -151,7 +151,10 @@ export class MdDatepicker<D> implements OnDestroy {
   }
   private _disabled: boolean;
 
-  /** Emits new selected date when selected date changes. */
+  /**
+   * Emits new selected date when selected date changes.
+   * @deprecated Switch to the `dateChange` and `dateInput` binding on the input element.
+   */
   @Output() selectedChanged = new EventEmitter<D>();
 
   /** Whether the calendar is open. */


### PR DESCRIPTION
* Deprecates the `selectedChanged` output on the datepicker component in favor of the `dateChange` and `dateInput` bindings on the input element.

Closes #6000