### PR TITLE
chore: remove drag event from gestures demo

### DIFF
--- a/src/demo-app/gestures/gestures-demo.html
+++ b/src/demo-app/gestures/gestures-demo.html
@@ -1,10 +1,9 @@
 <div class="demo-gestures">
-    <div (drag)="dragCount = dragCount + 1" (pan)="panCount = panCount + 1"
-         (longpress)="longpressCount = longpressCount + 1" (press)="pressCount = pressCount + 1"
-         (swipe)="swipeCount = swipeCount + 1" (slide)="slideCount = slideCount + 1">
+    <div (pan)="panCount = panCount + 1" (longpress)="longpressCount = longpressCount + 1"
+         (press)="pressCount = pressCount + 1" (swipe)="swipeCount = swipeCount + 1"
+         (slide)="slideCount = slideCount + 1">
         Drag, swipe, or press me.
     </div>
-    <p>Drag: {{dragCount}}</p>
     <p>Pan: {{panCount}}</p>
     <p>Longpress: {{longpressCount}}</p>
     <p>Press: {{pressCount}}</p>

--- a/src/demo-app/gestures/gestures-demo.ts
+++ b/src/demo-app/gestures/gestures-demo.ts
@@ -7,7 +7,6 @@ import {Component} from '@angular/core';
   styleUrls: ['gestures-demo.css'],
 })
 export class GesturesDemo {
-  dragCount: number = 0;
   panCount: number = 0;
   pressCount: number = 0;
   longpressCount: number = 0;


### PR DESCRIPTION
* The custom recognizer called "drag" has been removed a long time (https://github.com/angular/material2/pull/1744) ago to avoid collisions with the native `drag` events.
* The demo app still shows the drag event on the gestures demo (which apparently doesn't work now anymore)