### PR TITLE
fix(select): server-side rendering error with preselected value

### DIFF
--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -146,7 +146,11 @@ export class MdOption extends _MdOptionMixinBase implements CanDisableRipple {
 
   /** Sets focus onto this option. */
   focus(): void {
-    this._getHostElement().focus();
+    const element = this._getHostElement();
+
+    if ('focus' in element) {
+      element.focus();
+    }
   }
 
   /**

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -55,6 +55,7 @@ import {
 // considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
 // tslint:disable-next-line:no-unused-variable
 import {ScrollStrategy, RepositionScrollStrategy} from '../core/overlay/scroll';
+import {Platform} from '@angular/cdk/platform';
 
 /**
  * The following style constants are necessary to save here in order
@@ -109,6 +110,13 @@ export const SELECT_PANEL_PADDING_Y = 16;
  * this value or more away from the viewport boundary.
  */
 export const SELECT_PANEL_VIEWPORT_PADDING = 8;
+
+/**
+ * Default minimum width of the trigger based on the CSS.
+ * Used as a fallback for server-side rendering.
+ * @docs-private
+ */
+const SELECT_TRIGGER_MIN_WIDTH = 112;
 
 /** Injection token that determines the scroll handling while a select is open. */
 export const MD_SELECT_SCROLL_STRATEGY =
@@ -365,6 +373,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
     private _viewportRuler: ViewportRuler,
     private _changeDetectorRef: ChangeDetectorRef,
     private _overlay: Overlay,
+    private _platform: Platform,
     renderer: Renderer2,
     elementRef: ElementRef,
     @Optional() private _dir: Directionality,
@@ -529,7 +538,9 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
    * the overlay width to the trigger width.
    */
   private _setTriggerWidth(): void {
-    this._triggerWidth = this._getTriggerRect().width;
+    this._triggerWidth = this._platform.isBrowser ? this._getTriggerRect().width :
+        SELECT_TRIGGER_MIN_WIDTH;
+
     this._changeDetectorRef.markForCheck();
   }
 

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -159,10 +159,10 @@
 <md-radio-button name="onions" disabled>Red</md-radio-button>
 
 <h2>Select</h2>
-<md-select>
-  <md-option>Glass</md-option>
-  <md-option>Ceramic</md-option>
-  <md-option>Steel</md-option>
+<md-select value="ceramic">
+  <md-option value="glass">Glass</md-option>
+  <md-option value="ceramic">Ceramic</md-option>
+  <md-option value="steel">Steel</md-option>
 </md-select>
 
 <h2>Sidenav</h2>


### PR DESCRIPTION
Fixes a server-side rendering error in `md-select` if it has a preselected value, in addition to one in the `md-option` component.

Fixes #6045.