### PR TITLE
fix(textarea): server-side rendering error when using mdTextareaAutosize

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -8,6 +8,7 @@
 
 import {Directive, ElementRef, Input, AfterViewInit, Optional, Self} from '@angular/core';
 import {NgControl} from '@angular/forms';
+import {Platform} from '@angular/cdk/platform';
 
 
 /**
@@ -57,7 +58,11 @@ export class MdTextareaAutosize implements AfterViewInit {
   /** Cached height of a textarea with a single row. */
   private _cachedLineHeight: number;
 
-  constructor(private _elementRef: ElementRef, @Optional() @Self() formControl: NgControl) {
+  constructor(
+    private _elementRef: ElementRef,
+    private _platform: Platform,
+    @Optional() @Self() formControl: NgControl) {
+
     if (formControl && formControl.valueChanges) {
       formControl.valueChanges.subscribe(() => this.resizeToFitContent());
     }
@@ -84,8 +89,10 @@ export class MdTextareaAutosize implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this._cacheTextareaLineHeight();
-    this.resizeToFitContent();
+    if (this._platform.isBrowser) {
+      this._cacheTextareaLineHeight();
+      this.resizeToFitContent();
+    }
   }
 
   /** Sets a style property on the textarea element. */
@@ -131,6 +138,7 @@ export class MdTextareaAutosize implements AfterViewInit {
   /** Resize the textarea to fit its content. */
   resizeToFitContent() {
     const textarea = this._elementRef.nativeElement as HTMLTextAreaElement;
+
     if (textarea.value === this._previousValue) {
       return;
     }

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -208,3 +208,6 @@
 <h2>Tooltip</h2>
 
 <button mdTooltip="Action!">Go</button>
+
+<h2>Autosize textarea</h2>
+<textarea mdTextareaAutosize mdAutosizeMaxRows="10"></textarea>


### PR DESCRIPTION
Fixes a server-side rendering error when using the `mdTextareaAutosize` directive.

Fixes #6047.