### PR TITLE
build: payload status should not show all digits

### DIFF
--- a/tools/dashboard/functions/payload-github-status.ts
+++ b/tools/dashboard/functions/payload-github-status.ts
@@ -36,11 +36,12 @@ export const payloadGithubStatus = https.onRequest(async (request, response) => 
   // Better message about the diff that shows whether the payload increased or decreased.
   const diffMessage = packageDiff < 0 ? 'decrease' : 'increase';
   const diffFormatted = Math.abs(packageDiff).toFixed(2);
+  const packageSizeFormatted = packageSize.toFixed(2);
 
   await setGithubStatus(commitSha, {
     result: true,
     name: `${capitalizeFirstLetter(packageName)} Payload Size`,
-    description: `${packageSize}kb / ${diffFormatted}kb ${diffMessage} (ES2015 bundle)`
+    description: `${packageSizeFormatted}kb / ${diffFormatted}kb ${diffMessage} (ES2015 bundle)`
   });
 
   response.json({message: 'Payload Github status successfully set.'});


### PR DESCRIPTION
* Currently we always limit the difference in kilobytes to two digits after the decimal point. This also needs to be done for the full package size to avoid super long numbers.

![image](https://user-images.githubusercontent.com/4987015/28616150-ef153114-71fb-11e7-9b3e-d0f98895bf65.png)
