### PR TITLE
build: properly lint tooling source code

### DIFF
--- a/tools/gulp/tasks/validate-release.ts
+++ b/tools/gulp/tasks/validate-release.ts
@@ -39,7 +39,7 @@ task('validate-release:check-bundles', () => {
 function checkReleasePackage(packageName: string): string[] {
   const bundlePath = join(releasesDir, packageName, '@angular', `${packageName}.js`);
   const bundleContent = readFileSync(bundlePath, 'utf8');
-  let failures = [];
+  let failures: string[] = [];
 
   if (inlineStylesSourcemapRegex.exec(bundleContent) !== null) {
     failures.push('Bundles contain sourcemap references in component styles.');
@@ -61,7 +61,7 @@ function checkMaterialPackage(): string[] {
   const packagePath = join(releasesDir, 'material');
   const prebuiltThemesPath = join(packagePath, 'prebuilt-themes');
   const themingFilePath = join(packagePath, '_theming.scss');
-  const failures = [];
+  const failures: string[] = [];
 
   if (glob('*.css', {cwd: prebuiltThemesPath}).length === 0) {
     failures.push('Prebuilt themes are not present in the Material release output.');

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -1,5 +1,4 @@
 import {join} from 'path';
-import {readdirSync, lstatSync} from 'fs';
 import {ScriptTarget, ModuleKind, NewLineKind} from 'typescript';
 import {uglifyJsFile} from './minify-sources';
 import {createRollupBundle} from './rollup-helpers';

--- a/tools/package-tools/build-release.ts
+++ b/tools/package-tools/build-release.ts
@@ -48,7 +48,8 @@ export function composeRelease(packageName: string, options: ComposeReleaseOptio
 }
 
 /** Creates files necessary for a secondary entry-point. */
-function createFilesForSecondaryEntryPoint(packageName: string, packagePath: string, releasePath: string) {
+function createFilesForSecondaryEntryPoint(packageName: string, packagePath: string,
+                                           releasePath: string) {
   getSecondaryEntryPointsForPackage(packageName).forEach(entryPointName => {
     // Create a directory in the root of the package for this entry point that contains
     // * A package.json that lists the different bundle locations

--- a/tools/package-tools/entry-point-package-json.ts
+++ b/tools/package-tools/entry-point-package-json.ts
@@ -1,8 +1,9 @@
 import {join} from 'path';
-import {lstatSync, readdirSync, writeFileSync} from 'fs';
+import {writeFileSync} from 'fs';
 
 /** Creates a package.json for a secondary entry-point with the different bundle locations. */
-export function createEntryPointPackageJson(destDir: string, packageName: string, entryPointName: string) {
+export function createEntryPointPackageJson(destDir: string, packageName: string,
+                                            entryPointName: string) {
   const content = {
     name: `@angular/${packageName}/${entryPointName}`,
     typings: `../${entryPointName}.d.ts`,

--- a/tools/package-tools/gulp/build-tasks-gulp.ts
+++ b/tools/package-tools/gulp/build-tasks-gulp.ts
@@ -1,6 +1,5 @@
 import {dest, src, task} from 'gulp';
 import {join} from 'path';
-import {readFileSync, unlink, writeFileSync} from 'fs';
 import {main as tsc} from '@angular/tsc-wrapped';
 import {buildConfig} from '../build-config';
 import {composeRelease} from '../build-release';
@@ -27,8 +26,11 @@ const htmlMinifierOptions = {
  * Creates a set of gulp tasks that can build the specified package.
  * @param packageName Name of the package. Needs to be similar to the directory name in `src/`.
  * @param dependencies Required packages that will be built before building the current package.
+ * @param options Options that can be passed to adjust the gulp package tasks.
  */
-export function createPackageBuildTasks(packageName: string, dependencies: string[] = [], options: PackageTaskOptions = {}) {
+export function createPackageBuildTasks(packageName: string, dependencies: string[] = [],
+                                        options: PackageTaskOptions = {}) {
+
   // To avoid refactoring of the project the package material will map to the source path `lib/`.
   const packageRoot = join(packagesDir, packageName === 'material' ? 'lib' : packageName);
   const packageOut = join(outputDir, 'packages', packageName);

--- a/tools/package-tools/secondary-entry-points.ts
+++ b/tools/package-tools/secondary-entry-points.ts
@@ -1,8 +1,3 @@
-import {join} from 'path';
-import {readdirSync, lstatSync} from 'fs';
-import {buildConfig} from './build-config';
-
-
 /**
  * List of cdk entry-points in the order that they must be built. This is necessary because
  * some of the entry-points depend on each other. This is temporary until we switch to bazel.

--- a/tools/screenshot-test/functions/github.ts
+++ b/tools/screenshot-test/functions/github.ts
@@ -14,11 +14,13 @@ const authDomain = firebaseFunctions.config().firebase.authDomain;
 const toolName = firebaseFunctions.config().tool.name;
 
 export function updateGithubStatus(event: firebaseFunctions.Event<any>) {
-  if (!event.data.exists() || typeof event.data.val() != 'boolean') {
+  if (!event.data.exists() || typeof event.data.val() != 'boolean' && event.params) {
     return;
   }
-  let result = event.data.val() == true;
-  let {prNumber, sha} = event.params;
+
+  const result = event.data.val() == true;
+  const {prNumber, sha} = event.params!;
+
   return setGithubStatus(sha, {
       result: result,
       name: toolName,

--- a/tools/screenshot-test/functions/jwt-util.ts
+++ b/tools/screenshot-test/functions/jwt-util.ts
@@ -13,9 +13,10 @@ const secret = firebaseFunctions.config().secret.key;
  * Replace '/' with '.' to get the token.
  */
 function getSecureToken(event: firebaseFunctions.Event<any>) {
-  let {jwtHeader, jwtPayload, jwtSignature} = event.params;
+  const {jwtHeader, jwtPayload, jwtSignature} = event.params!;
   return `${jwtHeader}.${jwtPayload}.${jwtSignature}`;
 }
+
 
 /**
  * Verify that the event has a valid JsonWebToken. If the token is *not* valid,
@@ -23,7 +24,7 @@ function getSecureToken(event: firebaseFunctions.Event<any>) {
  */
 export function verifySecureToken(event: firebaseFunctions.Event<any>) {
   return new Promise((resolve, reject) => {
-    const prNumber = event.params['prNumber'];
+    const prNumber = event.params!['prNumber'];
     const secureToken = getSecureToken(event);
 
     return verifyJWT(secureToken, prNumber, secret, repoSlug).then(() => {

--- a/tools/screenshot-test/functions/test-goldens.ts
+++ b/tools/screenshot-test/functions/test-goldens.ts
@@ -23,7 +23,8 @@ export function copyTestImagesToGoldens(prNumber: string) {
           failedFilenames.push(childSnapshot.key);
         }
 
-        return ++counter === snapshot.numChildren();
+        counter++;
+        return counter === snapshot.numChildren();
       });
 
       return failedFilenames;

--- a/tools/screenshot-test/functions/test-goldens.ts
+++ b/tools/screenshot-test/functions/test-goldens.ts
@@ -15,17 +15,17 @@ const bucket = gcs.bucket(firebaseFunctions.config().firebase.storageBucket);
 export function copyTestImagesToGoldens(prNumber: string) {
   return firebaseAdmin.database().ref(`screenshot/reports/${prNumber}/results`).once('value')
     .then((snapshot: firebaseAdmin.database.DataSnapshot) => {
-      let failedFilenames: string[] = [];
+      const failedFilenames: string[] = [];
       let counter = 0;
-      snapshot.forEach((childSnapshot: firebaseAdmin.database.DataSnapshot) => {
-        if (childSnapshot.val() === false) {
+
+      snapshot.forEach(childSnapshot => {
+        if (childSnapshot.key && childSnapshot.val() === false) {
           failedFilenames.push(childSnapshot.key);
         }
-        counter++;
-        if (counter == snapshot.numChildren()) {
-          return true;
-        }
+
+        return ++counter === snapshot.numChildren();
       });
+
       return failedFilenames;
     }).then((failedFilenames: string[]) => {
       return bucket.getFiles({prefix: `screenshots/${prNumber}/test`}).then((data: any) => {

--- a/tools/screenshot-test/src/app/firebase.service.ts
+++ b/tools/screenshot-test/src/app/firebase.service.ts
@@ -71,10 +71,7 @@ export class FirebaseService {
             this._readResults(childSnapshot);
             break;
         }
-        counter++;
-        if (counter === snapshot.numChildren()) {
-          return true;
-        }
+        return ++counter === snapshot.numChildren();
       });
     });
   }
@@ -123,11 +120,10 @@ export class FirebaseService {
     this.screenshotResultSummary.testNames = [];
     this.screenshotResultSummary.testResultsByName.clear();
     childSnapshot.forEach((resultSnapshot: firebase.database.DataSnapshot) => {
-      this._addTestResults(resultSnapshot.key, resultSnapshot.val());
-      childCounter++;
-      if (childCounter === childSnapshot.numChildren()) {
-        return true;
+      if (resultSnapshot.key) {
+        this._addTestResults(resultSnapshot.key, resultSnapshot.val());
       }
+      return ++childCounter === childSnapshot.numChildren();
     });
   }
 

--- a/tools/screenshot-test/src/app/firebase.service.ts
+++ b/tools/screenshot-test/src/app/firebase.service.ts
@@ -71,7 +71,9 @@ export class FirebaseService {
             this._readResults(childSnapshot);
             break;
         }
-        return ++counter === snapshot.numChildren();
+
+        counter++;
+        return counter === snapshot.numChildren();
       });
     });
   }
@@ -123,7 +125,8 @@ export class FirebaseService {
       if (resultSnapshot.key) {
         this._addTestResults(resultSnapshot.key, resultSnapshot.val());
       }
-      return ++childCounter === childSnapshot.numChildren();
+      childCounter++;
+      return childCounter === childSnapshot.numChildren();
     });
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,13 +16,14 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material": ["./src/lib/public_api.ts"],
-      "@angular/cdk*": ["./src/cdk/*"],
-      "@angular/material-examples": ["./src/material-examples"]
+      "@angular/cdk/*": ["./src/cdk/*"],
+      "@angular/material-examples": ["./src/material-examples"],
+      "material2-build-tools": ["./tools/package-tools"]
     }
   },
   "include": [
     "src/**/*.ts",
-    "tools/**.ts"
+    "tools/**/*.ts"
   ],
   "exclude": [
     // Exclude files that depend on Node APIs because those depend on the Node types and therefore
@@ -31,6 +32,8 @@
 
     // IDEs should not type-check the different node_modules directories of the different packages.
     // This would cause the IDEs to be slower and also linters would check the node_modules.
-    "**/node_modules"
+    "node_modules/",
+    "tools/dashboard/node_modules/",
+    "tools/screenshot-test/node_modules/"
   ]
 }


### PR DESCRIPTION
* Fixes a glob that is responsible for IDE's TypeScript service and also for TSLint
* Fixes strict null check errors in the screenshot app. Currently the app can't be compiled properly since strict null checks had been introduced there as well.

**Note**: Two remaining lint issues coming from https://github.com/angular/material2/pull/6044