### PR TITLE
build: missing semicolon for typings re-exports

### DIFF
--- a/tools/package-tools/typings-reexport.ts
+++ b/tools/package-tools/typings-reexport.ts
@@ -4,8 +4,7 @@ import {join} from 'path';
 
 /** Create a typing file that links to the bundled definitions of NGC. */
 export function createTypingsReexportFile(outDir: string, from: string, fileName: string) {
-  writeFileSync(
-      join(outDir, `${fileName}.d.ts`),
-      `${buildConfig.licenseBanner}\nexport * from '${from}'`,
-      'utf-8');
+  writeFileSync(join(outDir, `${fileName}.d.ts`),
+    `${buildConfig.licenseBanner}\nexport * from '${from}';\n`,
+    'utf-8');
 }


### PR DESCRIPTION
* Adds a missing semicolon to the typing re-export statements.

**Note**: I know that Angular/Angular doesn't do that as well, but it doesn't hurt to write more *valid* TypeScript here (https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#1132-import-declarations)