### PR TITLE
fix(paginator): remove dependency on @angular/forms

### DIFF
--- a/src/lib/paginator/index.ts
+++ b/src/lib/paginator/index.ts
@@ -8,7 +8,6 @@
 
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
 import {MdButtonModule} from '../button/index';
 import {MdSelectModule} from '../select/index';
 import {MdPaginator} from './paginator';
@@ -19,7 +18,6 @@ import {MdTooltipModule} from '../tooltip/index';
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule,
     MdButtonModule,
     MdSelectModule,
     MdTooltipModule,

--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -5,7 +5,7 @@
 
   <md-select *ngIf="_displayedPageSizeOptions.length > 1"
              class="mat-paginator-page-size-select"
-             [ngModel]="pageSize"
+             [value]="pageSize"
              [aria-label]="_intl.itemsPerPageLabel"
              (change)="_changePageSize($event.value)">
     <md-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">


### PR DESCRIPTION
Since it's now possible to use `md-select` without `ngModel`, we can remove the dependency on `@angular/forms` from the paginator.

Fixes #5717.