### PR TITLE
fix(chips): add exportAs for chip and chip list

### DIFF
--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -41,6 +41,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
   moduleId: module.id,
   selector: 'md-chip-list, mat-chip-list',
   template: `<div class="mat-chip-list-wrapper"><ng-content></ng-content></div>`,
+  exportAs: 'mdChipList',
   host: {
     '[attr.tabindex]': '_tabIndex',
     'role': 'listbox',

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -53,6 +53,7 @@ export class MdBasicChip { }
   selector: `md-basic-chip, [md-basic-chip], md-chip, [md-chip],
              mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]`,
   inputs: ['color', 'disabled'],
+  exportAs: 'mdChip',
   host: {
     'class': 'mat-chip',
     'tabindex': '-1',


### PR DESCRIPTION
Adds `exportAs` declarations to the `MdChip` and `MdChipList` directives to make them a little more convenient to use in templates.

Fixes #6070.