### PR TITLE
build: dynamic cdk entrypoint mapping in tsconfigs

### DIFF
--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -21,15 +21,7 @@
     "types": [],
     "baseUrl": ".",
     "paths": {
-      "@angular/cdk/a11y": ["../../dist/packages/cdk/a11y/public_api"],
-      "@angular/cdk/bidi": ["../../dist/packages/cdk/bidi/public_api"],
-      "@angular/cdk/coercion": ["../../dist/packages/cdk/coercion/public_api"],
-      "@angular/cdk/keyboard": ["../../dist/packages/cdk/keyboard/public_api"],
-      "@angular/cdk/observe-content": ["../../dist/packages/cdk/observe-content/public_api"],
-      "@angular/cdk/platform": ["../../dist/packages/cdk/platform/public_api"],
-      "@angular/cdk/portal": ["../../dist/packages/cdk/portal/public_api"],
-      "@angular/cdk/rxjs": ["../../dist/packages/cdk/rxjs/public_api"],
-      "@angular/cdk/table": ["../../dist/packages/cdk/table/public_api"]
+      "@angular/cdk/*": ["../../dist/packages/cdk/*/public_api"]
     }
   },
   "files": [

--- a/src/lib/tsconfig-tests.json
+++ b/src/lib/tsconfig-tests.json
@@ -7,12 +7,7 @@
     "importHelpers": false,
     "module": "commonjs",
     "target": "es5",
-    "types": ["jasmine"],
-    "experimentalDecorators": true,
-    "strictNullChecks": true,
-    "paths": {
-      "@angular/cdk/*": ["../../dist/packages/cdk/*"]
-    }
+    "types": ["jasmine"]
   },
   "include": [
     "**/*.spec.ts",

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -21,16 +21,7 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material": ["../../dist/packages/material/public_api"],
-      "@angular/cdk/a11y": ["../../dist/packages/cdk/a11y/public_api"],
-      "@angular/cdk/bidi": ["../../dist/packages/cdk/bidi/public_api"],
-      "@angular/cdk/coercion": ["../../dist/packages/cdk/coercion/public_api"],
-      "@angular/cdk/platform": ["../../dist/packages/cdk/platform/public_api"],
-      "@angular/cdk/portal": ["../../dist/packages/cdk/portal/public_api"],
-      "@angular/cdk/keyboard": ["../../dist/packages/cdk/keyboard/public_api"],
-      "@angular/cdk/rxjs": ["../../dist/packages/cdk/rxjs/public_api"],
-      "@angular/cdk/table": ["../../dist/packages/cdk/table/public_api"],
-      "@angular/cdk/testing": ["../../dist/packages/cdk/testing/public_api"],
-      "@angular/cdk/observe-content": ["../../dist/packages/cdk/observe-content/public_api"]
+      "@angular/cdk/*": ["../../dist/packages/cdk/*/public_api"]
     }
   },
   "files": [


### PR DESCRIPTION
* Removes the hard-coded path mappings for the CDK entry points and replaces it with a dynamic solution.
* The `tsconfig-test.json` extends the path mappings from the normal `build` tsconfig.