### PR TITLE
chore: remove unused jasmine matcher types

### DIFF
--- a/src/lib/typings.d.ts
+++ b/src/lib/typings.d.ts
@@ -1,9 +1,1 @@
 declare var module: {id: string};
-
-/** Extends the interface for jasmine matchers to allow for custom matchers. */
-declare namespace jasmine {
-  interface Matchers {
-    toBeRole(expectedRole: string): boolean;
-    toMatchTableContent(expectedContent: any[]): boolean;
-  }
-}


### PR DESCRIPTION
* Removes unused jasmine matcher type definitions since the `jasmine-matchers.ts` file has been removed.