### PR TITLE
fix(icon): error when toggling icon with binding in IE11

### DIFF
--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -47,6 +47,7 @@ describe('MdIcon', () => {
         IconWithCustomFontCss,
         IconFromSvgName,
         IconWithAriaHiddenFalse,
+        IconWithBindingAndNgIf,
       ],
       providers: [
         MockBackend,
@@ -313,6 +314,23 @@ describe('MdIcon', () => {
       verifyPathChildElement(svgElement, 'left');
       expect(svgElement.getAttribute('viewBox')).toBeFalsy();
     });
+
+    it('should not throw when toggling an icon that has a binding in IE11', () => {
+      mdIconRegistry.addSvgIcon('fluffy', trust('cat.svg'));
+
+      const fixture = TestBed.createComponent(IconWithBindingAndNgIf);
+
+      fixture.detectChanges();
+
+      expect(() => {
+        fixture.componentInstance.showIcon = false;
+        fixture.detectChanges();
+
+        fixture.componentInstance.showIcon = true;
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
   });
 
   describe('custom fonts', () => {
@@ -405,3 +423,9 @@ class IconFromSvgName {
 
 @Component({template: '<md-icon aria-hidden="false">face</md-icon>'})
 class IconWithAriaHiddenFalse { }
+
+@Component({template: `<md-icon [svgIcon]="iconName" *ngIf="showIcon">{{iconName}}</md-icon>`})
+class IconWithBindingAndNgIf {
+  iconName = 'fluffy';
+  showIcon = true;
+}

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -33,12 +33,6 @@ export const _MdIconMixinBase = mixinColor(MdIconBase);
 
 /**
  * Component to display an icon. It can be used in the following ways:
- * - Specify the svgSrc input to load an SVG icon from a URL. The SVG content is directly inlined
- *   as a child of the <md-icon> component, so that CSS styles can easily be applied to it.
- *   The URL is loaded via an XMLHttpRequest, so it must be on the same domain as the page or its
- *   server must be configured to allow cross-domain requests.
- *   Example:
- *     <md-icon svgSrc="assets/arrow.svg"></md-icon>
  *
  * - Specify the svgIcon input to load an SVG icon from a URL previously registered with the
  *   addSvgIcon, addSvgIconInNamespace, addSvgIconSet, or addSvgIconSetInNamespace methods of
@@ -136,7 +130,7 @@ export class MdIcon extends _MdIconMixinBase implements OnChanges, OnInit, CanCo
 
   ngOnChanges(changes: SimpleChanges) {
     // Only update the inline SVG icon if the inputs changed, to avoid unnecessary DOM operations.
-    if ((changes.svgIcon || changes.svgSrc) && this.svgIcon) {
+    if (changes.svgIcon && this.svgIcon) {
       const [namespace, iconName] = this._splitIconName(this.svgIcon);
 
       first.call(this._mdIconRegistry.getNamedSvgIcon(iconName, namespace)).subscribe(
@@ -163,11 +157,12 @@ export class MdIcon extends _MdIconMixinBase implements OnChanges, OnInit, CanCo
 
   private _setSvgElement(svg: SVGElement) {
     const layoutElement = this._elementRef.nativeElement;
+    const childCount = layoutElement.childNodes.length;
 
     // Remove existing child nodes and add the new SVG element. Note that we can't
     // use innerHTML, because IE will throw if the element has a data binding.
-    for (let child of layoutElement.childNodes) {
-      this._renderer.removeChild(layoutElement, child);
+    for (let i = 0; i < childCount; i++) {
+      this._renderer.removeChild(layoutElement, layoutElement.childNodes[i]);
     }
 
     this._renderer.appendChild(layoutElement, svg);


### PR DESCRIPTION
* Fixes an error that was being logged by IE11 for icons that are toggled via `ngIf` and have a binding expression.
* Some minor readability improvements in the icon component.

Fixes #6093.