### PR TITLE
fix(select): set aria-multiselectable for multi-select

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1904,6 +1904,21 @@ describe('MdSelect', () => {
             .toBe('true', 'Expected aria-hidden to be true when the select is open.');
       });
 
+      it('should set `aria-multiselectable` to true on multi-select instances', () => {
+        fixture.destroy();
+
+        const multiFixture = TestBed.createComponent(MultiSelect);
+
+        multiFixture.detectChanges();
+        select = multiFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+        expect(select.getAttribute('aria-multiselectable')).toBe('true');
+      });
+
+      it('should set `aria-multiselectable` false on single-selection instances', () => {
+        expect(select.getAttribute('aria-multiselectable')).toBe('false');
+      });
+
     });
 
     describe('for options', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -156,6 +156,7 @@ export const _MdSelectMixinBase = mixinColor(mixinDisabled(MdSelectBase), 'prima
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': '_isErrorState()',
     '[attr.aria-owns]': '_optionIds',
+    '[attr.aria-multiselectable]': 'multiple',
     '[class.mat-select-disabled]': 'disabled',
     '[class.mat-select-invalid]': '_isErrorState()',
     '[class.mat-select-required]': 'required',


### PR DESCRIPTION
Sets the `aria-multiselectable` attribute to multi-select instances, as per https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox.