### PR TITLE
build: use version placeholder in package configs

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -59,14 +59,10 @@ publishPackage() {
   # Create the build commit and push the changes to the repository.
   cd ${repoDir}
 
-  # Update the package.json version to include the current commit SHA.
-  # Normally this "sed" call would just replace the version placeholder, but the version in the
-  # package.json file is already replaced by the release task of the current package.
-  sed -i "s/${buildVersion}/${buildVersion}-${commitSha}/g" package.json
-
-  # For build artifacts the different Angular packages that refer to the 0.0.0-PLACEHOLDER should
-  # be replaced with the Github builds that are published at the same time.
-  sed -i "s/0.0.0-PLACEHOLDER/${buildVersion}-${commitSha}/g" package.json
+  # Replace the version in every file recursively with a more specific version that also includes
+  # the SHA of the current build job. Normally this "sed" call would just replace the version
+  # placeholder, but the version placeholders have been replaced by the release task already.
+  sed -i "s/${buildVersion}/${buildVersion}-${commitSha}/g" $(find . -type f)
 
   # Prepare Git for pushing the artifacts to the repository.
   git config user.name "${commitAuthorName}"

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cdk",
-  "version": "2.0.0-beta.8",
+  "version": "0.0.0-PLACEHOLDER",
   "description": "Angular Material Component Development Kit",
   "main": "./bundles/cdk.umd.js",
   "module": "./@angular/cdk.es5.js",

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
-    "@angular/cdk": "2.0.0-beta.8",
+    "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "^4.0.0",
     "@angular/common": "^4.0.0"
   },

--- a/tools/package-tools/version-placeholders.ts
+++ b/tools/package-tools/version-placeholders.ts
@@ -6,7 +6,7 @@ import {spawnSync} from 'child_process';
 const versionPlaceholderText = '0.0.0-PLACEHOLDER';
 
 /** RegExp that matches version placeholders inside of a file. */
-const versionPlaceholderRegex = new RegExp(versionPlaceholderText);
+const versionPlaceholderRegex = new RegExp(versionPlaceholderText, 'g');
 
 /**
  * Walks through every file in a directory and replaces the version placeholders with the current


### PR DESCRIPTION
Recently the version placeholders had been replaced with hardcoded versions because it was necessary to be able to release the CDK.

But now the version placeholders are replaced in every file and therefore they can be used instead of the hardcoded values.