### PR TITLE
fix(list): :empty selector did not catch in mat-list-text

### DIFF
--- a/src/lib/list/list-item.html
+++ b/src/lib/list/list-item.html
@@ -9,9 +9,7 @@
               [mdListAvatar], [mdListIcon], [matListAvatar], [matListIcon]">
   </ng-content>
 
-  <div class="mat-list-text">
-    <ng-content select="[md-line], [mat-line], [mdLine], [matLine]"></ng-content>
-  </div>
+  <div class="mat-list-text"><ng-content select="[md-line], [mat-line], [mdLine], [matLine]"></ng-content></div>
 
   <ng-content></ng-content>
 </div>


### PR DESCRIPTION
Since there was a whitespace character (newline) in the HTML, :empty never triggered in the CSS