### PR TITLE
build: dynamic path mappings for cdk entry points

### DIFF
--- a/src/cdk/a11y/tsconfig-build.json
+++ b/src/cdk/a11y/tsconfig-build.json
@@ -1,15 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "outDir": "../../../dist/packages/cdk",
-    "baseUrl": ".",
-    "paths": {
-      "@angular/cdk/coercion": ["../../../dist/packages/cdk/coercion/public_api"],
-      "@angular/cdk/keyboard": ["../../../dist/packages/cdk/keyboard/public_api"],
-      "@angular/cdk/platform": ["../../../dist/packages/cdk/platform/public_api"],
-      "@angular/cdk/rxjs": ["../../../dist/packages/cdk/rxjs/public_api"]
-    }
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/bidi/tsconfig-build.json
+++ b/src/cdk/bidi/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/coercion/tsconfig-build.json
+++ b/src/cdk/coercion/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/keyboard/tsconfig-build.json
+++ b/src/cdk/keyboard/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/observe-content/tsconfig-build.json
+++ b/src/cdk/observe-content/tsconfig-build.json
@@ -1,12 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "outDir": "../../../dist/packages/cdk",
-    "baseUrl": ".",
-    "paths": {
-      "@angular/cdk/rxjs": ["../../../dist/packages/cdk/rxjs/public_api"]
-    }
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/platform/tsconfig-build.json
+++ b/src/cdk/platform/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/portal/tsconfig-build.json
+++ b/src/cdk/portal/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/rxjs/tsconfig-build.json
+++ b/src/cdk/rxjs/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/table/tsconfig-build.json
+++ b/src/cdk/table/tsconfig-build.json
@@ -1,12 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "outDir": "../../../dist/packages/cdk",
-    "baseUrl": ".",
-    "paths": {
-      "@angular/cdk/platform": ["../../../dist/packages/cdk/platform/index"]
-    }
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/testing/tsconfig-build.json
+++ b/src/cdk/testing/tsconfig-build.json
@@ -1,9 +1,5 @@
 {
   "extends": "../tsconfig-build",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "../../../dist/packages/cdk"
-  },
   "files": [
     "public_api.ts"
   ],

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -13,14 +13,16 @@
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "../../dist/packages/cdk",
-    "paths": {},
     "rootDir": ".",
     "sourceMap": true,
     "inlineSources": true,
     "target": "es2015",
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
-    "types": []
+    "types": [],
+    "paths": {
+      "@angular/cdk/*": ["../../dist/packages/cdk/*/public_api"]
+    }
   },
   "files": [
     "public_api.ts"


### PR DESCRIPTION
* No longer hard-codes the path mappings for dependencies of individual CDK secondary entry-points.