### PR TITLE
chore: update tslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14323,9 +14323,9 @@
       "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tslint": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
-      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
+      "integrity": "sha1-EOjas+MGH6YelELozuOYKs8gpqo=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
@@ -14345,15 +14345,6 @@
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
-        },
-        "tsutils": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.6.0.tgz",
-          "integrity": "sha1-5emceaiszTl3zhjYP98dI1psLrs=",
-          "dev": true,
-          "requires": {
-            "tslib": "1.7.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "stylelint": "^7.12.0",
     "ts-node": "^3.0.4",
     "tsconfig-paths": "^2.2.0",
-    "tslint": "~5.4.3",
+    "tslint": "~5.5.0",
     "tsutils": "^2.6.0",
     "typescript": "~2.2.1",
     "uglify-js": "^2.8.14",

--- a/src/cdk/rxjs/rx-chain.ts
+++ b/src/cdk/rxjs/rx-chain.ts
@@ -24,7 +24,7 @@ export class RxChain<T> {
    * Starts a new chain and specifies the initial `this` value.
    * @param context Initial `this` value for the chain.
    */
-  static from<T>(context: Observable<T>): StrictRxChain<T> {
+  static from<O>(context: Observable<O>): StrictRxChain<O> {
     return new RxChain(context);
   }
 

--- a/src/lib/core/style/focus-origin-monitor.ts
+++ b/src/lib/core/style/focus-origin-monitor.ts
@@ -84,9 +84,9 @@ export class FocusOriginMonitor {
     }
     // Check if we're already monitoring this element.
     if (this._elementInfo.has(element)) {
-      let info = this._elementInfo.get(element);
-      info!.checkChildren = checkChildren;
-      return info!.subject.asObservable();
+      let cachedInfo = this._elementInfo.get(element);
+      cachedInfo!.checkChildren = checkChildren;
+      return cachedInfo!.subject.asObservable();
     }
 
     // Create monitored element info.

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -93,9 +93,9 @@ task('markdown-docs', () => {
  */
 task('highlight-examples', () => {
   // rename files to fit format: [filename]-[filetype].html
-  const renameFile = (path: any) => {
-    const extension = path.extname.slice(1);
-    path.basename = `${path.basename}-${extension}`;
+  const renameFile = (filePath: any) => {
+    const extension = filePath.extname.slice(1);
+    filePath.basename = `${path.basename}-${extension}`;
   };
 
   return src('src/material-examples/**/*.+(html|css|ts)')


### PR DESCRIPTION
Updates tslint to 5.5.0 and resolves some errors that weren't being caught before. This version also has the advantage of printing out the full stack trace if one of the rules throws an error.