### PR TITLE
fix(input): underline should only be thicker if focused

### DIFF
--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -207,7 +207,7 @@ textarea.mat-input-element {
 
   .mat-input-ripple {
     position: absolute;
-    height: $mat-input-underline-height * 2;
+    height: $mat-input-underline-height;
     top: 0;
     left: 0;
     width: 100%;
@@ -215,6 +215,10 @@ textarea.mat-input-element {
     transform: scaleX(0.5);
     visibility: hidden;
     transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
+
+    .mat-focused & {
+      height: $mat-input-underline-height * 2;
+    }
 
     .mat-focused &,
     .mat-input-invalid & {


### PR DESCRIPTION
* Currently the underline of the input container is always `2px` thick if the input is invalid. As per specifications the underline should be `1dp/px` if not focused.

@mmalerba The specs are not too clear about the intended behavior here. There are sections about the thickness of the underline, but not specifically in relation to error handling.

References #6140