### PR TITLE
fix(dialog): better handling of custom ViewContainerRef with OnPush change detection

### DIFF
--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -14,12 +14,13 @@
       <hr>
 
       <a md-list-item
+         tabindex="-1"
          (click)="start.close()"
          [routerLink]="['/baseline']">
         Baseline
       </a>
     </md-nav-list>
-    <button md-button (click)="start.close()">CLOSE</button>
+    <button md-button tabindex="-1" (click)="start.close()">CLOSE</button>
   </md-sidenav>
   <div>
     <md-toolbar color="primary">

--- a/src/demo-app/dialog/dialog-demo.scss
+++ b/src/demo-app/dialog/dialog-demo.scss
@@ -1,8 +1,4 @@
-.demo-dialog {
-  color: rebeccapurple;
-}
-
 .demo-dialog-card {
-  max-width: 350px;
+  max-width: 405px;
   margin: 20px 0;
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -285,7 +285,8 @@ export class MdDatepicker<D> implements OnDestroy {
   /** Open the calendar as a dialog. */
   private _openAsDialog(): void {
     this._dialogRef = this._dialog.open(MdDatepickerContent, {
-      direction: this._dir ? this._dir.value : 'ltr'
+      direction: this._dir ? this._dir.value : 'ltr',
+      viewContainerRef: this._viewContainerRef,
     });
     this._dialogRef.afterClosed().subscribe(() => this.close());
     this._dialogRef.componentInstance.datepicker = this;


### PR DESCRIPTION
* Adds a `markForCheck` call after starting the dialog animation, in order to ensure that it animates away if it was opened from a component with OnPush change detection.
* Since we can't know whether the animation will start right after the `markForCheck`, these changes switch to starting the backdrop animation together with the dialog animation. This avoids some slight timing issues where the backdrop can start its animation a little too early.
* Simplifies the dialog animation streams to avoid having to subscribe to the `completed` callback in the `MdDialogRef`.
* Fixes the demo app sidenav jumping to the bottom when it is opened from the homepage.
* Fixes some alignment in the dialog demo that got thrown off by the new input width.

The dialog changes should solve issues like #5118.

@mmalerba I've reverted the changes from #6026 since it should work correctly with the `ViewContainerRef` now.