### PR TITLE
build: peer dependency for material-examples package

### DIFF
--- a/src/material-examples/package.json
+++ b/src/material-examples/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
+    "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "^4.0.0",
     "@angular/common": "^4.0.0",
-    "@angular/http": "^4.0.0"
+    "@angular/http": "^4.0.0",
+    "@angular/material": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
     "tslib": "^1.7.1"


### PR DESCRIPTION
* Adds peer dependencies for the CDK and Material to the examples package. This ensures that the API that is used in the examples is always compatible with the current installed version of the CDK or Material.

**Note**: This does not really affect the docs because the examples are just copied into the node_modules, but it's still good to have the peer dependencies specified.