### PR TITLE
a11y: add service to add aria-describedby labels

### DIFF
--- a/src/cdk/a11y/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer.spec.ts
@@ -1,0 +1,31 @@
+import {A11yModule, AriaDescriber} from '@angular/cdk/a11y';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component} from '@angular/core';
+
+fdescribe('AriaDescriber', () => {
+  let ariaDescriber: AriaDescriber;
+  let fixture: ComponentFixture<TestApp>;
+
+  describe('with default element', () => {
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [A11yModule],
+        declarations: [TestApp],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestApp);
+    });
+
+    it('should test', () => {
+      console.log(fixture.componentInstance.ariaDescriber);
+    });
+  });
+});
+
+@Component({template: `<div #element1></div>`})
+class TestApp {
+  constructor(public ariaDescriber: AriaDescriber) { }
+}

--- a/src/cdk/a11y/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer.spec.ts
@@ -1,31 +1,185 @@
-import {A11yModule, AriaDescriber} from '@angular/cdk/a11y';
+import {A11yModule} from './index';
+import {AriaDescriber, MESSAGES_CONTAINER_ID} from './aria-describer';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ElementRef, ViewChild} from '@angular/core';
 
-fdescribe('AriaDescriber', () => {
+describe('AriaDescriber', () => {
   let ariaDescriber: AriaDescriber;
+  let component: TestApp;
   let fixture: ComponentFixture<TestApp>;
 
-  describe('with default element', () => {
+  describe('with component provider', () => {
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [A11yModule],
-        declarations: [TestApp],
+        declarations: [TestApp]
       }).compileComponents();
     }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestApp);
+      component = fixture.componentInstance;
+      ariaDescriber = component.ariaDescriber;
     });
 
-    it('should test', () => {
-      console.log(fixture.componentInstance.ariaDescriber);
+    afterEach(() => {
+      ariaDescriber._unregisterAllMessages();
+    });
+
+    it('should initialize without the message container', () => {
+      expect(getMessagesContainer()).toBeNull();
+    });
+
+    it('should be able to create a message element', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+    });
+
+    it('should not register empty strings', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, '');
+      expect(getMessageElements()).toBe(null);
+    });
+
+    it('should de-dupe a message registered multiple times', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
+      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
+      ariaDescriber.addDescription(component.container3.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+      expectMessage(component.container1.nativeElement, 'My Message');
+    });
+
+    it('should be able to register multiple messages', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, 'First Message');
+      ariaDescriber.addDescription(component.container2.nativeElement, 'Second Message');
+      expectMessages(['First Message', 'Second Message']);
+      expectMessage(component.container1.nativeElement, 'First Message');
+      expectMessage(component.container2.nativeElement, 'Second Message');
+    });
+
+    it('should be able to unregister messages', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+
+      // Register again to check dedupe
+      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+
+      // Unregister one message and make sure the message is still present in the container
+      ariaDescriber.removeDescription(component.container1.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+
+      // Unregister the second message, message container should be gone
+      ariaDescriber.removeDescription(component.container2.nativeElement, 'My Message');
+      expect(getMessagesContainer()).toBeNull();
+    });
+
+    it('should be able to unregister messages while having others registered', () => {
+      ariaDescriber.addDescription(component.container1.nativeElement, 'Persistent Message');
+      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
+      expectMessages(['Persistent Message', 'My Message']);
+
+      // Register again to check dedupe
+      ariaDescriber.addDescription(component.container3.nativeElement, 'My Message');
+      expectMessages(['Persistent Message', 'My Message']);
+
+      // Unregister one message and make sure the message is still present in the container
+      ariaDescriber.removeDescription(component.container2.nativeElement, 'My Message');
+      expectMessages(['Persistent Message', 'My Message']);
+
+      // Unregister the second message, message container should be gone
+      ariaDescriber.removeDescription(component.container3.nativeElement, 'My Message');
+      expectMessages(['Persistent Message']);
+    });
+
+    it('should be able to append to an existing list of aria describedby', () => {
+      ariaDescriber.addDescription(component.container4.nativeElement, 'My Message');
+      expectMessages(['My Message']);
+      expectMessage(component.container4.nativeElement, 'My Message');
+    });
+  });
+
+  describe('without provider', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [A11yModule],
+        declarations: [TestAppWithoutProvider]
+      }).compileComponents();
+    }));
+
+    it('should fail to instantiate due to not importing describer as part of component', () => {
+      expect(() => {
+        TestBed.createComponent(TestAppWithoutProvider);
+      }).toThrow();
     });
   });
 });
 
-@Component({template: `<div #element1></div>`})
+function getMessagesContainer() {
+  return document.querySelector(`#${MESSAGES_CONTAINER_ID}`);
+}
+
+function getMessageElements(): Node[] | null {
+  const messagesContainer = getMessagesContainer();
+  if (!messagesContainer) { return null; }
+
+  return messagesContainer ?  Array.prototype.slice.call(messagesContainer.children) : null;
+}
+
+/** Checks that the messages array matches the existing created message elements. */
+function expectMessages(messages: string[]) {
+  const messageElements = getMessageElements();
+  if (!messageElements) {
+    fail(`Expected messages ${messages} but there were no message elements`);
+    return;
+  }
+
+  expect(messages.length).toBe(messageElements.length);
+  messages.forEach((message, i) => {
+    expect(messageElements[i].textContent).toBe(message);
+  });
+}
+
+/** Checks that an element points to a message element that contains the message. */
+function expectMessage(el: HTMLElement, message: string) {
+  const ariaDescribedBy = el.getAttribute('aria-describedby');
+  if (!ariaDescribedBy) {
+    fail(`No aria-describedby for ${el}`);
+    return;
+  }
+
+  const messages: string[] = [];
+  ariaDescribedBy.split(' ').forEach(referenceId => {
+    const messageElement = document.querySelector(`#${referenceId}`);
+    if (messageElement) {
+      messages.push(messageElement.textContent || '');
+    }
+  });
+
+  expect(messages).toContain(message);
+}
+
+@Component({
+  template: `
+    <div #container1></div>
+    <div #container2></div>
+    <div #container3></div>
+    <div #container4 aria-describedby="existing-aria-describedby1 existing-aria-describedby2"></div>
+  `,
+  providers: [AriaDescriber],
+})
 class TestApp {
+  @ViewChild('container1') container1: ElementRef;
+  @ViewChild('container2') container2: ElementRef;
+  @ViewChild('container3') container3: ElementRef;
+  @ViewChild('container4') container4: ElementRef;
+
+  constructor(public ariaDescriber: AriaDescriber) { }
+}
+
+@Component({
+  template: `<div #element1></div>`,
+})
+class TestAppWithoutProvider {
   constructor(public ariaDescriber: AriaDescriber) { }
 }

--- a/src/cdk/a11y/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer.spec.ts
@@ -100,6 +100,13 @@ describe('AriaDescriber', () => {
     expectMessages(['My Message']);
     expectMessage(component.element4, 'My Message');
   });
+
+  it('should be able to handle multiple regisitrations of the same message to an element', () => {
+    ariaDescriber.describe(component.element1, 'My Message');
+    ariaDescriber.describe(component.element1, 'My Message');
+    expectMessages(['My Message']);
+    expectMessage(component.element1, 'My Message');
+  });
 });
 
 function getMessagesContainer() {

--- a/src/cdk/a11y/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer.spec.ts
@@ -1,4 +1,4 @@
-import {A11yModule} from './index';
+import {A11yModule, CDK_DESCRIBEDBY_HOST_ATTRIBUTE} from './index';
 import {AriaDescriber, MESSAGES_CONTAINER_ID} from './aria-describer';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, ElementRef, ViewChild} from '@angular/core';
@@ -8,110 +8,97 @@ describe('AriaDescriber', () => {
   let component: TestApp;
   let fixture: ComponentFixture<TestApp>;
 
-  describe('with component provider', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [A11yModule],
+      declarations: [TestApp],
+      providers: [AriaDescriber],
+    }).compileComponents();
+  }));
 
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [A11yModule],
-        declarations: [TestApp]
-      }).compileComponents();
-    }));
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(TestApp);
-      component = fixture.componentInstance;
-      ariaDescriber = component.ariaDescriber;
-    });
-
-    afterEach(() => {
-      ariaDescriber._unregisterAllMessages();
-    });
-
-    it('should initialize without the message container', () => {
-      expect(getMessagesContainer()).toBeNull();
-    });
-
-    it('should be able to create a message element', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-    });
-
-    it('should not register empty strings', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, '');
-      expect(getMessageElements()).toBe(null);
-    });
-
-    it('should de-dupe a message registered multiple times', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
-      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
-      ariaDescriber.addDescription(component.container3.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-      expectMessage(component.container1.nativeElement, 'My Message');
-    });
-
-    it('should be able to register multiple messages', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, 'First Message');
-      ariaDescriber.addDescription(component.container2.nativeElement, 'Second Message');
-      expectMessages(['First Message', 'Second Message']);
-      expectMessage(component.container1.nativeElement, 'First Message');
-      expectMessage(component.container2.nativeElement, 'Second Message');
-    });
-
-    it('should be able to unregister messages', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-
-      // Register again to check dedupe
-      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-
-      // Unregister one message and make sure the message is still present in the container
-      ariaDescriber.removeDescription(component.container1.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-
-      // Unregister the second message, message container should be gone
-      ariaDescriber.removeDescription(component.container2.nativeElement, 'My Message');
-      expect(getMessagesContainer()).toBeNull();
-    });
-
-    it('should be able to unregister messages while having others registered', () => {
-      ariaDescriber.addDescription(component.container1.nativeElement, 'Persistent Message');
-      ariaDescriber.addDescription(component.container2.nativeElement, 'My Message');
-      expectMessages(['Persistent Message', 'My Message']);
-
-      // Register again to check dedupe
-      ariaDescriber.addDescription(component.container3.nativeElement, 'My Message');
-      expectMessages(['Persistent Message', 'My Message']);
-
-      // Unregister one message and make sure the message is still present in the container
-      ariaDescriber.removeDescription(component.container2.nativeElement, 'My Message');
-      expectMessages(['Persistent Message', 'My Message']);
-
-      // Unregister the second message, message container should be gone
-      ariaDescriber.removeDescription(component.container3.nativeElement, 'My Message');
-      expectMessages(['Persistent Message']);
-    });
-
-    it('should be able to append to an existing list of aria describedby', () => {
-      ariaDescriber.addDescription(component.container4.nativeElement, 'My Message');
-      expectMessages(['My Message']);
-      expectMessage(component.container4.nativeElement, 'My Message');
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestApp);
+    component = fixture.componentInstance;
+    ariaDescriber = component.ariaDescriber;
   });
 
-  describe('without provider', () => {
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [A11yModule],
-        declarations: [TestAppWithoutProvider]
-      }).compileComponents();
-    }));
+  afterEach(() => {
+    ariaDescriber.ngOnDestroy();
+  });
 
-    it('should fail to instantiate due to not importing describer as part of component', () => {
-      expect(() => {
-        TestBed.createComponent(TestAppWithoutProvider);
-      }).toThrow();
-    });
+  it('should initialize without the message container', () => {
+    expect(getMessagesContainer()).toBeNull();
+  });
+
+  it('should be able to create a message element', () => {
+    ariaDescriber.describe(component.element1, 'My Message');
+    expectMessages(['My Message']);
+  });
+
+  it('should not register empty strings', () => {
+    ariaDescriber.describe(component.element1, '');
+    expect(getMessageElements()).toBe(null);
+  });
+
+  it('should de-dupe a message registered multiple times', () => {
+    ariaDescriber.describe(component.element1, 'My Message');
+    ariaDescriber.describe(component.element2, 'My Message');
+    ariaDescriber.describe(component.element3, 'My Message');
+    expectMessages(['My Message']);
+    expectMessage(component.element1, 'My Message');
+    expectMessage(component.element2, 'My Message');
+    expectMessage(component.element3, 'My Message');
+  });
+
+  it('should be able to register multiple messages', () => {
+    ariaDescriber.describe(component.element1, 'First Message');
+    ariaDescriber.describe(component.element2, 'Second Message');
+    expectMessages(['First Message', 'Second Message']);
+    expectMessage(component.element1, 'First Message');
+    expectMessage(component.element2, 'Second Message');
+  });
+
+  it('should be able to unregister messages', () => {
+    ariaDescriber.describe(component.element1, 'My Message');
+    expectMessages(['My Message']);
+
+    // Register again to check dedupe
+    ariaDescriber.describe(component.element2, 'My Message');
+    expectMessages(['My Message']);
+
+    // Unregister one message and make sure the message is still present in the container
+    ariaDescriber.removeDescription(component.element1, 'My Message');
+    expect(component.element1.hasAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE)).toBeFalsy();
+    expectMessages(['My Message']);
+
+    // Unregister the second message, message container should be gone
+    ariaDescriber.removeDescription(component.element2, 'My Message');
+    expect(component.element2.hasAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE)).toBeFalsy();
+    expect(getMessagesContainer()).toBeNull();
+  });
+
+  it('should be able to unregister messages while having others registered', () => {
+    ariaDescriber.describe(component.element1, 'Persistent Message');
+    ariaDescriber.describe(component.element2, 'My Message');
+    expectMessages(['Persistent Message', 'My Message']);
+
+    // Register again to check dedupe
+    ariaDescriber.describe(component.element3, 'My Message');
+    expectMessages(['Persistent Message', 'My Message']);
+
+    // Unregister one message and make sure the message is still present in the container
+    ariaDescriber.removeDescription(component.element2, 'My Message');
+    expectMessages(['Persistent Message', 'My Message']);
+
+    // Unregister the second message, message container should be gone
+    ariaDescriber.removeDescription(component.element3, 'My Message');
+    expectMessages(['Persistent Message']);
+  });
+
+  it('should be able to append to an existing list of aria describedby', () => {
+    ariaDescriber.describe(component.element4, 'My Message');
+    expectMessages(['My Message']);
+    expectMessage(component.element4, 'My Message');
   });
 });
 
@@ -129,31 +116,25 @@ function getMessageElements(): Node[] | null {
 /** Checks that the messages array matches the existing created message elements. */
 function expectMessages(messages: string[]) {
   const messageElements = getMessageElements();
-  if (!messageElements) {
-    fail(`Expected messages ${messages} but there were no message elements`);
-    return;
-  }
+  expect(messageElements).toBeDefined();
 
-  expect(messages.length).toBe(messageElements.length);
+  expect(messages.length).toBe(messageElements!.length);
   messages.forEach((message, i) => {
-    expect(messageElements[i].textContent).toBe(message);
+    expect(messageElements![i].textContent).toBe(message);
   });
 }
 
 /** Checks that an element points to a message element that contains the message. */
-function expectMessage(el: HTMLElement, message: string) {
+function expectMessage(el: Element, message: string) {
   const ariaDescribedBy = el.getAttribute('aria-describedby');
-  if (!ariaDescribedBy) {
-    fail(`No aria-describedby for ${el}`);
-    return;
-  }
+  expect(ariaDescribedBy).toBeDefined();
 
-  const messages: string[] = [];
-  ariaDescribedBy.split(' ').forEach(referenceId => {
+  const cdkDescribedBy = el.getAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE);
+  expect(cdkDescribedBy).toBeDefined();
+
+  const messages = ariaDescribedBy!.split(' ').map(referenceId => {
     const messageElement = document.querySelector(`#${referenceId}`);
-    if (messageElement) {
-      messages.push(messageElement.textContent || '');
-    }
+    return messageElement ? messageElement.textContent : '';
   });
 
   expect(messages).toContain(message);
@@ -161,25 +142,25 @@ function expectMessage(el: HTMLElement, message: string) {
 
 @Component({
   template: `
-    <div #container1></div>
-    <div #container2></div>
-    <div #container3></div>
-    <div #container4 aria-describedby="existing-aria-describedby1 existing-aria-describedby2"></div>
+    <div #element1></div>
+    <div #element2></div>
+    <div #element3></div>
+    <div #element4 aria-describedby="existing-aria-describedby1 existing-aria-describedby2"></div>
   `,
-  providers: [AriaDescriber],
 })
 class TestApp {
-  @ViewChild('container1') container1: ElementRef;
-  @ViewChild('container2') container2: ElementRef;
-  @ViewChild('container3') container3: ElementRef;
-  @ViewChild('container4') container4: ElementRef;
+  @ViewChild('element1') _element1: ElementRef;
+  get element1(): Element { return this._element1.nativeElement; }
 
-  constructor(public ariaDescriber: AriaDescriber) { }
-}
+  @ViewChild('element2') _element2: ElementRef;
+  get element2(): Element { return this._element2.nativeElement; }
 
-@Component({
-  template: `<div #element1></div>`,
-})
-class TestAppWithoutProvider {
+  @ViewChild('element3') _element3: ElementRef;
+  get element3(): Element { return this._element3.nativeElement; }
+
+  @ViewChild('element4') _element4: ElementRef;
+  get element4(): Element { return this._element4.nativeElement; }
+
+
   constructor(public ariaDescriber: AriaDescriber) { }
 }

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -1,108 +1,116 @@
-import {Injectable} from '@angular/core';
+import {Injectable, Renderer2, Optional} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 
 /**
- * Interface used to register tooltip a11y message elements, with a count of how many tooltips have
- * the message and the reference to the a11y message element used for the aria-describedby.
+ * Interface used to register message elements and keep a count of how many registrations have
+ * the same message and the reference to the message element used for the aria-describedby.
  */
-export interface RegisteredA11yMessage {
+export interface RegisteredMessage {
   element: HTMLElement;
   count: number;
 }
 
-/** ID used for the body container where all a11y messages are appended. */
-export const A11Y_MESSAGES_CONTAINER_ID = 'md-tooltip-a11y-messages';
+/** ID used for the body container where all messages are appended. */
+export const MESSAGES_CONTAINER_ID = 'md-aria-describedby-messages';
 
-/** Global incremental identifier for each registered a11y message. */
-let latestA11yMessageId = 0;
+/** Global incremental identifier for each registered message element. */
+let nextId = 0;
 
-/** Global map of all registered a11y message elements that have been placed into the document. */
-const a11yMessages = new Map<string, RegisteredA11yMessage>();
+/** Global map of all registered message elements that have been placed into the document. */
+const registeredMessages = new Map<string, RegisteredMessage>();
 
+/** Container for all registered messages. */
+let messagesContainer: HTMLElement | null = null;
+
+/**
+ * Utility that creates visually hidden elements with a message content. Useful for elements that
+ * want to use aria-describedby to further describe themselves without adding additional visual
+ * content. Must be provided with as part of a component's injection tree so that it has access
+ * to the Renderer.
+ */
 @Injectable()
 export class AriaDescriber {
-  constructor(private _platform: Platform) { }
-
-  /**
-   * Registers the tooltip message for accessibility. If this message has not yet been
-   * registered, a new element will be created in a visually hidden container with the message
-   * as its content. This provides screenreaders a reference the tooltip trigger's aria-describedby.
-   * If an element has already been created for this message, increase that registered message's
-   * reference count.
-   */
-  registerMessage(message: string): RegisteredA11yMessage {
-    const a11yMessage = a11yMessages.get(message);
-    if (a11yMessage) {
-      a11yMessage.count++;
-    } else {
-      this._createA11yMessageElement(message);
+  constructor(private _platform: Platform,
+              @Optional() private _renderer: Renderer2) {
+    if (!_renderer) {
+      throw Error('AriaDescriber must be provided through a component\'s provider decorator ' +
+          'so that it has access to the Angular Renderer');
     }
-
-    return a11yMessages.get(message)!;
   }
 
   /**
-   * Removes the a11y tooltip message element if no other tooltips are registered with the same
-   * message. Otherwise, decrease the reference count of the registered a11y tooltip message.
+   * Registers the message for accessibility. If this message has not yet been
+   * registered, a new element will be created in a visually hidden container with the message
+   * as its content. This provides screenreaders a reference the trigger's aria-describedby.
+   * If an element has already been created for this message, increase that registered message's
+   * reference count.
+   * @returns Identifier of the created message element.
+   */
+  registerMessage(message: string): string {
+    if (!this._platform.isBrowser || !message) { return ''; }
+
+    const registeredMessage = registeredMessages.get(message);
+    if (registeredMessage) {
+      registeredMessage.count++;
+      return registeredMessage.element.id;
+    }
+
+    const messageElement = this._createMessageElement(message)!;
+    registeredMessages.set(message, {element: messageElement, count: 1});
+
+    return messageElement.id;
+  }
+
+  /**
+   * Removes the message element if this is the last count of its registration.
+   * Otherwise, decrease the reference count of the registered message.
    */
   unregisterMessage(message: string) {
     if (!this._platform.isBrowser || !message) { return; }
 
-    const a11yMessageElement = a11yMessages.get(message)!;
-    a11yMessageElement.count--;
+    const registeredMessage = registeredMessages.get(message)!;
+    registeredMessage.count--;
 
-    // Remove the a11y message if this was its last unique instance.
-    if (a11yMessageElement.count == 0) {
-      this._deleteA11yMessageElement(message);
+    // Remove the message if this was its last unique instance.
+    if (registeredMessage.count == 0) {
+      this._deleteMessageElement(message);
     }
 
     // If the global messages container no longer has any children, remove it.
-    if (!this._getA11yMessagesContainer()!.childNodes.length) {
-      document.body.removeChild(this._getA11yMessagesContainer()!);
+    if (messagesContainer && !messagesContainer!.childNodes.length) {
+      this._renderer.removeChild(document.body, messagesContainer);
+      messagesContainer = null;
     }
   }
 
   /**
-   * Creates a new element in the visually hidden a11y message container element with the message
+   * Creates a new element in the visually hidden message container element with the message
    * as its content.
    */
-  private _createA11yMessageElement(message: string) {
-    if (!this._platform.isBrowser) { return; }
-
+  private _createMessageElement(message: string): HTMLElement {
     // Create a visually hidden container for the accessibility messages if one does not yet exist.
-    if (!this._getA11yMessagesContainer()) {
-      this._createA11yMessagesContainer();
-    }
+    if (!messagesContainer) { this._createMessagesContainer(); }
 
-    const messageElement = document.createElement('div');
-    messageElement.id = `md-tooltip-message-${latestA11yMessageId++}`;
-    messageElement.textContent = message;
-
-    this._getA11yMessagesContainer()!.appendChild(messageElement);
-    a11yMessages.set(message, {element: messageElement, count: 1});
+    const messageElement = this._renderer.createElement('div');
+    this._renderer.setAttribute(messageElement, 'id', `md-aria-describedby-message-${nextId++}`);
+    this._renderer.appendChild(messageElement, this._renderer.createText(message));
+    this._renderer.appendChild(messagesContainer, messageElement);
 
     return messageElement;
   }
 
-  /** Deletes the a11y message element from the global a11y tooltip messages container. */
-  private _deleteA11yMessageElement(message: string) {
-    if (!this._platform.isBrowser) { return; }
-
-    const a11yMessage = a11yMessages.get(message)!;
-    this._getA11yMessagesContainer()!.removeChild(a11yMessage.element);
-    a11yMessages.delete(message);
+  /** Deletes the message element from the global messages container. */
+  private _deleteMessageElement(message: string) {
+    const registeredMessage = registeredMessages.get(message)!;
+    this._renderer.removeChild(messagesContainer, registeredMessage.element);
+    registeredMessages.delete(message);
   }
 
-  /** Creates the global container for all tooltip a11y messages. */
-  private _createA11yMessagesContainer() {
-    const a11yMessagesContainer = document.createElement('div');
-    a11yMessagesContainer.id = A11Y_MESSAGES_CONTAINER_ID;
-    a11yMessagesContainer.className = 'cdk-visually-hidden';
-    document.body.appendChild(a11yMessagesContainer);
-  }
-
-  /** Returns the global container for tooltip a11y messages. */
-  private _getA11yMessagesContainer() {
-    return document.getElementById(A11Y_MESSAGES_CONTAINER_ID);
+  /** Creates the global container for all aria-describedby messages. */
+  private _createMessagesContainer() {
+    messagesContainer = this._renderer.createElement('div');
+    this._renderer.setAttribute(messagesContainer, 'id', MESSAGES_CONTAINER_ID);
+    this._renderer.addClass(messagesContainer, 'cdk-visually-hidden');
+    this._renderer.appendChild(document.body, messagesContainer);
   }
 }

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -122,6 +122,7 @@ export class AriaDescriber {
     messagesContainer = this._renderer.createElement('div');
 
     this._renderer.setAttribute(messagesContainer, 'id', MESSAGES_CONTAINER_ID);
+    this._renderer.setAttribute(messagesContainer, 'aria-hidden', 'true');
     this._renderer.addClass(messagesContainer, 'cdk-visually-hidden');
     this._renderer.appendChild(document.body, messagesContainer);
   }

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -6,27 +6,33 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Optional, Renderer2} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
-import {addAriaReferencedId, removeAriaReferencedId} from './aria-reference';
+import {addAriaReferencedId, getAriaReferenceIds, removeAriaReferencedId} from './aria-reference';
 
 /**
  * Interface used to register message elements and keep a count of how many registrations have
  * the same message and the reference to the message element used for the aria-describedby.
  */
 export interface RegisteredMessage {
-  messageElement: HTMLElement;
-  hostElements: HTMLElement[];
+  messageElement: Element;
+  referenceCount: number;
 }
 
 /** ID used for the body container where all messages are appended. */
-export const MESSAGES_CONTAINER_ID = 'cdk-aria-describedby-messages';
+export const MESSAGES_CONTAINER_ID = 'cdk-describedby-message-container';
+
+/** ID prefix used for each created message element. */
+export const CDK_DESCRIBEDBY_ID_PREFIX = 'cdk-describedby-message';
+
+/** Attribute given to each host element that is described by a message element. */
+export const CDK_DESCRIBEDBY_HOST_ATTRIBUTE = 'cdk-describedby-host';
 
 /** Global incremental identifier for each registered message element. */
 let nextId = 0;
 
 /** Global map of all registered message elements that have been placed into the document. */
-const registeredMessages = new Map<string, RegisteredMessage>();
+const messageRegistry = new Map<string, RegisteredMessage>();
 
 /** Container for all registered messages. */
 let messagesContainer: HTMLElement | null = null;
@@ -34,102 +40,110 @@ let messagesContainer: HTMLElement | null = null;
 /**
  * Utility that creates visually hidden elements with a message content. Useful for elements that
  * want to use aria-describedby to further describe themselves without adding additional visual
- * content. Must be provided with as part of a component's injection tree so that it has access
- * to the Renderer.
+ * content.
+ * @docs-private
  */
 @Injectable()
 export class AriaDescriber {
-  constructor(private _platform: Platform,
-              @Optional() private _renderer: Renderer2) {
-    if (!_renderer) {
-      throw Error('AriaDescriber must be provided through a component\'s provider decorator ' +
-          'so that it has access to the Angular Renderer');
-    }
-  }
+  constructor(private _platform: Platform) { }
 
   /**
    * Adds to the host element an aria-describedby reference to a hidden element that contains
    * the message. If the same message has already been registered, then it will reuse the created
    * message element.
    */
-  addDescription(hostElement: HTMLElement, message: string) {
-    if (!this._platform.isBrowser || !message.trim()) { return; }
+  describe(hostElement: Element, message: string) {
+    if (!this._platform.isBrowser || !`${message}`.trim()) { return; }
 
-    if (!registeredMessages.get(message)) {
-      const messageElement = this._createMessageElement(message);
-      registeredMessages.set(message, {messageElement, hostElements: []});
+    if (!messageRegistry.has(message)) {
+      createMessageElement(message);
     }
 
-    const registeredMessage = registeredMessages.get(message)!;
-    registeredMessage.hostElements.push(hostElement);
-    addAriaReferencedId(hostElement, registeredMessage.messageElement.id, 'aria-describedby');
+    const registeredMessage = messageRegistry.get(message)!;
+    registeredMessage.referenceCount++;
+    addAriaReferencedId(hostElement, 'aria-describedby', registeredMessage.messageElement.id);
+    hostElement.setAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE, '');
   }
 
-  /**
-   * Removes the host element's aria-describedby reference to the message element.
-   */
-  removeDescription(hostElement: HTMLElement, message: string) {
-    if (!this._platform.isBrowser || !message.trim()) { return; }
-
-    const registeredMessage = registeredMessages.get(message)!;
-    registeredMessage.hostElements = registeredMessage.hostElements.filter(el => el != hostElement);
-    removeAriaReferencedId(hostElement, registeredMessage.messageElement.id, 'aria-describedby');
-
-    if (registeredMessage.hostElements.length == 0) {
-      this._deleteMessageElement(message);
+  /** Removes the host element's aria-describedby reference to the message element. */
+  removeDescription(hostElement: Element, message: string) {
+    if (!this._platform.isBrowser || !`${message}`.trim() ||
+        hostElement.getAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE) == null) {
+      return;
     }
 
-    if (messagesContainer!.childNodes.length == 0) {
-      this._deleteMessagesContainer();
+    const registeredMessage = messageRegistry.get(message)!;
+    registeredMessage.referenceCount--;
+
+    removeAriaReferencedId(hostElement, 'aria-describedby', registeredMessage.messageElement.id);
+    hostElement.removeAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE);
+
+    if (registeredMessage.referenceCount === 0) {
+      deleteMessageElement(message);
+    }
+
+    if (messagesContainer!.childNodes.length === 0) {
+      deleteMessagesContainer();
     }
   }
 
   /** Unregisters all created message elements and removes the message container. */
-  _unregisterAllMessages() {
-    registeredMessages.forEach((registeredMessage, message) => {
-      registeredMessage.hostElements.forEach(hostElement => {
-        this.removeDescription(hostElement, message);
-      });
-    });
+  ngOnDestroy() {
+    const describedElements = document.querySelectorAll(`[${CDK_DESCRIBEDBY_HOST_ATTRIBUTE}]`);
+    for (let i = 0; i < describedElements.length; i++) {
+      removeCdkDescribedByReferenceIds(describedElements[i]);
+      describedElements[i].removeAttribute(CDK_DESCRIBEDBY_HOST_ATTRIBUTE);
+    }
 
-    registeredMessages.clear();
+    if (messagesContainer) {
+      deleteMessagesContainer();
+    }
+
+    messageRegistry.clear();
   }
+}
 
-  /**
-   * Creates a new element in the visually hidden message container element with the message
-   * as its content.
-   */
-  private _createMessageElement(message: string): HTMLElement {
-    const messageElement = this._renderer.createElement('div');
-    this._renderer.setAttribute(messageElement, 'id', `cdk-aria-describedby-message-${nextId++}`);
-    this._renderer.appendChild(messageElement, this._renderer.createText(message));
+/**
+ * Creates a new element in the visually hidden message container element with the message
+ * as its content and adds it to the message registry.
+ */
+function createMessageElement(message: string) {
+  const messageElement = document.createElement('div');
+  messageElement.setAttribute('id', `${CDK_DESCRIBEDBY_ID_PREFIX}-${nextId++}`);
+  messageElement.appendChild(document.createTextNode(message)!);
 
-    if (!messagesContainer) { this._createMessagesContainer(); }
-    this._renderer.appendChild(messagesContainer, messageElement);
+  if (!messagesContainer) { createMessagesContainer(); }
+  messagesContainer!.appendChild(messageElement);
 
-    return messageElement;
-  }
+  messageRegistry.set(message, {messageElement, referenceCount: 0});
+}
 
-  /** Deletes the message element from the global messages container. */
-  private _deleteMessageElement(message: string) {
-    const messageElement = registeredMessages.get(message)!.messageElement;
-    this._renderer.removeChild(messagesContainer, messageElement);
-    registeredMessages.delete(message);
-  }
+/** Deletes the message element from the global messages container. */
+function deleteMessageElement(message: string) {
+  const messageElement = messageRegistry.get(message)!.messageElement;
+  messagesContainer!.removeChild(messageElement);
+  messageRegistry.delete(message);
+}
 
-  /** Creates the global container for all aria-describedby messages. */
-  private _createMessagesContainer() {
-    messagesContainer = this._renderer.createElement('div');
+/** Creates the global container for all aria-describedby messages. */
+function createMessagesContainer() {
+  messagesContainer = document.createElement('div');
 
-    this._renderer.setAttribute(messagesContainer, 'id', MESSAGES_CONTAINER_ID);
-    this._renderer.setAttribute(messagesContainer, 'aria-hidden', 'true');
-    this._renderer.addClass(messagesContainer, 'cdk-visually-hidden');
-    this._renderer.appendChild(document.body, messagesContainer);
-  }
+  messagesContainer.setAttribute('id', MESSAGES_CONTAINER_ID);
+  messagesContainer.setAttribute('aria-hidden', 'true');
+  messagesContainer.style.display = 'none';
+  document.body.appendChild(messagesContainer);
+}
 
-  /** Deletes the global messages container. */
-  private _deleteMessagesContainer() {
-    this._renderer.removeChild(document.body, messagesContainer);
-    messagesContainer = null;
-  }
+/** Deletes the global messages container. */
+function deleteMessagesContainer() {
+  document.body.removeChild(messagesContainer!);
+  messagesContainer = null;
+}
+
+function removeCdkDescribedByReferenceIds(element: Element) {
+  // Remove all aria-describedby reference IDs that are prefixed by CDK_DESCRIBEDBY_ID_PREFIX
+  const originalReferenceIds = getAriaReferenceIds(element, 'aria-describedby')
+      .filter(id => id.indexOf(CDK_DESCRIBEDBY_ID_PREFIX) != 0);
+  element.setAttribute('aria-describedby', originalReferenceIds.join(' '));
 }

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -20,7 +20,7 @@ export interface RegisteredMessage {
 }
 
 /** ID used for the body container where all messages are appended. */
-export const MESSAGES_CONTAINER_ID = 'md-aria-describedby-messages';
+export const MESSAGES_CONTAINER_ID = 'cdk-aria-describedby-messages';
 
 /** Global incremental identifier for each registered message element. */
 let nextId = 0;
@@ -101,7 +101,7 @@ export class AriaDescriber {
    */
   private _createMessageElement(message: string): HTMLElement {
     const messageElement = this._renderer.createElement('div');
-    this._renderer.setAttribute(messageElement, 'id', `md-aria-describedby-message-${nextId++}`);
+    this._renderer.setAttribute(messageElement, 'id', `cdk-aria-describedby-message-${nextId++}`);
     this._renderer.appendChild(messageElement, this._renderer.createText(message));
 
     if (!messagesContainer) { this._createMessagesContainer(); }

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -1,0 +1,108 @@
+import {Injectable} from '@angular/core';
+import {Platform} from '@angular/cdk/platform';
+
+/**
+ * Interface used to register tooltip a11y message elements, with a count of how many tooltips have
+ * the message and the reference to the a11y message element used for the aria-describedby.
+ */
+export interface RegisteredA11yMessage {
+  element: HTMLElement;
+  count: number;
+}
+
+/** ID used for the body container where all a11y messages are appended. */
+export const A11Y_MESSAGES_CONTAINER_ID = 'md-tooltip-a11y-messages';
+
+/** Global incremental identifier for each registered a11y message. */
+let latestA11yMessageId = 0;
+
+/** Global map of all registered a11y message elements that have been placed into the document. */
+const a11yMessages = new Map<string, RegisteredA11yMessage>();
+
+@Injectable()
+export class AriaDescriber {
+  constructor(private _platform: Platform) { }
+
+  /**
+   * Registers the tooltip message for accessibility. If this message has not yet been
+   * registered, a new element will be created in a visually hidden container with the message
+   * as its content. This provides screenreaders a reference the tooltip trigger's aria-describedby.
+   * If an element has already been created for this message, increase that registered message's
+   * reference count.
+   */
+  registerMessage(message: string): RegisteredA11yMessage {
+    const a11yMessage = a11yMessages.get(message);
+    if (a11yMessage) {
+      a11yMessage.count++;
+    } else {
+      this._createA11yMessageElement(message);
+    }
+
+    return a11yMessages.get(message)!;
+  }
+
+  /**
+   * Removes the a11y tooltip message element if no other tooltips are registered with the same
+   * message. Otherwise, decrease the reference count of the registered a11y tooltip message.
+   */
+  unregisterMessage(message: string) {
+    if (!this._platform.isBrowser || !message) { return; }
+
+    const a11yMessageElement = a11yMessages.get(message)!;
+    a11yMessageElement.count--;
+
+    // Remove the a11y message if this was its last unique instance.
+    if (a11yMessageElement.count == 0) {
+      this._deleteA11yMessageElement(message);
+    }
+
+    // If the global messages container no longer has any children, remove it.
+    if (!this._getA11yMessagesContainer()!.childNodes.length) {
+      document.body.removeChild(this._getA11yMessagesContainer()!);
+    }
+  }
+
+  /**
+   * Creates a new element in the visually hidden a11y message container element with the message
+   * as its content.
+   */
+  private _createA11yMessageElement(message: string) {
+    if (!this._platform.isBrowser) { return; }
+
+    // Create a visually hidden container for the accessibility messages if one does not yet exist.
+    if (!this._getA11yMessagesContainer()) {
+      this._createA11yMessagesContainer();
+    }
+
+    const messageElement = document.createElement('div');
+    messageElement.id = `md-tooltip-message-${latestA11yMessageId++}`;
+    messageElement.textContent = message;
+
+    this._getA11yMessagesContainer()!.appendChild(messageElement);
+    a11yMessages.set(message, {element: messageElement, count: 1});
+
+    return messageElement;
+  }
+
+  /** Deletes the a11y message element from the global a11y tooltip messages container. */
+  private _deleteA11yMessageElement(message: string) {
+    if (!this._platform.isBrowser) { return; }
+
+    const a11yMessage = a11yMessages.get(message)!;
+    this._getA11yMessagesContainer()!.removeChild(a11yMessage.element);
+    a11yMessages.delete(message);
+  }
+
+  /** Creates the global container for all tooltip a11y messages. */
+  private _createA11yMessagesContainer() {
+    const a11yMessagesContainer = document.createElement('div');
+    a11yMessagesContainer.id = A11Y_MESSAGES_CONTAINER_ID;
+    a11yMessagesContainer.className = 'cdk-visually-hidden';
+    document.body.appendChild(a11yMessagesContainer);
+  }
+
+  /** Returns the global container for tooltip a11y messages. */
+  private _getA11yMessagesContainer() {
+    return document.getElementById(A11Y_MESSAGES_CONTAINER_ID);
+  }
+}

--- a/src/cdk/a11y/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer.ts
@@ -85,6 +85,8 @@ export class AriaDescriber {
 
   /** Unregisters all created message elements and removes the message container. */
   ngOnDestroy() {
+    if (!this._platform.isBrowser) { return; }
+
     const describedElements = document.querySelectorAll(`[${CDK_DESCRIBEDBY_HOST_ATTRIBUTE}]`);
     for (let i = 0; i < describedElements.length; i++) {
       removeCdkDescribedByReferenceIds(describedElements[i]);

--- a/src/cdk/a11y/aria-reference.spec.ts
+++ b/src/cdk/a11y/aria-reference.spec.ts
@@ -49,14 +49,20 @@ describe('AriaReference', () => {
     expect(['reference_1']);
   });
 
+  it('should retrieve ids that are deliminated by extra whitespace', () => {
+    testElement!.setAttribute('aria-describedby', 'reference_1      reference_2');
+    expect(getAriaReferenceIds(testElement!, 'aria-describedby'))
+        .toEqual(['reference_1', 'reference_2']);
+  });
+
   /** Utility that adds the id to the test element with an arbitrary aria attribute. */
   function addId(id: string) {
-    addAriaReferencedId(testElement!, id, 'aria-describedby');
+    addAriaReferencedId(testElement!, 'aria-describedby', id);
   }
 
   /** Utility that removes the id to the test element with an arbitrary aria attribute. */
   function removeId(id: string) {
-    removeAriaReferencedId(testElement!, id, 'aria-describedby');
+    removeAriaReferencedId(testElement!, 'aria-describedby', id);
   }
 
   /**

--- a/src/cdk/a11y/aria-reference.spec.ts
+++ b/src/cdk/a11y/aria-reference.spec.ts
@@ -1,0 +1,71 @@
+import {addAriaReferencedId, getAriaReferenceIds, removeAriaReferencedId} from './aria-reference';
+
+describe('AriaReference', () => {
+  let testElement: HTMLElement | null;
+
+  beforeEach(() => {
+    testElement = document.createElement('div');
+    document.body.appendChild(testElement);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(testElement!);
+  });
+
+  it('should be able to append/remove aria reference IDs', () => {
+    addId('reference_1');
+    expectIds(['reference_1']);
+
+    addId('reference_2');
+    expectIds(['reference_1', 'reference_2']);
+
+    removeId('reference_1');
+    expectIds(['reference_2']);
+
+    removeId('reference_2');
+    expectIds([]);
+  });
+
+  it('should trim whitespace when adding/removing reference IDs', () => {
+    addId('   reference_1   ');
+    addId('   reference_2   ');
+    expectIds(['reference_1', 'reference_2']);
+
+    removeId('  reference_1  ');
+    expectIds(['reference_2']);
+
+    removeId('  reference_2  ');
+    expectIds([]);
+  });
+
+  it('should ignore empty string', () => {
+    addId('  ');
+    expectIds([]);
+  });
+
+  it('should not add the same reference id if it already exists', () => {
+    addId('reference_1');
+    addId('reference_1');
+    expect(['reference_1']);
+  });
+
+  /** Utility that adds the id to the test element with an arbitrary aria attribute. */
+  function addId(id: string) {
+    addAriaReferencedId(testElement!, id, 'aria-describedby');
+  }
+
+  /** Utility that removes the id to the test element with an arbitrary aria attribute. */
+  function removeId(id: string) {
+    removeAriaReferencedId(testElement!, id, 'aria-describedby');
+  }
+
+  /**
+   * Expects the equal array from getAriaReferenceIds and a space-deliminated list from
+   * the actual element attribute. If ids is empty, assumes the element should not have any
+   * value
+   */
+  function expectIds(ids: string[]) {
+    expect(getAriaReferenceIds(testElement!, 'aria-describedby')).toEqual(ids);
+    expect(testElement!.getAttribute('aria-describedby')).toBe(ids.length ? ids.join(' ') : '');
+  }
+});

--- a/src/cdk/a11y/aria-reference.spec.ts
+++ b/src/cdk/a11y/aria-reference.spec.ts
@@ -13,39 +13,39 @@ describe('AriaReference', () => {
   });
 
   it('should be able to append/remove aria reference IDs', () => {
-    addId('reference_1');
-    expectIds(['reference_1']);
+    addAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
+    expectIds('aria-describedby', ['reference_1']);
 
-    addId('reference_2');
-    expectIds(['reference_1', 'reference_2']);
+    addAriaReferencedId(testElement!, 'aria-describedby', 'reference_2');
+    expectIds('aria-describedby', ['reference_1', 'reference_2']);
 
-    removeId('reference_1');
-    expectIds(['reference_2']);
+    removeAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
+    expectIds('aria-describedby', ['reference_2']);
 
-    removeId('reference_2');
-    expectIds([]);
+    removeAriaReferencedId(testElement!, 'aria-describedby', 'reference_2');
+    expectIds('aria-describedby', []);
   });
 
   it('should trim whitespace when adding/removing reference IDs', () => {
-    addId('   reference_1   ');
-    addId('   reference_2   ');
-    expectIds(['reference_1', 'reference_2']);
+    addAriaReferencedId(testElement!, 'aria-describedby', '    reference_1   ');
+    addAriaReferencedId(testElement!, 'aria-describedby', '    reference_2   ');
+    expectIds('aria-describedby', ['reference_1', 'reference_2']);
 
-    removeId('  reference_1  ');
-    expectIds(['reference_2']);
+    removeAriaReferencedId(testElement!, 'aria-describedby', '   reference_1   ');
+    expectIds('aria-describedby', ['reference_2']);
 
-    removeId('  reference_2  ');
-    expectIds([]);
+    removeAriaReferencedId(testElement!, 'aria-describedby', '   reference_2   ');
+    expectIds('aria-describedby', []);
   });
 
   it('should ignore empty string', () => {
-    addId('  ');
-    expectIds([]);
+    addAriaReferencedId(testElement!, 'aria-describedby', '  ');
+    expectIds('aria-describedby', []);
   });
 
   it('should not add the same reference id if it already exists', () => {
-    addId('reference_1');
-    addId('reference_1');
+    addAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
+    addAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
     expect(['reference_1']);
   });
 
@@ -55,23 +55,13 @@ describe('AriaReference', () => {
         .toEqual(['reference_1', 'reference_2']);
   });
 
-  /** Utility that adds the id to the test element with an arbitrary aria attribute. */
-  function addId(id: string) {
-    addAriaReferencedId(testElement!, 'aria-describedby', id);
-  }
-
-  /** Utility that removes the id to the test element with an arbitrary aria attribute. */
-  function removeId(id: string) {
-    removeAriaReferencedId(testElement!, 'aria-describedby', id);
-  }
-
   /**
    * Expects the equal array from getAriaReferenceIds and a space-deliminated list from
    * the actual element attribute. If ids is empty, assumes the element should not have any
    * value
    */
-  function expectIds(ids: string[]) {
-    expect(getAriaReferenceIds(testElement!, 'aria-describedby')).toEqual(ids);
-    expect(testElement!.getAttribute('aria-describedby')).toBe(ids.length ? ids.join(' ') : '');
+  function expectIds(attr: string, ids: string[]) {
+    expect(getAriaReferenceIds(testElement!, attr)).toEqual(ids);
+    expect(testElement!.getAttribute(attr)).toBe(ids.length ? ids.join(' ') : '');
   }
 });

--- a/src/cdk/a11y/aria-reference.ts
+++ b/src/cdk/a11y/aria-reference.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** IDs are deliminated by an empty space, as per the spec. */
+const ID_DELIMINATOR = ' ';
+
+/** Adds an aria reference ID to an element's aria property if it is not already present. */
+export function addAriaReferencedId(el: HTMLElement, id: string, attr: string) {
+  const ids = getAriaReferenceIds(el, attr);
+  if (ids.some(existingId => existingId.trim() == id.trim())) { return; }
+  ids.push(id.trim());
+
+  el.setAttribute(attr, ids.join(ID_DELIMINATOR));
+}
+
+/** Removes an aria reference ID from an element's aria property. */
+export function removeAriaReferencedId(el: HTMLElement, id: string, attr: string) {
+  const ids = getAriaReferenceIds(el, attr);
+  const filteredIds = ids.filter(val => val != id.trim());
+
+  el.setAttribute(attr, filteredIds.join(ID_DELIMINATOR));
+}
+
+/** Returns a list of an element's aria reference IDs for the provided aria attribute. */
+export function getAriaReferenceIds(el: HTMLElement, attr: string): string[] {
+  const ids = (el.getAttribute(attr) || '').trim();
+  return ids ? ids.split(ID_DELIMINATOR).map(id => id.trim()) : [];
+}

--- a/src/cdk/a11y/aria-reference.ts
+++ b/src/cdk/a11y/aria-reference.ts
@@ -9,8 +9,11 @@
 /** IDs are deliminated by an empty space, as per the spec. */
 const ID_DELIMINATOR = ' ';
 
-/** Adds an aria reference ID to an element's aria property if it is not already present. */
-export function addAriaReferencedId(el: HTMLElement, id: string, attr: string) {
+/**
+ * Adds the given ID to the specified ARIA attribute on an element.
+ * Used for attributes such as aria-labelledby, aria-owns, etc.
+ */
+export function addAriaReferencedId(el: Element, attr: string, id: string) {
   const ids = getAriaReferenceIds(el, attr);
   if (ids.some(existingId => existingId.trim() == id.trim())) { return; }
   ids.push(id.trim());
@@ -18,16 +21,26 @@ export function addAriaReferencedId(el: HTMLElement, id: string, attr: string) {
   el.setAttribute(attr, ids.join(ID_DELIMINATOR));
 }
 
-/** Removes an aria reference ID from an element's aria property. */
-export function removeAriaReferencedId(el: HTMLElement, id: string, attr: string) {
+/**
+ * Removes the given ID from the specified ARIA attribute on an element.
+ * Used for attributes such as aria-labelledby, aria-owns, etc.
+ */
+export function removeAriaReferencedId(el: Element, attr: string, id: string) {
   const ids = getAriaReferenceIds(el, attr);
   const filteredIds = ids.filter(val => val != id.trim());
 
   el.setAttribute(attr, filteredIds.join(ID_DELIMINATOR));
 }
 
-/** Returns a list of an element's aria reference IDs for the provided aria attribute. */
-export function getAriaReferenceIds(el: HTMLElement, attr: string): string[] {
-  const ids = (el.getAttribute(attr) || '').trim();
-  return ids ? ids.split(ID_DELIMINATOR).map(id => id.trim()) : [];
+/**
+ * Gets the list of IDs referenced by the given ARIA attribute on an element.
+ * Used for attributes such as aria-labelledby, aria-owns, etc.
+ */
+export function getAriaReferenceIds(el: Element, attr: string): string[] {
+  const idsValue = (el.getAttribute(attr) || '').trim();
+
+  // Get string array of all individual ids (whitespace deliminated) in the attribute value
+  const idsArray = idsValue.match(/\S+/g) || [];
+
+  return idsArray.map(id => id.trim());
 }

--- a/src/cdk/a11y/aria-reference.ts
+++ b/src/cdk/a11y/aria-reference.ts
@@ -37,10 +37,6 @@ export function removeAriaReferencedId(el: Element, attr: string, id: string) {
  * Used for attributes such as aria-labelledby, aria-owns, etc.
  */
 export function getAriaReferenceIds(el: Element, attr: string): string[] {
-  const idsValue = (el.getAttribute(attr) || '').trim();
-
   // Get string array of all individual ids (whitespace deliminated) in the attribute value
-  const idsArray = idsValue.match(/\S+/g) || [];
-
-  return idsArray.map(id => id.trim());
+  return (el.getAttribute(attr) || '').match(/\S+/g) || [];
 }

--- a/src/cdk/a11y/public_api.ts
+++ b/src/cdk/a11y/public_api.ts
@@ -12,12 +12,13 @@ import {LIVE_ANNOUNCER_PROVIDER} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
 import {CommonModule} from '@angular/common';
 import {PlatformModule} from '@angular/cdk/platform';
+import {AriaDescriber} from './aria-describer';
 
 @NgModule({
   imports: [CommonModule, PlatformModule],
   declarations: [FocusTrapDirective, FocusTrapDeprecatedDirective],
   exports: [FocusTrapDirective, FocusTrapDeprecatedDirective],
-  providers: [InteractivityChecker, FocusTrapFactory, LIVE_ANNOUNCER_PROVIDER]
+  providers: [InteractivityChecker, FocusTrapFactory, AriaDescriber, LIVE_ANNOUNCER_PROVIDER]
 })
 export class A11yModule {}
 
@@ -28,3 +29,4 @@ export * from './interactivity-checker';
 export * from './list-key-manager';
 export * from './activedescendant-key-manager';
 export * from './focus-key-manager';
+export * from './aria-describer';

--- a/src/cdk/a11y/public_api.ts
+++ b/src/cdk/a11y/public_api.ts
@@ -7,26 +7,32 @@
  */
 
 import {NgModule} from '@angular/core';
-import {FocusTrapDirective, FocusTrapDeprecatedDirective, FocusTrapFactory} from './focus-trap';
+import {FocusTrapDeprecatedDirective, FocusTrapDirective, FocusTrapFactory} from './focus-trap';
 import {LIVE_ANNOUNCER_PROVIDER} from './live-announcer';
 import {InteractivityChecker} from './interactivity-checker';
 import {CommonModule} from '@angular/common';
 import {PlatformModule} from '@angular/cdk/platform';
-import {AriaDescriber} from './aria-describer';
+import {AriaDescriber, ARIA_DESCRIBER_PROVIDER} from './aria-describer';
 
 @NgModule({
   imports: [CommonModule, PlatformModule],
   declarations: [FocusTrapDirective, FocusTrapDeprecatedDirective],
   exports: [FocusTrapDirective, FocusTrapDeprecatedDirective],
-  providers: [InteractivityChecker, FocusTrapFactory, AriaDescriber, LIVE_ANNOUNCER_PROVIDER]
+  providers: [
+    InteractivityChecker,
+    FocusTrapFactory,
+    AriaDescriber,
+    LIVE_ANNOUNCER_PROVIDER,
+    ARIA_DESCRIBER_PROVIDER
+  ]
 })
 export class A11yModule {}
 
-export * from './live-announcer';
+export * from './activedescendant-key-manager';
+export * from './aria-describer';
 export * from './fake-mousedown';
+export * from './focus-key-manager';
 export * from './focus-trap';
 export * from './interactivity-checker';
 export * from './list-key-manager';
-export * from './activedescendant-key-manager';
-export * from './focus-key-manager';
-export * from './aria-describer';
+export * from './live-announcer';

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -1,7 +1,44 @@
+<button *ngFor="let tooltip of tooltips" mdTooltip="Tooltip message">I'm a button with a</button>
+<button (click)="tooltips.push('another')">Add tooltip</button>
+<button (click)="tooltips.shift()" [disabled]="tooltips.length == 0">Remove tooltip</button>
+
 <div class="demo-tooltip">
   <h1>Tooltip Demo</h1>
 
   <div class="centered" cdk-scrollable>
+    <button #tooltip="mdTooltip"
+            md-raised-button
+            color="primary"
+            [mdTooltip]="message"
+            [mdTooltipPosition]="position"
+            [mdTooltipDisabled]="disabled"
+            [mdTooltipShowDelay]="showDelay"
+            [mdTooltipHideDelay]="hideDelay"
+            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
+      Mouse over to see the tooltip
+    </button>
+    <button #tooltip="mdTooltip"
+            md-raised-button
+            color="primary"
+            [mdTooltip]="message"
+            [mdTooltipPosition]="position"
+            [mdTooltipDisabled]="disabled"
+            [mdTooltipShowDelay]="showDelay"
+            [mdTooltipHideDelay]="hideDelay"
+            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
+      Mouse over to see the tooltip
+    </button>
+    <button #tooltip="mdTooltip"
+            md-raised-button
+            color="primary"
+            [mdTooltip]="message"
+            [mdTooltipPosition]="position"
+            [mdTooltipDisabled]="disabled"
+            [mdTooltipShowDelay]="showDelay"
+            [mdTooltipHideDelay]="hideDelay"
+            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
+      Mouse over to see the tooltip
+    </button>
     <button #tooltip="mdTooltip"
             md-raised-button
             color="primary"

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -1,44 +1,11 @@
-<button *ngFor="let tooltip of tooltips" mdTooltip="Tooltip message">I'm a button with a</button>
-<button (click)="tooltips.push('another')">Add tooltip</button>
+<button *ngFor="let tooltip of tooltips" mdTooltip="Tooltip message">Tooltip Button</button>
+<button (click)="tooltips.push(null)">Add tooltip</button>
 <button (click)="tooltips.shift()" [disabled]="tooltips.length == 0">Remove tooltip</button>
 
 <div class="demo-tooltip">
   <h1>Tooltip Demo</h1>
 
   <div class="centered" cdk-scrollable>
-    <button #tooltip="mdTooltip"
-            md-raised-button
-            color="primary"
-            [mdTooltip]="message"
-            [mdTooltipPosition]="position"
-            [mdTooltipDisabled]="disabled"
-            [mdTooltipShowDelay]="showDelay"
-            [mdTooltipHideDelay]="hideDelay"
-            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
-      Mouse over to see the tooltip
-    </button>
-    <button #tooltip="mdTooltip"
-            md-raised-button
-            color="primary"
-            [mdTooltip]="message"
-            [mdTooltipPosition]="position"
-            [mdTooltipDisabled]="disabled"
-            [mdTooltipShowDelay]="showDelay"
-            [mdTooltipHideDelay]="hideDelay"
-            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
-      Mouse over to see the tooltip
-    </button>
-    <button #tooltip="mdTooltip"
-            md-raised-button
-            color="primary"
-            [mdTooltip]="message"
-            [mdTooltipPosition]="position"
-            [mdTooltipDisabled]="disabled"
-            [mdTooltipShowDelay]="showDelay"
-            [mdTooltipHideDelay]="hideDelay"
-            [mdTooltipClass]="{'red-tooltip': showExtraClass}">
-      Mouse over to see the tooltip
-    </button>
     <button #tooltip="mdTooltip"
             md-raised-button
             color="primary"
@@ -66,7 +33,7 @@
   </p>
   <p>
     <strong>Message: </strong>
-    <md-form-field><input mdInput type="text" [(ngModel)]="message"></md-form-field>
+    <md-form-field><input mdInput [(ngModel)]="message"></md-form-field>
   </p>
 
   <p>

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -12,7 +12,7 @@ import {TooltipPosition} from '@angular/material';
 export class TooltipDemo {
   position: TooltipPosition = 'below';
   message: string = 'Here is the tooltip';
-  tooltips = [];
+  tooltips: string[] = [];
   disabled = false;
   showDelay = 0;
   hideDelay = 1000;

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -12,6 +12,7 @@ import {TooltipPosition} from '@angular/material';
 export class TooltipDemo {
   position: TooltipPosition = 'below';
   message: string = 'Here is the tooltip';
+  tooltips = [];
   disabled = false;
   showDelay = 0;
   hideDelay = 1000;

--- a/src/lib/tooltip/index.ts
+++ b/src/lib/tooltip/index.ts
@@ -12,7 +12,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {PlatformModule} from '@angular/cdk/platform';
 import {MdCommonModule} from '../core';
 import {MdTooltip, TooltipComponent, MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER} from './tooltip';
-import {A11yModule} from '@angular/cdk/a11y';
+import {A11yModule, ARIA_DESCRIBER_PROVIDER} from '@angular/cdk/a11y';
 
 
 @NgModule({
@@ -26,7 +26,7 @@ import {A11yModule} from '@angular/cdk/a11y';
   exports: [MdTooltip, TooltipComponent, MdCommonModule],
   declarations: [MdTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
-  providers: [MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER],
+  providers: [MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER, ARIA_DESCRIBER_PROVIDER],
 })
 export class MdTooltipModule {}
 

--- a/src/lib/tooltip/index.ts
+++ b/src/lib/tooltip/index.ts
@@ -12,6 +12,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {PlatformModule} from '@angular/cdk/platform';
 import {MdCommonModule} from '../core';
 import {MdTooltip, TooltipComponent, MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER} from './tooltip';
+import {A11yModule} from '@angular/cdk/a11y';
 
 
 @NgModule({
@@ -19,7 +20,8 @@ import {MdTooltip, TooltipComponent, MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER} from '
     CommonModule,
     OverlayModule,
     MdCommonModule,
-    PlatformModule
+    PlatformModule,
+    A11yModule,
   ],
   exports: [MdTooltip, TooltipComponent, MdCommonModule],
   declarations: [MdTooltip, TooltipComponent],

--- a/src/lib/tooltip/tooltip.md
+++ b/src/lib/tooltip/tooltip.md
@@ -35,3 +35,9 @@ which both accept a number in milliseconds to delay before applying the display 
 
 To turn off the tooltip and prevent it from showing to the user, use the `mdTooltipDisabled` input flag.
 
+### Accessibility
+
+Elements with the `mdTooltip` will add an `aria-describedby` label that provides a reference
+to a visually hidden element containing the tooltip's message. This provides screenreaders the
+information needed to read out the tooltip's contents when the end-user focuses on the element
+triggering the tooltip.

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -27,7 +27,6 @@ import {
   TOOLTIP_PANEL_CLASS,
   TooltipPosition
 } from './index';
-import {A11Y_MESSAGES_CONTAINER_ID} from './tooltip';
 
 
 const initialTooltipMessage = 'initial tooltip message';

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -409,6 +409,13 @@ describe('MdTooltip', () => {
       expect(tooltipWrapper).toBeTruthy('Expected tooltip to be shown.');
       expect(tooltipWrapper.getAttribute('dir')).toBe('rtl', 'Expected tooltip to be in RTL mode.');
     }));
+
+    fit('should be able to set the tooltip message as a number', fakeAsync(() => {
+      fixture.componentInstance.message = 100;
+      fixture.detectChanges();
+
+      expect(tooltipDirective.message).toBe('100');
+    }));
   });
 
   it('should create a unique a11y message element for each unique message', () => {
@@ -561,7 +568,7 @@ describe('MdTooltip', () => {
 })
 class BasicTooltipDemo {
   position: string = 'below';
-  message: string = initialTooltipMessage;
+  message: any = initialTooltipMessage;
   showButton: boolean = true;
   showTooltipClass = false;
   @ViewChild(MdTooltip) tooltip: MdTooltip;

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -293,6 +293,10 @@ describe('MdTooltip', () => {
       expect(overlayContainerElement.textContent).toBe('');
     }));
 
+    fit('should have an aria-described element with the tooltip message', fakeAsync(() => {
+      const button = fixture.nativeElement.querySelector('button');
+    }));
+
     it('should not try to dispose the tooltip when destroyed and done hiding', fakeAsync(() => {
       tooltipDirective.show();
       fixture.detectChanges();
@@ -416,45 +420,6 @@ describe('MdTooltip', () => {
 
       expect(tooltipDirective.message).toBe('100');
     }));
-  });
-
-  it('should create a unique a11y message element for each unique message', () => {
-    const dynamicTooltipsFixture = TestBed.createComponent(DynamicTooltipsDemo);
-    dynamicTooltipsFixture.detectChanges();
-
-    // No tooltips, no tooltip a11y container
-    let a11yMessageContainer = document.querySelector(`#${A11Y_MESSAGES_CONTAINER_ID}`)!;
-    expect(a11yMessageContainer).toBe(null);
-
-    // One tooltip, one message - expect the container and one a11y message
-    dynamicTooltipsFixture.componentInstance.tooltips = ['message_1'];
-    dynamicTooltipsFixture.detectChanges();
-    a11yMessageContainer = document.querySelector(`#${A11Y_MESSAGES_CONTAINER_ID}`)!;
-    expect(a11yMessageContainer.childNodes.length).toBe(1);
-    expect(a11yMessageContainer.childNodes[0].textContent).toBe('message_1');
-
-    // Add 'message_2' - Two tooltips, two messages - expect two a11y messages
-    dynamicTooltipsFixture.componentInstance.tooltips = ['message_1', 'message_2'];
-    dynamicTooltipsFixture.detectChanges();
-    a11yMessageContainer = document.querySelector(`#${A11Y_MESSAGES_CONTAINER_ID}`)!;
-    expect(a11yMessageContainer.childNodes.length).toBe(2);
-    expect(a11yMessageContainer.childNodes[0].textContent).toBe('message_1');
-    expect(a11yMessageContainer.childNodes[1].textContent).toBe('message_2');
-
-    // Add 'message_1' - Three tooltips, two messages - expect two a11y messages
-    dynamicTooltipsFixture.componentInstance.tooltips = ['message_1', 'message_2', 'message_1'];
-    dynamicTooltipsFixture.detectChanges();
-    a11yMessageContainer = document.querySelector(`#${A11Y_MESSAGES_CONTAINER_ID}`)!;
-    expect(a11yMessageContainer.childNodes.length).toBe(2);
-    expect(a11yMessageContainer.childNodes[0].textContent).toBe('message_1');
-    expect(a11yMessageContainer.childNodes[1].textContent).toBe('message_2');
-
-    // Remove 'message_2' - Two tooltips, one message - expect one a11y message
-    dynamicTooltipsFixture.componentInstance.tooltips = ['message_1', 'message_1'];
-    dynamicTooltipsFixture.detectChanges();
-    a11yMessageContainer = document.querySelector(`#${A11Y_MESSAGES_CONTAINER_ID}`)!;
-    expect(a11yMessageContainer.childNodes.length).toBe(1);
-    expect(a11yMessageContainer.childNodes[0].textContent).toBe('message_1');
   });
 
   describe('scrollable usage', () => {

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -6,7 +6,13 @@ import {
   TestBed,
   tick
 } from '@angular/core/testing';
-import {ChangeDetectionStrategy, Component, DebugElement, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ElementRef,
+  ViewChild
+} from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -293,9 +299,20 @@ describe('MdTooltip', () => {
       expect(overlayContainerElement.textContent).toBe('');
     }));
 
-    fit('should have an aria-described element with the tooltip message', fakeAsync(() => {
-      const button = fixture.nativeElement.querySelector('button');
-    }));
+    it('should have an aria-described element with the tooltip message', () => {
+      const dynamicTooltipsDemoFixture = TestBed.createComponent(DynamicTooltipsDemo);
+      const dynamicTooltipsComponent = dynamicTooltipsDemoFixture.componentInstance;
+
+      dynamicTooltipsComponent.tooltips = ['Tooltip One', 'Tooltip Two'];
+      dynamicTooltipsDemoFixture.detectChanges();
+
+      const buttons = dynamicTooltipsComponent.getButtons();
+      const firstButtonAria = buttons[0].getAttribute('aria-describedby');
+      expect(document.querySelector(`#${firstButtonAria}`)!.textContent).toBe('Tooltip One');
+
+      const secondButtonAria = buttons[1].getAttribute('aria-describedby');
+      expect(document.querySelector(`#${secondButtonAria}`)!.textContent).toBe('Tooltip Two');
+    });
 
     it('should not try to dispose the tooltip when destroyed and done hiding', fakeAsync(() => {
       tooltipDirective.show();
@@ -587,7 +604,6 @@ class OnPushTooltipDemo {
 @Component({
   selector: 'app',
   template: `
-      {{tooltips}} Test
     <button *ngFor="let tooltip of tooltips"
             [mdTooltip]="tooltip">
       Button {{tooltip}}
@@ -595,4 +611,10 @@ class OnPushTooltipDemo {
 })
 class DynamicTooltipsDemo {
   tooltips: Array<string> = [];
+
+  constructor(private _elementRef: ElementRef) {}
+
+  getButtons() {
+    return this._elementRef.nativeElement.querySelectorAll('button');
+  }
 }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -410,7 +410,7 @@ describe('MdTooltip', () => {
       expect(tooltipWrapper.getAttribute('dir')).toBe('rtl', 'Expected tooltip to be in RTL mode.');
     }));
 
-    fit('should be able to set the tooltip message as a number', fakeAsync(() => {
+    it('should be able to set the tooltip message as a number', fakeAsync(() => {
       fixture.componentInstance.message = 100;
       fixture.detectChanges();
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -453,13 +453,14 @@ export class MdTooltip implements OnDestroy {
 
     // Remove the a11y message if this was its last unique instance.
     const a11yMessageElement = a11yMessages.get(message);
-    if (a11yMessageElement && --a11yMessageElement.count == 0) {
+    if (a11yMessageElement && a11yMessageElement.count == 1) {
       this._deleteA11yMessageElement(message);
+      a11yMessageElement.count--;
     }
 
     // If the global messages container no longer has any children, remove it.
     if (!this._getA11yMessagesContainer()!.childNodes.length) {
-      document.body.removeChild(this._getA11yMessagesContainer()!);
+      this._renderer.removeChild(document.body, this._getA11yMessagesContainer());
     }
   }
 
@@ -475,9 +476,9 @@ export class MdTooltip implements OnDestroy {
       this._createA11yMessagesContainer();
     }
 
-    const messageElement = document.createElement('div');
+    const messageElement = this._renderer.createElement('div');
     messageElement.id = `md-tooltip-message-${latestA11yMessageId++}`;
-    messageElement.innerHTML = message;
+    messageElement.textContent = message;
 
     this._getA11yMessagesContainer()!.appendChild(messageElement);
     a11yMessages.set(message, {element: messageElement, count: 1});
@@ -490,7 +491,7 @@ export class MdTooltip implements OnDestroy {
     if (!this._platform.isBrowser) { return; }
 
     const a11yMessage = a11yMessages.get(message)!;
-    this._getA11yMessagesContainer()!.removeChild(a11yMessage.element);
+    this._renderer.removeChild(this._getA11yMessagesContainer()!, a11yMessage.element);
     a11yMessages.delete(message);
   }
 
@@ -516,11 +517,10 @@ export class MdTooltip implements OnDestroy {
 
   /** Creates the global container for all tooltip a11y messages. */
   private _createA11yMessagesContainer() {
-    const a11yMessagesContainer = document.createElement('div');
+    const a11yMessagesContainer = this._renderer.createElement('div');
     a11yMessagesContainer.id = A11Y_MESSAGES_CONTAINER_ID;
-    a11yMessagesContainer.className = 'cdk-visually-hidden';
-
-    document.body.appendChild(a11yMessagesContainer);
+    this._renderer.addClass(a11yMessagesContainer, 'cdk-visually-hidden');
+    this._renderer.appendChild(document.body, a11yMessagesContainer);
   }
 
   /** Returns the global container for tooltip a11y messages. */

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -78,15 +78,22 @@ export const MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER = {
   useFactory: MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER_FACTORY
 };
 
+/**
+ * Interface used to register tooltip a11y message elements, with a count of how many tooltips have
+ * the message and the reference to the a11y message element used for the aria-describedby.
+ */
 export interface RegisteredA11yMessage {
   element: HTMLElement;
   count: number;
 }
 
+/** ID used for the body container where all a11y messages are appended. */
 export const A11Y_MESSAGES_CONTAINER_ID = 'md-tooltip-a11y-messages';
 
+/** Global incremental identifier for each registered a11y message.
 let latestA11yMessageId = 0;
 
+/** Global map of all registered a11y message elements that have been placed into the document. */
 const a11yMessages = new Map<string, RegisteredA11yMessage>();
 
 /**

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -148,13 +148,14 @@ export class MdTooltip implements OnDestroy {
   /** The message to be displayed in the tooltip */
   @Input('mdTooltip') get message() { return this._message; }
   set message(value: string) {
-    if (this._message) { this._ariaDescriber.unregisterMessage(this._message); }
+    if (this._message) {
+      this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message);
+    }
 
     // If the message is not a string (e.g. number), convert it to a string and trim it.
     this._message = value ? `${value}`.trim() : '';
     this._updateTooltipMessage();
-
-    this._setAriaDescribedBy();
+    this._ariaDescriber.addDescription(this._elementRef.nativeElement, this.message);
   }
 
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */
@@ -240,7 +241,7 @@ export class MdTooltip implements OnDestroy {
       this._leaveListener();
     }
 
-    this._ariaDescriber.unregisterMessage(this.message);
+    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this.message);
   }
 
   /** Shows the tooltip after the delay in ms, defaults to tooltip-delay-show or 0ms if no input */
@@ -405,26 +406,6 @@ export class MdTooltip implements OnDestroy {
     if (this._tooltipInstance) {
       this._tooltipInstance.tooltipClass = tooltipClass;
       this._tooltipInstance._markForCheck();
-    }
-  }
-
-  /** Returns the trigger's aria-describedby attribute. */
-  private _getAriaDescribedby(): string {
-    return this._elementRef.nativeElement.getAttribute('aria-describedby');
-  }
-
-  /** Sets the trigger's aria-describedby attribute to the tooltip message element. */
-  private _setAriaDescribedBy() {
-    // Return if an aria-describedby already exists and it is not referencing a tooltip message.
-    const ariaDescribedBy = this._elementRef.nativeElement.getAttribute('aria-describedby');
-    if (ariaDescribedBy && ariaDescribedBy.indexOf('md-tooltip-message') == -1) { return; }
-
-    if (this.message) {
-      this._renderer.setAttribute(
-          this._elementRef.nativeElement, 'aria-describedby',
-          this._ariaDescriber.registerMessage(this.message));
-    } else {
-      this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', '');
     }
   }
 }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -255,7 +255,6 @@ export class MdTooltip implements OnDestroy {
     }
 
     this._unregisterA11yMessage(this.message);
-
   }
 
   /** Shows the tooltip after the delay in ms, defaults to tooltip-delay-show or 0ms if no input */

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -95,6 +95,7 @@ export const MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER = {
     '(touchend)': 'hide(' + TOUCHEND_HIDE_DELAY + ')',
   },
   exportAs: 'mdTooltip',
+  providers: [AriaDescriber],
 })
 export class MdTooltip implements OnDestroy {
   _overlayRef: OverlayRef | null;
@@ -419,10 +420,9 @@ export class MdTooltip implements OnDestroy {
     if (ariaDescribedBy && ariaDescribedBy.indexOf('md-tooltip-message') == -1) { return; }
 
     if (this.message) {
-      const registeredA11yMessage = this._ariaDescriber.registerMessage(this.message);
-      const tooltipMessageElementId = registeredA11yMessage.element.id;
       this._renderer.setAttribute(
-          this._elementRef.nativeElement, 'aria-describedby', tooltipMessageElementId);
+          this._elementRef.nativeElement, 'aria-describedby',
+          this._ariaDescriber.registerMessage(this.message));
     } else {
       this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', '');
     }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -42,7 +42,8 @@ import {
   // tslint:disable-next-line:no-unused-variable
   ScrollStrategy,
 } from '@angular/cdk/overlay';
-import {coerceBooleanProperty, ESCAPE} from '@angular/cdk/coercion';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {ESCAPE} from '@angular/cdk/keyboard';
 
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
@@ -90,7 +91,7 @@ export interface RegisteredA11yMessage {
 /** ID used for the body container where all a11y messages are appended. */
 export const A11Y_MESSAGES_CONTAINER_ID = 'md-tooltip-a11y-messages';
 
-/** Global incremental identifier for each registered a11y message.
+/** Global incremental identifier for each registered a11y message. */
 let latestA11yMessageId = 0;
 
 /** Global map of all registered a11y message elements that have been placed into the document. */
@@ -478,8 +479,6 @@ export class MdTooltip implements OnDestroy {
     messageElement.id = `md-tooltip-message-${latestA11yMessageId++}`;
     messageElement.innerHTML = message;
 
-    console.log(this._getA11yMessagesContainer());
-    console.log(messageElement);
     this._getA11yMessagesContainer()!.appendChild(messageElement);
     a11yMessages.set(message, {element: messageElement, count: 1});
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -43,7 +43,7 @@ import {
   ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {ESCAPE} from '@angular/cdk/keyboard';
+import {ESCAPE} from '@angular/cdk/keycodes';
 import {AriaDescriber} from '@angular/cdk/a11y';
 
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -451,17 +451,19 @@ export class MdTooltip implements OnDestroy {
   private _unregisterA11yMessage(message: string) {
     if (!this._platform.isBrowser || !this.message) { return; }
 
+    const a11yMessageElement = a11yMessages.get(message)!;
+    a11yMessageElement.count--;
+
     // Remove the a11y message if this was its last unique instance.
-    const a11yMessageElement = a11yMessages.get(message);
-    if (a11yMessageElement && a11yMessageElement.count == 1) {
+    if (a11yMessageElement.count == 0) {
       this._deleteA11yMessageElement(message);
-      a11yMessageElement.count--;
     }
 
     // If the global messages container no longer has any children, remove it.
     if (!this._getA11yMessagesContainer()!.childNodes.length) {
       this._renderer.removeChild(document.body, this._getA11yMessagesContainer());
     }
+
   }
 
   /**

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -95,7 +95,6 @@ export const MD_TOOLTIP_SCROLL_STRATEGY_PROVIDER = {
     '(touchend)': 'hide(' + TOUCHEND_HIDE_DELAY + ')',
   },
   exportAs: 'mdTooltip',
-  providers: [AriaDescriber],
 })
 export class MdTooltip implements OnDestroy {
   _overlayRef: OverlayRef | null;
@@ -155,7 +154,7 @@ export class MdTooltip implements OnDestroy {
     // If the message is not a string (e.g. number), convert it to a string and trim it.
     this._message = value ? `${value}`.trim() : '';
     this._updateTooltipMessage();
-    this._ariaDescriber.addDescription(this._elementRef.nativeElement, this.message);
+    this._ariaDescriber.describe(this._elementRef.nativeElement, this.message);
   }
 
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */


### PR DESCRIPTION
Service adds a new element in the document body that contains the message. This is pointed to by the host element using `aria-describedby` for screenreaders to read out.

Used by tooltip and improved its accessibility. (add show on focus, escape keyboard shortcut)