### PR TITLE
chore(tslint): custom rules invoke superclass methods

### DIFF
--- a/tools/tslint-rules/noExposedTodoRule.js
+++ b/tools/tslint-rules/noExposedTodoRule.js
@@ -28,6 +28,8 @@ class NoExposedTodoWalker extends Lint.RuleWalker {
         this.addFailureAt(commentRange.pos, commentRange.end - commentRange.pos, ERROR_MESSAGE);
       }
     });
+
+    super.visitSourceFile(sourceFile);
   }
 }
 

--- a/tools/tslint-rules/requireLicenseBannerRule.js
+++ b/tools/tslint-rules/requireLicenseBannerRule.js
@@ -50,6 +50,8 @@ class RequireLicenseBannerWalker extends Lint.RuleWalker {
     if (licenseCommentPos !== 0) {
       return this.addFailureAt(0, 0, ERROR_MESSAGE, tslintFix);
     }
+
+    super.visitSourceFile(sourceFile);
   }
 }
 


### PR DESCRIPTION
A few rules are not implemented properly because their associated walker is overwriting hooks from the `SyntaxWalker` superclass. Those custom hooks need to invoke the method on the superclass as well.

See https://palantir.github.io/tslint/develop/custom-rules/