### PR TITLE
fix(list): properly align contents in subheader

### DIFF
--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -46,8 +46,9 @@
     }
 
     .mat-subheader {
-      font: mat-font-weight($config, body-2) mat-font-size($config, body-2)
-            mat-font-family($config, body-2);
+      font-family: mat-font-family($config, body-2);
+      font-size: mat-font-size($config, body-2);
+      font-weight: mat-font-weight($config, body-2);
     }
   }
 
@@ -59,7 +60,9 @@
     }
 
     .mat-subheader {
-      font: mat-font-weight($config, body-2) mat-font-size($config, caption) $font-family;
+      font-family: $font-family;
+      font-size: mat-font-size($config, caption);
+      font-weight: mat-font-weight($config, body-2);
     }
   }
 }

--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -46,7 +46,8 @@
     }
 
     .mat-subheader {
-      @include mat-typography-level-to-styles($config, body-2);
+      font: mat-font-weight($config, body-2) mat-font-size($config, body-2)
+            mat-font-family($config, body-2);
     }
   }
 

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -121,6 +121,7 @@ $mat-dense-list-icon-size: 20px;
 // This mixin adjusts the heights and padding based on whether the list is in dense mode.
 @mixin mat-subheader-spacing($top-padding, $base-height) {
   height: $base-height;
+  line-height: $base-height - $mat-list-side-padding * 2;
 
   &:first-child {
     margin-top: -$top-padding;


### PR DESCRIPTION
* The line-height of the subheaders is currently based on the typography level. This is problematic because the subheader is set to a specific height and can't grow/shrink accordingly.

Fixes #6214