### PR TITLE
docs(datepicker): Add example for setLocale method

### DIFF
--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -128,6 +128,24 @@ By default the datepicker will use the locale code from the `LOCALE_ID` injectio
 export class MyApp {}
 ```
 
+#### Setting/Switching the locale at runtime
+It's possible to set/switch the locale at runtime using the setLocale method from 
+the DateAdapter.
+
+```ts
+import { DateAdapter, NativeDateAdapter } from '@angular/material';
+
+@Component({
+  selector:    'foo',
+  template: ''
+})
+export class FooComponent {
+  constructor(dateAdapter: DateAdapter<NativeDateAdapter>) {
+    dateAdapter.setLocale('de-DE');
+  }
+}
+```
+
 #### Choosing a date implementation and date format settings
 The datepicker was built to be date implementation agnostic. This means that it can be made to work
 with a variety of different date implementations. However it also means that developers need to make

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -128,9 +128,7 @@ By default the datepicker will use the locale code from the `LOCALE_ID` injectio
 export class MyApp {}
 ```
 
-#### Setting/Switching the locale at runtime
-It's possible to set/switch the locale at runtime using the setLocale method from 
-the DateAdapter.
+It's also possible to set the locale at runtime using the `setLocale` method of the `DateAdapter`.
 
 ```ts
 import { DateAdapter, NativeDateAdapter } from '@angular/material';


### PR DESCRIPTION
Add a usage example to show how the formatting locale of the datepicker can be be changed as that wasn't documented before.