### PR TITLE
docs(getting-started): mention importing hammer in same file as bootstrap

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -113,7 +113,7 @@ To install via npm, use the following command:
 npm install --save hammerjs
 ```
 
-After installing, import it on your app's root module.
+After installing, import it on your app's entry point (`src/main.ts`).
 ```ts
 import 'hammerjs';
 ```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -113,7 +113,7 @@ To install via npm, use the following command:
 npm install --save hammerjs
 ```
 
-After installing, import it on your app's entry point (`src/main.ts`).
+After installing, import it on your app's entry point (e.g. `src/main.ts`).
 ```ts
 import 'hammerjs';
 ```


### PR DESCRIPTION
As mentioned in #308, if hammerjs is imported in AppModule, Universal server-side rendering will fail as hammerjs is a browser specific library using window, document... So it must be imported in browser entry point src/main.ts instead.