### PR TITLE
fix(table): sort indicators backwards

### DIFF
--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -38,13 +38,13 @@ $mat-sort-header-arrow-thickness: 2px;
 
 .mat-sort-header-asc {
   display: block;
-  transform: rotate(45deg);
+  transform: rotate(225deg);
+  top: $mat-sort-header-arrow-thickness;
 }
 
 .mat-sort-header-desc {
   display: block;
-  transform: rotate(225deg);
-  top: $mat-sort-header-arrow-thickness;
+  transform: rotate(45deg);
 }
 
 .mat-sort-header-stem {


### PR DESCRIPTION
Changes the sort arrows so sort ascending points up and sort descending points down.

Fixes #6198