### PR TITLE
Don't exclude min and max dates from datepicker

### DIFF
--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -180,14 +180,14 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   }
 
   /** The form control validator for the min date. */
-  private _minValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  private _minValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null > {
     return (!this.min || !control.value ||
         this._dateAdapter.compareDate(this.min, control.value) <= 0) ?
         null : {'mdDatepickerMin': {'min': this.min, 'actual': control.value}};
   }
 
   /** The form control validator for the max date. */
-  private _maxValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  private _maxValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null > {
     return (!this.max || !control.value ||
         this._dateAdapter.compareDate(this.max, control.value) >= 0) ?
         null : {'mdDatepickerMax': {'max': this.max, 'actual': control.value}};


### PR DESCRIPTION
Let the selected date be the equal to the minimum or maximum date since setting a limits to values shouldn't exclude them.