### PR TITLE
ci: incorrect path to screenshot-test tool

### DIFF
--- a/scripts/deploy/deploy-screenshot-functions.sh
+++ b/scripts/deploy/deploy-screenshot-functions.sh
@@ -16,7 +16,7 @@ if [ -z ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} ]; then
 fi
 
 # Path to the screenshot tool in the project.
-screenshotToolFolder="tools/dashboard"
+screenshotToolFolder="tools/screenshot-test"
 
 # Path to the firebase binary of the root package.json
 firebaseBin=$(npm bin)/firebase


### PR DESCRIPTION
The deploy script for the screenshot-test tool right now references a incorrect directory. This means that the screenshot-test tool can't be uploaded for push builds right now.