### PR TITLE
build: fix docs generation highlight files task

### DIFF
--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -110,7 +110,7 @@ task('highlight-examples', () => {
   // rename files to fit format: [filename]-[filetype].html
   const renameFile = (filePath: any) => {
     const extension = filePath.extname.slice(1);
-    filePath.basename = `${path.basename}-${extension}`;
+    filePath.basename = `${filePath.basename}-${extension}`;
   };
 
   return src('src/material-examples/**/*.+(html|css|ts)')


### PR DESCRIPTION
Recently with https://github.com/angular/material2/commit/edcbb24f11ae776b94d97634ae91e9175ffd6f8a the ambigious variable `path` has been renamed to `filePath`, but there is one remaining instance of `path` that didn't get updated.

This currently causes the docs-content CI job to fail.