### PR TITLE
chore: fix missing types error for screenshot-tool functions

### DIFF
--- a/tools/screenshot-test/functions/package.json
+++ b/tools/screenshot-test/functions/package.json
@@ -2,10 +2,11 @@
   "name": "material2-screenshot-functions",
   "description": "Angular Material screenshot firebase functions",
   "dependencies": {
+    "@types/jsonwebtoken": "^7.2.3",
     "@google-cloud/storage": "^0.8.0",
     "firebase-admin": "~4.1.3",
     "firebase-functions": "^0.5.2",
-    "jsonwebtoken": "^7.3.0",
+    "jsonwebtoken": "^7.4.2",
     "request": "^2.81.0",
     "typescript": "^2.2.2",
     "ts-node": "^3.0.2"


### PR DESCRIPTION
The Google Cloud functions for the screenshot-test tool can't be deployed on the CI because there appear to be some errors that indicate that the types for the `jsonwebtoken` package are not installed.

This commit adds the types for the `jsonwebtoken` package to the dependencies (similar as for the dashboard)