### PR TITLE
build: fix error when running devapp on windows

### DIFF
--- a/tools/package-tools/secondary-entry-points.ts
+++ b/tools/package-tools/secondary-entry-points.ts
@@ -38,10 +38,10 @@ export function getSecondaryEntryPointsForPackage(pkg: BuildPackage) {
   buildNodes.forEach(node => {
     // Look for any imports that reference this same umbrella package and get the corresponding
     // BuildNode for each by looking at the import statements with grep.
-    node.deps = spawnSync('egrep', [
-      '-roh',
+    node.deps = spawnSync('grep', [
+      '-Eroh',
       '--include', '*.ts',
-      `from.'@angular/${packageName}/.+';`,
+      `from '@angular/${packageName}/.+';`,
       `${packageDir}/${node.name}/`
     ])
     .stdout


### PR DESCRIPTION
Currently developers using Windows are not able to serve the devapp because the secondary entry-points can't be resolved. This can happen because of two things:

* `egrep`, which is an alias for `grep -E` is not part of the global `$PATH` variable on Windows
* The Regular Expression for the `grep` call is ambiguous and expects zero-width characters to be present.

This PR changes the `spawnSync` call to use `grep -E` and also changes the Regular Expression to be more explicit about what characters to match after the `from`.

In reality it's still not really clear what characters was causing the RegExp to no longer match, or if it was more caused by the fact that NodeJS somehow tries to escape the quote in a bad way.

cc. @crisbeto 