### PR TITLE
fix(input): not working correctly in high contrast mode

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -58,10 +58,11 @@
   }
 
   .mat-input-underline {
-    background-color: $input-underline-color;
+    color: $input-underline-color;
 
     &.mat-disabled {
       @include mat-control-disabled-underline($input-underline-color);
+      color: transparent;
     }
   }
 
@@ -182,8 +183,7 @@
 
   .mat-input-infix {
     padding: $infix-padding 0;
-    // Throws off the baseline if we do it as a real margin, so we do it as a border instead.
-    border-top: $infix-margin-top solid transparent;
+    margin-top: $infix-margin-top;
   }
 
   .mat-input-element {

--- a/src/lib/input/input-container.scss
+++ b/src/lib/input/input-container.scss
@@ -1,5 +1,6 @@
 @import '../core/style/variables';
 @import '../core/style/vendor-prefixes';
+@import '../core/a11y/a11y';
 
 
 // Min amount of space between start and end hint.
@@ -195,6 +196,9 @@ textarea.mat-input-element {
   height: $mat-input-underline-height;
   width: 100%;
 
+  // Note that we use a border because a background won't be rendered in high contrast mode.
+  border-bottom: solid $mat-input-underline-height currentColor;
+
   &.mat-disabled {
     background-position: 0;
     background-color: transparent;
@@ -203,7 +207,7 @@ textarea.mat-input-element {
   .mat-input-ripple {
     position: absolute;
     height: $mat-input-underline-height;
-    top: 0;
+    top: $mat-input-underline-height;
     left: 0;
     width: 100%;
     transform-origin: 50%;
@@ -221,6 +225,12 @@ textarea.mat-input-element {
       transform: scaleX(1);
       transition: transform 150ms linear,
       background-color $swift-ease-in-duration $swift-ease-in-timing-function;
+    }
+
+    @include cdk-high-contrast {
+      // Hide the ripple in high contrast mode, because it covers
+      // the bottom border, blending it in with the background.
+      display: none;
     }
   }
 }

--- a/src/lib/input/input-container.spec.ts
+++ b/src/lib/input/input-container.spec.ts
@@ -644,7 +644,7 @@ describe('MdInputContainer without forms', function () {
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
-    input._onFocus();
+    input._focusChanged(true);
     fixture.detectChanges();
 
     expect(container.classList).toContain('mat-focused');
@@ -660,7 +660,7 @@ describe('MdInputContainer without forms', function () {
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
-    input._onFocus();
+    input._focusChanged(true);
     fixture.detectChanges();
 
     expect(input.focused).toBe(false);

--- a/src/lib/input/input-container.ts
+++ b/src/lib/input/input-container.ts
@@ -289,12 +289,6 @@ export class MdInputDirective implements OnChanges, OnDestroy, DoCheck {
     }
   }
 
-  _onFocus() {
-    if (!this._readonly) {
-      this.focused = true;
-    }
-  }
-
   /** Focuses the input element. */
   focus() {
     this._elementRef.nativeElement.focus();
@@ -302,7 +296,7 @@ export class MdInputDirective implements OnChanges, OnDestroy, DoCheck {
 
   /** Callback for the cases where the focused state of the input changes. */
   _focusChanged(isFocused: boolean) {
-    if (isFocused !== this.focused) {
+    if (isFocused !== this.focused && (!isFocused || !this._readonly)) {
       this.focused = isFocused;
       this._stateChanges.next();
     }


### PR DESCRIPTION
Fixes the input not working correctly in high contrast mode by:
* Using a margin instead of a border to do the spacing inside the input. Windows renders all borders in high contrast mode, even if they're transparent, which caused the input to have a 5px top border.
* Using a border to render the underline, instead of a background color.
* Hiding the ripple, because it was causing the underline to blend in with the background.

Also gets rid of an unused method.

Relates to #6257.