### PR TITLE
fix(tooltip): update tooltip template to allow HTML

### DIFF
--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -1,7 +1,7 @@
 <div class="mat-tooltip"
      [ngClass]="tooltipClass"
+     [innerHtml]="message"
      [style.transform-origin]="_transformOrigin"
      [@state]="_visibility"
      (@state.done)="_afterVisibilityAnimation($event)">
-  {{message}}
 </div>


### PR DESCRIPTION
There is often a need to add HTML to tooltips, specifically line breaks.