### PR TITLE
build: deploy screenshot app for push builds

### DIFF
--- a/scripts/deploy/deploy-screenshot-functions.sh
+++ b/scripts/deploy/deploy-screenshot-functions.sh
@@ -28,6 +28,6 @@ cd ${screenshotToolFolder}
 # to collect all function names before it can deploy them.
 (cd functions; npm install)
 
-# Deploy the screenshot functions to Firebase
-${firebaseBin} deploy --only functions --token ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} \
-  --non-interactive --project material2-screenshots
+# Deploy the screenshot application and functions to Firebase
+${firebaseBin} deploy --token ${MATERIAL2_SCREENSHOT_FIREBASE_DEPLOY_TOKEN} --non-interactive \
+  --project material2-screenshots


### PR DESCRIPTION
* Currently only the screenshot functions are deployed, but not he screenshot application. With this change the application will be also deployed on Travis Push builds.

**Note**:  This should fix cases where the screenshot application serves the demo-app (https://material2-screenshots.firebaseapp.com/)

Related to #6286 