### PR TITLE
fix(select,autocomplete): darken selected option

### DIFF
--- a/src/lib/core/option/_option-theme.scss
+++ b/src/lib/core/option/_option-theme.scss
@@ -30,7 +30,7 @@
 
     // In multiple mode there is a checkbox to show that the option is selected.
     &.mat-selected:not(.mat-option-multiple) {
-      background: mat-color($background, hover);
+      background: mat-color($background, hover, 0.12);
     }
 
     &.mat-active {


### PR DESCRIPTION
Darkens the selected option background in order to distinguish it from the ones that are focused or hovered.

Fixes #6229.