### PR TITLE
fix(overlay): error when removing empty string theme

### DIFF
--- a/src/lib/core/overlay/overlay-container.ts
+++ b/src/lib/core/overlay/overlay-container.ts
@@ -25,7 +25,9 @@ export class OverlayContainer {
   get themeClass(): string { return this._themeClass; }
   set themeClass(value: string) {
     if (this._containerElement) {
-      this._containerElement.classList.remove(this._themeClass);
+      if (this._themeClass) {
+        this._containerElement.classList.remove(this._themeClass);
+      }
 
       if (value) {
         this._containerElement.classList.add(value);

--- a/src/lib/core/overlay/overlay.spec.ts
+++ b/src/lib/core/overlay/overlay.spec.ts
@@ -476,6 +476,11 @@ describe('OverlayContainer theming', () => {
     expect(overlayContainerElement.classList).not.toContain('initial-theme');
     expect(overlayContainerElement.classList).toContain('new-theme');
   });
+
+  it('should not throw when switching from a blank theme', () => {
+    overlayContainer.themeClass = '';
+    expect(() => overlayContainer.themeClass = 'new-theme').not.toThrow();
+  });
 });
 
 /** Simple component for testing ComponentPortal. */


### PR DESCRIPTION
Something I ran into while doing #6305. If the previous overlay theme is a blank string, switching to another theme throws an error.