### PR TITLE
chore(build): add examples to docs build and annotate table examples

### DIFF
--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -73,8 +73,8 @@ import {PizzaPartyComponent,SnackBarComponentExample} from './snack-bar-componen
 import {SnackBarOverviewExample} from './snack-bar-overview/snack-bar-overview-example';
 import {SortOverviewExample} from './sort-overview/sort-overview-example';
 import {TableBasicExample} from './table-basic/table-basic-example';
-import {TableHttpExample} from './table-http/table-http-example';
 import {TableFilteringExample} from './table-filtering/table-filtering-example';
+import {TableHttpExample} from './table-http/table-http-example';
 import {TableOverviewExample} from './table-overview/table-overview-example';
 import {TablePaginationExample} from './table-pagination/table-pagination-example';
 import {TableSortingExample} from './table-sorting/table-sorting-example';
@@ -446,15 +446,15 @@ export const EXAMPLE_COMPONENTS = {
     additionalFiles: null,
     selectorName: null
   },
-  'table-http': {
-    title: 'Table retrieving data through HTTP',
-    component: TableHttpExample,
-    additionalFiles: null,
-    selectorName: null
-  },
   'table-filtering': {
     title: 'Table with filtering',
     component: TableFilteringExample,
+    additionalFiles: null,
+    selectorName: null
+  },
+  'table-http': {
+    title: 'Table retrieving data through HTTP',
+    component: TableHttpExample,
     additionalFiles: null,
     selectorName: null
   },

--- a/src/material-examples/table-basic/table-basic-example.ts
+++ b/src/material-examples/table-basic/table-basic-example.ts
@@ -3,6 +3,9 @@ import {DataSource} from '@angular/cdk/table';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
+/**
+ * @title Basic table
+ */
 @Component({
   selector: 'table-basic-example',
   styleUrls: ['table-basic-example.css'],

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -10,6 +10,9 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/switchMap';
 
+/**
+ * @title Table retrieving data through HTTP
+ */
 @Component({
   selector: 'table-http-example',
   styleUrls: ['table-http-example.css'],

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -64,6 +64,7 @@ task('docs', [
   'highlight-examples',
   'api-docs',
   'minified-api-docs',
+  'build-examples-module',
   'plunker-example-assets',
 ]);
 


### PR DESCRIPTION
This PR adds the examples module build to the docs build chain and adds annotations for the missing table examples.