### PR TITLE
fix(xxx-intl): replace misused EventEmitter with Subject

### DIFF
--- a/src/lib/datepicker/calendar.spec.ts
+++ b/src/lib/datepicker/calendar.spec.ts
@@ -154,7 +154,7 @@ describe('MdCalendar', () => {
             .querySelector('.mat-calendar-period-button');
 
         intl.switchToYearViewLabel = 'Go to year view?';
-        intl.changes.emit();
+        intl.changes.next();
         fixture.detectChanges();
 
         expect(button.getAttribute('aria-label')).toBe('Go to year view?');

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import {Subject} from 'rxjs/Subject';
 
 
 /** Datepicker data that requires internationalization. */

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, EventEmitter} from '@angular/core';
+import {Injectable} from '@angular/core';
+import { Subject } from 'rxjs/Subject';
 
 
 /** Datepicker data that requires internationalization. */
@@ -16,7 +17,7 @@ export class MdDatepickerIntl {
    * Stream that emits whenever the labels here are changed. Use this to notify
    * components if the labels have changed after initialization.
    */
-  changes: EventEmitter<void> = new EventEmitter<void>();
+  changes: Subject<void> = new Subject<void>();
 
   /** A label for the calendar popup (used by screen readers). */
   calendarLabel = 'Calendar';

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -571,7 +571,7 @@ describe('MdDatepicker', () => {
           const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
 
           intl.openCalendarLabel = 'Open the calendar, perhaps?';
-          intl.changes.emit();
+          intl.changes.next();
           fixture.detectChanges();
 
           expect(toggle.getAttribute('aria-label')).toBe('Open the calendar, perhaps?');

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import {Subject} from 'rxjs/Subject';
 
 /**
  * To modify the labels and text displayed, create a new instance of MdPaginatorIntl and

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, EventEmitter} from '@angular/core';
+import {Injectable} from '@angular/core';
+import { Subject } from 'rxjs/Subject';
 
 /**
  * To modify the labels and text displayed, create a new instance of MdPaginatorIntl and
@@ -18,7 +19,7 @@ export class MdPaginatorIntl {
    * Stream that emits whenever the labels here are changed. Use this to notify
    * components if the labels have changed after initialization.
    */
-  changes: EventEmitter<void> = new EventEmitter<void>();
+  changes: Subject<void> = new Subject<void>();
 
   /** A label for the page size selector. */
   itemsPerPageLabel = 'Items per page:';

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -96,7 +96,7 @@ describe('MdPaginator', () => {
         const label = fixture.nativeElement.querySelector('.mat-paginator-page-size-label');
 
         intl.itemsPerPageLabel = '1337 items per page';
-        intl.changes.emit();
+        intl.changes.next();
         fixture.detectChanges();
 
         expect(label.textContent).toBe('1337 items per page');

--- a/src/lib/sort/sort-header-intl.ts
+++ b/src/lib/sort/sort-header-intl.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, EventEmitter} from '@angular/core';
+import {Injectable} from '@angular/core';
+import { Subject } from 'rxjs/Subject';
 import {SortDirection} from './sort-direction';
 
 /**
@@ -19,7 +20,7 @@ export class MdSortHeaderIntl {
    * Stream that emits whenever the labels here are changed. Use this to notify
    * components if the labels have changed after initialization.
    */
-  changes: EventEmitter<void> = new EventEmitter<void>();
+  changes: Subject<void> = new Subject<void>();
 
   /** ARIA label for the sorting button. */
   sortButtonLabel = (id: string) => {

--- a/src/lib/sort/sort-header-intl.ts
+++ b/src/lib/sort/sort-header-intl.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import {Subject} from 'rxjs/Subject';
 import {SortDirection} from './sort-direction';
 
 /**

--- a/src/lib/sort/sort.spec.ts
+++ b/src/lib/sort/sort.spec.ts
@@ -148,7 +148,7 @@ describe('MdSort', () => {
       const button = header.querySelector('.mat-sort-header-button');
 
       intl.sortButtonLabel = () => 'Sort all of the things';
-      intl.changes.emit();
+      intl.changes.next();
       fixture.detectChanges();
 
       expect(button.getAttribute('aria-label')).toBe('Sort all of the things');


### PR DESCRIPTION
According to https://angular.io/api/core/EventEmitter#description, EventEmitter is not for services. And Subject is preferrable.