### PR TITLE
feat(datepicker): export unexported components for potential extension

### DIFF
--- a/src/lib/datepicker/index.ts
+++ b/src/lib/datepicker/index.ts
@@ -47,10 +47,14 @@ export * from './year-view';
     A11yModule,
   ],
   exports: [
+    MdCalendar,
+    MdCalendarBody,
     MdDatepicker,
     MdDatepickerContent,
     MdDatepickerInput,
     MdDatepickerToggle,
+    MdMonthView,
+    MdYearView,
   ],
   declarations: [
     MdCalendar,


### PR DESCRIPTION
Although the team has export those files, but users can't redeclare them in another NgModule for angular constraints. It's impossible for someone to extend the functionality or create a custom date(time)picker view without this patch.