### PR TITLE
ci: shorter wait timeout for saucelabs and browserstack

### DIFF
--- a/scripts/browserstack/wait-tunnel.sh
+++ b/scripts/browserstack/wait-tunnel.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TUNNEL_LOG="$LOGS_DIR/browserstack-tunnel.log"
+WAIT_DELAY=60
 
 # Method that prints the logfile output of the browserstack tunnel.
 printLog() {
@@ -24,7 +25,9 @@ fi
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
 
-  if [ $counter -gt 240 ]; then
+  # Counter needs to be multiplied by two because the while loop only sleeps a half second.
+  # This has been made in favor of better progress logging (printing dots every half second)
+  if [ $counter -gt $[${WAIT_DELAY} * 2] ]; then
     echo
     echo "Timed out after 2 minutes waiting for tunnel ready file"
     printLog
@@ -32,7 +35,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   fi
 
   printf "."
-  sleep .5
+  sleep 0.5
 done
 
 echo ""

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TUNNEL_LOG="$LOGS_DIR/saucelabs-tunnel.log"
+WAIT_DELAY=60
 
 # Method that prints the logfile output of the saucelabs tunnel.
 printLog() {
@@ -16,7 +17,9 @@ let "counter=0"
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"
 
-  if [ $counter -gt 240 ]; then
+  # Counter needs to be multiplied by two because the while loop only sleeps a half second.
+  # This has been made in favor of better progress logging (printing dots every half second)
+  if [ $counter -gt $[${WAIT_DELAY} * 2] ]; then
     echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
     printLog
@@ -24,7 +27,7 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   fi
 
   printf "."
-  sleep .5
+  sleep 0.5
 done
 
 echo ""


### PR DESCRIPTION
Changes the wait timeout for Saucelabs and Browserstack from 2 minutes to 1 minute. 

This is now possible because if the timeout fails, we still re-try to create a connection a second time.