### PR TITLE
chore(): add sort module to universal app

### DIFF
--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -211,6 +211,26 @@
   <md-toolbar-row>Toolbar</md-toolbar-row>
 </md-toolbar>
 
+<h2>Sort</h2>
+
+<table mdSort>
+  <tr>
+    <th md-sort-header="name">Name</th>
+    <th md-sort-header="calories">Calories</th>
+    <th md-sort-header="fat">Fat</th>
+    <th md-sort-header="carbs">Carbs</th>
+    <th md-sort-header="protein">Protein</th>
+  </tr>
+
+  <tr>
+    <td>Cupcake</td>
+    <td>305</td>
+    <td>4</td>
+    <td>67</td>
+    <td>4</td>
+  </tr>
+</table>
+
 <h2>Tooltip</h2>
 
 <button mdTooltip="Action!">Go</button>

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -26,6 +26,7 @@ import {
   MdSliderModule,
   MdSlideToggleModule,
   MdSnackBarModule,
+  MdSortModule,
   MdTabsModule,
   MdToolbarModule,
   MdTooltipModule,
@@ -91,6 +92,7 @@ export class KitchenSink {
     MdToolbarModule,
     MdTooltipModule,
     MdExpansionModule,
+    MdSortModule,
 
     // CDK Modules
     CdkTableModule


### PR DESCRIPTION
* Adds the `MdSortModule` to the universal app. This means that it will be part of the prerender check on the CI.

**Note**: It makes sense to check the `mdSort` module because it includes components and directives that may cause problems in the server platform.