### PR TITLE
chore: remove duplicated key managers

### DIFF
--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -20,7 +20,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import {MdOption} from '../core';
-import {ActiveDescendantKeyManager} from '../core/a11y/activedescendant-key-manager';
+import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
 
 /**
  * Autocomplete IDs need to be unique across components, so this counter exists outside of

--- a/src/lib/core/a11y/activedescendant-key-manager.ts
+++ b/src/lib/core/a11y/activedescendant-key-manager.ts
@@ -6,35 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ListKeyManager, ListKeyManagerOption} from './list-key-manager';
-
-/**
- * This is the interface for highlightable items (used by the ActiveDescendantKeyManager).
- * Each item must know how to style itself as active or inactive and whether or not it is
- * currently disabled.
- */
-export interface Highlightable extends ListKeyManagerOption {
-  setActiveStyles(): void;
-  setInactiveStyles(): void;
-}
-
-export class ActiveDescendantKeyManager<T> extends ListKeyManager<Highlightable & T> {
-
-  /**
-   * This method sets the active item to the item at the specified index.
-   * It also adds active styles to the newly active item and removes active
-   * styles from the previously active item.
-   */
-  setActiveItem(index: number): void {
-    Promise.resolve().then(() => {
-      if (this.activeItem) {
-        this.activeItem.setInactiveStyles();
-      }
-      super.setActiveItem(index);
-      if (this.activeItem) {
-        this.activeItem.setActiveStyles();
-      }
-    });
-  }
-
-}
+export {ActiveDescendantKeyManager, Highlightable} from '@angular/cdk/a11y';

--- a/src/lib/core/a11y/focus-key-manager.ts
+++ b/src/lib/core/a11y/focus-key-manager.ts
@@ -6,27 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ListKeyManager, ListKeyManagerOption} from './list-key-manager';
-
-/**
- * This is the interface for focusable items (used by the FocusKeyManager).
- * Each item must know how to focus itself, whether or not it is currently disabled
- * and be able to supply it's label.
- */
-export interface FocusableOption extends ListKeyManagerOption {
-  focus(): void;
-}
-
-export class FocusKeyManager<T> extends ListKeyManager<FocusableOption & T> {
-  /**
-   * This method sets the active item to the item at the specified index.
-   * It also adds focuses the newly active item.
-   */
-  setActiveItem(index: number): void {
-    super.setActiveItem(index);
-
-    if (this.activeItem) {
-      this.activeItem.focus();
-    }
-  }
-}
+export {FocusKeyManager, FocusableOption} from '@angular/cdk/a11y';


### PR DESCRIPTION
Removes the FocusKeyManager class that was duplicated from the CDK.