### PR TITLE
build: fix screenshot tool deployment

### DIFF
--- a/scripts/ci/travis-deploy.sh
+++ b/scripts/ci/travis-deploy.sh
@@ -30,7 +30,7 @@ if [[ "${DEPLOY_MODE}" == "docs-content" ]]; then
 fi
 
 if [[ "${DEPLOY_MODE}" == "screenshot-tool" ]]; then
-  ./scripts/deploy/deploy-screenshot-functions.sh
+  ./scripts/deploy/deploy-screenshot-tool.sh
 fi
 
 if [[ "${DEPLOY_MODE}" == "dashboard" ]]; then


### PR DESCRIPTION
* Currently the screenshot tool application is not built in the deploy script. This causes Firebase to throw an error because the target directory does not exist.