### PR TITLE
fix(theming): Light green 700 contrast should be white

### DIFF
--- a/src/lib/core/theming/_palette.scss
+++ b/src/lib/core/theming/_palette.scss
@@ -366,7 +366,7 @@ $mat-light-green: (
     400: $black-87-opacity,
     500: $black-87-opacity,
     600: $black-87-opacity,
-    700: $black-87-opacity,
+    700: white,
     800: white,
     900: white,
     A100: $black-87-opacity,


### PR DESCRIPTION
According to [Material Design Guidelines](https://material.io/guidelines/style/color.html#color-color-palette) Light Green 700 contrast color
should be white.