### PR TITLE
fix(paginator): underlying select vertical alignment

### DIFF
--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -32,6 +32,8 @@ $mat-paginator-button-increment-icon-margin: 16px;
 }
 
 .mat-paginator-page-size-select {
+  // Since the select won't have a placeholder we can remove the space that is reserved for it.
+  padding-top: 0;
   margin: $mat-paginator-selector-margin;
 
   .mat-select-trigger {


### PR DESCRIPTION
Fixes the paginator's `md-select` not being align correctly.

Fixes #6338.