### PR TITLE
chore: add md-table to universal app

### DIFF
--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -250,12 +250,24 @@
 
 <h2>CDK Table</h2>
 
-<cdk-table #table [dataSource]="cdkTableDataSource">
+<cdk-table #table [dataSource]="tableDataSource">
   <ng-container cdkColumnDef="userId">
     <cdk-header-cell *cdkHeaderCellDef>ID</cdk-header-cell>
     <cdk-cell *cdkCellDef="let row">{{row.userId}}</cdk-cell>
   </ng-container>
 
-  <cdk-header-row *cdkHeaderRowDef="cdkTableColumns" ></cdk-header-row>
-  <cdk-row *cdkRowDef="let row; columns: cdkTableColumns;"></cdk-row>
+  <cdk-header-row *cdkHeaderRowDef="tableColumns" ></cdk-header-row>
+  <cdk-row *cdkRowDef="let row; columns: tableColumns;"></cdk-row>
 </cdk-table>
+
+<h2>Material Table</h2>
+
+<md-table [dataSource]="tableDataSource">
+  <ng-container cdkColumnDef="userId">
+    <md-header-cell *cdkHeaderCellDef>ID</md-header-cell>
+    <md-cell *cdkCellDef="let row"> {{row.userId}} </md-cell>
+  </ng-container>
+
+  <md-header-row *cdkHeaderRowDef="tableColumns"></md-header-row>
+  <md-row *cdkRowDef="let row; columns: tableColumns;"></md-row>
+</md-table>

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -27,6 +27,7 @@ import {
   MdSlideToggleModule,
   MdSnackBarModule,
   MdSortModule,
+  MdTableModule,
   MdTabsModule,
   MdToolbarModule,
   MdTooltipModule,
@@ -45,11 +46,11 @@ import 'rxjs/add/observable/of';
 })
 export class KitchenSink {
 
-  /** List of columns for the CDK table. */
-  cdkTableColumns = ['userId'];
+  /** List of columns for the CDK and Material table. */
+  tableColumns = ['userId'];
 
-  /** Data source for the CDK table. */
-  cdkTableDataSource: DataSource<any> = {
+  /** Data source for the CDK and Material table. */
+  tableDataSource: DataSource<any> = {
     connect: () => Observable.of([
       { userId: 1 },
       { userId: 2 }
@@ -93,6 +94,7 @@ export class KitchenSink {
     MdTooltipModule,
     MdExpansionModule,
     MdSortModule,
+    MdTableModule,
 
     // CDK Modules
     CdkTableModule


### PR DESCRIPTION
* Adds the md-table component to the universal app. This means that it will be verified by the prerender task on the CI.