### PR TITLE
chore(a11y): fix up cdk-visually-hidden class

### DIFF
--- a/src/lib/core/a11y/_a11y.scss
+++ b/src/lib/core/a11y/_a11y.scss
@@ -7,7 +7,6 @@
     overflow: hidden;
     padding: 0;
     position: absolute;
-    text-transform: none;
     width: 1px;
   }
 }


### PR DESCRIPTION
This commit removes the redundant `text-transform` property from the
`cdk-visually-hidden` css class to conform with the *standard* concept
to visually hide content for accessibility.

**This is a non-breaking change.**

See also this [material2 commit discussion](https://github.com/angular/material2/commit/e99da663f74cc43e294eda1655114839aca5fda4#commitcomment-17523137) and this [talk of Accessible JavasScript](http://marcysutton.github.io/accessible-javascript/#/15) by @marcysutton.