### PR TITLE
fix(select): prevent clicks on hidden placeholder

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -9,8 +9,8 @@
     class="mat-select-placeholder"
     [class.mat-floating-placeholder]="_hasValue()"
     [@transformPlaceholder]="_getPlaceholderAnimationState()"
-    [style.opacity]="_getPlaceholderOpacity()"
-    [style.width.px]="_selectedValueWidth"> {{ placeholder }} </span>
+    [class.mat-select-placeholder-hidden]="_getPlaceholderVisibility()"
+    [style.width.px]="_selectedValueWidth">{{ placeholder }}</span>
 
   <span class="mat-select-value" *ngIf="_hasValue()">
     <span class="mat-select-value-text" [ngSwitch]="!!customTrigger">

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -80,6 +80,11 @@ $mat-select-trigger-underline-height: 1px !default;
   }
 }
 
+.mat-select-placeholder-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .mat-select-value {
   position: absolute;
   max-width: calc(100% - #{($mat-select-arrow-size + $mat-select-arrow-margin) * 2});

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2202,13 +2202,13 @@ describe('MdSelect', () => {
       fixture.componentInstance.floatPlaceholder = 'never';
       fixture.detectChanges();
 
-      expect(placeholder.style.opacity).toBe('1');
+      expect(placeholder.classList).not.toContain('mat-select-placeholder-hidden');
       expect(fixture.componentInstance.select._getPlaceholderAnimationState()).toBeFalsy();
 
       fixture.componentInstance.control.setValue('pizza-1');
       fixture.detectChanges();
 
-      expect(placeholder.style.opacity).toBe('0');
+      expect(placeholder.classList).toContain('mat-select-placeholder-hidden');
       expect(fixture.componentInstance.select._getPlaceholderAnimationState()).toBeFalsy();
     });
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -948,10 +948,10 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   }
 
   /**
-   * Determines the CSS `opacity` of the placeholder element.
+   * Determines whether the select's placeholder should be visible.
    */
-  _getPlaceholderOpacity(): string {
-    return (this.floatPlaceholder !== 'never' || this._selectionModel.isEmpty()) ? '1' : '0';
+  _getPlaceholderVisibility(): boolean {
+    return this.floatPlaceholder === 'never' && this._selectionModel.hasValue();
   }
 
   /** Returns the aria-label of the select component. */


### PR DESCRIPTION
Fixes being able to click on the placeholder when there's a value and `floatPlaceholder="never"`.

Fixes #6400.