### PR TITLE
fix(autocomplete): don't darken select option

### DIFF
--- a/src/lib/core/option/_option-theme.scss
+++ b/src/lib/core/option/_option-theme.scss
@@ -30,7 +30,7 @@
 
     // In multiple mode there is a checkbox to show that the option is selected.
     &.mat-selected:not(.mat-option-multiple) {
-      background: mat-color($background, hover, 0.12);
+      background: mat-color($background, hover);
     }
 
     &.mat-active {

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -52,6 +52,12 @@
     color: mat-color($foreground, text);
   }
 
+  .mat-select-panel {
+    .mat-option.mat-selected:not(.mat-option-multiple) {
+      background: mat-color($background, hover, 0.12);
+    }
+  }
+
   .mat-select:focus:not(.mat-select-disabled) {
     &.mat-primary {
       @include _mat-select-inner-content-theme($primary);


### PR DESCRIPTION
Scopes the darkening of selected options only to `md-select`.

Fixes #6407.