### PR TITLE
chore(demo): fix demo app reference to overlay

### DIFF
--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -32,7 +32,7 @@ System.config({
     '@angular/cdk/coercion': 'dist/bundles/cdk-coercion.umd.js',
     '@angular/cdk/keycodes': 'dist/bundles/cdk-keycodes.umd.js',
     '@angular/cdk/observers': 'dist/bundles/cdk-observers.umd.js',
-    '@angular/cdk/overlay': 'dist/bundles/cdk-overlay-content.umd.js',
+    '@angular/cdk/overlay': 'dist/bundles/cdk-overlay.umd.js',
     '@angular/cdk/platform': 'dist/bundles/cdk-platform.umd.js',
     '@angular/cdk/portal': 'dist/bundles/cdk-portal.umd.js',
     '@angular/cdk/rxjs': 'dist/bundles/cdk-rxjs.umd.js',


### PR DESCRIPTION
Fixes typo in the demo app is referencing the wrong overlay module...

```
'@angular/cdk/overlay': 'dist/bundles/cdk-overlay-content.umd.js',
```

where it should be referencing:

```
'@angular/cdk/overlay': 'dist/bundles/cdk-overlay.umd.js',
```