### PR TITLE
refactor: remove usages of `if in` checks

### DIFF
--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -145,7 +145,7 @@ export class MdOption {
   focus(): void {
     const element = this._getHostElement();
 
-    if ('focus' in element) {
+    if (typeof element.focus === 'function') {
       element.focus();
     }
   }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -278,7 +278,9 @@ export class MdDatepicker<D> implements OnDestroy {
     if (this._calendarPortal && this._calendarPortal.isAttached) {
       this._calendarPortal.detach();
     }
-    if (this._focusedElementBeforeOpen && 'focus' in this._focusedElementBeforeOpen) {
+    if (this._focusedElementBeforeOpen &&
+      typeof this._focusedElementBeforeOpen.focus === 'function') {
+
       this._focusedElementBeforeOpen.focus();
       this._focusedElementBeforeOpen = null;
     }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -150,7 +150,7 @@ export class MdDialogContainer extends BasePortalHost {
     const toFocus = this._elementFocusedBeforeDialogWasOpened;
 
     // We need the extra check, because IE can set the `activeElement` to null in some cases.
-    if (toFocus && 'focus' in toFocus) {
+    if (toFocus && typeof toFocus.focus === 'function') {
       toFocus.focus();
     }
 

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -699,7 +699,7 @@ describe('MdSlideToggle with forms', () => {
     }));
 
     it('should prevent the form from submit when being required', () => {
-      if ('reportValidity' in inputElement === false) {
+      if (typeof (inputElement as any).reportValidity === 'undefined') {
         // If the browser does not report the validity then the tests will break.
         // e.g Safari 8 on Mobile.
         return;


### PR DESCRIPTION
This is something that came up in https://github.com/angular/material2/pull/2907#discussion_r130968388. We shouldn't be using the `if ('someString' in obj)` checks, because they can be broken by minifiers that rename class members.