### PR TITLE
fix(list-key-manager): typehead not handling non-English input

### DIFF
--- a/src/cdk/a11y/list-key-manager.spec.ts
+++ b/src/cdk/a11y/list-key-manager.spec.ts
@@ -408,9 +408,9 @@ describe('Key managers', () => {
       });
 
       it('should debounce the input key presses', fakeAsync(() => {
-        keyManager.onKeydown(createKeyboardEvent('keydown', 79)); // types "o"
-        keyManager.onKeydown(createKeyboardEvent('keydown', 78)); // types "n"
-        keyManager.onKeydown(createKeyboardEvent('keydown', 69)); // types "e"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 79, undefined, 'o')); // types "o"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 78, undefined, 'n')); // types "n"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 69, undefined, 'e')); // types "e"
 
         expect(keyManager.activeItem).not.toBe(itemList.items[0]);
 
@@ -420,7 +420,7 @@ describe('Key managers', () => {
       }));
 
       it('should focus the first item that starts with a letter', fakeAsync(() => {
-        keyManager.onKeydown(createKeyboardEvent('keydown', 84)); // types "t"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 84, undefined, 't')); // types "t"
 
         tick(debounceInterval);
 
@@ -428,8 +428,8 @@ describe('Key managers', () => {
       }));
 
       it('should focus the first item that starts with sequence of letters', fakeAsync(() => {
-        keyManager.onKeydown(createKeyboardEvent('keydown', 84)); // types "t"
-        keyManager.onKeydown(createKeyboardEvent('keydown', 72)); // types "h"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 84, undefined, 't')); // types "t"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 72, undefined, 'h')); // types "h"
 
         tick(debounceInterval);
 
@@ -437,13 +437,28 @@ describe('Key managers', () => {
       }));
 
       it('should cancel any pending timers if a navigation key is pressed', fakeAsync(() => {
-        keyManager.onKeydown(createKeyboardEvent('keydown', 84)); // types "t"
-        keyManager.onKeydown(createKeyboardEvent('keydown', 72)); // types "h"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 84, undefined, 't')); // types "t"
+        keyManager.onKeydown(createKeyboardEvent('keydown', 72, undefined, 'h')); // types "h"
         keyManager.onKeydown(fakeKeyEvents.downArrow);
 
         tick(debounceInterval);
 
         expect(keyManager.activeItem).toBe(itemList.items[0]);
+      }));
+
+      it('should handle non-English input', fakeAsync(() => {
+        itemList.items = [
+          new FakeFocusable('едно'),
+          new FakeFocusable('две'),
+          new FakeFocusable('три')
+        ];
+
+        const keyboardEvent = createKeyboardEvent('keydown', 68, undefined, 'д');
+
+        keyManager.onKeydown(keyboardEvent); // types "д"
+        tick(debounceInterval);
+
+        expect(keyManager.activeItem).toBe(itemList.items[1]);
       }));
 
     });

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -30,7 +30,7 @@ export function createMouseEvent(type: string, x = 0, y = 0) {
 }
 
 /** Dispatches a keydown event from an element. */
-export function createKeyboardEvent(type: string, keyCode: number, target?: Element) {
+export function createKeyboardEvent(type: string, keyCode: number, target?: Element, key?: string) {
   let event = document.createEvent('KeyboardEvent') as any;
   // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
   let initEventFn = (event.initKeyEvent || event.initKeyboardEvent).bind(event);
@@ -42,6 +42,7 @@ export function createKeyboardEvent(type: string, keyCode: number, target?: Elem
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
   Object.defineProperties(event, {
     keyCode: { get: () => keyCode },
+    key: { get: () => key },
     target: { get: () => target }
   });
 


### PR DESCRIPTION
Since `String.fromCharCode` only maps the key codes to their English letter counterparts, the typeahead option in the `ListKeyManager` won't work for non-English input. These changes switch to using `event.key` and falling back to using `keyCode` and `fromCharCode`.