### PR TITLE
chore(overlay): refactor clipping detection calculation to its own file

### DIFF
--- a/src/cdk/overlay/position/connected-position.ts
+++ b/src/cdk/overlay/position/connected-position.ts
@@ -64,7 +64,7 @@ export class ConnectionPositionPair {
  *  |                        |
  *  --------------------------
  */
-export class ScrollableViewProperties {
+export class ScrollingVisibility {
   isOriginClipped: boolean;
   isOriginOutsideView: boolean;
   isOverlayClipped: boolean;
@@ -74,5 +74,5 @@ export class ScrollableViewProperties {
 /** The change event emitted by the strategy when a fallback position is used. */
 export class ConnectedOverlayPositionChange {
   constructor(public connectionPair: ConnectionPositionPair,
-              @Optional() public scrollableViewProperties: ScrollableViewProperties) {}
+              @Optional() public scrollableViewProperties: ScrollingVisibility) {}
 }

--- a/src/cdk/overlay/position/scroll-clip.ts
+++ b/src/cdk/overlay/position/scroll-clip.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO(jelbourn): move this to live with the rest of the scrolling code
+// TODO(jelbourn): someday replace this with IntersectionObservers
+
+/**
+ * Gets whether an element is scrolled outside of view by any of its parent scrolling containers.
+ * @param element Dimensions of the element (from getBoundingClientRect)
+ * @param scrollContainers Dimensions of element's scrolling containers (from getBoundingClientRect)
+ * @returns Whether the element is scrolled out of view
+ * @docs-private
+ */
+export function isElementScrolledOutsideView(element: ClientRect, scrollContainers: ClientRect[]) {
+  return scrollContainers.some(containerBounds => {
+    const outsideAbove = element.bottom < containerBounds.top;
+    const outsideBelow = element.top > containerBounds.bottom;
+    const outsideLeft = element.right < containerBounds.left;
+    const outsideRight = element.left > containerBounds.right;
+
+    return outsideAbove || outsideBelow || outsideLeft || outsideRight;
+  });
+}
+
+
+/**
+ * Gets whether an element is clipped by any of its scrolling containers.
+ * @param element Dimensions of the element (from getBoundingClientRect)
+ * @param scrollContainers Dimensions of element's scrolling containers (from getBoundingClientRect)
+ * @returns Whether the element is clipped
+ * @docs-private
+ */
+export function isElementClippedByScrolling(element: ClientRect, scrollContainers: ClientRect[]) {
+  return scrollContainers.some(scrollContainerRect => {
+    const clippedAbove = element.top < scrollContainerRect.top;
+    const clippedBelow = element.bottom > scrollContainerRect.bottom;
+    const clippedLeft = element.left < scrollContainerRect.left;
+    const clippedRight = element.right > scrollContainerRect.right;
+
+    return clippedAbove || clippedBelow || clippedLeft || clippedRight;
+  });
+}


### PR DESCRIPTION
Moving these functions out mainly to reduce the amount of code that goes in the position strategy