### PR TITLE
chore: fix nested menu test failure

### DIFF
--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -974,7 +974,7 @@ describe('MdMenu', () => {
           .not.toContain('mat-elevation-z3', 'Expected no stacked elevation.');
     });
 
-    it('should close all of the menus when the root is closed programmatically', () => {
+    it('should close all of the menus when the root is closed programmatically', fakeAsync(() => {
       compileTestComponent();
       instance.rootTrigger.openMenu();
       fixture.detectChanges();
@@ -991,9 +991,10 @@ describe('MdMenu', () => {
 
       instance.rootTrigger.closeMenu();
       fixture.detectChanges();
+      tick(500);
 
       expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(0, 'Expected no open menus');
-    });
+    }));
 
 
   });


### PR DESCRIPTION
Fixes a test failure that seems to have slipped through the cracks in between merging a fix and the update to Angular 4.3,