### PR TITLE
revert: chore(dialog): switch to OnPush change detection (#6287)"

### DIFF
--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -17,7 +17,6 @@ import {
   ChangeDetectorRef,
   ViewChild,
   ViewEncapsulation,
-  ChangeDetectionStrategy,
 } from '@angular/core';
 import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
 import {DOCUMENT} from '@angular/platform-browser';
@@ -51,7 +50,6 @@ export function throwMdDialogContentAlreadyAttachedError() {
   templateUrl: 'dialog-container.html',
   styleUrls: ['dialog.css'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('slideDialog', [
       // Note: The `enter` animation doesn't transition to something like `translate3d(0, 0, 0)
@@ -119,13 +117,7 @@ export class MdDialogContainer extends BasePortalHost {
     }
 
     this._savePreviouslyFocusedElement();
-
-    const componentRef = this._portalHost.attachComponentPortal(portal);
-
-    // Ensure that the initial view change are picked up.
-    componentRef.changeDetectorRef.markForCheck();
-
-    return componentRef;
+    return this._portalHost.attachComponentPortal(portal);
   }
 
   /**
@@ -138,12 +130,7 @@ export class MdDialogContainer extends BasePortalHost {
     }
 
     this._savePreviouslyFocusedElement();
-
-    const locals = this._portalHost.attachTemplatePortal(portal);
-
-    this._changeDetectorRef.markForCheck();
-
-    return locals;
+    return this._portalHost.attachTemplatePortal(portal);
   }
 
   /** Moves the focus inside the focus trap. */


### PR DESCRIPTION
This reverts commit 72360e2b11a9b13966da821893a32bc20422848c.

In discussion with @jelbourn and seeing tests fail internally. Considering that dialog should not be OnPush since it does not by default have the triggering view container ref to detect changes. Likely will see pushback from community on complexity of seeing changes occur in the dialog.