### PR TITLE
Fix unnecessary mat-tooltip message whitespace

### DIFF
--- a/src/lib/tooltip/tooltip.html
+++ b/src/lib/tooltip/tooltip.html
@@ -2,6 +2,4 @@
      [ngClass]="tooltipClass"
      [style.transform-origin]="_transformOrigin"
      [@state]="_visibility"
-     (@state.done)="_afterVisibilityAnimation($event)">
-  {{message}}
-</div>
+     (@state.done)="_afterVisibilityAnimation($event)">{{message}}</div>


### PR DESCRIPTION
This specifically addresses:
https://github.com/angular/material2/issues/3389#issuecomment-315534624

We ran into this just now.  We need a multi-line tooltip but using the suggested workaround results in "\n  " being displayed before the text.