### PR TITLE
fix(paginator): add type="button" to next/prev buttons

### DIFF
--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -20,7 +20,7 @@
   {{_intl.getRangeLabel(pageIndex, pageSize, length)}}
 </div>
 
-<button md-icon-button
+<button md-icon-button type="button" 
         class="mat-paginator-navigation-previous"
         (click)="previousPage()"
         [attr.aria-label]="_intl.previousPageLabel"
@@ -29,7 +29,7 @@
         [disabled]="!hasPreviousPage()">
   <div class="mat-paginator-increment"></div>
 </button>
-<button md-icon-button
+<button md-icon-button type="button" 
         class="mat-paginator-navigation-next"
         (click)="nextPage()"
         [attr.aria-label]="_intl.nextPageLabel"


### PR DESCRIPTION
Adding type="button" to previous/next buttons prevents submitting the form, if the paginator control is added to a form.