### PR TITLE
fix(chips): invalid aria-selected value for non-selectable chip

### DIFF
--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -194,13 +194,8 @@ describe('Chips', () => {
           expect(testComponent.chipSelect).not.toHaveBeenCalled();
         });
 
-        it('should have empty aria-selected', () => {
-          expect(chipNativeElement.getAttribute('aria-selected')).toBeFalsy();
-
-          testComponent.selectable = true;
-          fixture.detectChanges();
-
-          expect(chipNativeElement.getAttribute('aria-selected')).toBe('false');
+        it('should not have the aria-selected attribute', () => {
+          expect(chipNativeElement.hasAttribute('aria-selected')).toBe(false);
         });
       });
 

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -121,8 +121,8 @@ export class MdChip extends _MdChipMixinBase implements FocusableOption, OnDestr
   /** Emitted when the chip is destroyed. */
   @Output() destroy = new EventEmitter<MdChipEvent>();
 
-  get ariaSelected(): string {
-    return this.selectable ? this.selected.toString() : '';
+  get ariaSelected(): string | null {
+    return this.selectable ? this.selected.toString() : null;
   }
 
   constructor(renderer: Renderer2, elementRef: ElementRef) {


### PR DESCRIPTION
Currently the `aria-selected` value for a non-selectable chip is set to an empty string, however the allowed values for the attribute are `true` and `false`. These changes remove the `aria-selected` attribute if the chip is not selectable.