### PR TITLE
fix(expansion-panel): remove margin from top and bottom panels in accordion

### DIFF
--- a/src/lib/expansion/expansion-panel.scss
+++ b/src/lib/expansion/expansion-panel.scss
@@ -23,6 +23,14 @@
 
 .mat-expansion-panel-spacing {
   margin: 16px 0;
+
+  .mat-accordion &:first-child {
+    margin-top: 0;
+  }
+
+  .mat-accordion &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .mat-action-row {


### PR DESCRIPTION
Currently when the top-most or bottom-most expansion panels in an accordion are opened, they will add a top/bottom margin, causing them to shift away from the accordion edge. Since we try to avoid adding margins to the outside of components in general, these changes remove the top/bottom margins for the end panels.