### PR TITLE
fix(select): error if triggerValue is accessed from an empty select

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2176,6 +2176,13 @@ describe('MdSelect', () => {
         expect(() => fixture.detectChanges()).not.toThrow();
       }));
 
+
+    it('should not throw when the triggerValue is accessed when there is no selected value', () => {
+      const fixture = TestBed.createComponent(BasicSelect);
+      fixture.detectChanges();
+
+      expect(() => fixture.componentInstance.select.triggerValue).not.toThrow();
+    });
   });
 
   describe('change event', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -547,8 +547,12 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
 
   /** The value displayed in the trigger. */
   get triggerValue(): string {
+    if (!this._selectionModel || this._selectionModel.isEmpty()) {
+      return '';
+    }
+
     if (this._multiple) {
-      let selectedOptions = this._selectionModel.selected.map(option => option.viewValue);
+      const selectedOptions = this._selectionModel.selected.map(option => option.viewValue);
 
       if (this._isRtl()) {
         selectedOptions.reverse();


### PR DESCRIPTION
Fixes an error that was thrown if the `triggerValue` is accessed on a `md-select` that doesn't have a selected value, because the `triggerValue` assumed that there would always be a value.