### PR TITLE
fix(grid-list): figure not expanding to full width

### DIFF
--- a/src/lib/grid-list/grid-list.scss
+++ b/src/lib/grid-list/grid-list.scss
@@ -15,13 +15,13 @@ $mat-grid-list-text-padding: 16px;
 }
 
 .mat-grid-tile {
-  @include mat-fill;
   display: block;
+  position: absolute;
   overflow: hidden;
 
   .mat-figure {
+    @include mat-fill;
     display: flex;
-    position: absolute;
 
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fixes the grid list tile not expanding completely.

Fixes #6586. 

For reference:
![angular_material_-_google_chrome_2017-08-21_22-50-20](https://user-images.githubusercontent.com/4450522/29537745-245cbf8c-86c3-11e7-8191-cf624fceedd8.png)
