### PR TITLE
fix: deprecate CoreModule

### DIFF
--- a/src/demo-app/demo-material-module.ts
+++ b/src/demo-app/demo-material-module.ts
@@ -6,8 +6,6 @@ import {
   MdCardModule,
   MdCheckboxModule,
   MdChipsModule,
-  MdCoreModule,
-  MdTableModule,
   MdDatepickerModule,
   MdDialogModule,
   MdExpansionModule,
@@ -29,12 +27,19 @@ import {
   MdSlideToggleModule,
   MdSnackBarModule,
   MdSortModule,
+  MdTableModule,
   MdTabsModule,
   MdToolbarModule,
   MdTooltipModule,
   StyleModule
 } from '@angular/material';
 import {CdkTableModule} from '@angular/cdk/table';
+import {A11yModule} from '@angular/cdk/a11y';
+import {BidiModule} from '@angular/cdk/bidi';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {PlatformModule} from '@angular/cdk/platform';
+import {ObserversModule} from '@angular/cdk/observers';
+import {PortalModule} from '@angular/cdk/portal';
 
 /**
  * NgModule that includes all Material modules that are required to serve the demo-app.
@@ -57,7 +62,6 @@ import {CdkTableModule} from '@angular/cdk/table';
     MdInputModule,
     MdListModule,
     MdMenuModule,
-    MdCoreModule,
     MdPaginatorModule,
     MdProgressBarModule,
     MdProgressSpinnerModule,
@@ -74,7 +78,13 @@ import {CdkTableModule} from '@angular/cdk/table';
     MdTooltipModule,
     MdNativeDateModule,
     CdkTableModule,
-    StyleModule
+    StyleModule,
+    A11yModule,
+    BidiModule,
+    ObserversModule,
+    OverlayModule,
+    PlatformModule,
+    PortalModule,
   ]
 })
 export class DemoMaterialModule {}

--- a/src/lib/core/core.ts
+++ b/src/lib/core/core.ts
@@ -128,6 +128,7 @@ export {
   showOnDirtyErrorStateMatcher
 } from './error/error-options';
 
+/** @deprecated */
 @NgModule({
   imports: [
     MdLineModule,


### PR DESCRIPTION
Since most of this functionality has been moved into `@angular/cdk`, it
no longer makes sense to blob it all together in one NgModule inside
`@angular/material`.