### PR TITLE
compat(table): add mat-compatible rows

### DIFF
--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -10,7 +10,7 @@ import {NgModule} from '@angular/core';
 import {MdTable} from './table';
 import {CdkTableModule} from '@angular/cdk/table';
 import {MdCell, MdHeaderCell, MdCellDef, MdHeaderCellDef, MdColumnDef} from './cell';
-import {MdHeaderRow, MdRow, MdHeaderRowDef, MdRowDef} from './row';
+import {MdHeaderRow, MdRow, MdHeaderRowDef, MdRowDef, MatHeaderRowDef, MatRowDef} from './row';
 import {CommonModule} from '@angular/common';
 import {MdCommonModule} from '../core';
 
@@ -22,9 +22,11 @@ export * from './row';
   imports: [CdkTableModule, CommonModule, MdCommonModule],
   exports: [MdTable, MdCellDef, MdHeaderCellDef, MdColumnDef,
     MdHeaderRowDef, MdRowDef,
-    MdHeaderCell, MdCell, MdHeaderRow, MdRow],
+    MdHeaderCell, MdCell, MdHeaderRow, MdRow,
+    MatHeaderRowDef, MatRowDef],
   declarations: [MdTable, MdCellDef, MdHeaderCellDef, MdColumnDef,
     MdHeaderRowDef, MdRowDef,
-    MdHeaderCell, MdCell, MdHeaderRow, MdRow],
+    MdHeaderCell, MdCell, MdHeaderRow, MdRow,
+    MatHeaderRowDef, MatRowDef],
 })
 export class MdTableModule {}

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -26,11 +26,19 @@ export const _MdRow = CdkRow;
  * Captures the header row's template and other header properties such as the columns to display.
  */
 @Directive({
-  selector: '[mdHeaderRowDef], [matHeaderRowDef]',
+  selector: '[mdHeaderRowDef]',
   providers: [{provide: CdkHeaderRowDef, useExisting: MdHeaderRowDef}],
   inputs: ['columns: mdHeaderRowDef'],
 })
 export class MdHeaderRowDef extends _MdHeaderRowDef { }
+
+/** Mat-compatible version of MdHeaderRowDef */
+@Directive({
+  selector: '[matHeaderRowDef]',
+  providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
+  inputs: ['columns: matHeaderRowDef'],
+})
+export class MatHeaderRowDef extends _MdHeaderRowDef { }
 
 /**
  * Data row definition for the md-table.
@@ -42,6 +50,14 @@ export class MdHeaderRowDef extends _MdHeaderRowDef { }
   inputs: ['columns: mdRowDefColumns'],
 })
 export class MdRowDef extends _MdCdkRowDef { }
+
+/** Mat-compatible version of MdRowDef */
+@Directive({
+  selector: '[matRowDef]',
+  providers: [{provide: CdkRowDef, useExisting: MatRowDef}],
+  inputs: ['columns: matRowDefColumns'],
+})
+export class MatRowDef extends _MdCdkRowDef { }
 
 /** Header template container that contains the cell outlet. Adds the right class and role. */
 @Component({

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -45,7 +45,7 @@ export class MatHeaderRowDef extends _MdHeaderRowDef { }
  * Captures the header row's template and other row properties such as the columns to display.
  */
 @Directive({
-  selector: '[mdRowDef], [matRowDef]',
+  selector: '[mdRowDef]',
   providers: [{provide: CdkRowDef, useExisting: MdRowDef}],
   inputs: ['columns: mdRowDefColumns'],
 })


### PR DESCRIPTION
Adds support for using `matHeaderRowDef` and `matRowDef` - currently doesn't work since columns aren't recognized.