### PR TITLE
compat(sort): remove md prefix from sort change event

### DIFF
--- a/src/demo-app/table/person-data-source.ts
+++ b/src/demo-app/table/person-data-source.ts
@@ -15,7 +15,7 @@ export class PersonDataSource extends DataSource<any> {
   connect(): Observable<UserData[]> {
     const displayDataChanges = [
       this._paginator.page,
-      this._sort.mdSortChange,
+      this._sort.sortChange,
       this._peopleDatabase.dataChange
     ];
     return Observable.merge(...displayDataChanges).map(() => {

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -76,7 +76,7 @@ export class MdSortHeader implements MdSortable {
       throw getMdSortHeaderNotContainedWithinMdSortError();
     }
 
-    this._rerenderSubscription = merge(_sort.mdSortChange, _intl.changes).subscribe(() => {
+    this._rerenderSubscription = merge(_sort.sortChange, _intl.changes).subscribe(() => {
       changeDetectorRef.markForCheck();
     });
   }

--- a/src/lib/sort/sort.md
+++ b/src/lib/sort/sort.md
@@ -11,7 +11,7 @@ parent element with the `mdSort` directive, which will emit a `sortChange` event
  triggers sorting on the header.
 
 Users can trigger the sort header through a mouse click or keyboard action. When this happens, the
-`mdSort` will emit an `sortChange` event that contains the ID of the header triggered and the
+`mdSort` will emit a `sortChange` event that contains the ID of the header triggered and the
 direction to sort (`asc` or `desc`).
 
 #### Changing the sort order

--- a/src/lib/sort/sort.md
+++ b/src/lib/sort/sort.md
@@ -7,11 +7,11 @@ to tabular data.
 
 To add sorting behavior and styling to a set of table headers, add the `<md-sort-header>` component
 to each header and provide an `id` that will identify it. These headers should be contained within a
-parent element with the `mdSort` directive, which will emit an `mdSortChange` event when the user
+parent element with the `mdSort` directive, which will emit a `sortChange` event when the user
  triggers sorting on the header.
 
 Users can trigger the sort header through a mouse click or keyboard action. When this happens, the
-`mdSort` will emit an `mdSortChange` event that contains the ID of the header triggered and the
+`mdSort` will emit an `sortChange` event that contains the ID of the header triggered and the
 direction to sort (`asc` or `desc`).
 
 #### Changing the sort order

--- a/src/lib/sort/sort.spec.ts
+++ b/src/lib/sort/sort.spec.ts
@@ -198,11 +198,11 @@ function testSingleColumnSortDirectionSequence(fixture: ComponentFixture<SimpleM
          [mdSortStart]="start"
          [mdSortDirection]="direction"
          [mdSortDisableClear]="disableClear"
-         (mdSortChange)="latestSortEvent = $event">
-      <div id="defaultSortHeaderA" #defaultSortHeaderA md-sort-header="defaultSortHeaderA"> A </div>
-      <div id="defaultSortHeaderB" #defaultSortHeaderB md-sort-header="defaultSortHeaderB"> B </div>
-      <div id="overrideStart" md-sort-header="overrideStart" start="desc"> D </div>
-      <div id="overrideDisableClear" md-sort-header="overrideDisableClear" disableClear> E </div>
+         (sortChange)="latestSortEvent = $event">
+      <div id="defaultSortHeaderA" #defaultSortHeaderA md-sort-header="defaultSortHeaderA"> A</div>
+      <div id="defaultSortHeaderB" #defaultSortHeaderB md-sort-header="defaultSortHeaderB"> B</div>
+      <div id="overrideStart" md-sort-header="overrideStart" start="desc"> D</div>
+      <div id="overrideDisableClear" md-sort-header="overrideDisableClear" disableClear> E</div>
     </div>
   `
 })

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -72,7 +72,7 @@ export class MdSort {
   set _matSortDisableClear(v) { this.disableClear = v; }
 
   /** Event emitted when the user changes either the active sort or sort direction. */
-  @Output() mdSortChange = new EventEmitter<Sort>();
+  @Output() sortChange = new EventEmitter<Sort>();
 
   /**
    * Register function to be used by the contained MdSortables. Adds the MdSortable to the
@@ -106,7 +106,7 @@ export class MdSort {
       this.direction = this.getNextSortDirection(sortable);
     }
 
-    this.mdSortChange.next({active: this.active, direction: this.direction});
+    this.sortChange.next({active: this.active, direction: this.direction});
   }
 
   /** Returns the next sort direction of the active sortable, checking for potential overrides. */

--- a/src/material-examples/sort-overview/sort-overview-example.html
+++ b/src/material-examples/sort-overview/sort-overview-example.html
@@ -1,4 +1,4 @@
-<table mdSort (mdSortChange)="sortData($event)">
+<table mdSort (sortChange)="sortData($event)">
   <tr>
     <th md-sort-header="name">Dessert (100g)</th>
     <th md-sort-header="calories">Calories</th>

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -83,12 +83,12 @@ export class ExampleDataSource extends DataSource<GithubIssue> {
   /** Connect function called by the table to retrieve one stream containing the data to render. */
   connect(): Observable<GithubIssue[]> {
     const displayDataChanges = [
-      this.sort.mdSortChange,
+      this.sort.sortChange,
       this.paginator.page
     ];
 
     // If the user changes the sort order, reset back to the first page.
-    this.sort.mdSortChange.subscribe(() => this.paginator.pageIndex = 0);
+    this.sort.sortChange.subscribe(() => this.paginator.pageIndex = 0);
 
     return Observable.merge(...displayDataChanges)
       .startWith(null)

--- a/src/material-examples/table-overview/table-overview-example.ts
+++ b/src/material-examples/table-overview/table-overview-example.ts
@@ -140,7 +140,7 @@ export class ExampleDataSource extends DataSource<any> {
     // Listen for any changes in the base data, sorting, filtering, or pagination
     const displayDataChanges = [
       this._exampleDatabase.dataChange,
-      this._sort.mdSortChange,
+      this._sort.sortChange,
       this._filterChange,
       this._paginator.page,
     ];

--- a/src/material-examples/table-sorting/table-sorting-example.ts
+++ b/src/material-examples/table-sorting/table-sorting-example.ts
@@ -90,7 +90,7 @@ export class ExampleDataSource extends DataSource<any> {
   connect(): Observable<UserData[]> {
     const displayDataChanges = [
       this._exampleDatabase.dataChange,
-      this._sort.mdSortChange,
+      this._sort.sortChange,
     ];
 
     return Observable.merge(...displayDataChanges).map(() => {


### PR DESCRIPTION
BREAKING CHANGE: The sort event is renamed from `mdSortChange` to `sortChange`