### PR TITLE
build: shorter wait delay for tunnels

### DIFF
--- a/scripts/browserstack/wait-tunnel.sh
+++ b/scripts/browserstack/wait-tunnel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TUNNEL_LOG="$LOGS_DIR/browserstack-tunnel.log"
-WAIT_DELAY=60
+WAIT_DELAY=30
 
 # Method that prints the logfile output of the browserstack tunnel.
 printLog() {

--- a/scripts/ci/sources/tunnel.sh
+++ b/scripts/ci/sources/tunnel.sh
@@ -4,7 +4,7 @@
 source ./scripts/ci/sources/retry-call.sh
 
 # Variable the specifies how often the wait script should be invoked if it fails.
-WAIT_RETRIES=1
+WAIT_RETRIES=2
 
 start_tunnel() {
   case "$MODE" in

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TUNNEL_LOG="$LOGS_DIR/saucelabs-tunnel.log"
-WAIT_DELAY=60
+WAIT_DELAY=30
 
 # Method that prints the logfile output of the saucelabs tunnel.
 printLog() {


### PR DESCRIPTION
Updates the wait delay for Browserstack and Saucelabs from 60 seconds to 30 seconds. Since the wait delay is now pretty short, a second retry can be also executed if necessary.