### PR TITLE
build: update saucelabs connector

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-TUNNEL_FILE="sc-4.4.8-linux.tar.gz"
+TUNNEL_FILE="sc-4.4.9-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 


### PR DESCRIPTION
* Manually update the saucelabs connector binary to the latest version (using https://saucelabs.com/downloads/sc-latest-linux.tar.gz still seems to refer to an old version)