### PR TITLE
fix(expansion-panel): dark theme header hover color

### DIFF
--- a/src/lib/expansion/_expansion-theme.scss
+++ b/src/lib/expansion/_expansion-theme.scss
@@ -15,11 +15,13 @@
     border-top-color: mat-color($foreground, divider);
   }
 
-  .mat-expansion-panel-header:not([aria-disabled='true']) {
-    &.cdk-keyboard-focused,
-    &.cdk-program-focused,
-    &:hover {
-      background: mat-color($background, hover);
+  .mat-expansion-panel:not(.mat-expanded) .mat-expansion-panel-header {
+    &:not([aria-disabled='true']) {
+      &.cdk-keyboard-focused,
+      &.cdk-program-focused,
+      &:hover {
+        background: mat-color($background, hover);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the expansion panel header hover effect not being disabled for dark themes.

For reference:
![angular_material_-_google_chrome_2017-08-23_22-37-42](https://user-images.githubusercontent.com/4450522/29637852-c203aeb0-8855-11e7-8cdf-694934833e8c.png)
