### PR TITLE
build: better caching of node modules in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
 
 cache:
   directories:
-    - $HOME/.npm
+    - ./node_modules/


### PR DESCRIPTION
Currently the global `.npm` cache folder will be stored in the Travis CI cache. This doesn't really help making the Travis jobs faster because all packages still need to be copied and it's not guaranteed that all packages are properly added to the `.npm` cache.

Directly caching the `node_modules/` folder should make normal Travis jobs run faster. The only downside here is that other `node_modules/` directories inside of the `tools/` won't be cached anymore. Those can be also added to the Travis cache, but it would then lead to a way bigger cache that needs to be downloaded in every Travis job.