### PR TITLE
build: use minimatch for no-view-encapsulation rule

### DIFF
--- a/tools/tslint-rules/noViewEncapsulationRule.js
+++ b/tools/tslint-rules/noViewEncapsulationRule.js
@@ -1,4 +1,7 @@
 const Lint = require('tslint');
+const path = require('path');
+const minimatch = require('minimatch');
+
 const ERROR_MESSAGE = 'Components must turn off view encapsulation.';
 
 // TODO(crisbeto): combine this with the OnPush rule when it gets in.
@@ -17,11 +20,14 @@ class Walker extends Lint.RuleWalker {
   constructor(file, options) {
     super(...arguments);
 
-    // Whitelist with regular expressions to use when determining which files to lint.
-    const whitelist = options.ruleArguments;
+    // Globs that are used to determine which files to lint.
+    const fileGlobs = options.ruleArguments || [];
+
+    // Relative path for the current TypeScript source file.
+    const relativeFilePath = path.relative(process.cwd(), file.fileName);
 
     // Whether the file should be checked at all.
-    this._enabled = !whitelist.length || whitelist.some(p => new RegExp(p).test(file.fileName));
+    this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
   }
 
   visitClassDeclaration(node) {

--- a/tslint.json
+++ b/tslint.json
@@ -27,19 +27,9 @@
     "no-shadowed-variable": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
-    "no-exposed-todo": true,
     "member-access": [true, "no-public"],
     "no-debugger": true,
     "no-unused-variable": [true, {"ignore-pattern": "^_"}],
-    "no-rxjs-patch-imports": [
-      true,
-      "src/+(lib|cdk)/**/*.ts"
-    ],
-    "missing-rollup-globals": [
-      true,
-      "./tools/package-tools/rollup-globals.ts",
-      "src/+(lib|cdk|material-examples)/**/*.ts"
-    ],
     "one-line": [
       true,
       "check-catch",
@@ -79,10 +69,6 @@
       "check-type",
       "check-preblock"
     ],
-    "no-view-encapsulation": [
-      true,
-      "(lib|cdk)\/((?!spec.ts).)*.ts$"
-    ],
     // Bans jasmine helper functions that will prevent the CI from properly running tests.
     "ban": [
       true,
@@ -97,6 +83,26 @@
     "import-blacklist": [true, "rxjs"],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],
-    "require-license-banner": [true, "src/+(lib|cdk)/**/!(*.spec).ts"]
+
+    // Custom Rules
+
+    "no-exposed-todo": true,
+    "no-view-encapsulation": [
+      true,
+      "src/+(lib|cdk)/**/!(*.spec).ts"
+    ],
+    "require-license-banner": [
+      true,
+      "src/+(lib|cdk)/**/!(*.spec).ts"
+    ],
+    "no-rxjs-patch-imports": [
+      true,
+      "src/+(lib|cdk)/**/*.ts"
+    ],
+    "missing-rollup-globals": [
+      true,
+      "./tools/package-tools/rollup-globals.ts",
+      "src/+(lib|cdk|material-examples)/**/*.ts"
+    ]
   }
 }


### PR DESCRIPTION
* Replaces the Regular Expression file matching for the noViewEncapsulation rule with Minimatch. This makes the TSLint configuration more readable and is consistent with other custom rules.