### PR TITLE
build: stop building rxjs for closure compiler test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,6 +1760,12 @@
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true
     },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
     "clone-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
@@ -1775,6 +1781,17 @@
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -6452,13 +6469,13 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20170218.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20170218.0.0.tgz",
-      "integrity": "sha1-BZx/kc8cssGma0yV90X179D7S6Q=",
+      "version": "20170409.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20170409.0.0.tgz",
+      "integrity": "sha1-3Bvimp9+74YRNkUzsnG5+sdXyXA=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "vinyl": "1.2.0",
+        "vinyl": "2.1.0",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
@@ -16072,14 +16089,37 @@
       "dev": true
     },
     "vinyl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
+        "clone": "2.1.1",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.0.0",
+        "remove-trailing-separator": "1.0.2",
+        "replace-ext": "1.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "dev": true
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
+        }
       }
     },
     "vinyl-fs": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "firebase-tools": "^3.9.0",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",
-    "google-closure-compiler": "^20170218.0.0",
+    "google-closure-compiler": "20170409.0.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-clean-css": "^3.3.1",


### PR DESCRIPTION
For every Pull Request, a job that runs the Google Closure Compiler against the demo-app will be started. In the past Closure Compiler wasn't able to properly handle CommonJS packages from the node modules.

Now the Google Closure Compiler will be reconfigured to properly handle CommonJS packages (meaning that RxJS no longer needs to be built manually)