### PR TITLE
chore: missing router link in e2e app

### DIFF
--- a/e2e/components/card-e2e.spec.ts
+++ b/e2e/components/card-e2e.spec.ts
@@ -2,14 +2,14 @@ import {browser, by, element} from 'protractor';
 import {screenshot} from '../screenshot';
 
 describe('md-card', () => {
-  describe('card-fancy', () => {
-    beforeEach(() => browser.get('/card-fancy'));
 
-    it('should show a card', async () => {
-      const card = element(by.tagName('md-card'));
-      expect(card).toBeDefined();
+  beforeEach(() => browser.get('/cards'));
 
-      screenshot('fancy card example');
-    });
+  it('should show a card', async () => {
+    const card = element(by.tagName('md-card'));
+    expect(card).toBeDefined();
+
+    screenshot('fancy card example');
   });
+
 });

--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -3,6 +3,7 @@
 <md-nav-list *ngIf="showLinks">
   <a md-list-item [routerLink]="['block-scroll-strategy']">Block scroll strategy</a>
   <a md-list-item [routerLink]="['button']">Button</a>
+  <a md-list-item [routerLink]="['button-toggle']">Button Toggle</a>
   <a md-list-item [routerLink]="['checkbox']">Checkbox</a>
   <a md-list-item [routerLink]="['dialog']">Dialog</a>
   <a md-list-item [routerLink]="['fullscreen']">Fullscreen</a>
@@ -17,6 +18,8 @@
   <a md-list-item [routerLink]="['sidenav']">Sidenav</a>
   <a md-list-item [routerLink]="['slide-toggle']">Slide Toggle</a>
   <a md-list-item [routerLink]="['tabs']">Tabs</a>
+  <a md-list-item [routerLink]="['cards']">Cards</a>
+  <a md-list-item [routerLink]="['toolbar']">Toolbar</a>
 </md-nav-list>
 
 <main>

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -41,6 +41,6 @@ export const E2E_APP_ROUTES: Routes = [
   {path: 'sidenav', component: SidenavE2E},
   {path: 'slide-toggle', component: SlideToggleE2E},
   {path: 'tabs', component: BasicTabs},
-  {path: 'card-fancy', component: CardFancyExample},
+  {path: 'cards', component: CardFancyExample},
   {path: 'toolbar', component: ToolbarMultirowExample},
 ];


### PR DESCRIPTION
* Recently more examples have been added to the e2e-app. Those examples haven't been added to the nav bar yet.