### PR TITLE
fix(snack-bar): animation not starting for subsequent snack bars

### DIFF
--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -44,7 +44,7 @@ export class MdSnackBarRef<T> {
     this.containerInstance = containerInstance;
     // Dismiss snackbar on action.
     this.onAction().subscribe(() => this.dismiss());
-    containerInstance._onExit().subscribe(() => this._finishDismiss());
+    containerInstance._onExit.subscribe(() => this._finishDismiss());
   }
 
   /** Dismisses the snack bar. */
@@ -90,7 +90,7 @@ export class MdSnackBarRef<T> {
 
   /** Gets an observable that is notified when the snack bar has opened and appeared. */
   afterOpened(): Observable<void> {
-    return this.containerInstance._onEnter();
+    return this.containerInstance._onEnter;
   }
 
   /** Gets an observable that is notified when the snack bar action is called. */


### PR DESCRIPTION
Since the switch to OnPush change detection, opening a snack bar while another one is open, programmatically isn't guaranteed to actually show the second snack bar, because the user might not hit the zone (e.g. if it's through a timeout). These changes trigger change detection manually on open. I also got rid of a couple of redundant methods on the snack bar container.

Fixes #6222.

**Note:** It's tricky to write a unit test that captures this exact scenario, because all of the elements were already in the DOM, they just weren't being animated in. It also seems like the animations module wasn't setting the inline styles when I was running the unit tests.