### PR TITLE
fix(select): incorrect panel width when trigger is resized post initialization

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -189,15 +189,26 @@ describe('MdSelect', () => {
       });
     }));
 
-    it('should set the width of the overlay based on the trigger', async(() => {
+    it('should set the width of the overlay based on the trigger', fakeAsync(() => {
       trigger.style.width = '200px';
 
-      fixture.whenStable().then(() => {
-        trigger.click();
-        fixture.detectChanges();
-        const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-        expect(pane.style.minWidth).toBe('200px');
-      });
+      trigger.click();
+      fixture.detectChanges();
+      const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+      expect(pane.style.minWidth).toBe('200px');
+    }));
+
+    it('should set the correct overlay width when the trigger width was' +
+       ' changed after the placeholder was initialized', fakeAsync(() => {
+
+      fixture.componentInstance.select.placeholder = 'Lorem ipsum dolor sit amet.';
+      tick();
+
+      trigger.style.width = '300px';
+      trigger.click();
+      fixture.detectChanges();
+      const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+      expect(pane.style.minWidth).toBe('300px');
     }));
 
     it('should set the width of the overlay if the element was hidden initially', async(() => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -325,8 +325,12 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   set placeholder(value: string) {
     this._placeholder = value;
 
-    // Must wait to record the trigger width to ensure placeholder width is included.
-    Promise.resolve(null).then(() => this._setTriggerWidth());
+    // Only re-calculate the width if we've had a width before. This avoids issues in the
+    // cases where the width might be assigned at a later point (e.g. flex-layout).
+    if (this._triggerWidth) {
+      // Must wait to record the trigger width to ensure placeholder width is included.
+      Promise.resolve(null).then(() => this._setTriggerWidth());
+    }
   }
 
   /** Whether the component is required. */


### PR DESCRIPTION
Since we set and cache the trigger width in the `placeholder` setter, it means that we can potentially have an incorrect width if the trigger was resized after initialization. These changes switch to only updating the trigger width from the placeholder getter if there was a width already, which also has the advantage of not triggering a reflow on initialization, but deferring it until a select is opened.

Fixes #6655.