### PR TITLE
bug(tabs): fix inifinite tab loop #4639

### DIFF
--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -70,7 +70,7 @@ describe('MdTabGroup', () => {
       });
     }));
 
-    it('should support two-way binding for selectedIndex', async(() => {
+    it('should set to correct tab on fast change', async(() => {
       let component = fixture.componentInstance;
       component.selectedIndex = 0;
       fixture.detectChanges();

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -70,6 +70,25 @@ describe('MdTabGroup', () => {
       });
     }));
 
+    fit('should support two-way binding for selectedIndex', async(() => {
+      let component = fixture.componentInstance;
+      component.selectedIndex = 0;
+      fixture.detectChanges();
+
+      setTimeout(() => {
+        component.selectedIndex = 1;
+        fixture.detectChanges();
+
+        setTimeout(() => {
+          component.selectedIndex = 0;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(component.selectedIndex).toBe(0);
+          });
+        }, 1);
+      }, 1);
+    }));
+
     it('should change tabs based on selectedIndex', fakeAsync(() => {
       let component = fixture.componentInstance;
       let tabComponent = fixture.debugElement.query(By.css('md-tab-group')).componentInstance;

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -70,7 +70,7 @@ describe('MdTabGroup', () => {
       });
     }));
 
-    fit('should support two-way binding for selectedIndex', async(() => {
+    it('should support two-way binding for selectedIndex', async(() => {
       let component = fixture.componentInstance;
       component.selectedIndex = 0;
       fixture.detectChanges();

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -23,6 +23,7 @@ import {
   AfterContentChecked,
   OnDestroy,
   ViewEncapsulation,
+  NgZone,
 } from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
@@ -141,6 +142,7 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
 
   constructor(_renderer: Renderer2,
               elementRef: ElementRef,
+              private _zone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef) {
     super(_renderer, elementRef);
     this._groupId = nextId++;
@@ -165,7 +167,7 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
     if (this._selectedIndex != indexToSelect && this._selectedIndex != null) {
       this.selectChange.emit(this._createChangeEvent(indexToSelect));
       // prevent expression changed error
-      setTimeout(() => this.selectedIndexChange.emit(indexToSelect));
+      this._zone.run(() => this.selectedIndexChange.emit(indexToSelect));
     }
 
       // Setup the position for each tab and optionally setup an origin on the next selected tab.

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -25,8 +25,6 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {map} from '@angular/cdk/rxjs';
-import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import {MdTab} from './tab';
 import {merge} from 'rxjs/observable/merge';

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -131,9 +131,7 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
   private _backgroundColor: ThemePalette;
 
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
-  @Output() get selectedIndexChange(): Observable<number> {
-    return map.call(this.selectChange, event => event.index);
-  }
+  @Output() selectedIndexChange = new EventEmitter();
 
   /** Event emitted when focus has changed within a tab group. */
   @Output() focusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
@@ -157,9 +155,10 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
    * a new selected tab should transition in (from the left or right).
    */
   ngAfterContentChecked(): void {
-    // Clamp the next selected index to the bounds of 0 and the tabs length. Note the `|| 0`, which
-    // ensures that values like NaN can't get through and which would otherwise throw the
-    // component into an infinite loop (since Math.max(NaN, 0) === NaN).
+    // Clamp the next selected index to the boundsof 0 and the tabs length.
+    // Note the `|| 0`, which ensures that values like NaN can't get through
+    // and which would otherwise throw the component into an infinite loop
+    // (since Math.max(NaN, 0) === NaN).
     let indexToSelect = this._indexToSelect =
         Math.min(this._tabs.length - 1, Math.max(this._indexToSelect || 0, 0));
 
@@ -167,9 +166,11 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
     // the selected index has not yet been initialized.
     if (this._selectedIndex != indexToSelect && this._selectedIndex != null) {
       this.selectChange.emit(this._createChangeEvent(indexToSelect));
+      // prevent expression changed error
+      setTimeout(() => this.selectedIndexChange.emit(indexToSelect));
     }
 
-    // Setup the position for each tab and optionally setup an origin on the next selected tab.
+      // Setup the position for each tab and optionally setup an origin on the next selected tab.
     this._tabs.forEach((tab: MdTab, index: number) => {
       tab.position = index - indexToSelect;
       tab.isActive = index === indexToSelect;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -23,7 +23,6 @@ import {
   AfterContentChecked,
   OnDestroy,
   ViewEncapsulation,
-  NgZone,
 } from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
@@ -130,7 +129,7 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
   private _backgroundColor: ThemePalette;
 
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
-  @Output() selectedIndexChange = new EventEmitter();
+  @Output() selectedIndexChange: EventEmitter<number> = new EventEmitter();
 
   /** Event emitted when focus has changed within a tab group. */
   @Output() focusChange: EventEmitter<MdTabChangeEvent> = new EventEmitter<MdTabChangeEvent>();
@@ -142,7 +141,6 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
 
   constructor(_renderer: Renderer2,
               elementRef: ElementRef,
-              private _zone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef) {
     super(_renderer, elementRef);
     this._groupId = nextId++;
@@ -167,8 +165,8 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
     if (this._selectedIndex != indexToSelect && this._selectedIndex != null) {
       this.selectChange.emit(this._createChangeEvent(indexToSelect));
       // Emitting this value after change detection has run
-      // since the checked content may contain this variable
-      this._zone.run(() => this.selectedIndexChange.emit(indexToSelect));
+      // since the checked content may contain this variable'
+      Promise.resolve().then(() => this.selectedIndexChange.emit(indexToSelect));
     }
 
     // Setup the position for each tab and optionally setup an origin on the next selected tab.

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -166,11 +166,12 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
     // the selected index has not yet been initialized.
     if (this._selectedIndex != indexToSelect && this._selectedIndex != null) {
       this.selectChange.emit(this._createChangeEvent(indexToSelect));
-      // prevent expression changed error
+      // Emitting this value after change detection has run
+      // since the checked content may contain this variable
       this._zone.run(() => this.selectedIndexChange.emit(indexToSelect));
     }
 
-      // Setup the position for each tab and optionally setup an origin on the next selected tab.
+    // Setup the position for each tab and optionally setup an origin on the next selected tab.
     this._tabs.forEach((tab: MdTab, index: number) => {
       tab.position = index - indexToSelect;
       tab.isActive = index === indexToSelect;


### PR DESCRIPTION
@jelbourn @andrewseguin - The issue is the `selectChange` event is causing the `ngAfterContentChecked` to get recursively called because this change event is firing so quickly.

The root cause seems to be how mapping of the `selectedIndexChange` event was hooked up:

```typescript
@Output() get selectedIndexChange(): Observable<number> {
    return map.call(this.selectChange, event => event.index);
  }
```

switching this to its own `EventEmitter` resolved the problem. However, that created an issue with a expression changed error, I was able to patch that by adding a timeout around that event emit and solve the issue.