### PR TITLE
bug(tabs): tab spacing on desktop incorrect #3347

### DIFF
--- a/src/lib/tabs/_tabs-common.scss
+++ b/src/lib/tabs/_tabs-common.scss
@@ -6,7 +6,7 @@ $mat-tab-animation-duration: 500ms !default;
 // Mixin styles for labels that are contained within the tab header.
 @mixin tab-label {
   height: $mat-tab-bar-height;
-  padding: 0 12px;
+  padding: 0 24px;
   cursor: pointer;
   box-sizing: border-box;
   opacity: 0.6;

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -20,6 +20,7 @@
 @media ($mat-xsmall) {
   .mat-tab-label {
     min-width: 72px;
+    padding: 0 12px;
   }
 }
 

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -19,7 +19,12 @@
 
 @media ($mat-xsmall) {
   .mat-tab-label {
-    min-width: 72px;
+    padding: 0 12px;
+  }
+}
+
+@media ($mat-small) {
+  .mat-tab-label {
     padding: 0 12px;
   }
 }


### PR DESCRIPTION
Sets left/right padding on desktop to spec ( 24px ). Addresses #3347