### PR TITLE
fix(select): do not set min-width

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -5,7 +5,6 @@
 @import '../core/a11y/a11y';
 
 $mat-select-trigger-height: 30px !default;
-$mat-select-trigger-min-width: 112px !default;
 $mat-select-arrow-size: 5px !default;
 $mat-select-arrow-margin: 4px !default;
 $mat-select-panel-max-height: 256px !default;
@@ -20,7 +19,6 @@ $mat-select-trigger-underline-height: 1px !default;
   display: flex;
   align-items: center;
   height: $mat-select-trigger-height;
-  min-width: $mat-select-trigger-min-width;
   cursor: pointer;
   position: relative;
   box-sizing: border-box;


### PR DESCRIPTION
The select element should occupy the amount of space (width) allowed by the parent, this is the current state but if the width is lower than 112px the select element fixates on 112px.

> select element can also get a fixed value applied on it directly (`<md-select style="width: 40px">`)

With the deprecation of `/deep/`, `:ng-deep` etc... Overriding is not trivial  , unless `ViewEncapsulation.None` is used.

Since the `min-height` property is set on a child element of `md-select` (`.mat-select-trigger`) it can not be reached.
Setting `.mat-select-trigger` on a component's style will result in `.mat-select-trigger [_ng-content_....]`
 
This PR remove the `min-height` property.

@jelbourn if I'm missing something and this css property is still required we can still use it but move it to the host (`md-select`) so it can get overriden by a parent component.

Closes #2711
Closes #3090