### PR TITLE
fix(list): Vertically align elements in mdSubheader

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -112,9 +112,10 @@ $mat-dense-list-icon-size: 20px;
 }
 
 .mat-subheader {
-  display: block;
+  display: flex;
   box-sizing: border-box;
   padding: $mat-list-side-padding;
+  align-items: center;
 
   // This needs slightly more specificity, because it
   // can be overwritten by the typography styles.


### PR DESCRIPTION
Before the fix:
![image](https://user-images.githubusercontent.com/5906541/29800711-70b5b9a8-8c20-11e7-8b4c-a3390f750992.png)

After the fix:
![image](https://user-images.githubusercontent.com/5906541/29800696-65d3d380-8c20-11e7-896f-8ed63e4e6f96.png)

Text and `md-icon` were not vertically aligned inside of `mdSubheader`.
Fixes #6670 