### PR TITLE
build: create docs for missing cdk entry points

### DIFF
--- a/tools/dgeni/index.js
+++ b/tools/dgeni/index.js
@@ -86,8 +86,13 @@ let apiDocsPackage = new DgeniPackage('material2-api-docs', dgeniPackageDeps)
     'cdk/a11y/index.ts',
     'cdk/bidi/index.ts',
     'cdk/coercion/index.ts',
+    'cdk/collections/index.ts',
+    'cdk/keycodes/index.ts',
+    'cdk/overlay/index.ts',
     'cdk/platform/index.ts',
     'cdk/portal/index.ts',
+    'cdk/rxjs/index.ts',
+    'cdk/scrolling/index.ts',
     'cdk/table/index.ts',
 
     // @angular/material


### PR DESCRIPTION
* A few secondary entry points of the CDK are not added to the Dgeni processor and therefore no API HTML files will be generated.

@jelbourn Looked into the latest version of dgeni-packages which will soon include a update that allows us to show inherited members, but there are a lot of things we'd need to change. 

Let's wait until that PR (https://github.com/angular/dgeni-packages/pull/2439) is merged before proceeding.