### PR TITLE
fix(button-toggle): border radius ignored if option is selected

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -18,6 +18,7 @@ $mat-button-toggle-border-radius: 2px !default;
 
   cursor: pointer;
   white-space: nowrap;
+  overflow: hidden;
 }
 
 .mat-button-toggle-vertical {


### PR DESCRIPTION
As per Material Design specifications, the button-toggle group should always have a border radius.

This behavior has been implemented in the `md-button-toggle-group` component, but does not work properly if an option is selected or disabled.

This happens because selected and disabled button-toggles receives a background color, which overflows the clipped button-toggle-group.

Fixes #6689