### PR TITLE
fix(datepicker): Create a new injection token to avoid overriding LOCALE_ID

### DIFF
--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {InjectionToken} from '@angular/core';
+
+/** InjectionToken for datepicker that can be used to override default locale code. */
+export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE');
+
 /** Adapts type `D` to be usable as a date by cdk-based components that work with dates. */
 export abstract class DateAdapter<D> {
   /** The locale to use for all dates. */

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -6,10 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '@angular/core';
+import {InjectionToken, LOCALE_ID} from '@angular/core';
 
 /** InjectionToken for datepicker that can be used to override default locale code. */
 export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE');
+
+/** Provider for MAT_DATE_LOCALE injection token. */
+export const MAT_DATE_LOCALE_PROVIDER = {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID};
 
 /** Adapts type `D` to be usable as a date by cdk-based components that work with dates. */
 export abstract class DateAdapter<D> {

--- a/src/lib/core/datetime/index.ts
+++ b/src/lib/core/datetime/index.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
+import {LOCALE_ID, NgModule} from '@angular/core';
 import {DateAdapter} from './date-adapter';
-import {NativeDateAdapter} from './native-date-adapter';
+import {NativeDateAdapter, MAT_DATE_LOCALE} from './native-date-adapter';
 import {MD_DATE_FORMATS} from './date-formats';
 import {MD_NATIVE_DATE_FORMATS} from './native-date-formats';
 
@@ -20,7 +20,10 @@ export * from './native-date-formats';
 
 
 @NgModule({
-  providers: [{provide: DateAdapter, useClass: NativeDateAdapter}],
+  providers: [
+    {provide: DateAdapter, useClass: NativeDateAdapter},
+    {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID}
+  ],
 })
 export class NativeDateModule {}
 

--- a/src/lib/core/datetime/index.ts
+++ b/src/lib/core/datetime/index.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LOCALE_ID, NgModule} from '@angular/core';
-import {DateAdapter, MAT_DATE_LOCALE} from './date-adapter';
+import {NgModule} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE_PROVIDER} from './date-adapter';
 import {NativeDateAdapter} from './native-date-adapter';
 import {MD_DATE_FORMATS} from './date-formats';
 import {MD_NATIVE_DATE_FORMATS} from './native-date-formats';
-
 
 export * from './date-adapter';
 export * from './date-formats';
@@ -22,7 +21,7 @@ export * from './native-date-formats';
 @NgModule({
   providers: [
     {provide: DateAdapter, useClass: NativeDateAdapter},
-    {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID}
+    MAT_DATE_LOCALE_PROVIDER
   ],
 })
 export class NativeDateModule {}

--- a/src/lib/core/datetime/index.ts
+++ b/src/lib/core/datetime/index.ts
@@ -7,8 +7,8 @@
  */
 
 import {LOCALE_ID, NgModule} from '@angular/core';
-import {DateAdapter} from './date-adapter';
-import {NativeDateAdapter, MAT_DATE_LOCALE} from './native-date-adapter';
+import {DateAdapter, MAT_DATE_LOCALE} from './date-adapter';
+import {NativeDateAdapter} from './native-date-adapter';
 import {MD_DATE_FORMATS} from './date-formats';
 import {MD_NATIVE_DATE_FORMATS} from './native-date-formats';
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -1,6 +1,5 @@
 import {TestBed, async, inject} from '@angular/core/testing';
-import {LOCALE_ID} from '@angular/core';
-import {NativeDateAdapter, NativeDateModule, DateAdapter} from './index';
+import {NativeDateAdapter, NativeDateModule, DateAdapter, MAT_DATE_LOCALE} from './index';
 import {Platform} from '../platform/index';
 import {DEC, FEB, JAN, MAR} from '../testing/month-constants';
 
@@ -334,13 +333,13 @@ describe('NativeDateAdapter', () => {
 });
 
 
-describe('NativeDateAdapter with LOCALE_ID override', () => {
+describe('NativeDateAdapter with MAT_DATE_LOCALE override', () => {
   let adapter: NativeDateAdapter;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
-      providers: [{provide: LOCALE_ID, useValue: 'da-DK'}]
+      providers: [{provide: MAT_DATE_LOCALE, useValue: 'da-DK'}]
     }).compileComponents();
   }));
 

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -2,6 +2,7 @@ import {TestBed, async, inject} from '@angular/core/testing';
 import {NativeDateAdapter, NativeDateModule, DateAdapter, MAT_DATE_LOCALE} from './index';
 import {Platform} from '../platform/index';
 import {DEC, FEB, JAN, MAR} from '../testing/month-constants';
+import {LOCALE_ID} from '@angular/core';
 
 const SUPPORTS_INTL = typeof Intl != 'undefined';
 
@@ -347,7 +348,31 @@ describe('NativeDateAdapter with MAT_DATE_LOCALE override', () => {
     adapter = d;
   }));
 
-  it('should take the default locale id from the LOCALE_ID injection token', () => {
+  it('should take the default locale id from the MAT_DATE_LOCALE injection token', () => {
+    const expectedValue = SUPPORTS_INTL ?
+        ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'] :
+        ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+    expect(adapter.getDayOfWeekNames('long')).toEqual(expectedValue);
+  });
+
+});
+
+describe('NativeDateAdapter with LOCALE_ID override', () => {
+  let adapter: NativeDateAdapter;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NativeDateModule],
+      providers: [{provide: LOCALE_ID, useValue: 'da-DK'}]
+    }).compileComponents();
+  }));
+
+  beforeEach(inject([DateAdapter], (d: NativeDateAdapter) => {
+    adapter = d;
+  }));
+
+  it('should cascade locale id from the LOCALE_ID injection token to MAT_DATE_LOCALE', () => {
     const expectedValue = SUPPORTS_INTL ?
         ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'] :
         ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -48,12 +48,12 @@ function range<T>(length: number, valueFunction: (index: number) => T): T[] {
 }
 
 /** InjectionToken for datepicker that can be used to override default locale code. */
-export const MAT_DATE_LOCALE = new InjectionToken<string>('MdDateLocale');
+export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE');
 
 /** Adapts the native JS Date for use with cdk-based components that work with dates. */
 @Injectable()
 export class NativeDateAdapter extends DateAdapter<Date> {
-  constructor(@Optional() @Inject(MAT_DATE_LOCALE) matDateLocale: any) {
+  constructor(@Optional() @Inject(MAT_DATE_LOCALE) matDateLocale: string) {
     super();
     super.setLocale(matDateLocale);
   }

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional, InjectionToken} from '@angular/core';
-import {DateAdapter} from './date-adapter';
+import {Inject, Injectable, Optional} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE} from './date-adapter';
 import {extendObject} from '../util/object-extend';
 
 // TODO(mmalerba): Remove when we no longer support safari 9.
@@ -46,9 +46,6 @@ function range<T>(length: number, valueFunction: (index: number) => T): T[] {
   }
   return valuesArray;
 }
-
-/** InjectionToken for datepicker that can be used to override default locale code. */
-export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE');
 
 /** Adapts the native JS Date for use with cdk-based components that work with dates. */
 @Injectable()

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional, LOCALE_ID} from '@angular/core';
+import {Inject, Injectable, Optional, InjectionToken} from '@angular/core';
 import {DateAdapter} from './date-adapter';
 import {extendObject} from '../util/object-extend';
-
 
 // TODO(mmalerba): Remove when we no longer support safari 9.
 /** Whether the browser supports the Intl API. */
@@ -48,13 +47,15 @@ function range<T>(length: number, valueFunction: (index: number) => T): T[] {
   return valuesArray;
 }
 
+/** InjectionToken for datepicker that can be used to override default locale code. */
+export const MAT_DATE_LOCALE = new InjectionToken<string>('MdDateLocale');
 
 /** Adapts the native JS Date for use with cdk-based components that work with dates. */
 @Injectable()
 export class NativeDateAdapter extends DateAdapter<Date> {
-  constructor(@Optional() @Inject(LOCALE_ID) localeId: any) {
+  constructor(@Optional() @Inject(MAT_DATE_LOCALE) matDateLocale: any) {
     super();
-    super.setLocale(localeId);
+    super.setLocale(matDateLocale);
   }
 
   /**

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -116,9 +116,10 @@ three pieces via injection:
  3. The message strings used in the datepicker's UI.
 
 #### Setting the locale code
-By default `MAT_DATE_LOCALE` injection token will use the existing `LOCALE_ID` locale code from
-`@angular/core`. If you want to override it, you can provide a new value for the `MAT_DATE_LOCALE`
-token:
+By default, the `MAT_DATE_LOCALE` injection token will use the existing `LOCALE_ID` locale code
+from `@angular/core`. If you want to override it, you can provide a new value for the
+`MAT_DATE_LOCALE` token:
+
 ```ts
 @NgModule({
   providers: [

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -116,13 +116,13 @@ three pieces via injection:
  3. The message strings used in the datepicker's UI.
 
 #### Setting the locale code
-By default the datepicker will use the locale code from the `LOCALE_ID` injection token from
-`@angular/core`. If you want to override it, you can provide a new value for the token:
-
+By default `MAT_DATE_LOCALE` injection token will use the existing `LOCALE_ID` locale code from
+`@angular/core`. If you want to override it, you can provide a new value for the `MAT_DATE_LOCALE`
+token:
 ```ts
 @NgModule({
   providers: [
-    {provide: LOCALE_ID, useValue: 'en-GB'},
+    {provide: MAT_DATE_LOCALE, useValue: 'en-GB'},
   ],
 })
 export class MyApp {}


### PR DESCRIPTION
New injection token `MAT_DATE_LOCALE` is added to allow overriding locale code, while avoiding overriding `LOCALE_ID`.