### PR TITLE
fix(list): subheader margin being overwritten by typography

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -119,7 +119,8 @@ $mat-dense-list-icon-size: 20px;
   // This needs slightly more specificity, because it
   // can be overwritten by the typography styles.
   .mat-list &,
-  .mat-nav-list & {
+  .mat-nav-list &,
+  .mat-selection-list & {
     margin: 0;
   }
 }

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -118,7 +118,8 @@ $mat-dense-list-icon-size: 20px;
 
   // This needs slightly more specificity, because it
   // can be overwritten by the typography styles.
-  .mat-list & {
+  .mat-list &,
+  .mat-nav-list & {
     margin: 0;
   }
 }


### PR DESCRIPTION
`.mat-nav-list` and `.mat-selection-list` was forgotten in #5652