### PR TITLE
docs(typography): add note about font-family quotes

### DIFF
--- a/guides/typography.md
+++ b/guides/typography.md
@@ -58,7 +58,7 @@ creating a custom theme, you can create a custom **typography configuration**.
 // Define a custom typography config that overrides the font-family as well as the
 // `headlines` and `body-1` levels.
 $custom-typography: mat-typography-config(
-  $font-family: monospace,
+  $font-family: 'Roboto, monospace',
   $headline: mat-typography-level(32px, 48px, 700),
   $body-1: mat-typography-level(16px, 24px, 500)
 );
@@ -67,7 +67,8 @@ $custom-typography: mat-typography-config(
 As the above example demonstrates, a typography configuration is created by using the
 `mat-typography-config` function, which is given both the font-family and the set of typographic
 levels described earlier. Each typographic level is defined by the `mat-typography-level` function,
-which requires a `font-size`, `line-height`, and `font-weight`.
+which requires a `font-size`, `line-height`, and `font-weight`. **Note** that the `font-family`
+has to be in quotes.
 
 
 Once the custom typography definition is created, it can be consumed to generate styles via


### PR DESCRIPTION
Adds a note to the typography guide about the font-family having to be quoted. It seems like we can't handle this gracefully within the mixin using the built-in `is-string` function from SASS.

Fixes #6668.