### PR TITLE
docs(drawer): Add additional documentation for disableClose

### DIFF
--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -102,18 +102,6 @@ describe('MdDrawer', () => {
       expect(testComponent.backdropClickedCount).toBe(1);
     }));
 
-    it('should emit the escapeKeydown event when ESCAPE key is pressed', () => {
-      let fixture = TestBed.createComponent(BasicTestApp);
-      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MdDrawer));
-      expect(testComponent.escapeKeydownCount).toBe(0);
-
-      dispatchKeyboardEvent(drawer.nativeElement, 'keydown', ESCAPE);
-      fixture.detectChanges();
-
-      expect(testComponent.escapeKeydownCount).toBe(1);
-    });
-
     it('should close when pressing escape', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
 
@@ -398,8 +386,7 @@ class DrawerContainerTwoDrawerTestApp {
     <md-drawer-container (backdropClick)="backdropClicked()">
       <md-drawer #drawer position="start"
                  (open)="open()"
-                 (close)="close()"
-                 (escapeKeydown)="escapeKeydown()">
+                 (close)="close()">
         <button #drawerButton>Content.</button>
       </md-drawer>
       <button (click)="drawer.open()" class="open" #openButton></button>
@@ -410,7 +397,6 @@ class BasicTestApp {
   openCount: number = 0;
   closeCount: number = 0;
   backdropClickedCount: number = 0;
-  escapeKeydownCount: number = 0;
 
   @ViewChild('drawerButton') drawerButton: ElementRef;
   @ViewChild('openButton') openButton: ElementRef;
@@ -426,10 +412,6 @@ class BasicTestApp {
 
   backdropClicked() {
     this.backdropClickedCount++;
-  }
-
-  escapeKeydown() {
-    this.escapeKeydownCount++;
   }
 }
 

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -102,6 +102,18 @@ describe('MdDrawer', () => {
       expect(testComponent.backdropClickedCount).toBe(1);
     }));
 
+    it('should emit the escapeKeydown event when ESCAPE key is pressed', () => {
+      let fixture = TestBed.createComponent(BasicTestApp);
+      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
+      let drawer = fixture.debugElement.query(By.directive(MdDrawer));
+      expect(testComponent.escapeKeydownCount).toBe(0);
+
+      dispatchKeyboardEvent(drawer.nativeElement, 'keydown', ESCAPE);
+      fixture.detectChanges();
+
+      expect(testComponent.escapeKeydownCount).toBe(1);
+    });
+
     it('should close when pressing escape', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
 
@@ -386,7 +398,8 @@ class DrawerContainerTwoDrawerTestApp {
     <md-drawer-container (backdropClick)="backdropClicked()">
       <md-drawer #drawer position="start"
                  (open)="open()"
-                 (close)="close()">
+                 (close)="close()"
+                 (escapeKeydown)="escapeKeydown()">
         <button #drawerButton>Content.</button>
       </md-drawer>
       <button (click)="drawer.open()" class="open" #openButton></button>
@@ -397,6 +410,7 @@ class BasicTestApp {
   openCount: number = 0;
   closeCount: number = 0;
   backdropClickedCount: number = 0;
+  escapeKeydownCount: number = 0;
 
   @ViewChild('drawerButton') drawerButton: ElementRef;
   @ViewChild('openButton') openButton: ElementRef;
@@ -412,6 +426,10 @@ class BasicTestApp {
 
   backdropClicked() {
     this.backdropClickedCount++;
+  }
+
+  escapeKeydown() {
+    this.escapeKeydownCount++;
   }
 }
 

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -118,7 +118,7 @@ export class MdDrawer implements AfterContentInit, OnDestroy {
   /** Mode of the drawer; one of 'over', 'push' or 'side'. */
   @Input() mode: 'over' | 'push' | 'side' = 'over';
 
-  /** Whether the drawer can be closed with the escape key or not. */
+  /** Whether the drawer can be closed with the escape key or by clicking on the backdrop. */
   @Input()
   get disableClose(): boolean { return this._disableClose; }
   set disableClose(value: boolean) { this._disableClose = coerceBooleanProperty(value); }
@@ -151,6 +151,9 @@ export class MdDrawer implements AfterContentInit, OnDestroy {
 
   /** Event emitted when the drawer's position changes. */
   @Output('positionChanged') onPositionChanged = new EventEmitter<void>();
+
+  /** Event emitted when ESCAPE is pressed. */
+  @Output() escapeKeydown = new EventEmitter<void>();
 
   /** @deprecated */
   @Output('align-changed') onAlignChanged = new EventEmitter<void>();
@@ -259,9 +262,12 @@ export class MdDrawer implements AfterContentInit, OnDestroy {
    * @docs-private
    */
   handleKeydown(event: KeyboardEvent) {
-    if (event.keyCode === ESCAPE && !this.disableClose) {
-      this.close();
-      event.stopPropagation();
+    if (event.keyCode === ESCAPE) {
+      this.escapeKeydown.emit();
+      if (!this.disableClose) {
+        this.close();
+        event.stopPropagation();
+      }
     }
   }
 

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -152,9 +152,6 @@ export class MdDrawer implements AfterContentInit, OnDestroy {
   /** Event emitted when the drawer's position changes. */
   @Output('positionChanged') onPositionChanged = new EventEmitter<void>();
 
-  /** Event emitted when ESCAPE is pressed. */
-  @Output() escapeKeydown = new EventEmitter<void>();
-
   /** @deprecated */
   @Output('align-changed') onAlignChanged = new EventEmitter<void>();
 
@@ -262,12 +259,9 @@ export class MdDrawer implements AfterContentInit, OnDestroy {
    * @docs-private
    */
   handleKeydown(event: KeyboardEvent) {
-    if (event.keyCode === ESCAPE) {
-      this.escapeKeydown.emit();
-      if (!this.disableClose) {
-        this.close();
-        event.stopPropagation();
-      }
+    if (event.keyCode === ESCAPE && !this.disableClose) {
+      this.close();
+      event.stopPropagation();
     }
   }
 

--- a/src/lib/sidenav/sidenav.md
+++ b/src/lib/sidenav/sidenav.md
@@ -18,6 +18,14 @@ A sidenav container may contain one or two `<md-sidenav>` elements. When there a
 `<md-sidenav>` elements, each must be placed on a different side of the container.
 See the section on positioning below.
 
+
+### Sidenav vs. Drawer
+The difference between sidenav and drawer is that the sidenav takes up fullscreen whereas drawer is a smaller element
+that takes up a subsection of the screen. `md-sidenav` has to be placed inside `md-sidenav-container` and `md-drawer`
+has to be placed inside `md-drawer-container`. Currently `md-drawer` and `md-sidenav` support all the same features.
+However, in the future we expect to add different features specific to the different use cases.
+
+
 ### Sidenav mode
 The sidenav can render in one of three different ways based on the `mode` property.
 
@@ -71,18 +79,14 @@ html, body, material-app, md-sidenav-container, .my-content {
 For a sidenav with a FAB (Floating Action Button) or other floating element, the recommended approach is to place the FAB
 outside of the scrollable region and absolutely position it.
 
-### Sidenav vs. Drawer
-The difference between sidenav and drawer is that the sidenav takes up fullscreen whereas drawer is a smaller element
-that takes up a subsection of the screen. `md-sidenav` has to be placed inside `md-sidenav-container` and `md-drawer`
-has to be placed inside `md-drawer-container`. More functionalities will be added to sidenav in the future.
-
 
 ### Disabling closing of sidenav and drawer
 By default, sidenav and drawer can be closed either by clicking on the backdrop or by pressing <kbd>ESCAPE</kbd>.
-`disableClose` attribute can be set on `md-drawer` or `md-sidenav` to disable closing by two methods. To enable one
-of the two methods to allow closing with `disableClose` attribute set, then custom event handlers can be used as below:
+The `disableClose` attribute can be set on `md-drawer` or `md-sidenav` to disable automatic closing when the backdrop
+is clicked or <kbd>ESCAPE</kbd> is pressed. To add custom logic on backdrop click, add a `(backdropClick)` listener to
+`md-sidenav-container`. For custom <kdb>ESCAPE</kbd> logic, a standard `(keydown)` listener will suffice.
 ```html
-<md-drawer-container (backdropClick)="customBackdropClickHandler()">
-  <md-drawer disableClose (keydown)="customKeydownHandler($event)"></md-drawer>
-</md-drawer-container>
+<md-sidenav-container (backdropClick)="customBackdropClickHandler()">
+  <md-sidenav disableClose (keydown)="customKeydownHandler($event)"></md-sidenav>
+</md-sidenav-container>
 ```

--- a/src/lib/sidenav/sidenav.md
+++ b/src/lib/sidenav/sidenav.md
@@ -70,3 +70,19 @@ html, body, material-app, md-sidenav-container, .my-content {
 ### FABs inside sidenav
 For a sidenav with a FAB (Floating Action Button) or other floating element, the recommended approach is to place the FAB
 outside of the scrollable region and absolutely position it.
+
+### Sidenav vs. Drawer
+The difference between sidenav and drawer is that the sidenav takes up fullscreen whereas drawer is a smaller element
+that takes up a subsection of the screen. `md-sidenav` has to be placed inside `md-sidenav-container` and `md-drawer`
+has to be placed inside `md-drawer-container`. More functionalities will be added to sidenav in the future.
+
+
+### Disabling closing of sidenav and drawer
+By default, sidenav and drawer can be closed either by clicking on the backdrop or by pressing <kbd>ESCAPE</kbd>.
+`disableClose` attribute can be set on `md-drawer` or `md-sidenav` to disable closing by two methods. To enable one
+of the two methods to allow closing with `disableClose` attribute set, then custom event handlers can be used as below:
+```html
+<md-drawer-container (backdropClick)="customBackdropClickHandler()">
+  <md-drawer disableClose (keydown)="customKeydownHandler($event)"></md-drawer>
+</md-drawer-container>
+```

--- a/src/lib/sidenav/sidenav.md
+++ b/src/lib/sidenav/sidenav.md
@@ -18,8 +18,7 @@ A sidenav container may contain one or two `<md-sidenav>` elements. When there a
 `<md-sidenav>` elements, each must be placed on a different side of the container.
 See the section on positioning below.
 
-
-### Sidenav vs. Drawer
+`<md-drawer>` is a component that is similar to `<md-sidenav>`. 
 The difference between sidenav and drawer is that the sidenav takes up fullscreen whereas drawer is a smaller element
 that takes up a subsection of the screen. `md-sidenav` has to be placed inside `md-sidenav-container` and `md-drawer`
 has to be placed inside `md-drawer-container`. Currently `md-drawer` and `md-sidenav` support all the same features.

--- a/src/lib/sidenav/sidenav.md
+++ b/src/lib/sidenav/sidenav.md
@@ -18,13 +18,6 @@ A sidenav container may contain one or two `<md-sidenav>` elements. When there a
 `<md-sidenav>` elements, each must be placed on a different side of the container.
 See the section on positioning below.
 
-`<md-drawer>` is a component that is similar to `<md-sidenav>`. 
-The difference between sidenav and drawer is that the sidenav takes up fullscreen whereas drawer is a smaller element
-that takes up a subsection of the screen. `md-sidenav` has to be placed inside `md-sidenav-container` and `md-drawer`
-has to be placed inside `md-drawer-container`. Currently `md-drawer` and `md-sidenav` support all the same features.
-However, in the future we expect to add different features specific to the different use cases.
-
-
 ### Sidenav mode
 The sidenav can render in one of three different ways based on the `mode` property.
 
@@ -79,11 +72,11 @@ For a sidenav with a FAB (Floating Action Button) or other floating element, the
 outside of the scrollable region and absolutely position it.
 
 
-### Disabling closing of sidenav and drawer
-By default, sidenav and drawer can be closed either by clicking on the backdrop or by pressing <kbd>ESCAPE</kbd>.
-The `disableClose` attribute can be set on `md-drawer` or `md-sidenav` to disable automatic closing when the backdrop
+### Disabling closing of sidenav
+By default, sidenav can be closed either by clicking on the backdrop or by pressing <kbd>ESCAPE</kbd>.
+The `disableClose` attribute can be set on `md-sidenav` to disable automatic closing when the backdrop
 is clicked or <kbd>ESCAPE</kbd> is pressed. To add custom logic on backdrop click, add a `(backdropClick)` listener to
-`md-sidenav-container`. For custom <kdb>ESCAPE</kbd> logic, a standard `(keydown)` listener will suffice.
+`md-sidenav-container`. For custom <kbd>ESCAPE</kbd> logic, a standard `(keydown)` listener will suffice.
 ```html
 <md-sidenav-container (backdropClick)="customBackdropClickHandler()">
   <md-sidenav disableClose (keydown)="customKeydownHandler($event)"></md-sidenav>


### PR DESCRIPTION
`ESCAPE` keydown is exposed as an event to support various cases.

Fixes #6427 