### PR TITLE
fix(menu): nested menu error when items are rendered in a repeater

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -22,7 +22,7 @@ import {
 import {TemplatePortal} from '@angular/cdk/portal';
 import {filter, RxChain} from '@angular/cdk/rxjs';
 import {
-  AfterViewInit,
+  AfterContentInit,
   Directive,
   ElementRef,
   EventEmitter,
@@ -82,7 +82,7 @@ export const MENU_PANEL_TOP_PADDING = 8;
   },
   exportAs: 'matMenuTrigger'
 })
-export class MatMenuTrigger implements AfterViewInit, OnDestroy {
+export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _portal: TemplatePortal<any>;
   private _overlayRef: OverlayRef | null = null;
   private _menuOpen: boolean = false;
@@ -126,7 +126,7 @@ export class MatMenuTrigger implements AfterViewInit, OnDestroy {
     }
   }
 
-  ngAfterViewInit() {
+  ngAfterContentInit() {
     this._checkMenu();
 
     this.menu.close.subscribe(reason => {

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -48,7 +48,8 @@ describe('MatMenu', () => {
         CustomMenuPanel,
         CustomMenu,
         NestedMenu,
-        NestedMenuCustomElevation
+        NestedMenuCustomElevation,
+        NestedMenuRepeater
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -1029,6 +1030,21 @@ describe('MatMenu', () => {
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
+    it('should handle the items being rendered in a repeater', fakeAsync(() => {
+      const repeaterFixture = TestBed.createComponent(NestedMenuRepeater);
+      overlay = overlayContainerElement;
+
+      expect(() => repeaterFixture.detectChanges()).not.toThrow();
+
+      repeaterFixture.componentInstance.rootTriggerEl.nativeElement.click();
+      repeaterFixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(1, 'Expected one open menu');
+
+      dispatchMouseEvent(overlay.querySelector('.level-one-trigger')!, 'mouseenter');
+      repeaterFixture.detectChanges();
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(2, 'Expected two open menus');
+    }));
+
   });
 
 });
@@ -1222,4 +1238,29 @@ class NestedMenu {
 class NestedMenuCustomElevation {
   @ViewChild('rootTrigger') rootTrigger: MatMenuTrigger;
   @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+}
+
+
+@Component({
+  template: `
+    <button [matMenuTriggerFor]="root" #rootTriggerEl>Toggle menu</button>
+    <mat-menu #root="matMenu">
+      <button
+        mat-menu-item
+        class="level-one-trigger"
+        *ngFor="let item of items"
+        [matMenuTriggerFor]="levelOne">{{item}}</button>
+    </mat-menu>
+
+    <mat-menu #levelOne="matMenu">
+      <button mat-menu-item>Four</button>
+      <button mat-menu-item>Five</button>
+    </mat-menu>
+  `
+})
+class NestedMenuRepeater {
+  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef;
+  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+
+  items = ['one', 'two', 'three'];
 }


### PR DESCRIPTION
Fixes an error that was being thrown when the menu items that trigger a sub-menu are rendered in a repeater.

Fixes #6765.