### PR TITLE
fix(input): remove resize handle from non-textarea inputs

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -22,7 +22,6 @@
 
   // Prevent textareas from being resized outside the form field.
   max-width: 100%;
-  resize: vertical;
 
   // Needed to make last line of the textarea line up with the baseline.
   vertical-align: bottom;
@@ -45,5 +44,7 @@
 
 // Prevents IE from always adding a scrollbar by default.
 textarea.mat-input-element {
+  // Only allow resizing along the Y axis.
+  resize: vertical;
   overflow: auto;
 }


### PR DESCRIPTION
Fixes some input types getting a native resize handle, because we were setting the `resize: vertical` explicitly for all `.mat-input-element` instances.

Fixes #6757.