### PR TITLE
refactor: initialize to empty subscriptions

### DIFF
--- a/src/cdk/a11y/list-key-manager.ts
+++ b/src/cdk/a11y/list-key-manager.ts
@@ -29,7 +29,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   private _activeItem: T;
   private _wrap = false;
   private _letterKeyStream = new Subject<string>();
-  private _typeaheadSubscription: Subscription;
+  private _typeaheadSubscription = Subscription.EMPTY;
 
   // Buffer for the letters that the user has pressed when the typeahead option is turned on.
   private _pressedLetters: string[] = [];
@@ -60,9 +60,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
       throw Error('ListKeyManager items in typeahead mode must implement the `getLabel` method.');
     }
 
-    if (this._typeaheadSubscription) {
-      this._typeaheadSubscription.unsubscribe();
-    }
+    this._typeaheadSubscription.unsubscribe();
 
     // Debounce the presses of non-navigational keys, collect the ones that correspond to letters
     // and convert those letters back into a string. Afterwards find the first item that starts

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -95,12 +95,12 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
   private _overlayRef: OverlayRef;
   private _templatePortal: TemplatePortal<any>;
   private _hasBackdrop = false;
-  private _backdropSubscription: Subscription | null;
-  private _positionSubscription: Subscription;
+  private _backdropSubscription = Subscription.EMPTY;
+  private _positionSubscription = Subscription.EMPTY;
   private _offsetX: number = 0;
   private _offsetY: number = 0;
   private _position: ConnectedPositionStrategy;
-  private _escapeListener: Function;
+  private _escapeListener = () => {};
 
   /** Origin for the connected overlay. */
   @Input('cdkConnectedOverlayOrigin') origin: OverlayOrigin;
@@ -360,14 +360,8 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
       this.detach.emit();
     }
 
-    if (this._backdropSubscription) {
-      this._backdropSubscription.unsubscribe();
-      this._backdropSubscription = null;
-    }
-
-    if (this._escapeListener) {
-      this._escapeListener();
-    }
+    this._backdropSubscription.unsubscribe();
+    this._escapeListener();
   }
 
   /** Destroys the overlay created by this directive. */
@@ -376,17 +370,9 @@ export class ConnectedOverlayDirective implements OnDestroy, OnChanges {
       this._overlayRef.dispose();
     }
 
-    if (this._backdropSubscription) {
-      this._backdropSubscription.unsubscribe();
-    }
-
-    if (this._positionSubscription) {
-      this._positionSubscription.unsubscribe();
-    }
-
-    if (this._escapeListener) {
-      this._escapeListener();
-    }
+    this._backdropSubscription.unsubscribe();
+    this._positionSubscription.unsubscribe();
+    this._escapeListener();
   }
 
   /** Sets the event listener that closes the overlay when pressing Escape. */

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -66,7 +66,7 @@ export class MdChipList implements AfterContentInit, OnDestroy {
   protected _chipSet: WeakMap<MdChip, boolean> = new WeakMap();
 
   /** Subscription to tabbing out from the chip list. */
-  private _tabOutSubscription: Subscription;
+  private _tabOutSubscription = Subscription.EMPTY;
 
   /** Whether or not the chip is selectable. */
   protected _selectable: boolean = true;
@@ -126,9 +126,7 @@ export class MdChipList implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (this._tabOutSubscription) {
-      this._tabOutSubscription.unsubscribe();
-    }
+    this._tabOutSubscription.unsubscribe();
   }
 
   /**

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -171,7 +171,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
 
   private _validatorOnChange = () => {};
 
-  private _datepickerSubscription: Subscription;
+  private _datepickerSubscription = Subscription.EMPTY;
 
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
@@ -235,9 +235,7 @@ export class MdDatepickerInput<D> implements AfterContentInit, ControlValueAcces
   }
 
   ngOnDestroy() {
-    if (this._datepickerSubscription) {
-      this._datepickerSubscription.unsubscribe();
-    }
+    this._datepickerSubscription.unsubscribe();
   }
 
   registerOnValidatorChange(fn: () => void): void {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -200,7 +200,7 @@ export class MdDatepicker<D> implements OnDestroy {
   /** The element that was focused before the datepicker was opened. */
   private _focusedElementBeforeOpen: HTMLElement | null = null;
 
-  private _inputSubscription: Subscription;
+  private _inputSubscription = Subscription.EMPTY;
 
   constructor(private _dialog: MdDialog,
               private _overlay: Overlay,
@@ -217,11 +217,10 @@ export class MdDatepicker<D> implements OnDestroy {
 
   ngOnDestroy() {
     this.close();
+    this._inputSubscription.unsubscribe();
+
     if (this._popupRef) {
       this._popupRef.dispose();
-    }
-    if (this._inputSubscription) {
-      this._inputSubscription.unsubscribe();
     }
   }
 

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -72,7 +72,7 @@ import {Subscription} from 'rxjs/Subscription';
   ],
 })
 export class MdExpansionPanelHeader implements OnDestroy {
-  private _parentChangeSubscription: Subscription | null = null;
+  private _parentChangeSubscription = Subscription.EMPTY;
 
   constructor(
     @Host() public panel: MdExpansionPanel,
@@ -135,11 +135,7 @@ export class MdExpansionPanelHeader implements OnDestroy {
   }
 
   ngOnDestroy() {
-    if (this._parentChangeSubscription) {
-      this._parentChangeSubscription.unsubscribe();
-      this._parentChangeSubscription = null;
-    }
-
+    this._parentChangeSubscription.unsubscribe();
     this._focusOriginMonitor.stopMonitoring(this._element.nativeElement);
   }
 }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -196,10 +196,10 @@ export class MdSelectionList extends _MdSelectionListMixinBase
   _tabIndex = 0;
 
   /** Subscription to all list options' onFocus events */
-  private _optionFocusSubscription: Subscription;
+  private _optionFocusSubscription = Subscription.EMPTY;
 
   /** Subscription to all list options' destroy events  */
-  private _optionDestroyStream: Subscription;
+  private _optionDestroyStream = Subscription.EMPTY;
 
   /** The FocusKeyManager which handles focus. */
   _keyManager: FocusKeyManager<MdListOption>;
@@ -234,13 +234,8 @@ export class MdSelectionList extends _MdSelectionListMixinBase
   }
 
   ngOnDestroy(): void {
-    if (this._optionDestroyStream) {
-      this._optionDestroyStream.unsubscribe();
-    }
-
-    if (this._optionFocusSubscription) {
-      this._optionFocusSubscription.unsubscribe();
-    }
+    this._optionDestroyStream.unsubscribe();
+    this._optionFocusSubscription.unsubscribe();
   }
 
   focus() {

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -74,7 +74,7 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   private _previousElevation: string;
 
   /** Subscription to tab events on the menu panel */
-  private _tabSubscription: Subscription;
+  private _tabSubscription = Subscription.EMPTY;
 
   /** Config object to be passed into the menu's ngClass */
   _classList: any = {};
@@ -150,10 +150,7 @@ export class MdMenu implements AfterContentInit, MdMenuPanel, OnDestroy {
   }
 
   ngOnDestroy() {
-    if (this._tabSubscription) {
-      this._tabSubscription.unsubscribe();
-    }
-
+    this._tabSubscription.unsubscribe();
     this.close.emit();
     this.close.complete();
   }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -89,9 +89,9 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   private _portal: TemplatePortal<any>;
   private _overlayRef: OverlayRef | null = null;
   private _menuOpen: boolean = false;
-  private _closeSubscription: Subscription;
-  private _positionSubscription: Subscription;
-  private _hoverSubscription: Subscription;
+  private _closeSubscription = Subscription.EMPTY;
+  private _positionSubscription = Subscription.EMPTY;
+  private _hoverSubscription = Subscription.EMPTY;
 
   // Tracking input type is necessary so it's possible to only auto-focus
   // the first item of the list when the menu is opened via the keyboard
@@ -392,13 +392,9 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
 
   /** Cleans up the active subscriptions. */
   private _cleanUpSubscriptions(): void {
-    [
-      this._closeSubscription,
-      this._positionSubscription,
-      this._hoverSubscription
-    ]
-        .filter(subscription => !!subscription)
-        .forEach(subscription => subscription.unsubscribe());
+    this._closeSubscription.unsubscribe();
+    this._positionSubscription.unsubscribe();
+    this._hoverSubscription.unsubscribe();
   }
 
   /** Returns a stream that emits whenever an action that should close the menu occurs. */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -205,13 +205,13 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   private _panelOpen = false;
 
   /** Subscriptions to option events. */
-  private _optionSubscription: Subscription | null;
+  private _optionSubscription = Subscription.EMPTY;
 
   /** Subscription to changes in the option list. */
-  private _changeSubscription: Subscription;
+  private _changeSubscription = Subscription.EMPTY;
 
   /** Subscription to tab events while overlay is focused. */
-  private _tabSubscription: Subscription;
+  private _tabSubscription = Subscription.EMPTY;
 
   /** Whether filling out the select is required in the form.  */
   private _required: boolean = false;
@@ -466,14 +466,8 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
 
   ngOnDestroy() {
     this._dropSubscriptions();
-
-    if (this._changeSubscription) {
-      this._changeSubscription.unsubscribe();
-    }
-
-    if (this._tabSubscription) {
-      this._tabSubscription.unsubscribe();
-    }
+    this._changeSubscription.unsubscribe();
+    this._tabSubscription.unsubscribe();
   }
 
   /** Toggles the overlay panel open or closed. */
@@ -852,10 +846,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
 
   /** Unsubscribes from all option subscriptions. */
   private _dropSubscriptions(): void {
-    if (this._optionSubscription) {
-      this._optionSubscription.unsubscribe();
-      this._optionSubscription = null;
-    }
+    this._optionSubscription.unsubscribe();
   }
 
   /** Emits change event to set the model value. */

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -89,10 +89,10 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
   private _tabBodyWrapperHeight: number = 0;
 
   /** Subscription to tabs being added/removed. */
-  private _tabsSubscription: Subscription;
+  private _tabsSubscription = Subscription.EMPTY;
 
   /** Subscription to changes in the tab labels. */
-  private _tabLabelSubscription: Subscription;
+  private _tabLabelSubscription = Subscription.EMPTY;
 
   /** Whether the tab group should grow to the size of the active tab. */
   @Input()
@@ -199,13 +199,8 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
   }
 
   ngOnDestroy() {
-    if (this._tabsSubscription) {
-      this._tabsSubscription.unsubscribe();
-    }
-
-    if (this._tabLabelSubscription) {
-      this._tabLabelSubscription.unsubscribe();
-    }
+    this._tabsSubscription.unsubscribe();
+    this._tabLabelSubscription.unsubscribe();
   }
 
   /**
@@ -236,10 +231,7 @@ export class MdTabGroup extends _MdTabGroupMixinBase implements AfterContentInit
    * manually.
    */
   private _subscribeToTabLabels() {
-    if (this._tabLabelSubscription) {
-      this._tabLabelSubscription.unsubscribe();
-    }
-
+    this._tabLabelSubscription.unsubscribe();
     this._tabLabelSubscription = merge(...this._tabs.map(tab => tab._labelChange)).subscribe(() => {
       this._changeDetectorRef.markForCheck();
     });

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -92,7 +92,7 @@ export class MdTabHeader extends _MdTabHeaderMixinBase
   private _selectedIndexChanged = false;
 
   /** Combines listeners that will re-align the ink bar whenever they're invoked. */
-  private _realignInkBar: Subscription | null = null;
+  private _realignInkBar = Subscription.EMPTY;
 
   /** Whether the controls for pagination should be displayed */
   _showPaginationControls = false;
@@ -195,10 +195,7 @@ export class MdTabHeader extends _MdTabHeaderMixinBase
   }
 
   ngOnDestroy() {
-    if (this._realignInkBar) {
-      this._realignInkBar.unsubscribe();
-      this._realignInkBar = null;
-    }
+    this._realignInkBar.unsubscribe();
   }
 
   /**


### PR DESCRIPTION
Initializes most subscriptions to empty ones, avoiding the need to null-check them before unsubscribing.

**Note:** There are a few more candidates for refactor (namely the table and the scroll strategies), but in those cases we use the subscriptions to manage state.