### PR TITLE
feat(grid-list): Make responsive grid list

### DIFF
--- a/src/demo-app/grid-list/grid-list-demo.html
+++ b/src/demo-app/grid-list/grid-list-demo.html
@@ -1,91 +1,107 @@
 <div class="demo-grid-list">
-  <md-card>
-    <md-card-title>Basic grid list</md-card-title>
-    <md-card-content class="demo-basic-list">
-      <md-grid-list cols="4" [rowHeight]="basicRowHeight">
-        <md-grid-tile> One </md-grid-tile>
-        <md-grid-tile> Two </md-grid-tile>
-        <md-grid-tile> Three </md-grid-tile>
-        <md-grid-tile> Four </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
+  <div class="demo-grid-list-fixed">
+    <md-card>
+      <md-card-title>Basic grid list</md-card-title>
+      <md-card-content class="demo-basic-list">
+        <md-grid-list cols="4" [rowHeight]="basicRowHeight">
+          <md-grid-tile> One </md-grid-tile>
+          <md-grid-tile> Two </md-grid-tile>
+          <md-grid-tile> Three </md-grid-tile>
+          <md-grid-tile> Four </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+    </md-card>
 
-  <md-card>
-    <md-card-title>Fixed-height grid list</md-card-title>
-    <md-card-content>
-      <md-grid-list [cols]="fixedCols" [rowHeight]="fixedRowHeight">
-        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
-                      [style.background]="tile.color">
-          {{tile.text}}
+    <md-card>
+      <md-card-title>Fixed-height grid list</md-card-title>
+      <md-card-content>
+        <md-grid-list [cols]="fixedCols" [rowHeight]="fixedRowHeight">
+          <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
+                        [style.background]="tile.color">
+            {{tile.text}}
+          </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+      <md-card-actions>
+        <p>Change list cols: <input type="number" [(ngModel)]="fixedCols"></p>
+        <p>Change row height: <input type="number" [(ngModel)]="fixedRowHeight"></p>
+        <button md-button (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
+      </md-card-actions>
+    </md-card>
+
+    <md-card>
+      <md-card-title>Ratio-height grid list</md-card-title>
+      <md-card-content class="demo-ratio-list">
+        <md-grid-list cols="2" [rowHeight]="ratio" gutterSize="4px">
+          <md-grid-tile *ngFor="let tile of tiles" [style.background]="'lightblue'">
+            {{tile.text}}
+          </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+      <md-card-actions>
+        <p>Change ratio: <input [(ngModel)]="ratio"></p>
+      </md-card-actions>
+    </md-card>
+
+    <md-card>
+      <md-card-title>Fit-height grid list</md-card-title>
+      <md-card-content class="demo-fit-list">
+        <md-grid-list cols="2" rowHeight="fit" [gutterSize]="ratioGutter"
+                      [style.height]="fitListHeight">
+          <md-grid-tile *ngFor="let tile of tiles" [style.background]="'#F1EBBA'">
+            {{tile.text}}
+          </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+      <md-card-actions>
+        <p>Change list height: <input [(ngModel)]="fitListHeight"></p>
+        <p>Change gutter: <input type="number" [(ngModel)]="ratioGutter"></p>
+      </md-card-actions>
+    </md-card>
+
+    <md-card>
+      <md-card-title>Grid list with header</md-card-title>
+      <md-card-content>
+        <md-grid-list cols="3" rowHeight="200px">
+          <md-grid-tile *ngFor="let dog of dogs" style="background:gray">
+            <md-grid-tile-header>
+              <md-icon md-grid-avatar>info_outline</md-icon>
+              {{dog.name}}
+            </md-grid-tile-header>
+          </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+    </md-card>
+
+    <md-card>
+      <md-card-title>Grid list with footer</md-card-title>
+      <md-card-content>
+        <md-grid-list cols="3" rowHeight="200px">
+          <md-grid-tile *ngFor="let dog of dogs">
+            <img [alt]="dog.name" src="https://material.angularjs.org/material2_assets/ngconf/{{dog.name}}.png">
+            <md-grid-tile-footer>
+              <h3 md-line>{{dog.name}}</h3>
+              <span md-line>Human: {{dog.human}}</span>
+              <md-icon>star_border</md-icon>
+            </md-grid-tile-footer>
+          </md-grid-tile>
+        </md-grid-list>
+      </md-card-content>
+    </md-card>
+
+  </div>
+
+  <div class="demo-grid-list-responsive">
+    <md-card>
+      <md-grid-list gutterSize="4px" rowHeight="4:3"
+                    [responsiveGutterSize]="{'gt-md': '16px', 'gt-sm': '8px'}"
+                    [responsiveCols]="{'gt-md': '12', 'xs': '3', 'gt-xs': '8'}"
+                    [responsiveRowHeight]="{'gt-md': '1:1'}">
+        <md-grid-tile *ngFor="let tile of colorTiles" [style.background]="tile.color"
+                      [responsiveColspan]="{'gt-md': tile.colspan, 'gt-xs': tile.smallColspan}"
+                      [responsiveRowspan]="{'gt-md': tile.rowspan, 'gt-xs': tile.smallRowspan}">
         </md-grid-tile>
       </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
-      <p>Change list cols: <input type="number" [(ngModel)]="fixedCols"></p>
-      <p>Change row height: <input type="number" [(ngModel)]="fixedRowHeight"></p>
-      <button md-button (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
-    </md-card-actions>
-  </md-card>
-
-  <md-card>
-    <md-card-title>Ratio-height grid list</md-card-title>
-    <md-card-content class="demo-ratio-list">
-      <md-grid-list cols="2" [rowHeight]="ratio" gutterSize="4px">
-        <md-grid-tile *ngFor="let tile of tiles" [style.background]="'lightblue'">
-          {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
-      <p>Change ratio: <input [(ngModel)]="ratio"></p>
-    </md-card-actions>
-  </md-card>
-
-  <md-card>
-    <md-card-title>Fit-height grid list</md-card-title>
-    <md-card-content class="demo-fit-list">
-      <md-grid-list cols="2" rowHeight="fit" [gutterSize]="ratioGutter"
-                    [style.height]="fitListHeight">
-        <md-grid-tile *ngFor="let tile of tiles" [style.background]="'#F1EBBA'">
-          {{tile.text}}
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-    <md-card-actions>
-      <p>Change list height: <input [(ngModel)]="fitListHeight"></p>
-      <p>Change gutter: <input type="number" [(ngModel)]="ratioGutter"></p>
-    </md-card-actions>
-  </md-card>
-
-  <md-card>
-    <md-card-title>Grid list with header</md-card-title>
-    <md-card-content>
-      <md-grid-list cols="3" rowHeight="200px">
-        <md-grid-tile *ngFor="let dog of dogs" style="background:gray">
-          <md-grid-tile-header>
-            <md-icon md-grid-avatar>info_outline</md-icon>
-            {{dog.name}}
-          </md-grid-tile-header>
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
-
-  <md-card>
-    <md-card-title>Grid list with footer</md-card-title>
-    <md-card-content>
-      <md-grid-list cols="3" rowHeight="200px">
-        <md-grid-tile *ngFor="let dog of dogs">
-          <img [alt]="dog.name" src="https://material.angularjs.org/material2_assets/ngconf/{{dog.name}}.png">
-          <md-grid-tile-footer>
-            <h3 md-line>{{dog.name}}</h3>
-            <span md-line>Human: {{dog.human}}</span>
-            <md-icon>star_border</md-icon>
-          </md-grid-tile-footer>
-        </md-grid-tile>
-      </md-grid-list>
-    </md-card-content>
-  </md-card>
+    </md-card>
+  </div>
 </div>
-

--- a/src/demo-app/grid-list/grid-list-demo.scss
+++ b/src/demo-app/grid-list/grid-list-demo.scss
@@ -1,5 +1,8 @@
+
 .demo-grid-list {
-  width: 1100px;
+  .demo-grid-list-fixed {
+    width: 1100px;
+  }
 
   .mat-card {
     margin: 16px 0;

--- a/src/demo-app/grid-list/grid-list-demo.ts
+++ b/src/demo-app/grid-list/grid-list-demo.ts
@@ -32,4 +32,66 @@ export class GridListDemo {
   ratio = '4:1';
 
   addTileCols() { this.tiles[2].cols++; }
+
+  colors = [
+    '#ffebee', '#ffcdd2', '#ef9a9a', '#e57373', '#ef5350', '#f44336', '#e53935', '#d32f2f',
+    '#c62828', '#b71c1c', '#ff8a80', '#ff5252', '#ff1744', '#d50000', '#f8bbd0', '#f48fb1',
+    '#f06292', '#ec407a', '#e91e63', '#d81b60', '#c2185b', '#ad1457', '#880e4f', '#ff80ab',
+    '#ff4081', '#f50057', '#c51162', '#e1bee7', '#ce93d8', '#ba68c8', '#ab47bc', '#9c27b0',
+    '#8e24aa', '#7b1fa2', '#4a148c', '#ea80fc', '#e040fb', '#d500f9', '#aa00ff', '#ede7f6',
+    '#d1c4e9', '#b39ddb', '#9575cd', '#7e57c2', '#673ab7', '#5e35b1', '#4527a0', '#311b92',
+    '#b388ff', '#7c4dff', '#651fff', '#6200ea', '#c5cae9', '#9fa8da', '#7986cb', '#5c6bc0',
+    '#3f51b5', '#3949ab', '#303f9f', '#283593', '#1a237e', '#8c9eff', '#536dfe', '#3d5afe',
+    '#304ffe', '#e3f2fd', '#bbdefb', '#90caf9', '#64b5f6', '#42a5f5', '#2196f3', '#1e88e5',
+    '#1976d2', '#1565c0', '#0d47a1', '#82b1ff', '#448aff', '#2979ff', '#2962ff', '#b3e5fc',
+    '#81d4fa', '#4fc3f7', '#29b6f6', '#03a9f4', '#039be5', '#0288d1', '#0277bd', '#01579b',
+    '#80d8ff', '#40c4ff', '#00b0ff', '#0091ea', '#e0f7fa', '#b2ebf2', '#80deea', '#4dd0e1',
+    '#26c6da', '#00bcd4', '#00acc1', '#0097a7', '#00838f', '#006064', '#84ffff', '#18ffff',
+    '#00e5ff', '#00b8d4', '#e0f2f1', '#b2dfdb', '#80cbc4', '#4db6ac', '#26a69a', '#009688',
+    '#00897b', '#00796b', '#00695c', '#a7ffeb', '#64ffda', '#1de9b6', '#00bfa5', '#e8f5e9',
+    '#c8e6c9', '#a5d6a7', '#81c784', '#66bb6a', '#4caf50', '#43a047', '#388e3c', '#2e7d32',
+    '#1b5e20', '#b9f6ca', '#69f0ae', '#00e676', '#00c853', '#f1f8e9', '#dcedc8', '#c5e1a5',
+    '#aed581', '#9ccc65', '#8bc34a', '#7cb342', '#689f38', '#558b2f', '#33691e', '#ccff90',
+    '#b2ff59', '#76ff03', '#64dd17', '#f9fbe7', '#f0f4c3', '#e6ee9c', '#dce775', '#d4e157',
+    '#cddc39', '#c0ca33', '#afb42b', '#9e9d24', '#827717', '#f4ff81', '#eeff41', '#c6ff00',
+    '#aeea00', '#fffde7', '#fff9c4', '#fff59d', '#fff176', '#ffee58', '#ffeb3b', '#fdd835',
+    '#fbc02d', '#f9a825', '#f57f17', '#ffff8d', '#ffff00', '#ffea00', '#ffd600', '#fff8e1',
+    '#ffecb3', '#ffe082', '#ffd54f', '#ffca28', '#ffc107', '#ffb300', '#ffa000', '#ff8f00',
+    '#ff6f00', '#ffe57f', '#ffd740', '#ffc400', '#ffab00', '#fff3e0', '#ffe0b2', '#ffcc80',
+    '#ffb74d', '#ffa726', '#ff9800', '#fb8c00', '#f57c00', '#ef6c00', '#e65100', '#ffd180',
+    '#ffab40', '#ff9100', '#ff6d00', '#fbe9e7', '#ffccbc', '#ffab91', '#ff8a65', '#ff7043',
+    '#ff5722', '#f4511e', '#e64a19', '#d84315', '#bf360c', '#ff9e80', '#ff6e40', '#ff3d00',
+    '#dd2c00', '#d7ccc8', '#bcaaa4', '#795548', '#d7ccc8', '#bcaaa4', '#8d6e63', '#eceff1',
+    '#cfd8dc', '#b0bec5', '#90a4ae', '#78909c', '#607d8b', '#546e7a', '#cfd8dc', '#b0bec5',
+    '#78909c'];
+  colorTiles = this.generateTiles();
+
+  generateTiles() {
+    var tiles = [];
+    for (var i = 0; i < 46; i++) {
+      tiles.push({
+        color: this.randomColor(),
+        colspan: this.randomSpan(),
+        rowspan: this.randomSpan(),
+        smallRowspan: this.randomSpan(),
+        smallColspan: this.randomSpan(),
+      });
+    }
+    return tiles;
+  }
+
+  randomColor() {
+    return this.colors[Math.floor(Math.random() * this.colors.length)];
+  }
+
+  randomSpan() {
+    var r = Math.random();
+    if (r < 0.8) {
+      return 1;
+    } else if (r < 0.9) {
+      return 2;
+    } else {
+      return 3;
+    }
+  }
 }

--- a/src/lib/grid-list/grid-list.md
+++ b/src/lib/grid-list/grid-list.md
@@ -37,6 +37,42 @@ It is possible to set the rowspan and colspan of each `md-grid-tile` individuall
 exceed the number of `cols` in the `md-grid-list`. There is no such restriction on the `rowspan`
 however, more rows will simply be added for it the tile to fill.
 
+### Responsive number of columns, row height, and gutter size
+
+`window.matchMedia` is used to evaluate whether a given media query is true or false given the
+current device's screen / window size. The media query will be re-evaluated on resize.
+
+Grid list has pre-programmed support for media queries that match the layout breakpoints:
+
+#### Breakpoints
+| Breakpoint | mediaQuery                                  |
+|------------|---------------------------------------------|
+| xs         | (max-width: 599px)                          |
+| gt-xs	     | (min-width: 600px)                          |
+| sm	     | (min-width: 600px) and (max-width: 959px)   |
+| gt-sm	     | (min-width: 960px)                          |
+| md         | (min-width: 960px) and (max-width: 1279px)  |
+| gt-md	     | (min-width: 1280px)                         |
+| lg         | (min-width: 1280px) and (max-width: 1919px) |
+| gt-lg	     | (min-width: 1920px)                         |
+| xl         | (min-width: 1920px)                         |
+| landscape	 | landscape                                   |
+| portrait   | portrait                                    |
+| print	     | print                                       |
+
+See Material Design's Layout - [Adaptive UI][0] for more details.
+
+#### Usage
+```html
+<md-grid-list gutterSize="4px" rowHeight="4:3"
+              [responsiveGutterSize]="{'gt-md': '16px', 'gt-sm': '8px'}"
+              [responsiveCols]="{'gt-md': '12', 'xs': '3', 'gt-xs': '8'}"
+              [responsiveRowHeight]="{'gt-md': '1:1'}">
+    <md-grid-tile *ngFor="let tile of colorTiles" [style.background]="tile.color">
+    </md-grid-tile>
+</md-grid-list>
+```
+
 ### Tile headers and footers
 
 A header and footer can be added to an `md-grid-tile` using the `md-grid-tile-header` and
@@ -50,3 +86,5 @@ accessibility treatment based on the specific workflow of your application.
 
 If the grid-list is used to present a list of _non-interactive_ content items, then the grid-list
 element should be given `role="list"` and each tile should be given `role="listitem"`.
+
+ [0]: https://material.io/guidelines/layout/responsive-ui.html

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -1,4 +1,5 @@
-import {async, TestBed} from '@angular/core/testing';
+import {async, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {dispatchFakeEvent} from '@angular/cdk/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MdGridList, MdGridListModule} from './index';
@@ -28,6 +29,7 @@ describe('MdGridList', () => {
         GridListWithComplexLayout,
         GridListWithFootersWithoutLines,
         GridListWithFooterContainingTwoLines,
+        GridListWithResponsiveValues,
       ],
     });
 
@@ -265,6 +267,17 @@ describe('MdGridList', () => {
     expect(firstTile.style.marginTop).toBe('0px');
     expect(firstTile.style.left).toBe('0px');
   });
+
+  it('should get correct responsive values', fakeAsync(() => {
+    let fixture = TestBed.createComponent(GridListWithResponsiveValues);
+    let gridListElement = fixture.debugElement.query(By.directive(MdGridList));
+    let gridListInstance = gridListElement.injector.get<MdGridList>(MdGridList);
+
+    fixture.detectChanges();
+
+    expect(gridListInstance.cols).toBe(3, 'Expect cols number to use md');
+    expect(gridListInstance.gutterSize).toBe('3px', 'Expect gutter size use sm');
+  }));
 });
 
 
@@ -436,3 +449,20 @@ class GridListWithFootersWithoutLines { }
       </md-grid-tile>
     </md-grid-list>`})
 class GridListWithFooterContainingTwoLines { }
+
+@Component({template: `
+    <md-grid-list [responsiveCols]="responsiveCols"
+                  [responsiveGutterSize]="responsiveGutterSize"
+                  [responsiveRowHeight]="responsiveRowHeight">
+        <md-grid-tile *ngFor="let tile of tiles" [colspan]="tile.cols" [rowspan]="tile.rows"
+                      [style.background]="tile.color">
+          {{tile.text}}
+        </md-grid-tile>
+</md-grid-list>
+`})
+class GridListWithResponsiveValues {
+  responsiveCols = {'sm': 1, 'md': '3', 'lg': '8'};
+  responsiveGutterSize = {'sm': '1px', 'gt-sm': '3px', 'lg': '5px'};
+  responsiveRowHeight = {'sm': '100px', 'gt-sm': '1:1'};
+  tiles: any[];
+}

--- a/src/lib/grid-list/grid-util.ts
+++ b/src/lib/grid-list/grid-util.ts
@@ -1,0 +1,64 @@
+import {
+  coerceToString,
+  coerceToNumber,
+} from './grid-list-measure';
+
+export class MediaConfig {
+
+}
+export const MEDIA = {
+    'xs'        : '(max-width: 599px)'                         ,
+    'gt-xs'     : '(min-width: 600px)'                         ,
+    'sm'        : '(min-width: 600px) and (max-width: 959px)'  ,
+    'gt-sm'     : '(min-width: 960px)'                         ,
+    'md'        : '(min-width: 960px) and (max-width: 1279px)' ,
+    'gt-md'     : '(min-width: 1280px)'                        ,
+    'lg'        : '(min-width: 1280px) and (max-width: 1919px)',
+    'gt-lg'     : '(min-width: 1920px)'                        ,
+    'xl'        : '(min-width: 1920px)'                        ,
+    'landscape' : '(orientation: landscape)'                   ,
+    'portrait'  : '(orientation: portrait)'                    ,
+    'print' : 'print'
+};
+
+export const MEDIA_PRIORITY = [
+  'xl',
+  'gt-lg',
+  'lg',
+  'gt-md',
+  'md',
+  'gt-sm',
+  'sm',
+  'gt-xs',
+  'xs',
+  'landscape',
+  'portrait',
+  'print'
+];
+
+/**
+ * Find the appropriate value to use for current matchMedia
+ */
+export function matchedMedia(value: {}, defaultValue: number | string) {
+  for (let media of MEDIA_PRIORITY) {
+    if (window.matchMedia(MEDIA[media]).matches && value[media]) {
+      return value[media];
+    }
+  }
+  return defaultValue;
+}
+
+/**
+ * Process responsive values, make sure the returned value only contains keys and values for valid
+ * media. The value can be number or string.
+ */
+export function processResponsiveValues(mediaValues: {}, isNumber: boolean = true) {
+  let result = {};
+  for (let media of MEDIA_PRIORITY) {
+    if (mediaValues[media]) {
+      result[media] =
+        isNumber ? coerceToNumber(mediaValues[media]) : coerceToString(mediaValues[media]);
+    }
+  }
+  return result;
+}

--- a/src/lib/grid-list/index.ts
+++ b/src/lib/grid-list/index.ts
@@ -41,3 +41,4 @@ export class MdGridListModule {}
 
 export * from './grid-list';
 export {MdGridTile} from './grid-tile';
+export {MEDIA} from './grid-util';


### PR DESCRIPTION
- Allow users to set `responsiveCols`, `responsiveRowHeight`, `responsiveGutterSize` to grid list
- Allow users to set `responsiveColspan`, `responsiveRowspan` to grid tiles
- The value is a map like  `{ 'xs': '3', 'gt-xs': '5'}`
The breakpoints are the same as AngularJs Material