### PR TITLE
fix(tooltip): memory leak in _setTooltipMessage

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -271,7 +271,7 @@ export class MatTooltip implements OnDestroy {
     this._detach();
     this._portal = this._portal || new ComponentPortal(TooltipComponent, this._viewContainerRef);
     this._tooltipInstance = overlayRef.attach(this._portal).instance;
-    this._tooltipInstance.afterHidden().subscribe(() => this._detach());
+    this._tooltipInstance.afterHidden().pipe(takeUntil(this._destroyed)).subscribe(() => this._detach());
     this._setTooltipClass(this._tooltipClass);
     this._updateTooltipMessage();
     this._tooltipInstance!.show(this._position, delay);
@@ -325,7 +325,10 @@ export class MatTooltip implements OnDestroy {
         this._scrollDispatcher.getAncestorScrollContainers(this._elementRef)
       );
 
-    strategy.onPositionChange.pipe(filter(() => !!this._tooltipInstance), takeUntil(this._destroyed)).subscribe(change => {
+    strategy.onPositionChange.pipe(
+        filter(() => !!this._tooltipInstance),
+        takeUntil(this._destroyed)
+    ).subscribe(change => {
       if (change.scrollableViewProperties.isOverlayClipped && this._tooltipInstance!.isVisible()) {
         // After position changes occur and the overlay is clipped by
         // a parent scrollable then close the tooltip.
@@ -343,7 +346,7 @@ export class MatTooltip implements OnDestroy {
       scrollStrategy: this._scrollStrategy()
     });
 
-    this._overlayRef.detachments().subscribe(() => this._detach());
+    this._overlayRef.detachments().pipe(takeUntil(this._destroyed)).subscribe(() => this._detach());
 
     return this._overlayRef;
   }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -271,7 +271,9 @@ export class MatTooltip implements OnDestroy {
     this._detach();
     this._portal = this._portal || new ComponentPortal(TooltipComponent, this._viewContainerRef);
     this._tooltipInstance = overlayRef.attach(this._portal).instance;
-    this._tooltipInstance.afterHidden().pipe(takeUntil(this._destroyed)).subscribe(() => this._detach());
+    this._tooltipInstance.afterHidden()
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(() => this._detach());
     this._setTooltipClass(this._tooltipClass);
     this._updateTooltipMessage();
     this._tooltipInstance!.show(this._position, delay);
@@ -346,7 +348,9 @@ export class MatTooltip implements OnDestroy {
       scrollStrategy: this._scrollStrategy()
     });
 
-    this._overlayRef.detachments().pipe(takeUntil(this._destroyed)).subscribe(() => this._detach());
+    this._overlayRef.detachments()
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(() => this._detach());
 
     return this._overlayRef;
   }


### PR DESCRIPTION
The subscription to this._ngZone.onMicrotaskEmpty is causing memory leaks:
![image](https://user-images.githubusercontent.com/209500/29961437-f09b47c8-8eff-11e7-81fb-e0167e5c7f9f.png)
