### PR TITLE
chore: wrong link to stepper in demo app

### DIFF
--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -72,7 +72,7 @@ export class DemoApp {
     {name: 'Slider', route: '/slider'},
     {name: 'Slide Toggle', route: '/slide-toggle'},
     {name: 'Snack Bar', route: '/snack-bar'},
-    {name: 'Stepper', route: 'stepper'},
+    {name: 'Stepper', route: '/stepper'},
     {name: 'Table', route: '/table'},
     {name: 'Tabs', route: '/tabs'},
     {name: 'Toolbar', route: '/toolbar'},


### PR DESCRIPTION
Fixes the stepper link not pointing to the correct page.