### PR TITLE
fix(snackbar): swap enter and exit animation curves

### DIFF
--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -33,15 +33,16 @@ import {
   PortalHostDirective,
 } from '@angular/cdk/portal';
 import {first} from '@angular/cdk/rxjs';
+import {AnimationCurves, AnimationDurations} from '@angular/material/core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {MatSnackBarConfig} from './snack-bar-config';
 
 
-// TODO(jelbourn): we can't use constants from animation.ts here because you can't use
-// a text interpolation in anything that is analyzed statically with ngc (for AoT compile).
-export const SHOW_ANIMATION = '225ms cubic-bezier(0.4,0.0,1,1)';
-export const HIDE_ANIMATION = '195ms cubic-bezier(0.0,0.0,0.2,1)';
+export const SHOW_ANIMATION =
+    `${AnimationDurations.ENTERING} ${AnimationCurves.DECELERATION_CURVE}`;
+export const HIDE_ANIMATION =
+    `${AnimationDurations.EXITING} ${AnimationCurves.ACCELERATION_CURVE}`;
 
 /**
  * Internal component that wraps user-provided snack bar content.


### PR DESCRIPTION
- Uses the standard curve for both enter and exit animations
  - Previous entrance: http://cubic-bezier.com/#.4,0,1,1 (finishes animation too harshly)
  - Previous exit: http://cubic-bezier.com/#0,0,0.2,1 (starts animation too harshly)
  - Currently both: http://cubic-bezier.com/#.4,0,.2,1

- Use long animation duration [as spec shows](https://storage.googleapis.com/material-design/publish/material_v_11/assets/0B6Okdz75tqQsZV9TS3lTVHFzRUE/components_snackbar_usage_fabdo_005.webm)

