### PR TITLE
fix(card): add camel-cased selectors to content projection

### DIFF
--- a/src/lib/card/card-header.html
+++ b/src/lib/card/card-header.html
@@ -1,6 +1,8 @@
 <ng-content select="[mat-card-avatar], [matCardAvatar]"></ng-content>
 <div class="mat-card-header-text">
-  <ng-content select="mat-card-title, mat-card-subtitle, [mat-card-title], [mat-card-subtitle]">
-  </ng-content>
+  <ng-content
+      select="mat-card-title, mat-card-subtitle,
+      [mat-card-title], [mat-card-subtitle],
+      [matCardTitle], [matCardSubtitle]"></ng-content>
 </div>
 <ng-content></ng-content>

--- a/src/lib/card/card-title-group.html
+++ b/src/lib/card/card-title-group.html
@@ -1,6 +1,8 @@
 <div>
-  <ng-content select="mat-card-title, mat-card-subtitle, [mat-card-title], [mat-card-subtitle]">
-  </ng-content>
+  <ng-content
+      select="mat-card-title, mat-card-subtitle,
+      [mat-card-title], [mat-card-subtitle],
+      [matCardTitle], [matCardSubtitle]"></ng-content>
 </div>
 <ng-content select="img"></ng-content>
 <ng-content></ng-content>


### PR DESCRIPTION
Fixes the camel-cased selectors for `mdCardTitle` and `mdCardSubtitle` not being added to the content projection selector.

Fixes #6816.

@jelbourn this seems along the same lines as https://github.com/angular/material2/pull/5647, should I get rid of the dash-cased selectors while I'm at it?