### PR TITLE
fix(table): row content not centered in IE

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -12,6 +12,15 @@ $mat-row-horizontal-padding: 24px;
   align-items: center;
   min-height: $mat-row-height;
   padding: 0 $mat-row-horizontal-padding;
+
+  // Workaround for https://goo.gl/pFmjJD in IE 11. Adds a pseudo
+  // element that will stretch the row the correct height. See:
+  // https://connect.microsoft.com/IE/feedback/details/802625
+  &::after {
+    display: inline-block;
+    min-height: inherit;
+    content: '';
+  }
 }
 
 .mat-cell, .mat-header-cell {


### PR DESCRIPTION
Fixes the table row content not being centered vertically in IE [due to a flex bug](https://connect.microsoft.com/IE/feedback/details/802625).

Fixes #6813.
  