### PR TITLE
build: snapshot builds for moment-adapter

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -16,8 +16,8 @@ if [ -z ${MATERIAL2_BUILDS_TOKEN} ]; then
 fi
 
 # Material packages that need to published.
-PACKAGES=(cdk material)
-REPOSITORIES=(cdk-builds material2-builds)
+PACKAGES=(cdk material material-moment-adapter)
+REPOSITORIES=(cdk-builds material2-builds material2-moment-adapter-builds)
 
 # Command line arguments.
 COMMAND_ARGS=${*}


### PR DESCRIPTION
* Publishes the artifacts of the material-moment-adapter on a per-commit basis.

**Note**: Still need to figure out a name for the builds repository (and create it afterwards)