### PR TITLE
fix(common): don't log doctype warning when rendering server-side

### DIFF
--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -7,7 +7,6 @@
  */
 
 import {NgModule, InjectionToken, Optional, Inject, isDevMode} from '@angular/core';
-import {DOCUMENT} from '@angular/platform-browser';
 import {BidiModule} from '@angular/cdk/bidi';
 import {CompatibilityModule} from '../compatibility/compatibility';
 
@@ -33,11 +32,11 @@ export class MdCommonModule {
   /** Whether we've done the global sanity checks (e.g. a theme is loaded, there is a doctype). */
   private _hasDoneGlobalChecks = false;
 
-  constructor(
-    @Optional() @Inject(DOCUMENT) private _document: any,
-    @Optional() @Inject(MATERIAL_SANITY_CHECKS) _sanityChecksEnabled: boolean) {
+  /** Reference to the global `document` object. */
+  private _document = typeof document === 'object' && document ? document : null;
 
-    if (_sanityChecksEnabled && !this._hasDoneGlobalChecks && _document && isDevMode()) {
+  constructor(@Optional() @Inject(MATERIAL_SANITY_CHECKS) sanityChecksEnabled: boolean) {
+    if (sanityChecksEnabled && !this._hasDoneGlobalChecks && isDevMode()) {
       this._checkDoctype();
       this._checkTheme();
       this._hasDoneGlobalChecks = true;
@@ -45,7 +44,7 @@ export class MdCommonModule {
   }
 
   private _checkDoctype(): void {
-    if (!this._document.doctype) {
+    if (this._document && !this._document.doctype) {
       console.warn(
         'Current document does not have a doctype. This may cause ' +
         'some Angular Material components not to behave as expected.'
@@ -54,7 +53,7 @@ export class MdCommonModule {
   }
 
   private _checkTheme(): void {
-    if (typeof getComputedStyle === 'function') {
+    if (this._document && typeof getComputedStyle === 'function') {
       const testElement = this._document.createElement('div');
 
       testElement.classList.add('mat-theme-loaded-marker');


### PR DESCRIPTION
Prevents the doctype warning from being logged when rendering server-side in development mode. Previously, while we did have a `document`, it was not the same as the client-side `document` and thus didn't have a `doctype`. We didn't notice this earlier, because we run the server-side rendering check in production mode where the sanity checks are disabled.

Relates to #6292.