### PR TITLE
fix(menu): nested trigger staying highlighted after click

### DIFF
--- a/src/cdk/testing/dispatch-events.ts
+++ b/src/cdk/testing/dispatch-events.ts
@@ -25,6 +25,7 @@ export function dispatchKeyboardEvent(node: Node, type: string, keyCode: number)
 }
 
 /** Shorthand to dispatch a mouse event on the specified coordinates. */
-export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0): MouseEvent {
-  return dispatchEvent(node, createMouseEvent(type, x, y)) as MouseEvent;
+export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0,
+  event = createMouseEvent(type, x, y)): MouseEvent {
+  return dispatchEvent(node, event) as MouseEvent;
 }

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -59,9 +59,5 @@ export function createKeyboardEvent(type: string, keyCode: number, target?: Elem
 export function createFakeEvent(type: string) {
   const event = document.createEvent('Event');
   event.initEvent(type, true, true);
-
-  // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
-  event.preventDefault = () => Object.defineProperty(event, 'defaultPrevented', {get: () => true});
-
   return event;
 }

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -57,7 +57,11 @@ export function createKeyboardEvent(type: string, keyCode: number, target?: Elem
 
 /** Creates a fake event object with any desired event type. */
 export function createFakeEvent(type: string) {
-  let event = document.createEvent('Event');
+  const event = document.createEvent('Event');
   event.initEvent(type, true, true);
+
+  // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
+  event.preventDefault = () => Object.defineProperty(event, 'defaultPrevented', {get: () => true});
+
   return event;
 }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -413,6 +413,13 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
   _handleMousedown(event: MouseEvent): void {
     if (!isFakeMousedownFromScreenReader(event)) {
       this._openedByMouse = true;
+
+      // Since clicking on the trigger won't close the menu if it opens a sub-menu,
+      // we should prevent focus from moving onto it via click to avoid the
+      // highlight from lingering on the menu item.
+      if (this.triggersSubmenu) {
+        event.preventDefault();
+      }
     }
   }
 

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -29,6 +29,7 @@ import {
   dispatchMouseEvent,
   dispatchEvent,
   createKeyboardEvent,
+  dispatchFakeEvent,
 } from '@angular/cdk/testing';
 
 
@@ -1013,6 +1014,15 @@ describe('MdMenu', () => {
           .toContain('mat-menu-item-highlighted', 'Expected the trigger to be highlighted');
       expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(2, 'Expected two open menus');
     }));
+
+    it('should prevent the default mousedown action if the menu item opens a sub-menu', () => {
+      compileTestComponent();
+      instance.rootTrigger.openMenu();
+      fixture.detectChanges();
+
+      const event = dispatchFakeEvent(overlay.querySelector('[md-menu-item]')!, 'mousedown');
+      expect(event.defaultPrevented).toBe(true);
+    });
 
   });
 

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -29,7 +29,7 @@ import {
   dispatchMouseEvent,
   dispatchEvent,
   createKeyboardEvent,
-  dispatchFakeEvent,
+  createMouseEvent,
 } from '@angular/cdk/testing';
 
 
@@ -1020,8 +1020,13 @@ describe('MdMenu', () => {
       instance.rootTrigger.openMenu();
       fixture.detectChanges();
 
-      const event = dispatchFakeEvent(overlay.querySelector('[md-menu-item]')!, 'mousedown');
-      expect(event.defaultPrevented).toBe(true);
+      const event = createMouseEvent('mousedown');
+
+      Object.defineProperty(event, 'buttons', {get: () => 1});
+      event.preventDefault = jasmine.createSpy('preventDefault spy');
+
+      dispatchMouseEvent(overlay.querySelector('[md-menu-item]')!, 'mousedown', 0, 0, event);
+      expect(event.preventDefault).toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
Prevents the sub-menu trigger from staying highlighted if the user clicks on it and moves away to another menu item.

Fixes #6838.