### PR TITLE
fix(table): gracefully handle undefined/null columns

### DIFF
--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -42,8 +42,8 @@ export abstract class BaseRowDef {
 
   ngOnChanges(changes: SimpleChanges): void {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
-    // of the columns property.
-    const columns = changes['columns'].currentValue;
+    // of the columns property or an empty array if none is provided.
+    const columns = changes['columns'].currentValue || [];
     if (!this._columnsDiffer && columns) {
       this._columnsDiffer = this._differs.find(columns).create();
       this._columnsDiffer.diff(columns);

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -30,6 +30,7 @@ describe('CdkTable', () => {
         DuplicateColumnDefNameCdkTableApp,
         MissingColumnDefCdkTableApp,
         CrazyColumnNameCdkTableApp,
+        UndefinedColumnsCdkTableApp,
       ],
     }).compileComponents();
   }));
@@ -131,6 +132,21 @@ describe('CdkTable', () => {
   it('should throw an error if a column definition is requested but not defined', () => {
     expect(() => TestBed.createComponent(MissingColumnDefCdkTableApp).detectChanges())
         .toThrowError(getTableUnknownColumnError('column_a').message);
+  });
+
+  it('should not throw an error if columns are undefined on initialization', () => {
+    const undefinedColumnsFixture = TestBed.createComponent(UndefinedColumnsCdkTableApp);
+    undefinedColumnsFixture.detectChanges();
+
+    tableElement = undefinedColumnsFixture.nativeElement.querySelector('cdk-table');
+
+    expect(getHeaderRow(tableElement)).toBeNull('Should be no header without cells');
+
+    // Rows should be empty since there are no columns to display.
+    const rows = getRows(tableElement);
+    expect(rows[0].textContent).toBe('');
+    expect(rows[1].textContent).toBe('');
+    expect(rows[2].textContent).toBe('');
   });
 
   it('should be able to dynamically add/remove column definitions', () => {
@@ -750,6 +766,24 @@ class DuplicateColumnDefNameCdkTableApp {
   `
 })
 class MissingColumnDefCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="undefinedColumns"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: undefinedColumns"></cdk-row>
+    </cdk-table>
+  `
+})
+class UndefinedColumnsCdkTableApp {
+  undefinedColumns;
   dataSource: FakeDataSource = new FakeDataSource();
 }
 


### PR DESCRIPTION
Seeing errors in tables that define their columns after the table's content has been initialized. Column input to row definitions should default to an empty array.

Workaround for issue: Initialize column input as an empty array.

Fixes #6831