### PR TITLE
build: infinite loop when determining dependencies on windows

### DIFF
--- a/tools/package-tools/secondary-entry-points.ts
+++ b/tools/package-tools/secondary-entry-points.ts
@@ -92,7 +92,7 @@ function buildPackageImportStatementFindCommand(searchDirectory: string, package
   if (platform() === 'win32') {
     return {
       binary: 'findstr',
-      args: ['/r', `from.'@angular/${packageName}/.*'`, `${searchDirectory}\\*`]
+      args: ['/r', `from.'@angular/${packageName}/.*'`, `${searchDirectory}\\*.ts`]
     };
   } else {
     return {


### PR DESCRIPTION
Fixes the `findstr` command going into an infinite loop on Windows due to it not being scoped to TS files.