### PR TITLE
perf(dialog): avoid repainting dialog content element on scroll

### DIFF
--- a/src/lib/core/style/_vendor-prefixes.scss
+++ b/src/lib/core/style/_vendor-prefixes.scss
@@ -33,4 +33,9 @@
   cursor: -webkit-grabbing;
   cursor: grabbing;
 }
+
+@mixin backface-visibility($value) {
+  -webkit-backface-visibility: $value;
+  backface-visibility: $value;
+}
 /* stylelint-enable */

--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -1,4 +1,5 @@
 @import '../core/style/elevation';
+@import '../core/style/vendor-prefixes';
 @import '../core/a11y/a11y';
 
 
@@ -35,6 +36,9 @@ $mat-dialog-button-margin: 8px !default;
   max-height: $mat-dialog-max-height;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+
+  // Promote the content to a new GPU layer to avoid repaints on scroll.
+  @include backface-visibility(hidden);
 }
 
 .mat-dialog-title {


### PR DESCRIPTION
Fixes the `<md-dialog-content>` element being repainted on scroll.

Fixes #6878.