### PR TITLE
docs: sort class properties and methods

### DIFF
--- a/tools/dgeni/processors/categorizer.js
+++ b/tools/dgeni/processors/categorizer.js
@@ -44,8 +44,8 @@ module.exports = function categorizer() {
     decoratePublicDoc(classDoc);
 
     // Sort members
-    classDoc.methods.sort(sortMethods);
-    classDoc.properties.sort(sortProperties);
+    classDoc.methods.sort(sortMembers);
+    classDoc.properties.sort(sortMembers);
 
     // Categorize the current visited classDoc into its Angular type.
     if (isDirective(classDoc)) {
@@ -99,21 +99,8 @@ function filterDuplicateMembers(item, _index, array) {
   return array.filter((memberDoc, i) => memberDoc.name === item.name)[0] === item;
 }
 
-/** Sorts alphabetically by a member's name. */
-function sortByName(docA, docB) {
-  if (docA.name < docB.name) {
-    return -1;
-  }
-
-  if (docA.name > docB.name) {
-    return 1;
-  }
-
-  return 0;
-}
-
-/** Sort deprecated members to the end. */
-function sortByDeprecated(docA, docB) {
+/** Sorts members by deprecated status, member decorator, and name. */
+function sortMembers(docA, docB) {
   // Sort deprecated docs to the end
   if (!docA.isDeprecated && docB.isDeprecated) {
     return -1;
@@ -121,28 +108,6 @@ function sortByDeprecated(docA, docB) {
 
   if (docA.isDeprecated && !docB.isDeprecated) {
     return 1;
-  }
-
-  return 0;
-}
-
-/** Sorts methods by deprecated status and name. */
-function sortMethods(docA, docB) {
-  const deprecatedSort = sortByDeprecated(docA, docB);
-  if (!!deprecatedSort) {
-    return deprecatedSort
-  }
-
-  // Break ties by sorting alphabetically by name
-  return sortByName(docA, docB);
-}
-
-/** Sorts properties by deprecated status, decorator, and name. */
-function sortProperties(docA, docB) {
-  // Sort deprecated properties to the end
-  const deprecatedSort = sortByDeprecated(docA, docB);
-  if (!!deprecatedSort) {
-    return deprecatedSort
   }
 
   // Sort in the order of: Inputs, Outputs, neither
@@ -157,7 +122,15 @@ function sortProperties(docA, docB) {
   }
 
   // Break ties by sorting alphabetically on the name
-  return sortByName(docA, docB);
+  if (docA.name < docB.name) {
+    return -1;
+  }
+
+  if (docA.name > docB.name) {
+    return 1;
+  }
+
+  return 0;
 }
 
 /**


### PR DESCRIPTION
- Properties are sorted in the order of [Inputs, Outputs, neither]. Secondary sorting done alphabetically.
- Methods are sorted alphabetically.
- All deprecated members are sorted to the end.

On some components <sup>(ahem, [select](https://material.angular.io/components/select/api))</sup>, it's really hard to parse the API's list of properties and methods. This sorts them into a, hopefully, logical order.