### PR TITLE
fix(snackbar): correct theme colors

### DIFF
--- a/src/lib/snack-bar/_snack-bar-theme.scss
+++ b/src/lib/snack-bar/_snack-bar-theme.scss
@@ -6,8 +6,8 @@
   $accent: map-get($theme, accent);
 
   .mat-snack-bar-container {
-    background: if($is-dark-theme, map-get($mat-grey, 50), #323232);
-    color: if($is-dark-theme, $black-87-opacity, white);
+    background: if($is-dark-theme, #323232, map-get($mat-grey, 50));
+    color: if($is-dark-theme, white, $black-87-opacity);
   }
 
   .mat-simple-snackbar-action {


### PR DESCRIPTION
Currently default colors are used when dark theme is turned on and dark theme colors when it's turned off.
This change fixes the color assignment.