### PR TITLE
fix(progress-bar): query mode not reversing direction in rtl

### DIFF
--- a/src/lib/progress-bar/progress-bar.scss
+++ b/src/lib/progress-bar/progress-bar.scss
@@ -67,6 +67,11 @@ $mat-progress-bar-piece-animation-duration: 250ms !default;
 
   &[mode='query'] {
     transform: rotateZ(180deg);
+
+    &[dir='rtl'],
+    [dir='rtl'] & {
+      transform: rotateZ(180deg) rotateY(180deg);
+    }
   }
 
   &[mode='indeterminate'],


### PR DESCRIPTION
Fixes the progressbar in query mode not reversing its direction in RTL.