### PR TITLE
docs(table): remove duplicate css in the table-filtering-example

### DIFF
--- a/src/material-examples/table-filtering/table-filtering-example.css
+++ b/src/material-examples/table-filtering/table-filtering-example.css
@@ -8,14 +8,6 @@
 .example-header {
   min-height: 64px;
   display: flex;
-  align-items: center;
-  padding-left: 24px;
-  font-size: 20px;
-}
-
-.example-header {
-  min-height: 64px;
-  display: flex;
   align-items: baseline;
   padding: 8px 24px 0;
   font-size: 20px;


### PR DESCRIPTION
Remove the duplicate css in the table-filtering-example.css, just keep the current valid one.