### PR TITLE
fix(datepicker): toggle should disable compat

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -18,6 +18,7 @@ import {MdDatepicker} from './datepicker';
 import {MdDatepickerIntl} from './datepicker-intl';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
+import {MATERIAL_COMPATIBILITY_MODE} from '../core';
 
 
 @Component({
@@ -27,6 +28,9 @@ import {Subscription} from 'rxjs/Subscription';
   host: {
     'class': 'mat-datepicker-toggle',
   },
+  providers: [
+    {provide: MATERIAL_COMPATIBILITY_MODE, useValue: false}
+  ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -22,6 +22,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs/Subscription';
 import {merge} from 'rxjs/observable/merge';
 import {of as observableOf} from 'rxjs/observable/of';
+import {MATERIAL_COMPATIBILITY_MODE} from '../core';
 
 
 @Component({


### PR DESCRIPTION
The datepicker toggle uses `md-icon-button` and `md-icon` but this fails in compatibility mode. Force `MATERIAL_COMPATIBILITY_MODE` to be false for this component so that it does not fail in either mode

Closes #6942