### PR TITLE
fix(tabs): blurry content in IE

### DIFF
--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -68,11 +68,9 @@ export type MdTabBodyOriginState = 'left' | 'right';
   },
   animations: [
     trigger('translateTab', [
-      state('void', style({transform: 'translate3d(0%, 0, 0)'})),
+      // Note: transitions to `none` instead of 0, because some browsers might blur the content.
+      state('center, void, left-origin-center, right-origin-center', style({transform: 'none'})),
       state('left', style({transform: 'translate3d(-100%, 0, 0)'})),
-      state('left-origin-center', style({transform: 'translate3d(0%, 0, 0)'})),
-      state('right-origin-center', style({transform: 'translate3d(0%, 0, 0)'})),
-      state('center', style({transform: 'translate3d(0%, 0, 0)'})),
       state('right', style({transform: 'translate3d(100%, 0, 0)'})),
       transition('* => left, * => right, left => center, right => center',
           animate('500ms cubic-bezier(0.35, 0, 0.25, 1)')),


### PR DESCRIPTION
Fixes the content of tabs being blurred on IE due to a `transform`.

Fixes #6944.