### PR TITLE
fix(select): extra whitespace around placeholder

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -10,7 +10,7 @@
     [class.mat-floating-placeholder]="_hasValue()"
     [@transformPlaceholder]="_getPlaceholderAnimationState()"
     [style.opacity]="_getPlaceholderOpacity()"
-    [style.width.px]="_selectedValueWidth"> {{ placeholder }} </span>
+    [style.width.px]="_selectedValueWidth">{{ placeholder }}</span>
 
   <span class="mat-select-value" *ngIf="_hasValue()">
     <span class="mat-select-value-text" [ngSwitch]="!!customTrigger">

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -76,7 +76,7 @@ $mat-select-trigger-underline-height: 1px !default;
 
   // TODO: Double-check accessibility of this style
   .mat-select-required &::after {
-    content: '*';
+    content: ' *';
   }
 }
 


### PR DESCRIPTION
Fixes some extra whitespace being added around the placeholder.

Fixes #6923.