### PR TITLE
fix(snackbar): Docs example fixes

### DIFF
--- a/src/material-examples/card-fancy/card-fancy-example.css
+++ b/src/material-examples/card-fancy/card-fancy-example.css
@@ -3,6 +3,6 @@
 }
 
 .example-header-image {
-  background-image: url('../../../assets/img/examples/shiba1.jpg');
+  background-image: url('http://material.angular.io/assets/img/examples/shiba1.jpg');
   background-size: cover;
 }

--- a/src/material-examples/card-fancy/card-fancy-example.html
+++ b/src/material-examples/card-fancy/card-fancy-example.html
@@ -4,7 +4,7 @@
     <mat-card-title>Shiba Inu</mat-card-title>
     <mat-card-subtitle>Dog Breed</mat-card-subtitle>
   </mat-card-header>
-  <img mat-card-image src="assets/img/examples/shiba2.jpg" alt="Photo of a Shiba Inu">
+  <img mat-card-image src="http://material.angular.io/assets/img/examples/shiba2.jpg" alt="Photo of a Shiba Inu">
   <mat-card-content>
     <p>
       The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.

--- a/src/material-examples/snack-bar-component/snack-bar-component-example-snack.css
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example-snack.css
@@ -1,3 +1,0 @@
-.example-pizza-party {
-  color: hotpink;
-}

--- a/src/material-examples/snack-bar-component/snack-bar-component-example.ts
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example.ts
@@ -22,6 +22,6 @@ export class SnackBarComponentExample {
 @Component({
   selector: 'snack-bar-component-example-snack',
   templateUrl: 'snack-bar-component-example-snack.html',
-  styleUrls: ['snack-bar-component-example-snack.css'],
+  styles: [`.example-pizza-party { color: hotpink; }`],
 })
 export class PizzaPartyComponent {}


### PR DESCRIPTION
For #6952 #6951 

- Move snackbar inline
- Load card icons from urls absolutely rather than relatively