### PR TITLE
feat(selection-model): de/select multiple values at the same time

### DIFF
--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -22,6 +22,11 @@ describe('SelectionModel', () => {
       expect(model.isSelected(2)).toBe(true);
     });
 
+    it('should throw an error if multiple values are passed to model', () => {
+      expect(() => model.select(1, 2))
+        .toThrowError(/Cannot pass multiple values into SelectionModel with single-value mode/);
+    });
+
     it('should only preselect one value', () => {
       model = new SelectionModel(false, [1, 2]);
 
@@ -36,13 +41,29 @@ describe('SelectionModel', () => {
 
     beforeEach(() => model = new SelectionModel(true));
 
-    it('should be able to select multiple options at the same time', () => {
+    it('should be able to select multiple options', () => {
+      const onChangeSpy = jasmine.createSpy('onChange spy');
+
+      model.onChange!.subscribe(onChangeSpy);
       model.select(1);
       model.select(2);
 
       expect(model.selected.length).toBe(2);
       expect(model.isSelected(1)).toBe(true);
       expect(model.isSelected(2)).toBe(true);
+      expect(onChangeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should be able to select multiple options at the same time', () => {
+      const onChangeSpy = jasmine.createSpy('onChange spy');
+
+      model.onChange!.subscribe(onChangeSpy);
+      model.select(1, 2);
+
+      expect(model.selected.length).toBe(2);
+      expect(model.isSelected(1)).toBe(true);
+      expect(model.isSelected(2)).toBe(true);
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should be able to preselect multiple options', () => {

--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -1,4 +1,4 @@
-import {SelectionModel} from './selection';
+import {getMultipleValuesInSingleSelectionError, SelectionModel} from './selection';
 
 
 describe('SelectionModel', () => {
@@ -23,8 +23,7 @@ describe('SelectionModel', () => {
     });
 
     it('should throw an error if multiple values are passed to model', () => {
-      expect(() => model.select(1, 2))
-        .toThrowError(/Cannot pass multiple values into SelectionModel with single-value mode/);
+      expect(() => model.select(1, 2)).toThrow(getMultipleValuesInSingleSelectionError());
     });
 
     it('should only preselect one value', () => {

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -56,16 +56,18 @@ export class SelectionModel<T> {
   /**
    * Selects a value or an array of values.
    */
-  select(value: T): void {
-    this._markSelected(value);
+  select(...values: T[]): void {
+    this._warnMultipleValuesForSingleSelection(values);
+    values.forEach(value => this._markSelected(value));
     this._emitChangeEvent();
   }
 
   /**
    * Deselects a value or an array of values.
    */
-  deselect(value: T): void {
-    this._unmarkSelected(value);
+  deselect(...values: T[]): void {
+    this._warnMultipleValuesForSingleSelection(values);
+    values.forEach(value => this._unmarkSelected(value));
     this._emitChangeEvent();
   }
 
@@ -162,6 +164,13 @@ export class SelectionModel<T> {
       this._selection.forEach(value => this._unmarkSelected(value));
     }
   }
+
+  /** Throws an error if multiple values are passed into a selection model with a single value. */
+  private _warnMultipleValuesForSingleSelection(values: T[]) {
+    if (values.length > 1 && !this._isMulti) {
+      throwMultipleValuesInSingleSelectionError();
+    }
+  }
 }
 
 /**
@@ -170,4 +179,9 @@ export class SelectionModel<T> {
  */
 export class SelectionChange<T> {
   constructor(public added?: T[], public removed?: T[]) { }
+}
+
+/** Throws an error if multiple values are passed into a selection model with a single value. */
+export function throwMultipleValuesInSingleSelectionError() {
+  throw Error('Cannot pass multiple values into SelectionModel with single-value mode.');
 }

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -57,7 +57,7 @@ export class SelectionModel<T> {
    * Selects a value or an array of values.
    */
   select(...values: T[]): void {
-    this._warnMultipleValuesForSingleSelection(values);
+    this._verifyValueAssignment(values);
     values.forEach(value => this._markSelected(value));
     this._emitChangeEvent();
   }
@@ -66,7 +66,7 @@ export class SelectionModel<T> {
    * Deselects a value or an array of values.
    */
   deselect(...values: T[]): void {
-    this._warnMultipleValuesForSingleSelection(values);
+    this._verifyValueAssignment(values);
     values.forEach(value => this._unmarkSelected(value));
     this._emitChangeEvent();
   }
@@ -165,10 +165,13 @@ export class SelectionModel<T> {
     }
   }
 
-  /** Throws an error if multiple values are passed into a selection model with a single value. */
-  private _warnMultipleValuesForSingleSelection(values: T[]) {
+  /**
+   * Verifies the value assignment and throws an error if the specified value array is
+   * including multiple values while the selection model is not supporting multiple values.
+   */
+  private _verifyValueAssignment(values: T[]) {
     if (values.length > 1 && !this._isMulti) {
-      throwMultipleValuesInSingleSelectionError();
+      throw getMultipleValuesInSingleSelectionError();
     }
   }
 }
@@ -181,7 +184,10 @@ export class SelectionChange<T> {
   constructor(public added?: T[], public removed?: T[]) { }
 }
 
-/** Throws an error if multiple values are passed into a selection model with a single value. */
-export function throwMultipleValuesInSingleSelectionError() {
-  throw Error('Cannot pass multiple values into SelectionModel with single-value mode.');
+/**
+ * Returns an error that reports that multiple values are passed into a selection model
+ * with a single value.
+ */
+export function getMultipleValuesInSingleSelectionError() {
+  return Error('Cannot pass multiple values into SelectionModel with single-value mode.');
 }


### PR DESCRIPTION
Adds support for passing multiple values to the SelectionModel at the same time. This feature is described in the JSDoc already, but just wasn't implemented yet.

This functionality gives us more control about the `onChange` event, which will otherwise fire every time if for example multiple values need to be selected.

Related to #6896 