### PR TITLE
fix(common-module): check if computed styles are available

### DIFF
--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -62,6 +62,9 @@ export class MdCommonModule {
 
       const computedStyle = getComputedStyle(testElement);
 
+      // In some situations, the computed style of the test element can be null. For example in
+      // Firefox, the computed style is null if an application is running inside of a hidden iframe.
+      // See: https://bugzilla.mozilla.org/show_bug.cgi?id=548397
       if (computedStyle && computedStyle.display !== 'none') {
         console.warn(
           'Could not find Angular Material core theme. Most Material ' +

--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -60,7 +60,9 @@ export class MdCommonModule {
       testElement.classList.add('mat-theme-loaded-marker');
       this._document.body.appendChild(testElement);
 
-      if (getComputedStyle(testElement).display !== 'none') {
+      const computedStyle = getComputedStyle(testElement);
+
+      if (computedStyle && computedStyle.display !== 'none') {
         console.warn(
           'Could not find Angular Material core theme. Most Material ' +
           'components may not work as expected. For more info refer ' +


### PR DESCRIPTION
Due to a Firefox Bug (https://bugzilla.mozilla.org/show_bug.cgi?id=548397) the `getComputedStyle` call in the `MdCommonModule` will return `null` and cause a runtime exception because normally the computed styles are never `null` for the test element.

Since this it's very uncommon that a developer places a Angular Material application inside of a hidden iframe, a simple null check should be enough to get the application running.

Fixes #7000