### PR TITLE
fix(select): aria-labelledby should not be in DOM

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1701,6 +1701,15 @@ describe('MdSelect', () => {
         expect(select.getAttribute('aria-labelledby')).toBe('myLabelId');
       });
 
+      it('should not have aria-labelledby in the DOM if it`s not specified', async(() => {
+
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          expect(select.hasAttribute('aria-labelledby')).toBeFalsy();
+        });
+      }));
+
       it('should set the tabindex of the select to 0 by default', () => {
         expect(select.getAttribute('tabindex')).toEqual('0');
       });

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -394,7 +394,7 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   @Input('aria-label') ariaLabel: string = '';
 
   /** Input that can be used to specify the `aria-labelledby` attribute. */
-  @Input('aria-labelledby') ariaLabelledby: string = '';
+  @Input('aria-labelledby') ariaLabelledby: string;
 
   /** Combined stream of all of the child options' change events. */
   get optionSelectionChanges(): Observable<MdOptionSelectionChange> {


### PR DESCRIPTION
When there is no supplied aria-labelledby
it should not show up in the DOM at all

Relates to Issue #7015 