### PR TITLE
fix(tooltip): error on trigger escape presses while closed

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -19,7 +19,8 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {OverlayContainer, OverlayModule, Scrollable} from '@angular/cdk/overlay';
 import {Platform} from '@angular/cdk/platform';
-import {dispatchFakeEvent} from '@angular/cdk/testing';
+import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
+import {ESCAPE} from '@angular/cdk/keycodes';
 import {
   MdTooltip,
   MdTooltipModule,
@@ -467,6 +468,13 @@ describe('MdTooltip', () => {
 
       expect(tooltipDirective._isTooltipVisible()).toBe(true);
       expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
+    }));
+
+    it('should not throw when pressing ESCAPE', fakeAsync(() => {
+      expect(() => {
+        dispatchKeyboardEvent(buttonElement, 'keydown', ESCAPE);
+        fixture.detectChanges();
+      }).not.toThrow();
     }));
 
   });

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -273,7 +273,7 @@ export class MdTooltip implements OnDestroy {
 
   /** Handles the keydown events on the host element. */
   _handleKeydown(e: KeyboardEvent) {
-    if (this._tooltipInstance!.isVisible() && e.keyCode === ESCAPE) {
+    if (this._isTooltipVisible() && e.keyCode === ESCAPE) {
       e.stopPropagation();
       this.hide(0);
     }


### PR DESCRIPTION
Fixes an error being thrown when pressing escape on a tooltip trigger that isn't showing a tooltip.

Fixes #7009.