### PR TITLE
chore(menu): missing method call

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -417,7 +417,7 @@ export class MdMenuTrigger implements AfterViewInit, OnDestroy {
       // Since clicking on the trigger won't close the menu if it opens a sub-menu,
       // we should prevent focus from moving onto it via click to avoid the
       // highlight from lingering on the menu item.
-      if (this.triggersSubmenu) {
+      if (this.triggersSubmenu()) {
         event.preventDefault();
       }
     }


### PR DESCRIPTION
Fixes a method not being called, causing the check to always evaluate to true.