### PR TITLE
chore: move overlay-container specs

### DIFF
--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -1,6 +1,6 @@
 import {async, inject, TestBed} from '@angular/core/testing';
 import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
-import {PortalModule, TemplatePortalDirective} from '../portal/portal-directives';
+import {PortalModule, TemplatePortalDirective} from '@angular/cdk/portal';
 import {Overlay, OverlayContainer, OverlayModule} from './index';
 
 describe('OverlayContainer', () => {


### PR DESCRIPTION
It seems like the overlay container tests got left behind during the move to the CDK. These changes move them next to the container.