### PR TITLE
style(form-field): use easing function for underline

### DIFF
--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -160,6 +160,7 @@ $mat-form-field-underline-height: 1px !default;
     transform-origin: 50%;
     transform: scaleX(0.5);
     visibility: hidden;
+    opacity: 0;
     transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
 
     .mat-focused & {
@@ -169,9 +170,11 @@ $mat-form-field-underline-height: 1px !default;
     .mat-focused &,
     .mat-form-field-invalid & {
       visibility: visible;
+      opacity: 1;
       transform: scaleX(1);
-      transition: transform 150ms linear,
-      background-color $swift-ease-in-duration $swift-ease-in-timing-function;
+      transition: transform 300ms $swift-ease-out-timing-function,
+        opacity 100ms $swift-ease-out-timing-function,
+        background-color 300ms $swift-ease-out-timing-function;
     }
   }
 }


### PR DESCRIPTION
Tried to match what I see [in this animation](https://storage.googleapis.com/material-design/publish/material_v_12/assets/0B8wSqcLwbhFuREg4Q0R4M3VGejA/textfields-presslight-01.webm), but am curious if there are any official curves/durations from the UX team. In either case, I think some easing function is better than linear.

cc @mmalerba and note that no one is CODEOWNER of form-field