### PR TITLE
build: fix umd bundles build task

### DIFF
--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -172,7 +172,7 @@ export class PackageBundler {
   private getResolvedSecondaryEntryPointImportPaths(bundleOutputDir: string) {
     return this.buildPackage.secondaryEntryPoints.reduce((map, p) => {
       map[`@angular/${this.buildPackage.name}/${p}`] =
-          join(dirname(bundleOutputDir), 'material', `${p}.es5`);
+          join(dirname(bundleOutputDir), this.buildPackage.name, `${p}.es5.js`);
       return map;
     }, {} as {[key: string]: string});
   }


### PR DESCRIPTION
Currently when trying to serve the devapp, the `build-bundles` task seems to be broken. Rollup is not able to properly read the source files from the disk because the `.js` file extension is missing.

![image](https://user-images.githubusercontent.com/4987015/30486333-7cb82506-9a30-11e7-80fa-058a99541bec.png)


