### PR TITLE
fix(autocomplete): remove invalid aria markup

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -100,7 +100,6 @@ export function getMdAutocompleteMissingPanelError(): Error {
     'role': 'combobox',
     'autocomplete': 'off',
     'aria-autocomplete': 'list',
-    'aria-multiline': 'false',
     '[attr.aria-activedescendant]': 'activeOption?.id',
     '[attr.aria-expanded]': 'panelOpen.toString()',
     '[attr.aria-owns]': 'autocomplete?.id',

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1104,11 +1104,6 @@ describe('MdAutocomplete', () => {
           .toEqual('list', 'Expected aria-autocomplete attribute to equal list.');
     });
 
-    it('should set aria-multiline to false', () => {
-      expect(input.getAttribute('aria-multiline'))
-          .toEqual('false', 'Expected aria-multiline attribute to equal false.');
-    });
-
     it('should set aria-activedescendant based on the active option', async(() => {
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();


### PR DESCRIPTION
Removes the `aria-multiline` attribute, because it is not allowed on a `role="combobox"`.

Fixes #7100.