### PR TITLE
feat(select): add left/right_arrow key navigation

### DIFF
--- a/src/cdk/a11y/list-key-manager.ts
+++ b/src/cdk/a11y/list-key-manager.ts
@@ -108,7 +108,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
         const keyCode = event.keyCode;
 
         // Attempt to use the `event.key` which also maps it to the user's keyboard language,
-        // otherwise fall back to resolving alphanumeric characters via the keyCode.
+        // otherwise fall back to resolving alphanumeric characters via the keyCode
         if (event.key && event.key.length === 1) {
           this._letterKeyStream.next(event.key.toLocaleUpperCase());
         } else if ((keyCode >= A && keyCode <= Z) || (keyCode >= ZERO && keyCode <= NINE)) {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -21,7 +21,17 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {Directionality} from '@angular/cdk/bidi';
-import {DOWN_ARROW, END, ENTER, HOME, SPACE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
+import {
+  DOWN_ARROW,
+  END,
+  ENTER,
+  HOME,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  TAB,
+  UP_ARROW
+} from '@angular/cdk/keycodes';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {dispatchFakeEvent, dispatchKeyboardEvent, wrappedErrorMessage} from '@angular/cdk/testing';
@@ -1803,6 +1813,34 @@ describe('MdSelect', () => {
           'Expected value from second option to have been set on the model.');
       });
 
+      it('should be able to select options via the left/right arrow keys on a closed select',
+        () => {
+        const formControl = fixture.componentInstance.control;
+        const options = fixture.componentInstance.options.toArray();
+
+        expect(formControl.value).toBeFalsy('Expected no initial value.');
+
+        dispatchKeyboardEvent(select, 'keydown', RIGHT_ARROW);
+
+        expect(options[0].selected).toBe(true, 'Expected first option to be selected.');
+        expect(formControl.value).toBe(options[0].value,
+          'Expected value from first option to have been set on the model.');
+
+        dispatchKeyboardEvent(select, 'keydown', RIGHT_ARROW);
+        dispatchKeyboardEvent(select, 'keydown', RIGHT_ARROW);
+
+        // Note that the third option is skipped, because it is disabled.
+        expect(options[3].selected).toBe(true, 'Expected fourth option to be selected.');
+        expect(formControl.value).toBe(options[3].value,
+          'Expected value from fourth option to have been set on the model.');
+
+        dispatchKeyboardEvent(select, 'keydown', LEFT_ARROW);
+
+        expect(options[1].selected).toBe(true, 'Expected second option to be selected.');
+        expect(formControl.value).toBe(options[1].value,
+          'Expected value from second option to have been set on the model.');
+      });
+
       it('should open the panel when pressing the arrow keys on a closed multiple select', () => {
         fixture.destroy();
 
@@ -1822,6 +1860,48 @@ describe('MdSelect', () => {
         expect(instance.control.value).toBe(initialValue, 'Expected value to stay the same.');
         expect(event.defaultPrevented).toBe(true, 'Expected default to be prevented.');
       });
+
+      it('should open the panel when pressing the left_arrow keys on a closed multiple select',
+        () => {
+        fixture.destroy();
+
+        const multiFixture = TestBed.createComponent(MultiSelect);
+        const instance = multiFixture.componentInstance;
+
+        multiFixture.detectChanges();
+        select = multiFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+        const initialValue = instance.control.value;
+
+        expect(instance.select.panelOpen).toBe(false, 'Expected panel to be closed.');
+
+        const event = dispatchKeyboardEvent(select, 'keydown', LEFT_ARROW);
+
+        expect(instance.select.panelOpen).toBe(true, 'Expected panel to be open.');
+        expect(instance.control.value).toBe(initialValue, 'Expected value to stay the same.');
+        expect(event.defaultPrevented).toBe(true, 'Expected default to be prevented.');
+      });
+
+      it('should open the panel when pressing the right_arrow keys on a closed multiple select',
+      () => {
+      fixture.destroy();
+
+      const multiFixture = TestBed.createComponent(MultiSelect);
+      const instance = multiFixture.componentInstance;
+
+      multiFixture.detectChanges();
+      select = multiFixture.debugElement.query(By.css('md-select')).nativeElement;
+
+      const initialValue = instance.control.value;
+
+      expect(instance.select.panelOpen).toBe(false, 'Expected panel to be closed.');
+
+      const event = dispatchKeyboardEvent(select, 'keydown', RIGHT_ARROW);
+
+      expect(instance.select.panelOpen).toBe(true, 'Expected panel to be open.');
+      expect(instance.control.value).toBe(initialValue, 'Expected value to stay the same.');
+      expect(event.defaultPrevented).toBe(true, 'Expected default to be prevented.');
+    });
 
       it('should do nothing if the key manager did not change the active item', () => {
         const formControl = fixture.componentInstance.control;

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -32,7 +32,16 @@ import {
   isDevMode,
 } from '@angular/core';
 import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
-import {DOWN_ARROW, END, ENTER, HOME, SPACE, UP_ARROW} from '@angular/cdk/keycodes';
+import {
+  DOWN_ARROW,
+  END,
+  ENTER,
+  HOME,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  UP_ARROW
+} from '@angular/cdk/keycodes';
 import {FocusKeyManager} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
@@ -591,7 +600,8 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
       if (event.keyCode === ENTER || event.keyCode === SPACE) {
         event.preventDefault(); // prevents the page from scrolling down when pressing space
         this.open();
-      } else if (event.keyCode === UP_ARROW || event.keyCode === DOWN_ARROW) {
+      } else if (event.keyCode === UP_ARROW || event.keyCode === DOWN_ARROW ||
+                 event.keyCode === LEFT_ARROW || event.keyCode === RIGHT_ARROW) {
         this._handleArrowKey(event);
       }
     }
@@ -1166,9 +1176,16 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
 
       // Cycle though the select options even when the select is closed,
       // matching the behavior of the native select element.
-      // TODO(crisbeto): native selects also cycle through the options with left/right arrows,
-      // however the key manager only supports up/down at the moment.
-      this._keyManager.onKeydown(event);
+      // Update: added left/right arrows cycle to reflect the behavior
+      // of native select element. TODO(bogdancar): Move the left/right key
+      // logic to list-key-manager once implemented there.
+      if (event.keyCode === LEFT_ARROW) {
+        this._keyManager.setPreviousItemActive();
+      } else if (event.keyCode === RIGHT_ARROW) {
+        this._keyManager.setNextItemActive();
+      } else {
+        this._keyManager.onKeydown(event);
+      }
 
       const currentActiveItem = this._keyManager.activeItem as MdOption;
 


### PR DESCRIPTION
As suggested by crisbeto in the comments, added left/right_arrow key navigation on select when closed to reflect the native select behavior. This implementation is a temporary workaround to have the functionality. Normally this code belongs to the `list-key-manager`, but there was not implemented and a decision should be made on this specific behavior of left/right_arrow key press for all lists, before being added to `list-key-manager`.