### PR TITLE
fix(radio): defaulting to invalid name attribute

### DIFF
--- a/src/lib/radio/radio.html
+++ b/src/lib/radio/radio.html
@@ -15,7 +15,7 @@
          [id]="inputId"
          [checked]="checked"
          [disabled]="disabled"
-         [name]="name"
+         [attr.name]="name"
          [required]="required"
          [attr.aria-label]="ariaLabel"
          [attr.aria-labelledby]="ariaLabelledby"

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -638,6 +638,12 @@ describe('MatRadio', () => {
         expect(document.activeElement).toBe(fruitRadioNativeInputs[i]);
       }
     });
+
+    it('should not add the "name" attribute if it is not passed in', () => {
+      const radio = fixture.debugElement.nativeElement.querySelector('#nameless input');
+      expect(radio.hasAttribute('name')).toBe(false);
+    });
+
   });
 
   describe('with tabindex', () => {
@@ -711,6 +717,7 @@ class RadiosInsideRadioGroup {
                      [aria-labelledby]="ariaLabelledby">
     </mat-radio-button>
     <mat-radio-button name="fruit" value="raspberry">Raspberry</mat-radio-button>
+    <mat-radio-button id="nameless" value="no-name">No name</mat-radio-button>
   `
 })
 class StandaloneRadioButtons {


### PR DESCRIPTION
Fixes the radio button defaulting to `name="undefined"` for the underlying input, if the consumer hasn't passed in a name.

Relates to #7130.