### PR TITLE
build: fix payload calculation

### DIFF
--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -23,8 +23,8 @@ task('payload', ['material:clean-build'], async () => {
     // Material bundles
     material_umd: getBundleSize('material.umd.js'),
     material_umd_minified_uglify: getBundleSize('material.umd.min.js'),
-    material_fesm_2015: getBundleSize('material.js'),
-    material_fesm_2014: getBundleSize('material.es5.js'),
+    material_fesm_2015: getBundleSize('material.js') + getBundleSize('material/!(*.es5).js'),
+    material_fesm_2014: getBundleSize('material.es5.js') + getBundleSize('material/*.es5.js'),
     // CDK bundles
     cdk_umd: getBundleSize('cdk*.umd.js'),
     cdk_umd_minified_uglify: getBundleSize('cdk*.umd.min.js'),


### PR DESCRIPTION
* Due to the recent changes in the Material package, the payload is no longer calculated correctly. All components have been moved into different bundles instead of a single bundle.

**Note**: UMD bundles are not affected because the root UMD bundle still includes all sub-UMD bundles (= components)