### PR TITLE
chore(snack-bar): rename MdSnackBarRef `instance` to `componentInstance`

### DIFF
--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -16,7 +16,7 @@ import {MdSnackBarContainer} from './snack-bar-container';
  */
 export class MdSnackBarRef<T> {
   /** The instance of the component making up the content of the snack bar. */
-  instance: T;
+  componentInstance: T;
 
   /**
    * The instance of the component making up the content of the snack bar.

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -95,9 +95,9 @@ describe('MdSnackBar', () => {
 
     viewContainerFixture.detectChanges();
 
-    expect(snackBarRef.instance instanceof SimpleSnackBar)
+    expect(snackBarRef.componentInstance instanceof SimpleSnackBar)
       .toBe(true, 'Expected the snack bar content component to be SimpleSnackBar');
-    expect(snackBarRef.instance.snackBarRef)
+    expect(snackBarRef.componentInstance.snackBarRef)
       .toBe(snackBarRef,
             'Expected the snack bar reference to be placed in the component instance');
 
@@ -119,9 +119,9 @@ describe('MdSnackBar', () => {
 
     viewContainerFixture.detectChanges();
 
-    expect(snackBarRef.instance instanceof SimpleSnackBar)
+    expect(snackBarRef.componentInstance instanceof SimpleSnackBar)
       .toBe(true, 'Expected the snack bar content component to be SimpleSnackBar');
-    expect(snackBarRef.instance.snackBarRef)
+    expect(snackBarRef.componentInstance.snackBarRef)
       .toBe(snackBarRef, 'Expected the snack bar reference to be placed in the component instance');
 
     let messageElement = overlayContainerElement.querySelector('snack-bar-container')!;
@@ -391,7 +391,7 @@ describe('MdSnackBar', () => {
     it('should open a custom component', () => {
       const snackBarRef = snackBar.openFromComponent(BurritosNotification);
 
-      expect(snackBarRef.instance instanceof BurritosNotification)
+      expect(snackBarRef.componentInstance instanceof BurritosNotification)
         .toBe(true, 'Expected the snack bar content component to be BurritosNotification');
       expect(overlayContainerElement.textContent!.trim())
           .toBe('Burritos are on the way.', 'Expected component to have the proper text.');
@@ -400,7 +400,7 @@ describe('MdSnackBar', () => {
     it('should inject the snack bar reference into the component', () => {
       const snackBarRef = snackBar.openFromComponent(BurritosNotification);
 
-      expect(snackBarRef.instance.snackBarRef)
+      expect(snackBarRef.componentInstance.snackBarRef)
         .toBe(snackBarRef, 'Expected component to have an injected snack bar reference.');
     });
 
@@ -411,8 +411,8 @@ describe('MdSnackBar', () => {
         }
       });
 
-      expect(snackBarRef.instance.data).toBeTruthy('Expected component to have a data object.');
-      expect(snackBarRef.instance.data.burritoType)
+      expect(snackBarRef.componentInstance.data).toBeTruthy('Expected component to have a data object.');
+      expect(snackBarRef.componentInstance.data.burritoType)
         .toBe('Chimichanga', 'Expected the injected data object to be the one the user provided.');
     });
 

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -143,7 +143,7 @@ export class MdSnackBar {
     const contentRef = container.attachComponentPortal(portal);
 
     // We can't pass this via the injector, because the injector is created earlier.
-    snackBarRef.instance = contentRef.instance;
+    snackBarRef.componentInstance = contentRef.instance;
 
     return snackBarRef;
   }


### PR DESCRIPTION
BREAKING CHANGE: Renamed instance to componentInstance to be consistent with other dialogs

Closes #6252