### PR TITLE
chore(sort): fix invalid import path

### DIFF
--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -28,7 +28,7 @@ import {merge} from 'rxjs/observable/merge';
 import {MdSort, MdSortable} from './sort';
 import {MdSortHeaderIntl} from './sort-header-intl';
 import {getMdSortHeaderNotContainedWithinMdSortError} from './sort-errors';
-import {AnimationCurves, AnimationDurations} from '../core/animation/animation';
+import {AnimationCurves, AnimationDurations} from '@angular/material/core';
 
 const SORT_ANIMATION_TRANSITION =
     AnimationDurations.ENTERING + ' ' + AnimationCurves.STANDARD_CURVE;


### PR DESCRIPTION
* Fixes an incorrect import inside of the sort entry-point of Material. Due to a relative import to the core entry-point, the prerender task fails to execute and the packaging doesn't work properly either.