### PR TITLE
chore: remove cdk testing from rollup globals

### DIFF
--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -42,18 +42,14 @@ export const rollupGlobals = {
   '@angular/common/testing': 'ng.common.testing',
   '@angular/http/testing': 'ng.http.testing',
 
-
+  // Some packages are not really needed for the UMD bundles, but for the missingRollupGlobals rule.
+  '@angular/material-examples': 'ng.materialExamples',
   '@angular/material': 'ng.material',
   '@angular/cdk': 'ng.cdk',
 
   // Include secondary entry-points of the cdk and material packages
   ...rollupCdkEntryPoints,
   ...rollupMatEntryPoints,
-
-  // Some packages are not really needed for the UMD bundles, but for the missingRollupGlobals rule.
-  // TODO(devversion): remove by adding minimatch and better globbing to rules
-  '@angular/cdk/testing': 'ng.cdk.testing',
-  '@angular/material-examples': 'ng.materialExamples',
 
   'rxjs/BehaviorSubject': 'Rx',
   'rxjs/Observable': 'Rx',

--- a/tools/tslint-rules/tsLoaderRule.js
+++ b/tools/tslint-rules/tsLoaderRule.js
@@ -10,4 +10,4 @@ require('ts-node').register({
 // Add a noop rule so tslint doesn't complain.
 exports.Rule = class Rule extends Lint.Rules.AbstractRule {
   apply() {}
-}
+};


### PR DESCRIPTION
Previously the `missingRollupGlobals` tslint rule checked every TS file in the `src/` directory. This meant that the `@angular/cdk/testing` package from spec files needs to be added there as well.

With the recent switcht to Minimatch for our custom TSLint rules, the spec files are no longer linted and the testing package can be removed there.