### PR TITLE
build: round payload size for comparison

### DIFF
--- a/tools/gulp/tasks/payload.ts
+++ b/tools/gulp/tasks/payload.ts
@@ -93,10 +93,10 @@ async function calculatePayloadDiff(database: firebaseAdmin.database.Database, c
 
   // Calculate the payload diffs by subtracting the previous size of the FESM ES2015 bundles.
   const cdkFullSize = currentPayload.cdk_fesm_2015;
-  const cdkDiff = cdkFullSize - previousPayload.cdk_fesm_2015;
+  const cdkDiff = roundFileSize(cdkFullSize - previousPayload.cdk_fesm_2015);
 
   const materialFullSize = currentPayload.material_fesm_2015;
-  const materialDiff = materialFullSize - previousPayload.material_fesm_2015;
+  const materialDiff = roundFileSize(materialFullSize - previousPayload.material_fesm_2015);
 
   // Set the Github statuses for the packages by sending a HTTP request to the dashboard functions.
   await Promise.all([
@@ -173,4 +173,9 @@ function getCommitFromPreviousPayloadUpload(): string {
     // by just loading the SHA of the most recent commit in the target branch.
     return spawnSync('git', ['rev-parse', process.env['TRAVIS_BRANCH']]).stdout.toString().trim();
   }
+}
+
+/** Rounds the specified file size to two decimal places. */
+function roundFileSize(fileSize: number) {
+  return Math.round(fileSize * 100) / 100;
 }


### PR DESCRIPTION
In some cases the payload is still showing up in the CI even if there was no change to the library. This seems to be because the file sizes are not rounded and can sometimes be not very exact. Resulting in numbers like: `material_fesm_2014": 1004.1319999999998`.

To have a more readable output in the gulp task, the file sizes should be rounded. This also makes the diff comparsion in the Firebase function better.

See PRs like: https://github.com/angular/material2/pull/7169