### PR TITLE
fix(drawer): open event not firing on init

### DIFF
--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -126,6 +126,15 @@ describe('MatDrawer', () => {
       expect(testComponent.closeCount).toBe(1, 'Expected one close event.');
     }));
 
+    it('should fire the open event when open on init', fakeAsync(() => {
+      let fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
+
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.openCallback).toHaveBeenCalledTimes(1);
+    }));
+
     it('should not close by pressing escape when disableClose is set', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
       let testComponent = fixture.debugElement.componentInstance;
@@ -430,12 +439,14 @@ class DrawerSetToOpenedFalse { }
 @Component({
   template: `
     <mat-drawer-container>
-      <mat-drawer #drawer mode="side" opened="true">
+      <mat-drawer #drawer mode="side" opened="true" (open)="openCallback()">
         Closed Drawer.
       </mat-drawer>
     </mat-drawer-container>`,
 })
-class DrawerSetToOpenedTrue { }
+class DrawerSetToOpenedTrue {
+  openCallback = jasmine.createSpy('open callback');
+}
 
 @Component({
   template: `

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -329,9 +329,9 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
   _onAnimationEnd(event: AnimationEvent) {
     const {fromState, toState} = event;
 
-    if (toState === 'open' && fromState === 'void') {
+    if (toState.indexOf('open') === 0 && fromState === 'void') {
       this.onOpen.emit(new MatDrawerToggleResult('open', true));
-    } else if (toState === 'void' && fromState === 'open') {
+    } else if (toState === 'void' && fromState.indexOf('open') === 0) {
       this.onClose.emit(new MatDrawerToggleResult('close', true));
     }
 


### PR DESCRIPTION
Fixes a regression that caused the drawer not to fire its `open` event if it is open on init.

Fixes #7208.