### PR TITLE
fix(select): multiple change events emitted when changing options of a closed select

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2225,6 +2225,14 @@ describe('MdSelect', () => {
 
       expect(fixture.componentInstance.changeListener).toHaveBeenCalledTimes(1);
     });
+
+    it('should only emit one event when pressing the arrow keys on a closed select', () => {
+      const select = fixture.debugElement.query(By.css('md-select')).nativeElement;
+      dispatchKeyboardEvent(select, 'keydown', DOWN_ARROW);
+
+      expect(fixture.componentInstance.changeListener).toHaveBeenCalledTimes(1);
+    });
+
   });
 
   describe('floatPlaceholder option', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -1178,7 +1178,6 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
       if (currentActiveItem !== prevActiveItem) {
         this._clearSelection();
         this._setSelectionByValue(currentActiveItem.value, true);
-        this._propagateChanges();
       }
     }
   }


### PR DESCRIPTION
Prevents two change events being fired for the same change when selecting an option via the arrow keys on a closed select.

Fixes #7227.