### PR TITLE
chore: better color usage for chip demo

### DIFF
--- a/src/lib/chips/chips.md
+++ b/src/lib/chips/chips.md
@@ -35,7 +35,7 @@ between the two components. This directive adds chip-specific behaviors to the i
 within `<mat-form-field>` for adding and removing chips. The `<input>` with `MatChipInput` can
 be placed inside or outside the chip-list element.
 
-An exmaple of chip input placed inside the chip-list element.
+An example of chip input placed inside the chip-list element.
 <!-- example(chips-input) -->
 
 An example of chip input placed outside the chip-list element.

--- a/src/material-examples/chips-stacked/chips-stacked-example.html
+++ b/src/material-examples/chips-stacked/chips-stacked-example.html
@@ -1,7 +1,5 @@
 <mat-chip-list class="mat-chip-list-stacked">
-  <mat-chip *ngFor="let chipColor of availableColors"
-      selected="true"
-      color="{{chipColor.color}}">
-    {{chipColor.name}}
+  <mat-chip *ngFor="let chip of availableColors" selected="true" [color]="chip.color">
+    {{chip.name}}
   </mat-chip>
 </mat-chip-list>


### PR DESCRIPTION
* Improves the example for the chips that shows how the color can be set for chips.
* Fixes a typo in the chips readme

References #7243