### PR TITLE
fix(tooltip): don't open from programmatic focus

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -485,7 +485,21 @@ describe('MatTooltip', () => {
         dispatchKeyboardEvent(buttonElement, 'keydown', ESCAPE);
         fixture.detectChanges();
       }).not.toThrow();
+
+      tick(0);
     }));
+
+    it('should not show the tooltip on progammatic focus', fakeAsync(() => {
+      expect(tooltipDirective._tooltipInstance).toBeUndefined();
+
+      buttonElement.focus();
+      tick(0);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(overlayContainerElement.querySelector('.mat-tooltip')).toBeNull();
+    }));
+
 
   });
 


### PR DESCRIPTION
Prevents the tooltip from opening when its trigger is focused programmatically.

Fixes #7245.