### PR TITLE
chore(tabs): use custom portal template directive for hosting tab body content

### DIFF
--- a/src/lib/tabs/public-api.ts
+++ b/src/lib/tabs/public-api.ts
@@ -9,11 +9,14 @@
 export * from './tabs-module';
 export * from './tab-group';
 export {MatInkBar} from './ink-bar';
-export {MatTabBody, MatTabBodyOriginState, MatTabBodyPositionState} from './tab-body';
+export {
+  MatTabBody,
+  MatTabBodyOriginState,
+  MatTabBodyPositionState,
+  MatTabBodyPortal
+} from './tab-body';
 export {MatTabHeader, ScrollDirection} from './tab-header';
 export {MatTabLabelWrapper} from './tab-label-wrapper';
 export {MatTab} from './tab';
 export {MatTabLabel} from './tab-label';
 export {MatTabNav, MatTabLink} from './tab-nav-bar/index';
-
-

--- a/src/lib/tabs/tab-body.html
+++ b/src/lib/tabs/tab-body.html
@@ -2,5 +2,5 @@
      [@translateTab]="_position"
      (@translateTab.start)="_onTranslateTabStarted($event)"
      (@translateTab.done)="_onTranslateTabComplete($event)">
-  <ng-template cdkPortalOutlet></ng-template>
+  <ng-template matTabBodyHost></ng-template>
 </div>

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -2,10 +2,10 @@ import {Direction, Directionality} from '@angular/cdk/bidi';
 import {PortalModule, TemplatePortal} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRippleModule} from '@angular/material/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatTabBody} from './tab-body';
+import {MatTabBody, MatTabBodyPortal} from './tab-body';
 
 
 describe('MatTabBody', () => {
@@ -17,6 +17,7 @@ describe('MatTabBody', () => {
       imports: [CommonModule, PortalModule, MatRippleModule, NoopAnimationsModule],
       declarations: [
         MatTabBody,
+        MatTabBodyPortal,
         SimpleTabBodyApp,
       ],
       providers: [
@@ -145,30 +146,6 @@ describe('MatTabBody', () => {
       expect(fixture.componentInstance.tabBody._position).toBe('left');
     });
   });
-
-  describe('on centered', () => {
-    let fixture: ComponentFixture<SimpleTabBodyApp>;
-
-    beforeEach(fakeAsync(() => {
-      fixture = TestBed.createComponent(SimpleTabBodyApp);
-    }));
-
-    it('should attach the content when centered and detach when not', fakeAsync(() => {
-      fixture.componentInstance.position = 1;
-      fixture.detectChanges();
-      expect(fixture.componentInstance.tabBody._portalOutlet.hasAttached()).toBe(false);
-
-      fixture.componentInstance.position = 0;
-      fixture.detectChanges();
-      expect(fixture.componentInstance.tabBody._portalOutlet.hasAttached()).toBe(true);
-
-      fixture.componentInstance.position = 1;
-      fixture.detectChanges();
-      flushMicrotasks(); // Finish animation and let it detach in animation done handler
-      expect(fixture.componentInstance.tabBody._portalOutlet.hasAttached()).toBe(false);
-    }));
-  });
-
 });
 
 

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -26,13 +26,20 @@ describe('MatTabGroup', () => {
 
   describe('basic behavior', () => {
     let fixture: ComponentFixture<SimpleTabsTestApp>;
+    let element: HTMLElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleTabsTestApp);
+      element = fixture.nativeElement;
     });
 
     it('should default to the first tab', () => {
       checkSelectedIndex(1, fixture);
+    });
+
+    it('will properly load content on first change detection pass', () => {
+      fixture.detectChanges();
+      expect(element.querySelectorAll('.mat-tab-body')[1].querySelectorAll('span').length).toBe(3);
     });
 
     it('should change selected index on click', () => {
@@ -318,23 +325,26 @@ describe('MatTabGroup', () => {
           fixture.debugElement.query(By.directive(MatTabGroup)).componentInstance as MatTabGroup;
     });
 
-    it('should support a tab-group with the simple api', () => {
+    it('should support a tab-group with the simple api', async(() => {
       expect(getSelectedLabel(fixture).textContent).toMatch('Junk food');
       expect(getSelectedContent(fixture).textContent).toMatch('Pizza, fries');
 
       tabGroup.selectedIndex = 2;
       fixture.detectChanges();
+      // Use whenStable to wait for async observables and change detection to run in content.
+      fixture.whenStable().then(() => {
 
-      expect(getSelectedLabel(fixture).textContent).toMatch('Fruit');
-      expect(getSelectedContent(fixture).textContent).toMatch('Apples, grapes');
+        expect(getSelectedLabel(fixture).textContent).toMatch('Fruit');
+        expect(getSelectedContent(fixture).textContent).toMatch('Apples, grapes');
 
-      fixture.componentInstance.otherLabel = 'Chips';
-      fixture.componentInstance.otherContent = 'Salt, vinegar';
-      fixture.detectChanges();
+        fixture.componentInstance.otherLabel = 'Chips';
+        fixture.componentInstance.otherContent = 'Salt, vinegar';
+        fixture.detectChanges();
 
-      expect(getSelectedLabel(fixture).textContent).toMatch('Chips');
-      expect(getSelectedContent(fixture).textContent).toMatch('Salt, vinegar');
-    });
+        expect(getSelectedLabel(fixture).textContent).toMatch('Chips');
+        expect(getSelectedContent(fixture).textContent).toMatch('Salt, vinegar');
+      });
+    }));
 
     it('should support @ViewChild in the tab content', () => {
       expect(fixture.componentInstance.legumes).toBeTruthy();
@@ -415,7 +425,7 @@ describe('nested MatTabGroup with enabled animations', () => {
       </mat-tab>
       <mat-tab>
         <ng-template mat-tab-label>Tab Two</ng-template>
-        Tab two content
+        <span>Tab </span><span>two</span><span>content</span>
       </mat-tab>
       <mat-tab>
         <ng-template mat-tab-label>Tab Three</ng-template>

--- a/src/lib/tabs/tabs-module.ts
+++ b/src/lib/tabs/tabs-module.ts
@@ -14,7 +14,7 @@ import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatInkBar} from './ink-bar';
 import {MatTab} from './tab';
-import {MatTabBody} from './tab-body';
+import {MatTabBody, MatTabBodyPortal} from './tab-body';
 import {MatTabGroup} from './tab-group';
 import {MatTabHeader} from './tab-header';
 import {MatTabLabel} from './tab-label';
@@ -49,6 +49,7 @@ import {MatTabLink, MatTabNav} from './tab-nav-bar/tab-nav-bar';
     MatTabNav,
     MatTabLink,
     MatTabBody,
+    MatTabBodyPortal,
     MatTabHeader
   ],
   providers: [VIEWPORT_RULER_PROVIDER],


### PR DESCRIPTION
Related to #6832
By moving the entrance logic into the `MdTabBodyPortal` setting up the content after change detection is avoided.

Fixes #7032 #7061 