### PR TITLE
fix(autocomplete): don't open panel for readonly inputs

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -307,8 +307,10 @@ export class MdAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   _handleFocus(): void {
-    this._attachOverlay();
-    this._floatPlaceholder(true);
+    if (!this._element.nativeElement.readOnly) {
+      this._attachOverlay();
+      this._floatPlaceholder(true);
+    }
   }
 
   /**

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -118,6 +118,20 @@ describe('MdAutocomplete', () => {
       });
     }));
 
+    it('should not open the panel on focus if the input is readonly', async(() => {
+      const trigger = fixture.componentInstance.trigger;
+      input.readOnly = true;
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(false, 'Expected panel state to start out closed.');
+      dispatchFakeEvent(input, 'focusin');
+
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(trigger.panelOpen).toBe(false, 'Expected panel to stay closed.');
+      });
+    }));
+
     it('should open the panel programmatically', async(() => {
       expect(fixture.componentInstance.trigger.panelOpen)
           .toBe(false, `Expected panel state to start out closed.`);


### PR DESCRIPTION
Prevents the autocomplete panel from opening if the associated input is readonly.

Fixes #7269.