### PR TITLE
build: fix metadata exports for moment-adapter

### DIFF
--- a/src/material-moment-adapter/public_api.ts
+++ b/src/material-moment-adapter/public_api.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export * from './adapter';
+export * from './adapter/index';


### PR DESCRIPTION
Due to a re-export that uses the index shorthand, the exports inside of the bundled metadata file are empty. This seems to be caused by a bug in `@angular/compiler-cli`. A temporary fix is just using the expanded important.

Fixes #7262