### PR TITLE
build: faster demo-app building

### DIFF
--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -1,10 +1,10 @@
 /** Type declaration for ambient System. */
 declare const System: any;
 
-// Apply the CLI SystemJS configuration.
+// Configure the base path and map the different node packages.
 System.config({
   paths: {
-    'node:*': 'node_modules/*',
+    'node:*': 'node_modules/*'
   },
   map: {
     'rxjs': 'node:rxjs',
@@ -17,36 +17,69 @@ System.config({
     '@angular/compiler': 'node:@angular/compiler/bundles/compiler.umd.js',
     '@angular/http': 'node:@angular/http/bundles/http.umd.js',
     '@angular/forms': 'node:@angular/forms/bundles/forms.umd.js',
-    '@angular/router': 'node:@angular/router/bundles/router.umd.js',
     '@angular/animations': 'node:@angular/animations/bundles/animations.umd.js',
+    '@angular/router': 'node:@angular/router/bundles/router.umd.js',
     '@angular/animations/browser': 'node:@angular/animations/bundles/animations-browser.umd.js',
-    '@angular/platform-browser': 'node:@angular/platform-browser/bundles/platform-browser.umd.js',
     '@angular/platform-browser/animations':
-      'node:@angular/platform-browser/bundles/platform-browser-animations.umd.js',
+      'node:@angular/platform-browser/bundles/platform-browser-animations.umd',
+    '@angular/platform-browser':
+      'node:@angular/platform-browser/bundles/platform-browser.umd.js',
     '@angular/platform-browser-dynamic':
       'node:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
 
-    '@angular/material': 'dist/bundles/material.umd.js',
-    '@angular/material-moment-adapter': 'dist/bundles/material-moment-adapter.umd.js',
-    '@angular/cdk': 'dist/bundles/cdk.umd.js',
-    '@angular/cdk/a11y': 'dist/bundles/cdk-a11y.umd.js',
-    '@angular/cdk/bidi': 'dist/bundles/cdk-bidi.umd.js',
-    '@angular/cdk/coercion': 'dist/bundles/cdk-coercion.umd.js',
-    '@angular/cdk/collections': 'dist/bundles/cdk-collections.umd.js',
-    '@angular/cdk/keycodes': 'dist/bundles/cdk-keycodes.umd.js',
-    '@angular/cdk/observers': 'dist/bundles/cdk-observers.umd.js',
-    '@angular/cdk/overlay': 'dist/bundles/cdk-overlay.umd.js',
-    '@angular/cdk/platform': 'dist/bundles/cdk-platform.umd.js',
-    '@angular/cdk/portal': 'dist/bundles/cdk-portal.umd.js',
-    '@angular/cdk/rxjs': 'dist/bundles/cdk-rxjs.umd.js',
-    '@angular/cdk/scrolling': 'dist/bundles/cdk-scrolling.umd.js',
-    '@angular/cdk/stepper': 'dist/bundles/cdk-stepper.umd.js',
-    '@angular/cdk/table': 'dist/bundles/cdk-table.umd.js',
-    '@angular/cdk/testing': 'dist/bundles/cdk-testing.umd.js',
+    // TODO(devversion): replace once the index.ts file for the Material package has been added.
+    '@angular/material': 'dist/packages/material/public_api.js',
+    '@angular/cdk': 'dist/packages/cdk/index.js',
+    '@angular/cdk/a11y': 'dist/packages/cdk/a11y/index.js',
+    '@angular/cdk/bidi': 'dist/packages/cdk/bidi/index.js',
+    '@angular/cdk/coercion': 'dist/packages/cdk/coercion/index.js',
+    '@angular/cdk/collections': 'dist/packages/cdk/collections/index.js',
+    '@angular/cdk/keycodes': 'dist/packages/cdk/keycodes/index.js',
+    '@angular/cdk/observers': 'dist/packages/cdk/observers/index.js',
+    '@angular/cdk/overlay': 'dist/packages/cdk/overlay/index.js',
+    '@angular/cdk/platform': 'dist/packages/cdk/platform/index.js',
+    '@angular/cdk/portal': 'dist/packages/cdk/portal/index.js',
+    '@angular/cdk/rxjs': 'dist/packages/cdk/rxjs/index.js',
+    '@angular/cdk/scrolling': 'dist/packages/cdk/scrolling/index.js',
+    '@angular/cdk/stepper': 'dist/packages/cdk/stepper/index.js',
+    '@angular/cdk/table': 'dist/packages/cdk/table/index.js',
+
+    '@angular/material/autocomplete': 'dist/packages/material/autocomplete/index.js',
+    '@angular/material/button': 'dist/packages/material/button/index.js',
+    '@angular/material/button-toggle': 'dist/packages/material/button-toggle/index.js',
+    '@angular/material/card': 'dist/packages/material/card/index.js',
+    '@angular/material/checkbox': 'dist/packages/material/checkbox/index.js',
+    '@angular/material/chips': 'dist/packages/material/chips/index.js',
+    '@angular/material/core': 'dist/packages/material/core/index.js',
+    '@angular/material/datepicker': 'dist/packages/material/datepicker/index.js',
+    '@angular/material/dialog': 'dist/packages/material/dialog/index.js',
+    '@angular/material/expansion': 'dist/packages/material/expansion/index.js',
+    '@angular/material/form-field': 'dist/packages/material/form-field/index.js',
+    '@angular/material/grid-list': 'dist/packages/material/grid-list/index.js',
+    '@angular/material/icon': 'dist/packages/material/icon/index.js',
+    '@angular/material/input': 'dist/packages/material/input/index.js',
+    '@angular/material/list': 'dist/packages/material/list/index.js',
+    '@angular/material/menu': 'dist/packages/material/menu/index.js',
+    '@angular/material/paginator': 'dist/packages/material/paginator/index.js',
+    '@angular/material/progress-bar': 'dist/packages/material/progress-bar/index.js',
+    '@angular/material/progress-spinner': 'dist/packages/material/progress-spinner/index.js',
+    '@angular/material/radio': 'dist/packages/material/radio/index.js',
+    '@angular/material/select': 'dist/packages/material/select/index.js',
+    '@angular/material/sidenav': 'dist/packages/material/sidenav/index.js',
+    '@angular/material/slide-toggle': 'dist/packages/material/slide-toggle/index.js',
+    '@angular/material/slider': 'dist/packages/material/slider/index.js',
+    '@angular/material/snack-bar': 'dist/packages/material/snack-bar/index.js',
+    '@angular/material/sort': 'dist/packages/material/sort/index.js',
+    '@angular/material/stepper': 'dist/packages/material/stepper/index.js',
+    '@angular/material/table': 'dist/packages/material/table/index.js',
+    '@angular/material/tabs': 'dist/packages/material/tabs/index.js',
+    '@angular/material/toolbar': 'dist/packages/material/toolbar/index.js',
+    '@angular/material/tooltip': 'dist/packages/material/tooltip/index.js',
   },
   packages: {
     // Thirdparty barrels.
-    'rxjs': { main: 'index' },
+    'rxjs': {main: 'index'},
+
     // Set the default extension for the root package, because otherwise the demo-app can't
     // be built within the production mode. Due to missing file extensions.
     '.': {

--- a/tools/gulp/packages.ts
+++ b/tools/gulp/packages.ts
@@ -4,8 +4,7 @@ import {join} from 'path';
 export const cdkPackage = new BuildPackage('cdk');
 export const materialPackage = new BuildPackage('material', [cdkPackage]);
 export const examplesPackage = new BuildPackage('material-examples', [materialPackage, cdkPackage]);
-export const momentAdapterPackage = new BuildPackage('material-moment-adapter',
-    [materialPackage, cdkPackage]);
+export const momentAdapterPackage = new BuildPackage('material-moment-adapter', [materialPackage]);
 
 // The material package re-exports its secondary entry-points at the root so that all of the
 // components can still be imported through `@angular/material`.

--- a/tools/gulp/tasks/aot.ts
+++ b/tools/gulp/tasks/aot.ts
@@ -32,7 +32,7 @@ task('aot:copy-release', () => {
 });
 
 /** Build the demo-app and a release to confirm that the library is AOT-compatible. */
-task('aot:build', sequenceTask('aot:deps', 'aot:compiler-cli'));
+task('aot:build', sequenceTask('clean', 'aot:deps', 'aot:compiler-cli'));
 
 /** Build the demo-app and a release to confirm that the library is AOT-compatible. */
 task('aot:compiler-cli', execNodeTask(

--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -32,10 +32,11 @@ task(':watch:devapp', () => {
 
   // Custom watchers for the CDK, Material and Moment adapter package. This is necessary because
   // we only want to build the package as a single entry-point (using the tests task).
-  watchFiles(join(cdkPackage.sourceDir, '**/*'), ['cdk:build-tests']);
-  watchFiles(join(momentAdapterPackage.sourceDir, '**/*'), ['material-moment-adapter:build-tests']);
-  watchFiles(join(materialPackage.sourceDir, '**/!(*.scss)'), ['material:build-tests']);
+  watchFiles(join(cdkPackage.sourceDir, '**/*'), ['cdk:build-no-bundles']);
+  watchFiles(join(materialPackage.sourceDir, '**/!(*.scss)'), ['material:build-no-bundles']);
   watchFiles(join(materialPackage.sourceDir, '**/*.scss'), [':build:devapp:material-with-styles']);
+  watchFiles(join(momentAdapterPackage.sourceDir, '**/*'),
+      ['material-moment-adapter:build-no-bundles']);
 });
 
 /** Path to the demo-app tsconfig file. */
@@ -49,12 +50,12 @@ task(':serve:devapp', serverTask(outDir, true));
 // The themes for the demo-app are built by using the SCSS mixins from Material.
 // Therefore when SCSS files have been changed, the custom theme needs to be rebuilt.
 task(':build:devapp:material-with-styles', sequenceTask(
-  'material:build-tests', ':build:devapp:scss'
+  'material:build-no-bundles', ':build:devapp:scss'
 ));
 
 task('build:devapp', sequenceTask(
-  ['material-moment-adapter:build-tests', ':build:devapp:scss', ':build:devapp:assets'],
-  ':build:devapp:ts'
+  ['material-moment-adapter:build-no-bundles', ':build:devapp:assets'],
+  [':build:devapp:scss', ':build:devapp:ts']
 ));
 
 task('serve:devapp', ['build:devapp'], sequenceTask([':serve:devapp', ':watch:devapp']));

--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -30,7 +30,7 @@ task(':watch:devapp', () => {
   watchFiles(join(appDir, '**/*.scss'), [':build:devapp:scss']);
   watchFiles(join(appDir, '**/*.html'), [':build:devapp:assets']);
 
-  // Custom watchers for the CDk, Material and Moment adapter package. This is necessary because
+  // Custom watchers for the CDK, Material and Moment adapter package. This is necessary because
   // we only want to build the package as a single entry-point (using the tests task).
   watchFiles(join(cdkPackage.sourceDir, '**/*'), ['cdk:build-tests']);
   watchFiles(join(momentAdapterPackage.sourceDir, '**/*'), ['material-moment-adapter:build-tests']);

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -12,7 +12,7 @@ task(':test:build', sequenceTask(
   'clean',
   // Build tests for all different packages by just building the tests of the moment-adapter
   // package. All dependencies of that package (material, cdk) will be built as well.
-  'material-moment-adapter:build-tests'
+  'material-moment-adapter:build-no-bundles'
 ));
 
 /**

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -2,7 +2,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as gulp from 'gulp';
 import * as path from 'path';
-import {buildConfig, sequenceTask} from 'material2-build-tools';
+import {buildConfig} from 'material2-build-tools';
 
 /* Those imports lack typings. */
 const gulpClean = require('gulp-clean');

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -122,21 +122,6 @@ export function cleanTask(glob: string) {
   return () => gulp.src(glob, { read: false }).pipe(gulpClean(null));
 }
 
-
-/** Build an task that depends on all application build tasks. */
-export function buildAppTask(appName: string) {
-  const buildTasks = ['ts', 'scss', 'assets']
-    .map(taskName => `:build:${appName}:${taskName}`)
-    .filter(taskName => gulp.hasTask(taskName));
-
-  return sequenceTask(
-    // Build all required packages for serving the devapp by just building the moment-adapter
-    // package. All dependencies of that package (material, cdk) will be built automatically.
-    'material-moment-adapter:clean-build',
-    [...buildTasks]
-  );
-}
-
 /**
  * Create a task that serves a given directory in the project.
  * The server rewrites all node_module/ or dist/ requests to the correct directory.

--- a/tools/package-tools/gulp/build-tasks-gulp.ts
+++ b/tools/package-tools/gulp/build-tasks-gulp.ts
@@ -52,9 +52,9 @@ export function createPackageBuildTasks(buildPackage: BuildPackage) {
     `${taskName}:build:bundles`,
   ));
 
-  task(`${taskName}:build-tests`, sequenceTask(
+  task(`${taskName}:build-no-bundles`, sequenceTask(
     // Build all required tests before building.
-    ...dependencyNames.map(pkgName => `${pkgName}:build-tests`),
+    ...dependencyNames.map(pkgName => `${pkgName}:build-no-bundles`),
     // Build the ESM output that includes all test files. Also build assets for the package.
     [`${taskName}:build:esm:tests`, `${taskName}:assets`],
     // Inline assets into ESM output.

--- a/tools/package-tools/gulp/watch-files.ts
+++ b/tools/package-tools/gulp/watch-files.ts
@@ -1,13 +1,11 @@
 import {watch} from 'gulp';
 import {triggerLivereload} from './trigger-livereload';
 
-/** Options that will be passed to the watch function of Gulp.*/
-const gulpWatchOptions = { debounceDelay: 700 };
-
 /**
  * Function that watches a set of file globs and runs given Gulp tasks if a given file changes.
  * By default the livereload server will be also called on file change.
  */
-export function watchFiles(fileGlob: string | string[], tasks: string[], livereload = true) {
-  watch(fileGlob, gulpWatchOptions, [...tasks, () => livereload && triggerLivereload()]);
+export function watchFiles(fileGlob: string | string[], tasks: string[], livereload = true,
+                            debounceDelay = 700) {
+  watch(fileGlob, {debounceDelay}, [...tasks, () => livereload && triggerLivereload()]);
 }


### PR DESCRIPTION
* The demo-app no longer builds every secondary entry-point separately. Now the everything of a package is built at the same time (as for the tests). This is significantly faster than before.
* No longer builds the CDK package twice when building the tests or demo-app.

**Note**: It might be a bit slower when loading the page, because there is no UMD bundle anymore, but it's still a time win.
