### PR TITLE
fix(select): losing focus when selecting values through binding

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -872,6 +872,21 @@ describe('MdSelect', () => {
       expect(trigger.textContent).toContain('Steak, Pizza, Sandwich');
     });
 
+    it('should restore focus to the host element', () => {
+      const fixture = TestBed.createComponent(BasicSelectWithoutForms);
+
+      fixture.detectChanges();
+      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.detectChanges();
+
+      (overlayContainerElement.querySelector('md-option') as HTMLElement).click();
+      fixture.detectChanges();
+
+      const select = fixture.debugElement.nativeElement.querySelector('md-select');
+
+      expect(document.activeElement).toBe(select, 'Expected trigger to be focused.');
+    });
+
   });
 
   describe('disabled behavior', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -351,8 +351,10 @@ export class MdSelect extends _MdSelectMixinBase implements AfterContentInit, On
   @Input()
   get value() { return this._value; }
   set value(newValue: any) {
-    this.writeValue(newValue);
-    this._value = newValue;
+    if (newValue !== this._value) {
+      this.writeValue(newValue);
+      this._value = newValue;
+    }
   }
   private _value: any;
 


### PR DESCRIPTION
Fixes an issue that caused focus to be lost after selecting a value on a select that doesn't use Angular forms.

Fixes #7092.