### PR TITLE
fix(ripple): handle touch events

### DIFF
--- a/src/cdk/testing/dispatch-events.ts
+++ b/src/cdk/testing/dispatch-events.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createFakeEvent, createKeyboardEvent, createMouseEvent} from './event-objects';
+import {
+  createFakeEvent,
+  createKeyboardEvent,
+  createMouseEvent,
+  createTouchEvent
+} from './event-objects';
 
 /** Utility to dispatch any event on a Node. */
 export function dispatchEvent(node: Node | Window, event: Event): Event {
@@ -28,4 +33,9 @@ export function dispatchKeyboardEvent(node: Node, type: string, keyCode: number)
 export function dispatchMouseEvent(node: Node, type: string, x = 0, y = 0,
   event = createMouseEvent(type, x, y)): MouseEvent {
   return dispatchEvent(node, event) as MouseEvent;
+}
+
+/** Shorthand to dispatch a touch event on the specified coordinates. */
+export function dispatchTouchEvent(node: Node, type: string, x = 0, y = 0) {
+  return dispatchEvent(node, createTouchEvent(type, x, y));
 }

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -41,7 +41,7 @@ export function createTouchEvent(type: string, pageX = 0, pageY = 0) {
   // Most of the browsers don't have a "initTouchEvent" method that can be used to define
   // the touch details.
   Object.defineProperties(event, {
-    touches: { value: [touchDetails] }
+    touches: {value: [touchDetails]}
   });
 
   return event;

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -8,7 +8,7 @@
 
 /** Creates a browser MouseEvent with the specified options. */
 export function createMouseEvent(type: string, x = 0, y = 0) {
-  let event = document.createEvent('MouseEvent');
+  const event = document.createEvent('MouseEvent');
 
   event.initMouseEvent(type,
     false, /* canBubble */
@@ -25,6 +25,24 @@ export function createMouseEvent(type: string, x = 0, y = 0) {
     false, /* metaKey */
     0, /* button */
     null /* relatedTarget */);
+
+  return event;
+}
+
+/** Creates a browser TouchEvent with the specified pointer coordinates. */
+export function createTouchEvent(type: string, pageX = 0, pageY = 0) {
+  // In favor of creating events that work for most of the browsers, the event is created
+  // as a basic UI Event. The necessary details for the event will be set manually.
+  const event = document.createEvent('UIEvent');
+  const touchDetails = {pageX, pageY};
+
+  event.initUIEvent(type, true, true, window, 0);
+
+  // Most of the browsers don't have a "initTouchEvent" method that can be used to define
+  // the touch details.
+  Object.defineProperties(event, {
+    touches: { value: [touchDetails] }
+  });
 
   return event;
 }

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, fakeAsync, tick, inject} from '@angular/core/
 import {Component, ViewChild} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
-import {dispatchMouseEvent} from '@angular/cdk/testing';
+import {dispatchMouseEvent, dispatchTouchEvent} from '@angular/cdk/testing';
 import {RIPPLE_FADE_OUT_DURATION, RIPPLE_FADE_IN_DURATION} from './ripple-renderer';
 import {
   MdRipple, MdRippleModule, MD_RIPPLE_GLOBAL_OPTIONS, RippleState, RippleGlobalOptions
@@ -106,6 +106,20 @@ describe('MdRipple', () => {
 
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
     });
+
+    it('should launch ripples on touchstart', fakeAsync(() => {
+      dispatchTouchEvent(rippleTarget, 'touchstart');
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
+
+      tick(RIPPLE_FADE_IN_DURATION);
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
+
+      dispatchTouchEvent(rippleTarget, 'touchend');
+
+      tick(RIPPLE_FADE_OUT_DURATION);
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(0);
+    }));
 
     it('removes ripple after timeout', fakeAsync(() => {
       dispatchMouseEvent(rippleTarget, 'mousedown');


### PR DESCRIPTION
* Ripples are now launched on touchstart for touch devices. Before they were just launched after the click happened.

Fixes #7062