### PR TITLE
build: add placeholder for Angular version

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -4,8 +4,13 @@
  */
 const {join} = require('path');
 
+const package = require('./package.json');
+
 /** Current version of the project*/
-const buildVersion = require('./package.json').version;
+const buildVersion = package.version;
+
+/** Required Angular version for the project. */
+const angularVersion = package.dependencies['@angular/core'];
 
 /** License that will be placed inside of all created bundles. */
 const buildLicense = `/**
@@ -18,6 +23,7 @@ const buildLicense = `/**
 
 module.exports = {
   projectVersion: buildVersion,
+  angularVersion: angularVersion,
   projectDir: __dirname,
   packagesDir: join(__dirname, 'src'),
   outputDir: join(__dirname, 'dist'),

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
-    "@angular/core": "^4.4.3",
-    "@angular/common": "^4.4.3"
+    "@angular/core": "0.0.0-NG",
+    "@angular/common": "0.0.0-NG"
   },
   "dependencies": {
     "tslib": "^1.7.1"

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -23,8 +23,8 @@
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
-    "@angular/core": "^4.4.3",
-    "@angular/common": "^4.4.3"
+    "@angular/core": "0.0.0-NG",
+    "@angular/common": "0.0.0-NG"
   },
   "dependencies": {
     "tslib": "^1.7.1"

--- a/src/material-examples/package.json
+++ b/src/material-examples/package.json
@@ -24,9 +24,9 @@
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
-    "@angular/core": "^4.4.3",
-    "@angular/common": "^4.4.3",
-    "@angular/http": "^4.4.3",
+    "@angular/core": "0.0.0-NG",
+    "@angular/common": "0.0.0-NG",
+    "@angular/http": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/angular/material2#readme",
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
-    "@angular/core": "^4.4.3",
+    "@angular/core": "0.0.0-NG",
     "moment": "^2.18.1"
   },
   "dependencies": {

--- a/tools/package-tools/build-config.ts
+++ b/tools/package-tools/build-config.ts
@@ -3,6 +3,8 @@ import {findBuildConfig} from './find-build-config';
 export interface BuildConfig {
   /** Current version of the project. */
   projectVersion: string;
+  /** Required Angular version for the project. */
+  angularVersion: string;
   /** Path to the root of the project. */
   projectDir: string;
   /** Path to the directory where all packages are living. */

--- a/tools/package-tools/version-placeholders.ts
+++ b/tools/package-tools/version-placeholders.ts
@@ -6,7 +6,13 @@ import {spawnSync} from 'child_process';
 /** Variable that is set to the string for version placeholders. */
 const versionPlaceholderText = '0.0.0-PLACEHOLDER';
 
+/** Placeholder that will be replaced with the required Angular version. */
+const ngVersionPlaceholderText = '0.0.0-NG';
+
 /** RegExp that matches version placeholders inside of a file. */
+const ngVersionPlaceholderRegex = new RegExp(ngVersionPlaceholderText, 'g');
+
+/** Expression that matches Angular version placeholders within a file. */
 const versionPlaceholderRegex = new RegExp(versionPlaceholderText, 'g');
 
 /**
@@ -21,9 +27,9 @@ export function replaceVersionPlaceholders(packageDir: string) {
   // Walk through every file that contains version placeholders and replace those with the current
   // version of the root package.json file.
   files.forEach(filePath => {
-    let fileContent = readFileSync(filePath, 'utf-8');
-
-    fileContent = fileContent.replace(versionPlaceholderRegex, buildConfig.projectVersion);
+    const fileContent = readFileSync(filePath, 'utf-8')
+      .replace(ngVersionPlaceholderRegex, buildConfig.angularVersion)
+      .replace(versionPlaceholderRegex, buildConfig.projectVersion);
 
     writeFileSync(filePath, fileContent);
   });
@@ -43,12 +49,12 @@ function buildPlaceholderFindCommand(packageDir: string) {
   if (platform() === 'win32') {
     return {
       binary: 'findstr',
-      args: ['/msi', `/c:${versionPlaceholderText}`, `${packageDir}\\*`]
+      args: ['/msi', `"${ngVersionPlaceholderText} ${versionPlaceholderText}"`, `${packageDir}\\*`]
     };
   } else {
     return {
       binary: 'grep',
-      args: ['-ril', versionPlaceholderText, packageDir]
+      args: ['-ril', `"${ngVersionPlaceholderText}\\|${versionPlaceholderText}"`, packageDir]
     };
   }
 }


### PR DESCRIPTION
Adds the `0.0.0-NG` placeholder that will ensure that all published packages will have the same Angular requirements.