### PR TITLE
chore: remove dead link from demo app

### DIFF
--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -73,7 +73,6 @@ export class DemoApp {
     {name: 'Slider', route: '/slider'},
     {name: 'Snack Bar', route: '/snack-bar'},
     {name: 'Stepper', route: '/stepper'},
-    {name: 'Style', route: '/style'},
     {name: 'Table', route: '/table'},
     {name: 'Tabs', route: '/tabs'},
     {name: 'Toolbar', route: '/toolbar'},


### PR DESCRIPTION
Gets rid of the `/styles` link from the demo app since it was renamed to `/focus-origin` a few days ago.