### PR TITLE
chore: fix validate release task

### DIFF
--- a/tools/gulp/tasks/validate-release.ts
+++ b/tools/gulp/tasks/validate-release.ts
@@ -37,7 +37,17 @@ task('validate-release:check-bundles', () => {
 
 /** Task that validates the given release package before releasing. */
 function checkReleasePackage(packageName: string): string[] {
-  const bundlePath = join(releasesDir, packageName, '@angular', `${packageName}.js`);
+  return glob(join(releasesDir, packageName, 'esm2015/*.js'))
+    .reduce((failures: string[], bundlePath: string) => {
+      return failures.concat(checkEs2015ReleaseBundle(packageName, bundlePath));
+    }, []);
+}
+
+/**
+ * Checks an ES2015 bundle inside of a release package. Secondary entry-point bundles will be
+ * checked as well.
+ */
+function checkEs2015ReleaseBundle(packageName: string, bundlePath: string): string[] {
   const bundleContent = readFileSync(bundlePath, 'utf8');
   let failures: string[] = [];
 


### PR DESCRIPTION
* Updates the `gulp validate-release` task to work with the current package structure.