### PR TITLE
fix(list-key-manager): don't focus disabled items in typeahead mode

### DIFF
--- a/src/cdk/a11y/list-key-manager.spec.ts
+++ b/src/cdk/a11y/list-key-manager.spec.ts
@@ -481,6 +481,16 @@ describe('Key managers', () => {
         expect(keyManager.activeItem).toBe(itemList.items[0]);
       }));
 
+      it('should not focus disabled items', fakeAsync(() => {
+        expect(keyManager.activeItem).toBeFalsy();
+
+        itemList.items[0].disabled = true;
+        keyManager.onKeydown(createKeyboardEvent('keydown', 79, undefined, 'o')); // types "o"
+        tick(debounceInterval);
+
+        expect(keyManager.activeItem).toBeFalsy();
+      }));
+
     });
 
   });

--- a/src/cdk/a11y/list-key-manager.ts
+++ b/src/cdk/a11y/list-key-manager.ts
@@ -74,7 +74,9 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
         const items = this._items.toArray();
 
         for (let i = 0; i < items.length; i++) {
-          if (items[i].getLabel!().toUpperCase().trim().indexOf(inputString) === 0) {
+          let item = items[i];
+
+          if (!item.disabled && item.getLabel!().toUpperCase().trim().indexOf(inputString) === 0) {
             this.setActiveItem(i);
             break;
           }


### PR DESCRIPTION
Fixes the list key manager attempting to focus disabled items in typeahead mode.