### PR TITLE
style(ripple): start fade out on mouseup

### DIFF
--- a/src/lib/core/ripple/_ripple.scss
+++ b/src/lib/core/ripple/_ripple.scss
@@ -24,7 +24,8 @@ $mat-ripple-color-opacity: 0.1;
     border-radius: 50%;
     pointer-events: none;
 
-    transition: opacity, transform 0ms cubic-bezier(0, 0, 0.2, 1);
+    transition: opacity 0ms cubic-bezier(0.4, 0.0, 1, 1),
+                transform 0ms cubic-bezier(0, 0, 0.2, 1);
     transform: scale(0);
   }
 }

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -191,9 +191,9 @@ export class RippleRenderer {
 
     this._isMousedown = false;
 
-    // Fade-out all ripples that are not persistent.
+    // Fade-out all ripples that are completely visible and not persistent.
     this._activeRipples.forEach(ripple => {
-      if (!ripple.config.persistent) {
+      if (!ripple.config.persistent && ripple.state === RippleState.VISIBLE) {
         ripple.fadeOut();
       }
     });

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -191,9 +191,9 @@ export class RippleRenderer {
 
     this._isMousedown = false;
 
-    // Fade-out all ripples that are completely visible and not persistent.
+    // Fade-out all ripples that are not persistent.
     this._activeRipples.forEach(ripple => {
-      if (!ripple.config.persistent && ripple.state === RippleState.VISIBLE) {
+      if (!ripple.config.persistent) {
         ripple.fadeOut();
       }
     });


### PR DESCRIPTION
**Purpose**

The goal of this is to start the ripple fade out immediately after mouseup rather than having to wait until the ripple animation has completed. My intention was to match the behavior seen in md1 which feels snappier and cleaner.

**Background**

The change to make sure a ripple had completed its animation before hiding was made in #3400. It looks like the intention was to solve the problem of ripples not being added to the active ripple set until _after_ it was completed, as pointed out in #3398. However, it appears #3400 fixed that problem [anyway](https://github.com/angular/material2/pull/3400/files#diff-9bf3861c94a2bdcf0beae13a7f4b4c0eR104) by adding it to the active ripple set as soon as animation begins. Therefore, the additional check of making sure a ripple had completed its animation is not necessary.

**Before**

![ripple-b](https://user-images.githubusercontent.com/6475576/30990175-44da347e-a46e-11e7-8cae-130024351491.gif)


**After**

![ripple - a](https://user-images.githubusercontent.com/6475576/30990179-47665d30-a46e-11e7-9ab5-52b746cb7ceb.gif)


This is one that's been a nit of mine for a while, but I couldn't tell if the change a while back was intentional or accidental. @DevVersion, thoughts? If this ok, I'll add tests.