### PR TITLE
chore: re-add missing button to stepper e2e spec

### DIFF
--- a/src/material-examples/stepper-overview/stepper-overview-example.html
+++ b/src/material-examples/stepper-overview/stepper-overview-example.html
@@ -1,3 +1,5 @@
+<button mat-raised-button (click)="isLinear = true" id="toggle-linear">Enable linear mode</button>
+
 <mat-horizontal-stepper [linear]="isLinear">
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">


### PR DESCRIPTION
Re-adds a button that was missing from the stepper e2e setup, causing one of the tests to fail.