### PR TITLE
fix(input): apply readonly attribute when readonly

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -59,7 +59,7 @@ let nextUniqueId = 0;
     '[placeholder]': 'placeholder',
     '[disabled]': 'disabled',
     '[required]': 'required',
-    '[attr.readonly]': 'readonly',
+    '[readonly]': 'readonly',
     '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-invalid]': 'errorState',
     '(blur)': '_focusChanged(false)',

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -59,6 +59,7 @@ let nextUniqueId = 0;
     '[placeholder]': 'placeholder',
     '[disabled]': 'disabled',
     '[required]': 'required',
+    '[attr.readonly]': 'readonly',
     '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-invalid]': 'errorState',
     '(blur)': '_focusChanged(false)',


### PR DESCRIPTION
Fixes issue where the readonly attribute was no longer applied because it was made to be an `@Input`