### PR TITLE
feat(select): add support for custom error state matcher

### DIFF
--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
-import {FormControl, Validators} from '@angular/forms';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {FormControl, NgControl, Validators} from '@angular/forms';
+import {ErrorStateMatcher} from '@angular/material';
 
 
 let max = 5;
@@ -52,10 +53,16 @@ export class InputDemo {
     }
   }
 
-  customErrorStateMatcher(c: FormControl): boolean {
-    const hasInteraction = c.dirty || c.touched;
-    const isInvalid = c.invalid;
+  customErrorStateMatcher: ErrorStateMatcher = {
+    isErrorState: (control: NgControl | null) => {
+      if (control) {
+        const hasInteraction = control.dirty || control.touched;
+        const isInvalid = control.invalid;
 
-    return !!(hasInteraction && isInvalid);
-  }
+        return !!(hasInteraction && isInvalid);
+      }
+
+      return false;
+    }
+  };
 }

--- a/src/lib/core/error/error-options.ts
+++ b/src/lib/core/error/error-options.ts
@@ -6,29 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '@angular/core';
-import {FormControl, FormGroupDirective, NgForm} from '@angular/forms';
+import {Injectable} from '@angular/core';
+import {FormGroupDirective, NgForm, NgControl} from '@angular/forms';
 
-/** Injection token that can be used to specify the global error options. */
-export const MAT_ERROR_GLOBAL_OPTIONS =
-    new InjectionToken<ErrorOptions>('mat-error-global-options');
-
-export type ErrorStateMatcher =
-    (control: FormControl, form: FormGroupDirective | NgForm) => boolean;
-
-export interface ErrorOptions {
-  errorStateMatcher?: ErrorStateMatcher;
+/** Error state matcher that matches when a control is invalid and dirty. */
+@Injectable()
+export class ShowOnDirtyErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: NgControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    return !!(control && control.invalid && (control.dirty || (form && form.submitted)));
+  }
 }
 
-/** Returns whether control is invalid and is either touched or is a part of a submitted form. */
-export function defaultErrorStateMatcher(control: FormControl, form: FormGroupDirective | NgForm) {
-  const isSubmitted = form && form.submitted;
-  return !!(control.invalid && (control.touched || isSubmitted));
-}
-
-/** Returns whether control is invalid and is either dirty or is a part of a submitted form. */
-export function showOnDirtyErrorStateMatcher(control: FormControl,
-    form: FormGroupDirective | NgForm) {
-  const isSubmitted = form && form.submitted;
-  return !!(control.invalid && (control.dirty || isSubmitted));
+/** Provider that defines how form controls behave with regards to displaying error messages. */
+@Injectable()
+export class ErrorStateMatcher {
+  isErrorState(control: NgControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    return !!(control && control.invalid && (control.touched || (form && form.submitted)));
+  }
 }

--- a/src/lib/input/input-module.ts
+++ b/src/lib/input/input-module.ts
@@ -12,6 +12,7 @@ import {NgModule} from '@angular/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatTextareaAutosize} from './autosize';
 import {MatInput} from './input';
+import {ErrorStateMatcher} from '@angular/material/core';
 
 
 @NgModule({
@@ -31,5 +32,6 @@ import {MatInput} from './input';
     MatInput,
     MatTextareaAutosize,
   ],
+  providers: [ErrorStateMatcher],
 })
 export class MatInputModule {}

--- a/src/lib/input/input.md
+++ b/src/lib/input/input.md
@@ -111,12 +111,12 @@ warn color.
 
 ### Custom Error Matcher
 
-By default, error messages are shown when the control is invalid and either the user has interacted with
-(touched) the element or the parent form has been submitted. If you wish to override this
+By default, error messages are shown when the control is invalid and either the user has interacted
+with (touched) the element or the parent form has been submitted. If you wish to override this
 behavior (e.g. to show the error as soon as the invalid control is dirty or when a parent form group
 is invalid), you can use the `errorStateMatcher` property of the `matInput`. To use this property,
-create a function in your component class that returns a boolean. A result of `true` will display
-the error messages.
+create an `ErrorStateMatcher` object in your component class that has a `isErrorState` function which
+returns a boolean. A result of `true` will display the error messages.
 
 ```html
 <mat-form-field>
@@ -126,25 +126,26 @@ the error messages.
 ```
 
 ```ts
-function myErrorStateMatcher(control: FormControl, form: FormGroupDirective | NgForm): boolean {
-  // Error when invalid control is dirty, touched, or submitted
-  const isSubmitted = form && form.submitted;
-  return !!(control.invalid && (control.dirty || control.touched || isSubmitted));
+class MyErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: NgControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    // Error when invalid control is dirty, touched, or submitted
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted)));
+  }
 }
 ```
 
-A global error state matcher can be specified by setting the `MAT_ERROR_GLOBAL_OPTIONS` provider. This applies
-to all inputs. For convenience, `showOnDirtyErrorStateMatcher` is available in order to globally set
-input errors to show when the input is dirty and invalid.
+A global error state matcher can be specified by setting the `ErrorStateMatcher` provider. This
+applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is available in order to
+globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
 @NgModule({
   providers: [
-    {provide: MAT_ERROR_GLOBAL_OPTIONS, useValue: {errorStateMatcher: showOnDirtyErrorStateMatcher}}
+    {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
 })
 ```
-
 Here are the available global options:
 
 | Name              | Type     | Description |

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -12,9 +12,9 @@ import {
   Validators,
 } from '@angular/forms';
 import {
-  MAT_ERROR_GLOBAL_OPTIONS,
   MAT_PLACEHOLDER_GLOBAL_OPTIONS,
-  showOnDirtyErrorStateMatcher,
+  ShowOnDirtyErrorStateMatcher,
+  ErrorStateMatcher,
 } from '@angular/material/core';
 import {
   getMatFormFieldDuplicatedHintError,
@@ -926,12 +926,6 @@ describe('MatInput with forms', () => {
     });
 
     it('should display an error message when global error matcher returns true', () => {
-
-      // Global error state matcher that will always cause errors to show
-      function globalErrorStateMatcher() {
-        return true;
-      }
-
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         imports: [
@@ -944,11 +938,7 @@ describe('MatInput with forms', () => {
         declarations: [
           MatInputWithFormErrorMessages
         ],
-        providers: [
-          {
-            provide: MAT_ERROR_GLOBAL_OPTIONS,
-            useValue: { errorStateMatcher: globalErrorStateMatcher } }
-        ]
+        providers: [{provide: ErrorStateMatcher, useValue: {isErrorState: () => true}}]
       });
 
       let fixture = TestBed.createComponent(MatInputWithFormErrorMessages);
@@ -963,7 +953,7 @@ describe('MatInput with forms', () => {
       expect(containerEl.querySelectorAll('mat-error').length).toBe(1, 'Expected an error message');
     });
 
-    it('should display an error message when using showOnDirtyErrorStateMatcher', async(() => {
+    it('should display an error message when using ShowOnDirtyErrorStateMatcher', async(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         imports: [
@@ -976,12 +966,7 @@ describe('MatInput with forms', () => {
         declarations: [
           MatInputWithFormErrorMessages
         ],
-        providers: [
-          {
-            provide: MAT_ERROR_GLOBAL_OPTIONS,
-            useValue: { errorStateMatcher: showOnDirtyErrorStateMatcher }
-          }
-        ]
+        providers: [{provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}]
       });
 
       let fixture = TestBed.createComponent(MatInputWithFormErrorMessages);
@@ -1298,7 +1283,7 @@ class MatInputWithFormErrorMessages {
       <mat-form-field>
         <input matInput
             formControlName="name"
-            [errorStateMatcher]="customErrorStateMatcher.bind(this)">
+            [errorStateMatcher]="customErrorStateMatcher">
         <mat-hint>Please type something</mat-hint>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
@@ -1312,9 +1297,9 @@ class MatInputWithCustomErrorStateMatcher {
 
   errorState = false;
 
-  customErrorStateMatcher(): boolean {
-    return this.errorState;
-  }
+  customErrorStateMatcher = {
+    isErrorState: () => this.errorState
+  };
 }
 
 @Component({

--- a/src/lib/select/select-module.ts
+++ b/src/lib/select/select-module.ts
@@ -5,13 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatSelect, MatSelectTrigger, MAT_SELECT_SCROLL_STRATEGY_PROVIDER} from './select';
 import {MatCommonModule, MatOptionModule} from '@angular/material/core';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {MatFormFieldModule} from '@angular/material/form-field';
+import {ErrorStateMatcher} from '@angular/material/core';
 
 
 @NgModule({
@@ -23,6 +23,6 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   ],
   exports: [MatFormFieldModule, MatSelect, MatSelectTrigger, MatOptionModule, MatCommonModule],
   declarations: [MatSelect, MatSelectTrigger],
-  providers: [MAT_SELECT_SCROLL_STRATEGY_PROVIDER]
+  providers: [MAT_SELECT_SCROLL_STRATEGY_PROVIDER, ErrorStateMatcher]
 })
 export class MatSelectModule {}

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -28,7 +28,8 @@ import {
   extendObject,
   FloatPlaceholderType,
   MAT_PLACEHOLDER_GLOBAL_OPTIONS,
-  MatOption
+  MatOption,
+  ErrorStateMatcher,
 } from '@angular/material/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
@@ -97,6 +98,7 @@ describe('MatSelect', () => {
         FalsyValueSelect,
         SelectInsideFormGroup,
         NgModelCompareWithSelect,
+        CustomErrorBehaviorSelect,
       ],
       providers: [
         {provide: OverlayContainer, useFactory: () => {
@@ -2946,6 +2948,47 @@ describe('MatSelect', () => {
       expect(select.getAttribute('aria-invalid'))
           .toBe('true', 'Expected aria-invalid to be set to true.');
     });
+
+    it('should be able to override the error matching behavior via an @Input', () => {
+      fixture.destroy();
+
+      const customErrorFixture = TestBed.createComponent(CustomErrorBehaviorSelect);
+      const component = customErrorFixture.componentInstance;
+      const matcher = jasmine.createSpy('error state matcher').and.returnValue(true);
+
+      customErrorFixture.detectChanges();
+
+      expect(component.control.invalid).toBe(false);
+      expect(component.select.errorState).toBe(false);
+
+      customErrorFixture.componentInstance.errorStateMatcher = { isErrorState: matcher };
+      customErrorFixture.detectChanges();
+
+      expect(component.select.errorState).toBe(true);
+      expect(matcher).toHaveBeenCalled();
+    });
+
+    it('should be able to override the error matching behavior via the injection token', () => {
+      const errorStateMatcher: ErrorStateMatcher = {
+        isErrorState: jasmine.createSpy('error state matcher').and.returnValue(true)
+      };
+
+      fixture.destroy();
+
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatSelectModule, ReactiveFormsModule, FormsModule, NoopAnimationsModule],
+        declarations: [SelectInsideFormGroup],
+        providers: [{ provide: ErrorStateMatcher, useValue: errorStateMatcher }],
+      });
+
+      const errorFixture = TestBed.createComponent(SelectInsideFormGroup);
+      const component = errorFixture.componentInstance;
+
+      errorFixture.detectChanges();
+
+      expect(component.select.errorState).toBe(true);
+      expect(errorStateMatcher.isErrorState).toHaveBeenCalled();
+    });
   });
 
   describe('compareWith behavior', () => {
@@ -3617,6 +3660,7 @@ class InvalidSelectInForm {
 })
 class SelectInsideFormGroup {
   @ViewChild(FormGroupDirective) formGroupDirective: FormGroupDirective;
+  @ViewChild(MatSelect) select: MatSelect;
   formControl = new FormControl('', Validators.required);
   formGroup = new FormGroup({
     food: this.formControl
@@ -3750,4 +3794,23 @@ class NgModelCompareWithSelect {
   setFoodByCopy(newValue: {value: string, viewValue: string}) {
     this.selectedFood = extendObject({}, newValue);
   }
+}
+
+@Component({
+  template: `
+    <mat-select placeholder="Food" [formControl]="control" [errorStateMatcher]="errorStateMatcher">
+      <mat-option *ngFor="let food of foods" [value]="food.value">
+        {{ food.viewValue }}
+      </mat-option>
+    </mat-select>
+  `
+})
+class CustomErrorBehaviorSelect {
+  @ViewChild(MatSelect) select: MatSelect;
+  control = new FormControl();
+  foods: any[] = [
+    { value: 'steak-0', viewValue: 'Steak' },
+    { value: 'pizza-1', viewValue: 'Pizza' },
+  ];
+  errorStateMatcher: ErrorStateMatcher;
 }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -54,6 +54,7 @@ import {
   MatOptionSelectionChange,
   mixinDisabled,
   mixinTabIndex,
+  ErrorStateMatcher,
 } from '@angular/material/core';
 import {MatFormField, MatFormFieldControl} from '@angular/material/form-field';
 import {Observable} from 'rxjs/Observable';
@@ -377,6 +378,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Input that can be used to specify the `aria-labelledby` attribute. */
   @Input('aria-labelledby') ariaLabelledby: string;
 
+  /** An object used to control when error messages are shown. */
+  @Input() errorStateMatcher: ErrorStateMatcher;
+
   /** Unique id of the element. */
   @Input()
   get id() { return this._id; }
@@ -411,6 +415,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     private _viewportRuler: ViewportRuler,
     private _changeDetectorRef: ChangeDetectorRef,
     private _ngZone: NgZone,
+    private _defaultErrorStateMatcher: ErrorStateMatcher,
     renderer: Renderer2,
     elementRef: ElementRef,
     @Optional() private _dir: Directionality,
@@ -680,12 +685,10 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Whether the select is in an error state. */
   get errorState(): boolean {
-    const isInvalid = this.ngControl && this.ngControl.invalid;
-    const isTouched = this.ngControl && this.ngControl.touched;
-    const isSubmitted = (this._parentFormGroup && this._parentFormGroup.submitted) ||
-        (this._parentForm && this._parentForm.submitted);
+    const parent = this._parentFormGroup || this._parentForm;
+    const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;
 
-    return !!(isInvalid && (isTouched || isSubmitted));
+    return matcher.isErrorState(this.ngControl, parent);
   }
 
   private _initializeSelection(): void {

--- a/src/lib/stepper/stepper-module.ts
+++ b/src/lib/stepper/stepper-module.ts
@@ -12,7 +12,7 @@ import {CdkStepperModule} from '@angular/cdk/stepper';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
-import {MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {MatCommonModule, MatRippleModule, ErrorStateMatcher} from '@angular/material/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatStepHeader} from './step-header';
 import {MatStepLabel} from './step-label';
@@ -45,6 +45,6 @@ import {MatStepperIntl} from './stepper-intl';
   ],
   declarations: [MatHorizontalStepper, MatVerticalStepper, MatStep, MatStepLabel, MatStepper,
     MatStepperNext, MatStepperPrevious, MatStepHeader],
-  providers: [MatStepperIntl],
+  providers: [MatStepperIntl, ErrorStateMatcher],
 })
 export class MatStepperModule {}


### PR DESCRIPTION
* Allows for the select's error state matcher to be overwritten through an `@Input`.
* Switches `MatSelect` over to use the same global provider for its error state as `MatInput`.

**Note:** This is a resubmit of #6147 that works with our latest setup and excludes a few changes.

Fixes #7419