### PR TITLE
chore(dialog): add generic param for config data

### DIFF
--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -23,7 +23,7 @@ export interface DialogPosition {
 /**
  * Configuration for opening a modal dialog with the MatDialog service.
  */
-export class MatDialogConfig {
+export class MatDialogConfig<D = any> {
 
   /**
    * Where the attached component should live in Angular's *logical* component tree.
@@ -73,7 +73,7 @@ export class MatDialogConfig {
   position?: DialogPosition;
 
   /** Data being injected into the child component. */
-  data?: any = null;
+  data?: D | null = null;
 
   /** Layout direction for the dialog's content. */
   direction?: Direction = 'ltr';

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -114,8 +114,8 @@ export class MatDialog {
    * @param config Extra configuration options.
    * @returns Reference to the newly-opened dialog.
    */
-  open<T>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig): MatDialogRef<T> {
+  open<T, D = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+          config?: MatDialogConfig<D>): MatDialogRef<T> {
 
     const inProgressDialog = this.openDialogs.find(dialog => dialog._isAnimating());
 


### PR DESCRIPTION
Adds a generic parameter to the `MatDialogConfig` that indicates the type of its `data`.

BREAKING CHANGE: Material now requires at least TypeScript 2.4.

Fixes #4398.
