### PR TITLE
build: include importAs in metadata

### DIFF
--- a/tools/package-tools/build-release.ts
+++ b/tools/package-tools/build-release.ts
@@ -24,6 +24,7 @@ export function composeRelease(buildPackage: BuildPackage) {
   const {name, sourceDir} = buildPackage;
   const packageOut = buildPackage.outputDir;
   const releasePath = join(outputDir, 'releases', name);
+  const importAsName = `@angular/${name}`;
 
   inlinePackageMetadataFiles(packageOut);
 
@@ -48,7 +49,7 @@ export function composeRelease(buildPackage: BuildPackage) {
 
   replaceVersionPlaceholders(releasePath);
   createTypingsReexportFile(releasePath, './typings/index', name);
-  createMetadataReexportFile(releasePath, './typings/index', name);
+  createMetadataReexportFile(releasePath, './typings/index', name, importAsName);
 
   if (buildPackage.secondaryEntryPoints.length) {
     createFilesForSecondaryEntryPoint(buildPackage, releasePath);
@@ -70,7 +71,8 @@ export function composeRelease(buildPackage: BuildPackage) {
     createMetadataReexportFile(
         releasePath,
         buildPackage.secondaryEntryPoints.concat(['typings/index']).map(p => `./${p}`),
-        name);
+        name,
+        importAsName);
   }
 }
 
@@ -85,6 +87,7 @@ function createFilesForSecondaryEntryPoint(buildPackage: BuildPackage, releasePa
     // * An index.d.ts file that re-exports the index.d.ts from the typings/ directory
     // * A metadata.json re-export for this entry-point's metadata.
     const entryPointDir = join(releasePath, entryPointName);
+    const importAsName = `@angular/${name}/${entryPointName}`;
 
     mkdirpSync(entryPointDir);
     createEntryPointPackageJson(entryPointDir, name, entryPointName);
@@ -98,12 +101,13 @@ function createFilesForSecondaryEntryPoint(buildPackage: BuildPackage, releasePa
     // Create a typings and a metadata re-export within the entry-point to point to the
     // typings we just copied.
     createTypingsReexportFile(entryPointDir, `./typings/index`, 'index');
-    createMetadataReexportFile(entryPointDir, `./typings/index`, 'index');
+    createMetadataReexportFile(entryPointDir, `./typings/index`, 'index', importAsName);
 
     // Finally, create both a d.ts and metadata file for this entry-point in the root of
     // the package that re-exports from the entry-point's directory.
     createTypingsReexportFile(releasePath, `./${entryPointName}/index`, entryPointName);
-    createMetadataReexportFile(releasePath, `./${entryPointName}/index`, entryPointName);
+    createMetadataReexportFile(releasePath, `./${entryPointName}/index`, entryPointName,
+        importAsName);
   });
 }
 

--- a/tools/package-tools/metadata-reexport.ts
+++ b/tools/package-tools/metadata-reexport.ts
@@ -2,7 +2,8 @@ import {writeFileSync} from 'fs';
 import {join} from 'path';
 
 /** Creates a metadata file that re-exports the metadata bundle inside of the typings. */
-export function createMetadataReexportFile(destDir: string, from: string|string[], name: string) {
+export function createMetadataReexportFile(destDir: string, from: string|string[],
+                                           entryPointName: string, importAsName: string) {
   from = Array.isArray(from) ? from : [from];
 
   const metadataJsonContent = JSON.stringify({
@@ -10,8 +11,9 @@ export function createMetadataReexportFile(destDir: string, from: string|string[
     version: 3,
     metadata: {},
     exports: from.map(f => ({from: f})),
-    flatModuleIndexRedirect: true
+    flatModuleIndexRedirect: true,
+    importAs: importAsName
   }, null, 2);
 
-  writeFileSync(join(destDir, `${name}.metadata.json`), metadataJsonContent, 'utf-8');
+  writeFileSync(join(destDir, `${entryPointName}.metadata.json`), metadataJsonContent, 'utf-8');
 }


### PR DESCRIPTION
* Adds the `importAs` property to the generated metadata files for primary and secondary entry-points.