### PR TITLE
fix(overlay): detach method returns undefined

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -85,9 +85,9 @@ export class OverlayRef implements PortalHost {
 
   /**
    * Detaches an overlay from a portal.
-   * @returns Resolves when the overlay has been detached.
+   * @returns The portal detachment result.
    */
-  detach(): Promise<any> {
+  detach(): any {
     this.detachBackdrop();
 
     // When the overlay is detached, the pane element should disable pointer events.
@@ -99,7 +99,7 @@ export class OverlayRef implements PortalHost {
       this._config.scrollStrategy.disable();
     }
 
-    let detachmentResult = this._portalHost.detach();
+    const detachmentResult  = this._portalHost.detach();
 
     // Only emit after everything is detached.
     this._detachments.next();


### PR DESCRIPTION
Currently the JSDoc of the `detach` method describes that the method returns a Promise if the detaching is done. This is not the case and just `undefined` is being returned because every `PortalHost` implementation inside of the CDK is synchronously detaching the view.

In the future it might be useful to change this method back to a `Promise` in favor of animations, but for now it doesn't make sense return a `Promise` because the `attach` method is also synchronous.

Fixes #7408