### PR TITLE
chore(drawer): mark drawer container as scrollable

### DIFF
--- a/src/lib/sidenav/drawer-container.html
+++ b/src/lib/sidenav/drawer-container.html
@@ -5,6 +5,6 @@
 
 <ng-content select="mat-drawer-content">
 </ng-content>
-<mat-drawer-content *ngIf="!_content">
+<mat-drawer-content *ngIf="!_content" cdkScrollable>
   <ng-content></ng-content>
 </mat-drawer-content>

--- a/src/lib/sidenav/sidenav-container.html
+++ b/src/lib/sidenav/sidenav-container.html
@@ -5,6 +5,6 @@
 
 <ng-content select="mat-sidenav-content">
 </ng-content>
-<mat-sidenav-content *ngIf="!_content">
+<mat-sidenav-content *ngIf="!_content" cdkScrollable>
   <ng-content></ng-content>
 </mat-sidenav-content>

--- a/src/lib/sidenav/sidenav-module.ts
+++ b/src/lib/sidenav/sidenav-module.ts
@@ -11,12 +11,19 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
+import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 import {MatDrawer, MatDrawerContainer, MatDrawerContent} from './drawer';
 import {MatSidenav, MatSidenavContainer, MatSidenavContent} from './sidenav';
 
 
 @NgModule({
-  imports: [CommonModule, MatCommonModule, A11yModule, OverlayModule],
+  imports: [
+    CommonModule,
+    MatCommonModule,
+    A11yModule,
+    OverlayModule,
+    ScrollDispatchModule,
+  ],
   exports: [
     MatCommonModule,
     MatDrawer,


### PR DESCRIPTION
Re-adds the `cdkScrollable` directive on the drawer container. Without it connected overlays won't update when the user scrolls.