### PR TITLE
docs(api): Fixes broken api docs post mat upgrade

### DIFF
--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -90,11 +90,7 @@ export class MatDrawerContent implements AfterContentInit {
 
 
 /**
- * <mat-drawer> component.
- *
  * This component corresponds to a drawer that can be opened on the drawer container.
- *
- * Please refer to README.md for examples on how to use it.
  */
 @Component({
   moduleId: module.id,

--- a/tools/dgeni/processors/categorizer.js
+++ b/tools/dgeni/processors/categorizer.js
@@ -220,10 +220,11 @@ function getDirectiveOutputAlias(doc) {
 function getDirectiveSelectors(classDoc) {
   const directiveSelectors = getMetadataProperty(classDoc, 'selector');
 
+
   if (directiveSelectors) {
     // Filter blacklisted selectors and remove line-breaks in resolved selectors.
     return directiveSelectors.replace(/[\r\n]/g, '').split(/\s*,\s*/)
-      .filter(s => s !== '' && !s.includes('mat') && !SELECTOR_BLACKLIST.has(s));
+      .filter(s => s !== '' && !s.includes('md') && !SELECTOR_BLACKLIST.has(s));
   }
 }
 

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -1,15 +1,18 @@
 <h4 class="docs-api-h4 docs-api-class-name">
   <code>{$ class.name $}</code>
 </h4>
-<p class="docs-api-class-description">{$ class.description | marked | safe $}</p>
+
+{%- if class.description -%}
+<p class="docs-api-class-description">{$ class.description | safe $}</p>
+{%- endif -%}
 
 {%- if class.directiveSelectors -%}
-<div class="docs-api-directive-selectors">
+<p class="docs-api-directive-selectors">
   <span class="docs-api-class-selector-label">Selector:</span>
   {% for selector in class.directiveSelectors %}
     <span class="docs-api-class-selector-name">{$ selector $}</span>
   {% endfor %}
-</div>
+</p>
 {%- endif -%}
 
 {%- if class.directiveExportAs -%}


### PR DESCRIPTION
This PR does the following:

- Fixes directive selectors no longer matching after mat upgrade
- Removes extraneous docs from the drawer class
- Fixes empty paragraphs being inserted when no description provided
- Fixes paragraphs inserting multiple times when designated with `marked` - I didn't see anywhere where we actually leveraged marked anyway.

