### PR TITLE
feat(chips): Use all available space for the input

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -97,4 +97,5 @@ $mat-chip-input-margin: 3px;
 input.mat-chip-input {
   width: $mat-chip-input-width;
   margin: $mat-chip-input-margin;
+  flex: 1 0 $mat-chip-input-width;
 }


### PR DESCRIPTION
Currently, an input inside a chips list is limited to 150px, so it looks like this.

![Cutoff Name](https://user-images.githubusercontent.com/1882729/31061451-6eb3a072-a6d6-11e7-9dac-67b41d1d3087.png).

Adding flex lets the input use all available space and still wrap correctly.

![Using all avaible space](https://user-images.githubusercontent.com/1882729/31061470-a0e783d8-a6d6-11e7-8919-848e1c4cb10a.png)

![Wrapping](https://user-images.githubusercontent.com/1882729/31061487-cdbfb10a-a6d6-11e7-89c9-a5fe1cf38c41.png)