### PR TITLE
fix(stepper): don't grey out non-linear steps

### DIFF
--- a/src/lib/stepper/stepper-horizontal.html
+++ b/src/lib/stepper/stepper-horizontal.html
@@ -11,7 +11,7 @@
                      [icon]="_getIndicatorType(i)"
                      [label]="step.stepLabel || step.label"
                      [selected]="selectedIndex === i"
-                     [active]="step.completed || selectedIndex === i"
+                     [active]="step.completed || selectedIndex === i || !linear"
                      [optional]="step.optional">
     </mat-step-header>
     <div *ngIf="!isLast" class="mat-stepper-horizontal-line"></div>

--- a/src/lib/stepper/stepper-vertical.html
+++ b/src/lib/stepper/stepper-vertical.html
@@ -10,7 +10,7 @@
                    [icon]="_getIndicatorType(i)"
                    [label]="step.stepLabel || step.label"
                    [selected]="selectedIndex === i"
-                   [active]="step.completed || selectedIndex === i"
+                   [active]="step.completed || selectedIndex === i || !linear"
                    [optional]="step.optional">
   </mat-step-header>
 


### PR DESCRIPTION
No longer displays steps as disabled in non-linear mode. Previously they would be greyed-out, causing them to look disabled even though they're clickable.

Fixes #7260.