### PR TITLE
fix(theming): incorrect green-500 contrast color

### DIFF
--- a/src/lib/core/theming/_palette.scss
+++ b/src/lib/core/theming/_palette.scss
@@ -331,7 +331,7 @@ $mat-green: (
     200: $black-87-opacity,
     300: $black-87-opacity,
     400: $black-87-opacity,
-    500: white,
+    500: $black-87-opacity,
     600: white,
     700: white,
     800: $white-87-opacity,


### PR DESCRIPTION
As per the Material Design specifications, the 500-hue for the green palette should have a black (87% opacity) contrast color.

Reference: https://material.io/guidelines/style/color.html#color-color-palette

Fixes #7490