### PR TITLE
refactor(dialog): simplify dialog config typing

### DIFF
--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -31,43 +31,43 @@ export class MatDialogConfig {
    * component instantiated inside of the dialog. This does not affect where the dialog
    * content will be rendered.
    */
-  viewContainerRef?: ViewContainerRef;
+  viewContainerRef: ViewContainerRef;
 
   /** ID for the dialog. If omitted, a unique one will be generated. */
-  id?: string;
+  id: string;
 
   /** The ARIA role of the dialog element. */
-  role?: DialogRole = 'dialog';
+  role: DialogRole = 'dialog';
 
   /** Custom class for the overlay pane. */
-  panelClass?: string | string[] = '';
+  panelClass: string | string[] = '';
 
   /** Whether the dialog has a backdrop. */
-  hasBackdrop?: boolean = true;
+  hasBackdrop: boolean = true;
 
   /** Custom class for the backdrop, */
-  backdropClass?: string = '';
+  backdropClass: string = '';
 
   /** Whether the user can use escape or clicking outside to close a modal. */
-  disableClose?: boolean = false;
+  disableClose: boolean = false;
 
   /** Width of the dialog. */
-  width?: string = '';
+  width: string = '';
 
   /** Height of the dialog. */
-  height?: string = '';
+  height: string = '';
 
   /** Position overrides. */
-  position?: DialogPosition;
+  position: DialogPosition;
 
   /** Data being injected into the child component. */
-  data?: any = null;
+  data: any = null;
 
   /** Layout direction for the dialog's content. */
-  direction?: Direction = 'ltr';
+  direction: Direction = 'ltr';
 
   /** ID of the element that describes the dialog.  */
-  ariaDescribedBy?: string | null = null;
+  ariaDescribedBy: string | null = null;
 
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -115,7 +115,7 @@ export class MatDialog {
    * @returns Reference to the newly-opened dialog.
    */
   open<T>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig): MatDialogRef<T> {
+          config?: Partial<MatDialogConfig>): MatDialogRef<T> {
 
     const inProgressDialog = this.openDialogs.find(dialog => dialog._isAnimating());
 
@@ -124,16 +124,16 @@ export class MatDialog {
       return inProgressDialog;
     }
 
-    config = _applyConfigDefaults(config);
+    const _config = _applyConfigDefaults(config);
 
-    if (config.id && this.getDialogById(config.id)) {
-      throw Error(`Dialog with id "${config.id}" exists already. The dialog id must be unique.`);
+    if (_config.id && this.getDialogById(_config.id)) {
+      throw Error(`Dialog with id "${_config.id}" exists already. The dialog id must be unique.`);
     }
 
-    const overlayRef = this._createOverlay(config);
-    const dialogContainer = this._attachDialogContainer(overlayRef, config);
+    const overlayRef = this._createOverlay(_config);
+    const dialogContainer = this._attachDialogContainer(overlayRef, _config);
     const dialogRef =
-        this._attachDialogContent(componentOrTemplateRef, dialogContainer, overlayRef, config);
+        this._attachDialogContent(componentOrTemplateRef, dialogContainer, overlayRef, _config);
 
     if (!this.openDialogs.length) {
       document.addEventListener('keydown', this._boundKeydown);
@@ -181,20 +181,20 @@ export class MatDialog {
 
   /**
    * Creates an overlay config from a dialog config.
-   * @param dialogConfig The dialog configuration.
+   * @param config The dialog configuration.
    * @returns The overlay configuration.
    */
-  private _getOverlayConfig(dialogConfig: MatDialogConfig): OverlayConfig {
+  private _getOverlayConfig(config: MatDialogConfig): OverlayConfig {
     const state = new OverlayConfig({
       positionStrategy: this._overlay.position().global(),
       scrollStrategy: this._scrollStrategy(),
-      panelClass: dialogConfig.panelClass,
-      hasBackdrop: dialogConfig.hasBackdrop,
-      direction: dialogConfig.direction
+      panelClass: config.panelClass,
+      hasBackdrop: config.hasBackdrop,
+      direction: config.direction
     });
 
-    if (dialogConfig.backdropClass) {
-      state.backdropClass = dialogConfig.backdropClass;
+    if (config.backdropClass) {
+      state.backdropClass = config.backdropClass;
     }
 
     return state;
@@ -207,8 +207,8 @@ export class MatDialog {
    * @returns A promise resolving to a ComponentRef for the attached container.
    */
   private _attachDialogContainer(overlay: OverlayRef, config: MatDialogConfig): MatDialogContainer {
-    let containerPortal = new ComponentPortal(MatDialogContainer, config.viewContainerRef);
-    let containerRef: ComponentRef<MatDialogContainer> = overlay.attach(containerPortal);
+    const containerPortal = new ComponentPortal(MatDialogContainer, config.viewContainerRef);
+    const containerRef: ComponentRef<MatDialogContainer> = overlay.attach(containerPortal);
     containerRef.instance._config = config;
 
     return containerRef.instance;
@@ -324,6 +324,6 @@ export class MatDialog {
  * @param config Config to be modified.
  * @returns The new configuration object.
  */
-function _applyConfigDefaults(config?: MatDialogConfig): MatDialogConfig {
+function _applyConfigDefaults(config?: Partial<MatDialogConfig>): MatDialogConfig {
   return extendObject(new MatDialogConfig(), config);
 }


### PR DESCRIPTION
Uses a `Partial` when typing the parameters of `MdDialog.open`. The advantage of `Partial` is that we don't have to mark all fields of the `MdDialogConfig` as optional.