### PR TITLE
fix(form-field): move label before input

### DIFF
--- a/src/lib/form-field/form-field.html
+++ b/src/lib/form-field/form-field.html
@@ -6,8 +6,6 @@
     </div>
 
     <div class="mat-input-infix mat-form-field-infix">
-      <ng-content></ng-content>
-
       <span class="mat-input-placeholder-wrapper mat-form-field-placeholder-wrapper">
         <!-- We add aria-owns as a workaround for an issue in JAWS & NVDA where the label isn't
              read if it comes before the control in the DOM. -->
@@ -28,6 +26,8 @@
             *ngIf="!hideRequiredMarker && _control.required">*</span>
         </label>
       </span>
+
+      <ng-content></ng-content>
     </div>
 
     <div class="mat-input-suffix mat-form-field-suffix" *ngIf="_suffixChildren.length">

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -28,7 +28,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatInputModule} from './index';
 import {MatInput} from './input';
 
-describe('MatInput without forms', function () {
+describe('MatInput without forms', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -713,6 +713,17 @@ describe('MatInput without forms', function () {
     expect(input.focused).toBe(false);
     expect(container.classList).not.toContain('mat-focused');
   });
+
+  it('should render the label before the input', () => {
+    const fixture = TestBed.createComponent(MatInputWithId);
+    fixture.detectChanges();
+
+    const elements = fixture.debugElement.nativeElement.querySelectorAll('label, input');
+
+    expect(elements[0].nodeName).toBe('LABEL', 'Expected label to come first.');
+    expect(elements[1].nodeName).toBe('INPUT', 'Expected input to come after label.');
+  });
+
 });
 
 describe('MatInput with forms', () => {


### PR DESCRIPTION
Moves the form field label before the input in the DOM order which is aligned closer with the way native labels and inputs are used. It also falls back better if CSS is disabled/fails to load.

Fixes #7402.