### PR TITLE
docs: include @license headers for all src/.../*.ts files

### DIFF
--- a/src/demo-app/a11y/a11y-module.ts
+++ b/src/demo-app/a11y/a11y-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';

--- a/src/demo-app/a11y/a11y.ts
+++ b/src/demo-app/a11y/a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ElementRef, ViewChild, ViewEncapsulation} from '@angular/core';
 import {NavigationEnd, Router} from '@angular/router';
 

--- a/src/demo-app/a11y/autocomplete/autocomplete-a11y.ts
+++ b/src/demo-app/a11y/autocomplete/autocomplete-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/button-toggle/button-toggle-a11y.ts
+++ b/src/demo-app/a11y/button-toggle/button-toggle-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/button/button-a11y.ts
+++ b/src/demo-app/a11y/button/button-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/card/card-a11y.ts
+++ b/src/demo-app/a11y/card/card-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/checkbox/checkbox-a11y.ts
+++ b/src/demo-app/a11y/checkbox/checkbox-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 export interface Task {

--- a/src/demo-app/a11y/chips/chips-a11y.ts
+++ b/src/demo-app/a11y/chips/chips-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatChipInputEvent, MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/datepicker/datepicker-a11y.ts
+++ b/src/demo-app/a11y/datepicker/datepicker-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/dialog/dialog-a11y.ts
+++ b/src/demo-app/a11y/dialog/dialog-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material';
 

--- a/src/demo-app/a11y/expansion/expansion-a11y.ts
+++ b/src/demo-app/a11y/expansion/expansion-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/grid-list/grid-list-a11y.ts
+++ b/src/demo-app/a11y/grid-list/grid-list-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 export interface Dog {

--- a/src/demo-app/a11y/icon/icon-a11y.ts
+++ b/src/demo-app/a11y/icon/icon-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/input/input-a11y.ts
+++ b/src/demo-app/a11y/input/input-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 const USD_TO_JPY = 110.29;

--- a/src/demo-app/a11y/menu/menu-a11y.ts
+++ b/src/demo-app/a11y/menu/menu-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/progress-bar/progress-bar-a11y.ts
+++ b/src/demo-app/a11y/progress-bar/progress-bar-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/progress-spinner/progress-spinner-a11y.ts
+++ b/src/demo-app/a11y/progress-spinner/progress-spinner-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/radio/radio-a11y.ts
+++ b/src/demo-app/a11y/radio/radio-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/routes.ts
+++ b/src/demo-app/a11y/routes.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Routes} from '@angular/router';
 import {AutocompleteAccessibilityDemo} from './autocomplete/autocomplete-a11y';
 import {ButtonAccessibilityDemo} from './button/button-a11y';

--- a/src/demo-app/a11y/select/select-a11y.ts
+++ b/src/demo-app/a11y/select/select-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/slide-toggle/slide-toggle-a11y.ts
+++ b/src/demo-app/a11y/slide-toggle/slide-toggle-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/slider/slider-a11y.ts
+++ b/src/demo-app/a11y/slider/slider-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/snack-bar/snack-bar-a11y.ts
+++ b/src/demo-app/a11y/snack-bar/snack-bar-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/demo-app/a11y/tabs/routes.ts
+++ b/src/demo-app/a11y/tabs/routes.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Routes} from '@angular/router';
 
 import {SunnyTabContent, RainyTabContent, FoggyTabContent} from './tabs-a11y';

--- a/src/demo-app/a11y/tabs/tabs-a11y.ts
+++ b/src/demo-app/a11y/tabs/tabs-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/a11y/toolbar/toolbar-a11y.ts
+++ b/src/demo-app/a11y/toolbar/toolbar-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/a11y/tooltip/tooltip-a11y.ts
+++ b/src/demo-app/a11y/tooltip/tooltip-a11y.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
 import {FormControl, NgModel} from '@angular/forms';
 import 'rxjs/add/operator/startWith';

--- a/src/demo-app/baseline/baseline-demo.ts
+++ b/src/demo-app/baseline/baseline-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/button/button-demo.ts
+++ b/src/demo-app/button/button-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/card/card-demo.ts
+++ b/src/demo-app/card/card-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/checkbox/checkbox-demo.ts
+++ b/src/demo-app/checkbox/checkbox-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/chips/chips-demo.ts
+++ b/src/demo-app/chips/chips-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ENTER} from '@angular/cdk/keycodes';
 import {Component} from '@angular/core';
 import {MatChipInputEvent} from '@angular/material';

--- a/src/demo-app/dataset/colors.ts
+++ b/src/demo-app/dataset/colors.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export const COLORS = [
   'AliceBlue',
   'AntiqueWhite',

--- a/src/demo-app/dataset/names.ts
+++ b/src/demo-app/dataset/names.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export const NAMES: string[] = [
   'Abbott',
   'Acevedo',

--- a/src/demo-app/datepicker/datepicker-demo.ts
+++ b/src/demo-app/datepicker/datepicker-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatDatepickerInputEvent} from '@angular/material';
 

--- a/src/demo-app/demo-app-module.ts
+++ b/src/demo-app/demo-app-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ApplicationRef, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {HttpModule} from '@angular/http';

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {Component, ElementRef, Renderer2, ViewEncapsulation} from '@angular/core';
 

--- a/src/demo-app/demo-app/demo-module.ts
+++ b/src/demo-app/demo-app/demo-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {FullscreenOverlayContainer, OverlayContainer} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Routes} from '@angular/router';
 import {AccessibilityDemo} from '../a11y/a11y';
 import {ACCESSIBILITY_DEMO_ROUTES} from '../a11y/routes';

--- a/src/demo-app/demo-material-module.ts
+++ b/src/demo-app/demo-material-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {NgModule} from '@angular/core';
 import {
   MatAutocompleteModule,

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, Inject, ViewChild, TemplateRef} from '@angular/core';
 import {DOCUMENT} from '@angular/platform-browser';
 import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';

--- a/src/demo-app/drawer/drawer-demo.ts
+++ b/src/demo-app/drawer/drawer-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 
 

--- a/src/demo-app/expansion/expansion-demo.ts
+++ b/src/demo-app/expansion/expansion-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 
 @Component({

--- a/src/demo-app/focus-origin/focus-origin-demo.ts
+++ b/src/demo-app/focus-origin/focus-origin-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FocusMonitor} from '@angular/cdk/a11y';
 

--- a/src/demo-app/gestures/gestures-demo.ts
+++ b/src/demo-app/gestures/gestures-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/demo-app/grid-list/grid-list-demo.ts
+++ b/src/demo-app/grid-list/grid-list-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {MatIconRegistry} from '@angular/material';

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {FormControl, NgControl, Validators} from '@angular/forms';
 import {ErrorStateMatcher} from '@angular/material';

--- a/src/demo-app/list/list-demo.ts
+++ b/src/demo-app/list/list-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/live-announcer/live-announcer-demo.ts
+++ b/src/demo-app/live-announcer/live-announcer-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 

--- a/src/demo-app/main-aot.ts
+++ b/src/demo-app/main-aot.ts
@@ -1,4 +1,12 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
  * This is the main entry-point for the AOT compilation. File will be used to test AOT support.
  */
 

--- a/src/demo-app/main.ts
+++ b/src/demo-app/main.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {DemoAppModule} from './demo-app-module';
 

--- a/src/demo-app/menu/menu-demo.ts
+++ b/src/demo-app/menu/menu-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Overlay, OverlayOrigin, OverlayConfig} from '@angular/cdk/overlay';
 import {
   ComponentPortal,

--- a/src/demo-app/platform/platform-demo.ts
+++ b/src/demo-app/platform/platform-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {Platform, getSupportedInputTypes} from '@angular/cdk/platform';
 

--- a/src/demo-app/portal/portal-demo.ts
+++ b/src/demo-app/portal/portal-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ComponentPortal, Portal, TemplatePortalDirective} from '@angular/cdk/portal';
 import {Component, QueryList, ViewChildren} from '@angular/core';
 

--- a/src/demo-app/progress-bar/progress-bar-demo.ts
+++ b/src/demo-app/progress-bar/progress-bar-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/progress-spinner/progress-spinner-demo.ts
+++ b/src/demo-app/progress-spinner/progress-spinner-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/radio/radio-demo.ts
+++ b/src/demo-app/radio/radio-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/ripple/ripple-demo.ts
+++ b/src/demo-app/ripple/ripple-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild} from '@angular/core';
 import {MatRipple} from '@angular/material';
 

--- a/src/demo-app/screen-type/screen-type-demo.ts
+++ b/src/demo-app/screen-type/screen-type-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 import {BreakpointObserver, BreakpointState, Breakpoints} from '@angular/cdk/layout';
 import {Observable} from 'rxjs/Observable';

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MatSelectChange} from '@angular/material';

--- a/src/demo-app/sidenav/sidenav-demo.ts
+++ b/src/demo-app/sidenav/sidenav-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 
 

--- a/src/demo-app/slide-toggle/slide-toggle-demo.ts
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/slider/slider-demo.ts
+++ b/src/demo-app/slider/slider-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/snack-bar/snack-bar-demo.ts
+++ b/src/demo-app/snack-bar/snack-bar-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Dir} from '@angular/cdk/bidi';
 import {Component, ViewEncapsulation} from '@angular/core';
 import {

--- a/src/demo-app/stepper/stepper-demo.ts
+++ b/src/demo-app/stepper/stepper-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, Validators} from '@angular/forms';
 

--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 /** Type declaration for ambient System. */
 declare const System: any;
 

--- a/src/demo-app/table/people-database.ts
+++ b/src/demo-app/table/people-database.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Injectable} from '@angular/core';
 import {NAMES} from '../dataset/names';
 import {COLORS} from '../dataset/colors';

--- a/src/demo-app/table/person-data-source.ts
+++ b/src/demo-app/table/person-data-source.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {MatPaginator, MatSort} from '@angular/material';
 import {DataSource} from '@angular/cdk/collections';
 import {Observable} from 'rxjs/Observable';

--- a/src/demo-app/table/person-detail-data-source.ts
+++ b/src/demo-app/table/person-detail-data-source.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {DataSource} from '@angular/cdk/collections';
 import {Observable} from 'rxjs/Observable';
 import {UserData} from './people-database';

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild} from '@angular/core';
 import {PeopleDatabase, UserData} from './people-database';
 import {PersonDataSource} from './person-data-source';

--- a/src/demo-app/table/table-header-demo.ts
+++ b/src/demo-app/table/table-header-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, EventEmitter, Output} from '@angular/core';
 
 @Component({

--- a/src/demo-app/tabs/routes.ts
+++ b/src/demo-app/tabs/routes.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Routes} from '@angular/router';
 
 import {SunnyTabContent, RainyTabContent, FoggyTabContent} from '../tabs/tabs-demo';

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 

--- a/src/demo-app/toolbar/toolbar-demo.ts
+++ b/src/demo-app/toolbar/toolbar-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 import {TooltipPosition} from '@angular/material';
 

--- a/src/demo-app/typography/typography-demo.ts
+++ b/src/demo-app/typography/typography-demo.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/block-scroll-strategy/block-scroll-strategy-e2e.ts
+++ b/src/e2e-app/block-scroll-strategy/block-scroll-strategy-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 

--- a/src/e2e-app/button/button-e2e.ts
+++ b/src/e2e-app/button/button-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/checkbox/checkbox-e2e.ts
+++ b/src/e2e-app/checkbox/checkbox-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/dialog/dialog-e2e.ts
+++ b/src/e2e-app/dialog/dialog-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild, TemplateRef} from '@angular/core';
 import {MatDialog, MatDialogRef, MatDialogConfig} from '@angular/material';
 

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';

--- a/src/e2e-app/e2e-app/e2e-app.ts
+++ b/src/e2e-app/e2e-app/e2e-app.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/e2e-app/routes.ts
+++ b/src/e2e-app/e2e-app/routes.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Routes} from '@angular/router';
 import {Home} from './e2e-app';
 import {ButtonE2E} from '../button/button-e2e';

--- a/src/e2e-app/fullscreen/fullscreen-e2e.ts
+++ b/src/e2e-app/fullscreen/fullscreen-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ElementRef, Output, EventEmitter} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material';
 

--- a/src/e2e-app/grid-list/grid-list-e2e.ts
+++ b/src/e2e-app/grid-list/grid-list-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/icon/icon-e2e.ts
+++ b/src/e2e-app/icon/icon-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/input/input-e2e.ts
+++ b/src/e2e-app/input/input-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/main.ts
+++ b/src/e2e-app/main.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {platformBrowser} from '@angular/platform-browser';
 import {E2eAppModuleNgFactory} from './e2e-app-module.ngfactory';
 

--- a/src/e2e-app/menu/menu-e2e.ts
+++ b/src/e2e-app/menu/menu-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/progress-bar/progress-bar-e2e.ts
+++ b/src/e2e-app/progress-bar/progress-bar-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/progress-spinner/progress-spinner-e2e.ts
+++ b/src/e2e-app/progress-spinner/progress-spinner-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/radio/radio-e2e.ts
+++ b/src/e2e-app/radio/radio-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/sidenav/sidenav-e2e.ts
+++ b/src/e2e-app/sidenav/sidenav-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 

--- a/src/e2e-app/slide-toggle/slide-toggle-e2e.ts
+++ b/src/e2e-app/slide-toggle/slide-toggle-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/e2e-app/system-config.ts
+++ b/src/e2e-app/system-config.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 /** Type declaration for ambient System. */
 declare const System: any;
 

--- a/src/e2e-app/tabs/tabs-e2e.ts
+++ b/src/e2e-app/tabs/tabs-e2e.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 @Component({

--- a/src/material-examples/autocomplete-display/autocomplete-display-example.ts
+++ b/src/material-examples/autocomplete-display/autocomplete-display-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs/Observable';

--- a/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs/Observable';

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 

--- a/src/material-examples/autocomplete-simple/autocomplete-simple-example.ts
+++ b/src/material-examples/autocomplete-simple/autocomplete-simple-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 

--- a/src/material-examples/button-overview/button-overview-example.ts
+++ b/src/material-examples/button-overview/button-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/button-toggle-exclusive/button-toggle-exclusive-example.ts
+++ b/src/material-examples/button-toggle-exclusive/button-toggle-exclusive-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/button-toggle-overview/button-toggle-overview-example.ts
+++ b/src/material-examples/button-toggle-overview/button-toggle-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/button-types/button-types-example.ts
+++ b/src/material-examples/button-types/button-types-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/card-fancy/card-fancy-example.ts
+++ b/src/material-examples/card-fancy/card-fancy-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/card-overview/card-overview-example.ts
+++ b/src/material-examples/card-overview/card-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/cdk-table-basic/cdk-table-basic-example.ts
+++ b/src/material-examples/cdk-table-basic/cdk-table-basic-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';

--- a/src/material-examples/checkbox-configurable/checkbox-configurable-example.ts
+++ b/src/material-examples/checkbox-configurable/checkbox-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/checkbox-overview/checkbox-overview-example.ts
+++ b/src/material-examples/checkbox-overview/checkbox-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/chips-input/chips-input-example.ts
+++ b/src/material-examples/chips-input/chips-input-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatChipInputEvent} from '@angular/material';
 import {ENTER} from '@angular/cdk/keycodes';

--- a/src/material-examples/chips-overview/chips-overview-example.ts
+++ b/src/material-examples/chips-overview/chips-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/chips-stacked/chips-stacked-example.ts
+++ b/src/material-examples/chips-stacked/chips-stacked-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-api/datepicker-api-example.ts
+++ b/src/material-examples/datepicker-api/datepicker-api-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-filter/datepicker-filter-example.ts
+++ b/src/material-examples/datepicker-filter/datepicker-filter-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-min-max/datepicker-min-max-example.ts
+++ b/src/material-examples/datepicker-min-max/datepicker-min-max-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-overview/datepicker-overview-example.ts
+++ b/src/material-examples/datepicker-overview/datepicker-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-start-view/datepicker-start-view-example.ts
+++ b/src/material-examples/datepicker-start-view/datepicker-start-view-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/datepicker-touch/datepicker-touch-example.ts
+++ b/src/material-examples/datepicker-touch/datepicker-touch-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/dialog-content/dialog-content-example.ts
+++ b/src/material-examples/dialog-content/dialog-content-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material';
 

--- a/src/material-examples/dialog-data/dialog-data-example.ts
+++ b/src/material-examples/dialog-data/dialog-data-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, Inject} from '@angular/core';
 import {MatDialog, MAT_DIALOG_DATA} from '@angular/material';
 

--- a/src/material-examples/dialog-elements/dialog-elements-example.ts
+++ b/src/material-examples/dialog-elements/dialog-elements-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material';
 

--- a/src/material-examples/dialog-overview/dialog-overview-example.ts
+++ b/src/material-examples/dialog-overview/dialog-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, Inject} from '@angular/core';
 import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
 

--- a/src/material-examples/example-data.ts
+++ b/src/material-examples/example-data.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {EXAMPLE_COMPONENTS} from './example-module';
 
 

--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 
 /* tslint:disable */
 /** DO NOT MANUALLY EDIT THIS FILE, IT IS GENERATED VIA GULP 'build-examples-module' */

--- a/src/material-examples/expansion-overview/expansion-overview-example.ts
+++ b/src/material-examples/expansion-overview/expansion-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/expansion-steps/expansion-steps-example.ts
+++ b/src/material-examples/expansion-steps/expansion-steps-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/grid-list-dynamic/grid-list-dynamic-example.ts
+++ b/src/material-examples/grid-list-dynamic/grid-list-dynamic-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/grid-list-overview/grid-list-overview-example.ts
+++ b/src/material-examples/grid-list-overview/grid-list-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/icon-overview/icon-overview-example.ts
+++ b/src/material-examples/icon-overview/icon-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/icon-svg-example/icon-svg-example.ts
+++ b/src/material-examples/icon-svg-example/icon-svg-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {MatIconRegistry} from '@angular/material';

--- a/src/material-examples/index.ts
+++ b/src/material-examples/index.ts
@@ -1,1 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export * from './public-api';

--- a/src/material-examples/input-clearable/input-clearable-example.ts
+++ b/src/material-examples/input-clearable/input-clearable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/input-errors/input-errors-example.ts
+++ b/src/material-examples/input-errors/input-errors-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 

--- a/src/material-examples/input-form/input-form-example.ts
+++ b/src/material-examples/input-form/input-form-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/input-hint/input-hint-example.ts
+++ b/src/material-examples/input-hint/input-hint-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/input-overview/input-overview-example.ts
+++ b/src/material-examples/input-overview/input-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/input-prefix-suffix/input-prefix-suffix-example.ts
+++ b/src/material-examples/input-prefix-suffix/input-prefix-suffix-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/list-overview/list-overview-example.ts
+++ b/src/material-examples/list-overview/list-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/list-sections/list-sections-example.ts
+++ b/src/material-examples/list-sections/list-sections-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/list-selection/list-selection-example.ts
+++ b/src/material-examples/list-selection/list-selection-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/material-module.ts
+++ b/src/material-examples/material-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {NgModule} from '@angular/core';
 
 import {CdkTableModule} from '@angular/cdk/table';

--- a/src/material-examples/menu-icons/menu-icons-example.ts
+++ b/src/material-examples/menu-icons/menu-icons-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/menu-overview/menu-overview-example.ts
+++ b/src/material-examples/menu-overview/menu-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/nested-menu/nested-menu-example.ts
+++ b/src/material-examples/nested-menu/nested-menu-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/paginator-configurable/paginator-configurable-example.ts
+++ b/src/material-examples/paginator-configurable/paginator-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {PageEvent} from '@angular/material';
 

--- a/src/material-examples/paginator-overview/paginator-overview-example.ts
+++ b/src/material-examples/paginator-overview/paginator-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/progress-bar-configurable/progress-bar-configurable-example.ts
+++ b/src/material-examples/progress-bar-configurable/progress-bar-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/progress-bar-overview/progress-bar-overview-example.ts
+++ b/src/material-examples/progress-bar-overview/progress-bar-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/progress-spinner-configurable/progress-spinner-configurable-example.ts
+++ b/src/material-examples/progress-spinner-configurable/progress-spinner-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/progress-spinner-overview/progress-spinner-overview-example.ts
+++ b/src/material-examples/progress-spinner-overview/progress-spinner-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/public-api.ts
+++ b/src/material-examples/public-api.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export * from './example-data';
 export * from './example-module';
 

--- a/src/material-examples/radio-ng-model/radio-ng-model-example.ts
+++ b/src/material-examples/radio-ng-model/radio-ng-model-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/radio-overview/radio-overview-example.ts
+++ b/src/material-examples/radio-overview/radio-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/select-form/select-form-example.ts
+++ b/src/material-examples/select-form/select-form-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/select-overview/select-overview-example.ts
+++ b/src/material-examples/select-overview/select-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/sidenav-fab/sidenav-fab-example.ts
+++ b/src/material-examples/sidenav-fab/sidenav-fab-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 
 /**

--- a/src/material-examples/sidenav-overview/sidenav-overview-example.ts
+++ b/src/material-examples/sidenav-overview/sidenav-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/slide-toggle-configurable/slide-toggle-configurable-example.ts
+++ b/src/material-examples/slide-toggle-configurable/slide-toggle-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/slide-toggle-forms/slide-toggle-forms-example.ts
+++ b/src/material-examples/slide-toggle-forms/slide-toggle-forms-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 

--- a/src/material-examples/slide-toggle-overview/slide-toggle-overview-example.ts
+++ b/src/material-examples/slide-toggle-overview/slide-toggle-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/slider-configurable/slider-configurable-example.ts
+++ b/src/material-examples/slider-configurable/slider-configurable-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewEncapsulation} from '@angular/core';
 
 /**

--- a/src/material-examples/slider-overview/slider-overview-example.ts
+++ b/src/material-examples/slider-overview/slider-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/snack-bar-component/snack-bar-component-example.ts
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
+++ b/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 

--- a/src/material-examples/sort-overview/sort-overview-example.ts
+++ b/src/material-examples/sort-overview/sort-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {Sort} from '@angular/material';
 

--- a/src/material-examples/stepper-overview/stepper-overview-example.ts
+++ b/src/material-examples/stepper-overview/stepper-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 

--- a/src/material-examples/table-basic/table-basic-example.ts
+++ b/src/material-examples/table-basic/table-basic-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {Observable} from 'rxjs/Observable';

--- a/src/material-examples/table-filtering/table-filtering-example.ts
+++ b/src/material-examples/table-filtering/table-filtering-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, OnInit, ViewChild} from '@angular/core';
 import {Http} from '@angular/http';
 import {DataSource} from '@angular/cdk/collections';

--- a/src/material-examples/table-overview/table-overview-example.ts
+++ b/src/material-examples/table-overview/table-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {MatPaginator, MatSort} from '@angular/material';

--- a/src/material-examples/table-pagination/table-pagination-example.ts
+++ b/src/material-examples/table-pagination/table-pagination-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {MatPaginator} from '@angular/material';

--- a/src/material-examples/table-sorting/table-sorting-example.ts
+++ b/src/material-examples/table-sorting/table-sorting-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {MatSort} from '@angular/material';

--- a/src/material-examples/tabs-overview/tabs-overview-example.ts
+++ b/src/material-examples/tabs-overview/tabs-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/tabs-template-label/tabs-template-label-example.ts
+++ b/src/material-examples/tabs-template-label/tabs-template-label-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/toolbar-multirow/toolbar-multirow-example.ts
+++ b/src/material-examples/toolbar-multirow/toolbar-multirow-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/toolbar-overview/toolbar-overview-example.ts
+++ b/src/material-examples/toolbar-overview/toolbar-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/tooltip-overview/tooltip-overview-example.ts
+++ b/src/material-examples/tooltip-overview/tooltip-overview-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/material-examples/tooltip-position/tooltip-position-example.ts
+++ b/src/material-examples/tooltip-position/tooltip-position-example.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component} from '@angular/core';
 
 /**

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Component, NgModule} from '@angular/core';
 import {ServerModule} from '@angular/platform-server';
 import {BrowserModule} from '@angular/platform-browser';

--- a/src/universal-app/main.ts
+++ b/src/universal-app/main.ts
@@ -1,1 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export * from './kitchen-sink/kitchen-sink';

--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import 'reflect-metadata';
 import 'zone.js';
 


### PR DESCRIPTION
License headers are inconsistently provided for `.ts` files under `src`.
This change adds `@license` blocks where needed.  This change does not
affect `.d.ts`, `.spec.ts`, or files outside of `src`.