### PR TITLE
Highlight alternative Angular Material/CDK install

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -9,6 +9,8 @@ For existing apps, follow these steps to begin using Angular Material.
 npm install --save @angular/material @angular/cdk
 ```
 
+#### Alternative: Snapshot Build
+
 A snapshot build with the latest changes from master is also available. Note that this snapshot
 build should not be considered stable and may break between releases.
 


### PR DESCRIPTION
I've just spent hours to find an issue with my first Angular Material app. I didn't read the first sentence of the first step and was just copy/pasting npm install commands. I got a lot of weird issues and couldn't get a simple app running. Eventually I figured out I made a mistake in the first step, but only after a few hours. As installing both modules can really screw up everything, I think that highlighting the choice might be a good idea.