### PR TITLE
fix: missing exportAs names

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -68,6 +68,7 @@ export const _MatSlideToggleMixinBase =
 @Component({
   moduleId: module.id,
   selector: 'mat-slide-toggle',
+  exportAs: 'matSlideToggle',
   host: {
     'class': 'mat-slide-toggle',
     '[id]': 'id',

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -46,6 +46,7 @@ const SORT_ANIMATION_TRANSITION =
 @Component({
   moduleId: module.id,
   selector: '[mat-sort-header]',
+  exportAs: 'matSortHeader',
   templateUrl: 'sort-header.html',
   styleUrls: ['sort-header.css'],
   host: {

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -29,6 +29,7 @@ export interface Sort {
 /** Container for MatSortables to manage the sort state and provide default sort parameters. */
 @Directive({
   selector: '[matSort]',
+  exportAs: 'matSort',
 })
 export class MatSort {
   /** Collection of all registered sortables that this directive manages. */


### PR DESCRIPTION
* Due to rebasing it looks like some `exportAs` names were lost 