### PR TITLE
perf: remove persistent global scroll listener

### DIFF
--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -143,6 +143,26 @@ describe('Scroll Dispatcher', () => {
           'Expected global listeners to have been removed after the subscription has stopped.');
     });
 
+    it('should remove global listeners on unsubscribe, despite any other live scrollables', () => {
+      const fixture = TestBed.createComponent(NestedScrollingComponent);
+      fixture.detectChanges();
+
+      expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
+      expect(scroll.scrollableReferences.size).toBe(4, 'Expected multiple scrollables');
+
+      const subscription = scroll.scrolled(0).subscribe(() => {});
+
+      expect(scroll._globalSubscription).toBeTruthy(
+          'Expected global listeners after a subscription has been added.');
+
+      subscription.unsubscribe();
+
+      expect(scroll._globalSubscription).toBeNull(
+          'Expected global listeners to have been removed after the subscription has stopped.');
+      expect(scroll.scrollableReferences.size)
+          .toBe(4, 'Expected scrollable count to stay the same');
+    });
+
   });
 });
 

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -89,7 +89,7 @@ export class ScrollDispatcher {
         subscription.unsubscribe();
         this._scrolledCount--;
 
-        if (this._globalSubscription && !this.scrollableReferences.size && !this._scrolledCount) {
+        if (this._globalSubscription && !this._scrolledCount) {
           this._globalSubscription.unsubscribe();
           this._globalSubscription = null;
         }


### PR DESCRIPTION
* Removes the global scroll listener from the viewport ruler, which was being used to invalidate the scroll position cache. Caching the scroll position is pointless since it'll be invalidated very frequently. Since most Material components depend on the `ViewportRuler` one way or another, it meant that there was a good chance that the scroll listener would stay around forever.
* Fixes an issue that caused the scroll dispatcher not to remove its global scroll listener, if there are any scrollables on the page, even though nothing was subscribed to it.

Fixes #6882.