### PR TITLE
fix(overlay): import BidiModule in OverlayModule

### DIFF
--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -6,17 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule, Provider} from '@angular/core';
+import {BidiModule} from '@angular/cdk/bidi';
 import {PortalModule} from '@angular/cdk/portal';
-import {Overlay} from './overlay';
 import {ScrollDispatchModule, VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';
+import {NgModule, Provider} from '@angular/core';
+import {Overlay} from './overlay';
+import {OVERLAY_CONTAINER_PROVIDER} from './overlay-container';
 import {
   ConnectedOverlayDirective,
   MAT_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER,
   OverlayOrigin,
 } from './overlay-directives';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
-import {OVERLAY_CONTAINER_PROVIDER} from './overlay-container';
 import {ScrollStrategyOptions} from './scroll/scroll-strategy-options';
 
 export const OVERLAY_PROVIDERS: Provider[] = [
@@ -28,7 +29,7 @@ export const OVERLAY_PROVIDERS: Provider[] = [
 ];
 
 @NgModule({
-  imports: [PortalModule, ScrollDispatchModule],
+  imports: [BidiModule, PortalModule, ScrollDispatchModule],
   exports: [ConnectedOverlayDirective, OverlayOrigin, ScrollDispatchModule],
   declarations: [ConnectedOverlayDirective, OverlayOrigin],
   providers: [OVERLAY_PROVIDERS, ScrollStrategyOptions],


### PR DESCRIPTION
The ConnectedOverlayDirective uses `Directionality`, but the OverlayModule doesn't import BidiModule to make it available.