### PR TITLE
fix(sort): fix arrow on width-constrained headers

### DIFF
--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -29,6 +29,7 @@ $mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
 .mat-sort-header-arrow {
   height: $mat-sort-header-arrow-container-size;
   width: $mat-sort-header-arrow-container-size;
+  min-width: $mat-sort-header-arrow-container-size;
   margin: 0 0 0 $mat-sort-header-arrow-margin;
   position: relative;
   display: flex;


### PR DESCRIPTION
Fixes this when the container has small width: 

![6yrmbjqhtsz](https://user-images.githubusercontent.com/22898577/31256654-d0dde9be-a9e8-11e7-863b-45cf4fb6edbb.png)
