### PR TITLE
chore(selection-list): superfluous disabled check

### DIFF
--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -142,10 +142,6 @@ export class MatListOption extends _MatListOptionMixinBase
 
   ngAfterContentInit() {
     this._lineSetter = new MatLineSetter(this._lines, this._renderer, this._element);
-
-    if (this.selectionList.disabled) {
-      this.disabled = true;
-    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Removes the unnecessary `disabled` check in the `ngAfterContentInit` lifecycle hook of the selection list. The `selectionList.disabled` state is being respected by the getter.