### PR TITLE
build: fix version placeholder replacement

### DIFF
--- a/tools/package-tools/version-placeholders.ts
+++ b/tools/package-tools/version-placeholders.ts
@@ -49,12 +49,12 @@ function buildPlaceholderFindCommand(packageDir: string) {
   if (platform() === 'win32') {
     return {
       binary: 'findstr',
-      args: ['/msi', `"${ngVersionPlaceholderText} ${versionPlaceholderText}"`, `${packageDir}\\*`]
+      args: ['/msi', `${ngVersionPlaceholderText} ${versionPlaceholderText}`, `${packageDir}\\*`]
     };
   } else {
     return {
       binary: 'grep',
-      args: ['-ril', `"${ngVersionPlaceholderText}\\|${versionPlaceholderText}"`, packageDir]
+      args: ['-ril', `${ngVersionPlaceholderText}\\|${versionPlaceholderText}`, packageDir]
     };
   }
 }


### PR DESCRIPTION
Recently another placeholder for the Angular version has been introduced and the find commands had to be adjusted to search for a second text.

For some reason this change caused the placeholders to be only replaced partially. This is because the `spawnSync` argument was surrounded by quotes and the files with placeholders couldn't be found. The quotes caused the command to be executed with multiple quotes e.g. `grep ""R2|R2""` which breaks the query.

Fixes #7593