### PR TITLE
fix(progress-spinner): fallback animation not working

### DIFF
--- a/src/lib/progress-spinner/progress-spinner.html
+++ b/src/lib/progress-spinner/progress-spinner.html
@@ -19,6 +19,5 @@
     [style.animation-name]="'mat-progress-spinner-stroke-rotate-' + diameter"
     [style.stroke-dashoffset.px]="_strokeDashOffset"
     [style.stroke-dasharray.px]="_strokeCircumference"
-    [style.transform.rotate]="'360deg'"
     [style.stroke-width.px]="strokeWidth"></circle>
 </svg>

--- a/src/lib/progress-spinner/progress-spinner.scss
+++ b/src/lib/progress-spinner/progress-spinner.scss
@@ -14,9 +14,9 @@ $_mat-progress-spinner-default-circumference: $pi * $_mat-progress-spinner-defau
 
   svg {
     position: absolute;
-    transform: translate(-50%, -50%) rotate(-90deg);
-    top: 50%;
-    left: 50%;
+    transform: rotate(-90deg);
+    top: 0;
+    left: 0;
     transform-origin: center;
     overflow: visible;
   }

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -165,6 +165,11 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
       return this._strokeCircumference * (100 - this._value) / 100;
     }
 
+    // In fallback mode set the circle to 80% and rotate it with CSS.
+    if (this._fallbackAnimation && this.mode === 'indeterminate') {
+      return this._strokeCircumference * 0.2;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
* Fixes the fallback animation not looking like it's working, because it displays a full circle.
* Fixes an issue that causes the spinner to overflow its parent on IE and Edge. It's because they don't consider the `transform` when determining whether an element overflows.

Fixes #7599.