### PR TITLE
 feat(sort): show sort indicator on hover/focus/longpress

### DIFF
--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -235,7 +235,8 @@
     selected
   </div>
 
-  <mat-table [dataSource]="matTableDataSource" [trackBy]="userTrackBy" matSort
+  <mat-table [dataSource]="matTableDataSource" [trackBy]="userTrackBy"
+             matSort matSortActive="progress" matSortDirection="asc"
              #sortForDataSource="matSort">
 
     <!-- Checkbox Column -->

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -43,7 +43,7 @@ export class TableDemo {
   displayedColumns: UserProperties[] = [];
   trackByStrategy: TrackByStrategy = 'reference';
   changeReferences = false;
-  progressSortingDisabled = false;
+  progressSortingDisabled = true;
   highlights = new Set<string>();
   wasExpanded = new Set<UserData>();
 

--- a/src/lib/sort/sort-header.html
+++ b/src/lib/sort/sort-header.html
@@ -1,16 +1,25 @@
 <div class="mat-sort-header-container"
+     [class.mat-sort-header-sorted]="_isSorted()"
      [class.mat-sort-header-position-before]="arrowPosition == 'before'">
   <button class="mat-sort-header-button" type="button"
+          [attr.disabled]="_isDisabled() || null"
           [attr.aria-label]="_intl.sortButtonLabel(id)"
-          [attr.disabled]="_isDisabled() || null">
+          (focus)="_setIndicatorHintVisible(true)"
+          (blur)="_setIndicatorHintVisible(false)">
     <ng-content></ng-content>
   </button>
 
-  <div *ngIf="_isSorted()" class="mat-sort-header-arrow" [@indicatorToggle]="_sort.direction">
+  <!-- Disable animations while a current animation is running -->
+  <div class="mat-sort-header-arrow"
+       [@arrowOpacity]="_getArrowViewState()"
+       [@arrowPosition]="_getArrowViewState()"
+       [@allowChildren]="_getArrowDirectionState()"
+       (@arrowPosition.start)="_disableViewStateAnimation = true"
+       (@arrowPosition.done)="_disableViewStateAnimation = false">
     <div class="mat-sort-header-stem"></div>
-    <div class="mat-sort-header-indicator" [@indicator]="_sort.direction" >
-      <div class="mat-sort-header-pointer-left" [@leftPointer]="_sort.direction"></div>
-      <div class="mat-sort-header-pointer-right" [@rightPointer]="_sort.direction"></div>
+    <div class="mat-sort-header-indicator" [@indicator]="_getArrowDirectionState()">
+      <div class="mat-sort-header-pointer-left" [@leftPointer]="_getArrowDirectionState()"></div>
+      <div class="mat-sort-header-pointer-right" [@rightPointer]="_getArrowDirectionState()"></div>
       <div class="mat-sort-header-pointer-middle"></div>
     </div>
   </div>

--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -3,7 +3,7 @@ $mat-sort-header-arrow-container-size: 12px;
 $mat-sort-header-arrow-stem-size: 10px;
 $mat-sort-header-arrow-pointer-length: 6px;
 $mat-sort-header-arrow-thickness: 2px;
-$mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
+$mat-sort-header-arrow-hint-opacity: 0.38;
 
 .mat-sort-header-container {
   display: flex;
@@ -60,7 +60,6 @@ $mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
   position: absolute;
   top: 0;
   left: 0;
-  transition: $mat-sort-header-arrow-transition;
 }
 
 .mat-sort-header-pointer-middle {
@@ -76,7 +75,6 @@ $mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
   background: currentColor;
   width: $mat-sort-header-arrow-pointer-length;
   height: $mat-sort-header-arrow-thickness;
-  transition: $mat-sort-header-arrow-transition;
   position: absolute;
   top: 0;
 }

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -19,6 +19,7 @@ import {CdkColumnDef} from '@angular/cdk/table';
 import {Subscription} from 'rxjs/Subscription';
 import {merge} from 'rxjs/observable/merge';
 import {MatSort, MatSortable} from './sort';
+import {SortDirection} from './sort-direction';
 import {MatSortHeaderIntl} from './sort-header-intl';
 import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
 import {CanDisable, mixinDisabled} from '@angular/material/core';
@@ -29,6 +30,25 @@ import {matSortAnimations} from './sort-animations';
 export class MatSortHeaderBase {}
 export const _MatSortHeaderMixinBase = mixinDisabled(MatSortHeaderBase);
 
+/**
+ * Valid positions for the arrow to be in for its opacity and translation. If the state is a
+ * sort direction, the position of the arrow will be above/below and opacity 0. If the state is
+ * hint, the arrow will be in the center with a slight opacity. Active state means the arrow will
+ * be fully opaque in the center.
+ *
+ * @docs-private
+ */
+export type ArrowViewState = SortDirection | 'hint' | 'active';
+
+/**
+ * States describing the arrow's animated position (animating fromState -> toState).
+ * If the fromState is not defined, there will be no animated transition to the toState.
+ * @docs-private
+ */
+export interface ArrowViewStateTransition {
+  fromState?: ArrowViewState;
+  toState: ArrowViewState;
+}
 
 /**
  * Applies sorting behavior (click to change sort) and styles to an element, including an
@@ -47,7 +67,9 @@ export const _MatSortHeaderMixinBase = mixinDisabled(MatSortHeaderBase);
   styleUrls: ['sort-header.css'],
   host: {
     '(click)': '_handleClick()',
-    '[class.mat-sort-header-sorted]': '_isSorted()',
+    '(mouseenter)': '_setIndicatorHintVisible(true)',
+    '(longpress)': '_setIndicatorHintVisible(true)',
+    '(mouseleave)': '_setIndicatorHintVisible(false)',
     '[class.mat-sort-header-disabled]': '_isDisabled()',
   },
   encapsulation: ViewEncapsulation.None,
@@ -58,11 +80,34 @@ export const _MatSortHeaderMixinBase = mixinDisabled(MatSortHeaderBase);
     matSortAnimations.indicator,
     matSortAnimations.leftPointer,
     matSortAnimations.rightPointer,
-    matSortAnimations.indicatorToggle
+    matSortAnimations.arrowOpacity,
+    matSortAnimations.arrowPosition,
+    matSortAnimations.allowChildren,
   ]
 })
 export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortable, CanDisable {
   private _rerenderSubscription: Subscription;
+
+  /**
+   * Flag set to true when the indicator should be displayed while the sort is not active. Used to
+   * provide an affordance that the header is sortable by showing on focus and hover.
+   */
+  _showIndicatorHint: boolean = false;
+
+  /**
+   * The view transition state of the arrow (translation/ opacity) - indicates its `from` and `to`
+   * position through the animation. If animations are currently disabled, the fromState is removed
+   * so that there is no animation displayed.
+   */
+  _viewState: ArrowViewStateTransition;
+
+  /** The direction the arrow should be facing according to the current state. */
+  _arrowDirection: SortDirection = '';
+
+  /**
+   * Whether the view state animation should show the transition between the `from` and `to` states.
+   */
+  _disableViewStateAnimation = false;
 
   /**
    * ID of this sort header. If used within the context of a CdkColumnDef, this will default to
@@ -94,13 +139,30 @@ export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortabl
     }
 
     this._rerenderSubscription = merge(_sort.sortChange, _sort._stateChanges, _intl.changes)
-      .subscribe(() => changeDetectorRef.markForCheck());
+        .subscribe(() => {
+          if (this._isSorted()) {
+            this._updateArrowDirection();
+          }
+
+          // If this header was recently active and now no longer sorted, animate away the arrow.
+          if (!this._isSorted() && this._viewState && this._viewState.toState === 'active') {
+            this._disableViewStateAnimation = false;
+            this._setAnimationTransitionState({fromState: 'active', toState: this._arrowDirection});
+          }
+
+          changeDetectorRef.markForCheck();
+        });
   }
 
   ngOnInit() {
     if (!this.id && this._cdkColumnDef) {
       this.id = this._cdkColumnDef.name;
     }
+
+    // Initialize the direction of the arrow and set the view state to be immediately that state.
+    this._updateArrowDirection();
+    this._setAnimationTransitionState(
+        {toState: this._isSorted() ? 'active' : this._arrowDirection});
 
     this._sort.register(this);
   }
@@ -110,17 +172,93 @@ export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortabl
     this._rerenderSubscription.unsubscribe();
   }
 
-  /** Handles click events on the header. */
-  _handleClick() {
-    if (!this._isDisabled()) {
-      this._sort.sort(this);
+  /**
+   * Sets the "hint" state such that the arrow will be semi-transparently displayed as a hint to the
+   * user showing what the active sort will become. If set to false, the arrow will fade away.
+   */
+  _setIndicatorHintVisible(visible: boolean) {
+    // No-op if the sort header is disabled - should not make the hint visible.
+    if (this._isDisabled() && visible) { return; }
+
+    this._showIndicatorHint = visible;
+
+    if (!this._isSorted()) {
+      this._updateArrowDirection();
+      if (this._showIndicatorHint) {
+        this._setAnimationTransitionState({fromState: this._arrowDirection, toState: 'hint'});
+      } else {
+        this._setAnimationTransitionState({fromState: 'hint', toState: this._arrowDirection});
+      }
     }
+  }
+
+  /**
+   * Sets the animation transition view state for the arrow's position and opacity. If the
+   * `disableViewStateAnimation` flag is set to true, the `fromState` will be ignored so that
+   * no animation appears.
+   */
+  _setAnimationTransitionState(viewState: ArrowViewStateTransition) {
+    this._viewState = viewState;
+
+    // If the animation for arrow position state (opacity/translation) should be disabled,
+    // remove the fromState so that it jumps right to the toState.
+    if (this._disableViewStateAnimation) {
+      this._viewState = {toState: viewState.toState};
+    }
+  }
+
+  /** Triggers the sort on this sort header and removes the indicator hint. */
+  _handleClick() {
+    if (this._isDisabled()) { return; }
+
+    this._sort.sort(this);
+
+    // Do not show the animation if the header was already shown in the right position.
+    if (this._viewState.toState === 'hint' || this._viewState.toState === 'active') {
+      this._disableViewStateAnimation = true;
+    }
+
+    // If the arrow is now sorted, animate the arrow into place. Otherwise, animate it away into
+    // the direction it is facing.
+    const viewState: ArrowViewStateTransition = this._isSorted() ?
+        {fromState: this._arrowDirection, toState: 'active'} :
+        {fromState: 'active', toState: this._arrowDirection};
+    this._setAnimationTransitionState(viewState);
+
+    this._showIndicatorHint = false;
   }
 
   /** Whether this MatSortHeader is currently sorted in either ascending or descending order. */
   _isSorted() {
     return this._sort.active == this.id &&
         (this._sort.direction === 'asc' || this._sort.direction === 'desc');
+  }
+
+  /** Returns the animation state for the arrow direction (indicator and pointers). */
+  _getArrowDirectionState() {
+    return `${this._isSorted() ? 'active-' : ''}${this._arrowDirection}`;
+  }
+
+  /** Returns the arrow position state (opacity, translation). */
+  _getArrowViewState() {
+    const fromState = this._viewState.fromState;
+    return (fromState ? `${fromState}-to-` : '') + this._viewState.toState;
+  }
+
+  /**
+   * Updates the direction the arrow should be pointing. If it is not sorted, the arrow should be
+   * facing the start direction. Otherwise if it is sorted, the arrow should point in the currently
+   * active sorted direction. The reason this is updated through a function is because the direction
+   * should only be changed at specific times - when deactivated but the hint is displayed and when
+   * the sort is active and the direction changes. Otherwise the arrow's direction should linger
+   * in cases such as the sort becoming deactivated but we want to animate the arrow away while
+   * preserving its direction, even though the next sort direction is actually different and should
+   * only be changed once the arrow displays again (hint or activation).
+   */
+  _updateArrowDirection() {
+    this._arrowDirection = this._isSorted() ?
+        this._sort.direction :
+        (this.start || this._sort.start);
   }
 
   _isDisabled() {


### PR DESCRIPTION
Brings the sort header closer to spec but unfortunately takes away the cool animation that was added in #7180. Not sure how to reconcile the animation with this indicator hint. Perhaps only do the fade-away animation when sort is removed but not added?

Closes #6858, #8612