### PR TITLE
fix(select): open method triggered twice on click

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -508,7 +508,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Opens the overlay panel. */
   open(): void {
-    if (this.disabled || !this.options || !this.options.length) {
+    if (this.disabled || !this.options || !this.options.length || this._panelOpen) {
       return;
     }
 


### PR DESCRIPTION
Fixes the `open` method being triggered both by a click handler on the select trigger and the `onContainerClick` from the `MatFormField` integration.