### PR TITLE
refactor(scroll-dispatcher): API improvements

### DIFF
--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -4,7 +4,7 @@ import {ConnectedPositionStrategy} from './connected-position-strategy';
 import {ViewportRuler, VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';
 import {OverlayPositionBuilder} from './overlay-position-builder';
 import {ConnectedOverlayPositionChange} from './connected-position';
-import {Scrollable} from '@angular/cdk/scrolling';
+import {CdkScrollable} from '@angular/cdk/scrolling';
 import {Subscription} from 'rxjs/Subscription';
 import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 import {OverlayRef} from '../overlay-ref';
@@ -545,7 +545,7 @@ describe('ConnectedPositionStrategy', () => {
           {overlayX: 'start', overlayY: 'top'});
 
       strategy.withScrollableContainers([
-          new Scrollable(new FakeElementRef(scrollable), null!, null!, null!)]);
+          new CdkScrollable(new FakeElementRef(scrollable), null!, null!, null!)]);
       strategy.attach(fakeOverlayRef(overlayElement));
       positionChangeHandler = jasmine.createSpy('positionChangeHandler');
       onPositionChangeSubscription = strategy.onPositionChange.subscribe(positionChangeHandler);

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -19,7 +19,7 @@ import {
 import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {Observable} from 'rxjs/Observable';
-import {Scrollable} from '@angular/cdk/scrolling';
+import {CdkScrollable} from '@angular/cdk/scrolling';
 import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';
 import {OverlayRef} from '../overlay-ref';
 
@@ -46,7 +46,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   private _offsetY: number = 0;
 
   /** The Scrollable containers used to check scrollable view properties on position change. */
-  private scrollables: Scrollable[] = [];
+  private scrollables: CdkScrollable[] = [];
 
   /** Subscription to viewport resize events. */
   private _resizeSubscription = Subscription.EMPTY;
@@ -176,7 +176,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
    * Scrollable must be an ancestor element of the strategy's origin element.
    */
-  withScrollableContainers(scrollables: Scrollable[]) {
+  withScrollableContainers(scrollables: CdkScrollable[]) {
     this.scrollables = scrollables;
   }
 

--- a/src/cdk/overlay/scroll/index.ts
+++ b/src/cdk/overlay/scroll/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {Scrollable, ScrollDispatcher} from '@angular/cdk/scrolling';
+export {CdkScrollable, ScrollDispatcher} from '@angular/cdk/scrolling';
 
 // Export pre-defined scroll strategies and interface to build custom ones.
 export {ScrollStrategy} from './scroll-strategy';

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -20,7 +20,7 @@ import {ScrollDispatcher} from './scroll-dispatcher';
 @Directive({
   selector: '[cdk-scrollable], [cdkScrollable]'
 })
-export class Scrollable implements OnInit, OnDestroy {
+export class CdkScrollable implements OnInit, OnDestroy {
   private _elementScrolled: Subject<Event> = new Subject();
   private _scrollListener: Function | null;
 

--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -8,13 +8,13 @@
 
 import {NgModule} from '@angular/core';
 import {SCROLL_DISPATCHER_PROVIDER} from './scroll-dispatcher';
-import {Scrollable} from  './scrollable';
+import {CdkScrollable} from  './scrollable';
 import {PlatformModule} from '@angular/cdk/platform';
 
 @NgModule({
   imports: [PlatformModule],
-  exports: [Scrollable],
-  declarations: [Scrollable],
+  exports: [CdkScrollable],
+  declarations: [CdkScrollable],
   providers: [SCROLL_DISPATCHER_PROVIDER],
 })
 export class ScrollDispatchModule {}

--- a/src/cdk/testing/dispatch-events.ts
+++ b/src/cdk/testing/dispatch-events.ts
@@ -20,8 +20,8 @@ export function dispatchEvent(node: Node | Window, event: Event): Event {
 }
 
 /** Shorthand to dispatch a fake event on a specified node. */
-export function dispatchFakeEvent(node: Node | Window, type: string): Event {
-  return dispatchEvent(node, createFakeEvent(type));
+export function dispatchFakeEvent(node: Node | Window, type: string, canBubble?: boolean): Event {
+  return dispatchEvent(node, createFakeEvent(type, canBubble));
 }
 
 /** Shorthand to dispatch a keyboard event with a specified key code. */

--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -74,8 +74,8 @@ export function createKeyboardEvent(type: string, keyCode: number, target?: Elem
 }
 
 /** Creates a fake event object with any desired event type. */
-export function createFakeEvent(type: string) {
+export function createFakeEvent(type: string, canBubble = true, cancelable = true) {
   const event = document.createEvent('Event');
-  event.initEvent(type, true, true);
+  event.initEvent(type, canBubble, cancelable);
   return event;
 }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -17,7 +17,7 @@ import {AnimationEvent} from '@angular/animations';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {OverlayContainer, OverlayModule, Scrollable} from '@angular/cdk/overlay';
+import {OverlayContainer, OverlayModule, CdkScrollable} from '@angular/cdk/overlay';
 import {Platform} from '@angular/cdk/platform';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {ESCAPE} from '@angular/cdk/keycodes';
@@ -686,7 +686,7 @@ class ScrollableTooltipDemo {
  message: string = initialTooltipMessage;
  showButton: boolean = true;
 
- @ViewChild(Scrollable) scrollingContainer: Scrollable;
+ @ViewChild(CdkScrollable) scrollingContainer: CdkScrollable;
 
  scrollDown() {
      const scrollingContainerEl = this.scrollingContainer.getElementRef().nativeElement;

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -280,7 +280,11 @@ export class MatTooltip implements OnDestroy {
       .connectedTo(this._elementRef, origin.main, overlay.main)
       .withFallbackPosition(origin.fallback, overlay.fallback);
 
-    strategy.withScrollableContainers(this._scrollDispatcher.getScrollContainers(this._elementRef));
+    const scrollableAncestors = this._scrollDispatcher
+      .getAncestorScrollContainers(this._elementRef);
+
+    strategy.withScrollableContainers(scrollableAncestors);
+
     strategy.onPositionChange.subscribe(change => {
       if (this._tooltipInstance) {
         if (change.scrollableViewProperties.isOverlayClipped && this._tooltipInstance.isVisible()) {


### PR DESCRIPTION
* Adds the `ancestorScrolled` method that allows for the consumer to subscribe to scroll events coming from the element's parent scrollables.
* The `scrolled` and `ancestorScrolled` streams now expose the scrollable that was scrolled.

BREAKING CHANGES:
* The `getScrollContainers` method has been renamed to `getAncestorScrollContainers` to better describe what it does.
* The `ScrollDispatcher.scrollableReferences` property has been renamed to `scrollContainers`.
* The `ScrollDispatcher.scrollableContainsElement` method has been removed.
* The `Scrollable` class has been renamed to `CdkScrollable` for consistency.