### PR TITLE
chore: inconsistent package version in screenshot tool

### DIFF
--- a/tools/screenshot-test/package.json
+++ b/tools/screenshot-test/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^4.0.2",
+    "@angular/animations": "^4.4.4",
     "@angular/cdk": "angular/cdk-builds",
     "@angular/common": "^4.4.4",
     "@angular/compiler": "^4.4.4",


### PR DESCRIPTION
Makes the `@angular/animations` version of the screenshot tool consistent with the rest of the Angular dependencies.