### PR TITLE
fix(table): cell content should not stretch width

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -16,4 +16,6 @@ $mat-row-horizontal-padding: 24px;
 
 .mat-cell, .mat-header-cell {
   flex: 1;
+  overflow: hidden;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
When the table's width is reduced, cells should not allow their content to push their width since it breaks column alignment. Instead, their content should wrap within the column.