### PR TITLE
[Custom Typography] mat-font-weight for menu

### DIFF
--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -39,6 +39,7 @@
     font: {
       family: mat-font-family($config, subheading-2);
       size: mat-font-size($config, subheading-2);
+      weight: mat-font-weight($config, subheading-2);
     }
   }
 }


### PR DESCRIPTION
Custom typography font-weight was not being carried over for menu items. 

This change applies the subheading-2 font-weight to the mat-menu-typography mixin