### PR TITLE
fix(drawer): not restoring focus on close

### DIFF
--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -212,8 +212,6 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
         this._focusTrap.focusInitialElementWhenReady();
       }
     });
-
-    this.onClose.subscribe(() => this._restoreFocus());
   }
 
   /**
@@ -277,6 +275,7 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
       this._animationState = this._enableAnimations ? 'open' : 'open-instant';
     } else {
       this._animationState = 'void';
+      this._restoreFocus();
     }
 
     if (this._focusTrap) {


### PR DESCRIPTION
Currently the drawer restores focus on close after its closing animation is done and it contains the currently-focused element. This will always evaluate to false, because the sidenav gets a `visibility: hidden` which will blur any focused elements that it may have. With these changes the drawer will restore focus when the animation starts and it's still visible.

**Note:** we actually had a unit test for this, however it didn't catch the failure, because animations are disabled in tests.