### PR TITLE
build: fix subpixel failures when running locally

### DIFF
--- a/e2e/util/asserts.ts
+++ b/e2e/util/asserts.ts
@@ -24,8 +24,8 @@ export function expectFocusOn(element: FinderResult, expected = true): void {
  */
 export function expectLocation(element: FinderResult, {x, y}: Point): void {
   getElement(element).getLocation().then((location: Point) => {
-    expect(location.x).toEqual(x);
-    expect(location.y).toEqual(y);
+    expect(Math.round(location.x)).toEqual(Math.round(x));
+    expect(Math.round(location.y)).toEqual(Math.round(y));
   });
 }
 


### PR DESCRIPTION
Fixes a few e2e tests that were failing due to subpixel measurement differences.