### PR TITLE
chore(docs): add types to public and jsdoc cleanup

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -85,8 +85,8 @@ export class CdkStep implements OnChanges {
   @Input() label: string;
 
   @Input()
-  get editable() { return this._editable; }
-  set editable(value: any) {
+  get editable(): boolean { return this._editable; }
+  set editable(value: boolean) {
     this._editable = coerceBooleanProperty(value);
   }
   private _editable = true;
@@ -101,10 +101,10 @@ export class CdkStep implements OnChanges {
 
   /** Return whether step is completed or not. */
   @Input()
-  get completed() {
+  get completed(): boolean {
     return this._customCompleted == null ? this._defaultCompleted : this._customCompleted;
   }
-  set completed(value: any) {
+  set completed(value: boolean) {
     this._customCompleted = coerceBooleanProperty(value);
   }
   private _customCompleted: boolean | null = null;
@@ -140,8 +140,8 @@ export class CdkStepper {
 
   /** Whether the validity of previous steps should be checked or not. */
   @Input()
-  get linear() { return this._linear; }
-  set linear(value: any) { this._linear = coerceBooleanProperty(value); }
+  get linear(): boolean { return this._linear; }
+  set linear(value: boolean) { this._linear = coerceBooleanProperty(value); }
   private _linear = false;
 
   /** The index of the selected step. */
@@ -161,13 +161,14 @@ export class CdkStepper {
 
   /** The step that is selected. */
   @Input()
-  get selected() { return this._steps.toArray()[this.selectedIndex]; }
+  get selected(): CdkStep { return this._steps.toArray()[this.selectedIndex]; }
   set selected(step: CdkStep) {
     this.selectedIndex = this._steps.toArray().indexOf(step);
   }
 
   /** Event emitted when the selected step has changed. */
-  @Output() selectionChange = new EventEmitter<StepperSelectionEvent>();
+  @Output() selectionChange: EventEmitter<StepperSelectionEvent>
+      = new EventEmitter<StepperSelectionEvent>();
 
   /** The index of the step that the focus can be set. */
   _focusIndex: number = 0;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -140,7 +140,7 @@ export class CdkTable<T> implements CollectionViewer {
    * Stream containing the latest information on what rows are being displayed on screen.
    * Can be used by the data source to as a heuristic of what data should be provided.
    */
-  viewChange =
+  viewChange: BehaviorSubject<{start: number, end: number}> =
       new BehaviorSubject<{start: number, end: number}>({start: 0, end: Number.MAX_VALUE});
 
   // Placeholders within the table's template where the header and data rows will be inserted.

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -116,7 +116,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     return this._vertical;
   }
 
-  set vertical(value) {
+  set vertical(value: boolean) {
     this._vertical = coerceBooleanProperty(value);
   }
 
@@ -135,7 +135,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 
   /** Whether the toggle group is selected. */
   @Input()
-  get selected() {
+  get selected(): MatButtonToggle | null {
     return this._selected;
   }
 

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -48,7 +48,7 @@ export class MatChipInput {
    * Whether or not the chipEnd event will be emitted when the input is blurred.
    */
   @Input('matChipInputAddOnBlur')
-  get addOnBlur() { return this._addOnBlur; }
+  get addOnBlur(): boolean { return this._addOnBlur; }
   set addOnBlur(value: boolean) { this._addOnBlur = coerceBooleanProperty(value); }
   _addOnBlur: boolean = false;
 
@@ -62,7 +62,7 @@ export class MatChipInput {
 
   /** Emitted when a chip is to be added. */
   @Output('matChipInputTokenEnd')
-  chipEnd = new EventEmitter<MatChipInputEvent>();
+  chipEnd: EventEmitter<MatChipInputEvent> = new EventEmitter<MatChipInputEvent>();
 
   @Input() placeholder: string = '';
 
@@ -115,5 +115,5 @@ export class MatChipInput {
     }
   }
 
-  focus() { this._inputElement.focus(); }
+  focus(): void { this._inputElement.focus(); }
 }

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -210,15 +210,15 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
     this._id = value;
     this.stateChanges.next();
   }
-  get id() { return this._id || this._uid; }
+  get id(): string { return this._id || this._uid; }
 
   /** Required for FormFieldControl. Whether the chip list is required. */
   @Input()
-  set required(value: any) {
+  set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
-  get required() {
+  get required(): boolean {
     return this._required;
   }
 
@@ -228,7 +228,7 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
     this._placeholder = value;
     this.stateChanges.next();
   }
-  get placeholder() {
+  get placeholder(): string {
     return this._chipInput ? this._chipInput.placeholder : this._placeholder;
   }
 
@@ -306,7 +306,7 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
    * to facilitate the two-way binding for the `value` input.
    * @docs-private
    */
-  @Output() valueChange = new EventEmitter<any>();
+  @Output() valueChange: EventEmitter<any> = new EventEmitter<any>();
 
   /** The chip components contained within this chip list. */
   @ContentChildren(MatChip) chips: QueryList<MatChip>;
@@ -396,6 +396,7 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
     this.stateChanges.next();
   }
 
+  /** @docs-private */
   onContainerClick() {
     this.focus();
   }
@@ -404,7 +405,7 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
    * Focuses the the first non-disabled chip in this chip list, or the associated input when there
    * are no eligible chips.
    */
-  focus() {
+  focus(): void {
     // TODO: ARIA says this should focus the first `selected` chip if any are selected.
     // Focus on first element if there's no chipInput inside chip-list
     if (this._chipInput && this._chipInput.focused) {

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -145,7 +145,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   _onBlur = new Subject<MatChipEvent>();
 
   /** Emitted when the chip is selected or deselected. */
-  @Output() selectionChange = new EventEmitter<MatChipSelectionChange>();
+  @Output() selectionChange: EventEmitter<MatChipSelectionChange>
+      = new EventEmitter<MatChipSelectionChange>();
 
   /** Emitted when the chip is destroyed. */
   @Output() destroyed = new EventEmitter<MatChipEvent>();
@@ -154,16 +155,16 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
    * Emitted when the chip is destroyed.
    * @deprecated Use 'destroyed' instead.
    */
-  @Output() destroy = this.destroyed;
+  @Output() destroy: EventEmitter<MatChipEvent> = this.destroyed;
 
   /** Emitted when a chip is to be removed. */
-  @Output() removed = new EventEmitter<MatChipEvent>();
+  @Output() removed: EventEmitter<MatChipEvent> = new EventEmitter<MatChipEvent>();
 
   /**
    * Emitted when a chip is to be removed.
    * @deprecated Use `removed` instead.
    */
-  @Output('remove') onRemove = this.removed;
+  @Output('remove') onRemove: EventEmitter<MatChipEvent> = this.removed;
 
   get ariaSelected(): string | null {
     return this.selectable ? this.selected.toString() : null;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -147,8 +147,8 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   /** Whether the datepicker-input is disabled. */
   @Input()
-  get disabled() { return !!this._disabled; }
-  set disabled(value: any) {
+  get disabled(): boolean { return !!this._disabled; }
+  set disabled(value: boolean) {
     const newValue = coerceBooleanProperty(value);
 
     if (this._disabled !== newValue) {
@@ -159,10 +159,12 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   private _disabled: boolean;
 
   /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() dateChange = new EventEmitter<MatDatepickerInputEvent<D>>();
+  @Output() dateChange: EventEmitter<MatDatepickerInputEvent<D>>
+      = new EventEmitter<MatDatepickerInputEvent<D>>();
 
   /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() dateInput = new EventEmitter<MatDatepickerInputEvent<D>>();
+  @Output() dateInput: EventEmitter<MatDatepickerInputEvent<D>>
+      = new EventEmitter<MatDatepickerInputEvent<D>>();
 
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D|null>();

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -143,15 +143,15 @@ export class MatDatepicker<D> implements OnDestroy {
    * Whether the calendar UI is in touch mode. In touch mode the calendar opens in a dialog rather
    * than a popup and elements have more padding to allow for bigger touch targets.
    */
-  @Input() touchUi = false;
+  @Input() touchUi: boolean = false;
 
   /** Whether the datepicker pop-up should be disabled. */
   @Input()
-  get disabled() {
+  get disabled(): boolean {
     return this._disabled === undefined && this._datepickerInput ?
         this._datepickerInput.disabled : !!this._disabled;
   }
-  set disabled(value: any) {
+  set disabled(value: boolean) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this._disabled) {
@@ -165,13 +165,13 @@ export class MatDatepicker<D> implements OnDestroy {
    * Emits new selected date when selected date changes.
    * @deprecated Switch to the `dateChange` and `dateInput` binding on the input element.
    */
-  @Output() selectedChanged = new EventEmitter<D>();
+  @Output() selectedChanged: EventEmitter<D> = new EventEmitter<D>();
 
   /** Whether the calendar is open. */
-  opened = false;
+  opened: boolean = false;
 
   /** The id for the datepicker calendar. */
-  id = `mat-datepicker-${datepickerUid++}`;
+  id: string = `mat-datepicker-${datepickerUid++}`;
 
   /** The currently selected date. */
   get _selected(): D | null { return this._validSelected; }

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -27,7 +27,7 @@ export class MatDialogRef<T> {
   componentInstance: T;
 
   /** Whether the user is allowed to close the dialog. */
-  disableClose = this._containerInstance._config.disableClose;
+  disableClose: boolean | undefined = this._containerInstance._config.disableClose;
 
   /** Subject for notifying the user that the dialog has finished opening. */
   private _afterOpen = new Subject<void>();

--- a/src/lib/expansion/accordion-item.ts
+++ b/src/lib/expansion/accordion-item.ts
@@ -28,13 +28,13 @@ let nextId = 0;
 @Injectable()
 export class AccordionItem implements OnDestroy {
   /** Event emitted every time the AccordionItem is closed. */
-  @Output() closed = new EventEmitter<void>();
+  @Output() closed: EventEmitter<void> = new EventEmitter<void>();
   /** Event emitted every time the AccordionItem is opened. */
-  @Output() opened = new EventEmitter<void>();
+  @Output() opened: EventEmitter<void> = new EventEmitter<void>();
   /** Event emitted when the AccordionItem is destroyed. */
-  @Output() destroyed = new EventEmitter<void>();
+  @Output() destroyed: EventEmitter<void> = new EventEmitter<void>();
   /** The unique AccordionItem id. */
-  readonly id = `cdk-accordion-child-${nextId++}`;
+  readonly id: string = `cdk-accordion-child-${nextId++}`;
 
   /** Whether the AccordionItem is expanded. */
   @Input()

--- a/src/lib/expansion/accordion.ts
+++ b/src/lib/expansion/accordion.ts
@@ -24,7 +24,7 @@ let nextId = 0;
 })
 export class CdkAccordion {
   /** A readonly id value to use for unique selection coordination. */
-  readonly id = `cdk-accordion-${nextId++}`;
+  readonly id: string = `cdk-accordion-${nextId++}`;
 
   /** Whether the accordion should allow multiple expanded accordion items simulateously. */
   @Input() get multi(): boolean { return this._multi; }

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -28,11 +28,9 @@ import {EXPANSION_PANEL_ANIMATION_TIMING, MatExpansionPanel} from './expansion-p
 
 
 /**
- * <mat-expansion-panel-header> component.
+ * <mat-expansion-panel-header>
  *
  * This component corresponds to the header element of an <mat-expansion-panel>.
- *
- * Please refer to README.md for examples on how to use it.
  */
 @Component({
   moduleId: module.id,
@@ -157,7 +155,7 @@ export class MatExpansionPanelHeader implements OnDestroy {
 }
 
 /**
- * <mat-panel-description> directive.
+ * <mat-panel-description>
  *
  * This direction is to be used inside of the MatExpansionPanelHeader component.
  */
@@ -170,7 +168,7 @@ export class MatExpansionPanelHeader implements OnDestroy {
 export class MatExpansionPanelDescription {}
 
 /**
- * <mat-panel-title> directive.
+ * <mat-panel-title>
  *
  * This direction is to be used inside of the MatExpansionPanelHeader component.
  */

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -46,12 +46,10 @@ export type MatExpansionPanelState = 'expanded' | 'collapsed';
 export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,1)';
 
 /**
- * <mat-expansion-panel> component.
+ * <mat-expansion-panel>
  *
  * This component can be used as a single element to show expandable content, or as one of
  * multiple children of an element with the CdkAccordion directive attached.
- *
- * Please refer to README.md for examples on how to use it.
  */
 @Component({
   moduleId: module.id,

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -105,8 +105,8 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
 
   /** Whether the required marker should be hidden. */
   @Input()
-  get hideRequiredMarker() { return this._hideRequiredMarker; }
-  set hideRequiredMarker(value: any) {
+  get hideRequiredMarker(): boolean { return this._hideRequiredMarker; }
+  set hideRequiredMarker(value: boolean) {
     this._hideRequiredMarker = coerceBooleanProperty(value);
   }
   private _hideRequiredMarker: boolean;
@@ -127,7 +127,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
 
   /** Text for the form field hint. */
   @Input()
-  get hintLabel() { return this._hintLabel; }
+  get hintLabel(): string { return this._hintLabel; }
   set hintLabel(value: string) {
     this._hintLabel = value;
     this._processHints();
@@ -139,7 +139,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
 
   /** Whether the placeholder should always float, never float or float as the user types. */
   @Input()
-  get floatPlaceholder() { return this._floatPlaceholder; }
+  get floatPlaceholder(): FloatPlaceholderType { return this._floatPlaceholder; }
   set floatPlaceholder(value: FloatPlaceholderType) {
     if (value !== this._floatPlaceholder) {
       this._floatPlaceholder = value || this._placeholderOptions.float || 'auto';

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -76,13 +76,13 @@ export class MatGridList implements OnInit, AfterContentChecked {
 
   /** Amount of columns in the grid list. */
   @Input()
-  get cols() { return this._cols; }
-  set cols(value: any) { this._cols = coerceToNumber(value); }
+  get cols(): number { return this._cols; }
+  set cols(value: number) { this._cols = coerceToNumber(value); }
 
   /** Size of the grid list's gutter in pixels. */
   @Input()
-  get gutterSize() { return this._gutter; }
-  set gutterSize(value: any) { this._gutter = coerceToString(value); }
+  get gutterSize(): string { return this._gutter; }
+  set gutterSize(value: string) { this._gutter = coerceToString(value); }
 
   /** Set internal representation of row height from the user-provided value. */
   @Input()

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -43,12 +43,12 @@ export class MatGridTile {
   /** Amount of rows that the grid tile takes up. */
   @Input()
   get rowspan(): number { return this._rowspan; }
-  set rowspan(value) { this._rowspan = coerceToNumber(value); }
+  set rowspan(value: number) { this._rowspan = coerceToNumber(value); }
 
   /** Amount of columns that the grid tile takes up. */
   @Input()
   get colspan(): number { return this._colspan; }
-  set colspan(value) { this._colspan = coerceToNumber(value); }
+  set colspan(value: number) { this._colspan = coerceToNumber(value); }
 
   /**
    * Sets the style of the grid-tile element.  Needs to be set manually to avoid

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -30,7 +30,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck {
   private _maxRows: number;
 
   @Input('matAutosizeMinRows')
-  get minRows() { return this._minRows; }
+  get minRows(): number { return this._minRows; }
 
   set minRows(value: number) {
     this._minRows = value;
@@ -38,7 +38,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck {
   }
 
   @Input('matAutosizeMaxRows')
-  get maxRows() { return this._maxRows; }
+  get maxRows(): number { return this._maxRows; }
   set maxRows(value: number) {
     this._maxRows = value;
     this._setMaxHeight();
@@ -133,7 +133,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck {
   }
 
   /** Resize the textarea to fit its content. */
-  resizeToFitContent() {
+  resizeToFitContent(): void {
     this._cacheTextareaLineHeight();
 
     // If we haven't determined the line-height yet, we know we're still hidden and there's no point

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -93,12 +93,17 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
 
   /** Whether the element is disabled. */
   @Input()
-  get disabled() { return this.ngControl ? this.ngControl.disabled : this._disabled; }
-  set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
+  get disabled(): boolean {
+    if (this.ngControl) {
+      return this.ngControl.disabled || false;
+    }
+    return this._disabled;
+  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
 
   /** Unique id of the element. */
   @Input()
-  get id() { return this._id; }
+  get id(): string { return this._id; }
   set id(value: string) { this._id = value || this._uid; }
 
   /** Placeholder attribute of the element. */
@@ -106,12 +111,12 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
 
   /** Whether the element is required. */
   @Input()
-  get required() { return this._required; }
-  set required(value: any) { this._required = coerceBooleanProperty(value); }
+  get required(): boolean { return this._required; }
+  set required(value: boolean) { this._required = coerceBooleanProperty(value); }
 
   /** Input type of the element. */
   @Input()
-  get type() { return this._type; }
+  get type(): string { return this._type; }
   set type(value: string) {
     this._type = value || 'text';
     this._validateType();
@@ -129,7 +134,7 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
 
   /** The input element's value. */
   @Input()
-  get value() { return this._elementRef.nativeElement.value; }
+  get value(): string { return this._elementRef.nativeElement.value; }
   set value(value: string) {
     if (value !== this.value) {
       this._elementRef.nativeElement.value = value;
@@ -139,8 +144,8 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
 
   /** Whether the element is readonly. */
   @Input()
-  get readonly() { return this._readonly; }
-  set readonly(value: any) { this._readonly = coerceBooleanProperty(value); }
+  get readonly(): boolean { return this._readonly; }
+  set readonly(value: boolean) { this._readonly = coerceBooleanProperty(value); }
 
   protected _neverEmptyInputTypes = [
     'date',

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -102,12 +102,14 @@ export class MatListOption extends _MatListOptionMixinBase
 
   /** Whether the option is disabled. */
   @Input()
-  get disabled() { return (this.selectionList && this.selectionList.disabled) || this._disabled; }
-  set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
+  get disabled(): boolean {
+    return (this.selectionList && this.selectionList.disabled) || this._disabled;
+  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
 
   /** Whether the option is selected. */
   @Input()
-  get selected() { return this._selected; }
+  get selected(): boolean { return this._selected; }
   set selected(value: boolean) {
     const isSelected = coerceBooleanProperty(value);
 
@@ -121,10 +123,12 @@ export class MatListOption extends _MatListOptionMixinBase
   }
 
   /** Emitted when the option is selected. */
-  @Output() selectChange = new EventEmitter<MatSelectionListOptionEvent>();
+  @Output() selectChange: EventEmitter<MatSelectionListOptionEvent>
+      = new EventEmitter<MatSelectionListOptionEvent>();
 
   /** Emitted when the option is deselected. */
-  @Output() deselected = new EventEmitter<MatSelectionListOptionEvent>();
+  @Output() deselected: EventEmitter<MatSelectionListOptionEvent>
+      = new EventEmitter<MatSelectionListOptionEvent>();
 
   constructor(private _renderer: Renderer2,
               private _element: ElementRef,

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -94,7 +94,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
 
   /** Position of the menu in the X axis. */
   @Input()
-  get xPosition() { return this._xPosition; }
+  get xPosition(): MenuPositionX { return this._xPosition; }
   set xPosition(value: MenuPositionX) {
     if (value !== 'before' && value !== 'after') {
       throwMatMenuInvalidPositionX();
@@ -105,7 +105,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
 
   /** Position of the menu in the Y axis. */
   @Input()
-  get yPosition() { return this._yPosition; }
+  get yPosition(): MenuPositionY { return this._yPosition; }
   set yPosition(value: MenuPositionY) {
     if (value !== 'above' && value !== 'below') {
       throwMatMenuInvalidPositionY();
@@ -120,7 +120,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
   @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 
   /** Whether the menu should overlap its trigger. */
-  @Input() overlapTrigger = this._defaultOptions.overlapTrigger;
+  @Input() overlapTrigger: boolean = this._defaultOptions.overlapTrigger;
 
   /**
    * This method takes classes set on the host mat-menu element and applies them on the
@@ -142,7 +142,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
   }
 
   /** Event emitted when the menu is closed. */
-  @Output() close = new EventEmitter<void | 'click' | 'keydown'>();
+  @Output() close: EventEmitter<void | 'click' | 'keydown'>
+      = new EventEmitter<void | 'click' | 'keydown'>();
 
   constructor(
     private _elementRef: ElementRef,
@@ -201,7 +202,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    * Focus the first item in the menu. This method is used by the menu trigger
    * to focus the first item when the menu is opened by the ENTER key.
    */
-  focusFirstItem() {
+  focusFirstItem(): void {
     this._keyManager.setFirstItemActive();
   }
 

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -51,7 +51,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase implements FocusableOptio
   OnDestroy {
 
   /** Stream that emits when the menu item is hovered. */
-  hover: Subject<MatMenuItem> = new Subject();
+  hover: Subject<MatMenuItem> = new Subject<MatMenuItem>();
 
   /** Whether the menu item is highlighted. */
   _highlighted: boolean = false;

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -107,10 +107,10 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   @Input('matMenuTriggerFor') menu: MatMenuPanel;
 
   /** Event emitted when the associated menu is opened. */
-  @Output() onMenuOpen = new EventEmitter<void>();
+  @Output() onMenuOpen: EventEmitter<void> = new EventEmitter<void>();
 
   /** Event emitted when the associated menu is closed. */
-  @Output() onMenuClose = new EventEmitter<void>();
+  @Output() onMenuClose: EventEmitter<void> = new EventEmitter<void>();
 
   constructor(private _overlay: Overlay,
               private _element: ElementRef,

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -22,13 +22,13 @@ export class MatPaginatorIntl {
   changes: Subject<void> = new Subject<void>();
 
   /** A label for the page size selector. */
-  itemsPerPageLabel = 'Items per page:';
+  itemsPerPageLabel: string = 'Items per page:';
 
   /** A label for the button that increments the current page. */
-  nextPageLabel = 'Next page';
+  nextPageLabel: string = 'Next page';
 
   /** A label for the button that decrements the current page. */
-  previousPageLabel = 'Previous page';
+  previousPageLabel: string = 'Previous page';
 
   /** A label for the range of items within the current page and the length of the whole list. */
   getRangeLabel = (page: number, pageSize: number, length: number) => {

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -117,26 +117,26 @@ export class MatPaginator implements OnInit, OnDestroy {
   }
 
   /** Advances to the next page if it exists. */
-  nextPage() {
+  nextPage(): void {
     if (!this.hasNextPage()) { return; }
     this.pageIndex++;
     this._emitPageEvent();
   }
 
   /** Move back to the previous page if it exists. */
-  previousPage() {
+  previousPage(): void {
     if (!this.hasPreviousPage()) { return; }
     this.pageIndex--;
     this._emitPageEvent();
   }
 
   /** Whether there is a previous page. */
-  hasPreviousPage() {
+  hasPreviousPage(): boolean {
     return this.pageIndex >= 1 && this.pageSize != 0;
   }
 
   /** Whether there is a next page. */
-  hasNextPage() {
+  hasNextPage(): boolean {
     const numberOfPages = Math.ceil(this.length / this.pageSize) - 1;
     return this.pageIndex < numberOfPages && this.pageSize != 0;
   }

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -44,14 +44,14 @@ export class MatProgressBar {
 
   /** Value of the progressbar. Defaults to zero. Mirrored to aria-valuenow. */
   @Input()
-  get value() { return this._value; }
+  get value(): number { return this._value; }
   set value(v: number) { this._value = clamp(v || 0); }
 
   private _bufferValue: number = 0;
 
   /** Buffer value of the progress bar. Defaults to zero. */
   @Input()
-  get bufferValue() { return this._bufferValue; }
+  get bufferValue(): number { return this._bufferValue; }
   set bufferValue(v: number) { this._bufferValue = clamp(v || 0); }
 
   /**

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -309,7 +309,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Placeholder to be shown if no value has been selected. */
   @Input()
-  get placeholder() { return this._placeholder; }
+  get placeholder(): string { return this._placeholder; }
   set placeholder(value: string) {
     this._placeholder = value;
     this.stateChanges.next();
@@ -317,8 +317,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Whether the component is required. */
   @Input()
-  get required() { return this._required; }
-  set required(value: any) {
+  get required(): boolean { return this._required; }
+  set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
@@ -354,7 +354,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Value of the select control. */
   @Input()
-  get value() { return this._value; }
+  get value(): any { return this._value; }
   set value(newValue: any) {
     if (newValue !== this._value) {
       this.writeValue(newValue);
@@ -383,7 +383,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Unique id of the element. */
   @Input()
-  get id() { return this._id; }
+  get id(): string { return this._id; }
   set id(value: string) {
     this._id = value || this._uid;
     this.stateChanges.next();
@@ -409,7 +409,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    * to facilitate the two-way binding for the `value` input.
    * @docs-private
    */
-  @Output() valueChange = new EventEmitter<any>();
+  @Output() valueChange: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(
     private _viewportRuler: ViewportRuler,

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -138,7 +138,7 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
   /** The side that the drawer is attached to. */
   @Input()
   get position(): 'start' | 'end' { return this._position; }
-  set position(value) {
+  set position(value: 'start' | 'end') {
     // Make sure we have a valid value.
     value = value === 'end' ? 'end' : 'start';
     if (value != this._position) {
@@ -152,12 +152,12 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
   /** @deprecated */
   @Input()
   get align(): 'start' | 'end' { return this.position; }
-  set align(value) { this.position = value; }
+  set align(value: 'start' | 'end') { this.position = value; }
 
   /** Mode of the drawer; one of 'over', 'push' or 'side'. */
   @Input()
   get mode(): 'over' | 'push' | 'side' { return this._mode; }
-  set mode(value) {
+  set mode(value: 'over' | 'push' | 'side') {
     this._mode = value;
     this._modeChanged.next();
   }
@@ -203,19 +203,19 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
    * Event emitted when the drawer is fully opened.
    * @deprecated Use `openedChange` instead.
    */
-  @Output('open') onOpen = this._openedStream;
+  @Output('open') onOpen: Observable<void> = this._openedStream;
 
   /**
    * Event emitted when the drawer is fully closed.
    * @deprecated Use `openedChange` instead.
    */
-  @Output('close') onClose = this._closedStream;
+  @Output('close') onClose: Observable<void> = this._closedStream;
 
   /** Event emitted when the drawer's position changes. */
-  @Output('positionChanged') onPositionChanged = new EventEmitter<void>();
+  @Output('positionChanged') onPositionChanged: EventEmitter<void> = new EventEmitter<void>();
 
   /** @deprecated */
-  @Output('align-changed') onAlignChanged = new EventEmitter<void>();
+  @Output('align-changed') onAlignChanged: EventEmitter<void> = new EventEmitter<void>();
 
   /**
    * An observable that emits when the drawer mode changes. This is used by the drawer container to

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -220,12 +220,12 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   }
 
   /** Focuses the slide-toggle. */
-  focus() {
+  focus(): void {
     this._focusMonitor.focusVia(this._inputElement.nativeElement, 'keyboard');
   }
 
   /** Toggles the checked state of the slide-toggle. */
-  toggle() {
+  toggle(): void {
     this.checked = !this.checked;
   }
 
@@ -325,7 +325,7 @@ class SlideToggleRenderer {
   }
 
   /** Initializes the drag of the slide-toggle. */
-  startThumbDrag(checked: boolean) {
+  startThumbDrag(checked: boolean): void {
     if (this.dragging) { return; }
 
     this._thumbBarWidth = this._thumbBarEl.clientWidth - this._thumbEl.clientWidth;
@@ -349,7 +349,7 @@ class SlideToggleRenderer {
   }
 
   /** Updates the thumb containers position from the specified distance. */
-  updateThumbPosition(distance: number) {
+  updateThumbPosition(distance: number): void {
     this.dragPercentage = this._getDragPercentage(distance);
     // Calculate the moved distance based on the thumb bar width.
     let dragX = (this.dragPercentage / 100) * this._thumbBarWidth;

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -135,15 +135,15 @@ export class MatSlider extends _MatSliderMixinBase
     implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit {
   /** Whether the slider is inverted. */
   @Input()
-  get invert() { return this._invert; }
-  set invert(value: any) {
+  get invert(): boolean { return this._invert; }
+  set invert(value: boolean) {
     this._invert = coerceBooleanProperty(value);
   }
   private _invert = false;
 
   /** The maximum value that the slider can have. */
   @Input()
-  get max() { return this._max; }
+  get max(): number { return this._max; }
   set max(v: number) {
     this._max = coerceNumberProperty(v, this._max);
     this._percent = this._calculatePercentage(this._value);
@@ -155,7 +155,7 @@ export class MatSlider extends _MatSliderMixinBase
 
   /** The minimum value that the slider can have. */
   @Input()
-  get min() { return this._min; }
+  get min(): number { return this._min; }
   set min(v: number) {
     this._min = coerceNumberProperty(v, this._min);
 
@@ -172,7 +172,7 @@ export class MatSlider extends _MatSliderMixinBase
 
   /** The values at which the thumb will snap. */
   @Input()
-  get step() { return this._step; }
+  get step(): number { return this._step; }
   set step(v: number) {
     this._step = coerceNumberProperty(v, this._step);
 
@@ -188,7 +188,7 @@ export class MatSlider extends _MatSliderMixinBase
   /** Whether or not to show the thumb label. */
   @Input()
   get thumbLabel(): boolean { return this._thumbLabel; }
-  set thumbLabel(value) { this._thumbLabel = coerceBooleanProperty(value); }
+  set thumbLabel(value: boolean) { this._thumbLabel = coerceBooleanProperty(value); }
   private _thumbLabel: boolean = false;
 
   /** @deprecated */
@@ -220,7 +220,7 @@ export class MatSlider extends _MatSliderMixinBase
 
   /** Value of the slider. */
   @Input()
-  get value() {
+  get value(): number | null {
     // If the value needs to be read and it is still uninitialized, initialize it to the min.
     if (this._value === null) {
       this.value = this._min;
@@ -240,17 +240,17 @@ export class MatSlider extends _MatSliderMixinBase
 
   /** Whether the slider is vertical. */
   @Input()
-  get vertical() { return this._vertical; }
-  set vertical(value: any) {
+  get vertical(): boolean { return this._vertical; }
+  set vertical(value: boolean) {
     this._vertical = coerceBooleanProperty(value);
   }
   private _vertical = false;
 
   /** Event emitted when the slider value has changed. */
-  @Output() change = new EventEmitter<MatSliderChange>();
+  @Output() change: EventEmitter<MatSliderChange> = new EventEmitter<MatSliderChange>();
 
   /** Event emitted when the slider thumb moves. */
-  @Output() input = new EventEmitter<MatSliderChange>();
+  @Output() input: EventEmitter<MatSliderChange> = new EventEmitter<MatSliderChange>();
 
   /** The value to be used for display purposes. */
   get displayValue(): string | number {

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -60,18 +60,18 @@ export class MatSort {
    * May be overriden by the MatSortable's disable clear input.
    */
   @Input('matSortDisableClear')
-  get disableClear() { return this._disableClear; }
+  get disableClear(): boolean { return this._disableClear; }
   set disableClear(v: boolean) { this._disableClear = coerceBooleanProperty(v); }
   private _disableClear: boolean;
 
   /** Event emitted when the user changes either the active sort or sort direction. */
-  @Output('matSortChange') readonly sortChange = new EventEmitter<Sort>();
+  @Output('matSortChange') readonly sortChange: EventEmitter<Sort> = new EventEmitter<Sort>();
 
   /**
    * Register function to be used by the contained MatSortables. Adds the MatSortable to the
    * collection of MatSortables.
    */
-  register(sortable: MatSortable) {
+  register(sortable: MatSortable): void {
     if (!sortable.id) {
       throw getSortHeaderMissingIdError();
     }
@@ -86,12 +86,12 @@ export class MatSort {
    * Unregister function to be used by the contained MatSortables. Removes the MatSortable from the
    * collection of contained MatSortables.
    */
-  deregister(sortable: MatSortable) {
+  deregister(sortable: MatSortable): void {
     this.sortables.delete(sortable.id);
   }
 
   /** Sets the active sort id and determines the new sort direction. */
-  sort(sortable: MatSortable) {
+  sort(sortable: MatSortable): void {
     if (this.active != sortable.id) {
       this.active = sortable.id;
       this.direction = sortable.start ? sortable.start : this.start;

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -47,32 +47,32 @@ export class MatStepHeader implements OnDestroy {
 
   /** Index of the given step. */
   @Input()
-  get index() { return this._index; }
-  set index(value: any) {
+  get index(): number { return this._index; }
+  set index(value: number) {
     this._index = coerceNumberProperty(value);
   }
   private _index: number;
 
   /** Whether the given step is selected. */
   @Input()
-  get selected() { return this._selected; }
-  set selected(value: any) {
+  get selected(): boolean { return this._selected; }
+  set selected(value: boolean) {
     this._selected = coerceBooleanProperty(value);
   }
   private _selected: boolean;
 
   /** Whether the given step label is active. */
   @Input()
-  get active() { return this._active; }
-  set active(value: any) {
+  get active(): boolean { return this._active; }
+  set active(value: boolean) {
     this._active = coerceBooleanProperty(value);
   }
   private _active: boolean;
 
   /** Whether the given step is optional. */
   @Input()
-  get optional() { return this._optional; }
-  set optional(value: any) {
+  get optional(): boolean { return this._optional; }
+  set optional(value: boolean) {
     this._optional = coerceBooleanProperty(value);
   }
   private _optional: boolean;

--- a/src/lib/stepper/stepper-intl.ts
+++ b/src/lib/stepper/stepper-intl.ts
@@ -20,5 +20,5 @@ export class MatStepperIntl {
   changes: Subject<void> = new Subject<void>();
 
   /** Label that is rendered below optional steps. */
-  optionalLabel = 'Optional';
+  optionalLabel: string = 'Optional';
 }

--- a/tools/dgeni/processors/docs-private-filter.ts
+++ b/tools/dgeni/processors/docs-private-filter.ts
@@ -19,6 +19,10 @@ const INTERNAL_METHODS = [
   'registerOnChange',
   'registerOnTouched',
   'setDisabledState',
+  'setDescribedByIds',
+  'registerOnValidatorChange',
+  'onContainerClick',
+  'shouldPlaceholderFloat',
 
   // Don't ever need to document constructors
   'constructor',


### PR DESCRIPTION
This PR:

- Cleans up missing types on PUBLIC methods/properties
- Cleans up JSDoc comments
- Adds more excludes for internal methods