### PR TITLE
perf(menu,select): panel repainting on scroll

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -1,6 +1,7 @@
 @import './variables';
 @import './elevation';
 @import './list-common';
+@import './vendor-prefixes';
 
 /** The mixins below are shared between mat-menu and mat-select */
 
@@ -15,6 +16,10 @@ $mat-menu-icon-margin: 16px !default;
 
 @mixin mat-menu-base($default-elevation) {
   @include mat-overridable-elevation($default-elevation);
+
+  // Prevents the content from repainting on scroll.
+  @include backface-visibility(hidden);
+
   min-width: $mat-menu-overlay-min-width;
   max-width: $mat-menu-overlay-max-width;
   overflow: auto;


### PR DESCRIPTION
Prevents the menu and select panels from repainting while scrolling.

Fixes #7716.