### PR TITLE
fix(form-field): remove specific mention of matInput in error

### DIFF
--- a/src/lib/form-field/form-field-errors.ts
+++ b/src/lib/form-field/form-field-errors.ts
@@ -18,6 +18,5 @@ export function getMatFormFieldDuplicatedHintError(align: string): Error {
 
 /** @docs-private */
 export function getMatFormFieldMissingControlError(): Error {
-  return Error('mat-form-field must contain a MatFormFieldControl. ' +
-      'Did you forget to add matInput to the native input or textarea element?');
+  return Error('mat-form-field must contain a MatFormFieldControl.');
 }


### PR DESCRIPTION
Fixes https://github.com/angular/material2/issues/7297.

I think the error description [in the docs](https://material.angular.io/components/form-field/overview#error-mat-form-field-must-contain-a-matformfieldcontrol), makes this no longer necessary.

