### PR TITLE
fix(select): remove inert focus call

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -641,7 +641,6 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    */
   _onFadeInDone(): void {
     this._panelDoneAnimating = this.panelOpen;
-    this.panel.nativeElement.focus();
     this._changeDetectorRef.markForCheck();
   }
 


### PR DESCRIPTION
Removes an attempt to focus the select panel after the animation is done. This doesn't do anything, because the panel isn't focusable, however it'll start throwing in an upcoming Angular release.

cc @matsko 