### PR TITLE
chore: fix autocomplete test

### DIFF
--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -543,12 +543,12 @@ describe('MatAutocomplete', () => {
     }));
 
     it('should disable input in view when disabled programmatically', () => {
-      const inputUnderline =
-          fixture.debugElement.query(By.css('.mat-form-field-underline')).nativeElement;
+      const formFieldElement =
+          fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
 
       expect(input.disabled)
           .toBe(false, `Expected input to start out enabled in view.`);
-      expect(inputUnderline.classList.contains('mat-disabled'))
+      expect(formFieldElement.classList.contains('mat-form-field-disabled'))
           .toBe(false, `Expected input underline to start out with normal styles.`);
 
       fixture.componentInstance.stateCtrl.disable();
@@ -556,7 +556,7 @@ describe('MatAutocomplete', () => {
 
       expect(input.disabled)
           .toBe(true, `Expected input to be disabled in view when disabled programmatically.`);
-      expect(inputUnderline.classList.contains('mat-disabled'))
+      expect(formFieldElement.classList.contains('mat-form-field-disabled'))
           .toBe(true, `Expected input underline to display disabled styles.`);
     });
 


### PR DESCRIPTION
Due to https://github.com/angular/material2/commit/9b4f4355bc89cb83295f10b8d1bea6ba3ab4d6d5#diff-295d2cf77570f5880fd0c828fe60c2c4 the `mat-disabled` class is no longer being added to the underline element.

The disabled class is now being added to the host element of the `mat-form-field` component.