### PR TITLE
fix(drawer): re-add openedStart and closedStart events

### DIFF
--- a/src/demo-app/drawer/drawer-demo.html
+++ b/src/demo-app/drawer/drawer-demo.html
@@ -1,7 +1,7 @@
 <h2>Basic Use Case</h2>
 
 <mat-drawer-container class="demo-drawer-container">
-  <mat-drawer #start (open)="myinput.focus()" mode="side">
+  <mat-drawer #start (opened)="myinput.focus()" mode="side">
     Start Side Drawer
     <br>
     <button mat-button (click)="start.close()">Close</button>

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -189,21 +189,39 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
     return this.openedChange.pipe(filter(o => o), map(() => {}));
   }
 
+  /** Event emitted when the drawer has started opening. */
+  @Output()
+  get openedStart(): Observable<void> {
+    return this._animationStarted.pipe(
+      filter(e => e.fromState !== e.toState && e.toState.indexOf('open') === 0),
+      map(() => {})
+    );
+  }
+
   /** Event emitted when the drawer has been closed. */
   @Output('closed')
   get _closedStream(): Observable<void> {
     return this.openedChange.pipe(filter(o => !o), map(() => {}));
   }
 
+  /** Event emitted when the drawer has started closing. */
+  @Output()
+  get closedStart(): Observable<void> {
+    return this._animationStarted.pipe(
+      filter(e => e.fromState !== e.toState && e.toState === 'void'),
+      map(() => {})
+    );
+  }
+
   /**
    * Event emitted when the drawer is fully opened.
-   * @deprecated Use `openedChange` instead.
+   * @deprecated Use `opened` instead.
    */
   @Output('open') onOpen = this._openedStream;
 
   /**
    * Event emitted when the drawer is fully closed.
-   * @deprecated Use `openedChange` instead.
+   * @deprecated Use `closed` instead.
    */
   @Output('close') onClose = this._closedStream;
 
@@ -323,8 +341,10 @@ export class MatDrawer implements AfterContentInit, OnDestroy {
 
     // TODO(crisbeto): This promise is here for backwards-compatibility.
     // It should be removed next time we do breaking changes in the drawer.
-    return new Promise(resolve => {
-      (isOpen ? this.onOpen : this.onClose).pipe(first()).subscribe(resolve);
+    return new Promise<any>(resolve => {
+      this.openedChange.pipe(first()).subscribe(open => {
+        resolve(new MatDrawerToggleResult(open ? 'open' : 'close', true));
+      });
     });
   }
 


### PR DESCRIPTION
* Re-adds the `openedStart` and `closedStart` events due to popular demand.
* Fixes wrong signature for the returned promise from `toggle`. The signature states that the resolved value is supposed to be a `MatDrawerToggleResult` while in practice it was `undefined`.
* Splits out a long unit test into two smaller ones.

Fixes #6924.