### PR TITLE
fix(table): throw error when missing row defs

### DIFF
--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -12,7 +12,7 @@
  * @docs-private
  */
 export function getTableUnknownColumnError(id: string) {
-  return Error(`cdk-table: Could not find column with id "${id}".`);
+  return Error(`Could not find column with id "${id}".`);
 }
 
 /**
@@ -20,7 +20,7 @@ export function getTableUnknownColumnError(id: string) {
  * @docs-private
  */
 export function getTableDuplicateColumnNameError(name: string) {
-  return Error(`cdk-table: Duplicate column definition name provided: "${name}".`);
+  return Error(`Duplicate column definition name provided: "${name}".`);
 }
 
 /**
@@ -28,7 +28,7 @@ export function getTableDuplicateColumnNameError(name: string) {
  * @docs-private
  */
 export function getTableMultipleDefaultRowDefsError() {
-  return Error(`cdk-table: There can only be one default row without a when predicate function.`);
+  return Error(`There can only be one default row without a when predicate function.`);
 }
 
 /**
@@ -36,5 +36,14 @@ export function getTableMultipleDefaultRowDefsError() {
  * @docs-private
  */
 export function getTableMissingMatchingRowDefError() {
-  return Error(`cdk-table: Could not find a matching row definition for the provided row data.`);
+  return Error(`Could not find a matching row definition for the provided row data.`);
+}
+
+/**
+ * Returns an error to be thrown when there is no row definitions present in the content.
+ * @docs-private
+ */
+export function getTableMissingRowDefsError() {
+  return Error('Missing definitions for header and row, ' +
+      'cannot determine which columns should be rendered.');
 }

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -10,6 +10,7 @@ import {map} from 'rxjs/operators';
 import {
   getTableDuplicateColumnNameError,
   getTableMissingMatchingRowDefError,
+  getTableMissingRowDefsError,
   getTableMultipleDefaultRowDefsError,
   getTableUnknownColumnError
 } from './table-errors';
@@ -39,6 +40,7 @@ describe('CdkTable', () => {
         WhenRowCdkTableApp,
         WhenRowWithoutDefaultCdkTableApp,
         WhenRowMultipleDefaultsCdkTableApp,
+        MissingRowDefsCdkTableApp,
         BooleanRowCdkTableApp
       ],
     }).compileComponents();
@@ -156,6 +158,11 @@ describe('CdkTable', () => {
   it('should throw an error if a column definition is requested but not defined', () => {
     expect(() => TestBed.createComponent(MissingColumnDefCdkTableApp).detectChanges())
         .toThrowError(getTableUnknownColumnError('column_a').message);
+  });
+
+  it('should throw an error if the row definitions are missing', () => {
+    expect(() => TestBed.createComponent(MissingRowDefsCdkTableApp).detectChanges())
+        .toThrowError(getTableMissingRowDefsError().message);
   });
 
   it('should not throw an error if columns are undefined on initialization', () => {
@@ -996,6 +1003,20 @@ class DuplicateColumnDefNameCdkTableApp {
   `
 })
 class MissingColumnDefCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+    </cdk-table>
+  `
+})
+class MissingRowDefsCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
 }
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -183,7 +183,7 @@ export class CdkTable<T> implements CollectionViewer {
   }
 
   ngAfterContentInit() {
-    if (!this._headerDef && this._rowDefs.length == 0) {
+    if (!this._headerDef && !this._rowDefs.length) {
       throw getTableMissingRowDefsError();
     }
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -39,6 +39,7 @@ import {CdkCellDef, CdkColumnDef, CdkHeaderCellDef} from './cell';
 import {
   getTableDuplicateColumnNameError,
   getTableMissingMatchingRowDefError,
+  getTableMissingRowDefsError,
   getTableMultipleDefaultRowDefsError,
   getTableUnknownColumnError
 } from './table-errors';
@@ -182,6 +183,10 @@ export class CdkTable<T> implements CollectionViewer {
   }
 
   ngAfterContentInit() {
+    if (!this._headerDef && this._rowDefs.length == 0) {
+      throw getTableMissingRowDefsError();
+    }
+
     this._cacheColumnDefsByName();
     this._columnDefs.changes.subscribe(() => this._cacheColumnDefsByName());
     this._renderHeaderRow();


### PR DESCRIPTION
When users forgot to include a `<cdk-header-row>` and `<cdk-row>`, the error messaging is vague and not helpful. This provides a check to help them know where to start with debugging