### PR TITLE
fix(progress-spinner): coerce string values

### DIFF
--- a/src/lib/progress-spinner/progress-spinner.spec.ts
+++ b/src/lib/progress-spinner/progress-spinner.spec.ts
@@ -17,6 +17,7 @@ describe('MatProgressSpinner', () => {
         ProgressSpinnerCustomStrokeWidth,
         ProgressSpinnerCustomDiameter,
         SpinnerWithColor,
+        ProgressSpinnerWithStringValues,
       ],
     }).compileComponents();
   }));
@@ -184,6 +185,24 @@ describe('MatProgressSpinner', () => {
     expect(fixture.nativeElement.querySelector('svg').getAttribute('focusable')).toBe('false');
   });
 
+  it('should handle the number inputs being passed in as strings', () => {
+    const fixture = TestBed.createComponent(ProgressSpinnerWithStringValues);
+    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    const svgElement = spinner.nativeElement.querySelector('svg');
+
+    fixture.detectChanges();
+
+    expect(spinner.componentInstance.diameter).toBe(37);
+    expect(spinner.componentInstance.strokeWidth).toBe(11);
+    expect(spinner.componentInstance.value).toBe(25);
+
+    expect(spinner.nativeElement.style.width).toBe('38px');
+    expect(spinner.nativeElement.style.height).toBe('38px');
+    expect(svgElement.style.width).toBe('38px');
+    expect(svgElement.style.height).toBe('38px');
+    expect(svgElement.getAttribute('viewBox')).toBe('0 0 38 38');
+  });
+
 });
 
 
@@ -211,3 +230,10 @@ class SpinnerWithColor { color: string = 'primary'; }
 
 @Component({template: `<mat-progress-spinner value="50" [color]="color"></mat-progress-spinner>`})
 class ProgressSpinnerWithColor { color: string = 'primary'; }
+
+@Component({
+  template: `
+    <mat-progress-spinner value="25" diameter="37" strokeWidth="11"></mat-progress-spinner>
+  `
+})
+class ProgressSpinnerWithStringValues { }

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1870,7 +1870,6 @@ describe('MatSelect', () => {
 
         // There appears to be a small rounding error on IE, so we verify that the value is close,
         // not exact.
-        let platform = new Platform();
         if (platform.TRIDENT) {
           let difference =
               Math.abs(optionTop + (menuItemHeight - triggerHeight) / 2 - triggerTop);


### PR DESCRIPTION
Coerces any string values that are passed to `value`, `diameter` and `strokeWidth` to numbers.

Fixes #7790.