### PR TITLE
fix(select,input): inconsistent disabled text color

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -7,10 +7,9 @@
 
 @mixin mat-input-theme($theme) {
   $foreground: map-get($theme, foreground);
-  $is-dark-theme: map-get($theme, is-dark);
 
   .mat-input-element:disabled {
-    color: mat-color($foreground, secondary-text, if($is-dark-theme, 0.7, 0.42));
+    color: mat-color($foreground, disabled-text);
   }
 
   .mat-input-element {

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -10,12 +10,6 @@
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
   $warn: map-get($theme, warn);
-  $is-dark-theme: map-get($theme, is-dark);
-
-  .mat-select-disabled .mat-select-value,
-  .mat-select-arrow {
-    color: mat-color($foreground, secondary-text);
-  }
 
   .mat-select-content, .mat-select-panel-done-animating {
     background: mat-color($background, card);
@@ -23,6 +17,18 @@
 
   .mat-select-value {
     color: mat-color($foreground, text);
+  }
+
+  .mat-select-placeholder {
+    color: _mat-control-placeholder-color($theme);
+  }
+
+  .mat-select-disabled .mat-select-value {
+    color: mat-color($foreground, disabled-text);
+  }
+
+  .mat-select-arrow {
+    color: mat-color($foreground, secondary-text);
   }
 
   .mat-select-panel {
@@ -51,16 +57,8 @@
     }
 
     .mat-select.mat-select-disabled .mat-select-arrow {
-      color: mat-color($foreground, secondary-text);
+      color: mat-color($foreground, disabled-text);
     }
-  }
-
-  .mat-select.mat-select-disabled .mat-select-arrow {
-    color: mat-color($warn);
-  }
-
-  .mat-select-placeholder {
-    color: _mat-control-placeholder-color($theme);
   }
 }
 


### PR DESCRIPTION
Fixes the select and input having different disabled text colors and not taking colors from the palettes.

Fixes #7793.

**Note:** The disabled text color is currently wrong (It's supposed to be 0.5, but it's actually 0.3). It will be fixed by https://github.com/angular/material2/pull/7421.
**Another note:** Some screenshot test failures are to be expected because of the slightly different shades of grey.