### PR TITLE
fix(select): active item not being updated on click in multiple mode

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -3458,6 +3458,22 @@ describe('MatSelect', () => {
           'Expected `multiple` to have been set on dynamically-added option.');
     }));
 
+    it('should update the active item index on click', fakeAsync(() => {
+      trigger.click();
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.select._keyManager.activeItemIndex).toBe(0);
+
+      const options = overlayContainerElement.querySelectorAll('mat-option') as
+          NodeListOf<HTMLElement>;
+
+      options[2].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.select._keyManager.activeItemIndex).toBe(2);
+    }));
+
   });
 });
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -852,6 +852,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       this._selectionModel.toggle(option);
       this.stateChanges.next();
       wasSelected ? option.deselect() : option.select();
+      this._keyManager.setActiveItem(this._getOptionIndex(option)!);
       this._sortValues();
     } else {
       this._clearSelection(option.value == null ? undefined : option);


### PR DESCRIPTION
Fixes the active option not being updated when the user clicks inside a multi-select, causing it to be stuck on the first option.