### PR TITLE
chore(spinner): avoid deprecation warning in Safari

### DIFF
--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -203,7 +203,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
     }
 
     if (styleTag && styleTag.sheet) {
-      (styleTag.sheet as CSSStyleSheet).insertRule(this._getAnimationText());
+      (styleTag.sheet as CSSStyleSheet).insertRule(this._getAnimationText(), 0);
     }
 
     MatProgressSpinner.diameters.add(this.diameter);


### PR DESCRIPTION
Fixes a deprecation warning that was being logged by the spinner on Safari.