### PR TITLE
chore(button): remove attribute prefix check

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -131,10 +131,10 @@ export class MatButton extends _MatButtonMixinBase
     implements OnDestroy, CanDisable, CanColor, CanDisableRipple {
 
   /** Whether the button is round. */
-  _isRoundButton: boolean = this._hasAttributeWithPrefix('fab', 'mini-fab');
+  _isRoundButton: boolean = this._hasHostAttributes('mat-fab', 'mat-mini-fab');
 
   /** Whether the button is icon button. */
-  _isIconButton: boolean = this._hasAttributeWithPrefix('icon-button');
+  _isIconButton: boolean = this._hasHostAttributes('mat-icon-button');
 
   constructor(renderer: Renderer2,
               elementRef: ElementRef,
@@ -161,8 +161,8 @@ export class MatButton extends _MatButtonMixinBase
     return this.disableRipple || this.disabled;
   }
 
-  /** Gets whether the button has one of the given attributes with a 'mat-' prefix. */
-  _hasAttributeWithPrefix(...unprefixedAttributeNames: string[]) {
+  /** Gets whether the button has one of the given attributes. */
+  _hasHostAttributes(...attributes: string[]) {
     // If not on the browser, say that there are none of the attributes present.
     // Since these only affect how the ripple displays (and ripples only happen on the client),
     // detecting these attributes isn't necessary when not on the browser.
@@ -170,9 +170,7 @@ export class MatButton extends _MatButtonMixinBase
       return false;
     }
 
-    return unprefixedAttributeNames.some(suffix => {
-      return this._getHostElement().hasAttribute('mat-' + suffix);
-    });
+    return attributes.some(attribute => this._getHostElement().hasAttribute(attribute));
   }
 }
 


### PR DESCRIPTION
* Previously, the button had checks for attributes with the `md-` and `mat-` prefix. Since there is only one prefix now, the method can be updated to be more explicit and clean.