### PR TITLE
fix(datepicker): server-side rendering error in Angular 5

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.html
+++ b/src/lib/datepicker/datepicker-toggle.html
@@ -1,8 +1,8 @@
 <button mat-icon-button type="button" [attr.aria-label]="_intl.openCalendarLabel"
         [disabled]="disabled" (click)="_open($event)">
   <mat-icon>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%"
-         fill="currentColor" style="vertical-align: top" focusable="false">
+    <svg viewBox="0 0 24 24" width="100%" height="100%" fill="currentColor"
+         style="vertical-align: top" focusable="false">
       <path d="M0 0h24v24H0z" fill="none"/>
       <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
     </svg>


### PR DESCRIPTION
Fixes a server-side rendering error with the datepicker toggle in Angular 5. This is backported from #6018.

Fixes #7866.