### PR TITLE
docs(menu): move nested to section

### DIFF
--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -1,7 +1,6 @@
 `<mat-menu>` is a floating panel containing list of options.
 
 <!-- example(menu-overview) -->
-<!-- example(nested-menu) -->
 
 By itself, the `<mat-menu>` element does not render anything. The menu is attached to and opened
 via application of the `matMenuTriggerFor` directive:
@@ -92,6 +91,7 @@ that should trigger the sub-menu:
 </button>
 ```
 
+<!-- example(nested-menu) -->
 
 ### Keyboard interaction
 - <kbd>DOWN_ARROW</kbd>: Focuses the next menu item


### PR DESCRIPTION
This PR moves the nested docs demo to the appropriate section.