### PR TITLE
perf(tabs): avoid repainting while scrolling

### DIFF
--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,4 +1,8 @@
+@import '../core/style/vendor-prefixes';
+
 .mat-tab-body-content {
+  // Avoids repainting while scrolling.
+  @include backface-visibility(hidden);
   height: 100%;
   overflow: auto;
 


### PR DESCRIPTION
Along the same lines as #7721, #7719 and #6890 the tab body currently repaints on scroll.