### PR TITLE
fix(MatPaginatorIntl): Provide a provider if exists.

### DIFF
--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -48,7 +48,7 @@ export class MatPaginatorIntl {
 }
 
 /** @docs-private */
-export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(
+export function parentIntl(
     parentMatPaginatorIntl: MatPaginatorIntl) {
   return parentMatPaginatorIntl || new MatPaginatorIntl();
 }
@@ -58,5 +58,5 @@ export const MAT_PAGINATOR_INTL_PROVIDER = {
   // If there is already an MatPaginatorIntl available, use that. Otherwise, provide a new one.
   provide: MatPaginatorIntl,
   deps: [[new Optional(), new SkipSelf(), MatPaginatorIntl]],
-  useFactory: MAT_PAGINATOR_INTL_PROVIDER_FACTORY
+  useFactory: parentIntl
 };

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -48,9 +48,8 @@ export class MatPaginatorIntl {
 }
 
 /** @docs-private */
-export function parentIntl(
-    parentMatPaginatorIntl: MatPaginatorIntl) {
-  return parentMatPaginatorIntl || new MatPaginatorIntl();
+export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl) {
+  return parentIntl || new MatPaginatorIntl();
 }
 
 /** @docs-private */
@@ -58,5 +57,5 @@ export const MAT_PAGINATOR_INTL_PROVIDER = {
   // If there is already an MatPaginatorIntl available, use that. Otherwise, provide a new one.
   provide: MatPaginatorIntl,
   deps: [[new Optional(), new SkipSelf(), MatPaginatorIntl]],
-  useFactory: parentIntl
+  useFactory: MAT_PAGINATOR_INTL_PROVIDER_FACTORY
 };

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, SkipSelf, Optional } from '@angular/core';
 import {Subject} from 'rxjs/Subject';
 
 /**
@@ -46,3 +46,17 @@ export class MatPaginatorIntl {
     return `${startIndex + 1} - ${endIndex} of ${length}`;
   }
 }
+
+/** @docs-private */
+export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(
+    parentMatPaginatorIntl: MatPaginatorIntl) {
+  return parentMatPaginatorIntl || new MatPaginatorIntl();
+}
+
+/** @docs-private */
+export const MAT_PAGINATOR_INTL_PROVIDER = {
+  // If there is already an MatPaginatorIntl available, use that. Otherwise, provide a new one.
+  provide: MatPaginatorIntl,
+  deps: [[new Optional(), new SkipSelf(), MatPaginatorIntl]],
+  useFactory: MAT_PAGINATOR_INTL_PROVIDER_FACTORY
+};

--- a/src/lib/paginator/paginator-module.ts
+++ b/src/lib/paginator/paginator-module.ts
@@ -12,7 +12,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatSelectModule} from '@angular/material/select';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatPaginator} from './paginator';
-import { MAT_PAGINATOR_INTL_PROVIDER} from './paginator-intl';
+import {MAT_PAGINATOR_INTL_PROVIDER} from './paginator-intl';
 
 
 @NgModule({

--- a/src/lib/paginator/paginator-module.ts
+++ b/src/lib/paginator/paginator-module.ts
@@ -12,7 +12,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatSelectModule} from '@angular/material/select';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatPaginator} from './paginator';
-import {MatPaginatorIntl} from './paginator-intl';
+import { MAT_PAGINATOR_INTL_PROVIDER} from './paginator-intl';
 
 
 @NgModule({
@@ -24,6 +24,6 @@ import {MatPaginatorIntl} from './paginator-intl';
   ],
   exports: [MatPaginator],
   declarations: [MatPaginator],
-  providers: [MatPaginatorIntl],
+  providers: [MAT_PAGINATOR_INTL_PROVIDER],
 })
 export class MatPaginatorModule {}


### PR DESCRIPTION
If there is already a MatPaginatorIntl provider that one.  If not create a new instance.

@andrewseguin  I hope this is the correct implementation. If not let me know I will change it.
Next to this shouldn't this also be implemented for `sort-header-intl`
cc: @jelbourn
Closes #7344