### PR TITLE
chore(ripple): no longer update if `_matRippleTrigger` changes

### DIFF
--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -100,7 +100,7 @@ export class MatRipple implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if ((changes['trigger'] || changes['_matRippleTrigger']) && this.trigger) {
+    if (changes['trigger'] && this.trigger) {
       this._rippleRenderer.setTriggerElement(this.trigger);
     }
 


### PR DESCRIPTION
* Since the `md-` prefix is now removed completely, the `_matRippleTrigger` property is just `trigger` now.