### PR TITLE
feat(table): add access to filtered data in MatTableDataSource

### DIFF
--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -214,17 +214,40 @@
 <h3>MatTable With MatTableDataSource Example</h3>
 
 <mat-form-field>
-  <input matInput [formControl]="filter">
+  <input matInput #filter placeholder="Filter users">
 </mat-form-field>
 
-<div class="demo-table-container demo-mat-table-example mat-elevation-z4">
+<div class="demo-table-container demo-mat-table-example mat-elevation-z4 mat-table-selectable">
 
   <table-header-demo (shiftColumns)="displayedColumns.push(displayedColumns.shift())"
-                     (toggleColorColumn)="toggleColorColumn()">
+                     (toggleColorColumn)="toggleColorColumn()" *ngIf="selection.isEmpty()">
   </table-header-demo>
+  <div class="example-header example-selection-header"
+       *ngIf="!selection.isEmpty()">
+    {{selection.selected.length}}
+    {{selection.selected.length == 1 ? 'user' : 'users'}}
+    selected
+  </div>
 
   <mat-table [dataSource]="matTableDataSource" [trackBy]="userTrackBy" matSort
              #sortForDataSource="matSort">
+
+    <!-- Checkbox Column -->
+    <ng-container matColumnDef="select">
+      <mat-header-cell *matHeaderCellDef>
+        <mat-checkbox (change)="$event ? masterToggle() : null"
+                      [disabled]="!matTableDataSource.filteredData.length"
+                      [checked]="isMasterToggleChecked()"
+                      [indeterminate]="isMasterToggleIndeterminate()">
+        </mat-checkbox>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let row">
+        <mat-checkbox (click)="$event.stopPropagation()"
+                      (change)="$event ? selection.toggle(row) : null"
+                      [checked]="selection.isSelected(row)">
+        </mat-checkbox>
+      </mat-cell>
+    </ng-container>
 
     <!-- Column Definition: ID -->
     <ng-container cdkColumnDef="userId">
@@ -258,9 +281,11 @@
       <mat-cell *matCellDef="let row" [style.color]="row.color"> {{row.color}} </mat-cell>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-
+    <mat-header-row *matHeaderRowDef="matTableDataSourceColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: matTableDataSourceColumns;"
+             [class.selected]="selection.isSelected(row)"
+             (click)="selection.toggle(row)">
+    </mat-row>
   </mat-table>
 
   <mat-paginator #paginatorForDataSource

--- a/src/demo-app/table/table-demo.scss
+++ b/src/demo-app/table/table-demo.scss
@@ -73,7 +73,7 @@
   }
 }
 
-  /* Structure so that the table is contained on a card */
+/* Structure so that the table is contained on a card */
 .demo-table-container {
   max-height: 800px;
   display: flex;
@@ -98,6 +98,11 @@
   max-width: 160px;
 }
 
+.mat-column-select {
+  max-width: 48px;
+  overflow: inherit;
+}
+
 /* Progress bar styling */
 .cdk-column-progress {
   &.cdk-cell, &.mat-cell {
@@ -117,5 +122,22 @@
       border-radius: 8px;
       height: 8px;
     }
+  }
+}
+
+.example-selection-header {
+  height: 64px;
+  background: white;
+  display: flex;
+  align-items: center;
+  padding-left: 24px;
+}
+
+.mat-table-selectable {
+  .mat-row:hover {
+    background: #eeeeee;
+  }
+  .mat-row.selected {
+    background: #f5f5f5;
   }
 }

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -38,6 +38,14 @@ export class MatTableDataSource<T> implements DataSource<T> {
    */
   _renderChangesSubscription: Subscription;
 
+  /**
+   * The filtered set of data that has been matched by the filter string, or all the data if there
+   * is no filter. Useful for knowing the set of data the table represents.
+   * For example, a 'selectAll()' function would likely want to select the set of filtered data
+   * shown to the user rather than all the data.
+   */
+  filteredData: T[];
+
   /** Array of data that should be rendered by the table, where each object represents one row. */
   set data(data: T[]) { this._data.next(data); }
   get data() { return this._data.value; }
@@ -155,12 +163,12 @@ export class MatTableDataSource<T> implements DataSource<T> {
     // If there is a filter string, filter out data that does not contain it.
     // Each data object is converted to a string using the function defined by filterTermAccessor.
     // May be overriden for customization.
-    const filteredData =
+    this.filteredData =
         !this.filter ? data : data.filter(obj => this.filterPredicate(obj, this.filter));
 
-    if (this.paginator) { this._updatePaginator(filteredData.length); }
+    if (this.paginator) { this._updatePaginator(this.filteredData.length); }
 
-    return filteredData;
+    return this.filteredData;
   }
 
   /**

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -102,16 +102,19 @@ describe('MatTable', () => {
       // Change filter to a_1, should match one row
       dataSource.filter = 'a_1';
       fixture.detectChanges();
+      expect(dataSource.filteredData.length).toBe(1);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_1', 'b_1', 'c_1'],
       ]);
+
       flushMicrotasks();  // Resolve promise that updates paginator's length
       expect(dataSource.paginator!.length).toBe(1);
 
       // Change filter to '  A_2  ', should match one row (ignores case and whitespace)
       dataSource.filter = '  A_2  ';
       fixture.detectChanges();
+      expect(dataSource.filteredData.length).toBe(1);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_2', 'b_2', 'c_2'],
@@ -120,6 +123,7 @@ describe('MatTable', () => {
       // Change filter to empty string, should match all rows
       dataSource.filter = '';
       fixture.detectChanges();
+      expect(dataSource.filteredData.length).toBe(3);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_1', 'b_1', 'c_1'],

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -103,6 +103,7 @@ describe('MatTable', () => {
       dataSource.filter = 'a_1';
       fixture.detectChanges();
       expect(dataSource.filteredData.length).toBe(1);
+      expect(dataSource.filteredData[0]).toBe(dataSource.data[0]);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_1', 'b_1', 'c_1'],
@@ -115,6 +116,7 @@ describe('MatTable', () => {
       dataSource.filter = '  A_2  ';
       fixture.detectChanges();
       expect(dataSource.filteredData.length).toBe(1);
+      expect(dataSource.filteredData[0]).toBe(dataSource.data[1]);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_2', 'b_2', 'c_2'],
@@ -124,6 +126,9 @@ describe('MatTable', () => {
       dataSource.filter = '';
       fixture.detectChanges();
       expect(dataSource.filteredData.length).toBe(3);
+      expect(dataSource.filteredData[0]).toBe(dataSource.data[0]);
+      expect(dataSource.filteredData[1]).toBe(dataSource.data[1]);
+      expect(dataSource.filteredData[2]).toBe(dataSource.data[2]);
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_1', 'b_1', 'c_1'],


### PR DESCRIPTION
Users should be able to grab the result of the **filtered data** from the material table data source. This is different than the final result offered to the table, which may have been paginated.

Useful for features like selection, since a "select all" button would select every item in the table, not just what is displayed on the current page. 