### PR TITLE
fix(table): render cells even if data is falsy

### DIFF
--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -109,10 +109,10 @@ describe('CdkTable', () => {
   });
 
   it('should render cells even if row data is falsy', () => {
-    const evenSimplerCdkTableAppFixture = TestBed.createComponent(EvenSimplerCdkTableApp);
+    const booleanRowCdkTableAppFixture = TestBed.createComponent(EvenSimplerCdkTableApp);
     const evenSimplerCdkTableElement =
-        evenSimplerCdkTableAppFixture.nativeElement.querySelector('cdk-table');
-    evenSimplerCdkTableAppFixture.detectChanges();
+        booleanRowCdkTableAppFixture.nativeElement.querySelector('cdk-table');
+    booleanRowCdkTableAppFixture.detectChanges();
 
     expectTableToMatchContent(evenSimplerCdkTableElement, [
       [''], // Header row

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -38,7 +38,8 @@ describe('CdkTable', () => {
         UndefinedColumnsCdkTableApp,
         WhenRowCdkTableApp,
         WhenRowWithoutDefaultCdkTableApp,
-        WhenRowMultipleDefaultsCdkTableApp
+        WhenRowMultipleDefaultsCdkTableApp,
+        EvenSimplerCdkTableApp
       ],
     }).compileComponents();
   }));
@@ -105,6 +106,21 @@ describe('CdkTable', () => {
         });
       });
     });
+  });
+
+  it('should render cells even if row data is falsy', () => {
+    const evenSimplerCdkTableAppFixture = TestBed.createComponent(EvenSimplerCdkTableApp);
+    const evenSimplerCdkTableElement =
+        evenSimplerCdkTableAppFixture.nativeElement.querySelector('cdk-table');
+    evenSimplerCdkTableAppFixture.detectChanges();
+
+    expectTableToMatchContent(evenSimplerCdkTableElement, [
+      [''], // Header row
+      ['false'], // Data rows
+      ['true'],
+      ['false'],
+      ['true'],
+    ]);
   });
 
   it('should be able to apply class-friendly css class names for the column cells', () => {
@@ -619,6 +635,16 @@ class FakeDataSource extends DataSource<TestData> {
   }
 }
 
+class BooleanDataSource extends DataSource<boolean> {
+  _dataChange = new BehaviorSubject<boolean[]>([false, true, false, true]);
+
+  connect(): Observable<boolean[]> {
+    return this._dataChange;
+  }
+
+  disconnect() { }
+}
+
 @Component({
   template: `
     <cdk-table [dataSource]="dataSource">
@@ -649,6 +675,23 @@ class SimpleCdkTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef></cdk-header-cell>
+        <cdk-cell *cdkCellDef="let data"> {{data}} </cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+    </cdk-table>
+  `
+})
+class EvenSimplerCdkTableApp {
+  dataSource = new BooleanDataSource();
 }
 
 @Component({

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -39,7 +39,7 @@ describe('CdkTable', () => {
         WhenRowCdkTableApp,
         WhenRowWithoutDefaultCdkTableApp,
         WhenRowMultipleDefaultsCdkTableApp,
-        EvenSimplerCdkTableApp
+        BooleanRowCdkTableApp
       ],
     }).compileComponents();
   }));
@@ -109,12 +109,12 @@ describe('CdkTable', () => {
   });
 
   it('should render cells even if row data is falsy', () => {
-    const booleanRowCdkTableAppFixture = TestBed.createComponent(EvenSimplerCdkTableApp);
-    const evenSimplerCdkTableElement =
+    const booleanRowCdkTableAppFixture = TestBed.createComponent(BooleanRowCdkTableApp);
+    const booleanRowCdkTableElement =
         booleanRowCdkTableAppFixture.nativeElement.querySelector('cdk-table');
     booleanRowCdkTableAppFixture.detectChanges();
 
-    expectTableToMatchContent(evenSimplerCdkTableElement, [
+    expectTableToMatchContent(booleanRowCdkTableElement, [
       [''], // Header row
       ['false'], // Data rows
       ['true'],
@@ -690,7 +690,7 @@ class SimpleCdkTableApp {
     </cdk-table>
   `
 })
-class EvenSimplerCdkTableApp {
+class BooleanRowCdkTableApp {
   dataSource = new BooleanDataSource();
 }
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -342,10 +342,7 @@ export class CdkTable<T> implements CollectionViewer {
     //   CdkCellOutlet was instantiated as a result  of `createEmbeddedView`.
     this._rowPlaceholder.viewContainer.createEmbeddedView(row.template, context, index);
 
-    // Insert empty cells if there is no data to improve rendering time.
-    const cells = rowData ? this._getCellTemplatesForRow(row) : [];
-
-    cells.forEach(cell => {
+    this._getCellTemplatesForRow(row).forEach(cell => {
       CdkCellOutlet.mostRecentCellOutlet._viewContainer.createEmbeddedView(cell.template, context);
     });
 


### PR DESCRIPTION
This was an optimization assuming that undefined data was meant to create a row without cells. This is a faulty design decision and the logic is incorrect anyways (see issue, `0` and other falsy values caused empty rows).

Supported workaround to rendering empty rows is to use the `when` predicate that can define a row without columns.

Fixes #7902