### PR TITLE
chore: re-enable prerender checks for all components

### DIFF
--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -5,7 +5,9 @@ import {Observable} from 'rxjs/Observable';
 import {
   MatAutocompleteModule,
   MatButtonModule,
+  MatButtonToggleModule,
   MatCardModule,
+  MatCheckboxModule,
   MatChipsModule,
   MatDatepickerModule,
   MatDialogModule,
@@ -68,10 +70,9 @@ export class KitchenSink {
     BrowserModule.withServerTransition({appId: 'kitchen-sink'}),
     MatAutocompleteModule,
     MatButtonModule,
-    // Button toggle and checkbox can't work due to https://github.com/angular/angular/issues/17050
-    // MatButtonToggleModule,
+    MatButtonToggleModule,
     MatCardModule,
-    // MatCheckboxModule,
+    MatCheckboxModule,
     MatChipsModule,
     MatDatepickerModule,
     MatDialogModule,


### PR DESCRIPTION
Re-enables the prerender checks for the checkbox and button toggle modules since the issue that was breaking them initially has been resolved.