### PR TITLE
build: fix examples not building

### DIFF
--- a/tools/gulp/packages.ts
+++ b/tools/gulp/packages.ts
@@ -3,8 +3,8 @@ import {join} from 'path';
 
 export const cdkPackage = new BuildPackage('cdk');
 export const materialPackage = new BuildPackage('material', [cdkPackage]);
-export const examplesPackage = new BuildPackage('material-examples', [materialPackage, cdkPackage]);
 export const momentAdapterPackage = new BuildPackage('material-moment-adapter', [materialPackage]);
+export const examplesPackage = new BuildPackage('material-examples', [momentAdapterPackage]);
 
 // The material package re-exports its secondary entry-points at the root so that all of the
 // components can still be imported through `@angular/material`.


### PR DESCRIPTION
Fixes an error in the `material-examples` build, because the Moment adapter wasn't added as a dependency.