### PR TITLE
build: bump to tslint 5.8.0 and fix failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,16 +415,6 @@
         "@types/node": "7.0.43"
       }
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "a-sync-waterfall": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
@@ -2241,8 +2231,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -4300,7 +4290,6 @@
           "version": "0.13.4",
           "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.4.tgz",
           "integrity": "sha1-dbt/YJMc/J2U2gtdQIlQ0Lvw6Xk=",
-          "dev": true,
           "requires": {
             "array-uniq": "1.0.3",
             "arrify": "1.0.1",
@@ -4319,6 +4308,38 @@
             "split-array-stream": "1.0.3",
             "stream-events": "1.0.2",
             "string-format-obj": "1.1.0",
+            "through2": "2.0.3"
+          }
+        },
+        "@google-cloud/common-grpc": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.4.1.tgz",
+          "integrity": "sha1-CSZGB++4k0MJr/1jhJmG+7gPkhg=",
+          "requires": {
+            "@google-cloud/common": "0.13.4",
+            "dot-prop": "4.2.0",
+            "duplexify": "3.5.1",
+            "extend": "3.0.1",
+            "grpc": "1.6.6",
+            "is": "3.2.1",
+            "modelo": "4.2.0",
+            "retry-request": "2.0.5",
+            "through2": "2.0.3"
+          }
+        },
+        "@google-cloud/firestore": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.8.2.tgz",
+          "integrity": "sha512-Z9hoiZIIn1MN7lUZE0pStvkrTdzJnSyFyxDJ4VojkzF/lL4EAUr9USyWXol6HZYcERPjXIasHSXXTYwuXx8tmA==",
+          "requires": {
+            "@google-cloud/common": "0.13.4",
+            "@google-cloud/common-grpc": "0.4.1",
+            "bun": "0.0.12",
+            "extend": "3.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "google-gax": "0.14.1",
+            "grpc": "1.6.6",
+            "is": "3.2.1",
             "through2": "2.0.3"
           }
         },
@@ -4346,6 +4367,68 @@
             "through2": "2.0.3"
           }
         },
+        "@protobufjs/aspromise": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+          "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+          "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+          "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+          "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+          "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+          "requires": {
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/inquire": "1.1.0"
+          }
+        },
+        "@protobufjs/float": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+          "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+          "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+          "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+          "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+          "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@types/google-cloud__storage": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.5.tgz",
+          "integrity": "sha512-c82GoxSyQZASfOTpyMx8nvpIwySR+vXnkzymya9MQR7L+60ckLQVzn6yUMnOWgTDFM7EUzk79X5p8uSDx9jDVw==",
+          "requires": {
+            "@types/node": "8.0.22"
+          }
+        },
         "@types/jsonwebtoken": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz",
@@ -4355,20 +4438,41 @@
             "@types/node": "8.0.22"
           }
         },
+        "@types/long": {
+          "version": "3.0.32",
+          "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+          "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
+        },
         "@types/node": {
           "version": "8.0.22",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.22.tgz",
-          "integrity": "sha512-+YQ5JLlvLP24teVUdUDep83mAWIFoAnOMosrH/2+xDeU9YMUpmMJtYOqVtbivs37h2PL9svz0R3r/MfVuEvEIA==",
-          "dev": true
+          "integrity": "sha512-+YQ5JLlvLP24teVUdUDep83mAWIFoAnOMosrH/2+xDeU9YMUpmMJtYOqVtbivs37h2PL9svz0R3r/MfVuEvEIA=="
         },
         "ajv": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "arguejs": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
+          "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "requires": {
+            "array-uniq": "1.0.3"
           }
         },
         "array-uniq": {
@@ -4383,6 +4487,15 @@
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
+        "ascli": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+          "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+          "requires": {
+            "colour": "0.7.1",
+            "optjs": "3.2.2"
+          }
+        },
         "asn1": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -4392,8 +4505,7 @@
         "assert-plus": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
         },
         "async": {
           "version": "2.5.0",
@@ -4413,14 +4525,18 @@
         "aws-sign2": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
         },
         "aws4": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
           "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64url": {
           "version": "2.0.0",
@@ -4442,9 +4558,17 @@
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
           "requires": {
             "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
           }
         },
         "buffer-equal": {
@@ -4459,6 +4583,50 @@
           "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
           "dev": true
         },
+        "bun": {
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
+          "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
+          "requires": {
+            "readable-stream": "1.0.34"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
+        "bytebuffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+          "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+          "requires": {
+            "long": "3.2.0"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
         "capture-stack-trace": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -4471,11 +4639,31 @@
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
         "co": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "colour": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+          "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -4485,6 +4673,11 @@
           "requires": {
             "delayed-stream": "1.0.0"
           }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.6.0",
@@ -4530,7 +4723,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
           "requires": {
             "boom": "2.10.1"
           },
@@ -4539,7 +4731,6 @@
               "version": "2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true,
               "requires": {
                 "hoek": "2.16.3"
               }
@@ -4569,6 +4760,11 @@
             }
           }
         },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4579,7 +4775,6 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "dev": true,
           "requires": {
             "is-obj": "1.0.1"
           }
@@ -4667,33 +4862,29 @@
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
             "mime-types": "2.1.16"
           }
         },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+        },
         "gcp-metadata": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.2.0.tgz",
           "integrity": "sha1-Ytr8pl86YxvIzi7Dt3Zh9fk4ego=",
-          "dev": true,
           "requires": {
             "extend": "3.0.1",
             "retry-request": "2.0.5"
-          },
-          "dependencies": {
-            "retry-request": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-2.0.5.tgz",
-              "integrity": "sha1-0ImhShXbntYGhbhgK0D03MDT+zw=",
-              "dev": true,
-              "requires": {
-                "request": "2.81.0",
-                "through2": "2.0.3"
-              }
-            }
           }
         },
         "gcs-resumable-upload": {
@@ -4728,6 +4919,31 @@
             }
           }
         },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
         "google-auth-library": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
@@ -4744,12 +4960,72 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.1.tgz",
           "integrity": "sha1-yCYERJEt2M7szYOHYdVvRik3vQI=",
-          "dev": true,
           "requires": {
             "async": "2.5.0",
             "gcp-metadata": "0.2.0",
             "google-auth-library": "0.10.0",
             "request": "2.81.0"
+          }
+        },
+        "google-gax": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.1.tgz",
+          "integrity": "sha1-/oj7nVAw0mJ3xjUIp5r3s3F54Tk=",
+          "requires": {
+            "extend": "3.0.1",
+            "globby": "6.1.0",
+            "google-auto-auth": "0.5.4",
+            "google-proto-files": "0.13.1",
+            "grpc": "1.6.6",
+            "is-stream-ended": "0.1.3",
+            "lodash": "4.17.4",
+            "process-nextick-args": "1.0.7",
+            "protobufjs": "6.8.0",
+            "readable-stream": "2.3.3",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "7.0.43",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
+              "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ=="
+            },
+            "google-auto-auth": {
+              "version": "0.5.4",
+              "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
+              "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
+              "requires": {
+                "async": "2.5.0",
+                "google-auth-library": "0.10.0",
+                "object-assign": "3.0.0",
+                "request": "2.81.0"
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+            },
+            "protobufjs": {
+              "version": "6.8.0",
+              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.0.tgz",
+              "integrity": "sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==",
+              "requires": {
+                "@protobufjs/aspromise": "1.1.2",
+                "@protobufjs/base64": "1.1.2",
+                "@protobufjs/codegen": "2.0.4",
+                "@protobufjs/eventemitter": "1.1.0",
+                "@protobufjs/fetch": "1.1.0",
+                "@protobufjs/float": "1.0.2",
+                "@protobufjs/inquire": "1.1.0",
+                "@protobufjs/path": "1.1.2",
+                "@protobufjs/pool": "1.1.0",
+                "@protobufjs/utf8": "1.1.0",
+                "@types/long": "3.0.32",
+                "@types/node": "7.0.43",
+                "long": "3.2.0"
+              }
+            }
           }
         },
         "google-p12-pem": {
@@ -4761,11 +5037,843 @@
             "node-forge": "0.7.1"
           }
         },
+        "google-proto-files": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
+          "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g=="
+        },
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
+        },
+        "grpc": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.6.6.tgz",
+          "integrity": "sha1-IFF4T2vWE0aB+ixLXnXcgsbCP/o=",
+          "requires": {
+            "arguejs": "0.2.3",
+            "lodash": "4.17.4",
+            "nan": "2.7.0",
+            "node-pre-gyp": "0.6.38",
+            "protobufjs": "5.0.2"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.8",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            },
+            "co": {
+              "version": "4.6.0",
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            },
+            "ini": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+              "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+              "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "node-pre-gyp": {
+              "version": "0.6.38",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz",
+              "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
+              "requires": {
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.2",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.4.1",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "requires": {
+                "abbrev": "1.1.1",
+                "osenv": "0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            },
+            "qs": {
+              "version": "6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+            },
+            "rc": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            },
+            "semver": {
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+              "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+            },
+            "tar": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+              "requires": {
+                "debug": "2.6.9",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.3.3",
+                "rimraf": "2.6.2",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            },
+            "verror": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            }
+          }
         },
         "gtoken": {
           "version": "1.2.2",
@@ -4782,14 +5890,12 @@
         "har-schema": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
         },
         "har-validator": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -4808,7 +5914,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -4819,8 +5924,7 @@
         "hoek": {
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-parser-js": {
           "version": "0.4.8",
@@ -4831,7 +5935,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.1",
@@ -4844,17 +5947,39 @@
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
         "is": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
           "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-obj": {
           "version": "1.0.1",
@@ -4999,6 +6124,14 @@
             "safe-buffer": "5.1.1"
           }
         },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -5023,6 +6156,11 @@
           "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
           "dev": true
         },
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        },
         "make-dir": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
@@ -5041,22 +6179,27 @@
         "mime": {
           "version": "1.3.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-          "dev": true
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
         },
         "mime-db": {
           "version": "1.29.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-          "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
-          "dev": true
+          "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
         },
         "mime-types": {
           "version": "2.1.16",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-          "dev": true,
           "requires": {
             "mime-db": "1.29.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         },
         "modelo": {
@@ -5077,17 +6220,32 @@
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
           "dev": true
         },
+        "nan": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+        },
         "node-forge": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
           "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
           "dev": true
         },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
         "oauth-sign": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
@@ -5098,11 +6256,28 @@
             "wrappy": "1.0.2"
           }
         },
+        "optjs": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+          "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
         "performance-now": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
         },
         "pify": {
           "version": "2.3.0",
@@ -5110,11 +6285,35 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
+        },
+        "protobufjs": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
+          "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
+          "requires": {
+            "ascli": "1.0.1",
+            "bytebuffer": "5.0.1",
+            "glob": "7.1.2",
+            "yargs": "3.32.0"
+          }
         },
         "pump": {
           "version": "1.0.2",
@@ -5146,8 +6345,7 @@
         "qs": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         },
         "readable-stream": {
           "version": "2.3.3",
@@ -5168,7 +6366,6 @@
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -5198,7 +6395,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-2.0.5.tgz",
           "integrity": "sha1-0ImhShXbntYGhbhgK0D03MDT+zw=",
-          "dev": true,
           "requires": {
             "request": "2.81.0",
             "through2": "2.0.3"
@@ -5219,7 +6415,6 @@
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -5273,12 +6468,6 @@
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
-        "string-format-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
-          "integrity": "sha1-djVhCx7zlwE+hHi+mKFw4EmD0Gg=",
-          "dev": true
-        },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -5288,11 +6477,35 @@
             "safe-buffer": "5.1.1"
           }
         },
+        "string-format-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
+          "integrity": "sha1-djVhCx7zlwE+hHi+mKFw4EmD0Gg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
         "stringstream": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "stubs": {
           "version": "3.0.0",
@@ -5323,7 +6536,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -5405,6 +6617,20 @@
           "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
           "dev": true
         },
+        "window-size": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5433,6 +6659,25 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          }
         }
       }
     },
@@ -5443,7 +6688,6 @@
       "dev": true,
       "requires": {
         "@google-cloud/functions-emulator": "1.0.0-alpha.25",
-        "JSONStream": "1.3.1",
         "archiver": "0.16.0",
         "chalk": "1.1.3",
         "cjson": "0.3.3",
@@ -5463,6 +6707,7 @@
         "google-auto-auth": "0.7.2",
         "inquirer": "0.12.0",
         "jsonschema": "1.2.0",
+        "JSONStream": "1.3.1",
         "jsonwebtoken": "7.4.3",
         "lodash": "4.17.4",
         "open": "0.0.5",
@@ -9710,16 +10955,6 @@
         "through2": "0.6.5"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "0.0.5",
-            "through": "2.3.8"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -9731,6 +10966,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
           "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "0.0.5",
+            "through": "2.3.8"
+          }
         },
         "readable-stream": {
           "version": "1.0.34",
@@ -9795,6 +11040,16 @@
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
       "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg==",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsonwebtoken": {
       "version": "7.4.3",
@@ -14389,6 +15644,15 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-format-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
@@ -14420,15 +15684,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {
@@ -15456,13 +16711,14 @@
       "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tslint": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.7.0.tgz",
-      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.2.0",
         "commander": "2.11.0",
         "diff": "3.3.1",
         "glob": "7.1.2",
@@ -15470,14 +16726,52 @@
         "resolve": "1.4.0",
         "semver": "5.4.1",
         "tslib": "1.7.1",
-        "tsutils": "2.8.2"
+        "tsutils": "2.12.1"
       },
       "dependencies": {
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
+          "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+          "dev": true,
+          "requires": {
+            "tslib": "1.7.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "stylelint": "^7.12.0",
     "ts-node": "^3.0.4",
     "tsconfig-paths": "^2.2.0",
-    "tslint": "^5.7.0",
+    "tslint": "^5.8.0",
     "tsutils": "^2.6.0",
     "typescript": "~2.4.2",
     "uglify-js": "^2.8.14",

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -110,7 +110,7 @@ export class MatOption {
     private _element: ElementRef,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) private _parent: MatOptionParentComponent,
-    @Optional() public readonly group: MatOptgroup) {}
+    @Optional() readonly group: MatOptgroup) {}
 
   /**
    * Whether or not the option is currently active and ready to be selected.

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -44,7 +44,7 @@ export class MatDialogRef<T> {
   constructor(
     private _overlayRef: OverlayRef,
     private _containerInstance: MatDialogContainer,
-    public readonly id: string = `mat-dialog-${uniqueId++}`) {
+    readonly id: string = `mat-dialog-${uniqueId++}`) {
 
     // Emit when opening animation completes
     RxChain.from(_containerInstance._animationStateChanged)

--- a/tools/package-tools/build-package.ts
+++ b/tools/package-tools/build-package.ts
@@ -58,7 +58,7 @@ export class BuildPackage {
   }
   private _secondaryEntryPoints: string[];
 
-  constructor(public readonly name: string, public readonly dependencies: BuildPackage[] = []) {
+  constructor(readonly name: string, readonly dependencies: BuildPackage[] = []) {
     this.sourceDir = join(packagesDir, name);
     this.outputDir = join(outputDir, 'packages', name);
     this.esm5OutputDir = join(outputDir, 'packages', name, 'esm5');


### PR DESCRIPTION
Updates to `tslint@5.8.0` and fixes a few previously-uncaught failures.