### PR TITLE
feat(sort): if provider exists provider one, otherwise new one

### DIFF
--- a/src/lib/sort/sort-header-intl.ts
+++ b/src/lib/sort/sort-header-intl.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, SkipSelf, Optional} from '@angular/core';
 import {Subject} from 'rxjs/Subject';
 import {SortDirection} from './sort-direction';
 
@@ -32,3 +32,16 @@ export class MatSortHeaderIntl {
     return `Sorted by ${id} ${direction == 'asc' ? 'ascending' : 'descending'}`;
   }
 }
+/** @docs-private */
+export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl) {
+  return parentIntl || new MatSortHeaderIntl();
+}
+
+/** @docs-private */
+export const MAT_SORT_HEADER_INTL_PROVIDER = {
+  // If there is already an MatSortHeaderIntl available, use that. Otherwise, provide a new one.
+  provide: MatSortHeaderIntl,
+  deps: [[new Optional(), new SkipSelf(), MatSortHeaderIntl]],
+  useFactory: MAT_SORT_HEADER_INTL_PROVIDER_FACTORY
+};
+

--- a/src/lib/sort/sort-module.ts
+++ b/src/lib/sort/sort-module.ts
@@ -9,7 +9,7 @@
 import {NgModule} from '@angular/core';
 import {MatSortHeader} from './sort-header';
 import {MatSort} from './sort';
-import {MatSortHeaderIntl} from './sort-header-intl';
+import {MAT_SORT_HEADER_INTL_PROVIDER} from './sort-header-intl';
 import {CommonModule} from '@angular/common';
 
 
@@ -17,6 +17,6 @@ import {CommonModule} from '@angular/common';
   imports: [CommonModule],
   exports: [MatSort, MatSortHeader],
   declarations: [MatSort, MatSortHeader],
-  providers: [MatSortHeaderIntl]
+  providers: [MAT_SORT_HEADER_INTL_PROVIDER]
 })
 export class MatSortModule {}


### PR DESCRIPTION
As discussed in #7895 here is the PR that will implement the same pattern for the `MatSortHeaderIntl`.

cc: @jelbourn 