### PR TITLE
chore: fix plunker link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is the home for the Angular team's Material Design components built for and
 [Documentation, demos, and guides][aio] |
 [Google group](https://groups.google.com/forum/#!forum/angular-material2) |
 [Contributing](https://github.com/angular/material2/blob/master/CONTRIBUTING.md) |
-[Plunker Template](http://plnkr.co/edit/LSgU9X5sYVhx4bc3LBWm?p=preview) |
-[StackBlitz Template](https://stackblitz.com/edit/angular-material2-issue?file=app%2Fapp.component.ts)
+[Plunker Template](https://goo.gl/DlHd6U) |
+[StackBlitz Template](https://goo.gl/wwnhMV)
 
 ### Getting started
 


### PR DESCRIPTION
* The current Plunker link is referring to an anonymous Plunker that nobody can't change.
* Changes the Plunker and StackBlitz links in the Readme to the `goo.gl` shorthand links from the issue template.