### PR TITLE
fix: user-select mixin ignores value

### DIFF
--- a/src/lib/core/style/_vendor-prefixes.scss
+++ b/src/lib/core/style/_vendor-prefixes.scss
@@ -1,9 +1,9 @@
 /* stylelint-disable material/no-prefixes */
 @mixin user-select($value) {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+  -webkit-user-select: $value;
+  -moz-user-select: $value;
+  -ms-user-select: $value;
+  user-select: $value;
 }
 
 @mixin input-placeholder {


### PR DESCRIPTION
* Fixes that the `$value` parameter for the `user-select` mixin from core is ignored.