### PR TITLE
chore: remove unused directionality provider

### DIFF
--- a/src/cdk/bidi/directionality.ts
+++ b/src/cdk/bidi/directionality.ts
@@ -10,11 +10,9 @@ import {
   EventEmitter,
   Injectable,
   Optional,
-  SkipSelf,
   Inject,
   InjectionToken,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/platform-browser';
 
 
 export type Direction = 'ltr' | 'rtl';
@@ -52,16 +50,3 @@ export class Directionality {
     }
   }
 }
-
-/** @docs-private */
-export function DIRECTIONALITY_PROVIDER_FACTORY(parentDirectionality, _document) {
-  return parentDirectionality || new Directionality(_document);
-}
-
-/** @docs-private */
-export const DIRECTIONALITY_PROVIDER = {
-  // If there is already a Directionality available, use that. Otherwise, provide a new one.
-  provide: Directionality,
-  deps: [[new Optional(), new SkipSelf(), Directionality], [new Optional(), DOCUMENT]],
-  useFactory: DIRECTIONALITY_PROVIDER_FACTORY
-};

--- a/src/cdk/bidi/public-api.ts
+++ b/src/cdk/bidi/public-api.ts
@@ -6,13 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {
-  Directionality,
-  DIRECTIONALITY_PROVIDER_FACTORY,
-  DIRECTIONALITY_PROVIDER,
-  DIR_DOCUMENT,
-  Direction,
-} from './directionality';
+export {Directionality, DIR_DOCUMENT, Direction} from './directionality';
 export {Dir} from './dir';
 export * from './bidi-module';
 


### PR DESCRIPTION
Removes the `DIRECTIONALITY_PROVIDER` since it isn't being used anywhere. This seems to be a remnant of the old approach to dealing with directionality.