### PR TITLE
fix(table): broaden abstraction for filtering

### DIFF
--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -60,7 +60,7 @@ export class TableDemo {
         default: return '';
       }
     };
-    this.matTableDataSource.filterMatcher =
+    this.matTableDataSource.filterPredicate =
         (data: UserData, filter: string) => data.name.indexOf(filter) != -1;
     this.filter.valueChanges.subscribe(filter => this.matTableDataSource!.filter = filter);
   }

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -60,7 +60,8 @@ export class TableDemo {
         default: return '';
       }
     };
-    this.matTableDataSource.filterTermAccessor = (data: UserData) => data.name;
+    this.matTableDataSource.filterMatcher =
+        (data: UserData, filter: string) => data.name.indexOf(filter) != -1;
     this.filter.valueChanges.subscribe(filter => this.matTableDataSource!.filter = filter);
   }
 

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -44,7 +44,7 @@ export class MatTableDataSource<T> implements DataSource<T> {
 
   /**
    * Filter term that should be used to filter out objects from the data array. To override how
-   * data objects match to this filter string, provide a custom function for filterMatcher.
+   * data objects match to this filter string, provide a custom function for filterPredicate.
    */
   set filter(filter: string) { this._filter.next(filter); }
   get filter(): string { return this._filter.value; }
@@ -100,7 +100,7 @@ export class MatTableDataSource<T> implements DataSource<T> {
    * @param filter Filter string that has been set on the data source.
    * @returns Whether the filter matches against the data
    */
-  filterMatcher: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
+  filterPredicate: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
     // Transform the data into a lowercase string of all property values.
     const accumulator = (currentTerm, key) => currentTerm + data[key];
     const dataStr = Object.keys(data).reduce(accumulator, '').toLowerCase();
@@ -152,7 +152,7 @@ export class MatTableDataSource<T> implements DataSource<T> {
     // Each data object is converted to a string using the function defined by filterTermAccessor.
     // May be overriden for customization.
     const filteredData =
-        !this.filter ? data : data.filter(obj => this.filterMatcher(obj, this.filter));
+        !this.filter ? data : data.filter(obj => this.filterPredicate(obj, this.filter));
 
     if (this.paginator) { this._updatePaginator(filteredData.length); }
 

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -43,11 +43,8 @@ export class MatTableDataSource<T> implements DataSource<T> {
   get data() { return this._data.value; }
 
   /**
-   * Filter term that should be used to filter out objects from the data array. Will be transformed
-   * by the filterTransformer function, which by default will transform the filter into lowercase
-   * and remove surrounding whitespace. To override this behavior, provide a custom function on the
-   * filterTransformer. To override how data objects are converted to strings to match again,
-   * provide a custom function on filterTermAccessor.
+   * Filter term that should be used to filter out objects from the data array. To override how
+   * data objects match to this filter string, provide a custom function for filterMatcher.
    */
   set filter(filter: string) { this._filter.next(filter); }
   get filter(): string { return this._filter.value; }

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -94,7 +94,7 @@ export class MatTableDataSource<T> implements DataSource<T> {
    * Checks if a data object matches the data source's filter string. By default, each data object
    * is converted to a string of its properties and returns true if the filter has
    * at least one occurrence in that string. By default, the filter string has its whitespace
-   * removed and the match is case-insensitive. May be overriden for a custom implementation of
+   * trimmed and the match is case-insensitive. May be overriden for a custom implementation of
    * filter matching.
    * @param data Data object used to check against the filter.
    * @param filter Filter string that has been set on the data source.

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -98,7 +98,7 @@ describe('MatTable', () => {
       ]);
     });
 
-    fit('should be able to filter the table contents', fakeAsync(() => {
+    it('should be able to filter the table contents', fakeAsync(() => {
       // Change filter to a_1, should match one row
       dataSource.filter = 'a_1';
       fixture.detectChanges();

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -128,7 +128,7 @@ describe('MatTable', () => {
       ]);
 
       // Change filter function and filter, should match to rows with zebra.
-      dataSource.filterMatcher = (data, filter) => {
+      dataSource.filterPredicate = (data, filter) => {
         let dataStr;
         switch (data.a) {
           case 'a_1': dataStr = 'elephant'; break;

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -98,7 +98,7 @@ describe('MatTable', () => {
       ]);
     });
 
-    it('should be able to filter the table contents', fakeAsync(() => {
+    fit('should be able to filter the table contents', fakeAsync(() => {
       // Change filter to a_1, should match one row
       dataSource.filter = 'a_1';
       fixture.detectChanges();
@@ -109,8 +109,8 @@ describe('MatTable', () => {
       flushMicrotasks();  // Resolve promise that updates paginator's length
       expect(dataSource.paginator!.length).toBe(1);
 
-      // Change filter to a_2, should match one row
-      dataSource.filter = 'a_2';
+      // Change filter to '  A_2  ', should match one row (ignores case and whitespace)
+      dataSource.filter = '  A_2  ';
       fixture.detectChanges();
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
@@ -127,14 +127,17 @@ describe('MatTable', () => {
         ['a_3', 'b_3', 'c_3'],
       ]);
 
-      // Change filter function and filter, should match to rows.
-      dataSource.filterTermAccessor = data => {
+      // Change filter function and filter, should match to rows with zebra.
+      dataSource.filterMatcher = (data, filter) => {
+        let dataStr;
         switch (data.a) {
-          case 'a_1': return 'elephant';
-          case 'a_2': return 'zebra';
-          case 'a_3': return 'monkey';
-          default: return '';
+          case 'a_1': dataStr = 'elephant'; break;
+          case 'a_2': dataStr = 'zebra'; break;
+          case 'a_3': dataStr = 'monkey'; break;
+          default: dataStr = '';
         }
+
+        return dataStr.indexOf(filter) != -1;
       };
       dataSource.filter = 'zebra';
       fixture.detectChanges();


### PR DESCRIPTION
Currently the user can customize the `MatTableDataSource`'s filtering by providing a custom function of how to convert a data object into a filter string.

This may be too in-depth for most users and not as intuitive. 

This PR broadens the abstraction so that users instead will define a function that accepts data and a filter string, and returns true/false depending on if the data matches.

This also allows the data source some freedom in defaulting to a behavior where it trims/lowercases the filter but allows users to override that behavior easily.