### PR TITLE
fix(select): closing parent overlay when pressing escape

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1,5 +1,5 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {DOWN_ARROW, END, ENTER, HOME, SPACE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
+import {DOWN_ARROW, END, ENTER, HOME, SPACE, TAB, UP_ARROW, ESCAPE} from '@angular/cdk/keycodes';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {Platform} from '@angular/cdk/platform';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
@@ -269,6 +269,19 @@ describe('MatSelect', () => {
       expect(fixture.componentInstance.select.panelOpen).toBe(true);
 
       dispatchKeyboardEvent(trigger, 'keydown', TAB);
+      fixture.detectChanges();
+      tick(SELECT_CLOSE_ANIMATION);
+
+      expect(fixture.componentInstance.select.panelOpen).toBe(false);
+    }));
+
+    it('should close the panel when pressing escape', fakeAsync(() => {
+      trigger.click();
+      fixture.detectChanges();
+      tick(SELECT_OPEN_ANIMATION);
+      expect(fixture.componentInstance.select.panelOpen).toBe(true);
+
+      dispatchKeyboardEvent(trigger, 'keydown', ESCAPE);
       fixture.detectChanges();
       tick(SELECT_CLOSE_ANIMATION);
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -10,7 +10,7 @@ import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SelectionModel} from '@angular/cdk/collections';
-import {DOWN_ARROW, END, ENTER, HOME, SPACE, UP_ARROW} from '@angular/cdk/keycodes';
+import {DOWN_ARROW, END, ENTER, HOME, SPACE, UP_ARROW, ESCAPE} from '@angular/cdk/keycodes';
 import {
   ConnectedOverlayDirective,
   Overlay,
@@ -628,6 +628,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     } else if ((keyCode === ENTER || keyCode === SPACE) && this._keyManager.activeItem) {
       event.preventDefault();
       this._keyManager.activeItem._selectViaInteraction();
+    } else if (keyCode === ESCAPE) {
+      event.stopPropagation();
+      this.close();
     } else {
       this._keyManager.onKeydown(event);
     }


### PR DESCRIPTION
After the switch to `ActiveDescendantKeyManager`, the select was no longer handling the escape key functionality internally, but was delegating to the underlying overlay. Since the overlay listens to keyboard events on the document, it means that escape key presses will close any parent overlays along the way. These changes add the escape listener to the select itself and stop the event propagation.

**Note:** the overlay directive listener should be scoped to the overlay itself, but it's better if we defer refactoring it until #6682 gets in.

Fixes #7981.