### PR TITLE
fix(slider): prevent slider thumb from getting cropped

### DIFF
--- a/src/lib/slider/slider.scss
+++ b/src/lib/slider/slider.scss
@@ -393,6 +393,10 @@ $mat-slider-focus-ring-size: 30px !default;
     left: 50%;
   }
 
+  .mat-slider-thumb {
+    @include backface-visibility(hidden);
+  }
+
   .mat-slider-thumb-label {
     bottom: -$mat-slider-thumb-label-size / 2;
     left: -($mat-slider-thumb-label-size + $mat-slider-thumb-arrow-gap);


### PR DESCRIPTION
Slider thumb may sometimes get cropped by a scale transformation.
Removing backface visibility ensures that the thumb is painted correctly.