### PR TITLE
build(docs): exclude readme files

### DIFF
--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -697,7 +697,7 @@ export const EXAMPLE_COMPONENTS = {
     selectorName: null
   },
   'table-overview': {
-    title: 'Feature-rich data table',
+    title: 'Data table with sorting, pagination, and filtering.',
     component: TableOverviewExample,
     additionalFiles: null,
     selectorName: null

--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -100,7 +100,7 @@ task('markdown-docs', () => {
     }
   };
 
-  return src(['src/lib/**/*.md', 'guides/*.md'])
+  return src(['src/lib/**/!(README).md', 'guides/*.md'])
       .pipe(rename({prefix: 'material-'}))
       .pipe(markdown(markdownOptions))
       .pipe(transform(transformMarkdownFiles))
@@ -112,7 +112,7 @@ task('markdown-docs', () => {
 // disambiguating the output.
 /** Generates html files from the markdown overviews and guides for the cdk. */
 task('markdown-docs-cdk', () => {
-  return src(['src/cdk/**/*.md'])
+  return src(['src/cdk/**/!(README).md'])
       .pipe(rename({prefix: 'cdk-'}))
       .pipe(markdown(markdownOptions))
       .pipe(transform(transformMarkdownFiles))


### PR DESCRIPTION
* No longer copies and prefixes `README.md` files for the docs. Those are just in the repository for a better overview, but don't really have any use for the docs. Also they are conflicting with the `fetch` script on the material.angular.io repository.

```
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/slide-toggle/material-README.html'
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/slider/material-README.html'
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/snack-bar/material-README.html'
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/tabs/material-README.html'
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/toolbar/material-README.html'
cp: will not overwrite just-created './src/assets/documents/overview/material-README.html' with '../material2/dist/docs/markdown/tooltip/material-README.html'
```

* Also updates the `example-module.ts` file to the current state of the material-examples.