### PR TITLE
fix(input): remove IE clear icon

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -32,6 +32,11 @@
     box-shadow: none;
   }
 
+  // Remove IE's default clear icon.
+  &::-ms-clear {
+    display: none;
+  }
+
   // Note that we can't use something like visibility: hidden or
   // display: none, because IE ends up preventing the user from
   // focusing the input altogether.


### PR DESCRIPTION
Removes IE's native clear icon from inputs, because it makes them inconsistent between browsers.

Fixes #8076.