### PR TITLE
ci: skip more tasks if only markdown files changed

### DIFF
--- a/scripts/ci/travis-deploy.sh
+++ b/scripts/ci/travis-deploy.sh
@@ -33,19 +33,20 @@ echo ""
 if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
   if [[ "${DEPLOY_MODE}" == "screenshot-tool" ]]; then
     retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-screenshot-tool.sh
+  elif [[ "${DEPLOY_MODE}" == "dashboard" ]]; then
+    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-dashboard.sh
+  else
+    echo "Docs content and build artifacts won't be published in Travis cronjobs."
   fi
 
-  if [[ "${DEPLOY_MODE}" == "dashboard" ]]; then
-    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-dashboard.sh
-  fi
 # Deployment of the build artifacts and docs-content should only happen on a per-commit base.
 # The target is to provide build artifacts in the GitHub repository for every commit.
 else
   if [[ "${DEPLOY_MODE}" == "build-artifacts" ]]; then
     retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-build-artifacts.sh
-  fi
-
-  if [[ "${DEPLOY_MODE}" == "docs-content" ]]; then
+  elif [[ "${DEPLOY_MODE}" == "docs-content" ]]; then
     retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-docs-content.sh
+  else
+    echo "The dashboard and screenshot-tool will only be deployed in Travis cronjobs."
   fi
 fi

--- a/scripts/ci/travis-testing.sh
+++ b/scripts/ci/travis-testing.sh
@@ -25,8 +25,8 @@ else
 fi
 
 # Check if tests can be skipped
-if [[ ${fileDiff} =~ ^(.*\.md\s*)*$ ]] && (is_e2e || is_unit); then
-  echo "Skipping e2e and unit tests since only markdown files changed"
+if [[ ${fileDiff} =~ ^(.*\.md\s*)*$ ]]; then
+  echo "Skipping tests since only markdown files changed."
   exit 0
 fi
 


### PR DESCRIPTION
* No longer just skips the unit test and e2e tasks if only markdown files changed. Now everything will be skipped, since there is nothing that tests against the `.md` files.
* Prints messages for the deploy tasks that run inside of Pull Requests but end up in a NOOP.