### PR TITLE
feat(gestures): add injection token for specifying Hammer.js options

### DIFF
--- a/src/lib/core/gestures/gesture-annotations.ts
+++ b/src/lib/core/gestures/gesture-annotations.ts
@@ -9,7 +9,7 @@
 /**
  * Stripped-down HammerJS annotations to be used within Material, which are necessary,
  * because HammerJS is an optional dependency. For the full annotations see:
- * https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/hammerjs
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hammerjs/index.d.ts
  */
 
 /** @docs-private */
@@ -53,4 +53,17 @@ export interface HammerManager {
   emit(event: string, data: any): void;
   off(events: string, handler?: Function): void;
   on(events: string, handler: Function): void;
+}
+
+/** @docs-private */
+export interface HammerOptions {
+  cssProps?: {[key: string]: string};
+  domEvents?: boolean;
+  enable?: boolean | ((manager: HammerManager) => boolean);
+  preset?: any[];
+  touchAction?: string;
+  recognizers?: any[];
+
+  inputClass?: HammerInput;
+  inputTarget?: EventTarget;
 }

--- a/src/lib/core/gestures/gesture-config.spec.ts
+++ b/src/lib/core/gestures/gesture-config.spec.ts
@@ -1,0 +1,55 @@
+import {TestBed, async} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {GestureConfig, MAT_HAMMER_OPTIONS} from './gesture-config';
+
+describe('GestureConfig', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestApp],
+      providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
+    }).compileComponents();
+  }));
+
+  it('should instantiate HammerJS', () => {
+    spyOn(window, 'Hammer' as any).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+
+    expect(window['Hammer']).toHaveBeenCalled();
+  });
+
+  it('should be able to pass options to HammerJS', () => {
+    TestBed
+      .resetTestingModule()
+      .configureTestingModule({
+        declarations: [TestApp],
+        providers: [
+          {provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig},
+          {provide: MAT_HAMMER_OPTIONS, useValue: {cssProps: {touchAction: 'auto'}}}
+        ]
+      })
+      .compileComponents();
+
+    spyOn(window, 'Hammer' as any).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.nativeElement.querySelector('button');
+    const firstCallArgs = window['Hammer'].calls.first().args;
+
+    expect(firstCallArgs[0]).toBe(button);
+    expect(firstCallArgs[1].cssProps.touchAction).toBe('auto');
+  });
+
+});
+
+
+@Component({
+  template: `<button (longpress)="noop()">Long press me</button>`
+})
+class TestApp {
+  noop() {}
+}


### PR DESCRIPTION
Adds the `MAT_HAMMER_OPTIONS` injection token that allows users to pass in options to the Hammer.js constructor.

Fixes #7097.