### PR TITLE
feat(tooltip): add injection token for specifying the default delays

### DIFF
--- a/src/lib/tooltip/tooltip-module.ts
+++ b/src/lib/tooltip/tooltip-module.ts
@@ -12,7 +12,12 @@ import {PlatformModule} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
-import {MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER, MatTooltip, TooltipComponent} from './tooltip';
+import {
+  MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER,
+  MAT_TOOLTIP_DEFAULT_OPTIONS,
+  MatTooltip,
+  TooltipComponent,
+} from './tooltip';
 
 
 @NgModule({
@@ -26,6 +31,17 @@ import {MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER, MatTooltip, TooltipComponent} from
   exports: [MatTooltip, TooltipComponent, MatCommonModule],
   declarations: [MatTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
-  providers: [MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER, ARIA_DESCRIBER_PROVIDER],
+  providers: [
+    MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER,
+    ARIA_DESCRIBER_PROVIDER,
+    {
+      provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+      useValue: {
+        showDelay: 0,
+        hideDelay: 0,
+        touchendHideDelay: 1500
+      }
+    }
+  ],
 })
 export class MatTooltipModule {}

--- a/src/lib/tooltip/tooltip.md
+++ b/src/lib/tooltip/tooltip.md
@@ -5,27 +5,28 @@ over or longpresses an element.
 
 ### Positioning
 
-The tooltip will be displayed below the element but this can be configured using the `matTooltipPosition`
-input.
+The tooltip will be displayed below the element but this can be configured using the
+`matTooltipPosition` input.
 The tooltip can be displayed above, below, left, or right of the element. By default the position
 will be below. If the tooltip should switch left/right positions in an RTL layout direction, then
 the positions `before` and `after` should be used instead of `left` and `right`, respectively.
 
-| Position  | Description                                                                           |
-|-----------|---------------------------------------------------------------------------------------|
-| `above`   | Always display above the element                                                      |
-| `below `  | Always display beneath the element                                                    |
-| `left`    | Always display to the left of the element                                             |
-| `right`   | Always display to the right of the element                                            |
-| `before`  | Display to the left in left-to-right layout and to the right in right-to-left layout  |
-| `after`   | Display to the right in left-to-right layout and to the right in right-to-left layout |
+| Position  | Description                                                                          |
+|-----------|--------------------------------------------------------------------------------------|
+| `above`   | Always display above the element                                                     |
+| `below `  | Always display beneath the element                                                   |
+| `left`    | Always display to the left of the element                                            |
+| `right`   | Always display to the right of the element                                           |
+| `before`  | Display to the left in left-to-right layout and to the right in right-to-left layout |
+| `after`   | Display to the right in left-to-right layout and to the right in right-to-left layout|
 
 
 ### Showing and hiding
 
 The tooltip is immediately shown when the user's mouse hovers over the element and immediately
 hides when the user's mouse leaves. A delay in showing or hiding the tooltip can be added through
-the inputs `matTooltipShowDelay` and `matTooltipHideDelay`.
+the inputs `matTooltipShowDelay` and `matTooltipHideDelay`. The default show and hide delays can be
+configured through the `MAT_TOOLTIP_DEFAULT_OPTIONS` injection token.
 
 On mobile, the tooltip is displayed when the user longpresses the element and hides after a
 delay of 1500ms. The longpress behavior requires HammerJS to be loaded on the page.
@@ -33,7 +34,8 @@ delay of 1500ms. The longpress behavior requires HammerJS to be loaded on the pa
 The tooltip can also be shown and hidden through the `show` and `hide` directive methods,
 which both accept a number in milliseconds to delay before applying the display change.
 
-To turn off the tooltip and prevent it from showing to the user, use the `matTooltipDisabled` input flag.
+To turn off the tooltip and prevent it from showing to the user, use the `matTooltipDisabled` input
+flag.
 
 ### Accessibility
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -27,7 +27,8 @@ import {
   MatTooltipModule,
   SCROLL_THROTTLE_MS,
   TOOLTIP_PANEL_CLASS,
-  TooltipPosition
+  TooltipPosition,
+  MAT_TOOLTIP_DEFAULT_OPTIONS,
 } from './index';
 
 
@@ -153,6 +154,40 @@ describe('MatTooltip', () => {
       tick(tooltipDelay);
       expect(tooltipDirective._isTooltipVisible()).toBe(true);
       expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
+    }));
+
+    it('should be able to override the default show and hide delays', fakeAsync(() => {
+      TestBed
+        .resetTestingModule()
+        .configureTestingModule({
+          imports: [MatTooltipModule, OverlayModule, NoopAnimationsModule],
+          declarations: [BasicTooltipDemo],
+          providers: [{
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {showDelay: 1337, hideDelay: 7331}
+          }]
+        })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+      tooltipDirective = fixture.debugElement.query(By.css('button')).injector.get(MatTooltip);
+
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick();
+
+      expect(tooltipDirective._isTooltipVisible()).toBe(false);
+      tick(1337);
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      tooltipDirective.hide();
+      fixture.detectChanges();
+      tick();
+
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+      tick(7331);
+      expect(tooltipDirective._isTooltipVisible()).toBe(false);
     }));
 
     it('should set a css class on the overlay panel element', fakeAsync(() => {


### PR DESCRIPTION
Adds the `MAT_TOOLTIP_DEFAULT_OPTIONS` provider that allows users to set app-wide defaults for the tooltip delays.

Fixes #7928.