### PR TITLE
fix(tabs): incorrect ripple color for tabs with background

### DIFF
--- a/src/lib/tabs/_tabs-theme.scss
+++ b/src/lib/tabs/_tabs-theme.scss
@@ -111,6 +111,12 @@
   .mat-tab-header-pagination-disabled .mat-tab-header-pagination-chevron {
     border-color: mat-color($background-color, default-contrast, 0.4);
   }
+
+  // Set ripples color to be the contrast color of the new background. Otherwise the ripple
+  // color will be based on the app background color.
+  .mat-ripple-element {
+    background-color: mat-color($background-color, default-contrast, 0.12);
+  }
 }
 
 @mixin mat-tabs-typography($config) {


### PR DESCRIPTION
* Tabs with a background color need to set the ripple colors to be the contrast color. Otherwise the ripples might be too dark/or light, depending on the color palette that is being used.

**Issue**:


![](https://i.gyazo.com/530251addef380379d692486de711812.gif)
<sub>(Buggy mouse on the screen recorder)
