### PR TITLE
docs: show platform service

### DIFF
--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -15,39 +15,47 @@ const hasV8BreakIterator = (typeof(Intl) !== 'undefined' && (Intl as any).v8Brea
 /**
  * Service to detect the current platform by comparing the userAgent strings and
  * checking browser-specific global properties.
- * @docs-private
  */
 @Injectable()
 export class Platform {
+  /** Whether the Angular application is being rendered in the browser. */
   isBrowser: boolean = typeof document === 'object' && !!document;
 
-  /** Layout Engines */
-  EDGE = this.isBrowser && /(edge)/i.test(navigator.userAgent);
-  TRIDENT = this.isBrowser && /(msie|trident)/i.test(navigator.userAgent);
+  /** Whether the current browser is Microsoft Edge. */
+  EDGE: boolean = this.isBrowser && /(edge)/i.test(navigator.userAgent);
 
+  /** Whether the current rendering engine is Microsoft Trident. */
+  TRIDENT: boolean = this.isBrowser && /(msie|trident)/i.test(navigator.userAgent);
+
+  /** Whether the current rendering engine is Blink. */
   // EdgeHTML and Trident mock Blink specific things and need to be excluded from this check.
-  BLINK = this.isBrowser &&
+  BLINK: boolean = this.isBrowser &&
       (!!((window as any).chrome || hasV8BreakIterator) && !!CSS && !this.EDGE && !this.TRIDENT);
 
+  /** Whether the current rendering engine is WebKit. */
   // Webkit is part of the userAgent in EdgeHTML, Blink and Trident. Therefore we need to
   // ensure that Webkit runs standalone and is not used as another engine's base.
-  WEBKIT = this.isBrowser &&
+  WEBKIT: boolean = this.isBrowser &&
       /AppleWebKit/i.test(navigator.userAgent) && !this.BLINK && !this.EDGE && !this.TRIDENT;
 
-  /** Browsers and Platform Types */
-  IOS = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+  /** Whether the current platform is Apple iOS. */
+  IOS: boolean = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+      !(window as any).MSStream;
 
+  /** Whether the current browser is Firefox. */
   // It's difficult to detect the plain Gecko engine, because most of the browsers identify
   // them self as Gecko-like browsers and modify the userAgent's according to that.
   // Since we only cover one explicit Firefox case, we can simply check for Firefox
   // instead of having an unstable check for Gecko.
-  FIREFOX = this.isBrowser && /(firefox|minefield)/i.test(navigator.userAgent);
+  FIREFOX: boolean = this.isBrowser && /(firefox|minefield)/i.test(navigator.userAgent);
 
+  /** Whether the current platform is Android. */
   // Trident on mobile adds the android platform to the userAgent to trick detections.
-  ANDROID = this.isBrowser && /android/i.test(navigator.userAgent) && !this.TRIDENT;
+  ANDROID: boolean = this.isBrowser && /android/i.test(navigator.userAgent) && !this.TRIDENT;
 
+  /** Whether the current browser is Safari. */
   // Safari browsers will include the Safari keyword in their userAgent. Some browsers may fake
   // this and just place the Safari keyword in the userAgent. To be more safe about Safari every
   // Safari browser should also use Webkit as its layout engine.
-  SAFARI = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
+  SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 }


### PR DESCRIPTION
* No longer marks the `Platform` service from `@angular/cdk/platform` as `docs-private`. The platform service should be documented since it's useful and likely the only thing in the platform entry-point.