### PR TITLE
build(dgeni): render class descriptions as markdown

### DIFF
--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -10,7 +10,7 @@
 </h4>
 
 {%- if class.description -%}
-<p class="docs-api-class-description">{$ class.description | safe $}</p>
+<p class="docs-api-class-description">{$ class.description | marked | safe $}</p>
 {%- endif -%}
 
 {%- if class.directiveSelectors -%}


### PR DESCRIPTION
Fixes this,

![screen shot 2017-10-31 at 9 46 34 am](https://user-images.githubusercontent.com/6475576/32228262-2b8f3ddc-be24-11e7-83f6-da202bee3923.png)
