### PR TITLE
Update autocomplete-filter-example.ts

### DIFF
--- a/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
@@ -26,8 +26,8 @@ export class AutocompleteFilterExample {
 
    ngOnInit() {
       this.filteredOptions = this.myControl.valueChanges
-         .startWith(null)
-         .map(val => val ? this.filter(val) : this.options.slice());
+         .startWith('')
+         .map(val => this.filter(val));
    }
 
     filter(val: string): string[] {


### PR DESCRIPTION
Simplify the example. Starting with empty string rather than null allows for removing the null check logic.