### PR TITLE
fix(snack-bar): complete onAction observable on close

### DIFF
--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -79,6 +79,11 @@ export class MatSnackBarRef<T> {
   /** Cleans up the DOM after closing. */
   private _finishDismiss(): void {
     this._overlayRef.dispose();
+
+    if (!this._onAction.closed) {
+      this._onAction.complete();
+    }
+
     this._afterClosed.next();
     this._afterClosed.complete();
   }


### PR DESCRIPTION
* Completes the `onAction` observable when a snack bar is closed, no matter whether it was through an action.
* Refactors a few snack bar unit tests to use spies instead of toggling booleans.

Fixes #8181.