### PR TITLE
build: enable noUnusedParameters check in aot.

### DIFF
--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -7,8 +7,7 @@
     // Needed for Moment.js since it doesn't have a default export.
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "strictNullChecks": true,
     "outDir": ".",
     "paths": {

--- a/src/e2e-app/tsconfig-build.json
+++ b/src/e2e-app/tsconfig-build.json
@@ -5,8 +5,7 @@
     "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     // Don't use strict nulls for the e2e-app because the material-examples are not
     // strict-null compliant.
     "strictNullChecks": false,

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -5,8 +5,7 @@
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,
-    // TODO(crisbeto): disabled due to https://github.com/angular/angular/issues/17131
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -4,7 +4,6 @@
     "declaration": false,
     "stripInternal": false,
     "experimentalDecorators": true,
-    // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "module": "commonjs",

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -5,7 +5,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     // TODO(paul): Remove once Angular has been upgraded and supports noUnusedParameters in AOT.
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
* Re-enables the `noUnusedParameters` check in the e2eapp and demo-app (AOT).