### PR TITLE
build: tslint rule to enforce html tags escaping in comments

### DIFF
--- a/tools/tslint-rules/noUnscapedHtmlTagRule.js
+++ b/tools/tslint-rules/noUnscapedHtmlTagRule.js
@@ -1,0 +1,67 @@
+const ts = require('typescript');
+const utils = require('tsutils');
+const Lint = require('tslint');
+
+const ERROR_MESSAGE =
+  'An HTML tag may only appear in a JSDoc comment if it is escaped.' +
+  ' This prevents failures in document generation caused by a misinterpreted tag.';
+
+/**
+ * Rule that walks through all comments inside of the library and adds failures when it
+ * detects unescaped HTML tags inside of multi-line comments.
+ */
+class Rule extends Lint.Rules.AbstractRule {
+
+  apply(sourceFile) {
+    return this.applyWithWalker(new NoUnescapedHtmlTagWalker(sourceFile, this.getOptions()));
+  }
+}
+
+class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
+
+  visitSourceFile(sourceFile) {
+    utils.forEachComment(sourceFile, (fullText, commentRange) => {
+
+      let isEscapedHtmlTag = true;
+      const matches = new RegExp(/[<>]/);
+
+      const numberOfBackticks = fullText.split('`').length - 1;
+      if ((numberOfBackticks === 1) || ((numberOfBackticks === 0) && matches.test(fullText))) {
+        isEscapedHtmlTag = false;
+      }
+
+      // if there are no backticks and [<>], there's no need for any more checks
+      if ((numberOfBackticks > 1) && matches.test(fullText)) {
+        // if there are backticks there should be an even number of them
+        if (!!(numberOfBackticks % 2)) {
+          isEscapedHtmlTag = false;
+        } else {
+          /** 
+           * This logic behaves like a stack structure. isBacktickWithoutMatch plays
+           * the stack role: it is set to true whenever, during a comment scan, an 'open' 
+           * backtick is found in the string, and it is set back to false when the next matching
+           * (closing) backtick is found. Every backtick must have a matching. < and >
+           * must always be between two matching backticks.
+           */
+          const splitedFullText = fullText.split('');
+          let isBacktickWithoutMatch = false;
+
+          for (var i = 0; i < splitedFullText.length; i++) {
+            if (splitedFullText[i] === '`') {
+              isBacktickWithoutMatch = !isBacktickWithoutMatch;
+            } else if (matches.test(splitedFullText[i]) && !isBacktickWithoutMatch) {
+              isEscapedHtmlTag = false;
+              break;
+            }
+          }
+        }
+      }
+
+      if (commentRange.kind === ts.SyntaxKind.MultiLineCommentTrivia && !isEscapedHtmlTag) {
+        this.addFailureAt(commentRange.pos, commentRange.end - commentRange.pos, ERROR_MESSAGE);
+      }
+    });
+  }
+}
+
+exports.Rule = Rule;

--- a/tools/tslint-rules/noUnscapedHtmlTagRule.js
+++ b/tools/tslint-rules/noUnscapedHtmlTagRule.js
@@ -33,31 +33,29 @@ class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
   /** Gets whether the comment's HTML, if any, is properly escaped */
   parseForHtml(fullText) {
     const matches = new RegExp(/[<>]/);
-
     const backtickCount = fullText.split('`').length - 1;
-    if ((backtickCount === 1) || ((backtickCount === 0) && matches.test(fullText))) {
+
+    // An odd number of backticks or html without backticks is invalid
+    if ((backtickCount % 2) || ((backtickCount === 0) && matches.test(fullText))) {
       return false;
     }
 
-    // if there are no backticks and no [<>], there's no need for any more checks
-    if ((backtickCount > 1) && matches.test(fullText)) {
-      // if there are backticks there should be an even number of them
-      if (backtickCount % 2) {
+    // Text without html is valid
+    if (!matches.test(fullText)) {
+      return true;
+    }
+
+    // < and > must always be between two matching backticks.
+    const fullTextArray = fullText.split('');
+
+    // Whether an opening backtick has been found without a closing pair
+    let openBacktick = false;
+
+    for (let i = 0; i < fullTextArray.length; i++) {
+      if (fullTextArray[i] === '`') {
+        openBacktick = !openBacktick;
+      } else if (matches.test(fullTextArray[i]) && !openBacktick) {
         return false;
-      } else {
-        // < and > must always be between two matching backticks.
-        const fullTextArray = fullText.split('');
-
-        // Whether an opening backtick has been found without a closing pair
-        let openBacktick = false;
-
-        for (let i = 0; i < fullTextArray.length; i++) {
-          if (fullTextArray[i] === '`') {
-            openBacktick = !openBacktick;
-          } else if (matches.test(fullTextArray[i]) && !openBacktick) {
-            return false;
-          }
-        }
       }
     }
 

--- a/tools/tslint-rules/noUnscapedHtmlTagRule.js
+++ b/tools/tslint-rules/noUnscapedHtmlTagRule.js
@@ -32,11 +32,11 @@ class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
 
   /** Gets whether the comment's HTML, if any, is properly escaped */
   parseForHtml(fullText) {
-    const matches = new RegExp(/[<>]/);
+    const matches = /[<>]/;
     const backtickCount = fullText.split('`').length - 1;
 
     // An odd number of backticks or html without backticks is invalid
-    if ((backtickCount % 2) || ((backtickCount === 0) && matches.test(fullText))) {
+    if (backtickCount % 2 || (!backtickCount && matches.test(fullText))) {
       return false;
     }
 
@@ -46,15 +46,14 @@ class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
     }
 
     // < and > must always be between two matching backticks.
-    const fullTextArray = fullText.split('');
-
+    
     // Whether an opening backtick has been found without a closing pair
     let openBacktick = false;
 
-    for (let i = 0; i < fullTextArray.length; i++) {
-      if (fullTextArray[i] === '`') {
+    for (const char of fullText) {
+      if (char === '`') {
         openBacktick = !openBacktick;
-      } else if (matches.test(fullTextArray[i]) && !openBacktick) {
+      } else if (matches.test(char) && !openBacktick) {
         return false;
       }
     }

--- a/tslint.json
+++ b/tslint.json
@@ -80,11 +80,7 @@
       {"name": "Object.assign", "message": "Use the spread operator instead."}
     ],
     // Disallows importing the whole RxJS library. Submodules can be still imported.
-    "import-blacklist": [
-      true,
-      "rxjs",
-      "rxjs/operators"
-    ],
+    "import-blacklist": [true, "rxjs", "rxjs/operators"],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],
     // Namespaces are no allowed, because of Closure compiler.

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,6 @@
     "no-unused-expression": true,
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
-    "no-unescaped-html-tag": true,
     "no-debugger": true,
     "no-unused-variable": true,
     "one-line": [
@@ -119,7 +118,8 @@
     "missing-rollup-globals": [
       true,
       "./tools/package-tools/rollup-globals.ts",
-      "src/+(lib|cdk|material-examples|material-experimental|cdk-experimental)/**/*.ts"
-    ]
+      "src/+(lib|cdk|material-examples)/**/*.ts"
+    ],
+    "no-unescaped-html-tag": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -28,6 +28,7 @@
     "no-unused-expression": true,
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
+    "no-unescaped-html-tag": true,
     "no-debugger": true,
     "no-unused-variable": true,
     "one-line": [
@@ -79,7 +80,11 @@
       {"name": "Object.assign", "message": "Use the spread operator instead."}
     ],
     // Disallows importing the whole RxJS library. Submodules can be still imported.
-    "import-blacklist": [true, "rxjs", "rxjs/operators"],
+    "import-blacklist": [
+      true,
+      "rxjs",
+      "rxjs/operators"
+    ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],
     // Namespaces are no allowed, because of Closure compiler.

--- a/tslint.json
+++ b/tslint.json
@@ -118,7 +118,7 @@
     "missing-rollup-globals": [
       true,
       "./tools/package-tools/rollup-globals.ts",
-      "src/+(lib|cdk|material-examples)/**/*.ts"
+      "src/+(lib|cdk|material-examples|material-experimental|cdk-experimental)/**/*.ts"
     ],
     "no-unescaped-html-tag": true
   }


### PR DESCRIPTION
Refactoring of #5825 logic

cc @willshowell 

This rule will look for:

1 - Any HTML open/close tag delimiter (`<` or `>`) outside backtick pairs (``)

```html
/** 
 * The using of <svg> is very good because...
 */
```

```
/** 
 * Look for every occurrency of `i <= 18...
 */
```

2 - Any "opening" backtick without its "closing" match:

```html
/** 
 * The using of `<svg> is very good because...
 */
```

```
/** 
 * We recommend using backticks (`) to escape...
 */
```

And it will allow any html provided it's between backtick matching pairs:

```html
/** 
 * The using of `    <div><br></div> is very` good because...
 */
```
