### PR TITLE
chore(table): add sort accessor type to data source

### DIFF
--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -95,7 +95,8 @@ export class MatTableDataSource<T> implements DataSource<T> {
    * @param data Data object that is being accessed.
    * @param sortHeaderId The name of the column that represents the data.
    */
-  sortingDataAccessor = (data: T, sortHeaderId: string): string|number => {
+  sortingDataAccessor: ((data: T, sortHeaderId: string) => string|number) =
+      (data: T, sortHeaderId: string): string|number => {
     const value: any = data[sortHeaderId];
 
     // If the value is a string and only whitespace, return the value.


### PR DESCRIPTION
Realized we are missing a type here - docs site looks funny

![image](https://user-images.githubusercontent.com/22898577/32390939-7ea9d994-c08d-11e7-89c6-03c716f78ff5.png)
