### PR TITLE
docs: fix forms warning in custom form field example

### DIFF
--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.html
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.html
@@ -1,7 +1,7 @@
 <div [formGroup]="parts">
-  <input class="area" formControlName="area" size="3" [disabled]="disabled">
+  <input class="area" formControlName="area" size="3">
   <span>&ndash;</span>
-  <input class="exchange" formControlName="exchange" size="3" [disabled]="disabled">
+  <input class="exchange" formControlName="exchange" size="3">
   <span>&ndash;</span>
-  <input class="subscriber" formControlName="subscriber" size="4" [disabled]="disabled">
+  <input class="subscriber" formControlName="subscriber" size="4">
 </div>


### PR DESCRIPTION
Fixes a warning that is logged by `@angular/forms` for the custom form field example.

Fixes #8217.