### PR TITLE
fix(overlay): disposed overlays not removed from the key event stack

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -148,6 +148,7 @@ export class OverlayRef implements PortalOutlet {
     }
 
     this.detachBackdrop();
+    this._keyboardDispatcher.remove(this);
     this._portalOutlet.dispose();
     this._attachments.complete();
     this._backdropClick.complete();


### PR DESCRIPTION
Fixes overlays that are removed via `dispose` without being `detached` first not being removed from the stack inside the `OverlayKeyboardDispatcher`, causing them to block events for any subsequent overlays.