### PR TITLE
fix(select): error when attempting to open before init

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1870,7 +1870,6 @@ describe('MatSelect', () => {
 
         // There appears to be a small rounding error on IE, so we verify that the value is close,
         // not exact.
-        let platform = new Platform();
         if (platform.TRIDENT) {
           let difference =
               Math.abs(optionTop + (menuItemHeight - triggerHeight) / 2 - triggerTop);
@@ -2512,6 +2511,11 @@ describe('MatSelect', () => {
       expect(label.textContent).toContain('azziP',
           'Expected the displayed text to be "Pizza" in reverse.');
     }));
+
+    it('should not throw when attempting to open too early', () => {
+      const fixture = TestBed.createComponent(BasicSelect);
+      expect(() => fixture.componentInstance.select.open()).not.toThrow();
+    });
   });
 
   describe('change event', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -515,7 +515,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Opens the overlay panel. */
   open(): void {
-    if (this.disabled || !this.options.length) {
+    if (this.disabled || !this.options || !this.options.length) {
       return;
     }
 
@@ -605,7 +605,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** The value displayed in the trigger. */
   get triggerValue(): string {
-    if (!this._selectionModel || this._selectionModel.isEmpty()) {
+    if (this.empty) {
       return '';
     }
 
@@ -912,10 +912,12 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    * the first item instead.
    */
   private _highlightCorrectOption(): void {
-    if (this._selectionModel.isEmpty()) {
-      this._keyManager.setFirstItemActive();
-    } else {
-      this._keyManager.setActiveItem(this._getOptionIndex(this._selectionModel.selected[0])!);
+    if (this._keyManager) {
+      if (this.empty) {
+        this._keyManager.setFirstItemActive();
+      } else {
+        this._keyManager.setActiveItem(this._getOptionIndex(this._selectionModel.selected[0])!);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes an error that could be thrown by `mat-select` if it is opened before everything is done initializing.

Fixes #8236.