### PR TITLE
fix(slide-toggle): height collapsing if component doesn't have a label

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -48,6 +48,7 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   flex: 1;
   flex-direction: row;
   align-items: center;
+  height: inherit;
 
   cursor: pointer;
 }


### PR DESCRIPTION
Fixes the slide label component collapsing down to 16px if it doesn't have a label.

Fixes #8264.