### PR TITLE
fix(demo-app): fix aligned menu triggers and make page scrollable

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -167,3 +167,5 @@
     </mat-menu>
   </div>
 </div>
+
+<div style="height: 500px">This div is for testing scrolled menus.</div>

--- a/src/demo-app/menu/menu-demo.scss
+++ b/src/demo-app/menu/menu-demo.scss
@@ -8,6 +8,6 @@
   }
 
   .end-icon {
-    align-items: flex-end;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
This change keeps the classlist up to date when the menu panel is repositioned due to scrolling.

Since the menu does not need a correct `transform-origin` during its exit animation, this is not really noticeable or necessary. However, some users may be looking for positioning classes, or the animation may change in the future.

It also adds a scrolling to the demo app and fixes a misused style.
