### PR TITLE
fix(table): inaccurate row height

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -20,6 +20,7 @@ $mat-row-horizontal-padding: 24px;
   border-bottom-style: solid;
   align-items: center;
   padding: 0 $mat-row-horizontal-padding;
+  box-sizing: border-box;
 
   // Workaround for https://goo.gl/pFmjJD in IE 11. Adds a pseudo
   // element that will stretch the row the correct height. See:


### PR DESCRIPTION
Fixes the table border throwing of the table row height by one pixel.

Fixes #8299.