### PR TITLE
chore(overlay): export OverlayKeyboardDispatcher

### DIFF
--- a/src/cdk/overlay/public-api.ts
+++ b/src/cdk/overlay/public-api.ts
@@ -17,6 +17,7 @@ export {FullscreenOverlayContainer} from './fullscreen-overlay-container';
 export {OverlayRef} from './overlay-ref';
 export {ViewportRuler} from '@angular/cdk/scrolling';
 export {ComponentType} from '@angular/cdk/portal';
+export {OverlayKeyboardDispatcher} from './keyboard/overlay-keyboard-dispatcher';
 
 // Export pre-defined position strategies and interface to build custom ones.
 export {PositionStrategy} from './position/position-strategy';


### PR DESCRIPTION
- `OverlayKeyboardDispatcher` is exported to aide in extending the `Overlay` class.

Fixes #8309 