### PR TITLE
fix(overlay): complete key event stream on dispose

### DIFF
--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
@@ -94,4 +94,15 @@ describe('OverlayKeyboardDispatcher', () => {
     expect(overlayTwoSpy).not.toHaveBeenCalled();
   });
 
+  it('should complete the keydown stream on dispose', () => {
+    const overlayRef = overlay.create();
+    const completeSpy = jasmine.createSpy('keydown complete spy');
+
+    overlayRef.keydownEvents().subscribe(undefined, undefined, completeSpy);
+
+    overlayRef.dispose();
+
+    expect(completeSpy).toHaveBeenCalled();
+  });
+
 });

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -151,6 +151,7 @@ export class OverlayRef implements PortalOutlet {
     this._portalOutlet.dispose();
     this._attachments.complete();
     this._backdropClick.complete();
+    this._keydownEvents.complete();
 
     if (isAttached) {
       this._detachments.next();


### PR DESCRIPTION
Fixes the `keydownEvents` stream not being completed on dispose.