### PR TITLE
refactor(menu): simplify animation

### DIFF
--- a/src/lib/menu/menu-animations.ts
+++ b/src/lib/menu/menu-animations.ts
@@ -39,15 +39,10 @@ export const transformMenu: AnimationTriggerMetadata = trigger('transformMenu', 
     // as of 4.2, which causes the animation to be skipped if it starts from 0.
     transform: 'scale(0.01, 0.01)'
   })),
-  state('enter-start', style({
-    opacity: 1,
-    transform: 'scale(1, 0.5)'
-  })),
-  state('enter', style({
-    transform: 'scale(1, 1)'
-  })),
-  transition('void => enter-start', animate('100ms linear')),
-  transition('enter-start => enter', animate('300ms cubic-bezier(0.25, 0.8, 0.25, 1)')),
+  transition('void => enter', [
+    animate('100ms linear', style({opacity: 1, transform: 'scale(1, 0.5)'})),
+    animate('300ms cubic-bezier(0.25, 0.8, 0.25, 1)', style({transform: 'scale(1, 1)'}))
+  ]),
   transition('* => void', animate('150ms 50ms linear', style({opacity: 0})))
 ]);
 

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationEvent} from '@angular/animations';
 import {FocusKeyManager} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
 import {ESCAPE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
@@ -87,7 +86,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
   _classList: {[key: string]: boolean} = {};
 
   /** Current state of the panel animation. */
-  _panelAnimationState: 'void' | 'enter-start' | 'enter' = 'void';
+  _panelAnimationState: 'void' | 'enter' = 'void';
 
   /** Parent menu of the current menu panel. */
   parentMenu: MatMenuPanel | undefined;
@@ -268,21 +267,11 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
     }
   }
 
-  /** Starts the enter animation. */
-  _startAnimation() {
-    this._panelAnimationState = 'enter-start';
-  }
-
-  /** Resets the panel animation to its initial state. */
-  _resetAnimation() {
-    this._panelAnimationState = 'void';
-  }
-
-  /** Callback that is invoked when the panel animation completes. */
-  _onAnimationDone(event: AnimationEvent) {
-    // After the initial expansion is done, trigger the second phase of the enter animation.
-    if (event.toState === 'enter-start') {
-      this._panelAnimationState = 'enter';
-    }
+  /**
+   * Toggles the animation state of the menu panel.
+   * @param isOpen Whether the menu should be open.
+   */
+  _toggleAnimation(isOpen: boolean) {
+    this._panelAnimationState = isOpen ? 'enter' : 'void';
   }
 }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -199,7 +199,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       this._initMenu();
 
       if (this.menu instanceof MatMenu) {
-        this.menu._startAnimation();
+        this.menu._toggleAnimation(true);
       }
     }
   }
@@ -222,7 +222,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       this._closeSubscription.unsubscribe();
 
       if (this.menu instanceof MatMenu) {
-        this.menu._resetAnimation();
+        this.menu._toggleAnimation(false);
       }
     }
   }

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -5,7 +5,6 @@
     (keydown)="_handleKeydown($event)"
     (click)="closed.emit('click')"
     [@transformMenu]="_panelAnimationState"
-    (@transformMenu.done)="_onAnimationDone($event)"
     tabindex="-1"
     role="menu">
     <div class="mat-menu-content" [@fadeInItems]="'showing'">


### PR DESCRIPTION
Simplifies the menu animation by using keyframes to do the opening transition, rather than chaining a couple of animation events.