### PR TITLE
feat(paginator): allow page size selection to be disabled

### DIFF
--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -1,5 +1,5 @@
 <div class="mat-paginator-container">
-  <div class="mat-paginator-page-size">
+  <div class="mat-paginator-page-size" *ngIf="!hidePageSize">
     <div class="mat-paginator-page-size-label">
       {{_intl.itemsPerPageLabel}}
     </div>

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -264,6 +264,19 @@ describe('MatPaginator', () => {
     expect(withStringPaginator.pageSize).toEqual(10);
     expect(withStringPaginator.pageSizeOptions).toEqual([5, 10, 25, 100]);
   });
+
+  it('should be able to hide the page size select', () => {
+    const element = fixture.nativeElement;
+
+    expect(element.querySelector('.mat-paginator-page-size'))
+        .toBeTruthy('Expected select to be rendered.');
+
+    fixture.componentInstance.hidePageSize = true;
+    fixture.detectChanges();
+
+    expect(element.querySelector('.mat-paginator-page-size'))
+        .toBeNull('Expected select to be removed.');
+  });
 });
 
 function getPreviousButton(fixture: ComponentFixture<any>) {
@@ -279,6 +292,7 @@ function getNextButton(fixture: ComponentFixture<any>) {
     <mat-paginator [pageIndex]="pageIndex"
                    [pageSize]="pageSize"
                    [pageSizeOptions]="pageSizeOptions"
+                   [hidePageSize]="hidePageSize"
                    [length]="length"
                    (page)="latestPageEvent = $event">
     </mat-paginator>
@@ -288,6 +302,7 @@ class MatPaginatorApp {
   pageIndex = 0;
   pageSize = 10;
   pageSizeOptions = [5, 10, 25, 100];
+  hidePageSize = false;
   length = 100;
 
   latestPageEvent: PageEvent | null;

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -97,6 +97,9 @@ export class MatPaginator implements OnInit, OnDestroy {
   }
   private _pageSizeOptions: number[] = [];
 
+  /** Whether to hide the page size selection UI from the user. */
+  @Input() hidePageSize = false;
+
   /** Event emitted when the paginator changes the page size or page index. */
   @Output() page = new EventEmitter<PageEvent>();
 


### PR DESCRIPTION
Adds an input that allows the consumer to disable the page size selection entirely.

Fixes #8359.

**Note:** the AoT compilation error is coming from master and will be fixed in another PR.