### PR TITLE
docs: show additional interfaces

### DIFF
--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -85,7 +85,7 @@ export class RippleRenderer {
     }
 
     const radius = config.radius || distanceToFurthestCorner(x, y, containerRect);
-    const duration = RIPPLE_FADE_IN_DURATION * (1 / (config.speedFactor || 1));
+    const duration = RIPPLE_FADE_IN_DURATION / (config.speedFactor || 1);
     const offsetX = x - containerRect.left;
     const offsetY = y - containerRect.top;
 

--- a/src/lib/core/ripple/ripple.md
+++ b/src/lib/core/ripple/ripple.md
@@ -85,9 +85,4 @@ const globalRippleConfig: RippleGlobalOptions = {
 })
 ```
 
-All currently available global options are shown here:
-
-| Name            | Type    | Description                               |
-| --------------- | ------- | ----------------------------------------- |
-| disabled        | boolean | Whether ripples should show or not.       |
-| baseSpeedFactor | number  | Factor to adjust ripple speed.            |
+All available global options can be seen in the `RippleGlobalOptions` interface.

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -23,7 +23,17 @@ import {RippleConfig, RippleRenderer} from './ripple-renderer';
 import {RippleRef} from './ripple-ref';
 
 export interface RippleGlobalOptions {
+  /**
+   * Whether ripples should be disabled. Ripples can be still launched manually by using
+   * the `launch()` method. Therefore focus indicators will still show up.
+   */
   disabled?: boolean;
+
+  /**
+   * If set, the default duration of the fade-in animation is divided by this value. For example,
+   * setting it to 0.5 will cause the ripple fade-in animation to take twice as long.
+   * A changed speedFactor will not affect the fade-out duration of the ripples.
+   */
   baseSpeedFactor?: number;
 }
 

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -3,12 +3,14 @@ import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassL
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
 import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
 
+/** Extended Dgeni class-like document that includes separated class members. */
 export interface CategorizedClassLikeDoc extends ClassLikeExportDoc {
   methods: CategorizedMethodMemberDoc[];
   properties: CategorizedPropertyMemberDoc[];
   isDeprecated: boolean;
 }
 
+/** Extended Dgeni class document that includes extracted Angular metadata. */
 export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLikeDoc {
   isDirective: boolean;
   isService: boolean;
@@ -18,6 +20,7 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
   extendedDoc: ClassLikeExportDoc | null;
 }
 
+/** Extended Dgeni property-member document that includes extracted Angular metadata. */
 export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc {
   description: string;
   isDeprecated: boolean;
@@ -27,6 +30,7 @@ export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc {
   directiveOutputAlias: string;
 }
 
+/** Extended Dgeni method-member document that simplifies logic for the Dgeni template. */
 export interface CategorizedMethodMemberDoc extends NormalizedMethodMemberDoc {
   showReturns: boolean;
   isDeprecated: boolean;

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -1,0 +1,33 @@
+import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
+import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
+import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
+import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
+
+export interface CategorizedClassLikeDoc extends ClassLikeExportDoc {
+  methods: CategorizedMethodMemberDoc[];
+  properties: CategorizedPropertyMemberDoc[];
+  isDeprecated: boolean;
+}
+
+export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLikeDoc {
+  isDirective: boolean;
+  isService: boolean;
+  isNgModule: boolean;
+  directiveExportAs?: string | null;
+  directiveSelectors?: string[];
+  extendedDoc: ClassLikeExportDoc | null;
+}
+
+export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc {
+  description: string;
+  isDeprecated: boolean;
+  isDirectiveInput: boolean;
+  isDirectiveOutput: boolean;
+  directiveInputAlias: string;
+  directiveOutputAlias: string;
+}
+
+export interface CategorizedMethodMemberDoc extends NormalizedMethodMemberDoc {
+  showReturns: boolean;
+  isDeprecated: boolean;
+}

--- a/tools/dgeni/common/sort-members.ts
+++ b/tools/dgeni/common/sort-members.ts
@@ -1,5 +1,5 @@
-import {CategorizedMethodMemberDoc, CategorizedPropertyMemberDoc} from '../processors/categorizer';
 import {isDirectiveInput, isDirectiveOutput} from './decorators';
+import {CategorizedMethodMemberDoc, CategorizedPropertyMemberDoc} from './dgeni-definitions';
 
 /** Combined type for a categorized method member document. */
 type CategorizedMemberDoc = CategorizedMethodMemberDoc & CategorizedPropertyMemberDoc;

--- a/tools/dgeni/processors/component-grouper.ts
+++ b/tools/dgeni/processors/component-grouper.ts
@@ -1,9 +1,13 @@
-import {CategorizedClassDoc} from './categorizer';
 import {DocCollection, Document, Processor} from 'dgeni';
+import {InterfaceExportDoc} from 'dgeni-packages/typescript/api-doc-types/InterfaceExportDoc';
 import * as path from 'path';
+import {CategorizedClassDoc} from '../common/dgeni-definitions';
 
 /** Component group data structure. */
 export class ComponentGroup {
+
+  /** Unique document type for Dgeni. */
+  docType = 'componentGroup';
 
   /** Name of the component group. */
   name: string;
@@ -24,32 +28,26 @@ export class ComponentGroup {
   id: string;
 
   /** Known aliases for the component group. */
-  aliases: string[];
-
-  /** Unique document type for Dgeni. */
-  docType: string;
+  aliases: string[] = [];
 
   /** List of categorized class docs that are defining a directive. */
-  directives: CategorizedClassDoc[];
+  directives: CategorizedClassDoc[] = [];
 
   /** List of categorized class docs that are defining a service. */
-  services: CategorizedClassDoc[];
+  services: CategorizedClassDoc[] = [];
 
   /** Additional classes that belong to the component group. */
-  additionalClasses: CategorizedClassDoc[];
+  additionalClasses: CategorizedClassDoc[] = [];
+
+  /** Additional interfaces that belong to the component group. */
+  additionalInterfaces: InterfaceExportDoc[] = [];
 
   /** NgModule that defines the current component group. */
-  ngModule: CategorizedClassDoc | null;
+  ngModule: CategorizedClassDoc | null = null;
 
   constructor(name: string) {
     this.name = name;
     this.id = `component-group-${name}`;
-    this.aliases = [];
-    this.docType = 'componentGroup';
-    this.directives = [];
-    this.services = [];
-    this.additionalClasses = [];
-    this.ngModule = null;
   }
 }
 
@@ -97,6 +95,8 @@ export class ComponentGrouper implements Processor {
         group.ngModule = doc;
       } else if (doc.docType == 'class') {
         group.additionalClasses.push(doc);
+      } else if (doc.docType == 'interface') {
+        group.additionalInterfaces.push(doc);
       }
     });
 

--- a/tools/dgeni/templates/componentGroup.template.html
+++ b/tools/dgeni/templates/componentGroup.template.html
@@ -19,6 +19,10 @@
   {% include 'class.template.html' %}
 {% endmacro %}
 
+{% macro interface(interface) -%}
+  {% include 'interface.template.html' %}
+{% endmacro %}
+
 <div class="docs-api">
   <h2>
     API reference for Angular {$ doc.packageDisplayName $} {$ doc.displayName $}
@@ -58,6 +62,16 @@
     </h3>
     {% for other in doc.additionalClasses %}
       {$ class(other) $}
+    {% endfor %}
+  {%- endif -%}
+
+  {%- if doc.additionalInterfaces.length -%}
+    <h3 id="additional_interfaces" class="docs-header-link docs-api-h3">
+      <span header-link="additional_interfaces"></span>
+      Additional interfaces
+    </h3>
+    {% for item in doc.additionalInterfaces %}
+      {$ interface(item) $}
     {% endfor %}
   {%- endif -%}
 </div>

--- a/tools/dgeni/templates/interface.template.html
+++ b/tools/dgeni/templates/interface.template.html
@@ -1,0 +1,16 @@
+<h4 id="{$ interface.name $}" class="docs-header-link docs-api-h4 docs-api-interface-name">
+  <span header-link="{$ interface.name $}"></span>
+  <code>{$ interface.name $}</code>
+</h4>
+
+{%- if interface.description -%}
+<p class="docs-api-interface-description">{$ interface.description | marked | safe $}</p>
+{%- endif -%}
+
+{%- if interface.isDeprecated -%}
+<div class="docs-api-interface-deprecated-marker">Deprecated</div>
+{%- endif -%}
+
+{$ propertyList(interface.properties) $}
+
+{$ methodList(interface.methods) $}


### PR DESCRIPTION
* Shows additional interfaces in the Dgeni API documentation
* Adds documentation for the `RippleGlobalOptions`

Closes #8298.