### PR TITLE
fix: using correct global name in bundle

### DIFF
--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -3,7 +3,7 @@ import {uglifyJsFile} from './minify-sources';
 import {buildConfig} from './build-config';
 import {BuildPackage} from './build-package';
 import {rollupRemoveLicensesPlugin} from './rollup-remove-licenses';
-import {rollupGlobals} from './rollup-globals';
+import {rollupGlobals, dashCaseToCamelCase} from './rollup-globals';
 
 // There are no type definitions available for these imports.
 const rollup = require('rollup');
@@ -51,7 +51,7 @@ export class PackageBundler {
     return this.bundleEntryPoint({
       entryFile,
       esm5EntryFile,
-      moduleName: `ng.${packageName}.${entryPoint}`,
+      moduleName: `ng.${packageName}.${dashCaseToCamelCase(entryPoint)}`,
       esm2015Dest: join(bundlesDir, `${packageName}`, `${entryPoint}.js`),
       esm5Dest: join(bundlesDir, `${packageName}`, `${entryPoint}.es5.js`),
       umdDest: join(bundlesDir, `${packageName}-${entryPoint}.umd.js`),

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -3,7 +3,8 @@ import {getSubdirectoryNames} from './secondary-entry-points';
 import {buildConfig} from './build-config';
 
 /** Method that converts dash-case strings to a camel-based string. */
-const dashCaseToCamelCase = (str: string) => str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+export const dashCaseToCamelCase =
+  (str: string) => str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
 
 /** List of potential secondary entry-points for the cdk package. */
 const cdkSecondaryEntryPoints = getSubdirectoryNames(join(buildConfig.packagesDir, 'cdk'));


### PR DESCRIPTION
### Current Behavior:

**UMD bundles are completely BROKEN for global fallback!!!**
<sub>Even though I guess it's still low priority since few people are using it.</sub>

All material/cdk modules are using **camelCase** in import and **kebab-case** in export, making it unable to connect.

Export ([example](https://unpkg.com/@angular/material@5.0.0-rc0/bundles/material-form-field.umd.js)):

```javascript
global.ng.material['form-field'] /* kebab-case here */ = global.ng.material['form-field'] || {}
```

Import ([example](https://unpkg.com/@angular/material@5.0.0-rc0/bundles/material-input.umd.js)):

```javascript
global.ng.material.formField /* camelCase here */
```

### Expect Behavior:

Always use `camelCase` variable/property in global name.

### Others

+ Only modules with composite names were broken, single-word module not affected;
+ Not sure about the **scope** of this commit since it's too wide, any suggestion?