### PR TITLE
fix(slide-toggle): drag not working in edge

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -475,6 +475,29 @@ describe('MatSlideToggle without forms', () => {
           .toBeFalsy('Expected the slide-toggle to not emit a change event.');
     }));
 
+    it('should ignore clicks on the label element while dragging', fakeAsync(() => {
+      expect(slideToggle.checked).toBe(false);
+
+      gestureConfig.emitEventForElement('slidestart', slideThumbContainer);
+      gestureConfig.emitEventForElement('slide', slideThumbContainer, {
+        deltaX: 200 // Arbitrary, large delta that will be clamped to the end of the slide-toggle.
+      });
+      gestureConfig.emitEventForElement('slideend', slideThumbContainer);
+
+      expect(slideToggle.checked).toBe(true);
+
+      // Fake a change event that has been fired after dragging through the click on pointer
+      // release (noticeable on IE11, Edge)
+      inputElement.checked = false;
+      dispatchFakeEvent(inputElement, 'change');
+
+      // Flush the timeout for the slide ending.
+      tick();
+
+      expect(slideThumbContainer.classList).not.toContain('mat-dragging');
+      expect(slideToggle.checked).toBe(true);
+    }));
+
     it('should update the checked property of the input', fakeAsync(() => {
       expect(inputElement.checked).toBe(false);
 


### PR DESCRIPTION
Some browsers like Edge or IE11 emit `click` events differently than other browsers like Chrome. For example does Edge still emit a `click` event if the pointer drags something around and is being released over the `<label>` element. This doesn't happen on Chrome.

Right now this means that the new checked state from the drag is being reverted by the `click` event that then causes a `change` event on the underlying input element. To ensure that the behavior is the same across all supported browsers, the checked state from the `click` event is being ignored while dragging.

Fixes #8391