### PR TITLE
chore: fix test compilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,33 +5,33 @@
   "requires": true,
   "dependencies": {
     "@angular/animations": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.0.0.tgz",
-      "integrity": "sha1-ta0ZnGf5P3WVREd+/+ZnnhVJkfs=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.0.1.tgz",
+      "integrity": "sha1-qSsrGGpuWjGp8VhJEd1qp+FsXeE=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/common": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.0.0.tgz",
-      "integrity": "sha1-+W1mpRe5ldG6mygwnxXC41lnWCU=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.0.1.tgz",
+      "integrity": "sha1-QwBas8i4/68Xaq+zuGupMcPkvfk=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/compiler": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.0.0.tgz",
-      "integrity": "sha1-uf+/GMijnYt9rOxHMZOpDiTMK8k=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.0.1.tgz",
+      "integrity": "sha1-f9TH+ku770wUaWL6lGuCczCmyO0=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.0.0.tgz",
-      "integrity": "sha1-Dsu5N9hKT43ZTwwqR7B9LkaUyFM=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.0.1.tgz",
+      "integrity": "sha1-Um3BuzlPsWrZFmAe6pqgDrRLT/8=",
       "dev": true,
       "requires": {
         "chokidar": "1.7.0",
@@ -41,51 +41,51 @@
       }
     },
     "@angular/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.0.0.tgz",
-      "integrity": "sha1-T5dqIl993fNJkvLK2CTJVDpG9Mg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.0.1.tgz",
+      "integrity": "sha1-pKdK/H4gWNMLgmPrbWbarOn0J7o=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/forms": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.0.0.tgz",
-      "integrity": "sha1-x/3fo1OWdZrphSkgowzdqMQe0d4=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.0.1.tgz",
+      "integrity": "sha1-afMDxME9o8qg3mNDdYg4i2rWKyE=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/http": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.0.0.tgz",
-      "integrity": "sha1-Byiivgz7sHhyfF64fUyF1T/smlE=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.0.1.tgz",
+      "integrity": "sha1-NQy99jz6yJOWE9dT/wce1YpgVhs=",
       "dev": true,
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.0.0.tgz",
-      "integrity": "sha1-xwOPfN6AcFtiAUiXIx4YLuyXb+0=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.0.1.tgz",
+      "integrity": "sha1-FIld0w7Sow7nuZx2t2R0j0bBqGI=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.0.tgz",
-      "integrity": "sha1-iH4QbIsQOwQVz2FWpCXabYP0yJ0=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.1.tgz",
+      "integrity": "sha1-Fttn1S1FMVY6sVQpxr3+GLwb7cg=",
       "dev": true,
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@angular/platform-server": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-5.0.0.tgz",
-      "integrity": "sha1-h30l74FK+S//x7C1I7lxpv8iIBg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-5.0.1.tgz",
+      "integrity": "sha1-AFpk62V+Zw0mX9+ulHPxmnZPhzc=",
       "dev": true,
       "requires": {
         "domino": "1.0.30",
@@ -94,82 +94,82 @@
       }
     },
     "@angular/router": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.0.0.tgz",
-      "integrity": "sha1-/ktSGmc4QIvOMPk6U0mRQMk6T3Y=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.0.1.tgz",
+      "integrity": "sha1-msCPKTAu9gzf08eBDZbCZd7EY9Y=",
       "dev": true,
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@firebase/app": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.1.tgz",
-      "integrity": "sha512-LoZj/Igo1PbfSorPRCozTlBhrFvOyxZsiMo2fLyDa2w/gdPbMucpWUi0vIBronR6T/yNJRWdZyyHOMieLtnjcw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.2.tgz",
+      "integrity": "sha512-H2moN0Dl5LJn1AiRsCvwJsfE7PLKYYYJc+WKqAta+qIB/ZzBAay8NTVBYHiqsteLHc7gXofoi8zEUrGjbmz4OQ==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.1"
+        "@firebase/util": "0.1.2"
       }
     },
     "@firebase/auth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.2.0.tgz",
-      "integrity": "sha512-02tAnE1KcorVJRjs+xf0AngsRyYRpdZ9yDVHX+J5x2Z9v4qNpp1FPkx3A8hmqznCAgqc4C0EbaxHg0BcUlQsWw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.2.2.tgz",
+      "integrity": "sha512-/qUnCjil7Eb0KQVErkziuyIbG1FrszD6+ttGY7+DTTbN+/QGjyqwTizwGLQDF8Itvf29O7YWKEdsoJyiwn/F4Q==",
       "dev": true
     },
     "@firebase/database": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.2.tgz",
-      "integrity": "sha512-60D08yaQJ6RVegxriC/VNpHE2+/4itTtxBbo15P8WkFfnsjjJVK8AkkFiCjOxj6TccpjzoAz69Xe2/p8po2fEg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.3.tgz",
+      "integrity": "sha512-Uk9IRPYDmpDRBvnIZhs16iQX/7GxetslWD+7N6GKgEDmO9csPC+9hHmdXkcVc6cG7xHCePdRJGvhrVt3ax7Fcw==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.1",
-        "faye-websocket": "0.9.3"
+        "@firebase/util": "0.1.2",
+        "faye-websocket": "0.11.1"
       }
     },
     "@firebase/firestore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.1.2.tgz",
-      "integrity": "sha512-VqPLPKiSy0EzsQfA4w0qYT93KgkiL/NAIS6Ibajuuts2wbz2CBgsZM1nPvgJnaQCN8LPAT/Vvn2th7nMozFHag==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.1.4.tgz",
+      "integrity": "sha512-ltt3zvvZ6LE37oIfVm0zeNA0DPo75YKWkfIyEbFlXDWkeNIt3lunhB4L777weUzZOmcZhX8T6pHx6xZM+ysDkA==",
       "dev": true,
       "requires": {
-        "@firebase/webchannel-wrapper": "0.2.3"
+        "@firebase/webchannel-wrapper": "0.2.4"
       }
     },
     "@firebase/messaging": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.1.2.tgz",
-      "integrity": "sha512-fZHhO1FO2RHOVg8A0BhwF+Ay0A34AtMEyjo9csht+TQNEaG924Jkf2tUG13nqRda63tmjT5REeWnGv6qAZU4Jw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.1.3.tgz",
+      "integrity": "sha512-mQxG4y+wT7hCSsNzPGdFKjZ7/NLIdSJRYX59bLL3F0HMIuOlNtYXxKjN23vBGljwFufx3dQBtlX8beDBKbOv4Q==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.1"
+        "@firebase/util": "0.1.2"
       }
     },
     "@firebase/polyfill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.1.1.tgz",
-      "integrity": "sha512-XvZzppOmu5NZvWkvxZuWpD5VeMhyhhlrMvyFAwlOeYrJKcBFkIbmSX46Pe5ttuXYp6EjrVia/Bh1h2h0NYgE7g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.1.2.tgz",
+      "integrity": "sha512-5oneu9nOYDZkZWyfvBXFa+ORWj9HeOYhwWy4HSJzCLKLnOvQSSZRcNBD2cVrysGR8tZCEfyKqq3fnwtODCvIQg==",
       "dev": true,
       "requires": {
         "promise-polyfill": "6.0.2"
       }
     },
     "@firebase/storage": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.1.1.tgz",
-      "integrity": "sha512-ccnANSW/Sun8/pFssCdOsVQrdyDb/ReKU/P0rbDdU0LvnWkYEckegJrYSoDliHuht19qHSl5C062q82ZxReVRQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.1.2.tgz",
+      "integrity": "sha512-Il1+R2BbFfhwq4H6OAF+hpxr5mAxoD3CK/i/78CiDATtKR5OU9kuQf7T3V3khMeFspK0H6r02Oe9gTbS2XhPkQ==",
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.1.tgz",
-      "integrity": "sha512-HtJ3UEecoy2qjoTXwtp0tN4pVR+zH6+pSMtxLHSxgkAAExKsPJUp5W91O6LivjRdiakRwjMZEE9bVPFUCHDhlQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.2.tgz",
+      "integrity": "sha512-XzvnxTsPIukAJmBVpBOGTLVgz27Iyoudmum6Bqy8Czu2qhWjikhkE1UlND7Gh5BwTpBVr03axjovRXgh5xgIxw==",
       "dev": true
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.3.tgz",
-      "integrity": "sha512-EWSvoDVXmUwP1nP65ob1gEGiJi38Pv1e9dmL1DHBcupmYdST1cbYper6N2EVnCkzMIm2/EfZiGSL1nf8V4uiKg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.4.tgz",
+      "integrity": "sha512-jEpglcwMlwdXc/JgvJaJtCSkPMktnFeI0gAZxPrmbJxKVzMZJ2zM582NbW/r6M22pSdNWjcWeg1I2LRg3jQGQA==",
       "dev": true
     },
     "@google-cloud/common": {
@@ -191,93 +191,94 @@
         "methmeth": "1.1.0",
         "modelo": "4.2.0",
         "request": "2.83.0",
-        "retry-request": "3.1.0",
+        "retry-request": "3.1.1",
         "split-array-stream": "1.0.3",
         "stream-events": "1.0.2",
         "string-format-obj": "1.1.0",
         "through2": "2.0.3"
       }
     },
+    "@google-cloud/common-grpc": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.4.2.tgz",
+      "integrity": "sha1-jPb7vkGZdueOtuD+aoGXTEYfMaw=",
+      "dev": true,
+      "requires": {
+        "@google-cloud/common": "0.13.6",
+        "dot-prop": "2.4.0",
+        "duplexify": "3.5.1",
+        "extend": "3.0.1",
+        "grpc": "1.7.1",
+        "is": "3.2.1",
+        "modelo": "4.2.0",
+        "retry-request": "3.1.1",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "dot-prop": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
+          "integrity": "sha1-hI4o9/HVB0DGdHqzywdnBGK2+Jw=",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        }
+      }
+    },
+    "@google-cloud/firestore": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.9.0.tgz",
+      "integrity": "sha512-IoWsM1lkoBQffywJgbjJzzYMLPXSowOyrDRSx67u5kvPwTsYFl1AupPEOet48k/5tvaT4yhmhP2OsU+MSjrp5w==",
+      "dev": true,
+      "requires": {
+        "@google-cloud/common": "0.13.6",
+        "@google-cloud/common-grpc": "0.4.2",
+        "bun": "0.0.12",
+        "extend": "3.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "google-gax": "0.14.2",
+        "grpc": "1.7.1",
+        "is": "3.2.1",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.3"
+      }
+    },
     "@google-cloud/functions-emulator": {
-      "version": "1.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.25.tgz",
-      "integrity": "sha512-f1rn5SxjvUYeh/jibc4ccFFWgNK6qaE+eiFafgW/MlAsuGB+8DPYYIZ56ags80qtfCdL3j/ny40vmT1unO49HA==",
+      "version": "1.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.27.tgz",
+      "integrity": "sha1-0iEKArtKCQN95jpRLn1amMKBI+c=",
       "dev": true,
       "optional": true,
       "requires": {
-        "@google-cloud/storage": "1.2.1",
+        "@google-cloud/storage": "1.4.0",
         "adm-zip": "0.4.7",
-        "ajv": "5.2.2",
-        "body-parser": "1.17.2",
+        "ajv": "5.3.0",
+        "body-parser": "1.18.2",
         "cli-table2": "0.2.0",
         "colors": "1.1.2",
         "configstore": "3.1.1",
-        "express": "4.15.4",
-        "google-proto-files": "0.12.1",
-        "googleapis": "20.1.0",
+        "express": "4.16.2",
+        "google-proto-files": "0.14.1",
+        "googleapis": "22.2.0",
         "got": "7.1.0",
-        "grpc": "1.4.1",
+        "grpc": "1.7.1",
         "http-proxy": "1.16.2",
         "lodash": "4.17.4",
         "prompt": "1.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "semver": "5.4.1",
         "serializerr": "1.0.3",
         "tmp": "0.0.33",
         "uuid": "3.1.0",
-        "winston": "2.3.1",
-        "yargs": "8.0.2"
+        "winston": "2.4.0",
+        "yargs": "10.0.3"
       },
       "dependencies": {
-        "@google-cloud/storage": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.2.1.tgz",
-          "integrity": "sha1-oPLiCHG4YvDqZKkKxI/AiEXPlQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@google-cloud/common": "0.13.6",
-            "arrify": "1.0.1",
-            "async": "2.5.0",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
-            "extend": "3.0.1",
-            "gcs-resumable-upload": "0.8.2",
-            "hash-stream-validation": "0.2.1",
-            "is": "3.2.1",
-            "mime-types": "2.1.17",
-            "once": "1.4.0",
-            "pumpify": "1.3.5",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
-            "through2": "2.0.3"
-          }
-        },
-        "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true,
           "optional": true
         },
@@ -287,6 +288,17 @@
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true,
           "optional": true
+        },
+        "google-proto-files": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.1.tgz",
+          "integrity": "sha1-bl8V+L1mFdc8o/3QjN7DM2P5r4k=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "globby": "6.1.0",
+            "protobufjs": "6.8.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -305,6 +317,28 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
+          }
+        },
+        "protobufjs": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.0.tgz",
+          "integrity": "sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/base64": "1.1.2",
+            "@protobufjs/codegen": "2.0.4",
+            "@protobufjs/eventemitter": "1.1.0",
+            "@protobufjs/fetch": "1.1.0",
+            "@protobufjs/float": "1.0.2",
+            "@protobufjs/inquire": "1.1.0",
+            "@protobufjs/path": "1.1.2",
+            "@protobufjs/pool": "1.1.0",
+            "@protobufjs/utf8": "1.1.0",
+            "@types/long": "3.0.32",
+            "@types/node": "7.0.46",
+            "long": "3.2.0"
           }
         },
         "string-width": {
@@ -338,57 +372,25 @@
             "os-tmpdir": "1.0.2"
           }
         },
-        "winston": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-          "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "1.0.0",
-            "colors": "1.0.3",
-            "cycle": "1.0.3",
-            "eyes": "0.1.8",
-            "isstream": "0.1.2",
-            "stack-trace": "0.0.10"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-              "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-              "dev": true,
-              "optional": true
-            },
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "yargs-parser": "8.0.0"
           }
         }
       }
@@ -401,7 +403,7 @@
       "requires": {
         "@google-cloud/common": "0.13.6",
         "arrify": "1.0.1",
-        "async": "2.5.0",
+        "async": "2.6.0",
         "concat-stream": "1.6.0",
         "create-error-class": "3.0.2",
         "duplexify": "3.5.1",
@@ -419,6 +421,70 @@
         "through2": "2.0.3"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@types/chalk": {
       "version": "0.4.31",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
@@ -426,9 +492,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-cUE7dc4RJsRPCk8mbrgMAaglugcJbf1Oxp7DYi/aOj4+ggCxzddDQFZwCKWnqrLv4LJ89apyNJ7Y3pN79tAPVg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.5.tgz",
+      "integrity": "sha512-tIG0GpHum5IFb8Qze/cSv0w/0gNzHB+MUDftTQaxenx46z50g51/MPkNLssLz9+uZLzCDd35bT9qtWOTXZ21Gw==",
       "dev": true,
       "requires": {
         "@types/node": "7.0.46"
@@ -444,6 +510,15 @@
         "@types/node": "7.0.46"
       }
     },
+    "@types/google-cloud__storage": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.6.tgz",
+      "integrity": "sha512-X/hXFBpcnrfUjm6Q+9wTqVOlxKY5vC5aFMB4AIOnpuIhWmksJ5uVwry9Tr60buoYmeWbBGtx5JRWACJK9MhC+Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.46"
+      }
+    },
     "@types/gulp": {
       "version": "3.8.32",
       "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.32.tgz",
@@ -451,7 +526,7 @@
       "dev": true,
       "requires": {
         "@types/node": "7.0.46",
-        "@types/orchestrator": "0.3.0",
+        "@types/orchestrator": "0.3.2",
         "@types/vinyl": "2.0.1"
       }
     },
@@ -462,9 +537,24 @@
       "dev": true
     },
     "@types/jasmine": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.3.tgz",
-      "integrity": "sha512-2dJf9//QxTnFBXHsCqLbB55jlMreJQie9HhgsZrSgHveOKCWVmgcXgRyvIi22Ndk/dJ/e2srLOstk2NgVbb7XA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha512-NthRcmfDjp6PEevahmd3L5euekA/H2F7Xb+Mr9C5a8VYYA86pJIEMPqCDVUrJtVyFMY4Dv9XXnUYoSx9Nnxghg==",
+      "dev": true
+    },
+    "@types/jsonwebtoken": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz",
+      "integrity": "sha512-cVhxZfVCyTZd1P+2a+xXSR9to7hZTulNRLLCQMVfAevUqx2Ee+EgsiD/7pX8qvdXWP3nWgSoTjKRLMrIpdPVjQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.46"
+      }
+    },
+    "@types/long": {
+      "version": "3.0.32",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
       "dev": true
     },
     "@types/merge2": {
@@ -495,19 +585,19 @@
       "dev": true
     },
     "@types/orchestrator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.0.tgz",
-      "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.2.tgz",
+      "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
       "dev": true,
       "requires": {
         "@types/node": "7.0.46",
-        "@types/q": "0.0.37"
+        "@types/q": "1.0.6"
       }
     },
     "@types/q": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
-      "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.6.tgz",
+      "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
       "dev": true
     },
     "@types/run-sequence": {
@@ -521,9 +611,9 @@
       }
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.42",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.42.tgz",
-      "integrity": "sha1-dMt3+2BS7a/yqJhN2v2I1BnyXKw=",
+      "version": "2.53.43",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
+      "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
       "dev": true
     },
     "@types/vinyl": {
@@ -533,16 +623,6 @@
       "dev": true,
       "requires": {
         "@types/node": "7.0.46"
-      }
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
       }
     },
     "a-sync-waterfall": {
@@ -625,21 +705,21 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
@@ -715,70 +795,19 @@
       "dev": true
     },
     "archiver": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.16.0.tgz",
-      "integrity": "sha1-u1cDRomdCGXrd+1mcnqzxjT8GlA=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
+      "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
       "dev": true,
       "requires": {
-        "async": "1.4.2",
+        "archiver-utils": "1.3.0",
+        "async": "2.6.0",
         "buffer-crc32": "0.2.13",
-        "glob": "5.0.15",
-        "lazystream": "0.1.0",
-        "lodash": "3.10.1",
-        "readable-stream": "1.0.34",
-        "tar-stream": "1.2.2",
-        "zip-stream": "0.6.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3",
+        "tar-stream": "1.5.5",
+        "zip-stream": "1.2.0"
       }
     },
     "archiver-utils": {
@@ -793,17 +822,6 @@
         "lodash": "4.17.4",
         "normalize-path": "2.1.1",
         "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "lazystream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-          "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        }
       }
     },
     "archy": {
@@ -835,8 +853,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
       "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -957,7 +974,6 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "dev": true,
-      "optional": true,
       "requires": {
         "colour": "0.7.1",
         "optjs": "3.2.2"
@@ -982,9 +998,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -1015,7 +1031,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000748",
+        "caniuse-db": "1.0.30000764",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1035,9 +1051,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.4.2.tgz",
-      "integrity": "sha512-RyAyvCYPJ5y/Ov2mY67kuZG8SfxIAOAI0KuJ9nRXX/vDCL/RTcArGgtn5i2+uZjL23GC6eqMaJ6GjUEDEe11tw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.5.0.tgz",
+      "integrity": "sha512-onOXxjT3lXT3FfIBH5AIDxug+28Xw4q4XY66v+2rTRWg9o8dSiKr58ZWlCveh1cmE2kL5bT1KlO9PsSr7pWClA==",
       "dev": true
     },
     "axe-webdriverjs": {
@@ -1046,7 +1062,7 @@
       "integrity": "sha512-Nsb/6gyIGYFmQbo3NP14MZghNQff5m+v8D4ex4baad6DvtFzg6T843WZvbdb5F9oHCUWnXy5cgw4LhEpj4ffww==",
       "dev": true,
       "requires": {
-        "axe-core": "2.4.2"
+        "axe-core": "2.5.0"
       }
     },
     "babel-code-frame": {
@@ -1058,27 +1074,6 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1235,29 +1230,21 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
       "requires": {
-        "bytes": "2.4.0",
+        "bytes": "3.0.0",
         "content-type": "1.0.4",
-        "debug": "2.6.7",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "http-errors": "1.6.2",
-        "iconv-lite": "0.4.15",
+        "iconv-lite": "0.4.19",
         "on-finished": "2.3.0",
-        "qs": "6.4.0",
-        "raw-body": "2.2.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
         "type-is": "1.6.15"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        }
       }
     },
     "boom": {
@@ -1284,27 +1271,6 @@
         "repeating": "2.0.1",
         "string-width": "1.0.2",
         "widest-line": "1.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "brace-expansion": {
@@ -1351,7 +1317,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000748",
+        "caniuse-db": "1.0.30000764",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1424,20 +1390,54 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bun": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
+      "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "bytebuffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "long": "3.2.0"
       }
     },
     "bytes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "callsite": {
@@ -1473,9 +1473,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000748",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000748.tgz",
-      "integrity": "sha1-eF2e381kW/eVxv887TPEXVgMSKA=",
+      "version": "1.0.30000764",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000764.tgz",
+      "integrity": "sha1-1zqxGuYvap4vaYZ9bZwjrj8uXY0=",
       "dev": true
     },
     "canonical-path": {
@@ -1585,7 +1585,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1751,9 +1751,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1789,19 +1789,6 @@
         "yargs": "1.3.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "plur": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
@@ -1823,12 +1810,6 @@
             "postcss": "5.2.18"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
         "yargs": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
@@ -1847,8 +1828,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "combine-lists": {
       "version": "1.0.1",
@@ -1929,41 +1909,15 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.3.0.tgz",
-      "integrity": "sha1-lwk+Lhk/dWf6EyA9S43vzVlxpRk=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
-        "crc32-stream": "0.3.4",
-        "node-int64": "0.4.0",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
       }
     },
     "compressible": {
@@ -1988,23 +1942,6 @@
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
         "vary": "1.1.2"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "concat-map": {
@@ -2032,7 +1969,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
+        "make-dir": "1.1.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -2050,19 +1987,25 @@
         "utils-merge": "1.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "finalhandler": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
-        "utils-merge": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
       }
@@ -2159,33 +2102,33 @@
       "dev": true
     },
     "content-type-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
       "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.6.tgz",
-      "integrity": "sha512-AaQRALJYQVbfMs0UYJ3jf5yIAJwGnm/E7ETwzZMwF/3JDMyDaa4agLQomz94pcYiGH7zcrxFcwHApSODOYnunA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
+      "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.5.1",
-        "conventional-changelog-atom": "0.1.1",
-        "conventional-changelog-codemirror": "0.2.0",
-        "conventional-changelog-core": "1.9.2",
-        "conventional-changelog-ember": "0.2.8",
-        "conventional-changelog-eslint": "0.2.0",
-        "conventional-changelog-express": "0.2.0",
+        "conventional-changelog-angular": "1.5.2",
+        "conventional-changelog-atom": "0.1.2",
+        "conventional-changelog-codemirror": "0.2.1",
+        "conventional-changelog-core": "1.9.3",
+        "conventional-changelog-ember": "0.2.9",
+        "conventional-changelog-eslint": "0.2.1",
+        "conventional-changelog-express": "0.2.1",
         "conventional-changelog-jquery": "0.1.0",
         "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.2.0"
+        "conventional-changelog-jshint": "0.2.1"
       }
     },
     "conventional-changelog-angular": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.1.tgz",
-      "integrity": "sha512-AnjnPyqHp8yR2IOWsXYOCv6Ly0WC2rLRK04fgAS/5QoA3ovYLSoz9PKB5pcSG3M9lAf40IqZwU3R3G6Hy7XCSA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.2.tgz",
+      "integrity": "sha1-Kzj2Zf6cWSCvGi+C9Uf0ur5t5Xw=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -2193,36 +2136,36 @@
       }
     },
     "conventional-changelog-atom": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.1.tgz",
-      "integrity": "sha512-6Nlu/+MiD4gi7k3Z+N1vMJWpaPSdvFPWzPGnH4OXewHAxiAl0L/TT9CGgA01fosPxmYr4hMNtD7kyN0tkg8vIA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
+      "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.0.tgz",
-      "integrity": "sha512-jUbY98JoKdAOR5k3pOBiKZ+Iz9t2F84hL7x4WjSRW6x7FdeCEUOjyfml+YClE2h/h62Tf3mwur5jSO8upxxc1g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
+      "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.2.tgz",
-      "integrity": "sha512-L/boGKXaKWrlCU8bHa1QM36Pb/JopCPmekj5SFqqAuBfjya860xX2fAC5Ggelse++Bw39AZ2NrHwBnJrdwLlLw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.3.tgz",
+      "integrity": "sha1-KJn+d5OJoynw7EsnRsNt3vuY2i0=",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "2.0.1",
-        "conventional-commits-parser": "2.0.0",
+        "conventional-changelog-writer": "2.0.2",
+        "conventional-commits-parser": "2.0.1",
         "dateformat": "1.0.12",
         "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.2.0",
+        "git-raw-commits": "1.3.0",
         "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.2.2",
+        "git-semver-tags": "1.2.3",
         "lodash": "4.17.4",
         "normalize-package-data": "2.4.0",
         "q": "1.4.1",
@@ -2240,104 +2183,31 @@
             "get-stdin": "4.0.1",
             "meow": "3.7.0"
           }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
         }
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.8.tgz",
-      "integrity": "sha512-smsh0o/S95n22lrQZrSHYjJrxIGoFl+OFHK+q2KGHA2zRFrW7QilYM7VUjgmB+emzwqFguPjrq+D2U8iPhMNJg==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.9.tgz",
+      "integrity": "sha1-jsc8wFTjqwZGZ/sf61L+jvGxZDg=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.0.tgz",
-      "integrity": "sha512-WGKnC0bGPD6BHGiRBfYqNGfy6DZDn2jGs1yxPRT8I2796wYdGqsbDF4477o4fdsxUJvckoW2OFPqkmRMQaCHSA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
+      "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.0.tgz",
-      "integrity": "sha512-ujSEmbWfozC1iIjH5Pl7AKtREowvAl10whs1q6c7nZLnoNZK5CmdB2PQ/V42O6rCgUzaLX+ACRW2+g0A/Htqvw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
+      "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
@@ -2362,9 +2232,9 @@
       }
     },
     "conventional-changelog-jshint": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.0.tgz",
-      "integrity": "sha512-uUP4c0et6F2teapl+YY2JHFAHD401U5CkgI+P8PyU0y1zS8BdBy6EnhqgZEXhFOp9fPzUdic+Wv/9alOqw3agQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
+      "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -2372,13 +2242,13 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.1.tgz",
-      "integrity": "sha512-X4qC758celQOKw0iUPAsH5sJX6fH6N5dboFc3elXb1/SIKhsYMukhhaxWmxRdtVUSqGt9rZg8giwBQG5B2GeKg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.2.tgz",
+      "integrity": "sha1-tYV97RsAHa+aeLnNQJJvRcE0lJs=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.0.0",
+        "conventional-commits-filter": "1.1.0",
         "dateformat": "1.0.12",
         "handlebars": "4.0.11",
         "json-stringify-safe": "5.0.1",
@@ -2411,9 +2281,9 @@
       }
     },
     "conventional-commits-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-      "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.0.tgz",
+      "integrity": "sha1-H8Ka8wte2rdvVOIpxBGwxmPQ+es=",
       "dev": true,
       "requires": {
         "is-subset": "0.1.1",
@@ -2421,13 +2291,13 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.0.tgz",
-      "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.1.tgz",
+      "integrity": "sha1-HxXOa4RPfKQUlcgZDAgzwwuLFpM=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -2502,45 +2372,19 @@
       }
     },
     "crc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-      "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
       "dev": true
     },
     "crc32-stream": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
-      "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "crc": "3.5.0",
+        "readable-stream": "2.3.3"
       }
     },
     "create-error-class": {
@@ -2871,9 +2715,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -2920,13 +2764,13 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2"
+        "clone": "1.0.3"
       },
       "dependencies": {
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
           "dev": true
         }
       }
@@ -2943,7 +2787,29 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -2977,7 +2843,7 @@
       "dev": true,
       "requires": {
         "commander": "2.11.0",
-        "debug": "2.6.7",
+        "debug": "2.6.9",
         "filing-cabinet": "1.12.0",
         "precinct": "3.8.0"
       }
@@ -3228,7 +3094,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000748",
+        "caniuse-db": "1.0.30000764",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3338,6 +3204,12 @@
           "dev": true
         }
       }
+    },
+    "dom-storage": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.0.2.tgz",
+      "integrity": "sha1-7RfL9oq9EOCu+BgnE+KXxeS1ALA=",
+      "dev": true
     },
     "domelementtype": {
       "version": "1.3.0",
@@ -3908,56 +3780,48 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "optional": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.6",
-        "fresh": "0.5.0",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true,
           "optional": true
         },
@@ -3993,6 +3857,12 @@
           "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
           "dev": true
         },
+        "crc": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+          "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
+          "dev": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -4022,6 +3892,12 @@
           "requires": {
             "base64-url": "1.2.1"
           }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+          "dev": true
         }
       }
     },
@@ -4060,33 +3936,18 @@
       "requires": {
         "chalk": "1.1.3",
         "time-stamp": "1.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -4105,9 +3966,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
-      "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "dev": true,
       "requires": {
         "websocket-driver": "0.7.0"
@@ -4159,13 +4020,13 @@
       "requires": {
         "app-module-path": "1.1.0",
         "commander": "2.11.0",
-        "debug": "2.6.7",
+        "debug": "2.6.9",
         "enhanced-resolve": "3.0.3",
         "is-relative-path": "1.0.2",
         "module-definition": "2.2.4",
         "module-lookup-amd": "4.0.5",
         "object-assign": "4.1.1",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "resolve-dependency-path": "1.0.2",
         "sass-lookup": "1.1.0",
         "stylus-lookup": "1.0.2",
@@ -4192,10 +4053,11 @@
       "dev": true
     },
     "finalhandler": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
+      "optional": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.1",
@@ -4206,20 +4068,12 @@
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4291,788 +4145,45 @@
       }
     },
     "firebase": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.6.0.tgz",
-      "integrity": "sha512-lfVXLQiCNcNsmG7ZxQapQRdE/kZOjheBZVZ1MNK80GTsuK9RO7DYO5Qdf4K9Om8r7OBZ4nRp438kGkf24x7sOg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.6.2.tgz",
+      "integrity": "sha512-qI4qWZNO4/tS05goNaLYaxFd2/GgWVONPcqq+H1YyLi0ybWfF7oEVhw1dz8SY+7Xc5wc3S4jGSMi3apgINz1Zg==",
       "dev": true,
       "requires": {
-        "@firebase/app": "0.1.1",
-        "@firebase/auth": "0.2.0",
-        "@firebase/database": "0.1.2",
-        "@firebase/firestore": "0.1.2",
-        "@firebase/messaging": "0.1.2",
-        "@firebase/polyfill": "0.1.1",
-        "@firebase/storage": "0.1.1",
+        "@firebase/app": "0.1.2",
+        "@firebase/auth": "0.2.2",
+        "@firebase/database": "0.1.3",
+        "@firebase/firestore": "0.1.4",
+        "@firebase/messaging": "0.1.3",
+        "@firebase/polyfill": "0.1.2",
+        "@firebase/storage": "0.1.2",
         "dom-storage": "2.0.2",
         "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "base64url": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-          "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-        },
-        "buffer-equal-constant-time": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-        },
-        "dom-storage": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.0.2.tgz",
-          "integrity": "sha1-7RfL9oq9EOCu+BgnE+KXxeS1ALA=",
-          "dev": true
-        },
-        "ecdsa-sig-formatter": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-          "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-          "requires": {
-            "base64url": "2.0.0",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "faye-websocket": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
-          "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
-          "requires": {
-            "websocket-driver": "0.6.5"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.18.1",
-            "topo": "1.1.0"
-          }
-        },
-        "jsonwebtoken": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
-          "requires": {
-            "joi": "6.10.1",
-            "jws": "3.1.4",
-            "lodash.once": "4.1.1",
-            "ms": "2.0.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "jwa": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-          "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-          "requires": {
-            "base64url": "2.0.0",
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.9",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "jws": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-          "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-          "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "lodash.once": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "promise-polyfill": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
-          "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "websocket-driver": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-          "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-          "requires": {
-            "websocket-extensions": "0.1.1"
-          }
-        },
-        "websocket-extensions": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-          "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
-        },
-        "xmlhttprequest": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-          "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
       }
     },
     "firebase-admin": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-5.4.2.tgz",
-      "integrity": "sha1-AC9YvirYkBIp5SXsVfpybRL5BOs=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-5.5.0.tgz",
+      "integrity": "sha1-wxLgfcLCEmEFEwkwokjIHn1ux6c=",
       "dev": true,
       "requires": {
-        "@google-cloud/firestore": "0.8.2",
-        "@google-cloud/storage": "1.3.1",
-        "@types/google-cloud__storage": "1.1.5",
+        "@firebase/app": "0.1.2",
+        "@firebase/database": "0.1.3",
+        "@google-cloud/firestore": "0.9.0",
+        "@google-cloud/storage": "1.4.0",
+        "@types/google-cloud__storage": "1.1.6",
         "@types/jsonwebtoken": "7.2.3",
-        "@types/node": "8.0.33",
+        "@types/node": "8.0.51",
         "faye-websocket": "0.9.3",
         "google-auth-library": "0.10.0",
-        "jsonwebtoken": "7.1.9",
-        "lodash": "4.17.4",
+        "jsonwebtoken": "7.4.3",
         "node-forge": "0.7.1"
       },
       "dependencies": {
-        "@google-cloud/common": {
-          "version": "0.13.6",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
-          "integrity": "sha1-qdjhN7xCmkSrqWif5qDkMxeE+FM=",
-          "dev": true,
-          "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "google-auto-auth": "0.7.2",
-            "is": "3.2.1",
-            "log-driver": "1.2.5",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.0",
-            "request": "2.83.0",
-            "retry-request": "3.0.0",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
-            "through2": "2.0.3"
-          }
-        },
-        "@google-cloud/common-grpc": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.4.1.tgz",
-          "integrity": "sha1-CSZGB++4k0MJr/1jhJmG+7gPkhg=",
-          "dev": true,
-          "requires": {
-            "@google-cloud/common": "0.13.6",
-            "dot-prop": "2.4.0",
-            "duplexify": "3.5.1",
-            "extend": "3.0.1",
-            "grpc": "1.6.6",
-            "is": "3.2.1",
-            "modelo": "4.2.0",
-            "retry-request": "3.0.0",
-            "through2": "2.0.3"
-          }
-        },
-        "@google-cloud/firestore": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.8.2.tgz",
-          "integrity": "sha512-Z9hoiZIIn1MN7lUZE0pStvkrTdzJnSyFyxDJ4VojkzF/lL4EAUr9USyWXol6HZYcERPjXIasHSXXTYwuXx8tmA==",
-          "dev": true,
-          "requires": {
-            "@google-cloud/common": "0.13.6",
-            "@google-cloud/common-grpc": "0.4.1",
-            "bun": "0.0.12",
-            "extend": "3.0.1",
-            "functional-red-black-tree": "1.0.1",
-            "google-gax": "0.14.1",
-            "grpc": "1.6.6",
-            "is": "3.2.1",
-            "through2": "2.0.3"
-          }
-        },
-        "@google-cloud/storage": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.3.1.tgz",
-          "integrity": "sha512-tN2YttvQ33KwXuG2tpP3lEtxkZWV1yifc84YOusMjBCDoAal5GWXDPuCeFBI7cMs5LW+V2o3I9ZusOJZwYA8ug==",
-          "dev": true,
-          "requires": {
-            "@google-cloud/common": "0.13.6",
-            "arrify": "1.0.1",
-            "async": "2.5.0",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
-            "extend": "3.0.1",
-            "gcs-resumable-upload": "0.8.2",
-            "hash-stream-validation": "0.2.1",
-            "is": "3.2.1",
-            "mime-types": "2.1.17",
-            "once": "1.4.0",
-            "pumpify": "1.3.5",
-            "safe-buffer": "5.1.1",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
-            "through2": "2.0.3"
-          }
-        },
-        "@protobufjs/aspromise": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-          "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-          "dev": true
-        },
-        "@protobufjs/base64": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-          "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-          "dev": true
-        },
-        "@protobufjs/codegen": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-          "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-          "dev": true
-        },
-        "@protobufjs/eventemitter": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-          "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-          "dev": true
-        },
-        "@protobufjs/fetch": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-          "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/inquire": "1.1.0"
-          }
-        },
-        "@protobufjs/float": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-          "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-          "dev": true
-        },
-        "@protobufjs/inquire": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-          "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-          "dev": true
-        },
-        "@protobufjs/path": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-          "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-          "dev": true
-        },
-        "@protobufjs/pool": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-          "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-          "dev": true
-        },
-        "@protobufjs/utf8": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-          "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-          "dev": true
-        },
-        "@types/google-cloud__storage": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.5.tgz",
-          "integrity": "sha512-c82GoxSyQZASfOTpyMx8nvpIwySR+vXnkzymya9MQR7L+60ckLQVzn6yUMnOWgTDFM7EUzk79X5p8uSDx9jDVw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "8.0.33"
-          }
-        },
-        "@types/jsonwebtoken": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz",
-          "integrity": "sha512-cVhxZfVCyTZd1P+2a+xXSR9to7hZTulNRLLCQMVfAevUqx2Ee+EgsiD/7pX8qvdXWP3nWgSoTjKRLMrIpdPVjQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "8.0.33"
-          }
-        },
-        "@types/long": {
-          "version": "3.0.32",
-          "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-          "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
-          "dev": true
-        },
         "@types/node": {
-          "version": "8.0.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.33.tgz",
-          "integrity": "sha512-vmCdO8Bm1ExT+FWfC9sd9r4jwqM7o97gGy2WBshkkXbf/2nLAJQUrZfIhw27yVOtLUev6kSZc4cav/46KbDd8A==",
-          "dev": true
-        },
-        "ajv": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "arguejs": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
-          "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc=",
-          "dev": true
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "dev": true,
-          "requires": {
-            "array-uniq": "1.0.3"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "ascli": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-          "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-          "dev": true,
-          "requires": {
-            "colour": "0.7.1",
-            "optjs": "3.2.2"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "base64url": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-          "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-equal": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-          "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-          "dev": true
-        },
-        "buffer-equal-constant-time": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-          "dev": true
-        },
-        "bun": {
-          "version": "0.0.12",
-          "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
-          "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
-          }
-        },
-        "bytebuffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-          "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-          "dev": true,
-          "requires": {
-            "long": "3.2.0"
-          }
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "colour": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-          "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "configstore": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.0.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
-          },
-          "dependencies": {
-            "dot-prop": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-              "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-              "dev": true,
-              "requires": {
-                "is-obj": "1.0.1"
-              }
-            }
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "1.0.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "dot-prop": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
-          "integrity": "sha1-hI4o9/HVB0DGdHqzywdnBGK2+Jw=",
-          "dev": true,
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "duplexify": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-          "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "stream-shift": "1.0.0"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "ecdsa-sig-formatter": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-          "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-          "dev": true,
-          "requires": {
-            "base64url": "2.0.0",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "ent": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-          "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+          "version": "8.0.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.51.tgz",
+          "integrity": "sha512-El3+WJk2D/ppWNd2X05aiP5l2k4EwF7KwheknQZls+I26eSICoWRhRIJ56jGgw2dqNGQ5LtNajmBU2ajS28EvQ==",
           "dev": true
         },
         "faye-websocket": {
@@ -5083,1994 +4194,17 @@
           "requires": {
             "websocket-driver": "0.7.0"
           }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "functional-red-black-tree": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-          "dev": true
-        },
-        "gcp-metadata": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-          "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "retry-request": "3.0.0"
-          }
-        },
-        "gcs-resumable-upload": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.8.2.tgz",
-          "integrity": "sha512-PBl1OFABYxubxfYPh000I0+JLbQzBRtNqxzgxYboIQk2tdw7BvjJ2dVukk3YH4QM6GiUwqItyNqWBuxjLH8GhA==",
-          "dev": true,
-          "requires": {
-            "buffer-equal": "1.0.0",
-            "configstore": "3.1.1",
-            "google-auto-auth": "0.7.2",
-            "pumpify": "1.3.5",
-            "request": "2.83.0",
-            "stream-events": "1.0.2",
-            "through2": "2.0.3"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "dev": true,
-          "requires": {
-            "gtoken": "1.2.2",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-          "dev": true,
-          "requires": {
-            "async": "2.5.0",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
-            "request": "2.83.0"
-          }
-        },
-        "google-gax": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.1.tgz",
-          "integrity": "sha1-/oj7nVAw0mJ3xjUIp5r3s3F54Tk=",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "globby": "6.1.0",
-            "google-auto-auth": "0.5.4",
-            "google-proto-files": "0.13.1",
-            "grpc": "1.6.6",
-            "is-stream-ended": "0.1.3",
-            "lodash": "4.17.4",
-            "process-nextick-args": "1.0.7",
-            "protobufjs": "6.8.0",
-            "readable-stream": "2.3.3",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "7.0.43",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
-              "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
-              "dev": true
-            },
-            "google-auto-auth": {
-              "version": "0.5.4",
-              "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.5.4.tgz",
-              "integrity": "sha1-HYbHko1jPnWpwasDSlJ+/M5KQLE=",
-              "dev": true,
-              "requires": {
-                "async": "2.5.0",
-                "google-auth-library": "0.10.0",
-                "object-assign": "3.0.0",
-                "request": "2.83.0"
-              }
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-              "dev": true
-            },
-            "protobufjs": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.0.tgz",
-              "integrity": "sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==",
-              "dev": true,
-              "requires": {
-                "@protobufjs/aspromise": "1.1.2",
-                "@protobufjs/base64": "1.1.2",
-                "@protobufjs/codegen": "2.0.4",
-                "@protobufjs/eventemitter": "1.1.0",
-                "@protobufjs/fetch": "1.1.0",
-                "@protobufjs/float": "1.0.2",
-                "@protobufjs/inquire": "1.1.0",
-                "@protobufjs/path": "1.1.2",
-                "@protobufjs/pool": "1.1.0",
-                "@protobufjs/utf8": "1.1.0",
-                "@types/long": "3.0.32",
-                "@types/node": "7.0.43",
-                "long": "3.2.0"
-              }
-            }
-          }
-        },
-        "google-p12-pem": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-          "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
-          "dev": true,
-          "requires": {
-            "node-forge": "0.7.1"
-          }
-        },
-        "google-proto-files": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-          "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g==",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "grpc": {
-          "version": "1.6.6",
-          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.6.6.tgz",
-          "integrity": "sha1-IFF4T2vWE0aB+ixLXnXcgsbCP/o=",
-          "dev": true,
-          "requires": {
-            "arguejs": "0.2.3",
-            "lodash": "4.17.4",
-            "nan": "2.7.0",
-            "node-pre-gyp": "0.6.38",
-            "protobufjs": "5.0.2"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-              "dev": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-              "dev": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-              "dev": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-              "dev": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-              "dev": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-              "dev": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-              "dev": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-              "dev": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-              "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-              "dev": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-              "dev": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-              "dev": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "dev": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-              "dev": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-              "dev": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-              "dev": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-              "dev": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-              "dev": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-              "dev": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-              "dev": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-              "dev": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "dev": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-              "dev": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-              "dev": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-              "dev": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-              "dev": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-              "dev": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-              "dev": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-              "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-              "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-              "dev": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
-                }
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.38",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz",
-              "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
-              "dev": true,
-              "requires": {
-                "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.1",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.4.1",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "dev": true,
-              "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.4"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-              "dev": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-              "dev": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-              "dev": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-              "dev": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-              "dev": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-              "dev": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "dev": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-              "dev": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true
-            },
-            "semver": {
-              "version": "5.4.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-              "dev": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-              "dev": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-              "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-              "dev": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-              "dev": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-              "dev": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-              "dev": true,
-              "requires": {
-                "debug": "2.6.9",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.3",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-              "dev": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-              "dev": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-              "dev": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-              "dev": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-              "dev": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                }
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
-            }
-          }
-        },
-        "gtoken": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.2.tgz",
-          "integrity": "sha1-Fyd2oanZasCfwioA9b6DzubeiCA=",
-          "dev": true,
-          "requires": {
-            "google-p12-pem": "0.1.2",
-            "jws": "3.1.4",
-            "mime": "1.4.1",
-            "request": "2.83.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.2.3",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hash-stream-validation": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
-          "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
-          "dev": true,
-          "requires": {
-            "through2": "2.0.3"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
-        },
-        "http-parser-js": {
-          "version": "0.4.9",
-          "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-          "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
-        },
-        "is": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-          "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        },
-        "is-stream-ended": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-          "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.18.1",
-            "topo": "1.1.0"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true
-        },
-        "jsonwebtoken": {
-          "version": "7.1.9",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.1.9.tgz",
-          "integrity": "sha1-hHgE5SWL7FqUmajcSl56O64I1Yo=",
-          "dev": true,
-          "requires": {
-            "joi": "6.10.1",
-            "jws": "3.1.4",
-            "lodash.once": "4.1.1",
-            "ms": "0.7.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "jwa": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-          "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-          "dev": true,
-          "requires": {
-            "base64url": "2.0.0",
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.9",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "jws": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-          "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-          "dev": true,
-          "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "lodash.noop": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-          "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw=",
-          "dev": true
-        },
-        "lodash.once": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-          "dev": true
-        },
-        "log-driver": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-          "dev": true
-        },
-        "long": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
-          "dev": true
-        },
-        "make-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-          "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "methmeth": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
-          "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "modelo": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.0.tgz",
-          "integrity": "sha1-O0tCACOmbKfjK9uhbnEJN+FNGws=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
-          "dev": true
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "dev": true
-        },
-        "node-forge": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-          "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
-          "dev": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optjs": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-          "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "protobufjs": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-          "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
-          "dev": true,
-          "requires": {
-            "ascli": "1.0.1",
-            "bytebuffer": "5.0.1",
-            "glob": "7.1.2",
-            "yargs": "3.32.0"
-          }
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "pumpify": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-          "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "inherits": "2.0.3",
-            "pump": "1.0.2"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "retry-request": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.0.0.tgz",
-          "integrity": "sha1-i60rHc8Ek4uyEeLO2GLlkbgvGRc=",
-          "dev": true,
-          "requires": {
-            "request": "2.83.0",
-            "through2": "2.0.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "split-array-stream": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
-          "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
-          "dev": true,
-          "requires": {
-            "async": "2.5.0",
-            "is-stream-ended": "0.1.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stream-events": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
-          "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
-          "dev": true,
-          "requires": {
-            "stubs": "3.0.0"
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-          "dev": true
-        },
-        "string-format-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
-          "integrity": "sha1-djVhCx7zlwE+hHi+mKFw4EmD0Gg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "stubs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-          "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-          "dev": true
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "1.0.0"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "websocket-driver": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-          "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-          "dev": true,
-          "requires": {
-            "http-parser-js": "0.4.9",
-            "websocket-extensions": "0.1.2"
-          }
-        },
-        "websocket-extensions": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
-          "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
         }
       }
     },
     "firebase-tools": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.13.1.tgz",
-      "integrity": "sha1-LKgqXN1eiHxf6WHNgBnkqYdiX1o=",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.15.0.tgz",
+      "integrity": "sha1-H7qAH7N85D3Y0nA1MzSw5eaj/7M=",
       "dev": true,
       "requires": {
-        "@google-cloud/functions-emulator": "1.0.0-alpha.25",
-        "JSONStream": "1.3.1",
-        "archiver": "0.16.0",
+        "@google-cloud/functions-emulator": "1.0.0-alpha.27",
+        "archiver": "2.1.0",
         "chalk": "1.1.3",
         "cjson": "0.3.3",
         "cli-table": "0.3.1",
@@ -7089,6 +4223,7 @@
         "google-auto-auth": "0.7.2",
         "inquirer": "0.12.0",
         "jsonschema": "1.2.0",
+        "JSONStream": "1.3.1",
         "jsonwebtoken": "7.4.3",
         "lodash": "4.17.4",
         "open": "0.0.5",
@@ -7113,19 +4248,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
           "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
         },
         "configstore": {
           "version": "1.4.0",
@@ -7199,19 +4321,13 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "pkginfo": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
           "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "winston": {
@@ -7375,9 +4491,9 @@
       "optional": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from": {
@@ -7430,14 +4546,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -7595,7 +4711,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -7639,6 +4754,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -7784,7 +4905,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -7956,11 +5076,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -8168,7 +5290,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -8198,6 +5319,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -8206,14 +5335,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8337,7 +5458,7 @@
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "fstream-ignore": {
@@ -8350,6 +5471,12 @@
         "inherits": "2.0.3",
         "minimatch": "3.0.4"
       }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gather-stream": {
       "version": "1.0.0",
@@ -8389,7 +5516,7 @@
       "dev": true,
       "requires": {
         "extend": "3.0.1",
-        "retry-request": "3.1.0"
+        "retry-request": "3.1.1"
       }
     },
     "gcs-resumable-upload": {
@@ -8473,9 +5600,9 @@
       }
     },
     "git-raw-commits": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-      "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
+      "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
       "dev": true,
       "requires": {
         "dargs": "4.1.0",
@@ -8514,12 +5641,20 @@
       "requires": {
         "gitconfiglocal": "1.0.0",
         "pify": "2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "git-semver-tags": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.2.tgz",
-      "integrity": "sha512-fhINopzKBQ8m6YlQt7gPf6T6hFnTF84O7U+8kYJmfjjKk7gbmKGj+BLcKNWi+japPbBwCeXXnfKwThpJpR9ZnQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
+      "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
       "dev": true,
       "requires": {
         "meow": "3.7.0",
@@ -8697,17 +5832,24 @@
       }
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
         "array-union": "1.0.2",
-        "arrify": "1.0.1",
         "glob": "7.1.2",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "globjoin": {
@@ -8843,7 +5985,7 @@
       "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
       "dev": true,
       "requires": {
-        "gtoken": "1.2.2",
+        "gtoken": "1.2.3",
         "jws": "3.1.4",
         "lodash.noop": "3.0.1",
         "request": "2.83.0"
@@ -8855,7 +5997,7 @@
       "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "gcp-metadata": "0.3.1",
         "google-auth-library": "0.10.0",
         "request": "2.83.0"
@@ -8870,26 +6012,47 @@
         "chalk": "1.1.3",
         "vinyl": "2.1.0",
         "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "google-gax": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.2.tgz",
+      "integrity": "sha1-Kx8rhui+mKYgBBzucQ5PTOYbbis=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "globby": "6.1.0",
+        "google-auto-auth": "0.7.2",
+        "google-proto-files": "0.13.1",
+        "grpc": "1.7.1",
+        "is-stream-ended": "0.1.3",
+        "lodash": "4.17.4",
+        "process-nextick-args": "1.0.7",
+        "protobufjs": "6.8.0",
+        "readable-stream": "2.3.3",
+        "through2": "2.0.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "protobufjs": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.0.tgz",
+          "integrity": "sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/base64": "1.1.2",
+            "@protobufjs/codegen": "2.0.4",
+            "@protobufjs/eventemitter": "1.1.0",
+            "@protobufjs/fetch": "1.1.0",
+            "@protobufjs/float": "1.0.2",
+            "@protobufjs/inquire": "1.1.0",
+            "@protobufjs/path": "1.1.2",
+            "@protobufjs/pool": "1.1.0",
+            "@protobufjs/utf8": "1.1.0",
+            "@types/long": "3.0.32",
+            "@types/node": "7.0.46",
+            "long": "3.2.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -8903,16 +6066,15 @@
       }
     },
     "google-proto-files": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
-      "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ==",
-      "dev": true,
-      "optional": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
+      "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g==",
+      "dev": true
     },
     "googleapis": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-20.1.0.tgz",
-      "integrity": "sha512-UZYpUKPcwt28tZIvC+sT7yHtl56bMxnePNJBtZ3tG0OrQ1KegukirKRRuIxPavNCOcVC/ka5j/RRDhEIrYf5UA==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-22.2.0.tgz",
+      "integrity": "sha1-/XnDwm5+caT1ouwafaX7EV2IU9I=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8978,1243 +6140,845 @@
       }
     },
     "grpc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.4.1.tgz",
-      "integrity": "sha1-PuSoNGphPygjkoyfj5kIG2No7Hw=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.1.tgz",
+      "integrity": "sha512-lMgjZUzJx09VL5iCfs7rFagE5htikdv/9VzX/ji3zuwlzAhijqcU47bi5N5lbVw/UB2fxneeYg8sBTfQfd0c4A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "arguejs": "0.2.3",
         "lodash": "4.17.4",
         "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36",
+        "node-pre-gyp": "0.6.39",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.1",
+            "rc": "1.2.2",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
+            "rimraf": "2.6.2",
+            "semver": "5.4.1",
             "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "tar-pack": "3.4.1"
           },
           "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
-                }
-              }
-            },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
-                "abbrev": "1.1.0",
+                "abbrev": "1.0.9",
                 "osenv": "0.1.4"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-                  "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-                  "dev": true,
-                  "optional": true
-                },
-                "osenv": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-                  "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "os-homedir": "1.0.2",
-                    "os-tmpdir": "1.0.2"
-                  },
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.3.2"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "readable-stream": {
-                      "version": "2.3.2",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-                      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "safe-buffer": "5.1.1"
-                          }
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "1.1.2",
-                    "console-control-strings": "1.1.0",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.1",
-                    "signal-exit": "3.0.2",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.2"
-                  },
-                  "dependencies": {
-                    "aproba": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-                      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "dev": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                          "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                          "dev": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-                      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "string-width": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "rc": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-                  "dev": true,
-                  "optional": true
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-                  "dev": true,
-                  "optional": true
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                  "dev": true,
-                  "optional": true
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                  "dev": true,
-                  "optional": true
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-                  "dev": true,
-                  "optional": true
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-                  "dev": true,
-                  "optional": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "dev": true,
-                  "requires": {
-                    "delayed-stream": "1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                      "dev": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-                  "dev": true,
-                  "optional": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-                  "dev": true,
-                  "optional": true
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.15"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "ajv": "4.11.8",
-                    "har-schema": "1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "jsonify": "0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "boom": "2.10.1"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                      "dev": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.4.0",
-                    "sshpk": "1.13.1"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                          "dev": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                          "dev": true
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "0.14.5"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "assert-plus": "1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "0.1.1"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "assert-plus": "1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-                  "dev": true,
-                  "optional": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-                  "dev": true,
-                  "optional": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-                  "dev": true,
-                  "optional": true
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-                  "dev": true,
-                  "requires": {
-                    "mime-db": "1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                      "dev": true
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-                  "dev": true,
-                  "optional": true
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-                  "dev": true,
-                  "optional": true
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-                  "dev": true,
-                  "optional": true
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                  "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                  "dev": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-                  "dev": true,
-                  "optional": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "punycode": "1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                },
-                "uuid": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-                  "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-              "dev": true,
-              "requires": {
-                "glob": "7.1.2"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.2",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-                  "dev": true,
-                  "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
-                  },
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                      "dev": true
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                      "dev": true,
-                      "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "1.1.8"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-              "dev": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-              "dev": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                  "dev": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.1"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.2",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.8",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "ms": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.1"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                      "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4"
-                  },
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "brace-expansion": "1.1.8"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "balanced-match": "1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                              "dev": true,
-                              "optional": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-                  "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "safe-buffer": "5.1.1",
-                    "string_decoder": "1.0.3",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "safe-buffer": "5.1.1"
-                      }
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-                  "dev": true,
-                  "optional": true
-                }
               }
             }
           }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.3.3",
+            "rimraf": "2.6.2",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
         }
       }
     },
     "gtoken": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.2.tgz",
-      "integrity": "sha1-Fyd2oanZasCfwioA9b6DzubeiCA=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
+      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
       "dev": true,
       "requires": {
         "google-p12-pem": "0.1.2",
@@ -10244,29 +7008,10 @@
         "vinyl-fs": "0.3.14"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -10278,7 +7023,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "2.2.20",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "through2": "0.4.2"
       },
       "dependencies": {
@@ -10521,27 +7266,6 @@
         "v8flags": "2.1.1",
         "wreck": "6.3.0",
         "yargs": "3.32.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "gulp-connect": {
@@ -10844,6 +7568,12 @@
             }
           }
         },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+          "dev": true
+        },
         "vary": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
@@ -10853,14 +7583,14 @@
       }
     },
     "gulp-conventional-changelog": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.6.tgz",
-      "integrity": "sha512-zJ3ZfEukUqzLmFTWA5r8k9D4UAsymq+zsgINJmTRhw+H6Q1O9iCgREeye0gxicmusm6z6jI0fz5wLvlS66cmFg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.7.tgz",
+      "integrity": "sha1-Azf2hLSeKTWOYj4W6UtJ8FotK/E=",
       "dev": true,
       "requires": {
         "add-stream": "1.0.0",
         "concat-stream": "1.6.0",
-        "conventional-changelog": "1.1.6",
+        "conventional-changelog": "1.1.7",
         "gulp-util": "3.0.8",
         "object-assign": "4.1.1",
         "through2": "2.0.3"
@@ -10877,23 +7607,10 @@
         "through2": "2.0.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
           "dev": true
         },
         "clone-stats": {
@@ -10970,12 +7687,6 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
         "through2": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
@@ -10992,7 +7703,7 @@
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -11079,7 +7790,7 @@
       "requires": {
         "gulp-util": "3.0.8",
         "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.5.3",
+        "node-sass": "4.6.1",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
@@ -11120,23 +7831,10 @@
         "vinyl": "0.5.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
           "dev": true
         },
         "clone-stats": {
@@ -11157,19 +7855,13 @@
           "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
           "dev": true
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
         "vinyl": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -11232,7 +7924,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -11324,7 +8016,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -11377,12 +8069,12 @@
       "dev": true
     },
     "html-encoding-sniffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
-      "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html-minifier": {
@@ -11398,7 +8090,7 @@
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.1.4"
+        "uglify-js": "3.1.9"
       },
       "dependencies": {
         "source-map": {
@@ -11408,9 +8100,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.4.tgz",
-          "integrity": "sha512-DcbkPg11Lw2lAWpwCmQDX+qoR4JiII6ypsQmF6tscZtlxGPFAmSRUGuMoVT3/0EHqypVik/TpkH4ITiMJeQqQA==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.9.tgz",
+          "integrity": "sha512-ari2E89bD7f+fMU173NgF12JBcOhgoxeyuCs97h5K58IBENrnG9eVj2lFadrOPdqf0KifsxVmUQfzA2cHNxCZQ==",
           "dev": true,
           "requires": {
             "commander": "2.11.0",
@@ -11491,7 +8183,7 @@
       "dev": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.7",
+        "debug": "2.6.9",
         "extend": "3.0.1"
       }
     },
@@ -11503,15 +8195,15 @@
       "optional": true
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "image-diff": {
@@ -11643,27 +8335,6 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "interpret": {
@@ -11679,9 +8350,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true,
       "optional": true
     },
@@ -11723,9 +8394,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -12209,7 +8880,7 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.19.1",
+        "moment": "2.19.2",
         "topo": "1.1.0"
       },
       "dependencies": {
@@ -12279,12 +8950,12 @@
         "acorn": "2.7.0",
         "acorn-globals": "1.0.9",
         "array-equal": "1.0.0",
-        "content-type-parser": "1.0.1",
+        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
         "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.1",
-        "iconv-lite": "0.4.15",
+        "html-encoding-sniffer": "1.0.2",
+        "iconv-lite": "0.4.19",
         "nwmatcher": "1.4.3",
         "parse5": "1.5.1",
         "request": "2.83.0",
@@ -12292,17 +8963,9 @@
         "symbol-tree": "3.2.2",
         "tough-cookie": "2.3.3",
         "webidl-conversions": "3.0.1",
-        "whatwg-encoding": "1.0.1",
+        "whatwg-encoding": "1.0.3",
         "whatwg-url": "3.1.0",
         "xml-name-validator": "2.0.1"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-          "dev": true
-        }
       }
     },
     "json-parse-helpfulerror": {
@@ -12325,15 +8988,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -12368,16 +9022,6 @@
         "through2": "0.6.5"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "0.0.5",
-            "through": "2.3.8"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -12389,6 +9033,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
           "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "0.0.5",
+            "through": "2.3.8"
+          }
         },
         "readable-stream": {
           "version": "1.0.34",
@@ -12430,12 +9084,6 @@
         }
       }
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -12453,6 +9101,16 @@
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
       "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg==",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsonwebtoken": {
       "version": "7.4.3",
@@ -12480,9 +9138,9 @@
       }
     },
     "jszip": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.4.tgz",
-      "integrity": "sha512-z6w8iYIxZ/fcgul0j/OerkYnkomH8BZigvzbxVmr2h5HkZUrPtk2kjYtLkqR9wwQxEP6ecKNoKLsbhd18jfnGA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
         "core-js": "2.3.0",
@@ -12550,7 +9208,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "body-parser": "1.17.2",
+        "body-parser": "1.18.2",
         "chokidar": "1.7.0",
         "colors": "1.1.2",
         "combine-lists": "1.0.1",
@@ -12570,7 +9228,7 @@
         "optimist": "0.6.1",
         "qjobs": "1.1.5",
         "range-parser": "1.2.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
         "source-map": "0.5.7",
@@ -12680,7 +9338,7 @@
       "dev": true,
       "requires": {
         "q": "1.5.1",
-        "sauce-connect-launcher": "1.2.2",
+        "sauce-connect-launcher": "1.2.3",
         "saucelabs": "1.4.0",
         "wd": "1.4.1"
       },
@@ -12708,7 +9366,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -12748,38 +9406,12 @@
       "dev": true
     },
     "lazystream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "readable-stream": "2.3.3"
       }
     },
     "lcid": {
@@ -12879,7 +9511,7 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "livereload-js": {
@@ -12889,16 +9521,33 @@
       "dev": true
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
       }
     },
     "locate-path": {
@@ -13218,27 +9867,6 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "log4js": {
@@ -13287,8 +9915,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -13357,19 +9984,6 @@
         "walkdir": "0.0.11"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -13409,17 +10023,6 @@
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
-        "mz": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/mz/-/mz-2.4.0.tgz",
-          "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
-          "dev": true,
-          "requires": {
-            "any-promise": "1.3.0",
-            "object-assign": "4.1.1",
-            "thenify-all": "1.6.0"
-          }
-        },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -13440,12 +10043,6 @@
             "cli-spinners": "1.1.0",
             "log-symbols": "1.0.2"
           }
-        },
-        "pluralize": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-          "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
-          "dev": true
         },
         "rc": {
           "version": "1.1.6",
@@ -13474,12 +10071,6 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -13493,12 +10084,12 @@
       }
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -13663,81 +10254,6 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
       }
     },
     "merge-descriptors": {
@@ -13772,17 +10288,6 @@
         "methods": "1.1.2",
         "parseurl": "1.3.2",
         "vary": "1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "methods": {
@@ -13958,9 +10463,9 @@
       }
     },
     "moment": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
       "dev": true
     },
     "morgan": {
@@ -13974,17 +10479,6 @@
         "depd": "1.1.1",
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "ms": {
@@ -14099,9 +10593,9 @@
       "optional": true
     },
     "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.4.0.tgz",
+      "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -14208,7 +10702,7 @@
         "npmlog": "4.1.2",
         "osenv": "0.1.4",
         "request": "2.83.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
         "which": "1.3.0"
@@ -14239,16 +10733,10 @@
       "integrity": "sha1-iXNhjXJ9pVJqgwtH0HwNgD4KFcY=",
       "dev": true
     },
-    "node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
-    },
     "node-sass": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.1.tgz",
+      "integrity": "sha512-0zQQ7tjEK5W8RfW9LiQrkzfo7uLZ0QtZGV69rdKn5cFzdweHLJ14lR6xLPvI6UimkXMO8m0qDsXwUCNdnqV3sA==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -14271,19 +10759,6 @@
         "stdout-stream": "1.4.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "cross-spawn": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -14313,12 +10788,6 @@
             "lodash": "4.17.4",
             "minimatch": "3.0.4"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -14615,8 +11084,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
       "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ora": {
       "version": "0.2.3",
@@ -14628,27 +11096,6 @@
         "cli-cursor": "1.0.2",
         "cli-spinners": "0.1.2",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "orchestrator": {
@@ -14873,6 +11320,12 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true
+    },
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
@@ -14979,13 +11432,22 @@
       "dev": true
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "pify": "2.3.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "pause": {
@@ -15010,9 +11472,9 @@
       "dev": true
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
@@ -15053,6 +11515,12 @@
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
     },
+    "pluralize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "dev": true
+    },
     "portfinder": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
@@ -15081,29 +11549,6 @@
         "js-base64": "2.3.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "postcss-less": {
@@ -15332,7 +11777,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
       "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ascli": "1.0.1",
         "bytebuffer": "5.0.1",
@@ -15355,7 +11799,7 @@
       "requires": {
         "@types/node": "6.0.90",
         "@types/q": "0.0.32",
-        "@types/selenium-webdriver": "2.53.42",
+        "@types/selenium-webdriver": "2.53.43",
         "blocking-proxy": "0.0.5",
         "chalk": "1.1.3",
         "glob": "7.1.2",
@@ -15382,19 +11826,6 @@
           "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
           "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "saucelabs": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
@@ -15403,12 +11834,6 @@
           "requires": {
             "https-proxy-agent": "1.0.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         },
         "webdriver-manager": {
           "version": "12.0.6",
@@ -15424,7 +11849,7 @@
             "minimist": "1.2.0",
             "q": "1.4.1",
             "request": "2.83.0",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "semver": "5.4.1",
             "xml2js": "0.4.19"
           }
@@ -15432,14 +11857,14 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "optional": true,
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "prr": {
@@ -15568,7 +11993,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -15579,7 +12004,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -15591,13 +12016,14 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.15",
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
       }
     },
@@ -15643,26 +12069,45 @@
       }
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "load-json-file": "2.0.0",
+        "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -15717,7 +12162,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "redent": {
@@ -15837,17 +12282,6 @@
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        }
       }
     },
     "require-directory": {
@@ -15936,9 +12370,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -15996,9 +12430,9 @@
       }
     },
     "retry-request": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.1.0.tgz",
-      "integrity": "sha512-jOwZQlWR/boHhbAfzfOoUn28EDDotW2A7YxV2o5mfBb07H0k/zZAgbxRcckW08GKl/aT0JtPk1NViuk2BfHqVg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.1.1.tgz",
+      "integrity": "sha512-Sj3M3bC8ODJT+jfVxbTwvORRkFtc/AlDhhiMch5RJalLMAjz6+lIf5Q/Ox2esAM4tXcAYfG4ecNHPtaGNWIqvQ==",
       "dev": true,
       "requires": {
         "request": "2.83.0",
@@ -16022,9 +12456,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -16063,7 +12497,7 @@
         "browser-resolve": "1.11.2",
         "builtin-modules": "1.1.1",
         "is-module": "1.0.0",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "router": {
@@ -16087,25 +12521,10 @@
           "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
           "dev": true
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "dev": true
         }
       }
@@ -16142,9 +12561,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.0.tgz",
-      "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "requires": {
         "symbol-observable": "1.0.4"
       }
@@ -16164,7 +12583,7 @@
         "es6-promise": "3.3.1",
         "graceful-fs": "4.1.11",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "es6-promise": {
@@ -16192,79 +12611,6 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
         },
         "which-module": {
           "version": "1.0.0",
@@ -16326,16 +12672,16 @@
       }
     },
     "sauce-connect-launcher": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.2.tgz",
-      "integrity": "sha1-c0bMj73EQxkTI0ObBzNFH181IfI=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.3.tgz",
+      "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
       "dev": true,
       "requires": {
         "adm-zip": "0.4.7",
-        "async": "2.5.0",
+        "async": "2.6.0",
         "https-proxy-agent": "1.0.0",
         "lodash": "4.17.4",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "saucelabs": {
@@ -16363,7 +12709,7 @@
         "globs": "0.1.3",
         "mkdirp": "0.5.1",
         "mz": "2.7.0",
-        "node-sass": "4.5.3",
+        "node-sass": "4.6.1",
         "pretty-bytes": "4.0.2",
         "promise": "7.3.1",
         "yargs": "7.1.0"
@@ -16375,77 +12721,15 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+        "mz": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+          "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
+            "any-promise": "1.3.0",
+            "object-assign": "4.1.1",
+            "thenify-all": "1.6.0"
           }
         },
         "which-module": {
@@ -16513,8 +12797,8 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "3.1.4",
-        "rimraf": "2.6.1",
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
         "tmp": "0.0.30",
         "xml2js": "0.4.19"
       },
@@ -16555,41 +12839,26 @@
       }
     },
     "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "fresh": "0.5.0",
+        "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -16715,16 +12984,16 @@
       }
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.4"
+        "send": "0.16.1"
       }
     },
     "set-blocking": {
@@ -16871,9 +13140,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
         "hoek": "4.2.0"
@@ -17109,7 +13378,7 @@
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "is-stream-ended": "0.1.3"
       }
     },
@@ -17230,6 +13499,15 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-format-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
@@ -17263,15 +13541,6 @@
         "strip-ansi": "3.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "stringify-object": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.1.8.tgz",
@@ -17300,10 +13569,14 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -17358,19 +13631,6 @@
         "write-file-stdout": "0.0.2"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "plur": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
@@ -17391,12 +13651,6 @@
             "log-symbols": "1.0.2",
             "postcss": "5.2.18"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -17408,10 +13662,10 @@
       "requires": {
         "autoprefixer": "6.7.7",
         "balanced-match": "0.4.2",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "colorguard": "1.2.0",
         "cosmiconfig": "2.2.2",
-        "debug": "2.6.7",
+        "debug": "2.6.9",
         "doiuse": "2.6.0",
         "execall": "1.0.0",
         "file-entry-cache": "2.0.0",
@@ -17419,7 +13673,7 @@
         "globby": "6.1.0",
         "globjoin": "0.1.4",
         "html-tags": "2.0.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "known-css-properties": "0.2.0",
         "lodash": "4.17.4",
@@ -17459,7 +13713,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "balanced-match": {
@@ -17469,9 +13723,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -17485,19 +13739,6 @@
           "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
           "dev": true
         },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -17508,6 +13749,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "string-width": {
@@ -17624,19 +13871,6 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "configstore": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
@@ -17673,7 +13907,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "isarray": {
@@ -17690,12 +13924,6 @@
           "requires": {
             "isarray": "0.0.1"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         },
         "update-notifier": {
           "version": "1.0.3",
@@ -17810,9 +14038,9 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "chalk": "2.2.0",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
         "lodash": "4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
@@ -17830,13 +14058,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -17914,9 +14142,9 @@
       }
     },
     "tar-stream": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.2.tgz",
-      "integrity": "sha1-ljLyPZj9M9QWYbvewFSJEg3sYCg=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
         "bl": "1.2.1",
@@ -18241,7 +14469,7 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "diff": "3.4.0",
         "make-error": "1.3.0",
         "minimist": "1.2.0",
@@ -18258,13 +14486,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -18306,6 +14534,14 @@
       "requires": {
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "tsconfig-paths": {
@@ -18364,15 +14600,15 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "commander": "2.11.0",
         "diff": "3.4.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.0",
-        "tsutils": "2.12.1"
+        "tsutils": "2.12.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18381,13 +14617,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -18419,9 +14655,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
-      "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
+      "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
       "dev": true,
       "requires": {
         "tslib": "1.8.0"
@@ -18673,7 +14909,7 @@
             "graceful-fs": "3.0.11",
             "inherits": "2.0.3",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "graceful-fs": {
@@ -18732,19 +14968,6 @@
         "string-length": "1.0.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "configstore": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
@@ -18814,12 +15037,6 @@
           "requires": {
             "is-finite": "1.0.2"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         },
         "timed-out": {
           "version": "2.0.0",
@@ -18937,7 +15154,7 @@
         "i": "0.3.6",
         "mkdirp": "0.5.1",
         "ncp": "1.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -18950,9 +15167,9 @@
       }
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -19104,16 +15321,6 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
-        "strip-bom": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
-          }
-        },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -19191,7 +15398,7 @@
             "glob": "7.1.2",
             "lodash": "4.16.2",
             "readable-stream": "2.3.3",
-            "tar-stream": "1.5.4",
+            "tar-stream": "1.5.5",
             "walkdir": "0.0.11",
             "zip-stream": "1.2.0"
           }
@@ -19231,47 +15438,6 @@
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "compress-commons": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
-          "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
-          "dev": true,
-          "requires": {
-            "buffer-crc32": "0.2.13",
-            "crc32-stream": "2.0.0",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "crc": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
-          "dev": true
-        },
-        "crc32-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-          "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-          "dev": true,
-          "requires": {
-            "crc": "3.5.0",
-            "readable-stream": "2.3.3"
-          }
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -19383,41 +15549,11 @@
             "hoek": "2.16.3"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "dev": true,
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
-        },
-        "zip-stream": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-          "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
-          "dev": true,
-          "requires": {
-            "archiver-utils": "1.3.0",
-            "compress-commons": "1.2.2",
-            "lodash": "4.16.2",
-            "readable-stream": "2.3.3"
-          }
         }
       }
     },
@@ -19433,7 +15569,7 @@
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "2.53.42",
+        "@types/selenium-webdriver": "2.53.43",
         "selenium-webdriver": "2.53.3"
       },
       "dependencies": {
@@ -19456,7 +15592,7 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "tmp": "0.0.24",
             "ws": "1.1.2",
             "xml2js": "0.4.4"
@@ -19493,30 +15629,22 @@
       "dev": true,
       "requires": {
         "http-parser-js": "0.4.9",
-        "websocket-extensions": "0.1.2"
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
-      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
     "whatwg-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-      "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.13"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-          "dev": true
-        }
+        "iconv-lite": "0.4.19"
       }
     },
     "whatwg-url": {
@@ -19727,6 +15855,12 @@
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
       "dev": true
     },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
@@ -19767,9 +15901,9 @@
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -19798,46 +15932,15 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.6.0.tgz",
-      "integrity": "sha1-7pM67ZlvsYs0SpGuO10mTOxegSs=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "compress-commons": "0.3.0",
-        "lodash": "3.10.1",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3"
       }
     },
     "zone.js": {

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -468,7 +468,7 @@ describe('CdkTable', () => {
     dynamicDataSourceFixture.detectChanges();
 
     // Expect that the component has no data source and the table element reflects empty data.
-    expect(component.dataSource).toBe(undefined);
+    expect(component.dataSource).toBeUndefined();
     expectTableToMatchContent(tableElement, [
       ['Column A']
     ]);


### PR DESCRIPTION
Fixes a compilation error in the table tests and fixes the package-lock not being up to date.

**Note:** The tests currently time out. They'll be fixed by https://github.com/angular/material2/pull/8385.