### PR TITLE
fix(button): only show focus indicator for keyboard

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -51,10 +51,8 @@ $mat-mini-fab-padding: 8px !default;
     cursor: default;
   }
 
-  &.cdk-keyboard-focused, &.cdk-program-focused {
-    .mat-button-focus-overlay {
-      opacity: 1;
-    }
+  &.cdk-keyboard-focused .mat-button-focus-overlay {
+    opacity: 1;
   }
 
   &::-moz-focus-inner {


### PR DESCRIPTION
* No longer shows the focus indicator when the button is focused through `program`. This behavior should be similar across components like slide-toggle, checkbox, radio etc.

Fixes #8420