### PR TITLE
build: fix travis required tests not running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - env: "MODE=saucelabs_required"
     - env: "MODE=browserstack_required"
     - env: "MODE=travis_required"
-      env: "DEPLOY_MODE=build-artifacts"
+    - env: "DEPLOY_MODE=build-artifacts"
     - env: "DEPLOY_MODE=docs-content"
     - env: "DEPLOY_MODE=screenshot-tool"
     - env: "DEPLOY_MODE=dashboard"

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -110,7 +110,7 @@ describe('MatInput without forms', function () {
 
   it('should not be treated as empty if type is date',
       inject([Platform], (platform: Platform) => {
-        if (!(platform.TRIDENT || platform.FIREFOX || (platform.SAFARI && !platform.IOS))) {
+        if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
           let fixture = TestBed.createComponent(MatInputDateTestController);
           fixture.detectChanges();
 
@@ -123,7 +123,7 @@ describe('MatInput without forms', function () {
   // Firefox, Safari Desktop and IE don't support type="date" and fallback to type="text".
   it('should be treated as empty if type is date on Firefox and IE',
       inject([Platform], (platform: Platform) => {
-        if (platform.TRIDENT || platform.FIREFOX || (platform.SAFARI && !platform.IOS)) {
+        if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
           let fixture = TestBed.createComponent(MatInputDateTestController);
           fixture.detectChanges();
 

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -120,8 +120,8 @@ describe('MatInput without forms', function () {
         }
       }));
 
-  // Firefox, Safari Desktop and IE don't support type="date" and fallback to type="text".
-  it('should be treated as empty if type is date on Firefox and IE',
+  // Safari Desktop and IE don't support type="date" and fallback to type="text".
+  it('should be treated as empty if type is date in Safari Desktop or IE',
       inject([Platform], (platform: Platform) => {
         if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
           let fixture = TestBed.createComponent(MatInputDateTestController);


### PR DESCRIPTION
* Fixes that the `travis_required` CI mode isn't running. This mode is important for Firefox and Chrome testing.