### PR TITLE
build: update sauce connect

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-TUNNEL_FILE="sc-4.4.9-linux.tar.gz"
+TUNNEL_FILE="sc-4.4.10-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 


### PR DESCRIPTION
* Manually updates SauceConnect to v4.4.10

Unfortunately there is still no way to automatically download the latest version (https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)