### PR TITLE
fix(input): remove native IE reveal icon

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -32,8 +32,8 @@
     box-shadow: none;
   }
 
-  // Remove IE's default clear icon.
-  &::-ms-clear {
+  // Remove IE's default clear and reveal icons.
+  &::-ms-clear, &::-ms-reveal {
     display: none;
   }
 


### PR DESCRIPTION
Removes the password reveal icon, that IE adds by default on inputs, for cross-browser consistency.

Fixes #8390.