### PR TITLE
fix(fab-buttons): vertically align icons inside fab buttons

### DIFF
--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -51,7 +51,7 @@
 }
 
 // The text and icon should be vertical aligned inside a button
-.mat-button, .mat-raised-button, .mat-icon-button {
+.mat-button, .mat-raised-button, .mat-icon-button, .mat-fab, .mat-mini-fab {
   color: currentColor;
   .mat-button-wrapper > * {
     vertical-align: middle;


### PR DESCRIPTION
- added `.mat-fab` & `.mat-mini-fab`to the vertical align definition of buttons