### PR TITLE
chore: remove tslint type workaround

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -6,6 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {ESCAPE} from '@angular/cdk/keycodes';
+import {TemplatePortal} from '@angular/cdk/portal';
 import {
   Directive,
   ElementRef,
@@ -22,23 +26,16 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import {Direction, Directionality} from '@angular/cdk/bidi';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {ESCAPE} from '@angular/cdk/keycodes';
-import {TemplatePortal} from '@angular/cdk/portal';
+import {Subscription} from 'rxjs/Subscription';
 import {Overlay} from './overlay';
-import {OverlayRef} from './overlay-ref';
 import {OverlayConfig} from './overlay-config';
+import {OverlayRef} from './overlay-ref';
 import {
-  // This import is only used to define a generic type. The current TypeScript version incorrectly
-  // considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
-  // tslint:disable-next-line:no-unused-variable
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
 } from './position/connected-position';
 import {ConnectedPositionStrategy} from './position/connected-position-strategy';
 import {RepositionScrollStrategy, ScrollStrategy} from './scroll/index';
-import {Subscription} from 'rxjs/Subscription';
 
 
 /** Default set of positions for the overlay. Follows the behavior of a dropdown. */

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -13,9 +13,6 @@ import {
   Output,
   QueryList,
   Directive,
-  // This import is only used to define a generic type. The current TypeScript version incorrectly
-  // considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
-  // tslint:disable-next-line:no-unused-variable
   ElementRef,
   Component,
   ContentChild,

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -6,15 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Overlay, CdkOverlayOrigin, OverlayConfig} from '@angular/cdk/overlay';
-import {
-  ComponentPortal,
-  // This import is only used to define a generic type. The current TypeScript version incorrectly
-  // considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
-  // tslint:disable-next-line:no-unused-variable
-  Portal,
-  CdkPortal
-} from '@angular/cdk/portal';
+import {CdkOverlayOrigin, Overlay, OverlayConfig} from '@angular/cdk/overlay';
+import {CdkPortal, ComponentPortal, Portal} from '@angular/cdk/portal';
 import {
   Component,
   QueryList,
@@ -23,8 +16,8 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/filter';
 
 
 @Component({

--- a/tools/dashboard/src/app/dashboard-app.ts
+++ b/tools/dashboard/src/app/dashboard-app.ts
@@ -1,11 +1,7 @@
 import {Component} from '@angular/core';
 import {AngularFireDatabase} from 'angularfire2/database';
 import {Observable} from 'rxjs/Observable';
-
-// This import is only used to define a generic type. The current TypeScript version incorrectly
-// considers such imports as unused (https://github.com/Microsoft/TypeScript/issues/14953)
-// tslint:disable-next-line:no-unused-variable
-import {PayloadResult, CoverageResult} from './data-definitions';
+import {CoverageResult, PayloadResult} from './data-definitions';
 
 @Component({
   selector: 'dashboard-app',


### PR DESCRIPTION
* Due to a TSLint issue (https://github.com/palantir/tslint/issues/2470) imports that were used as a type argument were treated as unused. This has been fixed with TypeScript ^2.4.0 and the workaround (using `//tslint:disable` comments)  can be removed.

@jelbourn Also sorted the imports in those files using the module-based sort thing from WS.