### PR TITLE
fix(paginator): set default display value

### DIFF
--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -18,6 +18,10 @@ $mat-paginator-button-icon-width: 8px;
 $mat-paginator-button-decrement-icon-margin: 12px;
 $mat-paginator-button-increment-icon-margin: 16px;
 
+.mat-paginator {
+  display: block;
+}
+
 .mat-paginator-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Makes the `mat-paginator` a block-level element by default, instead of inline.

Fixes #8454.