### PR TITLE
fix(select):make input lable visible when selecting from mat-select

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -61,7 +61,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   padding-bottom: 0;
   max-height: $mat-select-panel-max-height;
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
-  margin-top: 10px; //makes floating label visible by moving dropdown panel 10px lower
+  margin-top: 10px; //makes floating label visible by moving dropdown panel 10px lower 
 
   @include cdk-high-contrast {
     outline: solid 1px;

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -61,7 +61,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   padding-bottom: 0;
   max-height: $mat-select-panel-max-height;
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
-  margin-top: 10px; //makes floating lable visible by moving dropdown panel 10px lower
+  margin-top: 10px; //makes floating label visible by moving dropdown panel 10px lower
 
   @include cdk-high-contrast {
     outline: solid 1px;

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -61,6 +61,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   padding-bottom: 0;
   max-height: $mat-select-panel-max-height;
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
+  margin-top: 10px; //makes floating lable visible by moving dropdown panel 10px lower
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Make input label visible so users know what they are selecting
Before : 
![image](https://user-images.githubusercontent.com/18407297/32913592-9fcce974-cac7-11e7-99d4-3024a9ec71fd.png)

After: 
![image](https://user-images.githubusercontent.com/18407297/32913637-c18de324-cac7-11e7-8e1c-a792a6c78cf5.png)
