### PR TITLE
refactor(focus-trap): better handling of server-side rendering

### DIFF
--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -313,3 +313,9 @@
   <mat-step label="Step 1">Content 1</mat-step>
   <mat-step label="Step 2">Content 2</mat-step>
 </mat-horizontal-stepper>
+
+<h2>Focus trap</h2>
+
+<div cdkTrapFocus cdkTrapFocusAutoCapture>
+  <button>Oh no, I'm trapped!</button>
+</div>


### PR DESCRIPTION
Now that Angular is using Domino, we don't have to completely shut off the focus trap when rendering on the server. These changes remove all the old checks and use the correct document injection token.