### PR TITLE
chore(checkbox): remove fake viewport ruler in tests

### DIFF
--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -9,8 +9,7 @@ import {
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {ViewportRuler} from '@angular/cdk/scrolling';
-import {dispatchFakeEvent, FakeViewportRuler} from '@angular/cdk/testing';
+import {dispatchFakeEvent} from '@angular/cdk/testing';
 import {MatCheckbox, MatCheckboxChange, MatCheckboxModule} from './index';
 import {RIPPLE_FADE_IN_DURATION, RIPPLE_FADE_OUT_DURATION} from '@angular/material/core';
 
@@ -34,9 +33,6 @@ describe('MatCheckbox', () => {
         CheckboxWithFormControl,
         CheckboxWithoutLabel,
         CheckboxWithTabindexAttr,
-      ],
-      providers: [
-        {provide: ViewportRuler, useClass: FakeViewportRuler}
       ]
     });
 


### PR DESCRIPTION
* Removes the unused ViewportRuler from the checkbox tests.