### PR TITLE
fix(checkbox): don't hide focus indicator on space press

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -365,8 +365,6 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     // Preventing bubbling for the second event will solve that issue.
     event.stopPropagation();
 
-    this._removeFocusRipple();
-
     if (!this.disabled) {
       // When user manually click on the checkbox, `indeterminate` is set to false.
       if (this._indeterminate) {


### PR DESCRIPTION
No longer hides the focus indicator ripple on click/space. Right now if a keyboard user tabs to the checkbox and presses SPACE to toggle the checkbox, the focus indicator ripple disappears. This makes it hard to see what element is focused or not.

For comparison, native checkboxes also keep the focus effect on keyboard press. Also Polymer follows the same convention with the focus indicator.