### PR TITLE
docs(scroll-dispatcher): add note about callback being run outside the NgZone

### DIFF
--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -73,6 +73,11 @@ export class ScrollDispatcher {
    * Returns an observable that emits an event whenever any of the registered Scrollable
    * references (or window, document, or body) fire a scrolled event. Can provide a time in ms
    * to override the default "throttle" time.
+   *
+   * **Note:** in order to avoid hitting change detection for every scroll event,
+   * all of the events emitted from this stream will be run outside the Angular zone.
+   * If you need to update any data bindings as a result of a scroll event, you have
+   * to run the callback using `NgZone.run`.
    */
   scrolled(auditTimeInMs: number = DEFAULT_SCROLL_TIME): Observable<CdkScrollable|void> {
     return this._platform.isBrowser ? Observable.create(observer => {


### PR DESCRIPTION
Since the `scrolled` events are being run outside the NgZone, it might be confusing if people decide to update their view as a result of a scroll event. These changes add a note on the method docs to avoid some of the confusion.

Relates to #8279.