### PR TITLE
fix(radio): coerce checked input binding

### DIFF
--- a/src/demo-app/radio/radio-demo.html
+++ b/src/demo-app/radio/radio-demo.html
@@ -1,6 +1,6 @@
 <h1>Basic Example</h1>
 <section class="demo-section">
-  <mat-radio-button name="group1">Option 1</mat-radio-button>
+  <mat-radio-button name="group1" checked>Option 1</mat-radio-button>
   <mat-radio-button name="group1">Option 2</mat-radio-button>
   <mat-radio-button name="group1" disabled="true">Option 3 (disabled)</mat-radio-button>
 </section>

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -365,11 +365,10 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   /** Whether this radio button is checked. */
   @Input()
-  get checked(): boolean {
-    return this._checked;
-  }
+  get checked(): boolean { return this._checked; }
+  set checked(value: boolean) {
+    const newCheckedState = coerceBooleanProperty(value);
 
-  set checked(newCheckedState: boolean) {
     if (this._checked != newCheckedState) {
       this._checked = newCheckedState;
 


### PR DESCRIPTION
* Coerces the `checked` input binding for radio-buttons. This allows developers to specify the initial checked radio-button from the template (similar to the native radio input element).