### PR TITLE
fix(selection-model): inaccurate selected value when accessed in change subscription

### DIFF
--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -102,6 +102,19 @@ describe('SelectionModel', () => {
       expect(event.added).toEqual([2]);
     });
 
+    it('should have updated the selected value before emitting the change event', () => {
+      let model = new SelectionModel(true);
+      let spy = jasmine.createSpy('SelectionModel change event');
+
+      // Note: this assertion is only here to run the getter.
+      expect(model.selected).toEqual([]);
+
+      model.onChange!.subscribe(() => spy(model.selected));
+      model.select(1);
+
+      expect(spy).toHaveBeenCalledWith([1]);
+    });
+
     describe('selection', () => {
       let model: SelectionModel<any>;
       let spy: jasmine.Spy;

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -118,8 +118,11 @@ export class SelectionModel<T> {
 
   /** Emits a change event and clears the records of selected and deselected values. */
   private _emitChangeEvent() {
+    // Clear the selected values so they can be re-cached.
+    this._selected = null;
+
     if (this._selectedToEmit.length || this._deselectedToEmit.length) {
-      let eventData = new SelectionChange(this._selectedToEmit, this._deselectedToEmit);
+      const eventData = new SelectionChange(this._selectedToEmit, this._deselectedToEmit);
 
       if (this.onChange) {
         this.onChange.next(eventData);
@@ -128,8 +131,6 @@ export class SelectionModel<T> {
       this._deselectedToEmit = [];
       this._selectedToEmit = [];
     }
-
-    this._selected = null;
   }
 
   /** Selects a value. */


### PR DESCRIPTION
Fixes the `selected` value being out of date in the `SelectionModel`, if it is accessed inside an `onChange` subscription.

Fixes #8584.