### PR TITLE
fix(menu): Set menu-item icon color only when not set on mat-icon

### DIFF
--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -20,7 +20,7 @@
     }
   }
 
-  .mat-menu-item .mat-icon,
+  .mat-menu-item .mat-icon:not([color]),
   .mat-menu-item-submenu-trigger::after {
     color: mat-color($foreground, 'icon');
   }

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -25,7 +25,7 @@ import {
   MenuPositionY,
   MatMenuItem,
 } from './index';
-import { MatIconModule } from "../icon/index";
+import { MatIconModule } from '../icon/index';
 import {MENU_PANEL_TOP_PADDING} from './menu-trigger';
 import {MatRipple} from '@angular/material/core';
 import {
@@ -225,16 +225,18 @@ describe('MatMenu', () => {
     expect(fixture.componentInstance.items.first.getLabel()).toBe('Item');
   });
 
-  it('should have an icon with the default theme color if mat-icon has no color attribute set', () => {
+  it('should have an icon with the default theme color if mat-icon has no color attribute set', 
+  () => {
     const fixture = TestBed.createComponent(ItemIconColorsMenu);
     fixture.detectChanges();
 
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    const matIconElement = overlayContainerElement.querySelector("mat-icon:not([color])") as HTMLElement;
+    const matIconElement = 
+          overlayContainerElement.querySelector('mat-icon:not([color])') as HTMLElement;
     const computedIconStyle = window.getComputedStyle(matIconElement);
-    expect(computedIconStyle.color).toBe("rgba(0, 0, 0, 0.54)");
+    expect(computedIconStyle.color).toBe('rgba(0, 0, 0, 0.54)');
   });
 
   it('should have an icon with the provided color if mat-icon has the color attribute set', () => {
@@ -244,9 +246,9 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    const matIconElement = overlayContainerElement.querySelector("mat-icon[color]") as HTMLElement;
+    const matIconElement = overlayContainerElement.querySelector('mat-icon[color]') as HTMLElement;
     const computedIconStyle = window.getComputedStyle(matIconElement);
-    expect(computedIconStyle.color).toBe("rgb(255, 64, 129)");
+    expect(computedIconStyle.color).toBe('rgb(255, 64, 129)');
   });
 
   it('should filter out non-text nodes when figuring out the label', () => {
@@ -1411,7 +1413,9 @@ class NestedMenuRepeater {
     <button [matMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
     <mat-menu #menu="matMenu">
       <button mat-menu-item> <mat-icon>notifications_off</mat-icon> Disable alerts </button>
-      <button mat-menu-item disabled> <mat-icon color="accent">bookmark</mat-icon> Bookmark </button>
+      <button mat-menu-item disabled> 
+        <mat-icon color="accent">bookmark</mat-icon> Bookmark 
+      </button>
     </mat-menu>
   `
 })

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -225,7 +225,7 @@ describe('MatMenu', () => {
     expect(fixture.componentInstance.items.first.getLabel()).toBe('Item');
   });
 
-  it('should have an icon with the default theme color if mat-icon has no color attribute set', 
+  it('should have an icon with the default theme color if mat-icon has no color attribute set',
   () => {
     const fixture = TestBed.createComponent(ItemIconColorsMenu);
     fixture.detectChanges();
@@ -233,7 +233,7 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    const matIconElement = 
+    const matIconElement =
           overlayContainerElement.querySelector('mat-icon:not([color])') as HTMLElement;
     const computedIconStyle = window.getComputedStyle(matIconElement);
     expect(computedIconStyle.color).toBe('rgba(0, 0, 0, 0.54)');
@@ -1413,8 +1413,8 @@ class NestedMenuRepeater {
     <button [matMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
     <mat-menu #menu="matMenu">
       <button mat-menu-item> <mat-icon>notifications_off</mat-icon> Disable alerts </button>
-      <button mat-menu-item disabled> 
-        <mat-icon color="accent">bookmark</mat-icon> Bookmark 
+      <button mat-menu-item disabled>
+        <mat-icon color="accent">bookmark</mat-icon> Bookmark
       </button>
     </mat-menu>
   `

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -25,6 +25,7 @@ import {
   MenuPositionY,
   MatMenuItem,
 } from './index';
+import { MatIconModule } from "../icon/index";
 import {MENU_PANEL_TOP_PADDING} from './menu-trigger';
 import {MatRipple} from '@angular/material/core';
 import {
@@ -44,7 +45,7 @@ describe('MatMenu', () => {
   beforeEach(async(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
-      imports: [MatMenuModule, NoopAnimationsModule],
+      imports: [MatIconModule, MatMenuModule, NoopAnimationsModule],
       declarations: [
         SimpleMenu,
         PositionedMenu,
@@ -54,6 +55,7 @@ describe('MatMenu', () => {
         NestedMenu,
         NestedMenuCustomElevation,
         NestedMenuRepeater,
+        ItemIconColorsMenu,
         FakeIcon
       ],
       providers: [
@@ -221,6 +223,30 @@ describe('MatMenu', () => {
     const fixture = TestBed.createComponent(SimpleMenu);
     fixture.detectChanges();
     expect(fixture.componentInstance.items.first.getLabel()).toBe('Item');
+  });
+
+  it('should have an icon with the default theme color if mat-icon has no color attribute set', () => {
+    const fixture = TestBed.createComponent(ItemIconColorsMenu);
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openMenu();
+    fixture.detectChanges();
+
+    const matIconElement = overlayContainerElement.querySelector("mat-icon:not([color])") as HTMLElement;
+    const computedIconStyle = window.getComputedStyle(matIconElement);
+    expect(computedIconStyle.color).toBe("rgba(0, 0, 0, 0.54)");
+  });
+
+  it('should have an icon with the provided color if mat-icon has the color attribute set', () => {
+    const fixture = TestBed.createComponent(ItemIconColorsMenu);
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openMenu();
+    fixture.detectChanges();
+
+    const matIconElement = overlayContainerElement.querySelector("mat-icon[color]") as HTMLElement;
+    const computedIconStyle = window.getComputedStyle(matIconElement);
+    expect(computedIconStyle.color).toBe("rgb(255, 64, 129)");
   });
 
   it('should filter out non-text nodes when figuring out the label', () => {
@@ -1378,6 +1404,22 @@ class NestedMenuRepeater {
   @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
 
   items = ['one', 'two', 'three'];
+}
+
+@Component({
+  template: `
+    <button [matMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item> <mat-icon>notifications_off</mat-icon> Disable alerts </button>
+      <button mat-menu-item disabled> <mat-icon color="accent">notifications_off</mat-icon> Disable alerts </button>
+    </mat-menu>
+  `
+})
+class ItemIconColorsMenu {
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild(MatMenu) menu: MatMenu;
+  @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 }
 
 @Component({

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1411,7 +1411,7 @@ class NestedMenuRepeater {
     <button [matMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
     <mat-menu #menu="matMenu">
       <button mat-menu-item> <mat-icon>notifications_off</mat-icon> Disable alerts </button>
-      <button mat-menu-item disabled> <mat-icon color="accent">notifications_off</mat-icon> Disable alerts </button>
+      <button mat-menu-item disabled> <mat-icon color="accent">bookmark</mat-icon> Bookmark </button>
     </mat-menu>
   `
 })

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -25,7 +25,6 @@ import {
   MenuPositionY,
   MatMenuItem,
 } from './index';
-import { MatIconModule } from '../icon/index';
 import {MENU_PANEL_TOP_PADDING} from './menu-trigger';
 import {MatRipple} from '@angular/material/core';
 import {
@@ -45,7 +44,7 @@ describe('MatMenu', () => {
   beforeEach(async(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
-      imports: [MatIconModule, MatMenuModule, NoopAnimationsModule],
+      imports: [MatMenuModule, NoopAnimationsModule],
       declarations: [
         SimpleMenu,
         PositionedMenu,
@@ -55,7 +54,6 @@ describe('MatMenu', () => {
         NestedMenu,
         NestedMenuCustomElevation,
         NestedMenuRepeater,
-        ItemIconColorsMenu,
         FakeIcon
       ],
       providers: [
@@ -223,32 +221,6 @@ describe('MatMenu', () => {
     const fixture = TestBed.createComponent(SimpleMenu);
     fixture.detectChanges();
     expect(fixture.componentInstance.items.first.getLabel()).toBe('Item');
-  });
-
-  it('should have an icon with the default theme color if mat-icon has no color attribute set',
-  () => {
-    const fixture = TestBed.createComponent(ItemIconColorsMenu);
-    fixture.detectChanges();
-
-    fixture.componentInstance.trigger.openMenu();
-    fixture.detectChanges();
-
-    const matIconElement =
-          overlayContainerElement.querySelector('mat-icon:not([color])') as HTMLElement;
-    const computedIconStyle = window.getComputedStyle(matIconElement);
-    expect(computedIconStyle.color).toBe('rgba(0, 0, 0, 0.54)');
-  });
-
-  it('should have an icon with the provided color if mat-icon has the color attribute set', () => {
-    const fixture = TestBed.createComponent(ItemIconColorsMenu);
-    fixture.detectChanges();
-
-    fixture.componentInstance.trigger.openMenu();
-    fixture.detectChanges();
-
-    const matIconElement = overlayContainerElement.querySelector('mat-icon[color]') as HTMLElement;
-    const computedIconStyle = window.getComputedStyle(matIconElement);
-    expect(computedIconStyle.color).toBe('rgb(255, 64, 129)');
   });
 
   it('should filter out non-text nodes when figuring out the label', () => {
@@ -1406,24 +1378,6 @@ class NestedMenuRepeater {
   @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
 
   items = ['one', 'two', 'three'];
-}
-
-@Component({
-  template: `
-    <button [matMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item> <mat-icon>notifications_off</mat-icon> Disable alerts </button>
-      <button mat-menu-item disabled>
-        <mat-icon color="accent">bookmark</mat-icon> Bookmark
-      </button>
-    </mat-menu>
-  `
-})
-class ItemIconColorsMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef;
-  @ViewChild(MatMenu) menu: MatMenu;
-  @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 }
 
 @Component({


### PR DESCRIPTION
Set the theme icon color only if the `color` input property was not set on the `mat-icon` component.

Fixes #8594