### PR TITLE
fix(autosize): remove resize handle

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -17,6 +17,7 @@ import {Platform} from '@angular/cdk/platform';
   selector: `textarea[mat-autosize], textarea[matTextareaAutosize]`,
   exportAs: 'matTextareaAutosize',
   host: {
+    'class': 'mat-autosize',
     // Textarea elements that have the directive applied should have a single row by default.
     // Browsers normally show two rows by default and therefore this limits the minRows binding.
     'rows': '1',

--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -53,3 +53,9 @@ textarea.mat-input-element {
   resize: vertical;
   overflow: auto;
 }
+
+// Remove the resize handle on autosizing textareas, because whatever height
+// the user resized to will be overwritten once they start typing again.
+textarea.mat-autosize {
+  resize: none;
+}


### PR DESCRIPTION
Removes the resize handle on autosize textareas, because the user's height will be overwritten once they start typing again.