### PR TITLE
chore: update chromedriver version for e2e tests

### DIFF
--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -42,7 +42,6 @@ if (process.env['TRAVIS']) {
   config.capabilities = {
     'browserName': 'chrome',
     'version': 'latest',
-    'chromedriverVersion': '2.28',
     'tunnel-identifier': process.env['TRAVIS_JOB_ID'],
     'build': process.env['TRAVIS_JOB_ID'],
     'name': 'Material E2E Tests',


### PR DESCRIPTION
* No longer explicitly specifies the Chrome Driver version for the e2e tests. The chrome driver associated with the latest Chrome version will be used now.