### PR TITLE
fix(chip-list): stateChanges stream not being completed

### DIFF
--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -345,6 +345,15 @@ describe('MatChipList', () => {
       });
     });
 
+    it('should complete the stateChanges stream on destroy', () => {
+      const spy = jasmine.createSpy('stateChanges complete');
+      const subscription = chipListInstance.stateChanges.subscribe(undefined, undefined, spy);
+
+      fixture.destroy();
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    });
+
   });
 
   describe('selection logic', () => {

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -359,6 +359,7 @@ export class MatChipList implements MatFormFieldControl<any>, ControlValueAccess
       this._changeSubscription.unsubscribe();
     }
     this._dropSubscriptions();
+    this.stateChanges.complete();
   }
 
 


### PR DESCRIPTION
Fixes the `stateChanges` subject not being completed, potentially causing a memory leak if the subscribers forget to unsubscribe.