### PR TITLE
chore: remove class re-export workaround

### DIFF
--- a/src/lib/checkbox/checkbox-required-validator.ts
+++ b/src/lib/checkbox/checkbox-required-validator.ts
@@ -16,8 +16,6 @@ import {
   NG_VALIDATORS,
 } from '@angular/forms';
 
-export const _MatCheckboxRequiredValidator = CheckboxRequiredValidator;
-
 export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => MatCheckboxRequiredValidator),
@@ -35,4 +33,4 @@ export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
   providers: [MAT_CHECKBOX_REQUIRED_VALIDATOR],
   host: {'[attr.required]': 'required ? "" : null'}
 })
-export class MatCheckboxRequiredValidator extends _MatCheckboxRequiredValidator {}
+export class MatCheckboxRequiredValidator extends CheckboxRequiredValidator {}

--- a/src/lib/expansion/accordion.ts
+++ b/src/lib/expansion/accordion.ts
@@ -10,9 +10,6 @@ import {Directive, Input} from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {CdkAccordion} from '@angular/cdk/accordion';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _CdkAccordion = CdkAccordion;
-
 /** MatAccordion's display modes. */
 export type MatAccordionDisplayMode = 'default' | 'flat';
 
@@ -26,7 +23,7 @@ export type MatAccordionDisplayMode = 'default' | 'flat';
     class: 'mat-accordion'
   }
 })
-export class MatAccordion extends _CdkAccordion {
+export class MatAccordion extends CdkAccordion {
   /** Whether the expansion indicator should be hidden. */
   @Input() get hideToggle(): boolean { return this._hideToggle; }
   set hideToggle(show: boolean) { this._hideToggle = coerceBooleanProperty(show); }

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -28,9 +28,6 @@ import {Subject} from 'rxjs/Subject';
 import {MatAccordion} from './accordion';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _CdkAccordionItem = CdkAccordionItem;
-
 /** Time and timing curve for expansion panel animations. */
 export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,1)';
 
@@ -43,7 +40,7 @@ export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatExpansionPanelBase extends _CdkAccordionItem {
+export class MatExpansionPanelBase extends CdkAccordionItem {
   constructor(accordion: MatAccordion,
               _changeDetectorRef: ChangeDetectorRef,
               _uniqueSelectionDispatcher: UniqueSelectionDispatcher) {

--- a/src/lib/stepper/step-label.ts
+++ b/src/lib/stepper/step-label.ts
@@ -9,13 +9,10 @@
 import {Directive, TemplateRef} from '@angular/core';
 import {CdkStepLabel} from '@angular/cdk/stepper';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatStepLabel = CdkStepLabel;
-
 @Directive({
   selector: '[matStepLabel]',
 })
-export class MatStepLabel extends _MatStepLabel {
+export class MatStepLabel extends CdkStepLabel {
   constructor(template: TemplateRef<any>) {
     super(template);
   }

--- a/src/lib/stepper/stepper-button.ts
+++ b/src/lib/stepper/stepper-button.ts
@@ -10,17 +10,13 @@ import {Directive} from '@angular/core';
 import {CdkStepper, CdkStepperNext, CdkStepperPrevious} from '@angular/cdk/stepper';
 import {MatStepper} from './stepper';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatStepperNext = CdkStepperNext;
-export const _MatStepperPrevious = CdkStepperPrevious;
-
 /** Button that moves to the next step in a stepper workflow. */
 @Directive({
   selector: 'button[matStepperNext]',
   host: {'(click)': '_stepper.next()'},
   providers: [{provide: CdkStepper, useExisting: MatStepper}]
 })
-export class MatStepperNext extends _MatStepperNext { }
+export class MatStepperNext extends CdkStepperNext { }
 
 /** Button that moves to the previous step in a stepper workflow. */
 @Directive({
@@ -28,4 +24,4 @@ export class MatStepperNext extends _MatStepperNext { }
   host: {'(click)': '_stepper.previous()'},
   providers: [{provide: CdkStepper, useExisting: MatStepper}]
 })
-export class MatStepperPrevious extends _MatStepperPrevious { }
+export class MatStepperPrevious extends CdkStepperPrevious { }

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -29,10 +29,6 @@ import {MatStepHeader} from './step-header';
 import {MatStepLabel} from './step-label';
 import {takeUntil} from 'rxjs/operators/takeUntil';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatStep = CdkStep;
-export const _MatStepper = CdkStepper;
-
 @Component({
   moduleId: module.id,
   selector: 'mat-step',
@@ -43,7 +39,7 @@ export const _MatStepper = CdkStepper;
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatStep extends _MatStep implements ErrorStateMatcher {
+export class MatStep extends CdkStep implements ErrorStateMatcher {
   /** Content for step label given by <ng-template matStepLabel>. */
   @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
 
@@ -68,7 +64,7 @@ export class MatStep extends _MatStep implements ErrorStateMatcher {
 @Directive({
   selector: '[matStepper]'
 })
-export class MatStepper extends _MatStepper implements AfterContentInit {
+export class MatStepper extends CdkStepper implements AfterContentInit {
   /** The list of step headers of the steps in the stepper. */
   @ViewChildren(MatStepHeader, {read: ElementRef}) _stepHeader: QueryList<ElementRef>;
 

--- a/src/lib/table/cell.ts
+++ b/src/lib/table/cell.ts
@@ -15,13 +15,6 @@ import {
   CdkHeaderCellDef,
 } from '@angular/cdk/table';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatCellDef = CdkCellDef;
-export const _MatHeaderCellDef = CdkHeaderCellDef;
-export const _MatColumnDef = CdkColumnDef;
-export const _MatHeaderCell = CdkHeaderCell;
-export const _MatCell = CdkCell;
-
 /**
  * Cell definition for the mat-table.
  * Captures the template of a column's data row cell as well as cell-specific properties.
@@ -30,7 +23,7 @@ export const _MatCell = CdkCell;
   selector: '[matCellDef]',
   providers: [{provide: CdkCellDef, useExisting: MatCellDef}]
 })
-export class MatCellDef extends _MatCellDef { }
+export class MatCellDef extends CdkCellDef { }
 
 /**
  * Header cell definition for the mat-table.
@@ -40,7 +33,7 @@ export class MatCellDef extends _MatCellDef { }
   selector: '[matHeaderCellDef]',
   providers: [{provide: CdkHeaderCellDef, useExisting: MatHeaderCellDef}]
 })
-export class MatHeaderCellDef extends _MatHeaderCellDef { }
+export class MatHeaderCellDef extends CdkHeaderCellDef { }
 
 /**
  * Column definition for the mat-table.
@@ -50,7 +43,7 @@ export class MatHeaderCellDef extends _MatHeaderCellDef { }
   selector: '[matColumnDef]',
   providers: [{provide: CdkColumnDef, useExisting: MatColumnDef}],
 })
-export class MatColumnDef extends _MatColumnDef {
+export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
   @Input('matColumnDef') name: string;
 }
@@ -63,7 +56,7 @@ export class MatColumnDef extends _MatColumnDef {
     'role': 'columnheader',
   },
 })
-export class MatHeaderCell extends _MatHeaderCell {
+export class MatHeaderCell extends CdkHeaderCell {
   constructor(columnDef: CdkColumnDef,
               elementRef: ElementRef) {
     super(columnDef, elementRef);
@@ -79,7 +72,7 @@ export class MatHeaderCell extends _MatHeaderCell {
     'role': 'gridcell',
   },
 })
-export class MatCell extends _MatCell {
+export class MatCell extends CdkCell {
   constructor(columnDef: CdkColumnDef,
               elementRef: ElementRef) {
     super(columnDef, elementRef);

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -15,12 +15,6 @@ import {
   CdkRowDef,
 } from '@angular/cdk/table';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatHeaderRowDef = CdkHeaderRowDef;
-export const _MatCdkRowDef = CdkRowDef;
-export const _MatHeaderRow = CdkHeaderRow;
-export const _MatRow = CdkRow;
-
 /**
  * Header row definition for the mat-table.
  * Captures the header row's template and other header properties such as the columns to display.
@@ -30,7 +24,7 @@ export const _MatRow = CdkRow;
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
   inputs: ['columns: matHeaderRowDef'],
 })
-export class MatHeaderRowDef extends _MatHeaderRowDef { }
+export class MatHeaderRowDef extends CdkHeaderRowDef { }
 
 /**
  * Data row definition for the mat-table.
@@ -42,7 +36,7 @@ export class MatHeaderRowDef extends _MatHeaderRowDef { }
   providers: [{provide: CdkRowDef, useExisting: MatRowDef}],
   inputs: ['columns: matRowDefColumns', 'when: matRowDefWhen'],
 })
-export class MatRowDef<T> extends _MatCdkRowDef<T> {
+export class MatRowDef<T> extends CdkRowDef<T> {
 }
 
 /** Header template container that contains the cell outlet. Adds the right class and role. */
@@ -59,7 +53,7 @@ export class MatRowDef<T> extends _MatCdkRowDef<T> {
   exportAs: 'matHeaderRow',
   preserveWhitespaces: false,
 })
-export class MatHeaderRow extends _MatHeaderRow { }
+export class MatHeaderRow extends CdkHeaderRow { }
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({
@@ -75,4 +69,4 @@ export class MatHeaderRow extends _MatHeaderRow { }
   exportAs: 'matRow',
   preserveWhitespaces: false,
 })
-export class MatRow extends _MatRow { }
+export class MatRow extends CdkRow { }

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -9,9 +9,6 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatTable = CdkTable;
-
 /**
  * Wrapper for the CdkTable with Material design styles.
  */
@@ -28,4 +25,4 @@ export const _MatTable = CdkTable;
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatTable<T> extends _MatTable<T> { }
+export class MatTable<T> extends CdkTable<T> { }

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -35,9 +35,6 @@ import {TemplatePortal, CdkPortalOutlet} from '@angular/cdk/portal';
 import {Directionality, Direction} from '@angular/cdk/bidi';
 import {Subscription} from 'rxjs/Subscription';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatTabBodyPortalBaseClass = CdkPortalOutlet;
-
 /**
  * These position states are used internally as animation states for the tab body. Setting the
  * position state to left, right, or center will transition the tab body from its current
@@ -66,7 +63,7 @@ export type MatTabBodyOriginState = 'left' | 'right';
 @Directive({
   selector: '[matTabBodyHost]'
 })
-export class MatTabBodyPortal extends _MatTabBodyPortalBaseClass implements OnInit, OnDestroy {
+export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestroy {
   /** A subscription to events for when the tab body begins centering. */
   private _centeringSub: Subscription;
 

--- a/src/lib/tabs/tab-label.ts
+++ b/src/lib/tabs/tab-label.ts
@@ -9,14 +9,11 @@
 import {Directive, TemplateRef, ViewContainerRef} from '@angular/core';
 import {CdkPortal} from '@angular/cdk/portal';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatTabLabelBaseClass = CdkPortal;
-
 /** Used to flag tab labels for use with the portal directive */
 @Directive({
   selector: '[mat-tab-label], [matTabLabel]',
 })
-export class MatTabLabel extends _MatTabLabelBaseClass {
+export class MatTabLabel extends CdkPortal {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
     super(templateRef, viewContainerRef);
   }


### PR DESCRIPTION
Removes cross-package class re-exports that have been created in favor of working around: https://github.com/angular/angular/issues/17849.