### PR TITLE
feat(sort): add the ability to disable sort toggling

### DIFF
--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -221,7 +221,13 @@
 
   <table-header-demo (shiftColumns)="displayedColumns.push(displayedColumns.shift())"
                      (toggleColorColumn)="toggleColorColumn()" *ngIf="selection.isEmpty()">
+
+    <button mat-menu-item (click)="progressSortingDisabled = !progressSortingDisabled">
+      <mat-icon>sort</mat-icon>
+      Toggle Progress Sorting
+    </button>
   </table-header-demo>
+
   <div class="example-header example-selection-header"
        *ngIf="!selection.isEmpty()">
     {{selection.selected.length}}
@@ -257,7 +263,10 @@
 
     <!-- Column Definition: Progress -->
     <ng-container matColumnDef="progress">
-      <mat-header-cell *matHeaderCellDef mat-sort-header> Progress </mat-header-cell>
+      <mat-header-cell
+        *matHeaderCellDef
+        [disabled]="progressSortingDisabled"
+        mat-sort-header> Progress </mat-header-cell>
       <mat-cell *matCellDef="let row">
         <div class="demo-progress-stat">{{row.progress}}%</div>
         <div class="demo-progress-indicator-container">

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -43,6 +43,7 @@ export class TableDemo {
   displayedColumns: UserProperties[] = [];
   trackByStrategy: TrackByStrategy = 'reference';
   changeReferences = false;
+  progressSortingDisabled = false;
   highlights = new Set<string>();
   wasExpanded = new Set<UserData>();
 

--- a/src/demo-app/table/table-header-demo.html
+++ b/src/demo-app/table/table-header-demo.html
@@ -15,5 +15,6 @@
       <mat-icon>color_lens</mat-icon>
       Toggle Color Column
     </button>
+    <ng-content></ng-content>
   </mat-menu>
 </div>

--- a/src/lib/sort/sort-header.html
+++ b/src/lib/sort/sort-header.html
@@ -1,7 +1,8 @@
 <div class="mat-sort-header-container"
      [class.mat-sort-header-position-before]="arrowPosition == 'before'">
   <button class="mat-sort-header-button" type="button"
-          [attr.aria-label]="_intl.sortButtonLabel(id)">
+          [attr.aria-label]="_intl.sortButtonLabel(id)"
+          [attr.disabled]="_isDisabled() || null">
     <ng-content></ng-content>
   </button>
 

--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -8,6 +8,10 @@ $mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
 .mat-sort-header-container {
   display: flex;
   cursor: pointer;
+
+  .mat-sort-header-disabled & {
+    cursor: default;
+  }
 }
 
 .mat-sort-header-position-before {
@@ -20,7 +24,7 @@ $mat-sort-header-arrow-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   align-items: center;
   padding: 0;
-  cursor: pointer;
+  cursor: inherit;
   outline: 0;
   font: inherit;
   color: currentColor;

--- a/src/lib/sort/sort.md
+++ b/src/lib/sort/sort.md
@@ -19,13 +19,18 @@ direction to sort (`asc` or `desc`).
 By default, a sort header starts its sorting at `asc` and then `desc`. Triggering the sort header
 after `desc` will remove sorting.
 
-To reverse the sort order for all headers, set the `matSortStart` to `desc` on the `matSort` 
-directive. To reverse the order only for a specific header, set the `start` input only on the header 
+To reverse the sort order for all headers, set the `matSortStart` to `desc` on the `matSort`
+directive. To reverse the order only for a specific header, set the `start` input only on the header
 instead.
 
-To prevent the user from clearing the sort sort state from an already sorted column, set 
-`matSortDisableClear` to `true` on the `matSort` to affect all headers, or set `disableClear` to 
+To prevent the user from clearing the sort sort state from an already sorted column, set
+`matSortDisableClear` to `true` on the `matSort` to affect all headers, or set `disableClear` to
 `true` on a specific header.
+
+#### Disabling sorting
+
+If you want to prevent the user from changing the sorting order of any column, you can use the
+`matSortDisabled` binding on the `mat-sort`, or the `disabled` on an single `mat-sort-header`.
 
 #### Using sort with the mat-table
 

--- a/src/lib/sort/sort.spec.ts
+++ b/src/lib/sort/sort.spec.ts
@@ -109,6 +109,43 @@ describe('MatSort', () => {
     testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc', '']);
   });
 
+  it('should allow for the cycling the sort direction to be disabled per column', () => {
+    const button = fixture.nativeElement.querySelector('#defaultSortHeaderA button');
+
+    component.sort('defaultSortHeaderA');
+    expect(component.matSort.direction).toBe('asc');
+    expect(button.getAttribute('disabled')).toBeFalsy();
+
+    component.disabledColumnSort = true;
+    fixture.detectChanges();
+
+    component.sort('defaultSortHeaderA');
+    expect(component.matSort.direction).toBe('asc');
+    expect(button.getAttribute('disabled')).toBe('true');
+  });
+
+  it('should allow for the cycling the sort direction to be disabled for all columns', () => {
+    const button = fixture.nativeElement.querySelector('#defaultSortHeaderA button');
+
+    component.sort('defaultSortHeaderA');
+    expect(component.matSort.active).toBe('defaultSortHeaderA');
+    expect(component.matSort.direction).toBe('asc');
+    expect(button.getAttribute('disabled')).toBeFalsy();
+
+    component.disableAllSort = true;
+    fixture.detectChanges();
+
+    component.sort('defaultSortHeaderA');
+    expect(component.matSort.active).toBe('defaultSortHeaderA');
+    expect(component.matSort.direction).toBe('asc');
+    expect(button.getAttribute('disabled')).toBe('true');
+
+    component.sort('defaultSortHeaderB');
+    expect(component.matSort.active).toBe('defaultSortHeaderA');
+    expect(component.matSort.direction).toBe('asc');
+    expect(button.getAttribute('disabled')).toBe('true');
+  });
+
   it('should reset sort direction when a different column is sorted', () => {
     component.sort('defaultSortHeaderA');
     expect(component.matSort.active).toBe('defaultSortHeaderA');
@@ -211,11 +248,16 @@ function testSingleColumnSortDirectionSequence(fixture: ComponentFixture<SimpleM
   template: `
     <div matSort
          [matSortActive]="active"
+         [matSortDisabled]="disableAllSort"
          [matSortStart]="start"
          [matSortDirection]="direction"
          [matSortDisableClear]="disableClear"
          (matSortChange)="latestSortEvent = $event">
-      <div id="defaultSortHeaderA" #defaultSortHeaderA mat-sort-header="defaultSortHeaderA">
+      <div
+        id="defaultSortHeaderA"
+        #defaultSortHeaderA
+        mat-sort-header="defaultSortHeaderA"
+        [disabled]="disabledColumnSort">
         A
       </div>
       <div id="defaultSortHeaderB" #defaultSortHeaderB mat-sort-header="defaultSortHeaderB">
@@ -233,6 +275,8 @@ class SimpleMatSortApp {
   start: SortDirection = 'asc';
   direction: SortDirection = '';
   disableClear: boolean;
+  disabledColumnSort = false;
+  disableAllSort = false;
 
   @ViewChild(MatSort) matSort: MatSort;
   @ViewChild('defaultSortHeaderA') matSortHeaderDefaultA: MatSortHeader;


### PR DESCRIPTION
Adds the ability for a `mat-sort-header` or `mat-sort` instance to be disabled, preventing the user from changing the sorting direction.

Fixes #8622.