### PR TITLE
build: run unit-tests locally in chrome headless

### DIFF
--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -5,7 +5,7 @@
  * Target can be either: BS (Browserstack) | SL (Saucelabs) | TC (Travis CI) | null (To not run)
  */
 const browserConfig = {
-  'ChromeHeadless_CI': { unitTest: {target: 'TC', required: true  }},
+  'ChromeHeadlessCI':  { unitTest: {target: 'TC', required: true  }},
   'FirefoxHeadless':   { unitTest: {target: 'TC', required: true  }},
   'ChromeBeta':        { unitTest: {target: null, required: false }},
   'FirefoxBeta':       { unitTest: {target: null, required: false }},

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -80,7 +80,7 @@ module.exports = (config) => {
     browserDisconnectTimeout: 20000,
     browserNoActivityTimeout: 240000,
     captureTimeout: 120000,
-    browsers: ['Chrome_1024x768'],
+    browsers: ['ChromeHeadlessLocal'],
 
     singleRun: false,
 

--- a/test/remote_browsers.json
+++ b/test/remote_browsers.json
@@ -1,12 +1,6 @@
 {
-  "ChromeHeadless_CI": {
+  "ChromeHeadlessLocal": {
     "base": "ChromeHeadless",
-    "flags": [
-      "--window-size=1024,768"
-    ]
-  },
-  "Chrome_1024x768": {
-    "base": "Chrome",
     "flags": [
       "--window-size=1024,768"
     ]
@@ -16,6 +10,9 @@
     "flags": [
       "-headless"
     ]
+  },
+  "ChromeHeadlessCI": {
+    "base": "ChromeHeadlessLocal"
   },
   "SL_CHROME": {
     "base": "SauceLabs",


### PR DESCRIPTION
Runs local tests in Chrome Headless. This speeds up the tests and also ensures more test stability. On Windows there are a lot of pixel deviation failures because the tests seemed to be affected by the screen resolution or window frame.

By running the tests headless, the Chrome launcher has more control about the rendering and pixel deviations like before won't happen anymore. It's still the same Chrome that runs, just that the screen is kind of emulated like in XVFB.

**Note**: For advanced debugging it's still easy to run without headless. Just run `gulp test:static`.