### PR TITLE
fix(stepper): set appropriate aria-orientation

### DIFF
--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -56,6 +56,11 @@ describe('MatHorizontalStepper', () => {
       expect(stepperEl.getAttribute('role')).toBe('tablist');
     });
 
+    it('should set the proper "aria-orientation"', () => {
+      let stepperEl = fixture.debugElement.query(By.css('mat-horizontal-stepper')).nativeElement;
+      expect(stepperEl.getAttribute('aria-orientation')).toBe('horizontal');
+    });
+
     it('should set aria-expanded of content correctly', () => {
       let stepContents = fixture.debugElement.queryAll(By.css(`.mat-horizontal-stepper-content`));
       assertCorrectAriaExpandedAttribute(fixture, stepContents);
@@ -225,6 +230,11 @@ describe('MatVerticalStepper', () => {
     it('should set the "tablist" role on stepper', () => {
       let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper')).nativeElement;
       expect(stepperEl.getAttribute('role')).toBe('tablist');
+    });
+
+    it('should set the proper "aria-orientation"', () => {
+      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper')).nativeElement;
+      expect(stepperEl.getAttribute('aria-orientation')).toBe('vertical');
     });
 
     it('should set aria-expanded of content correctly', () => {

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -90,6 +90,7 @@ export class MatStepper extends _MatStepper implements AfterContentInit {
   inputs: ['selectedIndex'],
   host: {
     'class': 'mat-stepper-horizontal',
+    'aria-orientation': 'horizontal',
     'role': 'tablist',
   },
   animations: [
@@ -116,6 +117,7 @@ export class MatHorizontalStepper extends MatStepper { }
   inputs: ['selectedIndex'],
   host: {
     'class': 'mat-stepper-vertical',
+    'aria-orientation': 'vertical',
     'role': 'tablist',
   },
   animations: [


### PR DESCRIPTION
Based on the accessibility guidelines (https://www.w3.org/TR/wai-aria-1.1/#tablist), tab lists (which the stepper uses internally) can have an `aria-orientation`. Since we have both vertical and horizontal steppers, these changes set the appropriate `aria-orientation` in order to match the stepper's orientation.