### PR TITLE
feat(overlay): horizontal fallbacks for cdkConnectedOverlay default positions

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -49,6 +49,12 @@ const defaultPositionList = [
   new ConnectionPositionPair(
       {originX: 'start', originY: 'top'},
       {overlayX: 'start', overlayY: 'bottom'}),
+  new ConnectionPositionPair(
+      {originX: 'end', originY: 'bottom'},
+      {overlayX: 'end', overlayY: 'top'}),
+  new ConnectionPositionPair(
+      {originX: 'end', originY: 'top'},
+      {overlayX: 'end', overlayY: 'bottom'}),
 ];
 
 /** Injection token that determines the scroll handling while the connected overlay is open. */


### PR DESCRIPTION
feat(overlay): horizontal fallbacks for cdkConnectedOverlay default positions

Fixes #8318