### PR TITLE
fix(scrolling): rename ScrollDispatchModule to ScrollingModule

### DIFF
--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -8,7 +8,7 @@
 
 import {BidiModule} from '@angular/cdk/bidi';
 import {PortalModule} from '@angular/cdk/portal';
-import {ScrollDispatchModule, VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';
+import {ScrollingModule, VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';
 import {NgModule, Provider} from '@angular/core';
 import {OVERLAY_KEYBOARD_DISPATCHER_PROVIDER} from './keyboard/overlay-keyboard-dispatcher';
 import {Overlay} from './overlay';
@@ -22,8 +22,8 @@ import {OverlayPositionBuilder} from './position/overlay-position-builder';
 
 
 @NgModule({
-  imports: [BidiModule, PortalModule, ScrollDispatchModule],
-  exports: [CdkConnectedOverlay, CdkOverlayOrigin, ScrollDispatchModule],
+  imports: [BidiModule, PortalModule, ScrollingModule],
+  exports: [CdkConnectedOverlay, CdkOverlayOrigin, ScrollingModule],
   declarations: [CdkConnectedOverlay, CdkOverlayOrigin],
   providers: [Overlay],
 })

--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
-import {CdkScrollable, ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {CdkScrollable, ScrollingModule} from '@angular/cdk/scrolling';
 import {MockNgZone} from '@angular/cdk/testing';
 import {Component, ElementRef, NgModule, NgZone} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
@@ -32,7 +32,7 @@ describe('ConnectedPositionStrategy', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ScrollDispatchModule, OverlayModule, OverlayTestModule],
+      imports: [ScrollingModule, OverlayModule, OverlayTestModule],
       providers: [{provide: NgZone, useFactory: () => zone = new MockNgZone()}]
     });
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
-import {CdkScrollable, ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {CdkScrollable, ScrollingModule} from '@angular/cdk/scrolling';
 import {MockNgZone} from '@angular/cdk/testing';
 import {Component, ElementRef, NgModule, NgZone} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
@@ -30,7 +30,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ScrollDispatchModule, OverlayModule, OverlayTestModule],
+      imports: [ScrollingModule, OverlayModule, OverlayTestModule],
       providers: [{provide: NgZone, useFactory: () => zone = new MockNgZone()}]
     });
 

--- a/src/cdk/scrolling/public-api.ts
+++ b/src/cdk/scrolling/public-api.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ScrollingModule} from './scrolling-module';
+
 export * from './scroll-dispatcher';
 export * from './scrollable';
 export * from './viewport-ruler';
 export * from './scrolling-module';
+
+/**
+ * @deprecated Renamed to ScrollingModule.
+ * @deletion-target 7.0.0
+ */
+export {ScrollingModule as ScrollDispatchModule};

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -1,6 +1,6 @@
 import {inject, TestBed, async, fakeAsync, ComponentFixture, tick} from '@angular/core/testing';
 import {NgModule, Component, ViewChild, ElementRef} from '@angular/core';
-import {CdkScrollable, ScrollDispatcher, ScrollDispatchModule} from './public-api';
+import {CdkScrollable, ScrollDispatcher, ScrollingModule} from './public-api';
 import {dispatchFakeEvent} from '@angular/cdk/testing';
 
 describe('Scroll Dispatcher', () => {
@@ -239,7 +239,7 @@ class NestedScrollingComponent {
 
 const TEST_COMPONENTS = [ScrollingComponent, NestedScrollingComponent];
 @NgModule({
-  imports: [ScrollDispatchModule],
+  imports: [ScrollingModule],
   providers: [ScrollDispatcher],
   exports: TEST_COMPONENTS,
   declarations: TEST_COMPONENTS,

--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -15,4 +15,4 @@ import {CdkScrollable} from './scrollable';
   exports: [CdkScrollable],
   declarations: [CdkScrollable],
 })
-export class ScrollDispatchModule {}
+export class ScrollingModule {}

--- a/src/cdk/scrolling/viewport-ruler.spec.ts
+++ b/src/cdk/scrolling/viewport-ruler.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, inject, fakeAsync, tick} from '@angular/core/testing';
-import {ScrollDispatchModule} from './public-api';
+import {ScrollingModule} from './public-api';
 import {ViewportRuler} from './viewport-ruler';
 import {dispatchFakeEvent} from '@angular/cdk/testing';
 
@@ -24,7 +24,7 @@ describe('ViewportRuler', () => {
   veryLargeElement.style.height = '6000px';
 
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [ScrollDispatchModule],
+    imports: [ScrollingModule],
     providers: [ViewportRuler]
   }));
 

--- a/src/lib/sidenav/sidenav-module.ts
+++ b/src/lib/sidenav/sidenav-module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {PlatformModule} from '@angular/cdk/platform';
-import {ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
@@ -18,7 +18,7 @@ import {MatSidenav, MatSidenavContainer, MatSidenavContent} from './sidenav';
   imports: [
     CommonModule,
     MatCommonModule,
-    ScrollDispatchModule,
+    ScrollingModule,
     PlatformModule,
   ],
   exports: [

--- a/src/lib/tabs/tab-header.spec.ts
+++ b/src/lib/tabs/tab-header.spec.ts
@@ -1,7 +1,7 @@
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {END, ENTER, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE} from '@angular/cdk/keycodes';
 import {PortalModule} from '@angular/cdk/portal';
-import {ScrollDispatchModule, ViewportRuler} from '@angular/cdk/scrolling';
+import {ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {CommonModule} from '@angular/common';
 import {Component, ViewChild} from '@angular/core';
@@ -30,7 +30,7 @@ describe('MatTabHeader', () => {
   beforeEach(async(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
-      imports: [CommonModule, PortalModule, MatRippleModule, ScrollDispatchModule],
+      imports: [CommonModule, PortalModule, MatRippleModule, ScrollingModule],
       declarations: [
         MatTabHeader,
         MatInkBar,


### PR DESCRIPTION
Renames the `ScrollDispatchModule` to `ScrollingModule` in order to match the `@angular/cdk/scrolling` entry point.