### PR TITLE
fix(overlay): add horizontal fallback positions to the connected overlay defaults

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -46,6 +46,12 @@ const defaultPositionList = [
   new ConnectionPositionPair(
       {originX: 'start', originY: 'top'},
       {overlayX: 'start', overlayY: 'bottom'}),
+  new ConnectionPositionPair(
+    {originX: 'end', originY: 'top'},
+    {overlayX: 'end', overlayY: 'bottom'}),
+  new ConnectionPositionPair(
+    {originX: 'end', originY: 'bottom'},
+    {overlayX: 'end', overlayY: 'top'}),
 ];
 
 /** Injection token that determines the scroll handling while the connected overlay is open. */


### PR DESCRIPTION
Adds horizontal fallbacks to the `CdkConnectedOverlay` directive default positions.

Fixes #8318.