### PR TITLE
fix(input): align caret color with spec

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -6,6 +6,9 @@
 
 
 @mixin mat-input-theme($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
   $foreground: map-get($theme, foreground);
   $is-dark-theme: map-get($theme, is-dark);
 
@@ -14,9 +17,20 @@
   }
 
   .mat-input-element {
+    caret-color: mat-color($primary);
+
     @include input-placeholder {
       color: _mat-control-placeholder-color($theme);
     }
+  }
+
+  .mat-accent .mat-input-element {
+    caret-color: mat-color($accent);
+  }
+
+  .mat-warn .mat-input-element,
+  .mat-form-field-invalid .mat-input-element {
+    caret-color: mat-color($warn);
   }
 }
 


### PR DESCRIPTION
Based on the text field spec (https://material.io/guidelines/components/text-fields.html), the input caret color should match the underline color.