### PR TITLE
fix(table): data source should sort empty values correctly

### DIFF
--- a/src/cdk/coercion/number-property.ts
+++ b/src/cdk/coercion/number-property.ts
@@ -10,8 +10,16 @@
 export function coerceNumberProperty(value: any): number;
 export function coerceNumberProperty<D>(value: any, fallback: D): number | D;
 export function coerceNumberProperty(value: any, fallbackValue = 0) {
+  return _isNumberValue(value) ? Number(value) : fallbackValue;
+}
+
+/**
+ * Whether the provided value is considered a number.
+ * @docs-private
+ */
+export function _isNumberValue(value: any): boolean {
   // parseFloat(value) handles most of the cases we're interested in (it treats null, empty string,
   // and other non-number values as NaN, where Number just uses 0) but it considers the string
   // '123hello' to be a valid number. Therefore we also check if Number(value) is NaN.
-  return isNaN(parseFloat(value as any)) || isNaN(Number(value)) ? fallbackValue : Number(value);
+  return !isNaN(parseFloat(value as any)) && !isNaN(Number(value));
 }

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -209,6 +209,42 @@ describe('MatTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
       ]);
+
+      // Expect that empty string row comes before the other values
+      component.sort.sort(component.sortHeader);
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A\xa0Sorted by a descending', 'Column B', 'Column C'],
+        ['a_3', 'b_3', 'c_3'],
+        ['a_2', 'b_2', 'c_2'],
+        ['', 'b_1', 'c_1'],
+      ]);
+    });
+
+    it('should by default correctly sort undefined values', () => {
+      // Activate column A sort
+      dataSource.data[0].a = undefined;
+
+      // Expect that undefined row comes before the other values
+      component.sort.sort(component.sortHeader);
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A\xa0Sorted by a ascending', 'Column B', 'Column C'],
+        ['', 'b_1', 'c_1'],
+        ['a_2', 'b_2', 'c_2'],
+        ['a_3', 'b_3', 'c_3'],
+      ]);
+
+
+      // Expect that undefined row comes after the other values
+      component.sort.sort(component.sortHeader);
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A\xa0Sorted by a descending', 'Column B', 'Column C'],
+        ['a_3', 'b_3', 'c_3'],
+        ['a_2', 'b_2', 'c_2'],
+        ['', 'b_1', 'c_1'],
+      ]);
     });
 
     it('should be able to page the table contents', fakeAsync(() => {
@@ -243,9 +279,9 @@ describe('MatTable', () => {
 });
 
 interface TestData {
-  a: string;
-  b: string;
-  c: string;
+  a: string|undefined;
+  b: string|undefined;
+  c: string|undefined;
 }
 
 class FakeDataSource extends DataSource<TestData> {


### PR DESCRIPTION
Also takes the sort function and adds it as an override-able predicate for users to inject their own method of sorting. It takes a `MatSort` rather than the `active` and `directive` properties in hopes that it's more stable in case we add properties to `MatSort` later on. Open to opinions on whether that's wise or not

Fixes #8485