### PR TITLE
perf(ripple): use passive event listeners

### DIFF
--- a/src/cdk/platform/features.ts
+++ b/src/cdk/platform/features.ts
@@ -14,7 +14,7 @@ let supportsPassiveEvents: boolean;
  * See: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
  */
 export function supportsPassiveEventListeners(): boolean {
-  if (supportsPassiveEvents == null) {
+  if (supportsPassiveEvents == null && typeof window !== 'undefined') {
     try {
       window.addEventListener('test', null!, Object.defineProperty({}, 'passive', {
         get: () => supportsPassiveEvents = true


### PR DESCRIPTION
Switches all of the ripple-related event listeners to be passive for improved performance and to prevent Chrome from logging warnings for almost every Material component. Also converts a few methods to arrow functions so we don't have to `bind` them explicitly.