### PR TITLE
build: skip artifact publish if tag already exists

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -36,9 +36,15 @@ publishPackage() {
   commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
   commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
   commitMessage=$(git log --oneline -n 1)
+  commitTag="${buildVersion}-${commitSha}"
 
   repoUrl="https://github.com/angular/${packageRepo}.git"
   repoDir="tmp/${packageRepo}"
+
+  if [[ $(git rev-parse -q --verify "refs/tags/${commitTag}") ]]; then
+    echo "Skipping publish because tag is already published"
+    exit 0
+  fi
 
   if [[ ! ${COMMAND_ARGS} == *--no-build* ]]; then
     # Create a release of the current repository.
@@ -62,7 +68,7 @@ publishPackage() {
   # Replace the version in every file recursively with a more specific version that also includes
   # the SHA of the current build job. Normally this "sed" call would just replace the version
   # placeholder, but the version placeholders have been replaced by the release task already.
-  sed -i "s/${buildVersion}/${buildVersion}-${commitSha}/g" $(find . -type f)
+  sed -i "s/${buildVersion}/${commitTag}/g" $(find . -type f)
 
   # Prepare Git for pushing the artifacts to the repository.
   git config user.name "${commitAuthorName}"
@@ -73,7 +79,7 @@ publishPackage() {
 
   git add -A
   git commit --allow-empty -m "${commitMessage}"
-  git tag "${buildVersion}-${commitSha}"
+  git tag "${commitTag}"
   git push origin master --tags
 
   echo "Published package artifacts for ${packageName}#${commitSha}."


### PR DESCRIPTION
* No longer errors the deployment if the artifacts have been published already. (e.g. Job restart)