### PR TITLE
Hide number spinner in firefox browsers.

### DIFF
--- a/src/material-examples/form-field-prefix-suffix/form-field-prefix-suffix-example.css
+++ b/src/material-examples/form-field-prefix-suffix/form-field-prefix-suffix-example.css
@@ -15,3 +15,7 @@ input.example-right-align::-webkit-outer-spin-button,
 input.example-right-align::-webkit-inner-spin-button {
   display: none;
 }
+
+input.example-right-align {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION

![screenshot-2017-11-30 form field angular material](https://user-images.githubusercontent.com/1639535/33420081-3e3a9bf4-d5d3-11e7-98a5-18584ceab4e3.png)
I have added the css for hiding the spinner appearing on input type number specific to firefox browser.
Tested in Firefox 57.0 (64-bit).