### PR TITLE
fix(select): change event emitted before data binding is updated

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2321,6 +2321,29 @@ describe('MatSelect', () => {
 
       expect(document.activeElement).toBe(select, 'Expected trigger to be focused.');
     }));
+
+    it('should update the data binding before emitting the change event', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicSelectWithoutForms);
+      const instance = fixture.componentInstance;
+      const spy = jasmine.createSpy('change spy');
+
+      fixture.detectChanges();
+      instance.select.change.subscribe(() => spy(instance.selectedFood));
+
+      expect(instance.selectedFood).toBeFalsy();
+
+      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.detectChanges();
+      flush();
+
+      (overlayContainerElement.querySelector('mat-option') as HTMLElement).click();
+      fixture.detectChanges();
+      flush();
+
+      expect(instance.selectedFood).toBe('steak-0');
+      expect(spy).toHaveBeenCalledWith('steak-0');
+    }));
+
   });
 
   describe('positioning', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -890,9 +890,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     }
 
     this._value = valueToEmit;
+    this.valueChange.emit(valueToEmit);
     this._onChange(valueToEmit);
     this.selectionChange.emit(new MatSelectChange(this, valueToEmit));
-    this.valueChange.emit(valueToEmit);
     this._changeDetectorRef.markForCheck();
   }
 


### PR DESCRIPTION
Fixes the select's `change` event emitting before the `value` binding has been updated, causing consumers that check the data-bound output to get a stale value.

Fixes #8739.