### PR TITLE
feat(table): support directly adding column, row, and header defs

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -36,6 +36,10 @@ export class CdkColumnDef {
   @Input('cdkColumnDef')
   get name(): string { return this._name; }
   set name(name: string) {
+    // If the directive is set without a name (updated programatically), then this setter will
+    // trigger with an empty string and should not overwrite the programatically set value.
+    if (!name) { return; }
+
     this._name = name;
     this.cssClassFriendlyName = name.replace(/[^a-z0-9_-]/ig, '-');
   }

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1,5 +1,5 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ContentChild, ContentChildren, Input, QueryList, ViewChild} from '@angular/core';
 import {CdkTable} from './table';
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
@@ -13,6 +13,8 @@ import {
   getTableMultipleDefaultRowDefsError,
   getTableUnknownColumnError
 } from './table-errors';
+import {CdkHeaderRowDef, CdkRowDef} from './row';
+import {CdkColumnDef} from './cell';
 
 describe('CdkTable', () => {
   let fixture: ComponentFixture<SimpleCdkTableApp>;
@@ -40,7 +42,9 @@ describe('CdkTable', () => {
         WhenRowWithoutDefaultCdkTableApp,
         WhenRowMultipleDefaultsCdkTableApp,
         MissingRowDefsCdkTableApp,
-        BooleanRowCdkTableApp
+        BooleanRowCdkTableApp,
+        WrapperCdkTableApp,
+        OuterTableApp,
       ],
     }).compileComponents();
   }));
@@ -182,7 +186,6 @@ describe('CdkTable', () => {
   it('should be able to dynamically add/remove column definitions', () => {
     const dynamicColumnDefFixture = TestBed.createComponent(DynamicColumnDefinitionsCdkTableApp);
     dynamicColumnDefFixture.detectChanges();
-    dynamicColumnDefFixture.detectChanges();
 
     const dynamicColumnDefTable = dynamicColumnDefFixture.nativeElement.querySelector('cdk-table');
     const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
@@ -230,6 +233,22 @@ describe('CdkTable', () => {
     getRows(tableElement).forEach(row => {
       expect(getCells(row).length).toBe(component.columnsToRender.length);
     });
+  });
+
+  it('should be able to register column, row, and header row definitions outside content', () => {
+    const outerTableAppFixture = TestBed.createComponent(OuterTableApp);
+    outerTableAppFixture.detectChanges();
+
+    // The first two columns were defined in the wrapped table component as content children,
+    // while the injected columns were provided to the wrapped table from the outer component.
+    // A special row was provided with a when predicate that shows the single column with text.
+    // The header row was defined by the outer component.
+    expectTableToMatchContent(outerTableAppFixture.nativeElement.querySelector('cdk-table'), [
+      ['Content Column A', 'Content Column B', 'Injected Column A', 'Injected Column B'],
+      ['injected row with when predicate'],
+      ['a_2', 'b_2', 'a_2', 'b_2'],
+      ['a_3', 'b_3', 'a_3', 'b_3']
+    ]);
   });
 
   describe('using when predicate', () => {
@@ -1070,6 +1089,72 @@ class RowContextCdkTableApp {
   columnsToRender = ['column_a'];
   enableRowContextClasses = false;
   enableCellContextClasses = false;
+}
+
+@Component({
+  selector: 'wrapper-table',
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="content_column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Content Column A </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+      </ng-container>
+      <ng-container cdkColumnDef="content_column_b">
+        <cdk-header-cell *cdkHeaderCellDef> Content Column B </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.b}} </cdk-cell>
+      </ng-container>
+
+      <cdk-row *cdkRowDef="let row; columns: columns"></cdk-row>
+    </cdk-table>
+  `
+})
+class WrapperCdkTableApp<T> {
+  @ContentChildren(CdkColumnDef) columnDefs: QueryList<CdkColumnDef>;
+  @ContentChild(CdkHeaderRowDef) headerRowDef: CdkHeaderRowDef;
+  @ContentChildren(CdkRowDef) rowDefs: QueryList<CdkRowDef<T>>;
+
+  @ViewChild(CdkTable) table: CdkTable<T>;
+
+  @Input() columns: string[];
+  @Input() dataSource: DataSource<T>;
+
+  ngAfterContentInit() {
+    // Register the content's column, row, and header row definitions.
+    this.columnDefs.forEach(columnDef => this.table.addColumnDef(columnDef));
+    this.rowDefs.forEach(rowDef => this.table.addRowDef(rowDef));
+    this.table.setHeaderRowDef(this.headerRowDef);
+  }
+}
+
+@Component({
+  template: `
+    <wrapper-table [dataSource]="dataSource" [columns]="columnsToRender">
+      <ng-container cdkColumnDef="injected_column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Injected Column A </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+      </ng-container>
+      <ng-container cdkColumnDef="injected_column_b">
+        <cdk-header-cell *cdkHeaderCellDef> Injected Column B </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.b}} </cdk-cell>
+      </ng-container>
+
+      <!-- Only used for the 'when' row, the first row -->
+      <ng-container cdkColumnDef="special_column">
+        <cdk-cell *cdkCellDef="let row"> injected row with when predicate </cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
+      <cdk-row class="first-row" *cdkRowDef="let row; columns: ['special_column']; when: firstRow">
+      </cdk-row>
+    </wrapper-table>
+  `
+})
+class OuterTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+  columnsToRender =
+      ['content_column_a', 'content_column_b', 'injected_column_a', 'injected_column_b'];
+
+  firstRow = i => i === 0;
 }
 
 function getElements(element: Element, query: string): Element[] {

--- a/src/demo-app/demo-app/demo-module.ts
+++ b/src/demo-app/demo-app/demo-module.ts
@@ -57,7 +57,7 @@ import {TooltipDemo} from '../tooltip/tooltip-demo';
 import {TypographyDemo} from '../typography/typography-demo';
 import {DemoApp, Home} from './demo-app';
 import {DEMO_APP_ROUTES} from './routes';
-import {TableDemoModule} from 'table/table-demo-module';
+import {TableDemoModule} from '../table/table-demo-module';
 
 @NgModule({
   imports: [

--- a/src/demo-app/demo-app/demo-module.ts
+++ b/src/demo-app/demo-app/demo-module.ts
@@ -32,10 +32,10 @@ import {ListDemo} from '../list/list-demo';
 import {LiveAnnouncerDemo} from '../live-announcer/live-announcer-demo';
 import {MenuDemo} from '../menu/menu-demo';
 import {
+  KeyboardTrackingPanel,
   OverlayDemo,
   RotiniPanel,
-  SpagettiPanel,
-  KeyboardTrackingPanel
+  SpagettiPanel
 } from '../overlay/overlay-demo';
 import {PlatformDemo} from '../platform/platform-demo';
 import {PortalDemo, ScienceJoke} from '../portal/portal-demo';
@@ -49,17 +49,15 @@ import {SlideToggleDemo} from '../slide-toggle/slide-toggle-demo';
 import {SliderDemo} from '../slider/slider-demo';
 import {SnackBarDemo} from '../snack-bar/snack-bar-demo';
 import {StepperDemo} from '../stepper/stepper-demo';
-import {PeopleDatabase} from '../table/people-database';
-import {TableDemo} from '../table/table-demo';
 import {ScreenTypeDemo} from '../screen-type/screen-type-demo';
 import {LayoutModule} from '@angular/cdk/layout';
-import {TableHeaderDemo} from '../table/table-header-demo';
 import {FoggyTabContent, RainyTabContent, SunnyTabContent, TabsDemo} from '../tabs/tabs-demo';
 import {ToolbarDemo} from '../toolbar/toolbar-demo';
 import {TooltipDemo} from '../tooltip/tooltip-demo';
 import {TypographyDemo} from '../typography/typography-demo';
 import {DemoApp, Home} from './demo-app';
 import {DEMO_APP_ROUTES} from './routes';
+import {TableDemoModule} from 'table/table-demo-module';
 
 @NgModule({
   imports: [
@@ -69,6 +67,7 @@ import {DEMO_APP_ROUTES} from './routes';
     RouterModule.forChild(DEMO_APP_ROUTES),
     DemoMaterialModule,
     LayoutModule,
+    TableDemoModule,
   ],
   declarations: [
     AutocompleteDemo,
@@ -117,8 +116,6 @@ import {DEMO_APP_ROUTES} from './routes';
     SpagettiPanel,
     StepperDemo,
     SunnyTabContent,
-    TableDemo,
-    TableHeaderDemo,
     TabsDemo,
     ToolbarDemo,
     TooltipDemo,
@@ -126,7 +123,6 @@ import {DEMO_APP_ROUTES} from './routes';
   ],
   providers: [
     {provide: OverlayContainer, useClass: FullscreenOverlayContainer},
-    PeopleDatabase
   ],
   entryComponents: [
     ContentElementDialog,

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -48,8 +48,8 @@ import {ToolbarDemo} from '../toolbar/toolbar-demo';
 import {TooltipDemo} from '../tooltip/tooltip-demo';
 import {TypographyDemo} from '../typography/typography-demo';
 import {DemoApp, Home} from './demo-app';
-import {TableDemoPage} from 'table/table-demo-page';
-import {TABLE_DEMO_ROUTES} from 'table/routes';
+import {TableDemoPage} from '../table/table-demo-page';
+import {TABLE_DEMO_ROUTES} from '../table/routes';
 
 export const DEMO_APP_ROUTES: Routes = [
   {path: '', component: DemoApp, children: [

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -42,13 +42,14 @@ import {SlideToggleDemo} from '../slide-toggle/slide-toggle-demo';
 import {SliderDemo} from '../slider/slider-demo';
 import {SnackBarDemo} from '../snack-bar/snack-bar-demo';
 import {StepperDemo} from '../stepper/stepper-demo';
-import {TableDemo} from '../table/table-demo';
 import {TABS_DEMO_ROUTES} from '../tabs/routes';
 import {TabsDemo} from '../tabs/tabs-demo';
 import {ToolbarDemo} from '../toolbar/toolbar-demo';
 import {TooltipDemo} from '../tooltip/tooltip-demo';
 import {TypographyDemo} from '../typography/typography-demo';
 import {DemoApp, Home} from './demo-app';
+import {TableDemoPage} from 'table/table-demo-page';
+import {TABLE_DEMO_ROUTES} from 'table/routes';
 
 export const DEMO_APP_ROUTES: Routes = [
   {path: '', component: DemoApp, children: [
@@ -85,7 +86,7 @@ export const DEMO_APP_ROUTES: Routes = [
     {path: 'slider', component: SliderDemo},
     {path: 'snack-bar', component: SnackBarDemo},
     {path: 'stepper', component: StepperDemo},
-    {path: 'table', component: TableDemo},
+    {path: 'table', component: TableDemoPage, children: TABLE_DEMO_ROUTES},
     {path: 'tabs', component: TabsDemo, children: TABS_DEMO_ROUTES},
     {path: 'toolbar', component: ToolbarDemo},
     {path: 'tooltip', component: TooltipDemo},

--- a/src/demo-app/table/custom-table/custom-table.html
+++ b/src/demo-app/table/custom-table/custom-table.html
@@ -1,0 +1,40 @@
+<mat-card class="demo-table-card">
+  <h3> MatTable with Simple Columns </h3>
+
+  <mat-table [dataSource]="simpleTableDataSource"
+             matSort #simpleTableSort="matSort">
+    <!-- Basic column: name is used for header label AND data property -->
+    <simple-column name="name" sortable></simple-column>
+    <simple-column name="position"></simple-column>
+
+    <!-- Name doesn't match the data property (or transform needed); define a custom data accessor -->
+    <simple-column name="weight" [dataAccessor]="getWeight"></simple-column>
+
+    <!-- Name doesn't match desired header text; define a custom label -->
+    <simple-column name="symbol" label="SYMBOL!"></simple-column>
+
+    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+    <mat-row *matRowDef="let data; columns: columnsToDisplay;"></mat-row>
+  </mat-table>
+</mat-card>
+
+
+
+<mat-card class="demo-table-card">
+  <h3> Wrapper Table </h3>
+
+  <wrapper-table [dataSource]="wrapperTableDataSource" [columns]="columnsToDisplay"
+                 matSort #wrapperTableSort="matSort">
+    <!-- Name (normal column) -->
+    <ng-container matColumnDef="name">
+      <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{element.name}} </mat-cell>
+    </ng-container>
+
+    <!-- Position (simple column) -->
+    <simple-column name="position"></simple-column>
+
+    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: columnsToDisplay; "></mat-row>
+  </wrapper-table>
+</mat-card>

--- a/src/demo-app/table/custom-table/custom-table.scss
+++ b/src/demo-app/table/custom-table/custom-table.scss
@@ -1,0 +1,8 @@
+.mat-table {
+  height: 300px;
+  overflow: auto;
+}
+
+.mat-card {
+  margin: 8px 0;
+}

--- a/src/demo-app/table/custom-table/custom-table.ts
+++ b/src/demo-app/table/custom-table/custom-table.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewChild} from '@angular/core';
+import {MatSort, MatTableDataSource} from '@angular/material';
+import {Element, ELEMENT_DATA} from 'table/element-data';
+
+@Component({
+  moduleId: module.id,
+  templateUrl: 'custom-table.html',
+  styleUrls: ['custom-table.css'],
+})
+export class CustomTableDemo {
+  columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
+  simpleTableDataSource = new MatTableDataSource<Element>(ELEMENT_DATA);
+  wrapperTableDataSource = new MatTableDataSource<Element>(ELEMENT_DATA);
+  getWeight = (data: Element) => '~' + data.weight;
+
+  @ViewChild('simpleTableSort') simpleTableSort: MatSort;
+  @ViewChild('wrapperTableSort') wrapperTableSort: MatSort;
+
+  ngAfterViewInit() {
+    this.simpleTableDataSource.sort = this.simpleTableSort;
+    this.wrapperTableDataSource.sort = this.wrapperTableSort;
+  }
+}

--- a/src/demo-app/table/custom-table/custom-table.ts
+++ b/src/demo-app/table/custom-table/custom-table.ts
@@ -8,7 +8,7 @@
 
 import {Component, ViewChild} from '@angular/core';
 import {MatSort, MatTableDataSource} from '@angular/material';
-import {Element, ELEMENT_DATA} from 'table/element-data';
+import {Element, ELEMENT_DATA} from '../element-data';
 
 @Component({
   moduleId: module.id,

--- a/src/demo-app/table/custom-table/simple-column.ts
+++ b/src/demo-app/table/custom-table/simple-column.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Input, Optional, ViewChild} from '@angular/core';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MatSortHeader} from '@angular/material/sort';
+import {MatColumnDef, MatTable} from '@angular/material';
+
+/**
+ * Column that shows simply shows text content for the header and row
+ * cells. By default, the name of this column will be assumed to be both the header
+ * text and data property used to access the data value to show in cells. To override
+ * the header text, provide a label text. To override the data cell values,
+ * provide a dataAccessor function that provides the string to display for each row's cell.
+ *
+ * Note that this component sets itself as visually hidden since it will show up in the `mat-table`
+ * DOM because it is an empty element with an ng-container (nothing rendered). It should not
+ * interfere with screen readers.
+ */
+@Component({
+  selector: 'simple-column',
+  template: `
+    <ng-container matColumnDef>
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{label || name}}
+      </mat-header-cell>
+
+      <mat-cell *matCellDef="let data">
+        {{getData(data)}}
+      </mat-cell>
+    </ng-container>
+  `,
+  host: {
+    'class': 'simple-column cdk-visually-hidden',
+    '[attr.ariaHidden]': 'true',
+  }
+})
+export class SimpleColumn<T> {
+  /** Column name that should be used to reference this column. */
+  @Input()
+  get name(): string { return this._name; }
+  set name(name: string) {
+    this._name = name;
+    this.columnDef.name = name;
+  }
+  _name: string;
+
+  /**
+   * Text label that should be used for the column header. If this property is not
+   * set, the header text will default to the column name.
+   */
+  @Input() label: string;
+
+  /**
+   * Accessor function to retrieve the data should be provided to the cell. If this
+   * property is not set, the data cells will assume that the column name is the same
+   * as the data property the cells should display.
+   */
+  @Input() dataAccessor: ((data: T, name: string) => string);
+
+  /** Alignment of the cell values. */
+  @Input() align: 'before' | 'after' = 'before';
+
+  /** Whether the column is sortable */
+  @Input()
+  get sortable(): boolean { return this._sortable; }
+  set sortable(sortable: boolean) {
+    this._sortable = coerceBooleanProperty(sortable);
+  }
+  _sortable: boolean;
+
+  @ViewChild(MatColumnDef) columnDef: MatColumnDef;
+
+  @ViewChild(MatSortHeader) sortHeader: MatSortHeader;
+
+  constructor(@Optional() public table: MatTable<any>) { }
+
+  ngOnInit() {
+    if (this.table) {
+      this.table.addColumnDef(this.columnDef);
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.table) {
+      this.table.removeColumnDef(this.columnDef);
+    }
+  }
+
+  getData(data: T): any {
+    return this.dataAccessor ? this.dataAccessor(data, this.name) : (<any>data)[this.name];
+  }
+}

--- a/src/demo-app/table/custom-table/wrapper-table.html
+++ b/src/demo-app/table/custom-table/wrapper-table.html
@@ -1,0 +1,15 @@
+<mat-table [dataSource]="dataSource">
+  <ng-content></ng-content>
+
+  <!-- Weight Column -->
+  <ng-container matColumnDef="weight">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Weight </mat-header-cell>
+    <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
+  </ng-container>
+
+  <!-- Color Column -->
+  <ng-container matColumnDef="symbol">
+    <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
+    <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>
+  </ng-container>
+</mat-table>

--- a/src/demo-app/table/custom-table/wrapper-table.ts
+++ b/src/demo-app/table/custom-table/wrapper-table.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ContentChild, ContentChildren, Input, QueryList, ViewChild} from '@angular/core';
+import {DataSource} from '@angular/cdk/collections';
+import {MatColumnDef, MatHeaderRowDef, MatRowDef, MatTable} from '@angular/material';
+import {SimpleColumn} from './simple-column';
+
+@Component({
+  moduleId: module.id,
+  selector: 'wrapper-table',
+  templateUrl: 'wrapper-table.html',
+  styles: [`
+    .mat-table {
+      height: 300px;
+      overflow: auto;
+    }
+  `]
+})
+export class WrapperTable<T> {
+  /** Different ways the client can add column definitions */
+  @ContentChildren(SimpleColumn) simpleColumns: QueryList<SimpleColumn<T>>;
+  @ContentChildren(MatColumnDef) columnDefs: QueryList<MatColumnDef>;
+
+  @ContentChild(MatHeaderRowDef) headerRowDef: MatHeaderRowDef;
+  @ContentChildren(MatRowDef) rowDefs: QueryList<MatRowDef<T>>;
+
+  @ViewChild(MatTable) table: MatTable<T>;
+
+  @Input() columns: string[];
+
+  @Input() dataSource: DataSource<T>;
+
+  ngAfterContentInit() {
+    // Register the simple columns to the table
+    this.simpleColumns.forEach(simpleColumn => this.table.addColumnDef(simpleColumn.columnDef));
+
+    // Register the normal column defs to the table
+    this.columnDefs.forEach(columnDef => this.table.addColumnDef(columnDef));
+
+    // Register any custom row definitions to the table
+    this.rowDefs.forEach(rowDef => this.table.addRowDef(rowDef));
+
+    // Register the header row definition.
+    this.table.setHeaderRowDef(this.headerRowDef);
+  }
+}

--- a/src/demo-app/table/element-data.ts
+++ b/src/demo-app/table/element-data.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface Element {
+  position: number;
+  name: string;
+  weight: number;
+  symbol: string;
+}
+
+export const ELEMENT_DATA: Element[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+  {position: 11, name: 'Sodium', weight: 22.9897, symbol: 'Na'},
+  {position: 12, name: 'Magnesium', weight: 24.305, symbol: 'Mg'},
+  {position: 13, name: 'Aluminum', weight: 26.9815, symbol: 'Al'},
+  {position: 14, name: 'Silicon', weight: 28.0855, symbol: 'Si'},
+  {position: 15, name: 'Phosphorus', weight: 30.9738, symbol: 'P'},
+  {position: 16, name: 'Sulfur', weight: 32.065, symbol: 'S'},
+  {position: 17, name: 'Chlorine', weight: 35.453, symbol: 'Cl'},
+  {position: 18, name: 'Argon', weight: 39.948, symbol: 'Ar'},
+  {position: 19, name: 'Potassium', weight: 39.0983, symbol: 'K'},
+  {position: 20, name: 'Calcium', weight: 40.078, symbol: 'Ca'},
+];

--- a/src/demo-app/table/routes.ts
+++ b/src/demo-app/table/routes.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Routes} from '@angular/router';
+import {TableDemo} from 'table/table-demo';
+import {CustomTableDemo} from 'table/custom-table/custom-table';
+
+export const TABLE_DEMO_ROUTES: Routes = [
+  {path: '', redirectTo: 'main-demo', pathMatch: 'full'},
+  {path: 'main-demo', component: TableDemo},
+  {path: 'custom-table', component: CustomTableDemo},
+];

--- a/src/demo-app/table/routes.ts
+++ b/src/demo-app/table/routes.ts
@@ -7,8 +7,8 @@
  */
 
 import {Routes} from '@angular/router';
-import {TableDemo} from 'table/table-demo';
-import {CustomTableDemo} from 'table/custom-table/custom-table';
+import {TableDemo} from './table-demo';
+import {CustomTableDemo} from './custom-table/custom-table';
 
 export const TABLE_DEMO_ROUTES: Routes = [
   {path: '', redirectTo: 'main-demo', pathMatch: 'full'},

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -8,7 +8,7 @@
 
 import {NgModule} from '@angular/core';
 import {TableDemo} from './table-demo';
-import {TableHeaderDemo} from './table/table-header-demo';
+import {TableHeaderDemo} from './table-header-demo';
 import {PeopleDatabase} from './people-database';
 import {TableDemoPage} from './table-demo-page';
 import {CustomTableDemo} from './custom-table/custom-table';

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -7,11 +7,11 @@
  */
 
 import {NgModule} from '@angular/core';
-import {TableDemo} from 'table/table-demo';
-import {TableHeaderDemo} from 'table/table-header-demo';
-import {PeopleDatabase} from 'table/people-database';
-import {TableDemoPage} from 'table/table-demo-page';
-import {CustomTableDemo} from 'table/custom-table/custom-table';
+import {TableDemo} from './table-demo';
+import {TableHeaderDemo} from './table/table-header-demo';
+import {PeopleDatabase} from './people-database';
+import {TableDemoPage} from './table-demo-page';
+import {CustomTableDemo} from './custom-table/custom-table';
 import {
   MatButtonModule,
   MatCardModule,
@@ -27,8 +27,8 @@ import {FormsModule} from '@angular/forms';
 import {CdkTableModule} from '@angular/cdk/table';
 import {CommonModule} from '@angular/common';
 import {RouterModule} from '@angular/router';
-import {WrapperTable} from 'table/custom-table/wrapper-table';
-import {SimpleColumn} from 'table/custom-table/simple-column';
+import {WrapperTable} from './custom-table/wrapper-table';
+import {SimpleColumn} from './custom-table/simple-column';
 
 @NgModule({
   imports: [

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {TableDemo} from 'table/table-demo';
+import {TableHeaderDemo} from 'table/table-header-demo';
+import {PeopleDatabase} from 'table/people-database';
+import {TableDemoPage} from 'table/table-demo-page';
+import {CustomTableDemo} from 'table/custom-table/custom-table';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatIconModule,
+  MatInputModule, MatMenuModule,
+  MatPaginatorModule,
+  MatRadioModule,
+  MatSortModule,
+  MatTableModule, MatTabsModule
+} from '@angular/material';
+import {FormsModule} from '@angular/forms';
+import {CdkTableModule} from '@angular/cdk/table';
+import {CommonModule} from '@angular/common';
+import {RouterModule} from '@angular/router';
+import {WrapperTable} from 'table/custom-table/wrapper-table';
+import {SimpleColumn} from 'table/custom-table/simple-column';
+
+@NgModule({
+  imports: [
+    CdkTableModule,
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatInputModule,
+    MatMenuModule,
+    MatPaginatorModule,
+    MatRadioModule,
+    MatSortModule,
+    MatTableModule,
+    MatTabsModule,
+    RouterModule,
+  ],
+  declarations: [
+    CustomTableDemo,
+    TableDemo,
+    TableDemoPage,
+    TableHeaderDemo,
+    WrapperTable,
+    SimpleColumn,
+  ],
+  providers: [
+    PeopleDatabase
+  ],
+})
+export class TableDemoModule { }

--- a/src/demo-app/table/table-demo-page.html
+++ b/src/demo-app/table/table-demo-page.html
@@ -1,0 +1,10 @@
+<nav mat-tab-nav-bar>
+  <a mat-tab-link *ngFor="let link of links"
+     [active]="rla.isActive"
+     [routerLink]="link.link"
+     routerLinkActive #rla="routerLinkActive">
+    {{link.name}}
+  </a>
+</nav>
+
+<router-outlet></router-outlet>

--- a/src/demo-app/table/table-demo-page.ts
+++ b/src/demo-app/table/table-demo-page.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  templateUrl: 'table-demo-page.html',
+})
+export class TableDemoPage {
+  links = [
+    {name: 'Main Page', link: 'main-demo'},
+    {name: 'Custom Table', link: 'custom-table'},
+  ];
+}

--- a/src/lib/table/table-module.ts
+++ b/src/lib/table/table-module.ts
@@ -9,8 +9,8 @@
 import {NgModule} from '@angular/core';
 import {MatTable} from './table';
 import {CdkTableModule} from '@angular/cdk/table';
-import {MatCell, MatHeaderCell, MatCellDef, MatHeaderCellDef, MatColumnDef} from './cell';
-import {MatHeaderRow, MatRow, MatHeaderRowDef, MatRowDef} from './row';
+import {MatCell, MatCellDef, MatColumnDef, MatHeaderCell, MatHeaderCellDef} from './cell';
+import {MatHeaderRow, MatHeaderRowDef, MatRow, MatRowDef} from './row';
 import {CommonModule} from '@angular/common';
 import {MatCommonModule} from '@angular/material/core';
 


### PR DESCRIPTION
_PR touches 17 files, but majority of this is demo code. Real work is all contained in `cdk/table.ts` and a very minor change to `CdkColumnDef`._

This allow the table to use definitions beyond what it can grab via `ContentChildren`. Useful for several different features such as being able to create separate components that wrap columns as well as wrapper tables that can come with pre-generated columns (e.g. a table that comes with a selection column).

Starts foundation for features such as the `simple-table` and `simple-column` which will further lower the learning curve of the table by reducing complexity in building a starter table.

Note that the table demo component is now using routes to divide out some features, with this one being the first. Most of this PR is just demo code changes to accommodate this and add the usage of this feature.