### PR TITLE
fix(input): allow color inputs in mat-form-field

### DIFF
--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -8,7 +8,7 @@
 
       <table style="width: 100%" cellspacing="0"><tr>
         <td>
-          <mat-form-field style="width: 100%" floatPlaceholder="never">
+          <mat-form-field style="width: 100%" floatLabel="never">
             <input matInput placeholder="First name">
           </mat-form-field>
         </td>
@@ -304,8 +304,15 @@
     </p>
 
     <p>
-      <mat-form-field [floatPlaceholder]="floatingLabel">
+      <mat-form-field [floatLabel]="floatingLabel">
         <input matInput placeholder="Placeholder">
+      </mat-form-field>
+    </p>
+
+    <p>
+      <mat-form-field [floatLabel]="floatingLabel">
+        <mat-label>What is your favorite color?</mat-label>
+        <input matInput type="color" value="#00ff00">
       </mat-form-field>
     </p>
 

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -31,7 +31,6 @@ import {MAT_INPUT_VALUE_ACCESSOR} from './input-value-accessor';
 const MAT_INPUT_INVALID_TYPES = [
   'button',
   'checkbox',
-  'color',
   'file',
   'hidden',
   'image',

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -103,7 +103,7 @@
 
 <h2>Input</h2>
 
-<mat-form-field floatPlaceholder="never">
+<mat-form-field floatLabel="never">
   <input matInput placeholder="name">
 </mat-form-field>
 


### PR DESCRIPTION
* Allows users to put an `input[type='color']` inside a form field.
* Cleans out a few leftover `floatPlaceholder` usages.

Fixes #8686.