### PR TITLE
fix(global-position-strategy): error if disposed before applied

### DIFF
--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -5,6 +5,7 @@ import {OverlayModule, Overlay, OverlayRef, GlobalPositionStrategy} from '../ind
 describe('GlobalPositonStrategy', () => {
   let element: HTMLElement;
   let strategy: GlobalPositionStrategy;
+  let hasOverlayAttached: boolean;
 
   beforeEach(() => {
     TestBed.configureTestingModule({imports: [OverlayModule]});
@@ -15,11 +16,18 @@ describe('GlobalPositonStrategy', () => {
 
     element = document.createElement('div');
     document.body.appendChild(element);
-    strategy.attach({overlayElement: element} as OverlayRef);
+    hasOverlayAttached = true;
+    strategy.attach({
+      overlayElement: element,
+      hasAttached: () => hasOverlayAttached
+    } as OverlayRef);
   });
 
   afterEach(() => {
-    element.parentNode!.removeChild(element);
+    if (element.parentNode) {
+      element.parentNode.removeChild(element);
+    }
+
     strategy.dispose();
   });
 
@@ -150,5 +158,13 @@ describe('GlobalPositonStrategy', () => {
 
     expect(element.style.marginTop).toBe('0px');
     expect((element.parentNode as HTMLElement).style.alignItems).toBe('flex-start');
+  });
+
+  it('should not throw when attempting to apply after the overlay has been disposed', () => {
+    strategy.dispose();
+    element.parentNode!.removeChild(element);
+    hasOverlayAttached = false;
+
+    expect(() => strategy.apply()).not.toThrow();
   });
 });

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -146,6 +146,13 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * @returns Resolved when the styles have been applied.
    */
   apply(): void {
+    // Since the overlay ref applies the strategy asynchronously, it could
+    // have been disposed before it ends up being applied. If that is the
+    // case, we shouldn't do anything.
+    if (!this._overlayRef.hasAttached()) {
+      return;
+    }
+
     const element = this._overlayRef.overlayElement;
 
     if (!this._wrapper && element.parentNode) {


### PR DESCRIPTION
Fixes an error that is thrown by the `GlobalPositionStrategy` if its connected `OverlayRef` is disposed before the strategy is applied. This could happen, because the `OverlayRef` applies the position strategy asynchronously.

Fixes #8758.