### PR TITLE
chore(checkbox): remove leftover console.log

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -381,7 +381,6 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       if (this.indeterminate && this._clickAction !== 'check') {
 
         Promise.resolve().then(() => {
-          console.log(`reset indeterminate`);
           this._indeterminate = false;
           this.indeterminateChange.emit(this._indeterminate);
         });


### PR DESCRIPTION
Gets rid of a `console.log` that was left over from 537b8b552a9442869ed0fbddb5939a1dfafb3f6b.