### PR TITLE
fix(layout): handle platforms that don't support matchMedia

### DIFF
--- a/src/cdk/layout/media-matcher.ts
+++ b/src/cdk/layout/media-matcher.ts
@@ -20,7 +20,7 @@ export class MediaMatcher {
   private _matchMedia: (query: string) => MediaQueryList;
 
   constructor(private platform: Platform) {
-    this._matchMedia = this.platform.isBrowser ?
+    this._matchMedia = this.platform.isBrowser && window.matchMedia ?
       // matchMedia is bound to the window scope intentionally as it is an illegal invocation to
       // call it from a different scope.
       window.matchMedia.bind(window) :


### PR DESCRIPTION
Adds an extra check to ensure that the current platform supports `window.matchMedia`.

Fixes #8710.