### PR TITLE
fix(select): complete state change event

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1698,6 +1698,25 @@ describe('MatSelect', () => {
     }));
   });
 
+  describe('change events', () => {
+    beforeEach(async(() => configureMatSelectTestingModule([SelectWithPlainTabindex])));
+
+    it('should complete the stateChanges stream on destroy', () => {
+      const fixture = TestBed.createComponent(SelectWithPlainTabindex);
+      fixture.detectChanges();
+
+      const debugElement = fixture.debugElement.query(By.directive(MatSelect));
+      const select = debugElement.componentInstance;
+
+      const spy = jasmine.createSpy('stateChanges complete');
+      const subscription = select.stateChanges.subscribe(undefined, undefined, spy);
+
+      fixture.destroy();
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    });
+  });
+
   describe('when initially hidden', () => {
     beforeEach(async(() => configureMatSelectTestingModule([BasicSelectInitiallyHidden])));
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -503,6 +503,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   ngOnDestroy() {
     this._destroy.next();
     this._destroy.complete();
+    this.stateChanges.complete();
   }
 
   /** Toggles the overlay panel open or closed. */


### PR DESCRIPTION
The FormField component binds to the select's `stateChanges` stream but the stream is never completed. This PR completes that stream just like the Input component does.

Ref: https://github.com/angular/material2/blob/master/src/lib/form-field/form-field.ts#L188