### PR TITLE
fix(select): not marked as touched when clicking away

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1118,7 +1118,7 @@ describe('MatSelect', () => {
             .not.toContain('mat-selected', `Expected option w/ the old value not to be selected.`);
       }));
 
-      it('should set the control to touched when the select is touched', fakeAsync(() => {
+      it('should set the control to touched when the select is blurred', fakeAsync(() => {
         expect(fixture.componentInstance.control.touched)
             .toEqual(false, `Expected the control to start off as untouched.`);
 
@@ -1139,6 +1139,26 @@ describe('MatSelect', () => {
 
         expect(fixture.componentInstance.control.touched)
             .toEqual(true, `Expected the control to be touched as soon as focus left the select.`);
+      }));
+
+      it('should set the control to touched when the panel is closed', fakeAsync(() => {
+        expect(fixture.componentInstance.control.touched)
+            .toBe(false, 'Expected the control to start off as untouched.');
+
+        trigger.click();
+        dispatchFakeEvent(trigger, 'blur');
+        fixture.detectChanges();
+        flush();
+
+        expect(fixture.componentInstance.control.touched)
+            .toBe(false, 'Expected the control to stay untouched when menu opened.');
+
+        fixture.componentInstance.select.close();
+        fixture.detectChanges();
+        flush();
+
+        expect(fixture.componentInstance.control.touched)
+            .toBe(true, 'Expected the control to be touched when the panel was closed.');
       }));
 
       it('should not set touched when a disabled select is touched', fakeAsync(() => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -540,6 +540,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     if (this._panelOpen) {
       this._panelOpen = false;
       this._changeDetectorRef.markForCheck();
+      this._onTouched();
       this.focus();
     }
   }


### PR DESCRIPTION
Currently `mat-select` is only marked as touched when the trigger is blurred. This means that it still considered untouched if the user opens the panel and clicks away, which then requires another click to show any validation messages. These changes switch to considering the control as touched whenever the panel is closed.

Fixes #8573.