### PR TITLE
chore(tooltip): remove unsupported mat-tooltip selector

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -85,7 +85,7 @@ export const MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER = {
  * https://material.google.com/components/tooltips.html
  */
 @Directive({
-  selector: '[mat-tooltip], [matTooltip]',
+  selector: '[matTooltip]',
   exportAs: 'matTooltip',
   host: {
     '(longpress)': 'show()',


### PR DESCRIPTION
The `mat-tooltip` selector was left in after the major refactorings

Technically not a breaking change since `mat-tooltip` doesn't work anyways (message is not populated by `mat-tooltip` anymore)

Fixes #8780 