### PR TITLE
docs: Fix column names in table-examples

### DIFF
--- a/src/material-examples/table-basic/table-basic-example.html
+++ b/src/material-examples/table-basic/table-basic-example.html
@@ -22,7 +22,7 @@
       <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
     </ng-container>
 
-    <!-- Color Column -->
+    <!-- Symbol Column -->
     <ng-container matColumnDef="symbol">
       <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>

--- a/src/material-examples/table-filtering/table-filtering-example.html
+++ b/src/material-examples/table-filtering/table-filtering-example.html
@@ -25,7 +25,7 @@
       <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
     </ng-container>
 
-    <!-- Color Column -->
+    <!-- Symbol Column -->
     <ng-container matColumnDef="symbol">
       <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>

--- a/src/material-examples/table-pagination/table-pagination-example.html
+++ b/src/material-examples/table-pagination/table-pagination-example.html
@@ -19,7 +19,7 @@
       <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
     </ng-container>
 
-    <!-- Color Column -->
+    <!-- Symbol Column -->
     <ng-container matColumnDef="symbol">
       <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>

--- a/src/material-examples/table-selection/table-selection-example.html
+++ b/src/material-examples/table-selection/table-selection-example.html
@@ -35,7 +35,7 @@
       <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
     </ng-container>
 
-    <!-- Color Column -->
+    <!-- Symbol Column -->
     <ng-container matColumnDef="symbol">
       <mat-header-cell *matHeaderCellDef> Symbol </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>

--- a/src/material-examples/table-sorting/table-sorting-example.html
+++ b/src/material-examples/table-sorting/table-sorting-example.html
@@ -19,7 +19,7 @@
       <mat-cell *matCellDef="let element"> {{element.weight}} </mat-cell>
     </ng-container>
 
-    <!-- Color Column -->
+    <!-- Symbol Column -->
     <ng-container matColumnDef="symbol">
       <mat-header-cell *matHeaderCellDef mat-sort-header> Symbol </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element.symbol}} </mat-cell>


### PR DESCRIPTION
Fix column name `Color Column` -> `Symbol Column` because those columns
are showing symbol