### PR TITLE
fix(connected-position-strategy): allow positions to be updated after init

### DIFF
--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -11,6 +11,7 @@ import {
   OverlayContainer,
   ConnectedPositionStrategy,
   ConnectedOverlayPositionChange,
+  ConnectionPositionPair,
 } from '../index';
 
 
@@ -544,6 +545,32 @@ describe('ConnectedPositionStrategy', () => {
         expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect!.top));
         expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect!.left));
       });
+
+      it('should allow for the positions to be updated after init', () => {
+        strategy = positionBuilder.connectedTo(
+            fakeElementRef,
+            {originX: 'start', originY: 'bottom'},
+            {overlayX: 'start', overlayY: 'top'});
+
+        strategy.attach(fakeOverlayRef(overlayElement));
+        strategy.apply();
+
+        let overlayRect = overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect!.bottom));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect!.left));
+
+        strategy.withPositions([new ConnectionPositionPair(
+          {originX: 'start', originY: 'bottom'},
+          {overlayX: 'end', overlayY: 'top'}
+        )]);
+
+        strategy.apply();
+
+        overlayRect = overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect!.bottom));
+        expect(Math.floor(overlayRect.right)).toBe(Math.floor(originRect!.left));
+      });
+
     }
   });
 

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -257,6 +257,15 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   }
 
   /**
+   * Overwrites the current set of positions with an array of new ones.
+   * @param positions Position pairs to be set on the strategy.
+   */
+  withPositions(positions: ConnectionPositionPair[]): this {
+    this._preferredPositions = positions.slice();
+    return this;
+  }
+
+  /**
    * Gets the horizontal (x) "start" dimension based on whether the overlay is in an RTL context.
    * @param rect
    */


### PR DESCRIPTION
Backports the ability to update a connected overlay's positioning from the new flexible connected position strategy. This helps facilitate cases like #8653 without having to overwrite the entire position strategy.