### PR TITLE
docs: add descriptions to properties initialized through the constructor

### DIFF
--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -33,7 +33,11 @@ let _uniqueAutocompleteIdCounter = 0;
 
 /** Event object that is emitted when an autocomplete option is selected */
 export class MatAutocompleteSelectedEvent {
-  constructor(public source: MatAutocomplete, public option: MatOption) { }
+  constructor(
+    /** Reference to the autocomplete panel that emitted the event. */
+    public source: MatAutocomplete,
+    /** Option that was selected. */
+    public option: MatOption) { }
 }
 
 

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -69,8 +69,10 @@ export class MatChipInput {
   @Output('matChipInputTokenEnd')
   chipEnd = new EventEmitter<MatChipInputEvent>();
 
+  /** The input's placeholder text. */
   @Input() placeholder: string = '';
 
+  /** Whether the input is empty. */
   get empty(): boolean {
     let value: string | null = this._inputElement.value;
     return (value == null || value === '');

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -60,7 +60,11 @@ let nextUniqueId = 0;
 
 /** Change event object that is emitted when the chip list value has changed. */
 export class MatChipListChange {
-  constructor(public source: MatChipList, public value: any) { }
+  constructor(
+    /** Chip list that emitted the event. */
+    public source: MatChipList,
+    /** Value of the chip list when the event was emitted. */
+    public value: any) { }
 }
 
 

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -29,7 +29,13 @@ export interface MatChipEvent {
 
 /** Event object emitted by MatChip when selected or deselected. */
 export class MatChipSelectionChange {
-  constructor(public source: MatChip, public selected: boolean, public isUserInput = false) { }
+  constructor(
+    /** Reference to the chip that emitted the event. */
+    public source: MatChip,
+    /** Whether the chip that emitted the event is selected. */
+    public selected: boolean,
+    /** Whether the selection change was a result of a user interaction. */
+    public isUserInput = false) { }
 }
 
 

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -32,7 +32,11 @@ let _uniqueIdCounter = 0;
 
 /** Event object emitted by MatOption when selected or deselected. */
 export class MatOptionSelectionChange {
-  constructor(public source: MatOption, public isUserInput = false) { }
+  constructor(
+    /** Reference to the option that emitted the event. */
+    public source: MatOption,
+    /** Whether the change in the option's value was a result of a user action. */
+    public isUserInput = false) { }
 }
 
 /**

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -61,7 +61,11 @@ export class MatDatepickerInputEvent<D> {
   /** The new value for the target datepicker input. */
   value: D | null;
 
-  constructor(public target: MatDatepickerInput<D>, public targetElement: HTMLElement) {
+  constructor(
+    /** Reference to the datepicker input component that emitted the event. */
+    public target: MatDatepickerInput<D>,
+    /** Reference to the native input element associated with the datepicker input. */
+    public targetElement: HTMLElement) {
     this.value = this.target.value;
   }
 }
@@ -104,7 +108,9 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     }
   }
 
-  @Input() set matDatepickerFilter(filter: (date: D | null) => boolean) {
+  /** Function that can be used to filter out dates within the datepicker. */
+  @Input()
+  set matDatepickerFilter(filter: (date: D | null) => boolean) {
     this._dateFilter = filter;
     this._validatorOnChange();
   }

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -29,14 +29,15 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck {
   private _minRows: number;
   private _maxRows: number;
 
+  /** Minimum amount of rows in the textarea. */
   @Input('matAutosizeMinRows')
   get minRows() { return this._minRows; }
-
   set minRows(value: number) {
     this._minRows = value;
     this._setMinHeight();
   }
 
+  /** Maximum amount of rows in the textarea. */
   @Input('matAutosizeMaxRows')
   get maxRows() { return this._maxRows; }
   set maxRows(value: number) {

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -122,6 +122,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
     this.setPositionClasses();
   }
 
+  /** @docs-private */
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
 
   /** List of the items inside of a menu. */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -137,7 +137,11 @@ export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER = {
 
 /** Change event object that is emitted when the select value has changed. */
 export class MatSelectChange {
-  constructor(public source: MatSelect, public value: any) { }
+  constructor(
+    /** Reference to the select that emitted the change event. */
+    public source: MatSelect,
+    /** Current value of the select that emitted the event. */
+    public value: any) { }
 }
 
 // Boilerplate for applying mixins to MatSelect.

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -51,7 +51,11 @@ export function throwMatDuplicatedDrawerError(position: string) {
  * @deprecated
  */
 export class MatDrawerToggleResult {
-  constructor(public type: 'open' | 'close', public animationFinished: boolean) {}
+  constructor(
+    /** Whether the drawer is opened or closed. */
+    public type: 'open' | 'close',
+    /** Whether the drawer animation is finished. */
+    public animationFinished: boolean) {}
 }
 
 

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -41,7 +41,9 @@ let nextId = 0;
 
 /** A simple change event emitted on focus or selection changes. */
 export class MatTabChangeEvent {
+  /** Index of the currently-selected tab. */
   index: number;
+  /** Reference to the currently-selected tab. */
   tab: MatTab;
 }
 

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -53,7 +53,11 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
 
   /** The portal that will be the hosted content of the tab */
   private _contentPortal: TemplatePortal<any> | null = null;
-  get content(): TemplatePortal<any> | null { return this._contentPortal; }
+
+  /** @docs-private */
+  get content(): TemplatePortal<any> | null {
+    return this._contentPortal;
+  }
 
   /** Emits whenever the label changes. */
   _labelChange = new Subject<void>();


### PR DESCRIPTION
Adds the missing docs to some of the properties that are declared through the constructor params.

Fixes #8789.