### PR TITLE
docs(chips): Property binding

### DIFF
--- a/src/lib/chips/chips.md
+++ b/src/lib/chips/chips.md
@@ -46,7 +46,7 @@ An example of chip input placed outside the chip-list element.
     <mat-chip>Chip 1</mat-chip>
     <mat-chip>Chip 2</mat-chip>
   </mat-chip-list>
-  <input matChipInputFor="chipList">
+  <input [matChipInputFor]="chipList">
 </mat-form-field>
 ```
 


### PR DESCRIPTION
Added property binding to chips example code to prevent runtime error.