### PR TITLE
chore: re-bump rxjs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material2-srcs",
-  "version": "5.0.0-rc.2",
+  "version": "5.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13204,11 +13204,11 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
-      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
       "requires": {
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -14655,9 +14655,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/forms": "^5.0.0",
     "@angular/platform-browser": "^5.0.0",
     "core-js": "^2.4.1",
-    "rxjs": "5.5.2",
+    "rxjs": "^5.5.5",
     "systemjs": "0.19.43",
     "tsickle": "^0.24.x",
     "tslib": "^1.7.1",


### PR DESCRIPTION
Now that rxjs 5.5.4 is out, we don't have to lock down to 5.5.2 in order to avoid e2e and test app failures.