### PR TITLE
chore: better tag check in publish-artifacts script

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -41,11 +41,6 @@ publishPackage() {
   repoUrl="https://github.com/angular/${packageRepo}.git"
   repoDir="tmp/${packageRepo}"
 
-  if [[ $(git rev-parse -q --verify "refs/tags/${commitTag}") ]]; then
-    echo "Skipping publish because tag is already published"
-    exit 0
-  fi
-
   if [[ ! ${COMMAND_ARGS} == *--no-build* ]]; then
     # Create a release of the current repository.
     $(npm bin)/gulp ${packageName}:build-release:clean
@@ -64,6 +59,11 @@ publishPackage() {
 
   # Create the build commit and push the changes to the repository.
   cd ${repoDir}
+
+  if [[ $(git ls-remote origin "refs/tags/${commitTag}") ]]; then
+    echo "Skipping publish because tag is already published"
+    exit 0
+  fi
 
   # Replace the version in every file recursively with a more specific version that also includes
   # the SHA of the current build job. Normally this "sed" call would just replace the version


### PR DESCRIPTION
Currently the publish-artifacts script checks for the tag in the local repository copy. Since the builds repository will be cloned with a depth of `1`, the tags aren't being checked properly.

To be more sure about the tag existence, the `git ls-remote` command can be used.