### PR TITLE
perf: remove element if ripples are disabled

### DIFF
--- a/src/lib/button/button.html
+++ b/src/lib/button/button.html
@@ -1,7 +1,6 @@
 <span class="mat-button-wrapper"><ng-content></ng-content></span>
-<div matRipple class="mat-button-ripple"
+<div matRipple class="mat-button-ripple" *ngIf="!_isRippleDisabled()"
      [class.mat-button-ripple-round]="_isRoundButton || _isIconButton"
-     [matRippleDisabled]="_isRippleDisabled()"
      [matRippleCentered]="_isIconButton"
      [matRippleTrigger]="_getHostElement()"></div>
 <div class="mat-button-focus-overlay"></div>

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -187,11 +187,7 @@ describe('MatButton', () => {
     let fixture: ComponentFixture<TestApp>;
     let testComponent: TestApp;
     let buttonDebugElement: DebugElement;
-    let buttonRippleDebugElement: DebugElement;
-    let buttonRippleInstance: MatRipple;
     let anchorDebugElement: DebugElement;
-    let anchorRippleDebugElement: DebugElement;
-    let anchorRippleInstance: MatRipple;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TestApp);
@@ -200,38 +196,34 @@ describe('MatButton', () => {
       testComponent = fixture.componentInstance;
 
       buttonDebugElement = fixture.debugElement.query(By.css('button[mat-button]'));
-      buttonRippleDebugElement = buttonDebugElement.query(By.directive(MatRipple));
-      buttonRippleInstance = buttonRippleDebugElement.injector.get<MatRipple>(MatRipple);
 
       anchorDebugElement = fixture.debugElement.query(By.css('a[mat-button]'));
-      anchorRippleDebugElement = anchorDebugElement.query(By.directive(MatRipple));
-      anchorRippleInstance = anchorRippleDebugElement.injector.get<MatRipple>(MatRipple);
     });
 
     it('should disable the ripple if matRippleDisabled input is set', () => {
-      expect(buttonRippleInstance.disabled).toBeFalsy();
+      expect(buttonDebugElement.query(By.directive(MatRipple))).not.toBeNull();
 
       testComponent.rippleDisabled = true;
       fixture.detectChanges();
 
-      expect(buttonRippleInstance.disabled).toBeTruthy();
+      expect(buttonDebugElement.query(By.directive(MatRipple))).toBeNull();
     });
 
     it('should disable the ripple when the button is disabled', () => {
-      expect(buttonRippleInstance.disabled).toBeFalsy(
+      expect(buttonDebugElement.query(By.directive(MatRipple))).not.toBeNull(
         'Expected an enabled button[mat-button] to have an enabled ripple'
       );
-      expect(anchorRippleInstance.disabled).toBeFalsy(
+      expect(anchorDebugElement.query(By.directive(MatRipple))).not.toBeNull(
         'Expected an enabled a[mat-button] to have an enabled ripple'
       );
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
 
-      expect(buttonRippleInstance.disabled).toBeTruthy(
+      expect(buttonDebugElement.query(By.directive(MatRipple))).toBeNull(
         'Expected a disabled button[mat-button] not to have an enabled ripple'
       );
-      expect(anchorRippleInstance.disabled).toBeTruthy(
+      expect(anchorDebugElement.query(By.directive(MatRipple))).toBeNull(
         'Expected a disabled a[mat-button] not to have an enabled ripple'
       );
     });

--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -16,9 +16,8 @@
            [attr.aria-checked]="_getAriaChecked()"
            (change)="_onInteractionEvent($event)"
            (click)="_onInputClick($event)">
-    <div matRipple class="mat-checkbox-ripple"
+    <div matRipple class="mat-checkbox-ripple" *ngIf="!_isRippleDisabled()"
          [matRippleTrigger]="label"
-         [matRippleDisabled]="_isRippleDisabled()"
          [matRippleRadius]="_rippleConfig.radius"
          [matRippleSpeedFactor]="_rippleConfig.speedFactor"
          [matRippleCentered]="_rippleConfig.centered">

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -440,7 +440,7 @@ describe('MatCheckbox', () => {
         expect(checkboxNativeElement.querySelectorAll('.mat-ripple-element').length).toBe(1);
       });
 
-      it('should remove ripple if matRippleDisabled input is set', () => {
+      it('should remove ripple if disableRipple input is set', () => {
         testComponent.disableRipple = true;
         fixture.detectChanges();
 

--- a/src/lib/core/option/option.html
+++ b/src/lib/core/option/option.html
@@ -3,7 +3,6 @@
 
 <span class="mat-option-text"><ng-content></ng-content></span>
 
-<div class="mat-option-ripple" mat-ripple
-     [matRippleTrigger]="_getHostElement()"
-     [matRippleDisabled]="disabled || disableRipple">
+<div class="mat-option-ripple" matRipple *ngIf="!disabled && !disableRipple"
+     [matRippleTrigger]="_getHostElement()">
 </div>

--- a/src/lib/list/list-item.html
+++ b/src/lib/list/list-item.html
@@ -1,7 +1,6 @@
 <div class="mat-list-item-content">
-  <div class="mat-list-item-ripple" mat-ripple
-       [matRippleTrigger]="_getHostElement()"
-       [matRippleDisabled]="_isRippleDisabled()">
+  <div matRipple class="mat-list-item-ripple" *ngIf="!_isRippleDisabled()"
+       [matRippleTrigger]="_getHostElement()">
   </div>
 
   <ng-content select="[mat-list-avatar], [mat-list-icon], [matListAvatar], [matListIcon]">

--- a/src/lib/list/list-option.html
+++ b/src/lib/list/list-option.html
@@ -2,10 +2,9 @@
   [class.mat-list-item-content-reverse]="checkboxPosition == 'after'"
   [class.mat-list-item-disabled]="disabled">
 
-  <div mat-ripple
-    class="mat-list-item-ripple"
-    [matRippleTrigger]="_getHostElement()"
-    [matRippleDisabled]="_isRippleDisabled()"></div>
+  <div matRipple class="mat-list-item-ripple" *ngIf="!_isRippleDisabled()"
+       [matRippleTrigger]="_getHostElement()">
+  </div>
 
   <mat-pseudo-checkbox #autocheckbox
     [state]="selected ? 'checked' : 'unchecked'"

--- a/src/lib/menu/menu-item.html
+++ b/src/lib/menu/menu-item.html
@@ -1,5 +1,4 @@
 <ng-content></ng-content>
-<div class="mat-menu-ripple" matRipple
-     [matRippleDisabled]="disableRipple || disabled"
+<div matRipple class="mat-menu-ripple" *ngIf="!disabled && !disableRipple"
      [matRippleTrigger]="_getHostElement()">
 </div>

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1,42 +1,42 @@
-import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {ESCAPE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
+import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
+import {ScrollDispatcher} from '@angular/cdk/scrolling';
+import {
+  createKeyboardEvent,
+  createMouseEvent,
+  dispatchEvent,
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  dispatchMouseEvent,
+} from '@angular/cdk/testing';
 import {
   Component,
   ElementRef,
   EventEmitter,
   Input,
   Output,
+  QueryList,
   TemplateRef,
   ViewChild,
   ViewChildren,
-  QueryList,
 } from '@angular/core';
-import {Direction, Directionality} from '@angular/cdk/bidi';
-import {OverlayContainer, Overlay} from '@angular/cdk/overlay';
-import {ESCAPE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
+import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {MatRipple} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Subject} from 'rxjs/Subject';
 import {
   MAT_MENU_DEFAULT_OPTIONS,
   MatMenu,
+  MatMenuItem,
   MatMenuModule,
   MatMenuPanel,
   MatMenuTrigger,
   MenuPositionX,
   MenuPositionY,
-  MatMenuItem,
 } from './index';
-import {MENU_PANEL_TOP_PADDING, MAT_MENU_SCROLL_STRATEGY} from './menu-trigger';
-import {MatRipple} from '@angular/material/core';
-import {
-  dispatchKeyboardEvent,
-  dispatchMouseEvent,
-  dispatchEvent,
-  createKeyboardEvent,
-  createMouseEvent,
-  dispatchFakeEvent,
-} from '@angular/cdk/testing';
-import {Subject} from 'rxjs/Subject';
-import {ScrollDispatcher} from '@angular/cdk/scrolling';
+import {MAT_MENU_SCROLL_STRATEGY, MENU_PANEL_TOP_PADDING} from './menu-trigger';
 
 
 describe('MatMenu', () => {
@@ -563,10 +563,10 @@ describe('MatMenu', () => {
 
       fixture.componentInstance.trigger.openMenu();
 
-      const item = fixture.debugElement.query(By.css('.mat-menu-item'));
-      const ripple = item.query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      // The first menu item in the `SimpleMenu` component should have ripples enabled by default.
+      const items = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
 
-      expect(ripple.disabled).toBe(false);
+      expect(items[0].query(By.directive(MatRipple))).not.toBeNull();
     });
 
     it('should disable ripples on disabled items', () => {
@@ -577,9 +577,8 @@ describe('MatMenu', () => {
 
       // The second menu item in the `SimpleMenu` component is disabled.
       const items = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
-      const ripple = items[1].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
 
-      expect(ripple.disabled).toBe(true);
+      expect(items[1].query(By.directive(MatRipple))).toBeNull();
     });
 
     it('should disable ripples if disableRipple is set', () => {
@@ -590,9 +589,8 @@ describe('MatMenu', () => {
 
       // The third menu item in the `SimpleMenu` component has ripples disabled.
       const items = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
-      const ripple = items[2].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
 
-      expect(ripple.disabled).toBe(true);
+      expect(items[2].query(By.directive(MatRipple))).toBeNull();
     });
   });
 

--- a/src/lib/radio/radio.html
+++ b/src/lib/radio/radio.html
@@ -5,9 +5,8 @@
   <div class="mat-radio-container">
     <div class="mat-radio-outer-circle"></div>
     <div class="mat-radio-inner-circle"></div>
-    <div mat-ripple class="mat-radio-ripple"
+    <div matRipple class="mat-radio-ripple" *ngIf="!_isRippleDisabled()"
          [matRippleTrigger]="label"
-         [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="_rippleConfig.centered"
          [matRippleRadius]="_rippleConfig.radius"
          [matRippleSpeedFactor]="_rippleConfig.speedFactor">

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -271,7 +271,7 @@ describe('MatRadio', () => {
         .toBe(1, 'Expected an enabled radio button to show ripples');
     });
 
-    it('should not show ripples if matRippleDisabled input is set', () => {
+    it('should not show ripples if disableRipple input is set', () => {
       testComponent.disableRipple = true;
       fixture.detectChanges();
 

--- a/src/lib/slide-toggle/slide-toggle-module.ts
+++ b/src/lib/slide-toggle/slide-toggle-module.ts
@@ -6,21 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {A11yModule} from '@angular/cdk/a11y';
 import {ObserversModule} from '@angular/cdk/observers';
 import {PlatformModule} from '@angular/cdk/platform';
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {
-  GestureConfig,
-  MatCommonModule,
-  MatRippleModule,
-} from '@angular/material/core';
+import {GestureConfig, MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {A11yModule} from '@angular/cdk/a11y';
 import {MatSlideToggle} from './slide-toggle';
 
 
 @NgModule({
-  imports: [MatRippleModule, MatCommonModule, PlatformModule, ObserversModule, A11yModule],
+  imports: [
+    A11yModule,
+    CommonModule,
+    MatRippleModule,
+    MatCommonModule,
+    ObserversModule,
+    PlatformModule,
+  ],
   exports: [MatSlideToggle, MatCommonModule],
   declarations: [MatSlideToggle],
   providers: [

--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -22,9 +22,8 @@
 
       <div class="mat-slide-toggle-thumb"></div>
 
-      <div class="mat-slide-toggle-ripple" mat-ripple
+      <div matRipple class="mat-slide-toggle-ripple" *ngIf="!disabled && !disableRipple"
            [matRippleTrigger]="label"
-           [matRippleDisabled]="disableRipple || disabled"
            [matRippleCentered]="_rippleConfig.centered"
            [matRippleRadius]="_rippleConfig.radius"
            [matRippleSpeedFactor]="_rippleConfig.speedFactor">


### PR DESCRIPTION
Removes the ripple container element if ripples should be disabled for most of the Material components. This gives us a performance boost because the ripple events aren't being added if ripples are disabled.

In theory I would say that using `*ngIf` instead of `[matRippleDisabled]` is more appropriate in most of the components, but there are also cases where the ripple container can't be removed completely and for that, the `[matRippleDisabled]` binding is the right choice.

From a performance perspective, if someone often changes the disabled/disableRipple state, the event listeners will be removed and re-added. This seems to be like a trade-off. A possible solution for that would be to just keep the current implementation and just not register the events if the ripple directive is set to `disabled` initially (and afterwards register events if it turns enabled again).

Fixes #8854.