### PR TITLE
fix(menu): not closing when overlay is detached externally

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -188,7 +188,6 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
 
   ngOnDestroy() {
     this._tabSubscription.unsubscribe();
-    this.closed.emit();
     this.closed.complete();
   }
 

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -193,9 +193,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   openMenu(): void {
     if (!this._menuOpen) {
       this._createOverlay().attach(this._portal);
-      this._closeSubscription = this._menuClosingActions().subscribe(() => {
-        this.menu.close.emit();
-      });
+      this._closeSubscription = this._menuClosingActions().subscribe(() => this.closeMenu());
       this._initMenu();
 
       if (this.menu instanceof MatMenu) {
@@ -218,8 +216,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _destroyMenu() {
     if (this._overlayRef && this.menuOpen) {
       this._resetMenu();
-      this._overlayRef.detach();
       this._closeSubscription.unsubscribe();
+      this._overlayRef.detach();
 
       if (this.menu instanceof MatMenu) {
         this.menu._resetAnimation();
@@ -400,13 +398,14 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   /** Returns a stream that emits whenever an action that should close the menu occurs. */
   private _menuClosingActions() {
     const backdrop = this._overlayRef!.backdropClick();
+    const detachments = this._overlayRef!.detachments();
     const parentClose = this._parentMenu ? this._parentMenu.close : observableOf();
     const hover = this._parentMenu ? this._parentMenu._hovered().pipe(
       filter(active => active !== this._menuItemInstance),
       filter(() => this._menuOpen)
     ) : observableOf();
 
-    return merge(backdrop, parentClose, hover);
+    return merge(backdrop, parentClose, hover, detachments);
   }
 
   /** Handles mouse presses on the trigger. */


### PR DESCRIPTION
Fixes the menu panel not being closed when its `OverlayRef` is detached externally using `detach`, for example when using the `CloseScrollStrategy`.

**Note:** this is a re-submit of #8654 due to some sync issues.