### PR TITLE
fix(chip,stepper): compile cleanly with `"fullTemplateTypeCheck"`

### DIFF
--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -136,9 +136,6 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   /** The chip input to add more chips */
   protected _chipInput: MatChipInput;
 
-  /** The aria-describedby attribute on the chip list for improved a11y. */
-  protected _ariaDescribedby: string;
-
   /** Id of the chip list */
   protected _id: string;
 
@@ -156,7 +153,10 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   /** Placeholder for the chip list. Alternatively, placeholder can be set on MatChipInput */
   protected _placeholder: string;
 
-  /** Tab index for the chip list. */
+  /** The aria-describedby attribute on the chip list for improved a11y. */
+  _ariaDescribedby: string;
+
+    /** Tab index for the chip list. */
   _tabIndex = 0;
 
   /**

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -10,7 +10,7 @@
      [class.mat-step-label-active]="active"
      [class.mat-step-label-selected]="selected">
   <!-- If there is a label template, use it. -->
-  <ng-container *ngIf="_templateLabel()" [ngTemplateOutlet]="label.template">
+  <ng-container *ngIf="_templateLabel()" [ngTemplateOutlet]="_templateLabel()!.template">
   </ng-container>
   <!-- It there is no label template, fall back to the text label. -->
   <div class="mat-step-text-label" *ngIf="_stringLabel()">{{label}}</div>


### PR DESCRIPTION
Using chip or step-header in an application will cause errors
if the application enables `"fullTemplateTypeCheck"`.