### PR TITLE
build: expand validateDecoratorsRule to support blacklisting

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -96,7 +96,8 @@
         "encapsulation": "\\.None$",
         "moduleId": "^module\\.id$",
         "preserveWhitespaces": "false$",
-        "changeDetection": "\\.OnPush$"
+        "changeDetection": "\\.OnPush$",
+        "!styles": ".*"
       }
     }, "src/+(lib|cdk|material-experimental)/**/!(*.spec).ts"],
     "require-license-banner": [


### PR DESCRIPTION
Expands the decorator validation rule to support blacklisting properties whose values match a pattern. This allows disabling things like inline styles.