### PR TITLE
chore: missing type for parameter in autosize

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -170,7 +170,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
    * @param force Whether to force a height recalculation. By default the height will be
    *    recalculated only if the value changed since the last call.
    */
-  resizeToFitContent(force = false) {
+  resizeToFitContent(force: boolean = false) {
     this._cacheTextareaLineHeight();
 
     // If we haven't determined the line-height yet, we know we're still hidden and there's no point

--- a/tools/dgeni/common/normalize-method-parameters.ts
+++ b/tools/dgeni/common/normalize-method-parameters.ts
@@ -37,22 +37,23 @@ export function normalizeMethodParameters(method: NormalizedMethodMemberDoc) {
         method.params = [];
       }
 
-      const hasExistingParameterInfo = method.params.some(p => p.name == parameterName);
+      if (!parameterType) {
+        console.warn(`Missing parameter type information (${parameterName}) in ` +
+          `${method.fileInfo.relativePath}:${method.startingLine}`);
+        return;
+      }
 
-      if (!hasExistingParameterInfo) {
-        if (!parameterType) {
-          console.warn(`Missing parameter type information (${parameterName}) in ` +
-              `${method.fileInfo.relativePath}:${method.startingLine}`);
-          return;
-        }
+      const existingParameterInfo = method.params.find(p => p.name == parameterName);
 
-        const newParameterInfo = {
+      if (!existingParameterInfo) {
+        method.params.push({
           name: parameterName,
           type: parameterType.trim(),
           isOptional: isOptional
-        };
-
-        method.params.push(newParameterInfo);
+        });
+      } else {
+        existingParameterInfo.type = parameterType.trim();
+        existingParameterInfo.isOptional = isOptional;
       }
     });
   }


### PR DESCRIPTION
* The `MatTextareaAutosize` directive misses a type for the `resizeToFitContent` method. The `gulp api-docs` task showed that the type is missing.
* Improves the `normalizeMethodParameters` method in the Dgeni setup, to also add type information to parameters that have been parsed properly by Dgeni, but still miss a type.