### PR TITLE
build: fix IE and Edge test flakes

### DIFF
--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
@@ -2,8 +2,7 @@ import {TestBed, inject} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {Component, NgModule} from '@angular/core';
-import {Overlay} from '../overlay';
-import {OverlayModule} from '../index';
+import {OverlayModule, OverlayContainer, Overlay} from '../index';
 import {OverlayKeyboardDispatcher} from './overlay-keyboard-dispatcher';
 import {ComponentPortal} from '@angular/cdk/portal';
 
@@ -16,12 +15,15 @@ describe('OverlayKeyboardDispatcher', () => {
     TestBed.configureTestingModule({
       imports: [OverlayModule, TestComponentModule],
     });
+
+    inject([OverlayKeyboardDispatcher, Overlay], (kbd: OverlayKeyboardDispatcher, o: Overlay) => {
+      keyboardDispatcher = kbd;
+      overlay = o;
+    })();
   });
 
-  beforeEach(inject([OverlayKeyboardDispatcher, Overlay],
-        (kbd: OverlayKeyboardDispatcher, o: Overlay) => {
-    keyboardDispatcher = kbd;
-    overlay = o;
+  afterEach(inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+    overlayContainer.ngOnDestroy();
   }));
 
   it('should track overlays in order as they are attached and detached', () => {

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -7,14 +7,6 @@ describe('OverlayContainer', () => {
   let overlay: Overlay;
   let overlayContainer: OverlayContainer;
 
-  beforeAll(() => {
-    // Remove any stale overlay containers from previous tests that didn't clean up correctly.
-    const staleContainers = document.querySelectorAll('.cdk-overlay-container');
-    for (let i = staleContainers.length - 1; i >= 0; i--) {
-      staleContainers[i].parentNode!.removeChild(staleContainers[i]);
-    }
-  });
-
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [OverlayTestModule]


### PR DESCRIPTION
* Fixes the `OverlayKeyboardDispatcher` tests leaking `.cdk-overlay-container` instances which can throw off any subsequent tests. This seems to be what is causing the current test flakes in master that happen if the tests are run in a minimized browser window.
* Gets rid of the explicit cleanup of overlay containers in the overlay container tests. This can cause tests to be even flakier if there are any leaks, in addition to being unnecessary because there shouldn't be any containers to begin with.