### PR TITLE
fix(select): alt + arrow key not opening in single-selection mode

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -251,6 +251,36 @@ describe('MatSelect', () => {
               'Expected value from second option to have been set on the model.');
         }));
 
+        it('should open a single-selection select using ALT + DOWN_ARROW', fakeAsync(() => {
+          const {control: formControl, select: selectInstance} = fixture.componentInstance;
+
+          expect(selectInstance.panelOpen).toBe(false, 'Expected select to be closed.');
+          expect(formControl.value).toBeFalsy('Expected no initial value.');
+
+          const event = createKeyboardEvent('keydown', DOWN_ARROW);
+          Object.defineProperty(event, 'altKey', {get: () => true});
+
+          dispatchEvent(select, event);
+
+          expect(selectInstance.panelOpen).toBe(true, 'Expected select to be open.');
+          expect(formControl.value).toBeFalsy('Expected value not to have changed.');
+        }));
+
+        it('should open a single-selection select using ALT + UP_ARROW', fakeAsync(() => {
+          const {control: formControl, select: selectInstance} = fixture.componentInstance;
+
+          expect(selectInstance.panelOpen).toBe(false, 'Expected select to be closed.');
+          expect(formControl.value).toBeFalsy('Expected no initial value.');
+
+          const event = createKeyboardEvent('keydown', UP_ARROW);
+          Object.defineProperty(event, 'altKey', {get: () => true});
+
+          dispatchEvent(select, event);
+
+          expect(selectInstance.panelOpen).toBe(true, 'Expected select to be open.');
+          expect(formControl.value).toBeFalsy('Expected value not to have changed.');
+        }));
+
         it('should be able to select options by typing on a closed select', fakeAsync(() => {
           const formControl = fixture.componentInstance.control;
           const options = fixture.componentInstance.options.toArray();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -636,7 +636,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     const isArrowKey = keyCode === DOWN_ARROW || keyCode === UP_ARROW;
     const isOpenKey = keyCode === ENTER || keyCode === SPACE;
 
-    if (isOpenKey || (this.multiple && isArrowKey)) {
+    if (isOpenKey || ((this.multiple || event.altKey) && isArrowKey)) {
       event.preventDefault(); // prevents the page from scrolling down when pressing space
       this.open();
     } else if (!this.multiple) {


### PR DESCRIPTION
Fixes not being able to open a closed `mat-select` in single selection mode using the alt + up/down arrow combo. It seems like this was introduced when we added the ability go through the values using arrow keys on a closed select.