### PR TITLE
build(artifacts): sed should not update .git/ files

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -41,6 +41,8 @@ publishPackage() {
   repoUrl="https://github.com/angular/${packageRepo}.git"
   repoDir="tmp/${packageRepo}"
 
+  echo "Starting publish process of ${packageName} for ${commitTag}.."
+
   if [[ ! ${COMMAND_ARGS} == *--no-build* ]]; then
     # Create a release of the current repository.
     $(npm bin)/gulp ${packageName}:build-release:clean
@@ -50,15 +52,23 @@ publishPackage() {
   rm -rf ${repoDir}
   mkdir -p ${repoDir}
 
+  echo "Starting cloning process of ${repoUrl} into ${repoDir}.."
+
   # Clone the repository and only fetch the last commit to download less unused data.
   git clone ${repoUrl} ${repoDir} --depth 1
+
+  echo "Successfully cloned ${repoUrl} into ${repoDir}."
 
   # Copy the build files to the repository
   rm -rf ${repoDir}/*
   cp -r ${buildDir}/* ${repoDir}
 
+  echo "Removed everything from ${packageRepo} and added the new build output."
+
   # Create the build commit and push the changes to the repository.
   cd ${repoDir}
+
+  echo "Switched into the repository directory (${repoDir})."
 
   if [[ $(git ls-remote origin "refs/tags/${commitTag}") ]]; then
     echo "Skipping publish because tag is already published"
@@ -68,7 +78,9 @@ publishPackage() {
   # Replace the version in every file recursively with a more specific version that also includes
   # the SHA of the current build job. Normally this "sed" call would just replace the version
   # placeholder, but the version placeholders have been replaced by the release task already.
-  sed -i "s/${buildVersion}/${commitTag}/g" $(find . -type f)
+  sed -i "s/${buildVersion}/${commitTag}/g" $(find . -type f -not -path '*\/.*')
+
+  echo "Updated the build version in every file to include the SHA of the latest commit."
 
   # Prepare Git for pushing the artifacts to the repository.
   git config user.name "${commitAuthorName}"
@@ -76,6 +88,8 @@ publishPackage() {
   git config credential.helper "store --file=.git/credentials"
 
   echo "https://${MATERIAL2_BUILDS_TOKEN}:@github.com" > .git/credentials
+
+  echo "Git configuration has been updated to match the last commit author. Publishing now.."
 
   git add -A
   git commit --allow-empty -m "${commitMessage}"


### PR DESCRIPTION
* Adds more logging messages to the publish artifacts script (better debugging)
* Updates the `find` command for the version `sed` call to no longer match files inside of the `.git/` directory (might lead to a broken .git/ setup)