### PR TITLE
fix(table): fix header row height to follow material guidelines

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -1,4 +1,5 @@
 $mat-row-height: 48px;
+$mat-header-row-height: 56px;
 $mat-row-horizontal-padding: 24px;
 
 .mat-table {
@@ -10,8 +11,15 @@ $mat-row-horizontal-padding: 24px;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   align-items: center;
-  min-height: $mat-row-height;
   padding: 0 $mat-row-horizontal-padding;
+}
+
+.mat-header-row {
+  min-height: $mat-header-row-height;
+}
+
+.mat-row {
+  min-height: $mat-row-height;
 }
 
 .mat-cell, .mat-header-cell {


### PR DESCRIPTION
Change the header row height from 48px to 56dx, as per
https://material.io/guidelines/components/data-tables.html#data-tables-specs

In response to issue #8206