### PR TITLE
docs(tabs): correct typo

### DIFF
--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -62,7 +62,7 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
   /** Emits whenever the label changes. */
   _labelChange = new Subject<void>();
 
-  /** Emits whenevfer the disable changes */
+  /** Emits whenever the disable changes */
   _disableChange = new Subject<void>();
 
   /**


### PR DESCRIPTION
I found a typo word in comments and correct it.

"whenevfer" to "whenever"