### PR TITLE
fix(typography): deprecation warning if null font family is passed in

### DIFF
--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -26,7 +26,7 @@
     $font-family: _mat-get-type-value($config, $level, font-family);
   }
 
-  @return unquote($font-family);
+  @return if($font-family == null, $font-family, unquote($font-family));
 }
 
 // Converts a typography level into CSS styles.
@@ -41,7 +41,11 @@
   @if ($font-size == inherit or
        $font-weight == inherit or
        $line-height == inherit or
-       $font-family == inherit) {
+       $font-family == inherit or
+       $font-size == null or
+       $font-weight == null or
+       $line-height == null or
+       $font-family == null) {
 
     font-size: $font-size;
     font-weight: $font-weight;


### PR DESCRIPTION
* Fixes a deprecation warning that gets logged by `mat-font-family` if the consumer passes in `null` as the `font-family`.
* Adds better handling if any of the typography properties are null.

Fixes #8973.