### PR TITLE
fix(button-toggle): inaccurate name passed down to input if no name is assigned

### DIFF
--- a/src/lib/button-toggle/button-toggle.html
+++ b/src/lib/button-toggle/button-toggle.html
@@ -4,7 +4,7 @@
          [id]="inputId"
          [checked]="checked"
          [disabled]="disabled || null"
-         [name]="name"
+         [attr.name]="name"
          [attr.aria-label]="ariaLabel"
          [attr.aria-labelledby]="ariaLabelledby"
          (change)="_onInputChange($event)"

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -578,6 +578,10 @@ describe('MatButtonToggle without forms', () => {
       expect(document.activeElement).toBe(nativeRadioInput);
     });
 
+    it('should not assign a name to the underlying input if one is not passed in', () => {
+      expect(buttonToggleNativeElement.querySelector('input')!.getAttribute('name')).toBeFalsy();
+    });
+
   });
 
   describe('with provided aria-label ', () => {


### PR DESCRIPTION
Fixes the button toggle setting the underlying input's name to `"undefined"` if the consumer hasn't passed in a name.