### PR TITLE
fix(dialog): change order of button actions

### DIFF
--- a/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
+++ b/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
@@ -40,6 +40,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button mat-raised-button color="primary" mat-dialog-close>Submit</button>
   <button mat-raised-button mat-dialog-close>Close</button>
+  <button mat-raised-button color="primary" mat-dialog-close>Submit</button>
 </mat-dialog-actions>

--- a/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
+++ b/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
@@ -41,5 +41,5 @@
 
 <mat-dialog-actions>
   <button mat-raised-button mat-dialog-close>Close</button>
-  <button mat-raised-button color="primary" mat-dialog-close>Submit</button>
+  <button mat-raised-button color="primary" mat-dialog-close cdkFocusInitial>Submit</button>
 </mat-dialog-actions>

--- a/src/demo-app/a11y/dialog/dialog-fruit-a11y.html
+++ b/src/demo-app/a11y/dialog/dialog-fruit-a11y.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title>Fruit</h2>
 <div mat-dialog-content>Which would you like to choose?</div>
 <div mat-dialog-actions>
-  <button mat-button mat-dialog-close="apple" aria-label="Apple">Apple</button>
   <button mat-button mat-dialog-close="peach" aria-label="Peach">Peach</button>
+  <button mat-button mat-dialog-close="apple" aria-label="Apple">Apple</button>
 </div>

--- a/src/material-examples/dialog-content/dialog-content-example-dialog.html
+++ b/src/material-examples/dialog-content/dialog-content-example-dialog.html
@@ -4,7 +4,7 @@
   <p>Learn one way to build applications with Angular and reuse your code and abilities to build 
     apps for any deployment target. For web, mobile web, native mobile and native desktop.</p>
   
-  <h3>SPEED & PERFORMANCE</h3>
+  <h3>SPEED &amp; PERFORMANCE</h3>
   <p>Achieve the maximum speed possible on the Web Platform today, and take it further, via Web 
     Workers and server-side rendering. Angular puts you in control over scalability. Meet huge data requirements 
     by building data models on RxJS, Immutable.js or another push-model.</p>
@@ -20,6 +20,6 @@
     that supports Google's largest applications.</p>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="true" tabindex="1">Install</button>
   <button mat-button mat-dialog-close tabindex="-1">Cancel</button>
+  <button mat-button [mat-dialog-close]="true" tabindex="1">Install</button>
 </mat-dialog-actions>

--- a/src/material-examples/dialog-content/dialog-content-example-dialog.html
+++ b/src/material-examples/dialog-content/dialog-content-example-dialog.html
@@ -21,5 +21,5 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close>Cancel</button>
-  <button mat-button [mat-dialog-close]="true" cdk-focus-initial>Install</button>
+  <button mat-button [mat-dialog-close]="true" cdkFocusInitial>Install</button>
 </mat-dialog-actions>

--- a/src/material-examples/dialog-content/dialog-content-example-dialog.html
+++ b/src/material-examples/dialog-content/dialog-content-example-dialog.html
@@ -20,6 +20,6 @@
     that supports Google's largest applications.</p>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close tabindex="-1">Cancel</button>
-  <button mat-button [mat-dialog-close]="true" tabindex="1">Install</button>
+  <button mat-button mat-dialog-close>Cancel</button>
+  <button mat-button [mat-dialog-close]="true" cdk-focus-initial>Install</button>
 </mat-dialog-actions>

--- a/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
@@ -6,6 +6,6 @@
   </mat-form-field>
 </div>
 <div mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="data.animal" tabindex="2">Ok</button>
   <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
+  <button mat-button [mat-dialog-close]="data.animal" tabindex="2">Ok</button>
 </div>

--- a/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
@@ -6,6 +6,6 @@
   </mat-form-field>
 </div>
 <div mat-dialog-actions>
-  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
-  <button mat-button [mat-dialog-close]="data.animal" tabindex="2">Ok</button>
+  <button mat-button (click)="onNoClick()">No Thanks</button>
+  <button mat-button [mat-dialog-close]="data.animal" cdk-focus-initial>Ok</button>
 </div>

--- a/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
@@ -7,5 +7,5 @@
 </div>
 <div mat-dialog-actions>
   <button mat-button (click)="onNoClick()">No Thanks</button>
-  <button mat-button [mat-dialog-close]="data.animal" cdk-focus-initial>Ok</button>
+  <button mat-button [mat-dialog-close]="data.animal" cdkFocusInitial>Ok</button>
 </div>


### PR DESCRIPTION
Change order of buttons for affirmative actions, according to [Material guidelines](https://material.io/guidelines/components/dialogs.html#dialogs-specs). This fixes #9019 