### PR TITLE
feat(observe-content): allow for the MutationObserver to be disabled

### DIFF
--- a/src/cdk/observers/BUILD.bazel
+++ b/src/cdk/observers/BUILD.bazel
@@ -5,6 +5,6 @@ ng_module(
   name = "observers",
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/cdk/observers",
-  deps = ["@rxjs"],
+  deps = ["@rxjs", "//src/cdk/coercion"],
   tsconfig = ":tsconfig-build.json",
 )

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -17,7 +17,10 @@ import {
   AfterContentInit,
   Injectable,
   NgZone,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subject} from 'rxjs/Subject';
 import {debounceTime} from 'rxjs/operators/debounceTime';
 
@@ -40,11 +43,22 @@ export class MutationObserverFactory {
   selector: '[cdkObserveContent]',
   exportAs: 'cdkObserveContent',
 })
-export class CdkObserveContent implements AfterContentInit, OnDestroy {
+export class CdkObserveContent implements AfterContentInit, OnChanges, OnDestroy {
   private _observer: MutationObserver | null;
+  private _disabled = false;
 
   /** Event emitted for each change in the element's content. */
   @Output('cdkObserveContent') event = new EventEmitter<MutationRecord[]>();
+
+  /**
+   * Whether observing content is disabled. This option can be used
+   * to disconnect the underlying MutationObserver until it is needed.
+   */
+  @Input('cdkObserveContentDisabled')
+  get disabled() { return this._disabled; }
+  set disabled(value: any) {
+    this._disabled = coerceBooleanProperty(value);
+  }
 
   /** Used for debouncing the emitted values to the observeContent event. */
   private _debouncer = new Subject<MutationRecord[]>();
@@ -73,21 +87,36 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
       });
     });
 
-    if (this._observer) {
-      this._observer.observe(this._elementRef.nativeElement, {
-        'characterData': true,
-        'childList': true,
-        'subtree': true
-      });
+    if (!this.disabled) {
+      this._enable();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['disabled']) {
+      changes['disabled'].currentValue ? this._disable() : this._enable();
     }
   }
 
   ngOnDestroy() {
+    this._disable();
+    this._debouncer.complete();
+  }
+
+  private _disable() {
     if (this._observer) {
       this._observer.disconnect();
     }
+  }
 
-    this._debouncer.complete();
+  private _enable() {
+    if (this._observer) {
+      this._observer.observe(this._elementRef.nativeElement, {
+        characterData: true,
+        childList: true,
+        subtree: true
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Adds the ability for users to disable the underlying `MutationObserver` inside the `CdkObserveContent` directive. This can be useful in the cases where it might be expensive to continue observing an element while it is invisible (e.g. an item inside of a closed dropdown).