### PR TITLE
build: enable fullTemplateTypeCheck everywhere

### DIFF
--- a/src/cdk/a11y/tsconfig-build.json
+++ b/src/cdk/a11y/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/a11y",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/accordion/tsconfig-build.json
+++ b/src/cdk/accordion/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/accordion",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/bidi/tsconfig-build.json
+++ b/src/cdk/bidi/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/bidi",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/coercion/tsconfig-build.json
+++ b/src/cdk/coercion/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/coercion",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/collections/tsconfig-build.json
+++ b/src/cdk/collections/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/collections",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/keycodes/tsconfig-build.json
+++ b/src/cdk/keycodes/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/keycodes",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/layout/tsconfig-build.json
+++ b/src/cdk/layout/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/layout",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/observers/tsconfig-build.json
+++ b/src/cdk/observers/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/observers",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/overlay/tsconfig-build.json
+++ b/src/cdk/overlay/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/overlay",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/platform/tsconfig-build.json
+++ b/src/cdk/platform/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/platform",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/portal/tsconfig-build.json
+++ b/src/cdk/portal/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/portal",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/scrolling/tsconfig-build.json
+++ b/src/cdk/scrolling/tsconfig-build.json
@@ -8,6 +8,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/scrolling",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/stepper/tsconfig-build.json
+++ b/src/cdk/stepper/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/stepper",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/table/tsconfig-build.json
+++ b/src/cdk/table/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/table",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -32,6 +32,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -20,7 +20,8 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "fullTemplateTypeCheck": true
   },
   "include": [
     // Include the index.ts for each secondary entry-point

--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -29,6 +29,8 @@
     "./main-aot.ts"
   ],
   "angularCompilerOptions": {
-    "skipTemplateCodegen": false
+    "skipTemplateCodegen": false,
+    // TODO: disabled for now due to @angular/forms
+    "fullTemplateTypeCheck": false
   }
 }

--- a/src/e2e-app/tsconfig-build.json
+++ b/src/e2e-app/tsconfig-build.json
@@ -37,6 +37,8 @@
     "./system-config.ts"
   ],
   "angularCompilerOptions": {
-    "skipMetadataEmit": true
+    "skipMetadataEmit": true,
+    // TODO: disabled for now due to @angular/forms
+    "fullTemplateTypeCheck": false
   }
 }

--- a/src/lib/autocomplete/tsconfig-build.json
+++ b/src/lib/autocomplete/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/autocomplete",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/button-toggle/tsconfig-build.json
+++ b/src/lib/button-toggle/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/button-toggle",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/button/tsconfig-build.json
+++ b/src/lib/button/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/button",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/card/tsconfig-build.json
+++ b/src/lib/card/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/card",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/checkbox/tsconfig-build.json
+++ b/src/lib/checkbox/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/checkbox",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/chips/tsconfig-build.json
+++ b/src/lib/chips/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/chips",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/core/tsconfig-build.json
+++ b/src/lib/core/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/core",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -227,7 +227,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   constructor(
       private _elementRef: ElementRef,
-      @Optional() private _dateAdapter: DateAdapter<D>,
+      @Optional() public _dateAdapter: DateAdapter<D>,
       @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
       @Optional() private _formField: MatFormField) {
     if (!this._dateAdapter) {

--- a/src/lib/datepicker/tsconfig-build.json
+++ b/src/lib/datepicker/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/datepicker",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/dialog/tsconfig-build.json
+++ b/src/lib/dialog/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/dialog",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/expansion/tsconfig-build.json
+++ b/src/lib/expansion/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/expansion",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/form-field/tsconfig-build.json
+++ b/src/lib/form-field/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/form-field",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/grid-list/tsconfig-build.json
+++ b/src/lib/grid-list/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/grid-list",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/icon/tsconfig-build.json
+++ b/src/lib/icon/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/icon",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/input/tsconfig-build.json
+++ b/src/lib/input/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/input",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/list/tsconfig-build.json
+++ b/src/lib/list/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/list",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/menu/tsconfig-build.json
+++ b/src/lib/menu/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/menu",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/paginator/tsconfig-build.json
+++ b/src/lib/paginator/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/paginator",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/progress-bar/tsconfig-build.json
+++ b/src/lib/progress-bar/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/progress-bar",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/progress-spinner/tsconfig-build.json
+++ b/src/lib/progress-spinner/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/progress-spinner",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/radio/tsconfig-build.json
+++ b/src/lib/radio/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/radio",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/select/tsconfig-build.json
+++ b/src/lib/select/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/select",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/sidenav/tsconfig-build.json
+++ b/src/lib/sidenav/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/sidenav",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/slide-toggle/tsconfig-build.json
+++ b/src/lib/slide-toggle/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/slide-toggle",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/slider/tsconfig-build.json
+++ b/src/lib/slider/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/slider",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/snack-bar/tsconfig-build.json
+++ b/src/lib/snack-bar/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/snack-bar",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/sort/tsconfig-build.json
+++ b/src/lib/sort/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/sort",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/stepper/tsconfig-build.json
+++ b/src/lib/stepper/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/stepper",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/table/tsconfig-build.json
+++ b/src/lib/table/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/table",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/tabs/tsconfig-build.json
+++ b/src/lib/tabs/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/tabs",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/toolbar/tsconfig-build.json
+++ b/src/lib/toolbar/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/toolbar",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/tooltip/tsconfig-build.json
+++ b/src/lib/tooltip/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/tooltip",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -37,6 +37,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/lib/tsconfig-tests.json
+++ b/src/lib/tsconfig-tests.json
@@ -16,7 +16,8 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "fullTemplateTypeCheck": true
   },
   "include": [
     "**/*.spec.ts",

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -36,6 +36,8 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material-examples",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    // TODO: disabled for now due to @angular/forms
+    "fullTemplateTypeCheck": false
   }
 }

--- a/src/material-experimental/dialog/tsconfig-build.json
+++ b/src/material-experimental/dialog/tsconfig-build.json
@@ -9,6 +9,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material-experimental/dialog",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/material-experimental/tsconfig-build.json
+++ b/src/material-experimental/tsconfig-build.json
@@ -35,6 +35,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material-experimental",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/material-experimental/tsconfig-tests.json
+++ b/src/material-experimental/tsconfig-tests.json
@@ -12,7 +12,8 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "fullTemplateTypeCheck": true
   },
   "include": [
     "**/*.spec.ts",

--- a/src/material-moment-adapter/tsconfig-build.json
+++ b/src/material-moment-adapter/tsconfig-build.json
@@ -35,6 +35,7 @@
     "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material-moment-adapter",
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
   }
 }

--- a/src/material-moment-adapter/tsconfig-tests.json
+++ b/src/material-moment-adapter/tsconfig-tests.json
@@ -12,7 +12,8 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "fullTemplateTypeCheck": true
   },
   "include": [
     "**/*.spec.ts",

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -27,6 +27,7 @@
     "main.ts"
   ],
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true
+    "annotateForClosureCompiler": true,
+    "fullTemplateTypeCheck": true
   }
 }


### PR DESCRIPTION
* Enables the `fullTemplateTypeCheck` compiler option (almost) everywhere so we can get notified of failures earlier. It is disabled for the demo app, e2e and AoT checks, because of an issue with `@angular/forms`.
* Fixes a compilation error in the datepicker input that was picked up as a result.