### PR TITLE
Revert "fix(chips): event propagation not stopped by remove button (#8872)

### DIFF
--- a/src/lib/chips/chip-remove.spec.ts
+++ b/src/lib/chips/chip-remove.spec.ts
@@ -1,8 +1,7 @@
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {fakeAsync, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChip, MatChipsModule} from './index';
-import {dispatchFakeEvent} from '@angular/cdk/testing';
 
 describe('Chip Remove', () => {
   let fixture: ComponentFixture<any>;
@@ -10,7 +9,7 @@ describe('Chip Remove', () => {
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [
@@ -19,6 +18,9 @@ describe('Chip Remove', () => {
     });
 
     TestBed.compileComponents();
+  }));
+
+  beforeEach(async(() => {
     fixture = TestBed.createComponent(TestChip);
     testChip = fixture.debugElement.componentInstance;
     fixture.detectChanges();
@@ -28,14 +30,14 @@ describe('Chip Remove', () => {
   }));
 
   describe('basic behavior', () => {
-    it('should apply the `mat-chip-remove` CSS class', () => {
-      const hrefElement = chipNativeElement.querySelector('a')!;
+    it('should applies the `mat-chip-remove` CSS class', () => {
+      let hrefElement = chipNativeElement.querySelector('a')!;
 
       expect(hrefElement.classList).toContain('mat-chip-remove');
     });
 
-    it('should emit (remove) on click', () => {
-      const hrefElement = chipNativeElement.querySelector('a')!;
+    it('should emits (remove) on click', () => {
+      let hrefElement = chipNativeElement.querySelector('a')!;
 
       testChip.removable = true;
       fixture.detectChanges();
@@ -46,19 +48,6 @@ describe('Chip Remove', () => {
 
       expect(testChip.didRemove).toHaveBeenCalled();
     });
-
-    it('should prevent the default click action', () => {
-      const hrefElement = chipNativeElement.querySelector('a')!;
-
-      testChip.removable = true;
-      fixture.detectChanges();
-
-      const event = dispatchFakeEvent(hrefElement, 'click');
-      fixture.detectChanges();
-
-      expect(event.defaultPrevented).toBe(true);
-    });
-
   });
 });
 

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -308,7 +308,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   selector: '[matChipRemove]',
   host: {
     'class': 'mat-chip-remove',
-    '(click)': '_handleClick($event)',
+    '(click)': '_handleClick()',
   }
 })
 export class MatChipRemove {
@@ -316,14 +316,9 @@ export class MatChipRemove {
   }
 
   /** Calls the parent chip's public `remove()` method if applicable. */
-  _handleClick(event: MouseEvent): void {
+  _handleClick(): void {
     if (this._parentChip.removable) {
       this._parentChip.remove();
-
-      // Note: the parent chip does something similar, however since we're removing it,
-      // its event handler will be unbound before it has had the chance to fire.
-      event.preventDefault();
-      event.stopPropagation();
     }
   }
 }


### PR DESCRIPTION
This reverts commit c7e2d4ec7367d6d42f19f7b3082d281b3fa6502e.

Found that this failed some tests that expected `focus` to be called in the chip, but the `handleClick` was not handled due to the remove's `stopPropagation`