### PR TITLE
build: fix sourcemap paths

### DIFF
--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -4,6 +4,7 @@ import {buildConfig} from './build-config';
 import {BuildPackage} from './build-package';
 import {rollupRemoveLicensesPlugin} from './rollup-remove-licenses';
 import {rollupGlobals, dashCaseToCamelCase} from './rollup-globals';
+import {remapSourcemap} from './sourcemap-remap';
 
 // There are no type definitions available for these imports.
 const rollup = require('rollup');
@@ -66,7 +67,6 @@ export class PackageBundler {
    */
   private async bundleEntryPoint(config: BundlesConfig) {
     // Build FESM-2015 bundle file.
-    // TODO: re-add sorcery when we upgrade to Angular 5.x
     await this.createRollupBundle({
       moduleName: config.moduleName,
       entry: config.entryFile,
@@ -75,7 +75,6 @@ export class PackageBundler {
     });
 
     // Build FESM-5 bundle file.
-    // TODO: re-add sorcery when we upgrade to Angular 5.x
     await this.createRollupBundle({
       moduleName: config.moduleName,
       entry: config.esm5EntryFile,
@@ -84,7 +83,6 @@ export class PackageBundler {
     });
 
     // Create UMD bundle of ES5 output.
-    // TODO: re-add sorcery when we upgrade to Angular 5.x
     await this.createRollupBundle({
       moduleName: config.moduleName,
       entry: config.esm5Dest,
@@ -93,8 +91,15 @@ export class PackageBundler {
     });
 
     // Create a minified UMD bundle using UglifyJS
-    // TODO: re-add sorcery when we upgrade to Angular 5.x
     uglifyJsFile(config.umdDest, config.umdMinDest);
+
+    // Remaps the sourcemaps to be based on top of the original TypeScript source files.
+    await Promise.all([
+      remapSourcemap(config.esm2015Dest),
+      remapSourcemap(config.esm5Dest),
+      remapSourcemap(config.umdDest),
+      remapSourcemap(config.umdMinDest),
+    ]);
   }
 
   /** Creates a rollup bundle of a specified JavaScript file.*/

--- a/tools/package-tools/minify-sources.ts
+++ b/tools/package-tools/minify-sources.ts
@@ -1,18 +1,21 @@
 import {writeFileSync} from 'fs';
+import {basename} from 'path';
 
 // There are no type definitions available for these imports.
 const uglify = require('uglify-js');
 
 /** Minifies a JavaScript file by using UglifyJS2. Also writes sourcemaps to the output. */
 export function uglifyJsFile(inputPath: string, outputPath: string) {
-  const sourcemapOut = `${outputPath}.map`;
+  const sourceMapPath = `${outputPath}.map`;
+
   const result = uglify.minify(inputPath, {
-    outSourceMap: sourcemapOut,
+    inSourceMap: `${inputPath}.map`,
+    outSourceMap: basename(sourceMapPath),
     output: {
       comments: 'some'
     }
   });
 
   writeFileSync(outputPath, result.code);
-  writeFileSync(sourcemapOut, result.map);
+  writeFileSync(sourceMapPath, result.map);
 }


### PR DESCRIPTION
* Fixes that the minified UMD bundles include absolute paths (e.g.. `/usr/local/google/home/andrewjs`)
* Fixes that the sourcemaps are referring to files in the `dist/packages` folder (using sorcery again; seems work fine now with source-map-explorer and Chrome DevTools)

Closes #9012