### PR TITLE
refactor(dialog): switch to common keyboard handling and move keyboard logic into individual dialog

### DIFF
--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -7,6 +7,7 @@
  */
 
 import {OverlayRef, GlobalPositionStrategy} from '@angular/cdk/overlay';
+import {ESCAPE} from '@angular/cdk/keycodes';
 import {filter} from 'rxjs/operators/filter';
 import {take} from 'rxjs/operators/take';
 import {DialogPosition} from './dialog-config';
@@ -68,6 +69,10 @@ export class MatDialogRef<T, R = any> {
       this._afterClosed.complete();
       this.componentInstance = null!;
     });
+
+    _overlayRef.keydownEvents()
+      .pipe(filter(event => event.keyCode === ESCAPE && !this.disableClose))
+      .subscribe(() => this.close());
   }
 
   /**

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -7,7 +7,6 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {ESCAPE} from '@angular/cdk/keycodes';
 import {
   BlockScrollStrategy,
   Overlay,
@@ -30,7 +29,6 @@ import {
 import {Observable} from 'rxjs/Observable';
 import {defer} from 'rxjs/observable/defer';
 import {of as observableOf} from 'rxjs/observable/of';
-import {filter} from 'rxjs/operators/filter';
 import {startWith} from 'rxjs/operators/startWith';
 import {Subject} from 'rxjs/Subject';
 import {MatDialogConfig} from './dialog-config';
@@ -233,11 +231,6 @@ export class MatDialog {
         }
       });
     }
-
-    // Close when escape keydown event occurs
-    overlayRef.keydownEvents().pipe(
-      filter(event => event.keyCode === ESCAPE && !dialogRef.disableClose)
-    ).subscribe(() => dialogRef.close());
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       dialogContainer.attachTemplatePortal(

--- a/src/material-experimental/dialog/dialog-ref.ts
+++ b/src/material-experimental/dialog/dialog-ref.ts
@@ -8,8 +8,10 @@
 
 
 import {OverlayRef, GlobalPositionStrategy, OverlaySizeConfig} from '@angular/cdk/overlay';
+import {ESCAPE} from '@angular/cdk/keycodes';
 import {Observable} from 'rxjs/Observable';
 import {map} from 'rxjs/operators/map';
+import {filter} from 'rxjs/operators/filter';
 import {DialogPosition} from './dialog-config';
 import {CdkDialogContainer} from './dialog-container';
 
@@ -52,6 +54,11 @@ export class DialogRef<T, R = any> {
       this._overlayRef.dispose();
       this.componentInstance = null!;
     });
+
+    // Close when escape keydown event occurs
+    _overlayRef.keydownEvents()
+      .pipe(filter(event => event.keyCode === ESCAPE && !this.disableClose))
+      .subscribe(() => this.close());
   }
 
   /** Gets an observable that emits when the overlay's backdrop has been clicked. */


### PR DESCRIPTION
* Refactors the dialogs to use the common keyboard provider, rather than binding to the document.
* Moves the responsibility for handling the keyboard events from the dialog provider to the individual dialogs.