### PR TITLE
fix(overlay): default options not being applied correctly

### DIFF
--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -52,7 +52,9 @@ export class OverlayConfig {
 
   constructor(config?: OverlayConfig) {
     if (config) {
-      Object.keys(config).forEach(key => this[key] = config[key]);
+      Object.keys(config)
+        .filter(key => typeof config[key] !== 'undefined')
+        .forEach(key => this[key] = config[key]);
     }
   }
 }

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -239,6 +239,16 @@ describe('Overlay', () => {
     expect(callbackOrder).toEqual(['attach', 'detach']);
   });
 
+  it('should default to the ltr direction', () => {
+    const overlayRef = overlay.create({hasBackdrop: true});
+    expect(overlayRef.getConfig().direction).toBe('ltr');
+  });
+
+  it('should skip undefined values when applying the defaults', () => {
+    const overlayRef = overlay.create({direction: undefined});
+    expect(overlayRef.getConfig().direction).toBe('ltr');
+  });
+
   describe('positioning', () => {
     let config: OverlayConfig;
 

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -27,10 +27,6 @@ import {DOCUMENT} from '@angular/common';
 /** Next overlay unique ID. */
 let nextUniqueId = 0;
 
-/** The default config for newly created overlays. */
-let defaultConfig = new OverlayConfig();
-
-
 /**
  * Service to create Overlays. Overlays are dynamically added pieces of floating UI, meant to be
  * used as a low-level building building block for other components. Dialogs, tooltips, menus,
@@ -58,10 +54,11 @@ export class Overlay {
    * @param config Configuration applied to the overlay.
    * @returns Reference to the created overlay.
    */
-  create(config: OverlayConfig = defaultConfig): OverlayRef {
+  create(config?: OverlayConfig): OverlayRef {
     const pane = this._createPaneElement();
     const portalOutlet = this._createPortalOutlet(pane);
-    return new OverlayRef(portalOutlet, pane, config, this._ngZone, this._keyboardDispatcher);
+    return new OverlayRef(portalOutlet, pane, new OverlayConfig(config), this._ngZone,
+        this._keyboardDispatcher);
   }
 
   /**


### PR DESCRIPTION
* Fixes the overlay defaults not being applied correctly when the passed in object isn't an instance of the `OverlayConfig`. This caused some issues like the `dir` being set to `"undefined"` if the consumer didn't specify it.
* Tweaks the logic that applies the overlay config defaults to skip keys with `undefined` values.