### PR TITLE
build: missing overview files in docs-content

### DIFF
--- a/src/material-examples/example-module.ts
+++ b/src/material-examples/example-module.ts
@@ -45,6 +45,7 @@ import {DialogContentExampleDialog,DialogContentExample} from './dialog-content/
 import {DialogDataExampleDialog,DialogDataExample} from './dialog-data/dialog-data-example';
 import {DialogElementsExampleDialog,DialogElementsExample} from './dialog-elements/dialog-elements-example';
 import {DialogOverviewExampleDialog,DialogOverviewExample} from './dialog-overview/dialog-overview-example';
+import {DividerOverviewExample} from './divider-overview/divider-overview-example';
 import {ElevationOverviewExample} from './elevation-overview/elevation-overview-example';
 import {ExpansionOverviewExample} from './expansion-overview/expansion-overview-example';
 import {ExpansionStepsExample} from './expansion-steps/expansion-steps-example';
@@ -127,7 +128,6 @@ import {ToolbarMultirowExample} from './toolbar-multirow/toolbar-multirow-exampl
 import {ToolbarOverviewExample} from './toolbar-overview/toolbar-overview-example';
 import {TooltipOverviewExample} from './tooltip-overview/tooltip-overview-example';
 import {TooltipPositionExample} from './tooltip-position/tooltip-position-example';
-import {DividerOverviewExample} from './divider-overview/divider-overview-example';
 
 export const EXAMPLE_COMPONENTS = {
   'autocomplete-display': {
@@ -323,7 +323,7 @@ export const EXAMPLE_COMPONENTS = {
     selectorName: 'DialogOverviewExample, DialogOverviewExampleDialog'
   },
   'divider-overview': {
-    title: 'Divider Overview',
+    title: 'Basic divider',
     component: DividerOverviewExample,
     additionalFiles: null,
     selectorName: null

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -94,12 +94,10 @@ export class PackageBundler {
     uglifyJsFile(config.umdDest, config.umdMinDest);
 
     // Remaps the sourcemaps to be based on top of the original TypeScript source files.
-    await Promise.all([
-      remapSourcemap(config.esm2015Dest),
-      remapSourcemap(config.esm5Dest),
-      remapSourcemap(config.umdDest),
-      remapSourcemap(config.umdMinDest),
-    ]);
+    await remapSourcemap(config.esm2015Dest);
+    await remapSourcemap(config.esm5Dest);
+    await remapSourcemap(config.umdDest);
+    await remapSourcemap(config.umdMinDest);
   }
 
   /** Creates a rollup bundle of a specified JavaScript file.*/


### PR DESCRIPTION
* Fixes that the overview files are not copied to the docs-content repository.
* Reworks the old publish-docs-content script to be more structured and clean
* Fixes potential compilation issues with sorcery (sequentially write files)
* Updates the example-module to reflect the example files.

References #8949. References https://github.com/angular/material2-docs-content/issues/2

@jelbourn @mmalerba Related PR for the docs repository: https://github.com/angular/material.angular.io/pull/360