### PR TITLE
fix(accordion-item): emitting closed event while closed

### DIFF
--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -32,44 +32,54 @@ describe('CdkAccordionItem', () => {
     });
 
     it('should toggle its expanded state', () => {
-      expect(item.expanded).toBeFalsy();
+      expect(item.expanded).toBe(false);
       item.toggle();
-      expect(item.expanded).toBeTruthy();
+      expect(item.expanded).toBe(true);
       item.toggle();
-      expect(item.expanded).toBeFalsy();
+      expect(item.expanded).toBe(false);
     });
 
     it('should set its expanded state to expanded', () => {
       item.expanded = false;
       item.open();
-      expect(item.expanded).toBeTruthy();
+      expect(item.expanded).toBe(true);
     });
 
     it('should set its expanded state to closed', () => {
       item.expanded = true;
       item.close();
-      expect(item.expanded).toBeFalsy();
+      expect(item.expanded).toBe(false);
     });
 
     it('should emit a closed event', () => {
+      item.open();
+      fixture.detectChanges();
       spyOn(item.closed, 'emit');
       item.close();
       fixture.detectChanges();
-      expect(item.closed.emit).toHaveBeenCalledWith();
+      expect(item.closed.emit).toHaveBeenCalled();
+    });
+
+    it('should not emit a closed event when the item is closed already', () => {
+      expect(item.expanded).toBe(false);
+      spyOn(item.closed, 'emit');
+      item.close();
+      fixture.detectChanges();
+      expect(item.closed.emit).not.toHaveBeenCalled();
     });
 
     it('should emit an opened event', () => {
       spyOn(item.opened, 'emit');
       item.open();
       fixture.detectChanges();
-      expect(item.opened.emit).toHaveBeenCalledWith();
+      expect(item.opened.emit).toHaveBeenCalled();
     });
 
     it('should emit an destroyed event', () => {
       spyOn(item.destroyed, 'emit');
       item.ngOnDestroy();
       fixture.detectChanges();
-      expect(item.destroyed.emit).toHaveBeenCalledWith();
+      expect(item.destroyed.emit).toHaveBeenCalled();
     });
   });
 
@@ -88,16 +98,16 @@ describe('CdkAccordionItem', () => {
     });
 
     it('should not change expanded state based on unrelated items', () => {
-      expect(firstItem.expanded).toBeFalsy();
-      expect(secondItem.expanded).toBeFalsy();
+      expect(firstItem.expanded).toBe(false);
+      expect(secondItem.expanded).toBe(false);
       firstItem.open();
       fixture.detectChanges();
-      expect(firstItem.expanded).toBeTruthy();
-      expect(secondItem.expanded).toBeFalsy();
+      expect(firstItem.expanded).toBe(true);
+      expect(secondItem.expanded).toBe(false);
       secondItem.open();
       fixture.detectChanges();
-      expect(firstItem.expanded).toBeTruthy();
-      expect(secondItem.expanded).toBeTruthy();
+      expect(firstItem.expanded).toBe(true);
+      expect(secondItem.expanded).toBe(true);
     });
   });
 
@@ -117,16 +127,16 @@ describe('CdkAccordionItem', () => {
     });
 
     it('should change expanded state based on related items', () => {
-      expect(firstItem.expanded).toBeFalsy();
-      expect(secondItem.expanded).toBeFalsy();
+      expect(firstItem.expanded).toBe(false);
+      expect(secondItem.expanded).toBe(false);
       firstItem.open();
       fixture.detectChanges();
-      expect(firstItem.expanded).toBeTruthy();
-      expect(secondItem.expanded).toBeFalsy();
+      expect(firstItem.expanded).toBe(true);
+      expect(secondItem.expanded).toBe(false);
       secondItem.open();
       fixture.detectChanges();
-      expect(firstItem.expanded).toBeFalsy();
-      expect(secondItem.expanded).toBeTruthy();
+      expect(firstItem.expanded).toBe(false);
+      expect(secondItem.expanded).toBe(true);
     });
   });
 });

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -66,7 +66,7 @@ export class CdkAccordionItem implements OnDestroy {
       this._changeDetectorRef.markForCheck();
     }
   }
-  private _expanded: boolean;
+  private _expanded = false;
 
   /** Unregister function for _expansionDispatcher. */
   private _removeUniqueSelectionListener: () => void = () => {};


### PR DESCRIPTION
Fixes the accordion item emitting its closed event once, even if it is closed. It is due to the `expanded` property defaulting to `undefined`. Also includes making a few of the tests a bit more strict to ensure that the `expanded` property is always a boolean.

Fixes #9098.