### PR TITLE
fix(menu): inconsistent side padding for nested menu items in RTL

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -65,7 +65,7 @@ $mat-menu-submenu-indicator-size: 10px !default;
   }
 
   [dir='rtl'] & {
-    padding-right: $mat-menu-side-padding / 2;
+    padding-right: $mat-menu-side-padding;
     padding-left: $mat-menu-side-padding * 2;
 
     &::after {


### PR DESCRIPTION
Fixes the menu items inside of a sub-menu having half as much padding as they're supposed to in RTL.