### PR TITLE
fix(select): handle async changes to the option label

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1097,6 +1097,18 @@ describe('MatSelect', () => {
             .toBe(fixture.componentInstance.options.last);
       }));
 
+      it('should update the trigger when the selected option label is changed', fakeAsync(() => {
+        fixture.componentInstance.control.setValue('pizza-1');
+        fixture.detectChanges();
+
+        expect(trigger.textContent!.trim()).toBe('Pizza');
+
+        fixture.componentInstance.foods[1].viewValue = 'Calzone';
+        fixture.detectChanges();
+
+        expect(trigger.textContent!.trim()).toBe('Calzone');
+      }));
+
       it('should not select disabled options', fakeAsync(() => {
         trigger.click();
         fixture.detectChanges();


### PR DESCRIPTION
Currently `mat-select` doesn't react to changes in the label of its options, which is problematic, because the option label might be populated at a later point by a pipe or it might have changed while the select is closed. These changes add a `Subject` to the `MatOption` that will emit whenever the label changes and allows the select to react accordingly.

Fixes #7923.