### PR TITLE
feat(button): expose ripple instance

### DIFF
--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -1,7 +1,7 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {MatButtonModule} from './index';
+import {MatButtonModule, MatButton} from './index';
 import {MatRipple} from '@angular/material/core';
 
 
@@ -39,6 +39,13 @@ describe('MatButton', () => {
 
     expect(buttonDebugElement.nativeElement.classList).not.toContain('mat-accent');
     expect(aDebugElement.nativeElement.classList).not.toContain('mat-accent');
+  });
+
+  it('should expose the ripple instance', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    const button = fixture.debugElement.query(By.css('button')).componentInstance as MatButton;
+
+    expect(button.ripple).toBeTruthy();
   });
 
   it('should should not clear previous defined classes', () => {

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -14,12 +14,14 @@ import {
   Directive,
   ElementRef,
   OnDestroy,
+  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import {
   CanColor,
   CanDisable,
   CanDisableRipple,
+  MatRipple,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple
@@ -117,6 +119,9 @@ export class MatButton extends _MatButtonMixinBase
 
   /** Whether the button is icon button. */
   _isIconButton: boolean = this._hasHostAttributes('mat-icon-button');
+
+  /** Reference to the MatRipple instance of the button. */
+  @ViewChild(MatRipple) ripple: MatRipple;
 
   constructor(elementRef: ElementRef,
               private _platform: Platform,


### PR DESCRIPTION
* Exposes the `MatRipple` instance of the button as a public property.

This can be used to show ripple indicators for feature discoveries as seen on the specs (https://material.io/guidelines/growth-communications/feature-discovery.html#feature-discovery-design-patterns). 

_Also a short quote from the specs_
> "Ripples guide users through subsequent steps".

As soon as https://github.com/angular/material2/issues/7543 is being resolved, we can also have more detailed explanations about the `MatRipple` directive. We could also have a guide that shows how to launch ripples on such components with an exposed ripple instance (e.g. button, slide-toggle, checkbox, radio)

Closes #4179