### PR TITLE
build: docs task should not clean

### DIFF
--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -74,7 +74,6 @@ const markdownOptions = {
 
 /** Generate all docs content. */
 task('docs', sequenceTask(
-  'clean',
   [
     'markdown-docs-material',
     'markdown-docs-cdk',


### PR DESCRIPTION
* No longer cleans the dist/ folder because some deploy scripts depend on previous output inside of the dist folder.

This has been added accidentally with https://github.com/angular/material2/commit/e18292c7d220bb9ad9861665ba37726ee30f1c06