### PR TITLE
chore: bump travis nodejs version to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 dist: trusty
 
 node_js:
-  - '7'
+  - '8'
 
 addons:
   jwt:


### PR DESCRIPTION
@crisbeto I vaguely recall there was some issue w/ Angular preventing use of node 8, but I'm guessing it's likely resolved now.