### PR TITLE
CSS toolbar multiline comment

### DIFF
--- a/src/lib/toolbar/toolbar.md
+++ b/src/lib/toolbar/toolbar.md
@@ -52,8 +52,8 @@ easily accomplished with `display: flex`:
 ```
 ```scss
 .example-fill-remaining-space {
-  // This fills the remaining space, by using flexbox. 
-  // Every toolbar row uses a flexbox row layout.
+  /* This fills the remaining space, by using flexbox. 
+     Every toolbar row uses a flexbox row layout. */
   flex: 1 1 auto;
 }
 ```


### PR DESCRIPTION
Proposing changing comment type to be compatible with raw CSS and SCSS. Users without SCSS referring to the documentation won't have to update the code to now see the CSS work.