### PR TITLE
docs(dialog): remove unnecessary brackets

### DIFF
--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -81,7 +81,7 @@ For example:
 <mat-dialog-content>Are you sure?</mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close>No</button>
-  <!-- Can optionally provide a result for the closing dialog. -->
+  <!-- Optionally, a result can be provided for the closing dialog. -->
   <button mat-button [mat-dialog-close]="true">Yes</button>
 </mat-dialog-actions>
 ```
@@ -124,7 +124,7 @@ the `ComponentFactory` for it.
   providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule() {}
+export class AppModule {}
 ```
 
 ### Accessibility

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -81,7 +81,7 @@ For example:
 <mat-dialog-content>Are you sure?</mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close>No</button>
-  <!-- Optionally, a result can be provided for the closing dialog. -->
+  <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
   <button mat-button [mat-dialog-close]="true">Yes</button>
 </mat-dialog-actions>
 ```


### PR DESCRIPTION
- Removes the unnecessary brackets in the code snippet under the `configuring dialog content...` section.
- Also rephrases the comment in the code snippet under the `dialog content` section.