### PR TITLE
fix(list): prevent list icon shrinking

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -111,6 +111,7 @@ $mat-list-item-inset-divider-offset: 72px;
   }
 
   .mat-list-icon {
+    flex-shrink: 0;
     width: $icon-size;
     height: $icon-size;
     font-size: $icon-size;


### PR DESCRIPTION
* Since the list-item uses flexbox, it can happen that the `matListIcon` shrinks to make place for the `mat-list-text`. Similar as for the `matListAvatar` shrinking should be disabled for the `matListIcon`.

Fixes #8699