### PR TITLE
docs(dialog): fix tabindex breaking focus trap

### DIFF
--- a/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/material-examples/dialog-overview/dialog-overview-example-dialog.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content>
   <p>What's your favorite animal?</p>
   <mat-form-field>
-    <input matInput tabindex="1" [(ngModel)]="data.animal">
+    <input matInput [(ngModel)]="data.animal">
   </mat-form-field>
 </div>
 <div mat-dialog-actions>


### PR DESCRIPTION
Fixes issue where tabbing through the dialog overview would break out of the focus trap. Can be seen at https://material.angular.io/components/dialog/examples.