### PR TITLE
fix(button): incorrect text color when no color is passed in on dark theme

### DIFF
--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -77,6 +77,7 @@
 
   .mat-button, .mat-icon-button {
     background: transparent;
+    color: mat-color($foreground, text);
 
     @include _mat-button-focus-color($theme);
     @include _mat-button-theme-color($theme, 'color');


### PR DESCRIPTION
Fixes buttons without a set `color` having a dark text color on a dark background, if they aren't inside a component that provides the color for them (e.g. a sidenav container).

Fixes #9231.