### PR TITLE
build: fix builds not failing with compilation errors in unit tests

### DIFF
--- a/tools/package-tools/build-package.ts
+++ b/tools/package-tools/build-package.ts
@@ -107,6 +107,7 @@ export class BuildPackage {
     return ngcCompile(['-p', entryPointTsconfigPath]).catch(() => {
       const error = red(`Failed to compile ${secondaryEntryPoint} using ${entryPointTsconfigPath}`);
       console.error(error);
+      return Promise.reject(error);
     });
   }
 

--- a/tools/package-tools/compile-entry-point.ts
+++ b/tools/package-tools/compile-entry-point.ts
@@ -22,6 +22,7 @@ export async function compileEntryPoint(buildPackage: BuildPackage, tsconfigName
   return ngcCompile(ngcFlags).catch(() => {
     const error = red(`Failed to compile ${secondaryEntryPoint} using ${entryPointTsconfigPath}`);
     console.error(error);
+    return Promise.reject(error);
   });
 }
 


### PR DESCRIPTION
Fixes the CI continuing to run even though it failed to compile, due to a couple of promises that weren't rejecting properly. This should prevent things like #9073 from slipping through.
  