### PR TITLE
fix(checkbox): underlying native checkbox being rendered when parent uses css column layout

### DIFF
--- a/src/cdk/a11y/_a11y.scss
+++ b/src/cdk/a11y/_a11y.scss
@@ -8,6 +8,13 @@
     padding: 0;
     position: absolute;
     width: 1px;
+
+    // Avoid browsers rendering the focus ring in some cases.
+    outline: 0;
+
+    // Avoid some cases where the browser will still render the native controls (see #9049).
+    -webkit-appearance: none;
+    -moz-appearance: none;
   }
 }
 


### PR DESCRIPTION
Fixes an issue where the hidden native checkbox inside the `mat-checkbox` gets rendered if one of the ancestors is using a CSS column layout.

Fixes #9049.