### PR TITLE
fix(theming): provide text color through mat-app-background

### DIFF
--- a/src/lib/core/_core.scss
+++ b/src/lib/core/_core.scss
@@ -43,7 +43,10 @@
   // user's content isn't inside of a `mat-sidenav-container`.
   .mat-app-background {
     $background: map-get($theme, background);
+    $foreground: map-get($theme, foreground);
+
     background-color: mat-color($background, background);
+    color: mat-color($foreground, text);
   }
 
   // Marker that is used to determine whether the user has added a theme to their page.


### PR DESCRIPTION
Adds the default foreground text color to the `.mat-app-background`, otherwise the consumer can end up with dark text on a dark background if they're using a dark theme.

Relates to #9231.