### PR TITLE
refactor(portal): make TemplatePortal generic param optional

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -96,7 +96,7 @@ export class CdkOverlayOrigin {
 })
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   private _overlayRef: OverlayRef;
-  private _templatePortal: TemplatePortal<any>;
+  private _templatePortal: TemplatePortal;
   private _hasBackdrop = false;
   private _backdropSubscription = Subscription.EMPTY;
   private _positionSubscription = Subscription.EMPTY;

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -20,7 +20,7 @@ import {
 describe('Overlay', () => {
   let overlay: Overlay;
   let componentPortal: ComponentPortal<PizzaMsg>;
-  let templatePortal: TemplatePortal<any>;
+  let templatePortal: TemplatePortal;
   let overlayContainerElement: HTMLElement;
   let overlayContainer: OverlayContainer;
   let viewContainerFixture: ComponentFixture<TestComponentWithTemplatePortals>;

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -29,7 +29,7 @@ import {Portal, TemplatePortal, ComponentPortal, BasePortalOutlet} from './porta
   selector: '[cdk-portal], [cdkPortal], [portal]',
   exportAs: 'cdkPortal',
 })
-export class CdkPortal extends TemplatePortal<any> {
+export class CdkPortal extends TemplatePortal {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
     super(templateRef, viewContainerRef);
   }

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -107,22 +107,21 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
 /**
  * A `TemplatePortal` is a portal that represents some embedded template (TemplateRef).
  */
-export class TemplatePortal<C> extends Portal<C> {
+export class TemplatePortal<C = any> extends Portal<C> {
   /** The embedded template that will be used to instantiate an embedded View in the host. */
   templateRef: TemplateRef<C>;
 
   /** Reference to the ViewContainer into which the template will be stamped out. */
   viewContainerRef: ViewContainerRef;
 
+  /** Contextual data to be passed in to the embedded view. */
   context: C | undefined;
 
-  constructor(template: TemplateRef<any>, viewContainerRef: ViewContainerRef, context?: C) {
+  constructor(template: TemplateRef<C>, viewContainerRef: ViewContainerRef, context?: C) {
     super();
     this.templateRef = template;
     this.viewContainerRef = viewContainerRef;
-    if (context) {
-      this.context = context;
-    }
+    this.context = context;
   }
 
   get origin(): ElementRef {

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -116,7 +116,7 @@ export function getMatAutocompleteMissingPanelError(): Error {
 })
 export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   private _overlayRef: OverlayRef | null;
-  private _portal: TemplatePortal<any>;
+  private _portal: TemplatePortal;
   private _panelOpen: boolean = false;
 
   /** Strategy that is used to position the panel. */

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -109,7 +109,7 @@ export class MatExpansionPanel extends _MatExpansionPanelMixinBase
   @ContentChild(MatExpansionPanelContent) _lazyContent: MatExpansionPanelContent;
 
   /** Portal holding the user's content. */
-  _portal: TemplatePortal<any>;
+  _portal: TemplatePortal;
 
   constructor(@Optional() @Host() accordion: MatAccordion,
               _changeDetectorRef: ChangeDetectorRef,
@@ -148,7 +148,7 @@ export class MatExpansionPanel extends _MatExpansionPanelMixinBase
         filter(() => this.expanded && !this._portal),
         take(1)
       ).subscribe(() => {
-        this._portal = new TemplatePortal<any>(this._lazyContent._template, this._viewContainerRef);
+        this._portal = new TemplatePortal(this._lazyContent._template, this._viewContainerRef);
       });
     }
   }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -82,7 +82,7 @@ export const MENU_PANEL_TOP_PADDING = 8;
   exportAs: 'matMenuTrigger'
 })
 export class MatMenuTrigger implements AfterContentInit, OnDestroy {
-  private _portal: TemplatePortal<any>;
+  private _portal: TemplatePortal;
   private _overlayRef: OverlayRef | null = null;
   private _menuOpen: boolean = false;
   private _closeSubscription = Subscription.EMPTY;

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -156,7 +156,7 @@ describe('MatTabBody', () => {
   `
 })
 class SimpleTabBodyApp {
-  content: TemplatePortal<any>;
+  content: TemplatePortal;
   position: number;
   origin: number;
 

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -131,7 +131,7 @@ export class MatTabBody implements OnInit {
   @Output() _onCentered: EventEmitter<void> = new EventEmitter<void>(true);
 
   /** The tab body content to display. */
-  @Input('content') _content: TemplatePortal<any>;
+  @Input('content') _content: TemplatePortal;
 
   /** The shifted index position of the tab body, where zero represents the active center tab. */
   _position: MatTabBodyPositionState;

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -52,10 +52,10 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
   @Input('label') textLabel: string = '';
 
   /** The portal that will be the hosted content of the tab */
-  private _contentPortal: TemplatePortal<any> | null = null;
+  private _contentPortal: TemplatePortal | null = null;
 
   /** @docs-private */
-  get content(): TemplatePortal<any> | null {
+  get content(): TemplatePortal | null {
     return this._contentPortal;
   }
 


### PR DESCRIPTION
Makes the `C` generic param on the `TemplatePortal` optional, because it's only being used to type the `context` property which is optional itself. Also does some minor cleanup in the `TemplatePortal`.