### PR TITLE
fix(coercion): treat zero as falsy boolean

### DIFF
--- a/src/cdk/coercion/boolean-property.spec.ts
+++ b/src/cdk/coercion/boolean-property.spec.ts
@@ -15,7 +15,7 @@ describe('coerceBooleanProperty', () => {
   });
 
   it('should coerce zero to true', () => {
-    expect(coerceBooleanProperty(0)).toBe(true);
+    expect(coerceBooleanProperty(0)).toBe(false);
   });
 
   it('should coerce the string "false" to false', () => {

--- a/src/cdk/coercion/boolean-property.ts
+++ b/src/cdk/coercion/boolean-property.ts
@@ -8,5 +8,5 @@
 
 /** Coerces a data-bound value (typically a string) to a boolean. */
 export function coerceBooleanProperty(value: any): boolean {
-  return value != null && `${value}` !== 'false';
+  return value === '' || (!!value && `${value}` !== 'false');
 }


### PR DESCRIPTION
Right now the `coerceBooleanProperty` method coerces `0` to `true`. This is not aligning with the native behavior of DOM elements (e.g. setting the disabled property to 0).

@jelbourn This is a breaking change, because previously zero has been handled differently. I'm going to mark this as `major`. I'm not too sure if we want to handle zero that way, but it follows the DOM behavior, so I think it makes sense. If not, we can just close the issue and this PR, and keep everything as it is.

Fixes #9280.