### PR TITLE
build: add lint rule to prevent binding to class attribute directly

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -99,7 +99,11 @@
         "moduleId": "^module\\.id$",
         "preserveWhitespaces": "false$",
         "changeDetection": "\\.OnPush$",
-        "!styles": ".*"
+        "!styles": ".*",
+        "!host": "\\[class\\]"
+      },
+      "Directive": {
+        "!host": "\\[class\\]"
       }
     }, "src/+(lib|cdk|material-experimental|cdk-experimental)/**/!(*.spec).ts"],
     "require-license-banner": [


### PR DESCRIPTION
Adds a lint rule that prevents us from binding to `[class]` directly.

Fixes #8340.