### PR TITLE
docs(dialog): document how to set default options using MAT_DEFAULT_DIALOG_OPTIONS

### DIFF
--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -39,6 +39,16 @@ export class YourDialog {
 }
 ```
 
+Default dialog options can be specified by providing an instance of `MatDialogConfig` for MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
+
+```ts
+@NgModule({
+  providers: [
+    {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: {hasBackdrop: false}}
+  ]
+})
+```
+
 ### Sharing data with the Dialog component.
 If you want to share data with your dialog, you can use the `data` option to pass information to the dialog component.
 

--- a/src/lib/dialog/dialog.md
+++ b/src/lib/dialog/dialog.md
@@ -39,7 +39,9 @@ export class YourDialog {
 }
 ```
 
-Default dialog options can be specified by providing an instance of `MatDialogConfig` for MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
+### Specifying global configuration defaults
+Default dialog options can be specified by providing an instance of `MatDialogConfig` for
+MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
 
 ```ts
 @NgModule({

--- a/src/lib/form-field/form-field.md
+++ b/src/lib/form-field/form-field.md
@@ -38,7 +38,7 @@ present in the form field control. It can also be set to `auto` to restore the d
 
 <!-- example(form-field-label) -->
 
-Global default label options can be specified by setting providing a value for
+Global default label options can be specified by providing a value for
 `MAT_LABEL_GLOBAL_OPTIONS` in your application's root module. Like the property, the global
 setting can be either `always`, `never`, or `auto`.
 


### PR DESCRIPTION
Also fixes a small typo in `mat-form-field` docs.