### PR TITLE
fix(interactivity-checker): carefully handle frame elements

### DIFF
--- a/src/cdk/a11y/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker.spec.ts
@@ -337,6 +337,22 @@ describe('InteractivityChecker', () => {
         expect(checker.isTabbable(button)).toBe(true);
       });
 
+      it('should carefully try to access the frame element of an elements window', () => {
+        const iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+        const button = createFromTemplate('<button tabindex="1">Not Tabbable</button>');
+
+        appendElements([iframe]);
+
+        iframe.setAttribute('tabindex', '-1');
+        iframe.contentDocument.body.appendChild(button);
+
+        Object.defineProperty(iframe.contentWindow, 'frameElement', {
+          get: () => { throw 'Access Denied!'; }
+        });
+
+        expect(() => checker.isTabbable(button)).not.toThrow();
+      });
+
       it('should mark elements which are contentEditable as tabbable', () => {
         let editableEl = createFromTemplate('<div contenteditable="true">', true);
 

--- a/src/cdk/a11y/interactivity-checker.ts
+++ b/src/cdk/a11y/interactivity-checker.ts
@@ -60,11 +60,10 @@ export class InteractivityChecker {
       return false;
     }
 
-    let frameElement = getWindow(element).frameElement as HTMLElement;
+    const frameElement = getFrameElement(getWindow(element));
 
     if (frameElement) {
-
-      let frameType = frameElement && frameElement.nodeName.toLowerCase();
+      const frameType = frameElement && frameElement.nodeName.toLowerCase();
 
       // Frame elements inherit their tabindex onto all child elements.
       if (getTabIndexValue(frameElement) === -1) {
@@ -141,6 +140,19 @@ export class InteractivityChecker {
     return isPotentiallyFocusable(element) && !this.isDisabled(element) && this.isVisible(element);
   }
 
+}
+
+/**
+ * Returns the frame element from a window object. Since browsers like MS Edge throw errors if
+ * the frameElement property is being accessed from a different host address, this property
+ * should be accessed carefully.
+ */
+function getFrameElement(window: Window) {
+  try {
+    return window.frameElement as HTMLElement;
+  } catch (e) {
+    return null;
+  }
 }
 
 /** Checks whether the specified element has any geometry / rectangles. */


### PR DESCRIPTION
* Browsers like MS Edge throw errors if the frameElement property is being accessed from a different host address. This means that the `frameElement` property should be accessed carefully.

Fixes #3372