### PR TITLE
docs(getting started): mention MatIconModule

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -166,11 +166,10 @@ import {MatButtonModule, MatCheckboxModule, MatIconModule} from '@angular/materi
 export class PizzaPartyAppModule { }
 ```
 
-For more information on using Material Icons, check out the [Material Icons Guide](https://google.github.io/material-design-icons/) 
-and the official documentation of [MatIconModule](https://material.angular.io/components/icon/api).
+Note that `mat-icon` supports any font or svg icons; using Material Icons is one of many
+options. You can get more details in its [official documentation page](https://material.angular.io/components/icon/api).
 
-Note that `mat-icon` supports any font or svg icons; using Material Icons is one of many options.
-
+For more information on using Material Icons, check out the [Material Icons Guide](https://google.github.io/material-design-icons/). 
 
 ### Appendix: Configuring SystemJS
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -166,8 +166,8 @@ import {MatButtonModule, MatCheckboxModule, MatIconModule} from '@angular/materi
 export class PizzaPartyAppModule { }
 ```
 
-For more information on using Material Icons, check out the
-[Material Icons Guide](https://google.github.io/material-design-icons/).
+For more information on using Material Icons, check out the [Material Icons Guide](https://google.github.io/material-design-icons/) 
+and the official documentation of [MatIconModule](https://material.angular.io/components/icon).
 
 Note that `mat-icon` supports any font or svg icons; using Material Icons is one of many options.
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -167,7 +167,7 @@ export class PizzaPartyAppModule { }
 ```
 
 For more information on using Material Icons, check out the [Material Icons Guide](https://google.github.io/material-design-icons/) 
-and the official documentation of [MatIconModule](https://material.angular.io/components/icon).
+and the official documentation of [MatIconModule](https://material.angular.io/components/icon/api).
 
 Note that `mat-icon` supports any font or svg icons; using Material Icons is one of many options.
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -153,6 +153,19 @@ If you want to use the `mat-icon` component with the official
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 ```
 
+Additionally you have to import `MatIconModule` to your project.
+
+```ts
+import {MatButtonModule, MatCheckboxModule, MatIconModule} from '@angular/material';
+
+@NgModule({
+  ...
+  imports: [MatButtonModule, MatCheckboxModule, MatIconModule],
+  ...
+})
+export class PizzaPartyAppModule { }
+```
+
 For more information on using Material Icons, check out the
 [Material Icons Guide](https://google.github.io/material-design-icons/).
 


### PR DESCRIPTION
Once in a while someone comes up complaining about the Getting Started guide not explicitly mentioning the import of MatIconModule: 

- Related: #6413 and others