### PR TITLE
fix: too strict peer dependency of angular

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -9,8 +9,11 @@ const package = require('./package.json');
 /** Current version of the project*/
 const buildVersion = package.version;
 
-/** Required Angular version for the project. */
-const angularVersion = package.dependencies['@angular/core'];
+/**
+ * Required Angular version for all Angular Material packages. This version will be used
+ * as the peer dependency version for Angular in all release packages.
+ */
+const angularVersion = '^5.0.0';
 
 /** License that will be placed inside of all created bundles. */
 const buildLicense = `/**


### PR DESCRIPTION
* Right now the `peerDependency` of Angular will be the one from the `package.json`. This means that upcoming minor versions of Angular cause peer dependency warnings within Yarn or NPM.
* Adds a info to the publish task, because it can be easy to forget about the version in the config.

Fixes #9328