### PR TITLE
fix(overlay): unable to change CdkConnectedOverlay origin dynamically

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -256,6 +256,14 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if ((changes['origin'] || changes['_deprecatedOrigin']) && this._position) {
+      this._position.setOrigin(this.origin.elementRef);
+
+      if (this.open) {
+        this._position.apply();
+      }
+    }
+
     if (changes['open'] || changes['_deprecatedOpen']) {
       this.open ? this._attachOverlay() : this._detachOverlay();
     }

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -266,6 +266,15 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   }
 
   /**
+   * Sets the origin element, relative to which to position the overlay.
+   * @param origin Reference to the new origin element.
+   */
+  setOrigin(origin: ElementRef): this {
+    this._origin = origin.nativeElement;
+    return this;
+  }
+
+  /**
    * Gets the horizontal (x) "start" dimension based on whether the overlay is in an RTL context.
    * @param rect
    */


### PR DESCRIPTION
Fixes the `CdkConnectedOverlay` not handling changes of its `origin` after it's opened for the first time.

Fixes #9353.