### PR TITLE
wip: fix travis sandbox errors

### DIFF
--- a/test/remote_browsers.json
+++ b/test/remote_browsers.json
@@ -12,7 +12,8 @@
     ]
   },
   "ChromeHeadlessCI": {
-    "base": "ChromeHeadlessLocal"
+    "base": "ChromeHeadlessLocal",
+    "flags": ["--no-sandbox"]
   },
   "SL_CHROME": {
     "base": "SauceLabs",


### PR DESCRIPTION
Currently Travis throws sandboxing errors at random (see https://github.com/travis-ci/travis-ci/issues/8836), which causes the builds to be flaky (see https://travis-ci.org/angular/material2/jobs/328213122#L613). These changes address the issue by disabling sandboxing when running unit tests on the CI.