### PR TITLE
chore(tooltip): revert workaround for older Angular versions

### DIFF
--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -594,10 +594,7 @@ export class TooltipComponent {
     }
 
     if (toState === 'visible' || toState === 'hidden') {
-      // Note: as of Angular 4.3, the animations module seems to fire the `start` callback before
-      // the end if animations are disabled. Make this call async to ensure that it still fires
-      // at the appropriate time.
-      Promise.resolve().then(() => this._closeOnInteraction = true);
+      this._closeOnInteraction = true;
     }
   }
 


### PR DESCRIPTION
Reverts a workaround for a bug in Angular 4.x where the animation events would fire out of sequence if animations are disabled. The underlying issue appears to be fixed in Angular 5.