### PR TITLE
feat(form-field): support for different spec variants

### DIFF
--- a/src/demo-app/a11y/autocomplete/autocomplete-a11y.html
+++ b/src/demo-app/a11y/autocomplete/autocomplete-a11y.html
@@ -2,7 +2,8 @@
   <h2>Filtering and selection</h2>
   <p>Select your favorite state</p>
   <mat-form-field>
-    <input matInput placeholder="Search for a state" [matAutocomplete]="autocomplete"
+    <mat-label>Search for a state</mat-label>
+    <input matInput [matAutocomplete]="autocomplete"
       [(ngModel)]="value" (ngModelChange)="filteredStates = filter(value)">
     <mat-autocomplete #autocomplete="matAutocomplete">
       <mat-option *ngFor="let state of filteredStates" [value]="state.name">

--- a/src/demo-app/a11y/datepicker/datepicker-a11y.html
+++ b/src/demo-app/a11y/datepicker/datepicker-a11y.html
@@ -1,13 +1,13 @@
 <section>
   <h2>Choose a date (e.g. choose your date of birth)</h2>
   <mat-form-field>
+    <mat-label>Date of birth</mat-label>
     <input matInput
            [matDatepicker]="birthdayPicker"
            [(ngModel)]="birthday"
            #birthdayModel="ngModel"
            [max]="maxBirthday"
-           required
-           placeholder="Date of birth">
+           required>
     <mat-datepicker-toggle matSuffix [for]="birthdayPicker"></mat-datepicker-toggle>
     <mat-datepicker #birthdayPicker startView="year"></mat-datepicker>
     <mat-error *ngIf="birthdayModel.hasError('required')">
@@ -44,14 +44,14 @@
 <section>
   <h2>Choose date with startAt, min and max (e.g. schedule a departing and returning flight)</h2>
   <mat-form-field>
+    <mat-label>Departure date</mat-label>
     <input matInput
            [matDatepicker]="departPicker"
            [(ngModel)]="departDate"
            #departDateModel="ngModel"
            [min]="minTripDate"
            [max]="maxTripDate"
-           required
-           placeholder="Departure date">
+           required>
     <mat-datepicker-toggle matSuffix [for]="departPicker"></mat-datepicker-toggle>
     <mat-datepicker #departPicker [startAt]="startTripDate"></mat-datepicker>
     <mat-error *ngIf="departDateModel.hasError('required')">
@@ -65,13 +65,13 @@
     </mat-error>
   </mat-form-field>
   <mat-form-field>
+    <mat-label>Return date</mat-label>
     <input matInput
            [matDatepicker]="returnPicker"
            [(ngModel)]="returnDate"
            #returnDateModel="ngModel"
            [min]="departDate || minTripDate"
-           [max]="maxTripDate"
-           placeholder="Return date">
+           [max]="maxTripDate">
     <mat-datepicker-toggle matSuffix [for]="returnPicker"></mat-datepicker-toggle>
     <mat-datepicker #returnPicker [startAt]="startTripDate"></mat-datepicker>
     <mat-error *ngIf="returnDateModel.hasError('matDatepickerMin') && !departDate">
@@ -89,6 +89,7 @@
 <section>
   <h2>Choose date with date filter (e.g. schedule a doctor's appointment)</h2>
   <mat-form-field>
+    <mat-label>Appointment date</mat-label>
     <input matInput
            [matDatepicker]="appointmentPicker"
            [(ngModel)]="appointmentDate"
@@ -96,8 +97,7 @@
            [min]="minAppointmentDate"
            [max]="maxAppointmentDate"
            [matDatepickerFilter]="weekdaysOnly"
-           required
-           placeholder="Appointment date">
+           required>
     <mat-datepicker-toggle matSuffix [for]="appointmentPicker"></mat-datepicker-toggle>
     <mat-datepicker #appointmentPicker></mat-datepicker>
     <mat-error *ngIf="appointmentDateModel.hasError('required')">

--- a/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
+++ b/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
@@ -3,36 +3,44 @@
 <mat-dialog-content>
   <form class="example-form">
     <mat-form-field class="example-full-width">
-      <input matInput placeholder="Company (disabled)" disabled value="Google">
+      <mat-label>Company (disabled)</mat-label>
+      <input matInput disabled value="Google">
     </mat-form-field>
 
     <table class="example-full-width" cellspacing="0"><tr>
       <td><mat-form-field class="example-full-width">
-        <input matInput placeholder="First name">
+        <mat-label>First name</mat-label>
+        <input matInput>
       </mat-form-field></td>
       <td><mat-form-field class="example-full-width">
-        <input matInput placeholder="Long Last Name That Will Be Truncated">
+        <mat-label>Long last name that will be truncated</mat-label>
+        <input matInput>
       </mat-form-field></td>
     </tr></table>
 
     <p>
       <mat-form-field class="example-full-width">
-        <textarea matInput placeholder="Address">1600 Amphitheatre Pkwy</textarea>
+        <mat-label>Address</mat-label>
+        <textarea matInput>1600 Amphitheatre Pkwy</textarea>
       </mat-form-field>
       <mat-form-field class="example-full-width">
-        <textarea matInput placeholder="Address 2"></textarea>
+        <mat-label>Address 2</mat-label>
+        <textarea matInput></textarea>
       </mat-form-field>
     </p>
 
     <table class="example-full-width" cellspacing="0"><tr>
       <td><mat-form-field class="example-full-width">
-        <input matInput placeholder="City">
+        <mat-label>City</mat-label>
+        <input matInput>
       </mat-form-field></td>
       <td><mat-form-field class="example-full-width">
-        <input matInput placeholder="State">
+        <mat-label>State</mat-label>
+        <input matInput>
       </mat-form-field></td>
       <td><mat-form-field class="example-full-width">
-        <input matInput #postalCode maxlength="5" placeholder="Postal Code" value="94043">
+        <mat-label>Postal code</mat-label>
+        <input matInput #postalCode maxlength="5" value="94043">
         <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>
       </mat-form-field></td>
     </tr></table>

--- a/src/demo-app/a11y/input/input-a11y.html
+++ b/src/demo-app/a11y/input/input-a11y.html
@@ -1,18 +1,20 @@
 <section>
   <h2>Basic input box (e.g. name field)</h2>
   <mat-form-field floatLabel="never">
-    <input matInput placeholder="First name" [(ngModel)]="firstName">
+    <mat-label>First name</mat-label>
+    <input matInput [(ngModel)]="firstName">
   </mat-form-field>
   <mat-form-field floatLabel="never">
-    <input matInput placeholder="Last name" [(ngModel)]="lastName">
+    <mat-label>Last name</mat-label>
+    <input matInput [(ngModel)]="lastName">
   </mat-form-field>
 </section>
 
 <section>
   <h2>Input with hint (e.g. password field)</h2>
   <mat-form-field hideRequiredMarker>
-    <input matInput [type]="passwordType" placeholder="Password" [(ngModel)]="password" required
-           #passwordModel="ngModel">
+    <mat-label>Password</mat-label>
+    <input matInput [type]="passwordType" [(ngModel)]="password" required #passwordModel="ngModel">
     <button mat-icon-button matSuffix [attr.aria-label]="passwordToggleLabel"
             (click)="showPassword = !showPassword">
       <mat-icon>{{passwordToggleIcon}}</mat-icon>
@@ -25,8 +27,8 @@
 <section>
   <h2>Input with error message (e.g. email field)</h2>
   <mat-form-field>
-    <input matInput type="email" placeholder="Email" [(ngModel)]="email" required email
-           #emailModel="ngModel">
+    <mat-label>Email</mat-label>
+    <input matInput type="email" [(ngModel)]="email" required email #emailModel="ngModel">
     <mat-error *ngIf="emailModel.hasError('required')">You must enter your email.</mat-error>
     <mat-error *ngIf="emailModel.hasError('email')">Not a valid email address.</mat-error>
   </mat-form-field>
@@ -35,12 +37,14 @@
 <section>
   <h2>Input with prefix & suffix (e.g. currency converter)</h2>
   <mat-form-field floatLabel="always">
-    <input matInput type="number" placeholder="USD" [(ngModel)]="usd">
+    <mat-label>USD</mat-label>
+    <input matInput type="number" [(ngModel)]="usd">
     <span matPrefix>$</span>
   </mat-form-field>
   =
   <mat-form-field floatLabel="always">
-    <input matInput type="number" placeholder="JPY" [(ngModel)]="jpy">
+    <mat-label>JPY</mat-label>
+    <input matInput type="number" [(ngModel)]="jpy">
     <span matPrefix>‎¥‎</span>
   </mat-form-field>
   (as of 7/31/2017)

--- a/src/demo-app/a11y/select/select-a11y.html
+++ b/src/demo-app/a11y/select/select-a11y.html
@@ -3,7 +3,8 @@
   <p>Select your favorite color</p>
 
   <mat-form-field>
-    <mat-select placeholder="Colors" [(ngModel)]="selectedColor">
+    <mat-label>Colors</mat-label>
+    <mat-select [(ngModel)]="selectedColor">
       <mat-option *ngFor="let color of colors" [value]="color.value">
         {{ color.label }}
       </mat-option>
@@ -16,7 +17,8 @@
   <p>Pick toppings for your pizza</p>
 
   <mat-form-field>
-    <mat-select placeholder="Toppings" [(ngModel)]="selectedTopping" multiple>
+    <mat-label>Toppings</mat-label>
+    <mat-select [(ngModel)]="selectedTopping" multiple>
       <mat-option *ngFor="let topping of toppings" [value]="topping.value">
         {{ topping.label }}
       </mat-option>
@@ -29,7 +31,8 @@
   <p>Pick your Pokemon</p>
 
   <mat-form-field>
-    <mat-select placeholder="Pokemon" [(ngModel)]="selectedPokemon">
+    <mat-label>Pokemon</mat-label>
+    <mat-select [(ngModel)]="selectedPokemon">
       <mat-optgroup *ngFor="let group of pokemon" [label]="group.label">
         <mat-option *ngFor="let creature of group.pokemon" [value]="creature.value">
           {{ creature.label }}
@@ -44,21 +47,24 @@
 
   <div class="select-a11y-spacer">
     <mat-form-field  color="primary">
-      <mat-select placeholder="ZIP code">
+      <mat-label>ZIP code</mat-label>
+      <mat-select>
         <mat-option value="2000">2000</mat-option>
         <mat-option value="2100">2100</mat-option>
       </mat-select>
     </mat-form-field>
 
     <mat-form-field color="accent">
-      <mat-select placeholder="State">
+      <mat-label>State</mat-label>
+      <mat-select>
         <mat-option value="alaska">Alaska</mat-option>
         <mat-option value="alabama">Alabama</mat-option>
       </mat-select>
     </mat-form-field>
 
     <mat-form-field color="warn">
-      <mat-select placeholder="Language">
+      <mat-label>Language</mat-label>
+      <mat-select>
         <mat-option value="english">English</mat-option>
         <mat-option value="spanish">Spanish</mat-option>
       </mat-select>
@@ -67,21 +73,24 @@
 
   <div class="select-a11y-spacer">
     <mat-form-field color="primary">
-      <mat-select placeholder="Digimon" multiple>
+      <mat-label>Digimon</mat-label>
+      <mat-select multiple>
         <mat-option value="mihiramon">Mihiramon</mat-option>
         <mat-option value="sandiramon">Sandiramon</mat-option>
       </mat-select>
     </mat-form-field>
 
     <mat-form-field color="accent">
-      <mat-select placeholder="Drink" multiple>
+      <mat-label>Drink</mat-label>
+      <mat-select multiple>
         <mat-option value="water">Water</mat-option>
         <mat-option value="coke">Coke</mat-option>
       </mat-select>
     </mat-form-field>
 
     <mat-form-field color="warn">
-      <mat-select placeholder="Theme" multiple>
+      <mat-label>Theme</mat-label>
+      <mat-select multiple>
         <mat-option value="light">Light</mat-option>
         <mat-option value="dark">Dark</mat-option>
       </mat-select>

--- a/src/demo-app/autocomplete/autocomplete-demo.html
+++ b/src/demo-app/autocomplete/autocomplete-demo.html
@@ -7,7 +7,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <div>Reactive dirty: {{ stateCtrl.dirty }}</div>
 
     <mat-form-field floatLabel="never">
-      <input matInput placeholder="State" [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
+      <mat-label>State</mat-label>
+      <input matInput [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
       <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn">
         <mat-option *ngFor="let state of reactiveStates | async" [value]="state">
           <span>{{ state.name }}</span>
@@ -33,7 +34,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
     <!-- Added an ngIf below to test that autocomplete works with ngIf -->
     <mat-form-field *ngIf="true">
-      <input matInput placeholder="State" [matAutocomplete]="tdAuto" [(ngModel)]="currentState"
+      <mat-label>State</mat-label>
+      <input matInput [matAutocomplete]="tdAuto" [(ngModel)]="currentState"
         (ngModelChange)="tdStates = filterStates(currentState)" [disabled]="tdDisabled">
       <mat-autocomplete #tdAuto="matAutocomplete">
         <mat-option *ngFor="let state of tdStates" [value]="state.name">
@@ -56,9 +58,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <div>Option groups (currentGroupedState): {{ currentGroupedState }}</div>
 
     <mat-form-field>
+      <mat-label>State</mat-label>
       <input
         matInput
-        placeholder="State"
         [matAutocomplete]="groupedAuto"
         [(ngModel)]="currentGroupedState"
         (ngModelChange)="filteredGroupedStates = filterStateGroups(currentGroupedState)">

--- a/src/demo-app/baseline/baseline-demo.html
+++ b/src/demo-app/baseline/baseline-demo.html
@@ -11,18 +11,21 @@
     <mat-radio-button value="option_3">Radio 3</mat-radio-button>
     | Text 4 |
     <mat-form-field>
-      <input matInput placeholder="Input" value="Text Input">
+      <mat-label>Input</mat-label>
+      <input matInput value="Text Input">
     </mat-form-field>
     | Text 5 |
     <mat-form-field>
-      <mat-select placeholder="This placeholder is really really really long">
+      <mat-label>This label is really really really long</mat-label>
+      <mat-select>
         <mat-option value="option">Option</mat-option>
         <mat-option value="long">This option is really really really long</mat-option>
       </mat-select>
     </mat-form-field>
     | Text 6 |
     <mat-form-field>
-      <textarea matInput placeholder="Input" matTextareaAutosize>Textarea&#10;Line 2</textarea>
+      <mat-label>Input</mat-label>
+      <textarea matInput matTextareaAutosize>Textarea&#10;Line 2</textarea>
     </mat-form-field>
     | Text After
   </mat-card-content>
@@ -42,18 +45,21 @@
       <mat-radio-button value="option_3">Radio 3</mat-radio-button>
       | Text 4 |
       <mat-form-field>
-        <input matInput placeholder="Input" value="Text Input">
+        <mat-label>Input</mat-label>
+        <input matInput value="Text Input">
       </mat-form-field>
       | Text 5 |
       <mat-form-field>
-        <mat-select placeholder="This placeholder is really really really long">
+        <mat-label>This label is really really really long</mat-label>
+        <mat-select>
           <mat-option value="option">Option</mat-option>
           <mat-option value="long">This option is really really really long</mat-option>
         </mat-select>
       </mat-form-field>
       | Text 6 |
       <mat-form-field>
-        <textarea matInput placeholder="Input" matTextareaAutosize>Textarea&#10;Line 2</textarea>
+        <mat-label>Input</mat-label>
+        <textarea matInput matTextareaAutosize>Textarea&#10;Line 2</textarea>
       </mat-form-field>
       | Text After
     </h1>

--- a/src/demo-app/datepicker/datepicker-demo.html
+++ b/src/demo-app/datepicker/datepicker-demo.html
@@ -8,13 +8,15 @@
 </p>
 <p>
   <mat-form-field>
-    <input matInput [matDatepicker]="minDatePicker" [(ngModel)]="minDate" placeholder="Min date"
+    <mat-label>Min date</mat-label>
+    <input matInput [matDatepicker]="minDatePicker" [(ngModel)]="minDate"
         [disabled]="inputDisabled">
     <mat-datepicker-toggle matSuffix [for]="minDatePicker"></mat-datepicker-toggle>
     <mat-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
   </mat-form-field>
   <mat-form-field>
-    <input matInput [matDatepicker]="maxDatePicker" [(ngModel)]="maxDate" placeholder="Max date"
+    <mat-label>Max date</mat-label>
+    <input matInput [matDatepicker]="maxDatePicker" [(ngModel)]="maxDate"
         [disabled]="inputDisabled">
     <mat-datepicker-toggle matSuffix [for]="maxDatePicker"></mat-datepicker-toggle>
     <mat-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
@@ -22,7 +24,8 @@
 </p>
 <p>
   <mat-form-field>
-    <input matInput [matDatepicker]="startAtPicker" [(ngModel)]="startAt" placeholder="Start at date"
+    <mat-label>Start at date</mat-label>
+    <input matInput [matDatepicker]="startAtPicker" [(ngModel)]="startAt"
         [disabled]="inputDisabled">
     <mat-datepicker-toggle matSuffix [for]="startAtPicker"></mat-datepicker-toggle>
     <mat-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
@@ -34,6 +37,7 @@
 <p>
   <mat-datepicker-toggle [for]="resultPicker"></mat-datepicker-toggle>
   <mat-form-field>
+    <mat-label>Pick a date</mat-label>
     <input matInput
            #resultPickerModel="ngModel"
            [matDatepicker]="resultPicker"
@@ -42,7 +46,6 @@
            [max]="maxDate"
            [matDatepickerFilter]="filterOdd ? dateFilter : null"
            [disabled]="inputDisabled"
-           placeholder="Pick a date"
            (dateInput)="onDateInput($event)"
            (dateChange)="onDateChange($event)">
     <mat-datepicker
@@ -86,9 +89,9 @@
 <p>
   <mat-datepicker-toggle [for]="datePicker1"></mat-datepicker-toggle>
   <mat-form-field>
+    <mat-label>Input disabled</mat-label>
     <input matInput [matDatepicker]="datePicker1" [(ngModel)]="date" [min]="minDate" [max]="maxDate"
-           [matDatepickerFilter]="filterOdd ? dateFilter : null" disabled
-           placeholder="Input disabled">
+           [matDatepickerFilter]="filterOdd ? dateFilter : null" disabled>
     <mat-datepicker #datePicker1 [touchUi]="touch" [startAt]="startAt"
                    [startView]="yearView ? 'year' : 'month'"></mat-datepicker>
   </mat-form-field>
@@ -98,9 +101,9 @@
 <p>
   <mat-datepicker-toggle [for]="datePicker2"></mat-datepicker-toggle>
   <mat-form-field>
+    <mat-label>FormControl disabled</mat-label>
     <input matInput [matDatepicker]="datePicker2" [formControl]="dateCtrl" [min]="minDate"
-           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null"
-           placeholder="FormControl disabled">
+           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null">
     <mat-datepicker #datePicker2 [touchUi]="touch" [startAt]="startAt"
                     [startView]="yearView ? 'year' : 'month'"></mat-datepicker>
   </mat-form-field>
@@ -114,9 +117,9 @@
 <p>
   <mat-datepicker-toggle [for]="datePicker3"></mat-datepicker-toggle>
   <mat-form-field>
+    <mat-label>Input disabled, datepicker enabled</mat-label>
     <input matInput disabled [matDatepicker]="datePicker3" [(ngModel)]="date" [min]="minDate"
-           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null"
-           placeholder="Input disabled, datepicker enabled">
+           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null">
     <mat-datepicker #datePicker3 [touchUi]="touch" [disabled]="false" [startAt]="startAt"
                    [startView]="yearView ? 'year' : 'month'"></mat-datepicker>
   </mat-form-field>
@@ -126,9 +129,9 @@
 <p>
   <mat-datepicker-toggle [for]="datePicker4"></mat-datepicker-toggle>
   <mat-form-field>
+    <mat-label>Value binding</mat-label>
     <input matInput [matDatepicker]="datePicker4" [value]="date" [min]="minDate"
-           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null"
-           placeholder="Value binding">
+           [max]="maxDate" [matDatepickerFilter]="filterOdd ? dateFilter : null">
     <mat-datepicker #datePicker4 [touchUi]="touch" [startAt]="startAt"
                     [startView]="yearView ? 'year' : 'month'"></mat-datepicker>
   </mat-form-field>

--- a/src/demo-app/dialog/dialog-demo.html
+++ b/src/demo-app/dialog/dialog-demo.html
@@ -16,28 +16,34 @@
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.width" placeholder="Width">
+        <mat-label>Width</mat-label>
+        <input matInput [(ngModel)]="config.width">
       </mat-form-field>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.height" placeholder="Height">
-      </mat-form-field>
-    </p>
-
-    <p>
-      <mat-form-field>
-        <input matInput [(ngModel)]="config.minWidth" placeholder="Min Width">
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput [(ngModel)]="config.minHeight" placeholder="Min Height">
+        <mat-label>Height</mat-label>
+        <input matInput [(ngModel)]="config.height">
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.maxWidth" placeholder="Max Width">
+        <mat-label>Min width</mat-label>
+        <input matInput [(ngModel)]="config.minWidth">
       </mat-form-field>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.maxHeight" placeholder="Max Height">
+        <mat-label>Min height</mat-label>
+        <input matInput [(ngModel)]="config.minHeight">
+      </mat-form-field>
+    </p>
+
+    <p>
+      <mat-form-field>
+        <mat-label>Max width</mat-label>
+        <input matInput [(ngModel)]="config.maxWidth">
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Max height</mat-label>
+        <input matInput [(ngModel)]="config.maxHeight">
       </mat-form-field>
     </p>
 
@@ -45,19 +51,23 @@
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''" placeholder="Top">
+        <mat-label>Top</mat-label>
+        <input matInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''">
       </mat-form-field>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''" placeholder="Bottom">
+        <mat-label>Bottom</mat-label>
+        <input matInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''">
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.position.left" (change)="config.position.right = ''" placeholder="Left">
+        <mat-label>Left</mat-label>
+        <input matInput [(ngModel)]="config.position.left" (change)="config.position.right = ''">
       </mat-form-field>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.position.right" (change)="config.position.left = ''" placeholder="Right">
+        <mat-label>Right</mat-label>
+        <input matInput [(ngModel)]="config.position.right" (change)="config.position.left = ''">
       </mat-form-field>
     </p>
 
@@ -65,7 +75,8 @@
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.backdropClass" placeholder="Backdrop class">
+        <mat-label>Backdrop class</mat-label>
+        <input matInput [(ngModel)]="config.backdropClass">
       </mat-form-field>
     </p>
 
@@ -75,7 +86,8 @@
 
     <p>
       <mat-form-field>
-        <mat-select placeholder="Button alignment" [(ngModel)]="actionsAlignment">
+        <mat-label>Button alignment</mat-label>
+        <mat-select [(ngModel)]="actionsAlignment">
           <mat-option>Start</mat-option>
           <mat-option value="end">End</mat-option>
           <mat-option value="center">Center</mat-option>
@@ -85,7 +97,8 @@
 
     <p>
       <mat-form-field>
-        <input matInput [(ngModel)]="config.data.message" placeholder="Dialog message">
+        <mat-label>Dialog message</mat-label>
+        <input matInput [(ngModel)]="config.data.message">
       </mat-form-field>
     </p>
 
@@ -104,7 +117,8 @@
   <p>It's Jazz!</p>
 
   <mat-form-field>
-    <input matInput placeholder="How much?" #howMuch>
+    <mat-label>How much?</mat-label>
+    <input matInput #howMuch>
   </mat-form-field>
 
   <p> {{ data.message }} </p>

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -92,7 +92,8 @@ export class DialogDemo {
   <p>It's Jazz!</p>
 
   <mat-form-field>
-    <input matInput placeholder="How much?" #howMuch>
+    <mat-label>How much?</mat-label>
+    <input matInput #howMuch>
   </mat-form-field>
 
   <p> {{ data.message }} </p>

--- a/src/demo-app/expansion/expansion-demo.html
+++ b/src/demo-app/expansion/expansion-demo.html
@@ -19,11 +19,13 @@
 
 <br>
 <mat-form-field>
-  <input matInput [(ngModel)]="collapsedHeight" placeholder="Collapsed height">
+  <mat-label>Collapsed height</mat-label>
+  <input matInput [(ngModel)]="collapsedHeight">
 </mat-form-field>
 
 <mat-form-field>
-  <input matInput [(ngModel)]="expandedHeight" placeholder="Expanded height">
+  <mat-label>Expanded height</mat-label>
+  <input matInput [(ngModel)]="expandedHeight">
 </mat-form-field>
 <br>
 

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -528,44 +528,44 @@
 </mat-card>
 
 <mat-card class="demo-card demo-basic">
-  <mat-toolbar color="primary">Variants</mat-toolbar>
+  <mat-toolbar color="primary">Appearance</mat-toolbar>
   <mat-card-content>
-    <mat-form-field variant="legacy">
-      <input matInput placeholder="example" [(ngModel)]="legacyVariant" required>
+    <mat-form-field appearance="legacy">
+      <input matInput placeholder="example" [(ngModel)]="legacyAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
 
-    <mat-form-field variant="standard">
-      <input matInput placeholder="example" [(ngModel)]="standardVariant" required>
+    <mat-form-field appearance="standard">
+      <input matInput placeholder="example" [(ngModel)]="standardAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
 
-    <mat-form-field variant="box">
-      <input matInput placeholder="example" [(ngModel)]="boxVariant" required>
+    <mat-form-field appearance="box">
+      <input matInput placeholder="example" [(ngModel)]="boxAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
 
     <table style="width: 100%" cellspacing="0"><tr>
       <td>
-        <mat-form-field variant="legacy" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="legacyVariant" required>
+        <mat-form-field appearance="legacy" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="legacyAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>
       </td>
       <td>
-        <mat-form-field variant="standard" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="standardVariant" required>
+        <mat-form-field appearance="standard" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="standardAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>
       </td>
       <td>
-        <mat-form-field variant="box" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="boxVariant" required>
+        <mat-form-field appearance="box" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="boxAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -526,3 +526,50 @@
     </label>
   </mat-card-content>
 </mat-card>
+
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Variants</mat-toolbar>
+  <mat-card-content>
+    <mat-form-field variant="legacy">
+      <input matInput placeholder="example" [(ngModel)]="legacyVariant" required>
+      <mat-error>This field is required</mat-error>
+      <mat-hint>Please type something here</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field variant="standard">
+      <input matInput placeholder="example" [(ngModel)]="standardVariant" required>
+      <mat-error>This field is required</mat-error>
+      <mat-hint>Please type something here</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field variant="box">
+      <input matInput placeholder="example" [(ngModel)]="boxVariant" required>
+      <mat-error>This field is required</mat-error>
+      <mat-hint>Please type something here</mat-hint>
+    </mat-form-field>
+
+    <table style="width: 100%" cellspacing="0"><tr>
+      <td>
+        <mat-form-field variant="legacy" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="legacyVariant" required>
+          <mat-error>This field is required</mat-error>
+          <mat-hint>Please type something here</mat-hint>
+        </mat-form-field>
+      </td>
+      <td>
+        <mat-form-field variant="standard" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="standardVariant" required>
+          <mat-error>This field is required</mat-error>
+          <mat-hint>Please type something here</mat-hint>
+        </mat-form-field>
+      </td>
+      <td>
+        <mat-form-field variant="box" style="width: 100%">
+          <input matInput placeholder="example" [(ngModel)]="boxVariant" required>
+          <mat-error>This field is required</mat-error>
+          <mat-hint>Please type something here</mat-hint>
+        </mat-form-field>
+      </td>
+    </tr></table>
+  </mat-card-content>
+</mat-card>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -3,44 +3,51 @@
   <mat-card-content>
     <form>
       <mat-form-field class="demo-full-width">
-        <input matInput placeholder="Company (disabled)" disabled value="Google">
+        <mat-label>Company (disabled)</mat-label>
+        <input matInput disabled value="Google">
       </mat-form-field>
 
       <table style="width: 100%" cellspacing="0"><tr>
         <td>
           <mat-form-field style="width: 100%" floatLabel="never">
-            <input matInput placeholder="First name">
+            <mat-label>First name</mat-label>
+            <input matInput>
           </mat-form-field>
         </td>
         <td>
           <mat-form-field style="width: 100%">
-            <input matInput placeholder="Long Last Name That Will Be Truncated">
+            <mat-label>Long last name that will be truncated</mat-label>
+            <input matInput>
           </mat-form-field>
         </td>
       </tr></table>
       <p>
         <mat-form-field class="demo-full-width">
-          <textarea matInput placeholder="Address">1600 Amphitheatre Pkway</textarea>
+          <mat-label>Address</mat-label>
+          <textarea matInput>1600 Amphitheatre Pkway</textarea>
         </mat-form-field>
         <mat-form-field class="demo-full-width">
-          <textarea matInput placeholder="Address 2"></textarea>
+          <mat-label>Address 2</mat-label>
+          <textarea matInput></textarea>
         </mat-form-field>
       </p>
       <table style="width: 100%" cellspacing="0"><tr>
         <td>
           <mat-form-field class="demo-full-width">
-            <input matInput placeholder="City" value="Mountain View">
+            <mat-label>City</mat-label>
+            <input matInput value="Mountain View">
           </mat-form-field>
         </td>
         <td>
           <mat-form-field class="demo-full-width">
-            <input matInput placeholder="State" maxLength="2" value="CA">
+            <mat-label>State</mat-label>
+            <input matInput maxLength="2" value="CA">
           </mat-form-field>
         </td>
         <td>
           <mat-form-field class="demo-full-width">
-            <input matInput #postalCode maxLength="5" placeholder="Postal Code" value="94043"
-                   pattern="[0-9]{5}">
+            <mat-label>Postal code</mat-label>
+            <input matInput #postalCode maxLength="5" value="94043" pattern="[0-9]{5}">
             <mat-hint align="end">
               <mat-icon>mode_edit</mat-icon>
               <span aria-live="polite">{{postalCode.value.length}} / 5</span>
@@ -59,12 +66,14 @@
 
     <p>
       <mat-form-field>
-        <input matInput placeholder="example" [(ngModel)]="errorMessageExample1" required>
+        <mat-label>Example</mat-label>
+        <input matInput [(ngModel)]="errorMessageExample1" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
 
       <mat-form-field>
-        <input matInput placeholder="email" [formControl]="emailFormControl">
+        <mat-label>Email</mat-label>
+        <input matInput [formControl]="emailFormControl">
         <mat-error *ngIf="emailFormControl.hasError('required')">
           This field is required
         </mat-error>
@@ -77,7 +86,8 @@
     <h4>With hint</h4>
 
     <mat-form-field>
-      <input matInput placeholder="example" [(ngModel)]="errorMessageExample2" required>
+      <mat-label>Example</mat-label>
+      <input matInput [(ngModel)]="errorMessageExample2" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
@@ -87,8 +97,8 @@
       <h4>Inside a form</h4>
 
       <mat-form-field>
-        <input matInput name="example" placeholder="example"
-          [(ngModel)]="errorMessageExample3" required>
+        <mat-label>Example</mat-label>
+        <input matInput name="example" [(ngModel)]="errorMessageExample3" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
 
@@ -97,8 +107,8 @@
 
     <h4>With a custom error function</h4>
     <mat-form-field>
+      <mat-label>Example</mat-label>
       <input matInput
-        placeholder="example"
         [(ngModel)]="errorMessageExample4"
         [errorStateMatcher]="customErrorStateMatcher"
         required>
@@ -113,21 +123,24 @@
   <mat-card-content>
     <h4>Text</h4>
     <mat-form-field class="demo-text-align-end">
-      <input matInput placeholder="amount">
+      <mat-label>Amount</mat-label>
+      <input matInput>
       <span matPrefix>$&nbsp;</span>
       <span matSuffix>.00</span>
     </mat-form-field>
 
     <h4>Icons</h4>
     <mat-form-field>
-      <input matInput placeholder="amount">
+      <mat-label>Amount</mat-label>
+      <input matInput>
       <mat-icon matPrefix>attach_money</mat-icon>
       <mat-icon matSuffix>mode_edit</mat-icon>
     </mat-form-field>
 
     <h4>Icon buttons</h4>
     <mat-form-field>
-      <input matInput placeholder="amount">
+      <mat-label>Amount</mat-label>
+      <input matInput>
       <button mat-icon-button matPrefix><mat-icon>attach_money</mat-icon></button>
       <button mat-icon-button matSuffix><mat-icon>mode_edit</mat-icon></button>
     </mat-form-field>
@@ -139,37 +152,46 @@
   <mat-card-content>
     <h4>Input</h4>
     <mat-form-field color="primary" >
-      <input matInput placeholder="Default Color" value="example">
+      <mat-label>Default color</mat-label>
+      <input matInput value="example">
     </mat-form-field>
     <mat-form-field color="accent">
-      <input matInput placeholder="Accent Color" value="example">
+      <mat-label>Accent color</mat-label>
+      <input matInput value="example">
     </mat-form-field>
     <mat-form-field color="warn">
-      <input matInput placeholder="Warn Color" value="example">
+      <mat-label>Warn color</mat-label>
+      <input matInput value="example">
     </mat-form-field>
 
     <h4>Textarea</h4>
     <mat-form-field color="primary">
-      <textarea matInput placeholder="Default Color">example</textarea>
+      <mat-label>Default color</mat-label>
+      <textarea matInput>example</textarea>
     </mat-form-field>
     <mat-form-field color="accent">
-      <textarea matInput placeholder="Accent Color">example</textarea>
+      <mat-label>Accent color</mat-label>
+      <textarea matInput>example</textarea>
     </mat-form-field>
     <mat-form-field color="warn">
-      <textarea matInput placeholder="Warn Color">example</textarea>
+      <mat-label>Warn color</mat-label>
+      <textarea matInput>example</textarea>
     </mat-form-field>
 
     <h4>With error</h4>
     <mat-form-field color="primary" >
-      <input matInput placeholder="Default Color" [(ngModel)]="dividerColorExample1" required>
+      <mat-label>Default color</mat-label>
+      <input matInput [(ngModel)]="dividerColorExample1" required>
       <mat-error>This field is required</mat-error>
     </mat-form-field>
     <mat-form-field color="accent">
-      <input matInput placeholder="Accent Color" [(ngModel)]="dividerColorExample2" required>
+      <mat-label>Accent color</mat-label>
+      <input matInput [(ngModel)]="dividerColorExample2" required>
       <mat-error>This field is required</mat-error>
     </mat-form-field>
     <mat-form-field color="warn">
-      <input matInput placeholder="Warn Color" [(ngModel)]="dividerColorExample3" required>
+      <mat-label>Warn color</mat-label>
+      <input matInput [(ngModel)]="dividerColorExample3" required>
       <mat-error>This field is required</mat-error>
     </mat-form-field>
   </mat-card-content>
@@ -181,9 +203,9 @@
     <h4>Input</h4>
     <p>
       <mat-form-field class="demo-full-width">
+        <mat-label>Character count (100 max)</mat-label>
         <input matInput
                #characterCountInputHintExample
-               placeholder="Character count (100 max)"
                maxLength="100"
                value="Hello world. How are you?">
         <mat-hint align="end" aria-live="polite">
@@ -195,9 +217,9 @@
     <h4>Textarea</h4>
     <p>
       <mat-form-field class="demo-full-width">
+        <mat-label>Character count (100 max)</mat-label>
         <textarea matInput
                   #characterCountTextareaHintExample
-                  placeholder="Character count (100 max)"
                   maxLength="100">Hello world. How are you?</textarea>
         <mat-hint align="end" aria-live="polite">
           {{characterCountTextareaHintExample.value.length}} / 100
@@ -212,7 +234,8 @@
     <span>
       Hello&nbsp;
       <mat-form-field color="accent">
-        <input matInput [(ngModel)]="name" type="text" placeholder="First name">
+        <mat-label>First name</mat-label>
+        <input matInput [(ngModel)]="name" type="text">
       </mat-form-field>,
       how are you?
     </span>
@@ -220,35 +243,40 @@
   <mat-card-content>
     <p>
       <mat-form-field>
-        <input matInput disabled placeholder="Disabled field" value="Value">
+        <mat-label>Disabled field</mat-label>
+        <input matInput disabled value="Value">
       </mat-form-field>
       <mat-form-field>
-        <input matInput required placeholder="Required field">
+        <mat-label>Required field</mat-label>
+        <input matInput required>
       </mat-form-field>
     </p>
     <p>
       <mat-form-field style="width: 100%">
-        <input matInput placeholder="100% width placeholder">
+        <mat-label>100% width label</mat-label>
+        <input matInput>
       </mat-form-field>
     </p>
     <p>
       <mat-form-field style="width: 100%">
-        <input matInput #input placeholder="Character count (100 max)" maxLength="100">
+        <mat-label>Character count (100 max)</mat-label>
+        <input matInput #input maxLength="100">
         <mat-hint align="end" aria-live="polite">{{input.value.length}} / 100</mat-hint>
       </mat-form-field>
     </p>
     <p>
       <mat-form-field hintLabel="Hint label" style="width: 100%">
-        <input matInput placeholder="Show Hint Label">
+        <mat-label>Show hint label</mat-label>
+        <input matInput>
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
         <input matInput>
-        <mat-placeholder>
-          I <mat-icon>favorite</mat-icon> <b>bold</b> placeholder
-        </mat-placeholder>
+        <mat-label>
+          I <mat-icon>favorite</mat-icon> <b>bold</b> label
+        </mat-label>
         <mat-hint>
           I also <mat-icon>home</mat-icon> <i>italic</i> hint labels
         </mat-hint>
@@ -256,13 +284,15 @@
     </p>
     <p>
       <mat-form-field hintLabel="Hint label" style="width: 100%">
-        <input matInput #hintLabelWithCharCount placeholder="Show Hint Label With Character Count">
+        <mat-label>Show hint label with character count</mat-label>
+        <input matInput #hintLabelWithCharCount>
         <mat-hint align="end" aria-live="polite">{{hintLabelWithCharCount.value.length}}</mat-hint>
       </mat-form-field>
     </p>
     <p>
       <mat-form-field style="margin-bottom: 4em">
-        <textarea matInput #longHint placeholder="Enter text to count"></textarea>
+        <mat-label>Enter text to count</mat-label>
+        <textarea matInput #longHint></textarea>
         <mat-hint>
           Enter some text to count how many characters are in it. The character count is shown on
           the right.
@@ -305,7 +335,8 @@
 
     <p>
       <mat-form-field [floatLabel]="floatingLabel">
-        <input matInput placeholder="Placeholder">
+        <mat-label>Label</mat-label>
+        <input matInput>
       </mat-form-field>
     </p>
 
@@ -318,17 +349,20 @@
 
     <p>
       <mat-form-field>
-        <input matInput placeholder="Prefixed" value="example">
+        <mat-label>Prefixed</mat-label>
+        <input matInput value="example">
         <div matPrefix>Example:&nbsp;</div>
       </mat-form-field>
       <mat-form-field class="demo-text-align-end">
-        <input matInput placeholder="Suffixed" value="123">
+        <mat-label>Suffixed</mat-label>
+        <input matInput value="123">
         <span matSuffix>.00 €</span>
       </mat-form-field>
       <br/>
       Both:
       <mat-form-field class="demo-text-align-end">
-        <input matInput #email placeholder="Email Address" value="angular-core">
+        <mat-label>Email address</mat-label>
+        <input matInput #email value="angular-core">
         <span matPrefix><mat-icon [class.primary]="email.focused">email</mat-icon>&nbsp;</span>
         <span matSuffix [class.primary]="email.focused">&nbsp;@gmail.com</span>
       </mat-form-field>
@@ -358,10 +392,9 @@
         <td>{{i+1}}</td>
         <td>
           <mat-form-field>
+            <mat-label>Value</mat-label>
             <input matInput
                    type="number"
-                   placeholder="value"
-                   aria-label="hello"
                    [(ngModel)]="items[i].value">
           </mat-form-field>
         </td>
@@ -377,10 +410,13 @@
 <mat-card class="demo-card demo-basic">
   <mat-toolbar color="primary">Forms</mat-toolbar>
   <mat-card-content>
-    <mat-form-field><input matInput placeholder="reactive" [formControl]="formControl">
+    <mat-form-field>
+      <mat-label>Reactive</mat-label>
+      <input matInput [formControl]="formControl">
     </mat-form-field>
     <mat-form-field>
-      <input matInput placeholder="template" [(ngModel)]="model" required [disabled]="ctrlDisabled">
+      <mat-label>Template</mat-label>
+      <input matInput [(ngModel)]="model" required [disabled]="ctrlDisabled">
     </mat-form-field>
     <button mat-raised-button color="primary"
             (click)="formControl.enabled ? formControl.disable() : formControl.enable()">
@@ -391,7 +427,8 @@
     </button>
     <div>
       <mat-form-field>
-        <input matInput placeholder="delayed value" [formControl]="delayedFormControl">
+        <mat-label>Delayed value</mat-label>
+        <input matInput [formControl]="delayedFormControl">
       </mat-form-field>
     </div>
   </mat-card-content>
@@ -509,10 +546,10 @@
     <h3>&lt;textarea&gt; with mat-form-field</h3>
     <div>
       <mat-form-field>
+        <mat-label>Autosized textarea</mat-label>
         <textarea matInput
                   matTextareaAutosize
-                  matAutosizeMaxRows="10"
-                  placeholder="Autosized textarea"></textarea>
+                  matAutosizeMaxRows="10"></textarea>
       </mat-form-field>
     </div>
 
@@ -531,19 +568,22 @@
   <mat-toolbar color="primary">Appearance</mat-toolbar>
   <mat-card-content>
     <mat-form-field appearance="legacy">
-      <input matInput placeholder="example" [(ngModel)]="legacyAppearance" required>
+      <mat-label>Legacy appearance</mat-label>
+      <input matInput [(ngModel)]="legacyAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
 
     <mat-form-field appearance="standard">
-      <input matInput placeholder="example" [(ngModel)]="standardAppearance" required>
+      <mat-label>Standard appearance</mat-label>
+      <input matInput [(ngModel)]="standardAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
 
     <mat-form-field appearance="box">
-      <input matInput placeholder="example" [(ngModel)]="boxAppearance" required>
+      <mat-label>Box appearance</mat-label>
+      <input matInput [(ngModel)]="boxAppearance" required>
       <mat-error>This field is required</mat-error>
       <mat-hint>Please type something here</mat-hint>
     </mat-form-field>
@@ -551,21 +591,24 @@
     <table style="width: 100%" cellspacing="0"><tr>
       <td>
         <mat-form-field appearance="legacy" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="legacyAppearance" required>
+          <mat-label>Legacy appearance</mat-label>
+          <input matInput [(ngModel)]="legacyAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>
       </td>
       <td>
         <mat-form-field appearance="standard" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="standardAppearance" required>
+          <mat-label>Standard appearance</mat-label>
+          <input matInput [(ngModel)]="standardAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>
       </td>
       <td>
         <mat-form-field appearance="box" style="width: 100%">
-          <input matInput placeholder="example" [(ngModel)]="boxAppearance" required>
+          <mat-label>Box appearance</mat-label>
+          <input matInput [(ngModel)]="boxAppearance" required>
           <mat-error>This field is required</mat-error>
           <mat-hint>Please type something here</mat-hint>
         </mat-form-field>

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -38,7 +38,7 @@
           </mat-form-field>
         </td>
         <td>
-          <mat-form-field class="demo-full-width">
+          <mat-form-field class="demo-full-width" variant="box">
             <input matInput #postalCode maxLength="5" placeholder="Postal Code" value="94043"
                    pattern="[0-9]{5}">
             <mat-hint align="end">

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -38,7 +38,7 @@
           </mat-form-field>
         </td>
         <td>
-          <mat-form-field class="demo-full-width" variant="box">
+          <mat-form-field class="demo-full-width">
             <input matInput #postalCode maxLength="5" placeholder="Postal Code" value="94043"
                    pattern="[0-9]{5}">
             <mat-hint align="end">

--- a/src/demo-app/input/input-demo.scss
+++ b/src/demo-app/input/input-demo.scss
@@ -3,7 +3,6 @@
 }
 .demo-basic .mat-card-content {
   padding: 16px;
-  font-size: 16px;
 }
 .demo-full-width {
   width: 100%;

--- a/src/demo-app/input/input-demo.scss
+++ b/src/demo-app/input/input-demo.scss
@@ -3,6 +3,7 @@
 }
 .demo-basic .mat-card-content {
   padding: 16px;
+  font-size: 16px;
 }
 .demo-full-width {
   width: 100%;

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -52,6 +52,10 @@ export class InputDemo {
   delayedFormControl = new FormControl('');
   model = 'hello';
 
+  legacyVariant: string;
+  standardVariant: string;
+  boxVariant: string;
+
   constructor() {
     setTimeout(() => this.delayedFormControl.setValue('hello'), 100);
   }

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -52,9 +52,9 @@ export class InputDemo {
   delayedFormControl = new FormControl('');
   model = 'hello';
 
-  legacyVariant: string;
-  standardVariant: string;
-  boxVariant: string;
+  legacyAppearance: string;
+  standardAppearance: string;
+  boxAppearance: string;
 
   constructor() {
     setTimeout(() => this.delayedFormControl.setValue('hello'), 100);

--- a/src/demo-app/ripple/ripple-demo.html
+++ b/src/demo-app/ripple/ripple-demo.html
@@ -28,10 +28,12 @@
   </section>
   <section>
     <mat-form-field>
-      <input matInput placeholder="Ripple radius" aria-label="radius" [(ngModel)]="radius">
+      <mat-label>Ripple radius</mat-label>
+      <input matInput aria-label="radius" [(ngModel)]="radius">
     </mat-form-field>
     <mat-form-field>
-      <input matInput placeholder="Ripple color" aria-label="color" [(ngModel)]="rippleColor">
+      <mat-label>Ripple color</mat-label>
+      <input matInput aria-label="color" [(ngModel)]="rippleColor">
     </mat-form-field>
   </section>
   <section>

--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -7,7 +7,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <mat-card-subtitle>ngModel</mat-card-subtitle>
 
     <mat-form-field [floatLabel]="floatLabel" [color]="drinksTheme">
-      <mat-select placeholder="Drink" [(ngModel)]="currentDrink" [required]="drinksRequired"
+      <mat-label>Drink</mat-label>
+      <mat-select [(ngModel)]="currentDrink" [required]="drinksRequired"
         [disabled]="drinksDisabled" #drinkControl="ngModel">
         <mat-option>None</mat-option>
         <mat-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
@@ -50,7 +51,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
     <mat-card-content>
       <mat-form-field [color]="pokemonTheme">
-        <mat-select multiple placeholder="Pokemon" [(ngModel)]="currentPokemon"
+        <mat-label>Pokemon</mat-label>
+        <mat-select multiple [(ngModel)]="currentPokemon"
           [required]="pokemonRequired" [disabled]="pokemonDisabled" #pokemonControl="ngModel">
           <mat-option *ngFor="let creature of pokemon" [value]="creature.value">
             {{ creature.viewValue }}
@@ -78,7 +80,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <mat-card-subtitle>Without Angular forms</mat-card-subtitle>
 
     <mat-form-field>
-      <mat-select placeholder="Digimon" [(value)]="currentDigimon">
+      <mat-label>Digimon</mat-label>
+      <mat-select [(value)]="currentDigimon">
         <mat-option>None</mat-option>
         <mat-option *ngFor="let creature of digimon" [value]="creature.value">
           {{ creature.viewValue }}
@@ -97,7 +100,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
     <mat-card-content>
       <mat-form-field>
-        <mat-select placeholder="Pokemon" [(ngModel)]="currentPokemonFromGroup">
+        <mat-label>Pokemon</mat-label>
+        <mat-select [(ngModel)]="currentPokemonFromGroup">
           <mat-optgroup *ngFor="let group of pokemonGroups" [label]="group.name"
             [disabled]="group.disabled">
             <mat-option *ngFor="let creature of group.pokemon" [value]="creature.value">
@@ -114,11 +118,11 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <mat-card-subtitle>compareWith</mat-card-subtitle>
     <mat-card-content>
       <mat-form-field [color]="drinksTheme">
-        <mat-select placeholder="Drink"
-                   [(ngModel)]="currentDrinkObject"
-                   [required]="drinkObjectRequired"
-                   [compareWith]="compareByValue ? compareDrinkObjectsByValue : compareByReference"
-                   #drinkObjectControl="ngModel">
+        <mat-label>Drink</mat-label>
+        <mat-select [(ngModel)]="currentDrinkObject"
+                    [required]="drinkObjectRequired"
+                    [compareWith]="compareByValue ? compareDrinkObjectsByValue : compareByReference"
+                    #drinkObjectControl="ngModel">
           <mat-option *ngFor="let drink of drinks" [value]="drink" [disabled]="drink.disabled">
             {{ drink.viewValue }}
           </mat-option>
@@ -146,7 +150,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
       <mat-card-content>
         <mat-form-field>
-          <mat-select placeholder="Food i would like to eat" [formControl]="foodControl">
+          <mat-label>Food I would like to eat</mat-label>
+          <mat-select [formControl]="foodControl">
             <mat-option *ngFor="let food of foods" [value]="food.value"> {{ food.viewValue }}</mat-option>
           </mat-select>
         </mat-form-field>
@@ -167,7 +172,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
       <mat-card-content>
         <mat-form-field>
-          <mat-select placeholder="Starter Pokemon" (change)="latestChangeEvent = $event">
+          <mat-label>Starter pokemon</mat-label>
+          <mat-select (change)="latestChangeEvent = $event">
             <mat-option *ngFor="let creature of pokemon" [value]="creature.value">{{ creature.viewValue }}</mat-option>
           </mat-select>
         </mat-form-field>

--- a/src/demo-app/snack-bar/snack-bar-demo.html
+++ b/src/demo-app/snack-bar/snack-bar-demo.html
@@ -25,10 +25,10 @@
     <mat-checkbox [(ngModel)]="action">
       <p *ngIf="!action">Show button on snack bar</p>
       <mat-form-field *ngIf="action">
+        <mat-label>Snack bar action label</mat-label>
         <input matInput
                type="text"
                class="demo-button-label-input"
-               placeholder="Snack bar action label"
                [(ngModel)]="actionButtonLabel">
       </mat-form-field>
     </mat-checkbox>
@@ -37,10 +37,10 @@
     <mat-checkbox [(ngModel)]="setAutoHide">
       <p *ngIf="!setAutoHide">Auto hide after duration</p>
       <mat-form-field *ngIf="setAutoHide">
+        <mat-label>Auto hide duration in ms</mat-label>
         <input matInput
                type="number"
                class="demo-button-label-input"
-               placeholder="Auto Hide Duration in ms"
                [(ngModel)]="autoHide">
       </mat-form-field>
     </mat-checkbox>

--- a/src/demo-app/stepper/stepper-demo.html
+++ b/src/demo-app/stepper/stepper-demo.html
@@ -6,12 +6,14 @@
     <mat-step formGroupName="0" [stepControl]="formArray?.get([0])">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
-        <input matInput placeholder="First Name" formControlName="firstNameFormCtrl" required>
+        <mat-label>First name</mat-label>
+        <input matInput formControlName="firstNameFormCtrl" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
 
       <mat-form-field>
-        <input matInput placeholder="Last Name" formControlName="lastNameFormCtrl" required>
+        <mat-label>Last name</mat-label>
+        <input matInput formControlName="lastNameFormCtrl" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
       <div>
@@ -24,7 +26,8 @@
         <div>Fill out your email address</div>
       </ng-template>
       <mat-form-field>
-        <input matInput placeholder="Email address" formControlName="emailFormCtrl">
+        <mat-label>Email address</mat-label>
+        <input matInput formControlName="emailFormCtrl">
         <mat-error>The input is invalid.</mat-error>
       </mat-form-field>
       <div>
@@ -49,11 +52,13 @@
     <form [formGroup]="nameFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
-        <input matInput placeholder="First Name" formControlName="firstNameCtrl" required>
+        <mat-label>First name</mat-label>
+        <input matInput formControlName="firstNameCtrl" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
       <mat-form-field>
-        <input matInput placeholder="Last Name" formControlName="lastNameCtrl" required>
+        <mat-label>Last name</mat-label>
+        <input matInput formControlName="lastNameCtrl" required>
         <mat-error>This field is required</mat-error>
       </mat-form-field>
       <div>
@@ -66,7 +71,8 @@
     <form [formGroup]="emailFormGroup">
       <ng-template matStepLabel>Fill out your email address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Email address" formControlName="emailCtrl">
+        <mat-label>Email address</mat-label>
+        <input matInput formControlName="emailCtrl">
         <mat-error>The input is invalid</mat-error>
       </mat-form-field>
       <div>
@@ -93,11 +99,13 @@
   <mat-step [editable]="!isNonEditable">
     <ng-template matStepLabel>Fill out your name</ng-template>
     <mat-form-field>
-      <input matInput placeholder="First Name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput placeholder="Last Name">
+      <mat-label>Last name</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperNext type="button">Next</button>
@@ -109,7 +117,8 @@
       <div>Fill out your phone number</div>
     </ng-template>
     <mat-form-field>
-      <input matInput placeholder="Phone number">
+      <mat-label>Phone number</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperPrevious type="button">Back</button>
@@ -122,7 +131,8 @@
       <div>Fill out your address</div>
     </ng-template>
     <mat-form-field>
-      <input matInput placeholder="Address">
+      <mat-label>Address</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperPrevious type="button">Back</button>
@@ -143,11 +153,13 @@
 <mat-horizontal-stepper>
   <mat-step label="Fill out your name">
     <mat-form-field>
-      <input matInput placeholder="First Name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput placeholder="Last Name">
+      <mat-label>Last name</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperNext type="button">Next</button>
@@ -156,7 +168,8 @@
 
   <mat-step label="Fill out your phone number">
     <mat-form-field>
-      <input matInput placeholder="Phone number">
+      <mat-label>Phone number</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperPrevious type="button">Back</button>
@@ -166,7 +179,8 @@
 
   <mat-step label="Fill out your address">
     <mat-form-field>
-      <input matInput placeholder="Address">
+      <mat-label>Address</mat-label>
+      <input matInput>
     </mat-form-field>
     <div>
       <button mat-button matStepperPrevious type="button">Back</button>
@@ -187,7 +201,8 @@
   <mat-step *ngFor="let step of steps">
     <ng-template matStepLabel>{{step.label}}</ng-template>
     <mat-form-field>
-      <input matInput placeholder="Answer" [(ngModel)]="step.content">
+      <mat-label>Answer</mat-label>
+      <input matInput [(ngModel)]="step.content">
     </mat-form-field>
     <div>
       <button mat-button matStepperPrevious>Back</button>
@@ -200,7 +215,8 @@
 <mat-horizontal-stepper>
   <mat-step label="Step 1">
     <mat-form-field>
-      <textarea matInput placeholder="Autosize textarea" matTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
+      <mat-label>Autosize textarea</mat-label>
+      <textarea matInput matTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
     </mat-form-field>
   </mat-step>
 </mat-horizontal-stepper>

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -214,7 +214,8 @@
 <h3>MatTable With MatTableDataSource Example</h3>
 
 <mat-form-field>
-  <input matInput #filter placeholder="Filter users">
+  <mat-label>Filter users</mat-label>
+  <input matInput #filter>
 </mat-form-field>
 
 <div class="demo-table-container demo-mat-table-example mat-elevation-z4 mat-table-selectable">

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -89,7 +89,8 @@
         <br>
         <br>
         <mat-form-field>
-          <input matInput placeholder="Tab Label" [(ngModel)]="tab.label">
+          <mat-label>Tab label</mat-label>
+          <input matInput [(ngModel)]="tab.label">
         </mat-form-field>
         <br><br>
         <button mat-raised-button
@@ -141,7 +142,8 @@
       <br>
       <br>
       <mat-form-field>
-        <input matInput placeholder="Tab Label" [(ngModel)]="tab.label">
+        <mat-label>Tab label</mat-label>
+        <input matInput [(ngModel)]="tab.label">
       </mat-form-field>
     </div>
   </mat-tab>
@@ -187,7 +189,8 @@
       <br>
       <br>
       <mat-form-field>
-        <input matInput placeholder="Tab Label" [(ngModel)]="tab.label">
+        <mat-label>Tab label</mat-label>
+        <input matInput [(ngModel)]="tab.label">
       </mat-form-field>
     </div>
   </mat-tab>
@@ -217,7 +220,8 @@
       <br>
       <br>
       <mat-form-field>
-        <input matInput placeholder="Tab Label" [(ngModel)]="tab.label">
+        <mat-label>Tab label</mat-label>
+        <input matInput [(ngModel)]="tab.label">
       </mat-form-field>
     </div>
   </mat-tab>
@@ -283,7 +287,8 @@
   <mat-tab label="Tab 1">
     <div class="tab-content">
       <mat-form-field>
-        <textarea matInput placeholder="Autosize textarea" matTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
+        <mat-label>Autosize textarea</mat-label>
+        <textarea matInput matTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
       </mat-form-field>
     </div>
   </mat-tab>

--- a/src/lib/form-field/BUILD.bazel
+++ b/src/lib/form-field/BUILD.bazel
@@ -9,6 +9,9 @@ ng_module(
   module_name = "@angular/material/form-field",
   assets = [
     ":form_field_css",
+    ":form_field_box_css",
+    ":form_field_legacy_css",
+    ":form_field_standard_css",
     "//src/lib/input:input_css"
   ],
   deps = [
@@ -19,14 +22,31 @@ ng_module(
   tsconfig = ":tsconfig-build.json",
 )
 
-
 sass_binary(
   name = "form_field_scss",
   src = "form-field.scss",
   deps = ["//src/lib/core:core_scss_lib"],
 )
 
-# TODO(jelbourn): remove this when sass_binary supports specifying an output filename and dir.
+sass_binary(
+  name = "form_field_box_scss",
+  src = "form-field-box.scss",
+  deps = ["//src/lib/core:core_scss_lib"],
+)
+
+sass_binary(
+  name = "form_field_legacy_scss",
+  src = "form-field-legacy.scss",
+  deps = ["//src/lib/core:core_scss_lib"],
+)
+
+sass_binary(
+  name = "form_field_standard_scss",
+  src = "form-field-standard.scss",
+  deps = ["//src/lib/core:core_scss_lib"],
+)
+
+# TODO(jelbourn): remove these when sass_binary supports specifying an output filename and dir.
 # Copy the output of the sass_binary such that the filename and path match what we expect.
 genrule(
   name = "form_field_css",
@@ -35,3 +55,23 @@ genrule(
   cmd = "cat $(locations :form_field_scss) > $@",
 )
 
+genrule(
+  name = "form_field_box_css",
+  srcs = [":form_field_box_scss"],
+  outs = ["form-field-box.css"],
+  cmd = "cat $(locations :form_field_box_scss) > $@",
+)
+
+genrule(
+  name = "form_field_legacy_css",
+  srcs = [":form_field_legacy_scss"],
+  outs = ["form-field-legacy.css"],
+  cmd = "cat $(locations :form_field_legacy_scss) > $@",
+)
+
+genrule(
+  name = "form_field_standard_css",
+  srcs = [":form_field_standard_scss"],
+  outs = ["form-field-standard.css"],
+  cmd = "cat $(locations :form_field_standard_scss) > $@",
+)

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -33,4 +33,64 @@
   }
 }
 
-@mixin mat-form-field-box-typography($config) {}
+// Used to make instances of the _mat-form-field-label-floating mixin negligibly different,
+// and prevent Google's CSS Optimizer from collapsing the declarations. This is needed because some
+// of the selectors contain pseudo-classes not recognized in all browsers. If a browser encounters
+// an unknown pseudo-class it will discard the entire rule set.
+$mat-form-field-box-dedupe: 0;
+
+// Applies a floating label above the form field control itself.
+@mixin _mat-form-field-box-label-floating($font-scale, $infix-padding, $infix-margin-top) {
+  transform: translateY(-$infix-margin-top - $infix-padding + $mat-form-field-box-dedupe)
+             scale($font-scale);
+  width: 100% / $font-scale + $mat-form-field-box-dedupe;
+
+  // Prevent text bluriness when label is floating.
+  backface-visibility: initial;
+
+  $mat-form-field-box-dedupe: $mat-form-field-box-dedupe + 0.00001 !global;
+}
+
+@mixin mat-form-field-box-typography($config) {
+  // The unit-less line-height from the font config.
+  $line-height: mat-line-height($config, input);
+  // The amount to scale the font for the floating label and subscript.
+  $subscript-font-scale: 0.75;
+  // The padding on the infix. Mocks show half of the text size.
+  $infix-padding: 0.5em;
+  // The margin applied to the form-field-infix to reserve space for the floating label.
+  $infix-margin-top: 1em * $line-height * $subscript-font-scale;
+  // The amount we offset the label in the box variant.
+  $box-variant-label-offset: -0.5em * $line-height;
+
+  .mat-form-field-variant-box {
+    .mat-form-field-label {
+      margin-top: $box-variant-label-offset;
+    }
+
+    &.mat-form-field-can-float {
+      &.mat-form-field-should-float .mat-form-field-label,
+      .mat-input-server:focus + .mat-form-field-label-wrapper .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $infix-margin-top);
+      }
+
+      .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
+      .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $infix-margin-top);
+      }
+
+      // Server-side rendered matInput with a label attribute but label not shown
+      // (used as a pure CSS stand-in for mat-form-field-should-float).
+      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+      .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $infix-margin-top);
+      }
+    }
+  }
+}

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -11,14 +11,21 @@
   $is-dark-theme: map-get($theme, is-dark);
 
   $box-background: mat-color($foreground, base, if($is-dark-theme, 0.1, 0.06));
+  $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
 
   .mat-form-field-variant-box {
     .mat-form-field-flex {
       background-color: $box-background;
     }
+
+    .mat-form-field-underline::before {
+      background-color: $underline-color;
+    }
+
+    &.mat-form-field-disabled .mat-form-field-underline::before {
+      background-color: transparent;
+    }
   }
 }
 
-@mixin mat-form-field-box-typography($config) {
-
-}
+@mixin mat-form-field-box-typography($config) {}

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -4,7 +4,7 @@
 @import '../core/typography/typography-utils';
 
 
-// Theme styles that only apply to the box variant of the form-field.
+// Theme styles that only apply to the box appearance of the form-field.
 
 @mixin mat-form-field-box-theme($theme) {
   $foreground: map-get($theme, foreground);
@@ -14,7 +14,7 @@
   $box-disabled-background: mat-color($foreground, base, if($is-dark-theme, 0.05, 0.03));
   $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
 
-  .mat-form-field-variant-box {
+  .mat-form-field-appearance-box {
     .mat-form-field-flex {
       background-color: $box-background;
     }
@@ -57,26 +57,26 @@ $mat-form-field-box-dedupe: 0;
   $infix-padding: 0.5em;
   // The margin applied to the form-field-infix to reserve space for the floating label.
   $infix-margin-top: 1em * $line-height * $subscript-font-scale;
-  // The amount we offset the label in the box variant.
-  $box-variant-label-offset: -0.5em * $line-height;
+  // The amount we offset the label in the box appearance.
+  $box-appearance-label-offset: -0.5em * $line-height;
 
-  .mat-form-field-variant-box {
+  .mat-form-field-appearance-box {
     .mat-form-field-label {
-      margin-top: $box-variant-label-offset;
+      margin-top: $box-appearance-label-offset;
     }
 
     &.mat-form-field-can-float {
       &.mat-form-field-should-float .mat-form-field-label,
       .mat-input-server:focus + .mat-form-field-label-wrapper .mat-form-field-label {
         @include _mat-form-field-label-floating(
-                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $subscript-font-scale, $infix-padding + $box-appearance-label-offset,
                 $infix-margin-top);
       }
 
       .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _mat-form-field-label-floating(
-                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $subscript-font-scale, $infix-padding + $box-appearance-label-offset,
                 $infix-margin-top);
       }
 
@@ -85,7 +85,7 @@ $mat-form-field-box-dedupe: 0;
       .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _mat-form-field-label-floating(
-                $subscript-font-scale, $infix-padding + $box-variant-label-offset,
+                $subscript-font-scale, $infix-padding + $box-appearance-label-offset,
                 $infix-margin-top);
       }
     }

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -45,9 +45,6 @@ $mat-form-field-box-dedupe: 0;
              scale($font-scale);
   width: 100% / $font-scale + $mat-form-field-box-dedupe;
 
-  // Prevent text bluriness when label is floating.
-  backface-visibility: initial;
-
   $mat-form-field-box-dedupe: $mat-form-field-box-dedupe + 0.00001 !global;
 }
 

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -11,11 +11,16 @@
   $is-dark-theme: map-get($theme, is-dark);
 
   $box-background: mat-color($foreground, base, if($is-dark-theme, 0.1, 0.06));
+  $box-disabled-background: mat-color($foreground, base, if($is-dark-theme, 0.05, 0.03));
   $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
 
   .mat-form-field-variant-box {
     .mat-form-field-flex {
       background-color: $box-background;
+    }
+
+    &.mat-form-field-disabled .mat-form-field-flex {
+      background-color: $box-disabled-background;
     }
 
     .mat-form-field-underline::before {

--- a/src/lib/form-field/_form-field-box-theme.scss
+++ b/src/lib/form-field/_form-field-box-theme.scss
@@ -1,0 +1,24 @@
+@import '../core/theming/palette';
+@import '../core/theming/theming';
+@import '../core/style/form-common';
+@import '../core/typography/typography-utils';
+
+
+// Theme styles that only apply to the box variant of the form-field.
+
+@mixin mat-form-field-box-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $is-dark-theme: map-get($theme, is-dark);
+
+  $box-background: mat-color($foreground, base, if($is-dark-theme, 0.1, 0.06));
+
+  .mat-form-field-variant-box {
+    .mat-form-field-flex {
+      background-color: $box-background;
+    }
+  }
+}
+
+@mixin mat-form-field-box-typography($config) {
+
+}

--- a/src/lib/form-field/_form-field-legacy-theme.scss
+++ b/src/lib/form-field/_form-field-legacy-theme.scss
@@ -1,0 +1,123 @@
+@import '../core/theming/palette';
+@import '../core/theming/theming';
+@import '../core/style/form-common';
+@import '../core/typography/typography-utils';
+
+
+// Theme styles that only apply to the legacy variant of the form-field.
+
+@mixin mat-form-field-legacy-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $is-dark-theme: map-get($theme, is-dark);
+
+  $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
+
+  .mat-form-field-variant-legacy {
+    .mat-form-field-underline {
+      background-color: $underline-color;
+    }
+
+    &.mat-form-field-disabled .mat-form-field-underline {
+      @include mat-control-disabled-underline($underline-color);
+    }
+  }
+}
+
+// Used to make instances of the _mat-form-field-label-floating mixin negligibly different,
+// and prevent Google's CSS Optimizer from collapsing the declarations. This is needed because some
+// of the selectors contain pseudo-classes not recognized in all browsers. If a browser encounters
+// an unknown pseudo-class it will discard the entire rule set.
+$mat-form-field-legacy-dedupe: 0;
+
+// Applies a floating label above the form field control itself.
+@mixin _mat-form-field-label-floating($font-scale, $infix-padding, $infix-margin-top) {
+  // We use perspective to fix the text blurriness as described here:
+  // http://www.useragentman.com/blog/2014/05/04/fixing-typography-inside-of-2-d-css-transforms/
+  // This results in a small jitter after the label floats on Firefox, which the
+  // translateZ fixes.
+  transform: translateY(-$infix-margin-top - $infix-padding) scale($font-scale) perspective(100px)
+  translateZ(0.001px + $mat-form-field-legacy-dedupe);
+  // The tricks above used to smooth out the animation on chrome and firefox actually make things
+  // worse on IE, so we don't include them in the IE version.
+  -ms-transform: translateY(-$infix-margin-top - $infix-padding + $mat-form-field-legacy-dedupe)
+                 scale($font-scale);
+
+  width: 100% / $font-scale + $mat-form-field-legacy-dedupe;
+
+  $mat-form-field-legacy-dedupe: $mat-form-field-legacy-dedupe + 0.00001 !global;
+}
+
+@mixin mat-form-field-legacy-typography($config) {
+  // The unit-less line-height from the font config.
+  $line-height: mat-line-height($config, input);
+  // The amount to scale the font for the floating label and subscript.
+  $subscript-font-scale: 0.75;
+  // The amount of space between the top of the line and the top of the actual text
+  // (as a fraction of the font-size).
+  $line-spacing: ($line-height - 1) / 2;
+  // The padding on the infix. Mocks show half of the text size, but seem to measure from the edge
+  // of the text itself, not the edge of the line; therefore we subtract off the line spacing.
+  $infix-padding: 0.5em - $line-spacing;
+  // The margin applied to the form-field-infix to reserve space for the floating label.
+  $infix-margin-top: 1em * $line-height * $subscript-font-scale;
+  // The space between the bottom of the .mat-form-field-flex area and the subscript wrapper.
+  // Mocks show half of the text size, but this margin is applied to an element with the subscript
+  // text font size, so we need to divide by the scale factor to make it half of the original text
+  // size. We again need to subtract off the line spacing since the mocks measure to the edge of the
+  // text, not the  edge of the line.
+  $subscript-margin-top: 0.5em / $subscript-font-scale - ($line-spacing * 2);
+  // The padding applied to the form-field-wrapper to reserve space for the subscript, since it's
+  // absolutely positioned. This is a combination of the subscript's margin and line-height, but we
+  // need to multiply by the subscript font scale factor since the wrapper has a larger font size.
+  $wrapper-padding-bottom: ($subscript-margin-top + $line-height) * $subscript-font-scale;
+
+  .mat-form-field-variant-legacy {
+    .mat-form-field-wrapper {
+      padding-bottom: $wrapper-padding-bottom;
+    }
+
+    .mat-form-field-infix {
+      padding: $infix-padding 0;
+    }
+
+    &.mat-form-field-can-float {
+      &.mat-form-field-should-float .mat-form-field-label,
+      .mat-input-server:focus + .mat-form-field-label-wrapper .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding, $infix-margin-top);
+      }
+
+      .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
+      .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding, $infix-margin-top);
+      }
+
+      // Server-side rendered matInput with a label attribute but label not shown
+      // (used as a pure CSS stand-in for mat-form-field-should-float).
+      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+      .mat-form-field-label {
+        @include _mat-form-field-label-floating(
+                $subscript-font-scale, $infix-padding, $infix-margin-top);
+      }
+    }
+
+    .mat-form-field-label {
+      top: $infix-margin-top + $infix-padding;
+    }
+
+    .mat-form-field-underline {
+      // We want the underline to start at the end of the content box, not the padding box,
+      // so we move it up by the padding amount.
+      bottom: $wrapper-padding-bottom;
+    }
+
+    .mat-form-field-subscript-wrapper {
+      margin-top: $subscript-margin-top;
+
+      // We want the subscript to start at the end of the content box, not the padding box,
+      // so we move it up by the padding amount (adjusted for the smaller font size);
+      top: calc(100% - #{$wrapper-padding-bottom / $subscript-font-scale});
+    }
+  }
+}

--- a/src/lib/form-field/_form-field-legacy-theme.scss
+++ b/src/lib/form-field/_form-field-legacy-theme.scss
@@ -30,7 +30,7 @@
 $mat-form-field-legacy-dedupe: 0;
 
 // Applies a floating label above the form field control itself.
-@mixin _mat-form-field-label-floating($font-scale, $infix-padding, $infix-margin-top) {
+@mixin _mat-form-field-legacy-label-floating($font-scale, $infix-padding, $infix-margin-top) {
   // We use perspective to fix the text blurriness as described here:
   // http://www.useragentman.com/blog/2014/05/04/fixing-typography-inside-of-2-d-css-transforms/
   // This results in a small jitter after the label floats on Firefox, which the
@@ -83,13 +83,13 @@ $mat-form-field-legacy-dedupe: 0;
     &.mat-form-field-can-float {
       &.mat-form-field-should-float .mat-form-field-label,
       .mat-input-server:focus + .mat-form-field-label-wrapper .mat-form-field-label {
-        @include _mat-form-field-label-floating(
+        @include _mat-form-field-legacy-label-floating(
                 $subscript-font-scale, $infix-padding, $infix-margin-top);
       }
 
       .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
       .mat-form-field-label {
-        @include _mat-form-field-label-floating(
+        @include _mat-form-field-legacy-label-floating(
                 $subscript-font-scale, $infix-padding, $infix-margin-top);
       }
 
@@ -97,7 +97,7 @@ $mat-form-field-legacy-dedupe: 0;
       // (used as a pure CSS stand-in for mat-form-field-should-float).
       .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
       .mat-form-field-label {
-        @include _mat-form-field-label-floating(
+        @include _mat-form-field-legacy-label-floating(
                 $subscript-font-scale, $infix-padding, $infix-margin-top);
       }
     }

--- a/src/lib/form-field/_form-field-legacy-theme.scss
+++ b/src/lib/form-field/_form-field-legacy-theme.scss
@@ -4,7 +4,7 @@
 @import '../core/typography/typography-utils';
 
 
-// Theme styles that only apply to the legacy variant of the form-field.
+// Theme styles that only apply to the legacy appearance of the form-field.
 
 @mixin mat-form-field-legacy-theme($theme) {
   $foreground: map-get($theme, foreground);
@@ -12,7 +12,7 @@
 
   $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
 
-  .mat-form-field-variant-legacy {
+  .mat-form-field-appearance-legacy {
     .mat-form-field-underline {
       background-color: $underline-color;
     }
@@ -71,7 +71,7 @@ $mat-form-field-legacy-dedupe: 0;
   // need to multiply by the subscript font scale factor since the wrapper has a larger font size.
   $wrapper-padding-bottom: ($subscript-margin-top + $line-height) * $subscript-font-scale;
 
-  .mat-form-field-variant-legacy {
+  .mat-form-field-appearance-legacy {
     .mat-form-field-wrapper {
       padding-bottom: $wrapper-padding-bottom;
     }

--- a/src/lib/form-field/_form-field-standard-theme.scss
+++ b/src/lib/form-field/_form-field-standard-theme.scss
@@ -17,7 +17,7 @@
       background-color: $underline-color;
     }
 
-    .mat-form-field-disabled .mat-form-field-underline {
+    &.mat-form-field-disabled .mat-form-field-underline {
       @include mat-control-disabled-underline($underline-color);
     }
   }

--- a/src/lib/form-field/_form-field-standard-theme.scss
+++ b/src/lib/form-field/_form-field-standard-theme.scss
@@ -4,7 +4,7 @@
 @import '../core/typography/typography-utils';
 
 
-// Theme styles that only apply to the standard variant of the form-field.
+// Theme styles that only apply to the standard appearance of the form-field.
 
 @mixin mat-form-field-standard-theme($theme) {
   $foreground: map-get($theme, foreground);
@@ -12,7 +12,7 @@
 
   $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
 
-  .mat-form-field-variant-standard {
+  .mat-form-field-appearance-standard {
     .mat-form-field-underline {
       background-color: $underline-color;
     }

--- a/src/lib/form-field/_form-field-standard-theme.scss
+++ b/src/lib/form-field/_form-field-standard-theme.scss
@@ -1,0 +1,15 @@
+@import '../core/theming/palette';
+@import '../core/theming/theming';
+@import '../core/style/form-common';
+@import '../core/typography/typography-utils';
+
+
+// Theme styles that only apply to the standard variant of the form-field.
+
+@mixin mat-form-field-standard-theme($theme) {
+
+}
+
+@mixin mat-form-field-standard-typography($config) {
+
+}

--- a/src/lib/form-field/_form-field-standard-theme.scss
+++ b/src/lib/form-field/_form-field-standard-theme.scss
@@ -6,7 +6,6 @@
 
 // Theme styles that only apply to the standard variant of the form-field.
 
-
 @mixin mat-form-field-standard-theme($theme) {
   $foreground: map-get($theme, foreground);
   $is-dark-theme: map-get($theme, is-dark);

--- a/src/lib/form-field/_form-field-standard-theme.scss
+++ b/src/lib/form-field/_form-field-standard-theme.scss
@@ -6,10 +6,22 @@
 
 // Theme styles that only apply to the standard variant of the form-field.
 
+
 @mixin mat-form-field-standard-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $is-dark-theme: map-get($theme, is-dark);
 
+  $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
+
+  .mat-form-field-variant-standard {
+    .mat-form-field-underline {
+      background-color: $underline-color;
+    }
+
+    .mat-form-field-disabled .mat-form-field-underline {
+      @include mat-control-disabled-underline($underline-color);
+    }
+  }
 }
 
-@mixin mat-form-field-standard-typography($config) {
-
-}
+@mixin mat-form-field-standard-typography($config) {}

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -20,7 +20,6 @@
   $required-label-color: mat-color($accent);
 
   // Underline colors.
-  $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
   $underline-color-base: mat-color($foreground, divider, if($is-dark-theme, 1, 0.87));
   $underline-color-accent: mat-color($accent);
   $underline-color-warn: mat-color($warn);
@@ -48,14 +47,6 @@
 
   .mat-focused .mat-form-field-required-marker {
     color: $required-label-color;
-  }
-
-  .mat-form-field-underline {
-    background-color: $underline-color;
-  }
-
-  .mat-form-field-disabled .mat-form-field-underline {
-    @include mat-control-disabled-underline($underline-color);
   }
 
   .mat-form-field-ripple {

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -2,6 +2,8 @@
 @import '../core/theming/theming';
 @import '../core/style/form-common';
 @import '../core/typography/typography-utils';
+@import 'form-field-box-theme.scss';
+@import 'form-field-standard-theme.scss';
 
 
 @mixin mat-form-field-theme($theme) {
@@ -95,6 +97,9 @@
   .mat-error {
     color: $underline-color-warn;
   }
+
+  @include mat-form-field-standard-theme($theme);
+  @include mat-form-field-box-theme($theme);
 }
 
 // Used to make instances of the _mat-form-field-label-floating mixin negligibly different,

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -7,7 +7,7 @@
 @import 'form-field-standard-theme.scss';
 
 
-// Theme styles that apply to all variants of the form-field.
+// Theme styles that apply to all appearances of the form-field.
 
 @mixin mat-form-field-theme($theme) {
   $primary: map-get($theme, primary);

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -109,9 +109,6 @@ $mat-form-field-dedupe: 0;
              scale($font-scale);
   width: 100% / $font-scale + $mat-form-field-dedupe;
 
-  // Prevent text bluriness when label is floating.
-  backface-visibility: initial;
-
   $mat-form-field-dedupe: $mat-form-field-dedupe + 0.00001 !global;
 }
 

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -19,6 +19,7 @@
 
   // Underline colors.
   $underline-color: mat-color($foreground, divider, if($is-dark-theme, 0.7, 0.42));
+  $underline-color-base: mat-color($foreground, divider, if($is-dark-theme, 1, 0.87));
   $underline-color-accent: mat-color($accent);
   $underline-color-warn: mat-color($warn);
   $underline-focused-color: mat-color($primary);
@@ -56,21 +57,27 @@
   }
 
   .mat-form-field-ripple {
-    background-color: $underline-focused-color;
+    background-color: $underline-color-base;
+  }
 
-    &.mat-accent {
-      background-color: $underline-color-accent;
-    }
+  .mat-form-field.mat-focused {
+    .mat-form-field-ripple {
+      background-color: $underline-focused-color;
 
-    &.mat-warn {
-      background-color: $underline-color-warn;
+      &.mat-accent {
+        background-color: $underline-color-accent;
+      }
+
+      &.mat-warn {
+        background-color: $underline-color-warn;
+      }
     }
   }
 
   // Styling for the error state of the form field. Note that while the same can be
   // achieved with the ng-* classes, we use this approach in order to ensure that the same
   // logic is used to style the error state and to show the error messages.
-  .mat-form-field-invalid {
+  .mat-form-field.mat-form-field-invalid {
     .mat-form-field-label {
       color: $underline-color-warn;
 

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -124,9 +124,6 @@ $mat-form-field-dedupe: 0;
   // The amount to scale the font for the prefix and suffix icons.
   $prefix-suffix-icon-font-scale: 1.5;
 
-  // The amount of space between the top of the line and the top of the actual text
-  // (as a fraction of the font-size).
-  $line-spacing: ($line-height - 1) / 2;
   // The padding on the infix. Mocks show half of the text size.
   $infix-padding: 0.5em;
   // The margin applied to the form-field-infix to reserve space for the floating label.

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -3,6 +3,7 @@
 @import '../core/style/form-common';
 @import '../core/typography/typography-utils';
 @import 'form-field-box-theme.scss';
+@import 'form-field-legacy-theme.scss';
 @import 'form-field-standard-theme.scss';
 
 
@@ -91,6 +92,7 @@
     color: $underline-color-warn;
   }
 
+  @include mat-form-field-legacy-theme($theme);
   @include mat-form-field-standard-theme($theme);
   @include mat-form-field-box-theme($theme);
 }
@@ -99,7 +101,7 @@
 // and prevent Google's CSS Optimizer from collapsing the declarations. This is needed because some
 // of the selectors contain pseudo-classes not recognized in all browsers. If a browser encounters
 // an unknown pseudo-class it will discard the entire rule set.
-$dedupe: 0;
+$mat-form-field-dedupe: 0;
 
 // Applies a floating label above the form field control itself.
 @mixin _mat-form-field-label-floating($font-scale, $infix-padding, $infix-margin-top) {
@@ -108,14 +110,15 @@ $dedupe: 0;
   // This results in a small jitter after the label floats on Firefox, which the
   // translateZ fixes.
   transform: translateY(-$infix-margin-top - $infix-padding) scale($font-scale) perspective(100px)
-             translateZ(0.001px + $dedupe);
+             translateZ(0.001px + $mat-form-field-dedupe);
   // The tricks above used to smooth out the animation on chrome and firefox actually make things
   // worse on IE, so we don't include them in the IE version.
-  -ms-transform: translateY(-$infix-margin-top - $infix-padding + $dedupe) scale($font-scale);
+  -ms-transform: translateY(-$infix-margin-top - $infix-padding + $mat-form-field-dedupe)
+                 scale($font-scale);
 
-  width: 100% / $font-scale + $dedupe;
+  width: 100% / $font-scale + $mat-form-field-dedupe;
 
-  $dedupe: $dedupe + 0.00001 !global;
+  $mat-form-field-dedupe: $mat-form-field-dedupe + 0.00001 !global;
 }
 
 @mixin mat-form-field-typography($config) {
@@ -130,8 +133,7 @@ $dedupe: 0;
   // The amount of space between the top of the line and the top of the actual text
   // (as a fraction of the font-size).
   $line-spacing: ($line-height - 1) / 2;
-  // The padding on the infix. Mocks show half of the text size, but seem to measure from the edge
-  // of the text itself, not the edge of the line; therefore we subtract off the line spacing.
+  // The padding on the infix. Mocks show half of the text size.
   $infix-padding: 0.5em;
   // The margin applied to the form-field-infix to reserve space for the floating label.
   $infix-margin-top: 1em * $line-height * $subscript-font-scale;
@@ -142,8 +144,7 @@ $dedupe: 0;
   // The space between the bottom of the .mat-form-field-flex area and the subscript wrapper.
   // Mocks show half of the text size, but this margin is applied to an element with the subscript
   // text font size, so we need to divide by the scale factor to make it half of the original text
-  // size. We again need to subtract off the line spacing since the mocks measure to the edge of the
-  // text, not the  edge of the line.
+  // size.
   $subscript-margin-top: 0.5em / $subscript-font-scale;
   // The padding applied to the form-field-wrapper to reserve space for the subscript, since it's
   // absolutely positioned. This is a combination of the subscript's margin and line-height, but we
@@ -233,6 +234,7 @@ $dedupe: 0;
     top: calc(100% - #{$wrapper-padding-bottom / $subscript-font-scale});
   }
 
+  @include mat-form-field-legacy-typography($config);
   @include mat-form-field-standard-typography($config);
   @include mat-form-field-box-typography($config);
 }

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -105,18 +105,12 @@ $mat-form-field-dedupe: 0;
 
 // Applies a floating label above the form field control itself.
 @mixin _mat-form-field-label-floating($font-scale, $infix-padding, $infix-margin-top) {
-  // We use perspective to fix the text blurriness as described here:
-  // http://www.useragentman.com/blog/2014/05/04/fixing-typography-inside-of-2-d-css-transforms/
-  // This results in a small jitter after the label floats on Firefox, which the
-  // translateZ fixes.
-  transform: translateY(-$infix-margin-top - $infix-padding) scale($font-scale) perspective(100px)
-             translateZ(0.001px + $mat-form-field-dedupe);
-  // The tricks above used to smooth out the animation on chrome and firefox actually make things
-  // worse on IE, so we don't include them in the IE version.
-  -ms-transform: translateY(-$infix-margin-top - $infix-padding + $mat-form-field-dedupe)
-                 scale($font-scale);
-
+  transform: translateY(-$infix-margin-top - $infix-padding + $mat-form-field-dedupe)
+             scale($font-scale);
   width: 100% / $font-scale + $mat-form-field-dedupe;
+
+  // Prevent text bluriness when label is floating.
+  backface-visibility: initial;
 
   $mat-form-field-dedupe: $mat-form-field-dedupe + 0.00001 !global;
 }

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -6,6 +6,8 @@
 @import 'form-field-standard-theme.scss';
 
 
+// Theme styles that apply to all variants of the form-field.
+
 @mixin mat-form-field-theme($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
@@ -130,7 +132,7 @@ $dedupe: 0;
   $line-spacing: ($line-height - 1) / 2;
   // The padding on the infix. Mocks show half of the text size, but seem to measure from the edge
   // of the text itself, not the edge of the line; therefore we subtract off the line spacing.
-  $infix-padding: 0.5em - $line-spacing;
+  $infix-padding: 0.5em;
   // The margin applied to the form-field-infix to reserve space for the floating label.
   $infix-margin-top: 1em * $line-height * $subscript-font-scale;
   // Font size to use for the label and subscript text.
@@ -142,7 +144,7 @@ $dedupe: 0;
   // text font size, so we need to divide by the scale factor to make it half of the original text
   // size. We again need to subtract off the line spacing since the mocks measure to the edge of the
   // text, not the  edge of the line.
-  $subscript-margin-top: 0.5em / $subscript-font-scale - ($line-spacing * 2);
+  $subscript-margin-top: 0.5em / $subscript-font-scale;
   // The padding applied to the form-field-wrapper to reserve space for the subscript, since it's
   // absolutely positioned. This is a combination of the subscript's margin and line-height, but we
   // need to multiply by the subscript font scale factor since the wrapper has a larger font size.
@@ -230,4 +232,7 @@ $dedupe: 0;
     // so we move it up by the padding amount (adjusted for the smaller font size);
     top: calc(100% - #{$wrapper-padding-bottom / $subscript-font-scale});
   }
+
+  @include mat-form-field-standard-typography($config);
+  @include mat-form-field-box-typography($config);
 }

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -53,6 +53,16 @@ $mat-form-field-box-subscript-padding:
     height: $mat-form-field-box-underline-height;
   }
 
+  // Note that we need this specific of a selector because we don't want
+  // the hover effect to show when the user hovers over the hints.
+  &:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
+    .mat-form-field-ripple {
+      opacity: 1;
+      transform: none;
+      transition: opacity 600ms $swift-ease-out-timing-function;
+    }
+  }
+
   .mat-form-field-subscript-wrapper {
     padding: 0 $mat-form-field-box-subscript-padding;
   }

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -27,10 +27,6 @@ $mat-form-field-box-subscript-padding:
              $mat-form-field-box-side-padding;
   }
 
-  .mat-form-field-label {
-    transform: translateY(-50%);
-  }
-
   .mat-form-field-underline {
     height: $mat-form-field-box-border-radius;
     border-radius: 0 0 $mat-form-field-box-border-radius $mat-form-field-box-border-radius;

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -4,13 +4,33 @@
 
 // Styles that only apply to the standard variant of the form-field.
 
-$mat-form-field-box-border-radius: 4px;
-$mat-form-field-box-underline-height: 2px;
+// The border radius for the form field box.
+$mat-form-field-box-border-radius: 4px !default;
+// The height of the underline at the bottom of the form field box.
+$mat-form-field-box-underline-height: 2px !default;
+// The horizontal padding between the edge of the form field box and the start of the text.
+$mat-form-field-box-side-padding: 1em !default;
+// The vertical padding between the edge of the form field box and the start of the text as well as
+// between the floating label and the value.
+$mat-form-field-box-line-spacing: 0.5em !default;
+// The scale of the subscript and floating label text w.r.t the value text.
+$mat-form-field-box-subscript-font-scale: .75 !default;
+// The horizontal padding between the edge of the subscript box and the start of the subscript text.
+$mat-form-field-box-subscript-padding:
+    $mat-form-field-box-side-padding / $mat-form-field-box-subscript-font-scale;
 
 
 .mat-form-field-variant-box {
   .mat-form-field-flex {
     border-radius: $mat-form-field-box-border-radius;
+    padding: $mat-form-field-box-line-spacing $mat-form-field-box-side-padding 0
+             $mat-form-field-box-side-padding;
+  }
+
+  .mat-form-field-label {
+    // The perspective helps smooth out animations on Chrome and Firefox but isn't needed on IE.
+    transform: translateY(-50%) perspective(100px);
+    -ms-transform: translateY(-50%);
   }
 
   .mat-form-field-underline {
@@ -31,5 +51,9 @@ $mat-form-field-box-underline-height: 2px;
   .mat-form-field-ripple {
     bottom: 0;
     height: $mat-form-field-box-underline-height;
+  }
+
+  .mat-form-field-subscript-wrapper {
+    padding: 0 $mat-form-field-box-subscript-padding;
   }
 }

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -1,0 +1,14 @@
+@import '../core/style/variables';
+@import '../core/style/vendor-prefixes';
+
+
+// Styles that only apply to the standard variant of the form-field.
+
+$mat-form-field-box-border-radius: 4px;
+
+
+.mat-form-field-variant-box {
+  .mat-form-field-flex {
+    border-radius: $mat-form-field-box-border-radius;
+  }
+}

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -2,7 +2,7 @@
 @import '../core/style/vendor-prefixes';
 
 
-// Styles that only apply to the standard variant of the form-field.
+// Styles that only apply to the box variant of the form-field.
 
 // The border radius for the form field box.
 $mat-form-field-box-border-radius: 4px !default;
@@ -28,9 +28,7 @@ $mat-form-field-box-subscript-padding:
   }
 
   .mat-form-field-label {
-    // The perspective helps smooth out animations on Chrome and Firefox but isn't needed on IE.
-    transform: translateY(-50%) perspective(100px);
-    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
   }
 
   .mat-form-field-underline {

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -5,10 +5,31 @@
 // Styles that only apply to the standard variant of the form-field.
 
 $mat-form-field-box-border-radius: 4px;
+$mat-form-field-box-underline-height: 2px;
 
 
 .mat-form-field-variant-box {
   .mat-form-field-flex {
     border-radius: $mat-form-field-box-border-radius;
+  }
+
+  .mat-form-field-underline {
+    height: $mat-form-field-box-border-radius;
+    border-radius: 0 0 $mat-form-field-box-border-radius $mat-form-field-box-border-radius;
+    overflow: hidden;
+  }
+
+  .mat-form-field-underline::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: 0;
+    height: $mat-form-field-box-underline-height;
+    width: 100%;
+  }
+
+  .mat-form-field-ripple {
+    bottom: 0;
+    height: $mat-form-field-box-underline-height;
   }
 }

--- a/src/lib/form-field/form-field-box.scss
+++ b/src/lib/form-field/form-field-box.scss
@@ -2,7 +2,7 @@
 @import '../core/style/vendor-prefixes';
 
 
-// Styles that only apply to the box variant of the form-field.
+// Styles that only apply to the box appearance of the form-field.
 
 // The border radius for the form field box.
 $mat-form-field-box-border-radius: 4px !default;
@@ -14,13 +14,13 @@ $mat-form-field-box-side-padding: 1em !default;
 // between the floating label and the value.
 $mat-form-field-box-line-spacing: 0.5em !default;
 // The scale of the subscript and floating label text w.r.t the value text.
-$mat-form-field-box-subscript-font-scale: .75 !default;
+$mat-form-field-box-subscript-font-scale: 0.75 !default;
 // The horizontal padding between the edge of the subscript box and the start of the subscript text.
 $mat-form-field-box-subscript-padding:
     $mat-form-field-box-side-padding / $mat-form-field-box-subscript-font-scale;
 
 
-.mat-form-field-variant-box {
+.mat-form-field-appearance-box {
   .mat-form-field-flex {
     border-radius: $mat-form-field-box-border-radius;
     padding: $mat-form-field-box-line-spacing $mat-form-field-box-side-padding 0

--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -9,13 +9,7 @@ $mat-form-field-legacy-underline-height: 1px !default;
 
 
 .mat-form-field-variant-legacy {
-  .mat-form-field-label-wrapper {
-    filter: initial;
-  }
-
   .mat-form-field-label {
-    backface-visibility: initial;
-
     transform: perspective(100px);
     -ms-transform: none;
   }

--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -1,0 +1,31 @@
+@import '../core/style/variables';
+@import '../core/style/vendor-prefixes';
+
+
+// Styles that only apply to the legacy variant of the form-field.
+
+// The height of the underline.
+$mat-form-field-legacy-underline-height: 1px !default;
+
+
+.mat-form-field-variant-legacy {
+  // The underline is what's shown under the control, its prefix and its suffix.
+  // The ripple is the blue animation coming on top of it.
+  .mat-form-field-underline {
+    height: $mat-form-field-legacy-underline-height;
+  }
+
+  .mat-form-field-ripple {
+    top: 0;
+    height: $mat-form-field-legacy-underline-height * 2;
+  }
+
+  &.mat-form-field-disabled .mat-form-field-underline {
+    background-position: 0;
+    background-color: transparent;
+  }
+
+  &.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
+    height: $mat-form-field-legacy-underline-height;
+  }
+}

--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -2,13 +2,13 @@
 @import '../core/style/vendor-prefixes';
 
 
-// Styles that only apply to the legacy variant of the form-field.
+// Styles that only apply to the legacy appearance of the form-field.
 
 // The height of the underline.
 $mat-form-field-legacy-underline-height: 1px !default;
 
 
-.mat-form-field-variant-legacy {
+.mat-form-field-appearance-legacy {
   .mat-form-field-label {
     transform: perspective(100px);
     -ms-transform: none;

--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -9,6 +9,17 @@ $mat-form-field-legacy-underline-height: 1px !default;
 
 
 .mat-form-field-variant-legacy {
+  .mat-form-field-label-wrapper {
+    filter: initial;
+  }
+
+  .mat-form-field-label {
+    backface-visibility: initial;
+
+    transform: perspective(100px);
+    -ms-transform: none;
+  }
+
   // The underline is what's shown under the control, its prefix and its suffix.
   // The ripple is the blue animation coming on top of it.
   .mat-form-field-underline {

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -37,7 +37,7 @@ $mat-form-field-standard-padding-top: .5em !default;
 
   // Note that we need this specific of a selector because we don't want
   // the hover effect to show when the user hovers over the hints.
-  .mat-form-field:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
+  &:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
     .mat-form-field-ripple {
       opacity: 1;
       transform: none;

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -1,0 +1,10 @@
+@import '../core/style/variables';
+@import '../core/style/vendor-prefixes';
+
+
+// Styles that only apply to the standard variant of the form-field.
+
+
+.mat-form-field-variant-standard {
+
+}

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -5,27 +5,33 @@
 // Styles that only apply to the standard variant of the form-field.
 
 // The height of the underline.
-$mat-form-field-underline-height: 1px !default;
+$mat-form-field-standard-underline-height: 1px !default;
+// The bottom margin of the underline (used to push it up to align with box variant underline).
+$mat-form-field-standard-underline-margin-bottom: 1px !default;
+// The padding between the top of the form field and the label text (used to align the standard
+// form field with the box variant).
+$mat-form-field-standard-padding-top: .5em !default;
 
 
 .mat-form-field-variant-standard {
+  .mat-form-field-flex {
+    padding-top: $mat-form-field-standard-padding-top;
+  }
+
   // The underline is what's shown under the control, its prefix and its suffix.
   // The ripple is the blue animation coming on top of it.
   .mat-form-field-underline {
-    height: $mat-form-field-underline-height;
+    height: $mat-form-field-standard-underline-height;
+    margin-bottom: $mat-form-field-standard-underline-margin-bottom;
   }
 
   .mat-form-field-ripple {
     top: 0;
-    height: $mat-form-field-underline-height * 2;
+    height: $mat-form-field-standard-underline-height * 2;
   }
 
   &.mat-form-field-disabled .mat-form-field-underline {
     background-position: 0;
     background-color: transparent;
-  }
-
-  &.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
-    height: $mat-form-field-underline-height;
   }
 }

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -2,18 +2,18 @@
 @import '../core/style/vendor-prefixes';
 
 
-// Styles that only apply to the standard variant of the form-field.
+// Styles that only apply to the standard appearance of the form-field.
 
 // The height of the underline.
 $mat-form-field-standard-underline-height: 1px !default;
-// The bottom margin of the underline (used to push it up to align with box variant underline).
+// The bottom margin of the underline (used to push it up to align with box appearance underline).
 $mat-form-field-standard-underline-margin-bottom: 1px !default;
 // The padding between the top of the form field and the label text (used to align the standard
-// form field with the box variant).
-$mat-form-field-standard-padding-top: .5em !default;
+// form field with the box appearance).
+$mat-form-field-standard-padding-top: 0.5em !default;
 
 
-.mat-form-field-variant-standard {
+.mat-form-field-appearance-standard {
   .mat-form-field-flex {
     padding-top: $mat-form-field-standard-padding-top;
   }

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -4,7 +4,58 @@
 
 // Styles that only apply to the standard variant of the form-field.
 
+// The height of the underline.
+$mat-form-field-underline-height: 1px !default;
+
 
 .mat-form-field-variant-standard {
+  // The underline is what's shown under the control, its prefix and its suffix.
+  // The ripple is the blue animation coming on top of it.
+  .mat-form-field-underline {
+    position: absolute;
+    height: $mat-form-field-underline-height;
+    width: 100%;
 
+    .mat-form-field-ripple {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: $mat-form-field-underline-height * 2;
+      transform-origin: 50%;
+      transform: scaleX(0.5);
+      opacity: 0;
+      transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
+    }
+  }
+
+  &.mat-form-field-disabled .mat-form-field-underline {
+    background-position: 0;
+    background-color: transparent;
+  }
+
+  &.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
+    height: $mat-form-field-underline-height;
+  }
+
+  &.mat-focused,
+  &.mat-form-field-invalid {
+    .mat-form-field-ripple {
+      opacity: 1;
+      transform: scaleX(1);
+      transition: transform 300ms $swift-ease-out-timing-function,
+                  opacity 100ms $swift-ease-out-timing-function,
+                  background-color 300ms $swift-ease-out-timing-function;
+    }
+  }
+
+  // Note that we need this specific of a selector because we don't want
+  // the hover effect to show when the user hovers over the hints.
+  &:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
+    .mat-form-field-ripple {
+      opacity: 1;
+      transform: none;
+      transition: opacity 600ms $swift-ease-out-timing-function;
+    }
+  }
 }

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -34,4 +34,14 @@ $mat-form-field-standard-padding-top: .5em !default;
     background-position: 0;
     background-color: transparent;
   }
+
+  // Note that we need this specific of a selector because we don't want
+  // the hover effect to show when the user hovers over the hints.
+  .mat-form-field:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
+    .mat-form-field-ripple {
+      opacity: 1;
+      transform: none;
+      transition: opacity 600ms $swift-ease-out-timing-function;
+    }
+  }
 }

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -12,21 +12,12 @@ $mat-form-field-underline-height: 1px !default;
   // The underline is what's shown under the control, its prefix and its suffix.
   // The ripple is the blue animation coming on top of it.
   .mat-form-field-underline {
-    position: absolute;
     height: $mat-form-field-underline-height;
-    width: 100%;
+  }
 
-    .mat-form-field-ripple {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: $mat-form-field-underline-height * 2;
-      transform-origin: 50%;
-      transform: scaleX(0.5);
-      opacity: 0;
-      transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
-    }
+  .mat-form-field-ripple {
+    top: 0;
+    height: $mat-form-field-underline-height * 2;
   }
 
   &.mat-form-field-disabled .mat-form-field-underline {
@@ -36,26 +27,5 @@ $mat-form-field-underline-height: 1px !default;
 
   &.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {
     height: $mat-form-field-underline-height;
-  }
-
-  &.mat-focused,
-  &.mat-form-field-invalid {
-    .mat-form-field-ripple {
-      opacity: 1;
-      transform: scaleX(1);
-      transition: transform 300ms $swift-ease-out-timing-function,
-                  opacity 100ms $swift-ease-out-timing-function,
-                  background-color 300ms $swift-ease-out-timing-function;
-    }
-  }
-
-  // Note that we need this specific of a selector because we don't want
-  // the hover effect to show when the user hovers over the hints.
-  &:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
-    .mat-form-field-ripple {
-      opacity: 1;
-      transform: none;
-      transition: opacity 600ms $swift-ease-out-timing-function;
-    }
   }
 }

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -175,8 +175,8 @@ $mat-form-field-default-infix-width: 180px !default;
     opacity: 1;
     transform: scaleX(1);
     transition: transform 300ms $swift-ease-out-timing-function,
-    opacity 100ms $swift-ease-out-timing-function,
-    background-color 300ms $swift-ease-out-timing-function;
+                opacity 100ms $swift-ease-out-timing-function,
+                background-color 300ms $swift-ease-out-timing-function;
   }
 }
 

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -2,7 +2,7 @@
 @import '../core/style/vendor-prefixes';
 
 
-// Styles that apply to all variants of the form-field.
+// Styles that apply to all appearances of the form-field.
 
 // Min amount of space between start and end hint.
 $mat-form-field-hint-min-space: 1em !default;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -184,16 +184,6 @@ $mat-form-field-default-infix-width: 180px !default;
   }
 }
 
-// Note that we need this specific of a selector because we don't want
-// the hover effect to show when the user hovers over the hints.
-.mat-form-field:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
-  .mat-form-field-ripple {
-    opacity: 1;
-    transform: none;
-    transition: opacity 600ms $swift-ease-out-timing-function;
-  }
-}
-
 // Wrapper for the hints and error messages.
 .mat-form-field-subscript-wrapper {
   position: absolute;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -4,8 +4,6 @@
 
 // Min amount of space between start and end hint.
 $mat-form-field-hint-min-space: 1em !default;
-// The height of the underline.
-$mat-form-field-underline-height: 1px !default;
 // Infix stretches to fit the container, but naturally wants to be this wide. We set this in order
 // to have a a consistent natural size for the various types of controls that can go in a form
 // field.
@@ -153,57 +151,6 @@ $mat-form-field-default-infix-width: 180px !default;
 // animating up when the value is set programmatically).
 .mat-form-field-label:not(.mat-form-field-empty) {
   transition: none;
-}
-
-// The underline is what's shown under the control, its prefix and its suffix.
-// The ripple is the blue animation coming on top of it.
-.mat-form-field-underline {
-  position: absolute;
-  height: $mat-form-field-underline-height;
-  width: 100%;
-
-  .mat-form-field-disabled & {
-    background-position: 0;
-    background-color: transparent;
-  }
-
-  .mat-form-field-ripple {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: $mat-form-field-underline-height * 2;
-    transform-origin: 50%;
-    transform: scaleX(0.5);
-    visibility: hidden;
-    opacity: 0;
-    transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
-
-    .mat-form-field-invalid:not(.mat-focused) & {
-      height: $mat-form-field-underline-height;
-    }
-
-    .mat-focused &,
-    .mat-form-field-invalid & {
-      visibility: visible;
-      opacity: 1;
-      transform: scaleX(1);
-      transition: transform 300ms $swift-ease-out-timing-function,
-        opacity 100ms $swift-ease-out-timing-function,
-        background-color 300ms $swift-ease-out-timing-function;
-    }
-  }
-}
-
-// Note that we need this specific of a selector because we don't want
-// the hover effect to show when the user hovers over the hints.
-.mat-form-field:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
-  .mat-form-field-ripple {
-    visibility: visible;
-    opacity: 1;
-    transform: none;
-    transition: opacity 600ms $swift-ease-out-timing-function;
-  }
 }
 
 // Wrapper for the hints and error messages.

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -2,6 +2,8 @@
 @import '../core/style/vendor-prefixes';
 
 
+// Styles that apply to all variants of the form-field.
+
 // Min amount of space between start and end hint.
 $mat-form-field-hint-min-space: 1em !default;
 // Infix stretches to fit the container, but naturally wants to be this wide. We set this in order
@@ -33,6 +35,7 @@ $mat-form-field-default-infix-width: 180px !default;
 .mat-form-field-flex {
   display: inline-flex;
   align-items: baseline;
+  box-sizing: border-box;
   width: 100%;
 }
 
@@ -192,6 +195,7 @@ $mat-form-field-default-infix-width: 180px !default;
 // Wrapper for the hints and error messages.
 .mat-form-field-subscript-wrapper {
   position: absolute;
+  box-sizing: border-box;
   width: 100%;
   overflow: hidden; // prevents multi-line errors from overlapping the control
 }

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -78,6 +78,9 @@ $mat-form-field-default-infix-width: 180px !default;
   height: 100%;
   overflow: hidden;
   pointer-events: none;  // We shouldn't catch mouse events (let them through).
+
+  // Helps prevent text jumpiness when transforming the label.
+  filter: blur(0);
 }
 
 // The label itself. This is invisible unless it is. The logic to show it is
@@ -97,10 +100,6 @@ $mat-form-field-default-infix-width: 180px !default;
   text-overflow: ellipsis;
   overflow: hidden;
 
-  // The perspective helps smooth out animations on Chrome and Firefox but isn't needed on IE.
-  transform: perspective(100px);
-  -ms-transform: none;
-
   transform-origin: 0 0;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
   color $swift-ease-out-duration $swift-ease-out-timing-function,
@@ -108,6 +107,9 @@ $mat-form-field-default-infix-width: 180px !default;
 
   // Hide the label initially, and only show it when it's floating or the control is empty.
   display: none;
+
+  // Helps prevent text jumpiness when transforming the label.
+  backface-visibility: hidden;
 
   [dir='rtl'] & {
     transform-origin: 100% 0;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -153,6 +153,42 @@ $mat-form-field-default-infix-width: 180px !default;
   transition: none;
 }
 
+.mat-form-field-underline {
+  position: absolute;
+  width: 100%;
+}
+
+.mat-form-field-ripple {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  transform-origin: 50%;
+  transform: scaleX(0.5);
+  opacity: 0;
+  transition: background-color $swift-ease-in-duration $swift-ease-in-timing-function;
+}
+
+.mat-form-field.mat-focused,
+.mat-form-field.mat-form-field-invalid {
+  .mat-form-field-ripple {
+    opacity: 1;
+    transform: scaleX(1);
+    transition: transform 300ms $swift-ease-out-timing-function,
+    opacity 100ms $swift-ease-out-timing-function,
+    background-color 300ms $swift-ease-out-timing-function;
+  }
+}
+
+// Note that we need this specific of a selector because we don't want
+// the hover effect to show when the user hovers over the hints.
+.mat-form-field:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
+  .mat-form-field-ripple {
+    opacity: 1;
+    transform: none;
+    transition: opacity 600ms $swift-ease-out-timing-function;
+  }
+}
+
 // Wrapper for the hints and error messages.
 .mat-form-field-subscript-wrapper {
   position: absolute;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -195,6 +195,17 @@ $mat-form-field-default-infix-width: 180px !default;
   }
 }
 
+// Note that we need this specific of a selector because we don't want
+// the hover effect to show when the user hovers over the hints.
+.mat-form-field:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
+  .mat-form-field-ripple {
+    visibility: visible;
+    opacity: 1;
+    transform: none;
+    transition: opacity 600ms $swift-ease-out-timing-function;
+  }
+}
+
 // Wrapper for the hints and error messages.
 .mat-form-field-subscript-wrapper {
   position: absolute;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -78,9 +78,6 @@ $mat-form-field-default-infix-width: 180px !default;
   height: 100%;
   overflow: hidden;
   pointer-events: none;  // We shouldn't catch mouse events (let them through).
-
-  // Helps prevent text jumpiness when transforming the label.
-  filter: blur(0);
 }
 
 // The label itself. This is invisible unless it is. The logic to show it is
@@ -107,9 +104,6 @@ $mat-form-field-default-infix-width: 180px !default;
 
   // Hide the label initially, and only show it when it's floating or the control is empty.
   display: none;
-
-  // Helps prevent text jumpiness when transforming the label.
-  backface-visibility: hidden;
 
   [dir='rtl'] & {
     transform-origin: 100% 0;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -159,6 +159,8 @@ $mat-form-field-default-infix-width: 180px !default;
 .mat-form-field-underline {
   position: absolute;
   width: 100%;
+  // Need this so that the underline doesn't block the hover effect.
+  pointer-events: none;
 }
 
 .mat-form-field-ripple {
@@ -184,7 +186,7 @@ $mat-form-field-default-infix-width: 180px !default;
 
 // Note that we need this specific of a selector because we don't want
 // the hover effect to show when the user hovers over the hints.
-.mat-form-field:not(.mat-form-field-disabled) .mat-input-flex:hover ~ .mat-input-underline {
+.mat-form-field:not(.mat-form-field-disabled) .mat-form-field-flex:hover ~ .mat-form-field-underline {
   .mat-form-field-ripple {
     opacity: 1;
     transform: none;

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -59,6 +59,7 @@ let nextUniqueId = 0;
   styleUrls: [
     'form-field.css',
     'form-field-box.css',
+    'form-field-legacy.css',
     'form-field-standard.css',
     '../input/input.css',
   ],
@@ -67,7 +68,7 @@ let nextUniqueId = 0;
     'class': 'mat-input-container mat-form-field',
     '[class.mat-form-field-variant-standard]': 'variant == "standard"',
     '[class.mat-form-field-variant-box]': 'variant == "box"',
-    '[class.mat-form-field-variant-outline]': 'variant == "outline"',
+    '[class.mat-form-field-variant-legacy]': 'variant == "legacy"',
     '[class.mat-input-invalid]': '_control.errorState',
     '[class.mat-form-field-invalid]': '_control.errorState',
     '[class.mat-form-field-can-float]': '_canLabelFloat',
@@ -95,7 +96,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _labelOptions: LabelOptions;
 
   /** The form-field style variant. */
-  @Input() variant: 'standard' | 'box' | 'outline' = 'box';
+  @Input() variant: 'legacy' | 'standard' | 'box' = 'standard';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -95,7 +95,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _labelOptions: LabelOptions;
 
   /** The form-field style variant. */
-  @Input() variant: 'standard' | 'box' | 'outline' = 'box';
+  @Input() variant: 'standard' | 'box' | 'outline' = 'standard';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -7,8 +7,6 @@
  */
 
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {take} from 'rxjs/operators/take';
-import {startWith} from 'rxjs/operators/startWith';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -26,9 +24,12 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {FloatLabelType, MAT_LABEL_GLOBAL_OPTIONS, LabelOptions} from '@angular/material/core';
+import {FloatLabelType, LabelOptions, MAT_LABEL_GLOBAL_OPTIONS} from '@angular/material/core';
 import {fromEvent} from 'rxjs/observable/fromEvent';
+import {startWith} from 'rxjs/operators/startWith';
+import {take} from 'rxjs/operators/take';
 import {MatError} from './error';
+import {matFormFieldAnimations} from './form-field-animations';
 import {MatFormFieldControl} from './form-field-control';
 import {
   getMatFormFieldDuplicatedHintError,
@@ -36,14 +37,16 @@ import {
   getMatFormFieldPlaceholderConflictError,
 } from './form-field-errors';
 import {MatHint} from './hint';
-import {MatPlaceholder} from './placeholder';
 import {MatLabel} from './label';
+import {MatPlaceholder} from './placeholder';
 import {MatPrefix} from './prefix';
 import {MatSuffix} from './suffix';
-import {matFormFieldAnimations} from './form-field-animations';
 
 
 let nextUniqueId = 0;
+
+
+export type MatFormFieldVariant = 'legacy' | 'standard' | 'box';
 
 
 /** Container for form controls that applies Material Design styling and behavior. */
@@ -96,7 +99,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _labelOptions: LabelOptions;
 
   /** The form-field style variant. */
-  @Input() variant: 'legacy' | 'standard' | 'box' = 'legacy';
+  @Input() variant: MatFormFieldVariant = 'legacy';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -95,7 +95,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _labelOptions: LabelOptions;
 
   /** The form-field style variant. */
-  @Input() variant: 'standard' | 'box' | 'outline' = 'standard';
+  @Input() variant: 'standard' | 'box' | 'outline' = 'box';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -122,11 +122,11 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
 
   /** Whether the floating label should always float or not. */
   get _shouldAlwaysFloat() {
-    return this._floatLabel === 'always' && !this._showAlwaysAnimate;
+    return this.floatLabel === 'always' && !this._showAlwaysAnimate;
   }
 
   /** Whether the label can float or not. */
-  get _canLabelFloat() { return this._floatLabel !== 'never'; }
+  get _canLabelFloat() { return this.floatLabel !== 'never'; }
 
   /** State of the mat-hint and mat-error animations. */
   _subscriptAnimationState: string = '';
@@ -148,12 +148,21 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
    * @deprecated Use floatLabel instead.
    */
   @Input()
-  get floatPlaceholder(): FloatLabelType { return this._floatLabel; }
+  get floatPlaceholder(): FloatLabelType { return this.floatLabel; }
   set floatPlaceholder(value: FloatLabelType) { this.floatLabel = value; }
 
-  /** Whether the label should always float, never float or float as the user types. */
+  /**
+   * Whether the label should always float, never float or float as the user types.
+   *
+   * Note: only the legacy variant supports the `never` option. `never` was originally added as a
+   * way to make the floating label emulate the behavior of a standard input placeholder. However
+   * the form field now supports both floating labels and placeholders. Therefore in the non-legacy
+   * variants the `never` option has been disabled in favor of just using the placeholder.
+   */
   @Input()
-  get floatLabel(): FloatLabelType { return this._floatLabel; }
+  get floatLabel(): FloatLabelType {
+    return this.variant !== 'legacy' && this._floatLabel === 'never' ? 'auto' : this._floatLabel;
+  }
   set floatLabel(value: FloatLabelType) {
     if (value !== this._floatLabel) {
       this._floatLabel = value || this._labelOptions.float || 'auto';
@@ -247,11 +256,14 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   }
 
   _hideControlPlaceholder() {
-    return !this._hasLabel() || !this._shouldLabelFloat();
+    // In the legacy variant the placeholder is promoted to a label if no label is given.
+    return this.variant === 'legacy' && !this._hasLabel() ||
+        this._hasLabel() && !this._shouldLabelFloat();
   }
 
   _hasFloatingLabel() {
-    return this._hasLabel() || this._hasPlaceholder();
+    // In the legacy variant the placeholder is promoted to a label if no label is given.
+    return this._hasLabel() || this.variant === 'legacy' && this._hasPlaceholder();
   }
 
   /** Determines whether to display hints or errors. */
@@ -264,7 +276,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   _animateAndLockLabel(): void {
     if (this._hasFloatingLabel() && this._canLabelFloat) {
       this._showAlwaysAnimate = true;
-      this._floatLabel = 'always';
+      this.floatLabel = 'always';
 
       fromEvent(this._label.nativeElement, 'transitionend').pipe(take(1)).subscribe(() => {
         this._showAlwaysAnimate = false;

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -56,10 +56,18 @@ let nextUniqueId = 0;
   // MatInput is a directive and can't have styles, so we need to include its styles here.
   // The MatInput styles are fairly minimal so it shouldn't be a big deal for people who
   // aren't using MatInput.
-  styleUrls: ['form-field.css', '../input/input.css'],
+  styleUrls: [
+    'form-field.css',
+    'form-field-box.css',
+    'form-field-standard.css',
+    '../input/input.css',
+  ],
   animations: [matFormFieldAnimations.transitionMessages],
   host: {
     'class': 'mat-input-container mat-form-field',
+    '[class.mat-form-field-variant-standard]': 'variant == "standard"',
+    '[class.mat-form-field-variant-box]': 'variant == "box"',
+    '[class.mat-form-field-variant-outline]': 'variant == "outline"',
     '[class.mat-input-invalid]': '_control.errorState',
     '[class.mat-form-field-invalid]': '_control.errorState',
     '[class.mat-form-field-can-float]': '_canLabelFloat',
@@ -85,6 +93,9 @@ let nextUniqueId = 0;
 
 export class MatFormField implements AfterViewInit, AfterContentInit, AfterContentChecked {
   private _labelOptions: LabelOptions;
+
+  /** The form-field style variant. */
+  @Input() variant: 'standard' | 'box' | 'outline' = 'box';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -96,7 +96,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _labelOptions: LabelOptions;
 
   /** The form-field style variant. */
-  @Input() variant: 'legacy' | 'standard' | 'box' = 'standard';
+  @Input() variant: 'legacy' | 'standard' | 'box' = 'legacy';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -46,7 +46,7 @@ import {MatSuffix} from './suffix';
 let nextUniqueId = 0;
 
 
-export type MatFormFieldVariant = 'legacy' | 'standard' | 'box';
+export type MatFormFieldAppearance = 'legacy' | 'standard' | 'box';
 
 
 /** Container for form controls that applies Material Design styling and behavior. */
@@ -69,9 +69,9 @@ export type MatFormFieldVariant = 'legacy' | 'standard' | 'box';
   animations: [matFormFieldAnimations.transitionMessages],
   host: {
     'class': 'mat-input-container mat-form-field',
-    '[class.mat-form-field-variant-standard]': 'variant == "standard"',
-    '[class.mat-form-field-variant-box]': 'variant == "box"',
-    '[class.mat-form-field-variant-legacy]': 'variant == "legacy"',
+    '[class.mat-form-field-appearance-standard]': 'appearance == "standard"',
+    '[class.mat-form-field-appearance-box]': 'appearance == "box"',
+    '[class.mat-form-field-appearance-legacy]': 'appearance == "legacy"',
     '[class.mat-input-invalid]': '_control.errorState',
     '[class.mat-form-field-invalid]': '_control.errorState',
     '[class.mat-form-field-can-float]': '_canLabelFloat',
@@ -98,8 +98,8 @@ export type MatFormFieldVariant = 'legacy' | 'standard' | 'box';
 export class MatFormField implements AfterViewInit, AfterContentInit, AfterContentChecked {
   private _labelOptions: LabelOptions;
 
-  /** The form-field style variant. */
-  @Input() variant: MatFormFieldVariant = 'legacy';
+  /** The form-field appearance style. */
+  @Input() appearance: MatFormFieldAppearance = 'legacy';
 
   /** Color of the form field underline, based on the theme. */
   @Input() color: 'primary' | 'accent' | 'warn' = 'primary';
@@ -154,14 +154,14 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   /**
    * Whether the label should always float, never float or float as the user types.
    *
-   * Note: only the legacy variant supports the `never` option. `never` was originally added as a
+   * Note: only the legacy appearance supports the `never` option. `never` was originally added as a
    * way to make the floating label emulate the behavior of a standard input placeholder. However
    * the form field now supports both floating labels and placeholders. Therefore in the non-legacy
-   * variants the `never` option has been disabled in favor of just using the placeholder.
+   * appearances the `never` option has been disabled in favor of just using the placeholder.
    */
   @Input()
   get floatLabel(): FloatLabelType {
-    return this.variant !== 'legacy' && this._floatLabel === 'never' ? 'auto' : this._floatLabel;
+    return this.appearance !== 'legacy' && this._floatLabel === 'never' ? 'auto' : this._floatLabel;
   }
   set floatLabel(value: FloatLabelType) {
     if (value !== this._floatLabel) {
@@ -256,14 +256,14 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   }
 
   _hideControlPlaceholder() {
-    // In the legacy variant the placeholder is promoted to a label if no label is given.
-    return this.variant === 'legacy' && !this._hasLabel() ||
+    // In the legacy appearance the placeholder is promoted to a label if no label is given.
+    return this.appearance === 'legacy' && !this._hasLabel() ||
         this._hasLabel() && !this._shouldLabelFloat();
   }
 
   _hasFloatingLabel() {
-    // In the legacy variant the placeholder is promoted to a label if no label is given.
-    return this._hasLabel() || this.variant === 'legacy' && this._hasPlaceholder();
+    // In the legacy appearance the placeholder is promoted to a label if no label is given.
+    return this._hasLabel() || this.appearance === 'legacy' && this._hasPlaceholder();
   }
 
   /** Determines whether to display hints or errors. */

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -1,7 +1,7 @@
 import {Platform, PlatformModule} from '@angular/cdk/platform';
 import {createFakeEvent, dispatchFakeEvent, wrappedErrorMessage} from '@angular/cdk/testing';
 import {ChangeDetectionStrategy, Component, ViewChild} from '@angular/core';
-import {ComponentFixture, inject, TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {
   FormControl,
   FormGroup,
@@ -12,16 +12,17 @@ import {
   Validators,
 } from '@angular/forms';
 import {
-  MAT_LABEL_GLOBAL_OPTIONS,
-  ShowOnDirtyErrorStateMatcher,
   ErrorStateMatcher,
   FloatLabelType,
+  MAT_LABEL_GLOBAL_OPTIONS,
+  ShowOnDirtyErrorStateMatcher,
 } from '@angular/material/core';
 import {
   getMatFormFieldDuplicatedHintError,
   getMatFormFieldMissingControlError,
   getMatFormFieldPlaceholderConflictError,
-  MatFormField, MatFormFieldAppearance,
+  MatFormField,
+  MatFormFieldAppearance,
   MatFormFieldModule,
 } from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -21,7 +21,7 @@ import {
   getMatFormFieldDuplicatedHintError,
   getMatFormFieldMissingControlError,
   getMatFormFieldPlaceholderConflictError,
-  MatFormField,
+  MatFormField, MatFormFieldAppearance,
   MatFormFieldModule,
 } from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
@@ -1132,6 +1132,76 @@ describe('MatInput with forms', () => {
   }));
 });
 
+describe('MatInput with appearance', () => {
+  const nonLegacyAppearances: MatFormFieldAppearance[] = ['standard', 'box'];
+  let fixture: ComponentFixture<MatInputWithAppearance>;
+  let testComponent: MatInputWithAppearance;
+  let containerEl: HTMLElement;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        NoopAnimationsModule,
+        PlatformModule,
+        ReactiveFormsModule,
+      ],
+      declarations: [
+        MatInputWithAppearance,
+      ],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(fakeAsync(() => {
+    fixture = TestBed.createComponent(MatInputWithAppearance);
+    fixture.detectChanges();
+    testComponent = fixture.componentInstance;
+    containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+  }));
+
+  it('legacy appearance should promote placeholder to label', fakeAsync(() => {
+    testComponent.appearance = 'legacy';
+    fixture.detectChanges();
+
+    expect(containerEl.classList).toContain('mat-form-field-appearance-legacy');
+    expect(testComponent.formField._hasFloatingLabel()).toBe(true);
+    expect(testComponent.formField._hideControlPlaceholder()).toBe(true);
+  }));
+
+  it('non-legacy appearances should not promote placeholder to label', fakeAsync(() => {
+    for (let appearance of nonLegacyAppearances) {
+      testComponent.appearance = appearance;
+      fixture.detectChanges();
+
+      expect(containerEl.classList).toContain(`mat-form-field-appearance-${appearance}`);
+      expect(testComponent.formField._hasFloatingLabel()).toBe(false);
+      expect(testComponent.formField._hideControlPlaceholder()).toBe(false);
+    }
+  }));
+
+  it('legacy appearance should respect float never', fakeAsync(() => {
+    testComponent.appearance = 'legacy';
+    fixture.detectChanges();
+
+    expect(containerEl.classList).toContain('mat-form-field-appearance-legacy');
+    expect(testComponent.formField.floatLabel).toBe('never');
+  }));
+
+  it('non-legacy appearances should not respect float never', fakeAsync(() => {
+    for (let appearance of nonLegacyAppearances) {
+      testComponent.appearance = appearance;
+      fixture.detectChanges();
+
+      expect(containerEl.classList).toContain(`mat-form-field-appearance-${appearance}`);
+      expect(testComponent.formField.floatLabel).toBe('auto');
+    }
+  }));
+});
+
 @Component({
   template: `
     <mat-form-field>
@@ -1466,4 +1536,16 @@ class MatInputWithReadonlyInput {}
 })
 class MatInputWithLabelAndPlaceholder {
   floatLabel: FloatLabelType;
+}
+
+@Component({
+  template: `
+    <mat-form-field [appearance]="appearance" floatLabel="never">
+      <input matInput placeholder="Placeholder">
+    </mat-form-field>
+  `
+})
+class MatInputWithAppearance {
+  @ViewChild(MatFormField) formField: MatFormField;
+  appearance: MatFormFieldAppearance;
 }

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -46,8 +46,8 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   display: table-cell;
   vertical-align: middle;
 
-  // When used in a box variant form-field the arrow should be centered in the box.
-  .mat-form-field-variant-box & {
+  // When used in a box appearance form-field the arrow should be centered in the box.
+  .mat-form-field-appearance-box & {
     transform: translateY(-50%);
   }
 }

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -45,6 +45,11 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
 .mat-select-arrow-wrapper {
   display: table-cell;
   vertical-align: middle;
+
+  // When used in a box variant form-field the arrow should be centered in the box.
+  .mat-form-field-variant-box & {
+    transform: translateY(-50%);
+  }
 }
 
 .mat-select-arrow {

--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -105,5 +105,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
     // Remove the transition to prevent the placeholder
     // from overlapping when the label comes back down.
     transition: none;
+    // Prevents the '...' from showing on the parent element.
+    display: block;
   }
 }


### PR DESCRIPTION
Add support for variants and create 3 to start with: `legacy` (same as current master), `standard` (same as current master + a couple tweaks to be more in line with the spec), `box` (the box style from the spec).

Demos:
https://mmalerba-demo1.firebaseapp.com - current master
https://mmalerba-demo2.firebaseapp.com - default variant = legacy (should be identical to master)
https://mmalerba-demo3.firebaseapp.com - default variant = standard
https://mmalerba-demo4.firebaseapp.com - default variant = box

Couple notes:
- `legacy` is the actual default I used, so nothing should change for anyone unless they explicitly set a variant.
- I didn't add the background ripple shown in the `box` spec yet.
- Non-floating labels really don't work well with the `box` variant because of how the label is aligned (see the "first name" input at https://mmalerba-demo4.firebaseapp.com/input). Should we allow it to look broken? Ignore the `floatLabel="never"` option?
- Prefixes & suffixes look funky in the `box` variant. The reason is that we're using prefix/suffix for 2 different purposes:
  1. Icons/buttons such as a password visibility toggle (e.g. https://storage.googleapis.com/material-design/publish/material_v_12/assets/0B5ZSepuCX1xOdEc4cHZWV3ZzTzg/password1.png)
  2. Things like putting a '$' symbol in front of the user-inputted value. (e.g. https://storage.googleapis.com/material-design/publish/material_v_12/assets/0B5ZSepuCX1xOdVBQcERBbTJpSm8/prefix1.png)

I think (ii) is actually a misuse of the prefix/suffix. It should behave more like a placeholder that only appears once the label floats up. The spec provides more examples of this kind of thing here: https://material.io/guidelines/components/text-fields.html#text-fields-input-types. I think we should probably add support for formats to `MatInput` to handle this case rather than relying on the form-field's prefix/suffix. If you guys agree with this I'll go ahead and make the prefix/suffix behave like the icon case in the spec for `standard` and `box` and leave the `legacy` behavior as is.