### PR TITLE
feat(slider): add focus and blur methods do MatSlider class

### DIFF
--- a/src/demo-app/slider/slider-demo.html
+++ b/src/demo-app/slider/slider-demo.html
@@ -53,6 +53,11 @@ Label <mat-slider #slidey aria-label="Basic slider"></mat-slider>
            aria-label="Inverted vertical slider">
 </mat-slider>
 
+<h1>Set/lost focus to show thumblabel programmatically</h1>
+<mat-slider #demoSlider="matSlider" thumbLabel aria-label="Slider with thumb label"></mat-slider>
+<button (click)="demoSlider.focus()">Focus Slider</button>
+<button (click)="demoSlider.blur()">Blur Slider</button>
+
 <mat-tab-group>
   <mat-tab label="One">
     <mat-slider min="1" max="5" value="3" aria-label="Slider in a tab"></mat-slider>

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -267,6 +267,15 @@ export class MatSlider extends _MatSliderMixinBase
     return this.value || 0;
   }
 
+  /** set focus to the host element */
+  focus() {
+    this._focusHostElement();
+  }
+
+  blur() {
+    this._blurHostElement();
+  }
+
   /** onTouch function registered via registerOnTouch (ControlValueAccessor). */
   onTouched: () => any = () => {};
 
@@ -689,6 +698,13 @@ export class MatSlider extends _MatSliderMixinBase
    */
   private _focusHostElement() {
     this._elementRef.nativeElement.focus();
+  }
+
+  /**
+   * Blurs the native element.
+   */
+  private _blurHostElement() {
+    this._elementRef.nativeElement.blur();
   }
 
   /**

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -272,6 +272,7 @@ export class MatSlider extends _MatSliderMixinBase
     this._focusHostElement();
   }
 
+  /** blur the host element */
   blur() {
     this._blurHostElement();
   }
@@ -700,9 +701,7 @@ export class MatSlider extends _MatSliderMixinBase
     this._elementRef.nativeElement.focus();
   }
 
-  /**
-   * Blurs the native element.
-   */
+  /** Blurs the native element. */
   private _blurHostElement() {
     this._elementRef.nativeElement.blur();
   }


### PR DESCRIPTION
Does it need any tests?

<strike>Also there's a little side effect: if the thumb label is already visible and you try to show it programmatically by, let's say, clicking on a button, as the focus will be lost to the clicked button, the thumb label will disappear and appear again.</strike> Just realized that this is kind of normal (but I think it'd be better without this blinking)

![image](https://media.giphy.com/media/3o7527nWEC2cly2dKU/giphy.gif)

- Closes #9332 