### PR TITLE
docs: use correct naming Sass

### DIFF
--- a/guides/typography.md
+++ b/guides/typography.md
@@ -50,7 +50,7 @@ descendant native elements.
 ```
 
 ### Customization
-Typography customization is an extension of Angular Material's SASS-based theming. Similar to
+Typography customization is an extension of Angular Material's Sass-based theming. Similar to
 creating a custom theme, you can create a custom **typography configuration**.
 
 ```scss
@@ -73,7 +73,7 @@ has to be in quotes.
 
 
 Once the custom typography definition is created, it can be consumed to generate styles via
-different SASS mixins.
+different Sass mixins.
 
 ```scss
 // Override typography CSS classes (e.g., mat-h1, mat-display-1, mat-typography, etc.).

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -55,7 +55,7 @@
   @else {
     // Otherwise use the shorthand `font` to represent a typography level, because it's the the
     // least amount of bytes. Note that we need to use interpolation for `font-size/line-height`
-    // in order to prevent SASS from dividing the two values.
+    // in order to prevent Sass from dividing the two values.
     font: $font-weight #{$font-size}/#{$line-height} $font-family;
   }
 }

--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -53,7 +53,7 @@
   );
 
   // Loop through the levels and set the `font-family` of the ones that don't have one to the base.
-  // Note that SASS can't modify maps in place, which means that we need to merge and re-assign.
+  // Note that Sass can't modify maps in place, which means that we need to merge and re-assign.
   @each $key, $level in $config {
     @if map-get($level, font-family) == null {
       $new-level: map-merge($level, (font-family: $font-family));

--- a/tools/package-tools/gulp/build-tasks-gulp.ts
+++ b/tools/package-tools/gulp/build-tasks-gulp.ts
@@ -77,7 +77,7 @@ export function createPackageBuildTasks(buildPackage: BuildPackage) {
   task(`${taskName}:build:bundles`, () => buildPackage.createBundles());
 
   /**
-   * Asset tasks. Building SASS files and inlining CSS, HTML files into the ESM output.
+   * Asset tasks. Building Sass files and inlining CSS, HTML files into the ESM output.
    */
   task(`${taskName}:assets`, [
     `${taskName}:assets:scss`,

--- a/tools/stylelint/no-nested-mixin/index.js
+++ b/tools/stylelint/no-nested-mixin/index.js
@@ -7,7 +7,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 
 
 /**
- * Stylelint plugin that prevents nesting SASS mixins.
+ * Stylelint plugin that prevents nesting Sass mixins.
  */
 const plugin = stylelint.createPlugin(ruleName, isEnabled => {
   return (root, result) => {

--- a/tools/stylelint/no-prefixes/no-prefixes.js
+++ b/tools/stylelint/no-prefixes/no-prefixes.js
@@ -62,7 +62,7 @@ const plugin = stylelint.createPlugin(ruleName, browsers => {
 
     // Walk the rules and check if the selector needs prefixes.
     root.walkRules(rule => {
-      // Silence warnings for SASS selectors. Stylelint does this in their own rules as well:
+      // Silence warnings for Sass selectors. Stylelint does this in their own rules as well:
       // https://github.com/stylelint/stylelint/blob/master/lib/utils/isStandardSyntaxSelector.js
       parseSelector(rule.selector, { warn: () => {} }, rule, selectorTree => {
         selectorTree.walkPseudos(pseudoNode => {


### PR DESCRIPTION
According to the [official documentation](http://sass-lang.com/), the naming is `Sass`, not `SASS`. Just a quick fix in the docs.