### PR TITLE
refactor(focus-monitor): make checkChildren parameter optional

### DIFF
--- a/src/cdk/a11y/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor.spec.ts
@@ -30,7 +30,7 @@ describe('FocusMonitor', () => {
     focusMonitor = fm;
 
     changeHandler = jasmine.createSpy('focus origin change handler');
-    focusMonitor.monitor(buttonElement, false).subscribe(changeHandler);
+    focusMonitor.monitor(buttonElement).subscribe(changeHandler);
     patchElementFocus(buttonElement);
   }));
 

--- a/src/cdk/a11y/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor.ts
@@ -82,10 +82,10 @@ export class FocusMonitor {
    * @returns An observable that emits when the focus state of the element changes.
    *     When the element is blurred, null will be emitted.
    */
-  monitor(element: HTMLElement, checkChildren: boolean): Observable<FocusOrigin>;
+  monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin>;
   monitor(
       element: HTMLElement,
-      renderer: Renderer2 | boolean,
+      renderer?: Renderer2 | boolean,
       checkChildren?: boolean): Observable<FocusOrigin> {
     // TODO(mmalerba): clean up after deprecated signature is removed.
     if (!(renderer instanceof Renderer2)) {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -216,7 +216,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
   ngAfterViewInit() {
     this._focusMonitor
-      .monitor(this._inputElement.nativeElement, false)
+      .monitor(this._inputElement.nativeElement)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -82,7 +82,7 @@ export class MatExpansionPanelHeader implements OnDestroy {
     )
     .subscribe(() => this._changeDetectorRef.markForCheck());
 
-    _focusMonitor.monitor(_element.nativeElement, false);
+    _focusMonitor.monitor(_element.nativeElement);
   }
 
   /** Height of the header while the panel is expanded. */

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -540,7 +540,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   ngAfterViewInit() {
     this._focusMonitor
-      .monitor(this._inputElement.nativeElement, false)
+      .monitor(this._inputElement.nativeElement)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -156,7 +156,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     this._slideRenderer = new SlideToggleRenderer(this._elementRef, this._platform);
 
     this._focusMonitor
-      .monitor(this._inputElement.nativeElement, false)
+      .monitor(this._inputElement.nativeElement)
       .subscribe(focusOrigin => this._onInputFocusChange(focusOrigin));
   }
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -217,7 +217,7 @@ export class MatTooltip implements OnDestroy {
       element.style.webkitUserSelect = element.style.userSelect = '';
     }
 
-    _focusMonitor.monitor(element, false).subscribe(origin => {
+    _focusMonitor.monitor(element).subscribe(origin => {
       // Note that the focus monitor runs outside the Angular zone.
       if (!origin) {
         _ngZone.run(() => this.hide(0));


### PR DESCRIPTION
After we made the `renderer` param optional, `checkChildren` became required when using the two-param signature. These changes make it optional which is slightly more convenient on consumption.