### PR TITLE
chore(dgeni): better extraction of directive metadata

### DIFF
--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -1,7 +1,6 @@
 import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
 import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
-import {DirectiveMetadata} from './directive-metadata';
 import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
 
 /** Extended Dgeni class-like document that includes separated class members. */
@@ -18,7 +17,7 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
   isNgModule: boolean;
   directiveExportAs?: string | null;
   directiveSelectors?: string[];
-  directiveMetadata: DirectiveMetadata | null;
+  directiveMetadata: Map<string, any> | null;
   extendedDoc: ClassLikeExportDoc | null;
 }
 

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -1,6 +1,7 @@
 import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
 import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
+import {DirectiveMetadata} from './directive-metadata';
 import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
 
 /** Extended Dgeni class-like document that includes separated class members. */
@@ -17,6 +18,7 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
   isNgModule: boolean;
   directiveExportAs?: string | null;
   directiveSelectors?: string[];
+  directiveMetadata: DirectiveMetadata | null;
   extendedDoc: ClassLikeExportDoc | null;
 }
 

--- a/tools/dgeni/common/directive-metadata.ts
+++ b/tools/dgeni/common/directive-metadata.ts
@@ -7,13 +7,12 @@ import {
   StringLiteral, SyntaxKind
 } from 'typescript';
 
-export type DirectiveMetadata = Map<string, any>;
-
 /**
  * Determines the component or directive metadata from the specified Dgeni class doc. The resolved
  * directive metadata will be stored in a Map.
  *
- * Currently only string literal assignments and array literal assignments are supported.
+ * Currently only string literal assignments and array literal assignments are supported. Other
+ * value types are not necessary because they are not needed for any user-facing documentation.
  *
  * ```ts
  * @Component({
@@ -23,7 +22,7 @@ export type DirectiveMetadata = Map<string, any>;
  * export class MyComponent {}
  * ```
  */
-export function getDirectiveMetadata(classDoc: CategorizedClassDoc): DirectiveMetadata | null {
+export function getDirectiveMetadata(classDoc: CategorizedClassDoc): Map<string, any> | null {
   const declaration = classDoc.symbol.valueDeclaration;
 
   if (!declaration || !declaration.decorators) {

--- a/tools/dgeni/common/directive-metadata.ts
+++ b/tools/dgeni/common/directive-metadata.ts
@@ -1,0 +1,74 @@
+import {CategorizedClassDoc} from './dgeni-definitions';
+import {
+  ArrayLiteralExpression,
+  CallExpression,
+  ObjectLiteralExpression,
+  PropertyAssignment,
+  StringLiteral, SyntaxKind
+} from 'typescript';
+
+export type DirectiveMetadata = Map<string, any>;
+
+/**
+ * Determines the component or directive metadata from the specified Dgeni class doc. The resolved
+ * directive metadata will be stored in a Map.
+ *
+ * Currently only string literal assignments and array literal assignments are supported.
+ *
+ * ```ts
+ * @Component({
+ *   inputs: ["red", "blue"],
+ *   exportAs: "test"
+ * })
+ * export class MyComponent {}
+ * ```
+ */
+export function getDirectiveMetadata(classDoc: CategorizedClassDoc): DirectiveMetadata | null {
+  const declaration = classDoc.symbol.valueDeclaration;
+
+  if (!declaration || !declaration.decorators) {
+    return null;
+  }
+
+  const directiveDecorator = declaration.decorators
+    .filter(decorator => decorator.expression)
+    .filter(decorator => decorator.expression.kind === SyntaxKind.CallExpression)
+    .find(decorator => (decorator.expression as any).expression.getText() === 'Component' ||
+                       (decorator.expression as any).expression.getText() === 'Directive');
+
+  if (!directiveDecorator) {
+    return null;
+  }
+
+  // Since the actual decorator expression is by default a LeftHandSideExpression, and TypeScript
+  // doesn't allow a casting it to a CallExpression, we have to cast it to "any" before.
+  const expression = (directiveDecorator.expression as any) as CallExpression;
+
+  // The argument length of the CallExpression needs to be exactly one, because it's the single
+  // JSON object in the @Component/@Directive decorator.
+  if (expression.arguments.length !== 1) {
+    return null;
+  }
+
+  const objectExpression = expression.arguments[0] as ObjectLiteralExpression;
+  const resultMetadata = new Map<string, any>();
+
+  objectExpression.properties.forEach((prop: PropertyAssignment) => {
+
+    // Support ArrayLiteralExpression assignments in the directive metadata.
+    if (prop.initializer.kind === SyntaxKind.ArrayLiteralExpression) {
+      const arrayData = (prop.initializer as ArrayLiteralExpression).elements
+          .map((literal: StringLiteral) => literal.text);
+
+      resultMetadata.set(prop.name.getText(), arrayData);
+    }
+
+    // Support normal StringLiteral and NoSubstitutionTemplateLiteral assignments
+    if (prop.initializer.kind === SyntaxKind.StringLiteral ||
+        prop.initializer.kind === SyntaxKind.NoSubstitutionTemplateLiteral) {
+      resultMetadata.set(prop.name.getText(), (prop.initializer as StringLiteral).text);
+    }
+  });
+
+  return resultMetadata;
+}

--- a/tools/dgeni/common/property-bindings.ts
+++ b/tools/dgeni/common/property-bindings.ts
@@ -1,5 +1,4 @@
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
-import {DirectiveMetadata} from './directive-metadata';
 import {hasMemberDecorator} from './decorators';
 
 /** Interface that describes an Angular property binding. Can be either an input or output. */
@@ -12,7 +11,7 @@ export interface PropertyBinding {
  * Detects whether the specified property member is an input. If the property is an input, the
  * alias and input name will be returned.
  */
-export function getInputBindingData(doc: PropertyMemberDoc, metadata: DirectiveMetadata)
+export function getInputBindingData(doc: PropertyMemberDoc, metadata: Map<string, any>)
     : PropertyBinding | undefined {
   return getBindingPropertyData(doc, metadata, 'inputs', 'Input');
 }
@@ -21,7 +20,7 @@ export function getInputBindingData(doc: PropertyMemberDoc, metadata: DirectiveM
  * Detects whether the specified property member is an output. If the property is an output, the
  * alias and output name will be returned.
  */
-export function getOutputBindingData(doc: PropertyMemberDoc, metadata: DirectiveMetadata)
+export function getOutputBindingData(doc: PropertyMemberDoc, metadata: Map<string, any>)
     : PropertyBinding | undefined {
   return getBindingPropertyData(doc, metadata, 'outputs', 'Output');
 }
@@ -30,7 +29,7 @@ export function getOutputBindingData(doc: PropertyMemberDoc, metadata: Directive
  * Method that detects the specified type of property binding (either "output" or "input") from
  * the directive metadata or from the associated decorator on the property.
  */
-function getBindingPropertyData(doc: PropertyMemberDoc, metadata: DirectiveMetadata,
+function getBindingPropertyData(doc: PropertyMemberDoc, metadata: Map<string, any>,
                                 propertyName: string, decoratorName: string) {
 
   if (metadata) {

--- a/tools/dgeni/common/property-bindings.ts
+++ b/tools/dgeni/common/property-bindings.ts
@@ -1,0 +1,54 @@
+import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
+import {DirectiveMetadata} from './directive-metadata';
+import {hasMemberDecorator} from './decorators';
+
+/** Interface that describes an Angular property binding. Can be either an input or output. */
+export interface PropertyBinding {
+  name: string;
+  alias?: string;
+}
+
+/**
+ * Detects whether the specified property member is an input. If the property is an input, the
+ * alias and input name will be returned.
+ */
+export function getInputBindingData(doc: PropertyMemberDoc, metadata: DirectiveMetadata)
+    : PropertyBinding | undefined {
+  return getBindingPropertyData(doc, metadata, 'inputs', 'Input');
+}
+
+/**
+ * Detects whether the specified property member is an output. If the property is an output, the
+ * alias and output name will be returned.
+ */
+export function getOutputBindingData(doc: PropertyMemberDoc, metadata: DirectiveMetadata)
+    : PropertyBinding | undefined {
+  return getBindingPropertyData(doc, metadata, 'outputs', 'Output');
+}
+
+/**
+ * Method that detects the specified type of property binding (either "output" or "input") from
+ * the directive metadata or from the associated decorator on the property.
+ */
+function getBindingPropertyData(doc: PropertyMemberDoc, metadata: DirectiveMetadata,
+                                propertyName: string, decoratorName: string) {
+
+  if (metadata) {
+    const metadataValues: string[] = metadata.get(propertyName) || [];
+    const foundValue = metadataValues.find(value => value.split(':')[0] === doc.name);
+
+    if (foundValue) {
+      return {
+        name: doc.name,
+        alias: foundValue.split(':')[1]
+      };
+    }
+  }
+
+  if (hasMemberDecorator(doc, decoratorName)) {
+    return {
+      name: doc.name,
+      alias: doc.decorators!.find(d => d.name == decoratorName)!.arguments![0]
+    };
+  }
+}

--- a/tools/dgeni/common/sort-members.ts
+++ b/tools/dgeni/common/sort-members.ts
@@ -1,4 +1,3 @@
-import {isDirectiveInput, isDirectiveOutput} from './decorators';
 import {CategorizedMethodMemberDoc, CategorizedPropertyMemberDoc} from './dgeni-definitions';
 
 /** Combined type for a categorized method member document. */
@@ -16,13 +15,13 @@ export function sortCategorizedMembers(docA: CategorizedMemberDoc, docB: Categor
   }
 
   // Sort in the order of: Inputs, Outputs, neither
-  if ((isDirectiveInput(docA) && !isDirectiveInput(docB)) ||
-    (isDirectiveOutput(docA) && !isDirectiveInput(docB) && !isDirectiveOutput(docB))) {
+  if ((docA.isDirectiveInput && !docB.isDirectiveInput) ||
+    (docA.isDirectiveOutput && !docB.isDirectiveInput && !docB.isDirectiveOutput)) {
     return -1;
   }
 
-  if ((isDirectiveInput(docB) && !isDirectiveInput(docA)) ||
-    (isDirectiveOutput(docB) && !isDirectiveInput(docA) && !isDirectiveOutput(docA))) {
+  if ((docB.isDirectiveInput && !docA.isDirectiveInput) ||
+    (docB.isDirectiveOutput && !docA.isDirectiveInput && !docA.isDirectiveOutput)) {
     return 1;
   }
 

--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -28,7 +28,14 @@ export class MergeInheritedProperties implements Processor {
 
   private addMemberDocIfNotPresent(destination: ClassExportDoc, memberDoc: MemberDoc) {
     if (!destination.members.find(member => member.name === memberDoc.name)) {
-      destination.members.push(memberDoc);
+      // To be able to differentiate between member docs from the heritage clause and the
+      // member doc for the destination class, we clone the member doc. It's important to keep
+      // the prototype and reference because later, Dgeni identifies members and properties
+      // by using an instance comparison.
+      const newMemberDoc = Object.assign(Object.create(memberDoc), memberDoc);
+      newMemberDoc.containerDoc = destination;
+
+      destination.members.push(newMemberDoc);
     }
   }
 }


### PR DESCRIPTION
* No longer extracts the directive/component metadata using Regular Expressions.
* Fixes that inherited properties from interfaces or super-classes are not showing up as inputs/outputs if they are specified in the component/directive metadata.
* Now handles multi-line selectors (this was not possible using the Regular Expression)
* Fixes that merged inherited properties have a reference to the original document (this causes unexpected behavior; if properties are updated).

References #9299