### PR TITLE
docs: ensure jsdocs are properly set

### DIFF
--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -171,8 +171,7 @@ export class Dialog {
     return this.overlay.create(overlayConfig);
   }
 
-
-    /**
+  /**
    * Attaches an MatDialogContainer to a dialog's already-created overlay.
    * @param overlay Reference to the dialog's underlying overlay.
    * @param config The dialog configuration.
@@ -188,7 +187,7 @@ export class Dialog {
   }
 
 
-    /**
+  /**
    * Attaches the user-provided component to the already-created MatDialogContainer.
    * @param componentOrTemplateRef The type of component being loaded into the dialog,
    *     or a TemplateRef to instantiate as the content.
@@ -218,7 +217,7 @@ export class Dialog {
     return dialogRef;
   }
 
-   /**
+  /**
    * Attaches the user-provided component to the already-created MatDialogContainer.
    * @param componentOrTemplateRef The type of component being loaded into the dialog,
    *     or a TemplateRef to instantiate as the content.

--- a/src/cdk/a11y/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap.ts
@@ -25,7 +25,7 @@ import {DOCUMENT} from '@angular/common';
  * Node type of element nodes. Used instead of Node.ELEMENT_NODE
  * which is unsupported in Universal.
  * @docs-private
-*/
+ */
 const ELEMENT_NODE_TYPE = 1;
 
 /**

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -48,7 +48,7 @@ export class FullscreenOverlayContainer extends OverlayContainer {
   /**
    * When the page is put into fullscreen mode, a specific element is specified.
    * Only that element and its children are visible when in fullscreen mode.
-  */
+   */
   getFullscreenElement(): Element {
     return document.fullscreenElement ||
         document.webkitFullscreenElement ||

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -30,7 +30,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
   private _width: string = '';
   private _height: string = '';
 
-  /* A lazily-created wrapper for the overlay element that is used as a flex container.  */
+  /** A lazily-created wrapper for the overlay element that is used as a flex container.  */
   private _wrapper: HTMLElement | null = null;
 
   constructor(private _document: any) {}

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -137,7 +137,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   /** View -> model callback called when autocomplete has been touched */
   _onTouched = () => {};
 
-  /* The autocomplete panel to be attached to this trigger. */
+  /** The autocomplete panel to be attached to this trigger. */
   @Input('matAutocomplete') autocomplete: MatAutocomplete;
 
   constructor(private _element: ElementRef, private _overlay: Overlay,
@@ -154,7 +154,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     this._escapeEventStream.complete();
   }
 
-  /* Whether or not the autocomplete panel is open. */
+  /** Whether or not the autocomplete panel is open. */
   get panelOpen(): boolean {
     return this._panelOpen && this.autocomplete.showPanel;
   }
@@ -430,7 +430,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     }
   }
 
-   /**
+  /**
    * This method closes the panel, and if a value is specified, also sets the associated
    * control to that value. It will also mark the control as dirty if this interaction
    * stemmed from the user.
@@ -508,7 +508,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     return this._getConnectedElement().nativeElement.getBoundingClientRect().width;
   }
 
-  /** Reset active item to -1 so arrow events will activate the correct options.*/
+  /** Reset active item to -1 so arrow events will activate the correct options. */
   private _resetActiveItem(): void {
     this.autocomplete._keyManager.setActiveItem(-1);
   }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -313,7 +313,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   /** Whether or not the button toggle is a single selection. */
   private _isSingleSelector: boolean = false;
 
-  /** Unregister function for _buttonToggleDispatcher **/
+  /** Unregister function for _buttonToggleDispatcher */
   private _removeUniqueSelectionListener: () => void = () => {};
 
   @ViewChild('input') _inputElement: ElementRef;

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -23,12 +23,12 @@ import {
  */
 export const MAT_HAMMER_OPTIONS = new InjectionToken<HammerOptions>('MAT_HAMMER_OPTIONS');
 
-/* Adjusts configuration of our gesture library, Hammer. */
+/** Adjusts configuration of our gesture library, Hammer. */
 @Injectable()
 export class GestureConfig extends HammerGestureConfig {
   private _hammer: HammerStatic = typeof window !== 'undefined' ? (window as any).Hammer : null;
 
-  /* List of new event names to add to the gesture support list */
+  /** List of new event names to add to the gesture support list */
   events: string[] = this._hammer ? [
     'longpress',
     'slide',

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -39,8 +39,10 @@ export class TileCoordinator {
   /** Gets the total number of rows occupied by tiles */
   get rowCount(): number { return this.rowIndex + 1; }
 
-  /** Gets the total span of rows occupied by tiles.
-   * Ex: A list with 1 row that contains a tile with rowspan 2 will have a total rowspan of 2. */
+  /**
+   * Gets the total span of rows occupied by tiles.
+   * Ex: A list with 1 row that contains a tile with rowspan 2 will have a total rowspan of 2.
+   */
   get rowspan() {
     let lastRowMax = Math.max(...this.tracker);
     // if any of the tiles has a rowspan that pushes it beyond the total row count,

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -193,7 +193,7 @@ export class FixedTileStyler extends TileStyler {
  */
 export class RatioTileStyler extends TileStyler {
 
-  /** Ratio width:height given by user to determine row height.*/
+  /** Ratio width:height given by user to determine row height. */
   rowHeightRatio: number;
   baseTileHeight: string;
 

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -99,7 +99,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   private _strokeWidth: number;
   private _fallbackAnimation = false;
 
-  /** The width and height of the host element. Will grow with stroke width. **/
+  /** The width and height of the host element. Will grow with stroke width. */
   _elementSize = BASE_SIZE;
 
   /** Tracks diameters of existing instances to de-dupe generated styles (default d = 100) */

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -476,7 +476,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   /** Whether this radio is required. */
   private _required: boolean;
 
-  /** Value assigned to this radio.*/
+  /** Value assigned to this radio. */
   private _value: any = null;
 
   /** The child ripple instance. */
@@ -488,7 +488,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   /** Reference to the current focus ripple. */
   private _focusRipple: RippleRef | null;
 
-  /** Unregister function for _radioDispatcher **/
+  /** Unregister function for _radioDispatcher */
   private _removeUniqueSelectionListener: () => void = () => {};
 
   /** The native `<input type=radio>` element */

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -467,7 +467,7 @@ export class MatSlider extends _MatSliderMixinBase
     this._focusHostElement();
     this._updateValueFromPosition({x: event.clientX, y: event.clientY});
 
-    /* Emit a change and input event if the value changed. */
+    // Emit a change and input event if the value changed.
     if (oldValue != this.value) {
       this._emitInputEvent();
       this._emitChangeEvent();

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -789,7 +789,8 @@ class ComponentThatProvidesMatSnackBar {
 }
 
 
-/** Simple component to open snack bars from.
+/**
+ * Simple component to open snack bars from.
  * Create a real (non-test) NgModule as a workaround forRoot
  * https://github.com/angular/angular/issues/10760
  */

--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -108,7 +108,7 @@ export function hasDecorator(doc: {decorators?: {name: string}[]}, decoratorName
 /**
  * Decorates public exposed docs. Creates a property on the doc that indicates whether
  * the item is deprecated or not.
- **/
+ */
 export function decorateDeprecatedDoc(doc: {isDeprecated: boolean}) {
   doc.isDeprecated = isDeprecatedDoc(doc);
 }

--- a/tools/gulp/tasks/ci.ts
+++ b/tools/gulp/tasks/ci.ts
@@ -17,5 +17,5 @@ task('ci:payload', ['payload']);
 /** Task that uploads the coverage results to a firebase database. */
 task('ci:coverage', ['coverage:upload']);
 
-/** Task that verifies if all Material components are working with platform-server.*/
+/** Task that verifies if all Material components are working with platform-server. */
 task('ci:prerender', ['prerender']);

--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -5,7 +5,7 @@ const cloudStorage = require('@google-cloud/storage');
 // Firebase configuration for the Screenshot project. Use the config from the screenshot functions.
 const screenshotFirebaseConfig = require('../../screenshot-test/functions/config.json');
 
-/** Database URL of the dashboard firebase project.*/
+/** Database URL of the dashboard firebase project. */
 const dashboardDatabaseUrl = 'https://material2-board.firebaseio.com';
 
 /** Opens a connection to the Firebase dashboard app using a service account. */

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -4,7 +4,7 @@ import * as gulp from 'gulp';
 import * as path from 'path';
 import {buildConfig} from 'material2-build-tools';
 
-/* Those imports lack typings. */
+// Those imports lack typings.
 const gulpClean = require('gulp-clean');
 const gulpConnect = require('gulp-connect');
 

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -100,7 +100,7 @@ export class PackageBundler {
     await remapSourcemap(config.umdMinDest);
   }
 
-  /** Creates a rollup bundle of a specified JavaScript file.*/
+  /** Creates a rollup bundle of a specified JavaScript file. */
   private async createRollupBundle(config: RollupBundleConfig) {
     const bundleOptions = {
       context: 'this',

--- a/tools/package-tools/inline-resources.ts
+++ b/tools/package-tools/inline-resources.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-eval */
+// tslint:disable:no-eval
 
 import {dirname, join} from 'path';
 import {readFileSync, writeFileSync} from 'fs';

--- a/tools/package-tools/sourcemap-remap.ts
+++ b/tools/package-tools/sourcemap-remap.ts
@@ -4,7 +4,7 @@ const sorcery = require('sorcery');
 /**
  * Finds the original sourcemap of the file and maps it to the current file.
  * This is useful when multiple transformation happen (e.g TSC -> Rollup -> Uglify)
- **/
+ */
 export async function remapSourcemap(sourceFile: string) {
   // Once sorcery loaded the chain of sourcemaps, the new sourcemap will be written asynchronously.
   return (await sorcery.load(sourceFile)).write();

--- a/tools/screenshot-test/src/app/firebase.service.ts
+++ b/tools/screenshot-test/src/app/firebase.service.ts
@@ -41,7 +41,8 @@ export class FirebaseService {
     return firebase.storage().ref('goldens').child(filename).getDownloadURL();
   }
 
-  /** Set pull request number. All test information and pull request information will be retrived
+  /**
+   * Set pull request number. All test information and pull request information will be retrived
    * from database
    */
   set prNumber(prNumber: string) {

--- a/tslint.json
+++ b/tslint.json
@@ -84,6 +84,7 @@
     "linebreak-style": [true, "LF"],
     // Namespaces are no allowed, because of Closure compiler.
     "no-namespace": true,
+    "jsdoc-format": [true, "check-multiline-start"],
 
     // Custom Rules
     "ts-loader": true,


### PR DESCRIPTION
This PR does the following:

- Adds a new tslint rule ([https://palantir.github.io/tslint/rules/jsdoc-format/](jsdoc-format));
- Fixes all the JSDocs' occurrences that aren't properly formatted/set.
- It fixes the `MatAutocompleteTrigger`'s members (`autocomplete`, `panelOpen`), related in #8832, that aren't being displayed because the JSDocs were starting with `/* ...` instead of `/**...`;

cc @DevVersion.