### PR TITLE
fix(input): respect text-align value from form-field

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -26,6 +26,12 @@
   // Needed to make last line of the textarea line up with the baseline.
   vertical-align: bottom;
 
+  // User agent stylesheets set the text-align of inputs explicitly to "start". Those can be
+  // easily overwritten by targeting the input element using a simple CSS selector, but since
+  // the text-align will be applied most of the time on the `mat-form-field` to also align the
+  // placeholder, the alignment should be inherited here.
+  text-align: inherit;
+
   // Undo the red box-shadow glow added by Firefox on invalid inputs.
   // See https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-invalid
   &:-moz-ui-invalid {


### PR DESCRIPTION
User agent stylesheets set the text-align of inputs explicitly to "start". Those can be easily overwritten by targeting the input element using a simple CSS selector, but since the text-align will be applied most of the time on the `mat-form-field` to also align the placeholder/label, the alignment should be inherited on the input.

Related to #5332