### PR TITLE
chore(snack-bar): allow stronger typing for config data

### DIFF
--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -35,7 +35,7 @@ import {MatDialogConfig} from './dialog-config';
 import {MatDialogContainer} from './dialog-container';
 import {MatDialogRef} from './dialog-ref';
 
-
+/** Injection token that can be used to access the data that was passed in to a dialog. */
 export const MAT_DIALOG_DATA = new InjectionToken<any>('MatDialogData');
 
 /** Injection token that can be used to specify default dialog options. */

--- a/src/lib/snack-bar/snack-bar-config.ts
+++ b/src/lib/snack-bar/snack-bar-config.ts
@@ -10,6 +10,7 @@ import {ViewContainerRef, InjectionToken} from '@angular/core';
 import {AriaLivePoliteness} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
 
+/** Injection token that can be used to access the data that was passed in to a snack bar. */
 export const MAT_SNACK_BAR_DATA = new InjectionToken<any>('MatSnackBarData');
 
 /** Possible values for horizontalPosition on MatSnackBarConfig. */
@@ -21,7 +22,7 @@ export type MatSnackBarVerticalPosition = 'top' | 'bottom';
 /**
  * Configuration used when opening a snack-bar.
  */
-export class MatSnackBarConfig {
+export class MatSnackBarConfig<D = any> {
   /** The politeness level for the MatAriaLiveAnnouncer announcement. */
   politeness?: AriaLivePoliteness = 'assertive';
 
@@ -41,13 +42,13 @@ export class MatSnackBarConfig {
    * Extra CSS classes to be added to the snack bar container.
    * @deprecated Use `panelClass` instead.
    */
- extraClasses?: string | string[];
+  extraClasses?: string | string[];
 
   /** Text layout direction for the snack bar. */
   direction?: Direction = 'ltr';
 
   /** Data being injected into the child component. */
-  data?: any = null;
+  data?: D | null = null;
 
   /** The horizontal position to place the snack bar. */
   horizontalPosition?: MatSnackBarHorizontalPosition = 'center';


### PR DESCRIPTION
* Along the same lines as the dialog data, adds a generic param to the `MatSnackBarConfig` that allows consumers to type the `data` property.
* Adds a couple of missing docstrings to the `MAT_DIALOG_DATA` and `MAT_SNACK_BAR_DATA`.