### PR TITLE
build: fix chrome headless not starting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
-sudo: false
 dist: trusty
 
+# Temporary set sudo to required, because in normal container-based Travis jobs, the Chrome
+# binaries seem to be owned by root, and therefore can't be accessed by Karma. To workaround
+# the issue we temporary grant the CI sudo permissions.
+# https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
+sudo: required
+
 node_js:
-  - '8'
+  - '8.9.4'
 
 addons:
   jwt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ dist: trusty
 sudo: required
 
 node_js:
+  # Use the explicit NodeJS LTS version 8.9.4 to avoid any automatic upgrade of the version.
+  # This ensures that all Travis jobs run consistently and don't have different Node versions.
   - '8.9.4'
 
 addons:


### PR DESCRIPTION
* Applies a workaround for https://github.com/travis-ci/travis-ci/issues/8836 that fixes the Chrome launch issues. (similar workaround applied on angular/angular)