### PR TITLE
fix(slider): slider emiting changes on slide end when disabled

### DIFF
--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -249,6 +249,15 @@ describe('MatSlider without forms', () => {
       expect(sliderInstance.value).toBe(0);
     });
 
+    it('should not emit change when disabled', () => {
+      const onChangeSpy = jasmine.createSpy('slider onChange');
+      sliderInstance.change.subscribe(onChangeSpy);
+
+      dispatchSlideEventSequence(sliderNativeElement, 0, 0.5, gestureConfig);
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(0);
+    });
+
     it('should not add the mat-slider-active class on click when disabled', () => {
       expect(sliderNativeElement.classList).not.toContain('mat-slider-active');
 

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -518,7 +518,7 @@ export class MatSlider extends _MatSliderMixinBase
   _onSlideEnd() {
     this._isSliding = false;
 
-    if (this._valueOnSlideStart != this.value) {
+    if (this._valueOnSlideStart != this.value && !this.disabled) {
       this._emitChangeEvent();
     }
     this._valueOnSlideStart = null;


### PR DESCRIPTION
Currently, the slider is firing a change event on slideEnd when it is disabled. If it is disabled and the value of the slider doesn't change, it shouldn't have to emit any change event. 

I have added the test and its corresponding fix for it to pass. 