### PR TITLE
docs(demo-app): align a11y content, fix typo

### DIFF
--- a/src/demo-app/a11y/card/card-a11y.html
+++ b/src/demo-app/a11y/card/card-a11y.html
@@ -1,6 +1,6 @@
 <section>
   <h2>Dogs group</h2>
-  <p>Showing a card with a group of content</p>
+  <p>Showing a card with a group of content.</p>
   <mat-card class="example-card" role="group">
     <mat-card-content>
       <p>Herding Group</p>
@@ -18,7 +18,7 @@
 
 <section>
   <h2>Husky</h2>
-  <p>Showing a card with title only</p>
+  <p>Showing a card with title only.</p>
   <mat-card class="example-card">
     Siberian Husky
   </mat-card>
@@ -26,7 +26,7 @@
 
 <section>
   <h2>Malamute</h2>
-  <p>Showing a Card with title and subtitle. </p>
+  <p>Showing a Card with title and subtitle.</p>
   <mat-card class="example-card">
     <mat-card-title>Alaskan Malamute</mat-card-title>
     <mat-card-subtitle>Dog breed</mat-card-subtitle>
@@ -36,9 +36,7 @@
 
 <section>
   <h2>German Shepherd</h2>
-  <p>
-    Showing a card with title, subtitle, and a footer.
-  </p>
+  <p>Showing a card with title, subtitle, and a footer.</p>
   <mat-card class="example-card">
     <mat-card-subtitle>Dog breed</mat-card-subtitle>
     <mat-card-title>German Shepherd</mat-card-title>

--- a/src/demo-app/a11y/datepicker/datepicker-a11y.html
+++ b/src/demo-app/a11y/datepicker/datepicker-a11y.html
@@ -87,7 +87,7 @@
 </section>
 
 <section>
-  <h2>Choose date with date filter (e.g. schedule a doctor appointment)</h2>
+  <h2>Choose date with date filter (e.g. schedule a doctor's appointment)</h2>
   <mat-form-field>
     <input matInput
            [matDatepicker]="appointmentPicker"


### PR DESCRIPTION
Just some small fixes inside the demo-app, keeping things consistent.