### PR TITLE
doc(select): fix examples of symbols exported by forms modules.

### DIFF
--- a/src/lib/select/select.md
+++ b/src/lib/select/select.md
@@ -17,8 +17,8 @@ forms.
 
 <!-- example(select-value-binding) -->
 
-The `<mat-select>` also supports all of the form directives from the core `FormsModule` and
-`ReactiveFormsModule` (`ngModel`, `formControl`, etc.) As with native `<select>`, `<mat-select>`
+The `<mat-select>` also supports all of the form directives from the core `FormsModule` (`NgModel`) and
+`ReactiveFormsModule` (`FormControl`, `FormGroup`, etc.) As with native `<select>`, `<mat-select>`
 also supports a `compareWith` function. (Additional information about using a custom `compareWith`
 function can be found in the
 [Angular forms documentation](https://angular.io/api/forms/SelectControlValueAccessor#caveat-option-selection)).
@@ -67,7 +67,7 @@ on the group.
 
 ### Multiple selection
 
-`<mat-select>` defaults to single-selection mode, but can be configured to allow multiple selection 
+`<mat-select>` defaults to single-selection mode, but can be configured to allow multiple selection
 by setting the `multiple` property. This will allow the user to select multiple values at once. When
 using the `<mat-select>` in multiple selection mode, its value will be a sorted list of all selected
 values rather than a single value.


### PR DESCRIPTION
Fixes #9460