### PR TITLE
fix(form-field): unable to override font-size through typography config

### DIFF
--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -32,7 +32,7 @@
   $caption:       mat-typography-level(12px, 20px, 400),
   $button:        mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:         mat-typography-level(16px, 1.125, 400)
+  $input:         mat-typography-level(inherit, 1.125, 400)
 ) {
 
   // Declare an initial map with all of the levels.

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -146,10 +146,7 @@ $dedupe: 0;
   $wrapper-padding-bottom: ($subscript-margin-top + $line-height) * $subscript-font-scale;
 
   .mat-form-field {
-    font-family: mat-font-family($config);
-    font-size: inherit;
-    font-weight: mat-font-weight($config, input);
-    line-height: mat-line-height($config, input);
+    @include mat-typography-level-to-styles($config, input);
   }
 
   .mat-form-field-wrapper {


### PR DESCRIPTION
Fixes the form field ignoring the typography config's font size which prevents consumers from being able to override it.

fixes #9462 