### PR TITLE
docs: ensure docs are being shown for '@Input's

### DIFF
--- a/e2e/components/menu-e2e.spec.ts
+++ b/e2e/components/menu-e2e.spec.ts
@@ -168,7 +168,7 @@ describe('menu', () => {
       const trigger = await page.beforeTrigger().getLocation();
 
       // the menu's right corner must be attached to the trigger's right corner.
-      // menu = 112px wide. trigger = 60px wide.  112 - 60 =  52px of menu to the left of trigger.
+      // menu = 112px wide. trigger = 60px wide. 112 - 60 = 52px of menu to the left of trigger.
       // trigger.x (left corner) - 52px (menu left of trigger) = expected menu.x (left corner)
       // menu.y should equal trigger.y because only x position has changed.
       expectLocation(page.beforeMenu(), {x: trigger.x - 52, y: trigger.y});

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -24,7 +24,8 @@ export class CdkAccordion {
   readonly id = `cdk-accordion-${nextId++}`;
 
   /** Whether the accordion should allow multiple expanded accordion items simulateously. */
-  @Input() get multi(): boolean { return this._multi; }
+  @Input()
+  get multi(): boolean { return this._multi; }
   set multi(multi: boolean) { this._multi = coerceBooleanProperty(multi); }
-  private  _multi: boolean = false;
+  private _multi: boolean = false;
 }

--- a/src/cdk/bidi/dir.ts
+++ b/src/cdk/bidi/dir.ts
@@ -39,7 +39,7 @@ export class Dir implements Directionality, AfterContentInit, OnDestroy {
   @Output('dirChange') change = new EventEmitter<Direction>();
 
   /** @docs-private */
-  @Input('dir')
+  @Input()
   get dir(): Direction { return this._dir; }
   set dir(v: Direction) {
     const old = this._dir;

--- a/src/cdk/layout/media-matcher.ts
+++ b/src/cdk/layout/media-matcher.ts
@@ -66,7 +66,7 @@ function createEmptyStyleRule(query: string) {
   }
 }
 
-/** No-op matchMedia replacement for non-browser platforms.  */
+/** No-op matchMedia replacement for non-browser platforms. */
 function noopMatchMedia(query: string): MediaQueryList {
   return {
     matches: query === 'all' || query === '',

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -30,7 +30,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
   private _width: string = '';
   private _height: string = '';
 
-  /** A lazily-created wrapper for the overlay element that is used as a flex container.  */
+  /** A lazily-created wrapper for the overlay element that is used as a flex container. */
   private _wrapper: HTMLElement | null = null;
 
   constructor(private _document: any) {}

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -645,9 +645,9 @@ interface TestData {
 class FakeDataSource extends DataSource<TestData> {
   isConnected = false;
 
-  _dataChange = new BehaviorSubject<TestData[]>([]);
-  set data(data: TestData[]) { this._dataChange.next(data); }
   get data() { return this._dataChange.getValue(); }
+  set data(data: TestData[]) { this._dataChange.next(data); }
+  _dataChange = new BehaviorSubject<TestData[]>([]);
 
   constructor() {
     super();

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -490,7 +490,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   private _getOverlayPosition(): PositionStrategy {
-    this._positionStrategy =  this._overlay.position().connectedTo(
+    this._positionStrategy = this._overlay.position().connectedTo(
         this._getConnectedElement(),
         {originX: 'start', originY: 'bottom'}, {overlayX: 'start', overlayY: 'top'})
         .withFallbackPosition(

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -100,10 +100,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 
   /** `name` attribute for the underlying `input` element. */
   @Input()
-  get name(): string {
-    return this._name;
-  }
-
+  get name(): string { return this._name; }
   set name(value: string) {
     this._name = value;
     this._updateButtonToggleNames();
@@ -111,19 +108,12 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 
   /** Whether the toggle group is vertical. */
   @Input()
-  get vertical(): boolean {
-    return this._vertical;
-  }
-
-  set vertical(value: boolean) {
-    this._vertical = coerceBooleanProperty(value);
-  }
+  get vertical(): boolean { return this._vertical; }
+  set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
 
   /** Value of the toggle group. */
   @Input()
-  get value(): any {
-    return this._value;
-  }
+  get value(): any { return this._value; }
   set value(newValue: any) {
     if (this._value != newValue) {
       this._value = newValue;
@@ -141,10 +131,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 
   /** Whether the toggle group is selected. */
   @Input()
-  get selected(): MatButtonToggle | null {
-    return this._selected;
-  }
-
+  get selected(): MatButtonToggle | null { return this._selected; }
   set selected(selected: MatButtonToggle | null) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
@@ -259,10 +246,7 @@ export class MatButtonToggleGroupMultiple extends _MatButtonToggleGroupMixinBase
 
   /** Whether the toggle group is vertical. */
   @Input()
-  get vertical(): boolean {
-    return this._vertical;
-  }
-
+  get vertical(): boolean { return this._vertical; }
   set vertical(value) {
     this._vertical = coerceBooleanProperty(value);
   }
@@ -325,9 +309,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   buttonToggleGroupMultiple: MatButtonToggleGroupMultiple;
 
   /** Unique ID for the underlying `input` element. */
-  get inputId(): string {
-    return `${this.id}-input`;
-  }
+  get inputId(): string { return `${this.id}-input`; }
 
   /** The unique ID for this button toggle. */
   @Input() id: string;
@@ -354,10 +336,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
 
   /** MatButtonToggleGroup reads this to assign its own value. */
   @Input()
-  get value(): any {
-    return this._value;
-  }
-
+  get value(): any { return this._value; }
   set value(value: any) {
     if (this._value != value) {
       if (this.buttonToggleGroup != null && this.checked) {
@@ -373,7 +352,6 @@ export class MatButtonToggle implements OnInit, OnDestroy {
     return this._disabled || (this.buttonToggleGroup != null && this.buttonToggleGroup.disabled) ||
         (this.buttonToggleGroupMultiple != null && this.buttonToggleGroupMultiple.disabled);
   }
-
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
   }

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -155,7 +155,6 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-
   set align(v) {
     this.labelPosition = (v == 'start') ? 'after' : 'before';
   }
@@ -227,10 +226,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   /**
    * Whether the checkbox is checked.
    */
-  @Input() get checked() {
-    return this._checked;
-  }
-
+  @Input()
+  get checked() { return this._checked; }
   set checked(checked: boolean) {
     if (checked != this.checked) {
       this._checked = checked;
@@ -244,10 +241,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * checkable items. Note that whenever checkbox is manually clicked, indeterminate is immediately
    * set to false.
    */
-  @Input() get indeterminate() {
-    return this._indeterminate;
-  }
-
+  @Input()
+  get indeterminate() { return this._indeterminate; }
   set indeterminate(indeterminate: boolean) {
     let changed =  indeterminate != this._indeterminate;
     this._indeterminate = indeterminate;

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -223,30 +223,28 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
   /** Required for FormFieldControl. The ID of the chip list */
   @Input()
+  get id(): string { return this._id || this._uid; }
   set id(value: string) {
     this._id = value;
     this.stateChanges.next();
   }
-  get id(): string { return this._id || this._uid; }
 
   /** Required for FormFieldControl. Whether the chip list is required. */
   @Input()
+  get required(): boolean { return this._required; }
   set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
-  get required(): boolean {
-    return this._required;
-  }
 
   /** For FormFieldControl. Use chip input's placholder if there's a chip input */
   @Input()
+  get placeholder(): string {
+    return this._chipInput ? this._chipInput.placeholder : this._placeholder;
+  }
   set placeholder(value: string) {
     this._placeholder = value;
     this.stateChanges.next();
-  }
-  get placeholder(): string {
-    return this._chipInput ? this._chipInput.placeholder : this._placeholder;
   }
 
   /** Whether any chips or the matChipInput inside of this chip-list has focus. */
@@ -261,9 +259,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   }
 
   /** @docs-private */
-  get shouldLabelFloat(): boolean {
-    return !this.empty || this.focused;
-  }
+  get shouldLabelFloat(): boolean { return !this.empty || this.focused; }
 
   /** Whether this chip-list is disabled. */
   @Input()

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -97,9 +97,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
 
   /** Whether the chip is selected. */
   @Input()
-  get selected(): boolean {
-    return this._selected;
-  }
+  get selected(): boolean { return this._selected; }
   set selected(value: boolean) {
     this._selected = coerceBooleanProperty(value);
     this.selectionChange.emit({
@@ -123,11 +121,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
    * Whether or not the chips are selectable. When a chip is not selectable,
    * changes to it's selected state are always ignored.
    */
-  @Input() get selectable(): boolean {
-    return this._selectable;
-  }
-
-
+  @Input()
+  get selectable(): boolean { return this._selectable; }
   set selectable(value: boolean) {
     this._selectable = coerceBooleanProperty(value);
   }
@@ -135,11 +130,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   /**
    * Determines whether or not the chip displays the remove styling and emits (remove) events.
    */
-  @Input() get removable(): boolean {
-    return this._removable;
-  }
-
-
+  @Input()
+  get removable(): boolean { return this._removable; }
   set removable(value: boolean) {
     this._removable = coerceBooleanProperty(value);
   }

--- a/src/lib/core/common-behaviors/color.ts
+++ b/src/lib/core/common-behaviors/color.ts
@@ -20,7 +20,7 @@ export interface HasElementRef {
   _elementRef: ElementRef;
 }
 
-/** Possible color palette values.  */
+/** Possible color palette values. */
 export type ThemePalette = 'primary' | 'accent' | 'warn' | undefined;
 
 /** Mixin to augment a directive with a `color` property. */

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -14,7 +14,7 @@ describe('MatRipple', () => {
   let originalBodyMargin: string | null;
   let platform: Platform;
 
-  /** Extracts the numeric value of a pixel size string like '123px'.  */
+  /** Extracts the numeric value of a pixel size string like '123px'. */
   const pxStringToFloat = s => parseFloat(s) || 0;
   const startingWindowWidth = window.innerWidth;
   const startingWindowHeight = window.innerHeight;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -118,9 +118,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   /** The value of the input. */
   @Input()
-  get value(): D | null {
-    return this._value;
-  }
+  get value(): D | null { return this._value; }
   set value(value: D | null) {
     value = this._dateAdapter.deserialize(value);
     this._lastValueValid = !value || this._dateAdapter.isValid(value);

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -135,9 +135,7 @@ export class MatDatepicker<D> implements OnDestroy {
    * than a popup and elements have more padding to allow for bigger touch targets.
    */
   @Input()
-  get touchUi(): boolean {
-    return this._touchUi;
-  }
+  get touchUi(): boolean { return this._touchUi; }
   set touchUi(value: boolean) {
     this._touchUi = coerceBooleanProperty(value);
   }

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -86,7 +86,7 @@ export class MatDialogConfig<D = any> {
   /** Layout direction for the dialog's content. */
   direction?: Direction = 'ltr';
 
-  /** ID of the element that describes the dialog.  */
+  /** ID of the element that describes the dialog. */
   ariaDescribedBy?: string | null = null;
 
   /** Aria label to assign to the dialog element */

--- a/src/lib/divider/divider.ts
+++ b/src/lib/divider/divider.ts
@@ -27,12 +27,14 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 })
 export class MatDivider {
   /** Whether the divider is vertically aligned. */
-  @Input() get vertical(): boolean { return this._vertical; }
+  @Input()
+  get vertical(): boolean { return this._vertical; }
   set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
   private _vertical: boolean = false;
 
   /** Whether the divider is an inset divider. */
-  @Input() get inset(): boolean { return this._inset; }
+  @Input()
+  get inset(): boolean { return this._inset; }
   set inset(value: boolean) { this._inset = coerceBooleanProperty(value); }
   private _inset: boolean = false;
 }

--- a/src/lib/expansion/accordion.ts
+++ b/src/lib/expansion/accordion.ts
@@ -25,9 +25,10 @@ export type MatAccordionDisplayMode = 'default' | 'flat';
 })
 export class MatAccordion extends CdkAccordion {
   /** Whether the expansion indicator should be hidden. */
-  @Input() get hideToggle(): boolean { return this._hideToggle; }
+  @Input()
+  get hideToggle(): boolean { return this._hideToggle; }
   set hideToggle(show: boolean) { this._hideToggle = coerceBooleanProperty(show); }
-  private  _hideToggle: boolean = false;
+  private _hideToggle: boolean = false;
 
   /**
    * The display mode used for all expansion panels in the accordion. Currently two display

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -89,9 +89,7 @@ export class MatExpansionPanel extends _MatExpansionPanelMixinBase
 
   /** Whether the toggle indicator should be hidden. */
   @Input()
-  get hideToggle(): boolean {
-    return this._hideToggle;
-  }
+  get hideToggle(): boolean { return this._hideToggle; }
   set hideToggle(value: boolean) {
     this._hideToggle = coerceBooleanProperty(value);
   }

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -133,7 +133,7 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
     this._lineSetter = new MatLineSetter(this._lines, this._element);
   }
 
-  /** Whether this list item should show a ripple effect when clicked.  */
+  /** Whether this list item should show a ripple effect when clicked. */
   _isRippleDisabled() {
     return !this._isNavList || this.disableRipple || this._navList.disableRipple;
   }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -209,7 +209,7 @@ export class MatListOption extends _MatListOptionMixinBase
     return this._text ? this._text.nativeElement.textContent : '';
   }
 
-  /** Whether this list item should show a ripple effect when clicked.  */
+  /** Whether this list item should show a ripple effect when clicked. */
   _isRippleDisabled() {
     return this.disabled || this.disableRipple || this.selectionList.disableRipple;
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -130,11 +130,9 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
 
   /** Whether the menu should overlap its trigger. */
   @Input()
+  get overlapTrigger(): boolean { return this._overlapTrigger; }
   set overlapTrigger(value: boolean) {
     this._overlapTrigger = coerceBooleanProperty(value);
-  }
-  get overlapTrigger(): boolean {
-    return this._overlapTrigger;
   }
   private _overlapTrigger: boolean = this._defaultOptions.overlapTrigger;
 
@@ -164,8 +162,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    * @deprecated Use `panelClass` instead.
    */
   @Input()
-  set classList(classes: string) { this.panelClass = classes; }
   get classList(): string { return this.panelClass; }
+  set classList(classes: string) { this.panelClass = classes; }
 
   /** Event emitted when the menu is closed. */
   @Output() closed: EventEmitter<void | 'click' | 'keydown'>

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -113,9 +113,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
 
   /** The diameter of the progress spinner (will set width and height of svg). */
   @Input()
-  get diameter(): number {
-    return this._diameter;
-  }
+  get diameter(): number { return this._diameter; }
   set diameter(size: number) {
     this._diameter = coerceNumberProperty(size);
 
@@ -130,7 +128,6 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   get strokeWidth(): number {
     return this._strokeWidth || this.diameter / 10;
   }
-
   set strokeWidth(value: number) {
     this._strokeWidth = coerceNumberProperty(value);
   }

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -149,7 +149,6 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-
   set align(v) {
     this.labelPosition = (v == 'start') ? 'after' : 'before';
   }
@@ -160,7 +159,6 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
   get labelPosition(): 'before' | 'after' {
     return this._labelPosition;
   }
-
   set labelPosition(v) {
     this._labelPosition = (v == 'before') ? 'before' : 'after';
     this._markRadiosForCheck();
@@ -390,10 +388,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   /** The value of this radio button. */
   @Input()
-  get value(): any {
-    return this._value;
-  }
-
+  get value(): any { return this._value; }
   set value(value: any) {
     if (this._value != value) {
       this._value = value;
@@ -419,7 +414,6 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-
   set align(v) {
     this.labelPosition = (v == 'start') ? 'after' : 'before';
   }
@@ -431,7 +425,6 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   get labelPosition(): 'before' | 'after' {
     return this._labelPosition || (this.radioGroup && this.radioGroup.labelPosition) || 'after';
   }
-
   set labelPosition(value) {
     this._labelPosition = value;
   }

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -215,7 +215,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Whether or not the overlay panel is open. */
   private _panelOpen = false;
 
-  /** Whether filling out the select is required in the form.  */
+  /** Whether filling out the select is required in the form. */
   private _required: boolean = false;
 
   /** The scroll position of the overlay panel, calculated to center the selected option. */

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -324,9 +324,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
    */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(v: boolean) {
-    this.toggle(coerceBooleanProperty(v));
-  }
+  set opened(v: boolean) { this.toggle(coerceBooleanProperty(v)); }
 
   /**
    * Open the drawer.

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -74,7 +74,7 @@ export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortabl
   @Input() arrowPosition: 'before' | 'after' = 'after';
 
   /** Overrides the sort start value of the containing MatSort for this MatSortable. */
-  @Input('start') start: 'asc' | 'desc';
+  @Input() start: 'asc' | 'desc';
 
   /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
   @Input()

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -75,13 +75,13 @@ export class MatSort extends _MatSortMixinBase implements CanDisable, OnChanges,
 
   /** The sort direction of the currently active MatSortable. */
   @Input('matSortDirection')
+  get direction(): SortDirection { return this._direction; }
   set direction(direction: SortDirection) {
     if (isDevMode() && direction && direction !== 'asc' && direction !== 'desc') {
       throw getSortInvalidDirectionError(direction);
     }
     this._direction = direction;
   }
-  get direction(): SortDirection { return this._direction; }
   private _direction: SortDirection = '';
 
   /**

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -47,33 +47,25 @@ export class MatStepHeader implements OnDestroy {
   /** Index of the given step. */
   @Input()
   get index(): number { return this._index; }
-  set index(value: number) {
-    this._index = coerceNumberProperty(value);
-  }
+  set index(value: number) { this._index = coerceNumberProperty(value); }
   private _index: number;
 
   /** Whether the given step is selected. */
   @Input()
   get selected(): boolean { return this._selected; }
-  set selected(value: boolean) {
-    this._selected = coerceBooleanProperty(value);
-  }
+  set selected(value: boolean) { this._selected = coerceBooleanProperty(value); }
   private _selected: boolean;
 
   /** Whether the given step label is active. */
   @Input()
   get active(): boolean { return this._active; }
-  set active(value: boolean) {
-    this._active = coerceBooleanProperty(value);
-  }
+  set active(value: boolean) { this._active = coerceBooleanProperty(value); }
   private _active: boolean;
 
   /** Whether the given step is optional. */
   @Input()
   get optional(): boolean { return this._optional; }
-  set optional(value: boolean) {
-    this._optional = coerceBooleanProperty(value);
-  }
+  set optional(value: boolean) { this._optional = coerceBooleanProperty(value); }
   private _optional: boolean;
 
   constructor(

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -49,25 +49,25 @@ export class MatTableDataSource<T> implements DataSource<T> {
   filteredData: T[];
 
   /** Array of data that should be rendered by the table, where each object represents one row. */
-  set data(data: T[]) { this._data.next(data); }
   get data() { return this._data.value; }
+  set data(data: T[]) { this._data.next(data); }
 
   /**
    * Filter term that should be used to filter out objects from the data array. To override how
    * data objects match to this filter string, provide a custom function for filterPredicate.
    */
-  set filter(filter: string) { this._filter.next(filter); }
   get filter(): string { return this._filter.value; }
+  set filter(filter: string) { this._filter.next(filter); }
 
   /**
    * Instance of the MatSort directive used by the table to control its sorting. Sort changes
    * emitted by the MatSort will trigger an update to the table's rendered data.
    */
+  get sort(): MatSort | null { return this._sort; }
   set sort(sort: MatSort|null) {
     this._sort = sort;
     this._updateChangeSubscription();
   }
-  get sort(): MatSort|null { return this._sort; }
   private _sort: MatSort|null;
 
   /**
@@ -80,11 +80,11 @@ export class MatTableDataSource<T> implements DataSource<T> {
    * e.g. `[pageLength]=100` or `[pageIndex]=1`, then be sure that the paginator's view has been
    * initialized before assigning it to this data source.
    */
+  get paginator(): MatPaginator | null { return this._paginator; }
   set paginator(paginator: MatPaginator|null) {
     this._paginator = paginator;
     this._updateChangeSubscription();
   }
-  get paginator(): MatPaginator|null { return this._paginator; }
   private _paginator: MatPaginator|null;
 
   /**

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -134,8 +134,8 @@ export class MatTabBody implements OnInit {
   @Input('content') _content: TemplatePortal<any>;
 
   /** The shifted index position of the tab body, where zero represents the active center tab. */
-  _position: MatTabBodyPositionState;
-  @Input('position') set position(position: number) {
+  @Input()
+  set position(position: number) {
     if (position < 0) {
       this._position = this._getLayoutDirection() == 'ltr' ? 'left' : 'right';
     } else if (position > 0) {
@@ -144,12 +144,11 @@ export class MatTabBody implements OnInit {
       this._position = 'center';
     }
   }
+  _position: MatTabBodyPositionState;
 
   /** The origin position from which this tab should appear when it is centered into view. */
-  _origin: MatTabBodyOriginState;
-
-  /** The origin position from which this tab should appear when it is centered into view. */
-  @Input('origin') set origin(origin: number) {
+  @Input()
+  set origin(origin: number) {
     if (origin == null) { return; }
 
     const dir = this._getLayoutDirection();
@@ -159,6 +158,7 @@ export class MatTabBody implements OnInit {
       this._origin = 'right';
     }
   }
+  _origin: MatTabBodyOriginState;
 
   constructor(private _elementRef: ElementRef,
               @Optional() private _dir: Directionality) { }

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -110,10 +110,10 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
 
   /** The index of the active tab. */
   @Input()
+  get selectedIndex(): number | null { return this._selectedIndex; }
   set selectedIndex(value: number | null) {
     this._indexToSelect = coerceNumberProperty(value, null);
   }
-  get selectedIndex(): number | null { return this._selectedIndex; }
   private _selectedIndex: number | null = null;
 
   /** Position of the tab header. */

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -310,6 +310,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
   }
 
   /** Sets the distance in pixels that the tab header should be transformed in the X-axis. */
+  get scrollDistance(): number { return this._scrollDistance; }
   set scrollDistance(v: number) {
     this._scrollDistance = Math.max(0, Math.min(this._getMaxScrollDistance(), v));
 
@@ -318,7 +319,6 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this._scrollDistanceChanged = true;
     this._checkScrollingControls();
   }
-  get scrollDistance(): number { return this._scrollDistance; }
 
   /**
    * Moves the tab list in the 'before' or 'after' direction (towards the beginning of the list or

--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
@@ -44,18 +44,14 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
     return !n.area && !n.exchange && !n.subscriber;
   }
 
-  get shouldLabelFloat() {
-    return this.focused || !this.empty;
-  }
+  get shouldLabelFloat() { return this.focused || !this.empty; }
 
   id = `my-tel-input-${MyTelInput.nextId++}`;
 
   describedBy = '';
 
   @Input()
-  get placeholder() {
-    return this._placeholder;
-  }
+  get placeholder() { return this._placeholder; }
   set placeholder(plh) {
     this._placeholder = plh;
     this.stateChanges.next();
@@ -63,9 +59,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
   private _placeholder: string;
 
   @Input()
-  get required() {
-    return this._required;
-  }
+  get required() { return this._required; }
   set required(req) {
     this._required = coerceBooleanProperty(req);
     this.stateChanges.next();
@@ -73,9 +67,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
   private _required = false;
 
   @Input()
-  get disabled() {
-    return this._disabled;
-  }
+  get disabled() { return this._disabled; }
   set disabled(dis) {
     this._disabled = coerceBooleanProperty(dis);
     this.stateChanges.next();
@@ -97,7 +89,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
   }
 
   constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef) {
-    this.parts =  fb.group({
+    this.parts = fb.group({
       'area': '',
       'exchange': '',
       'subscriber': '',

--- a/tools/dgeni/processors/categorizer.ts
+++ b/tools/dgeni/processors/categorizer.ts
@@ -87,7 +87,7 @@ export class Categorizer implements Processor {
     if (isDirective(classDoc)) {
       classDoc.isDirective = true;
       classDoc.directiveExportAs = getMetadataProperty(classDoc, 'exportAs');
-      classDoc.directiveSelectors =  getDirectiveSelectors(classDoc);
+      classDoc.directiveSelectors = getDirectiveSelectors(classDoc);
     } else if (isService(classDoc)) {
       classDoc.isService = true;
     } else if (isNgModule(classDoc)) {

--- a/tools/screenshot-test/functions/screenshot-functions.ts
+++ b/tools/screenshot-test/functions/screenshot-functions.ts
@@ -55,14 +55,14 @@ const dataTypes = ['result', 'sha', 'travis'];
 /** The Json Web Token format. The token is stored in data path. */
 const jwtFormat = '{jwtHeader}/{jwtPayload}/{jwtSignature}';
 
-/** The temporary folder name for screenshot data that needs to be validated via JWT.  */
+/** The temporary folder name for screenshot data that needs to be validated via JWT. */
 const tempFolder = '/untrustedInbox';
 
 
 /** Untrusted report data for a PR */
 const reportPath = `${tempFolder}/screenshot/reports/{prNumber}/${jwtFormat}/`;
 /** Untrusted image data for a PR */
-const imagePath =  `${tempFolder}/screenshot/images/{prNumber}/${jwtFormat}/`;
+const imagePath = `${tempFolder}/screenshot/images/{prNumber}/${jwtFormat}/`;
 /** Trusted report data for a PR */
 const trustedReportPath = `screenshot/reports/{prNumber}`;
 

--- a/tools/screenshot-test/functions/util/github.ts
+++ b/tools/screenshot-test/functions/util/github.ts
@@ -22,7 +22,7 @@ export function setGithubStatus(commitSHA: string,
     description: statusData.description
   });
 
-  let headers =  {
+  let headers = {
     'Authorization': `token ${token}`,
     'User-Agent': `${statusData.name}/1.0`,
     'Content-Type': 'application/json'

--- a/tools/screenshot-test/src/app/result/result.component.ts
+++ b/tools/screenshot-test/src/app/result/result.component.ts
@@ -32,9 +32,7 @@ export class ResultComponent {
    * Test result, auto set collapse to be the same as the result value
    */
   @Input()
-  get result() {
-    return this._result;
-  }
+  get result() { return this._result; }
   set result(value: boolean) {
     this._result = value;
     this.collapse = value;
@@ -50,9 +48,7 @@ export class ResultComponent {
 
   /** Mode: the result card has three modes, flip, side by side, and diff */
   @Input()
-  get mode() {
-    return this._mode;
-  }
+  get mode() { return this._mode; }
   set mode(value: 'flip' | 'side-by-side' | 'diff') {
     this._mode = value;
     this.modeEvent.emit(value);
@@ -62,10 +58,7 @@ export class ResultComponent {
 
   /** When mode is "flip" whether we show the test image or the golden image */
   @Input()
-  get flipping() {
-    return this._flipping;
-  }
-
+  get flipping() { return this._flipping; }
   set flipping(value: boolean) {
     this._flipping = value;
     this.flippingEvent.emit(value);


### PR DESCRIPTION
This PR basically makes sure that _getters_ appear before _setters_. Why?

Apparently docs aren't being shown up if *setters* appear before *getters*, e.g.:
https://github.com/angular/material2/blob/7af132d51c0076033f2c32a80ccc01f95f2b8d51/src/lib/tabs/tab-group.ts#L112-L117

For reference: #9452.

**PS:**

Not sure about this, but I think it'd be great if we could create a custom rule to enforce the (apparently) standard convention:

- `getter`;
- `setter`;
- `_property`;