### PR TITLE
build: remove chrome sandbox workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: node_js
 dist: trusty
-
-# Temporary set sudo to required, because in normal container-based Travis jobs, the Chrome
-# binaries seem to be owned by root, and therefore can't be accessed by Karma. To workaround
-# the issue we temporary grant the CI sudo permissions.
-# https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
-sudo: required
+sudo: false
 
 node_js:
   # Use the explicit NodeJS LTS version 8.9.4 to avoid any automatic upgrade of the version.

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -37,6 +37,7 @@ const config = {
 
 if (process.env['TRAVIS']) {
   const key = require('../scripts/saucelabs/sauce_config');
+
   config.sauceUser = process.env['SAUCE_USERNAME'];
   config.sauceKey = key;
   config.capabilities = {

--- a/test/remote_browsers.json
+++ b/test/remote_browsers.json
@@ -5,14 +5,18 @@
       "--window-size=1024,768"
     ]
   },
+  "ChromeHeadlessCI": {
+    "base": "ChromeHeadless",
+    "flags": [
+      "--window-size=1024,768",
+      "--no-sandbox"
+    ]
+  },
   "FirefoxHeadless": {
     "base": "Firefox",
     "flags": [
       "-headless"
     ]
-  },
-  "ChromeHeadlessCI": {
-    "base": "ChromeHeadlessLocal"
   },
   "SL_CHROME": {
     "base": "SauceLabs",


### PR DESCRIPTION
In order to align with the `angular/angular` setup, we also remove the temporary Chrome Headless Sandbox workaround in favor of faster Travis CI containers. To be able to still use headless chrome, we specify the `no-sandbox` flag.

Reference https://github.com/angular/angular/pull/21641