### PR TITLE
fix(stepper): header collapsing if box-sizing is set

### DIFF
--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -13,6 +13,7 @@ $mat-step-header-icon-size: 16px !default;
   outline: none;
   cursor: pointer;
   position: relative;
+  box-sizing: content-box;
 }
 
 .mat-step-optional {


### PR DESCRIPTION
Fixes the stepper header collapsing if the user has `box-sizing: border-box` set to everything.

Fixes #9501.