### PR TITLE
fix(overlay): attempting to position overlay if it was detached immediately after being attached

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -82,7 +82,10 @@ export class OverlayRef implements PortalOutlet {
     // before attempting to position it, as the position may depend on the size of the rendered
     // content.
     this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
-      this.updatePosition();
+      // The overlay could've been detached before the zone has stabilized.
+      if (this.hasAttached()) {
+        this.updatePosition();
+      }
     });
 
     // Enable pointer events for the overlay pane element.

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -255,6 +255,22 @@ describe('Overlay', () => {
 
       expect(overlayContainerElement.querySelectorAll('.fake-positioned').length).toBe(1);
     }));
+
+    it('should not apply the position if it detaches before the zone stabilizes', fakeAsync(() => {
+      config.positionStrategy = new FakePositionStrategy();
+
+      const overlayRef = overlay.create(config);
+
+      spyOn(config.positionStrategy, 'apply');
+
+      overlayRef.attach(componentPortal);
+      overlayRef.detach();
+      viewContainerFixture.detectChanges();
+      tick();
+
+      expect(config.positionStrategy.apply).not.toHaveBeenCalled();
+    }));
+
   });
 
   describe('size', () => {


### PR DESCRIPTION
Adds a check that ensures that the `OverlayRef` doesn't attempt to position itself if it was detached before the zone managed to stabilize. This manifested itself as an issue in the select where it could end up throwing an error, because the relevant nodes are no longer in the DOM.

Fixes #9406.