### PR TITLE
fix(datepicker): set border radius on calendar popup

### DIFF
--- a/src/lib/datepicker/datepicker-content.scss
+++ b/src/lib/datepicker/datepicker-content.scss
@@ -28,6 +28,7 @@ $mat-datepicker-touch-max-height: 788px;
   @include mat-elevation(8);
 
   display: block;
+  border-radius: 2px;
 
   .mat-calendar {
     width: $mat-datepicker-non-touch-calendar-width;


### PR DESCRIPTION
Adds a `border-radius` to the datepicker's calendar, in order to align it with all of the other overlays.