### PR TITLE
RxJS lettable operators are now called pipeable operators

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -127,7 +127,7 @@ class ConfigBuilder {
 ```
 
 #### RxJS
-When dealing with RxJS operators, import the lettable operator (e.g.
+When dealing with RxJS operators, import the pipeable operator (e.g.
 `import {map} from 'rxjs/operators/map'`), as opposed to using the "patch" imports which pollute the
 user's global Observable object (e.g. `import 'rxjs/add/operator/map'`):
 


### PR DESCRIPTION
As of RxJS v6.0.0-alpha.2 "lettable" operators are called pipeable:

https://github.com/ReactiveX/rxjs/blob/6.0.0-alpha.2/doc/lettable-operators.md