### PR TITLE
fix(native-date-adapter): avoid error when formatting edge case dates in IE11 and Edge

### DIFF
--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -359,6 +359,14 @@ describe('NativeDateAdapter', () => {
   it('should create an invalid date', () => {
     assertValidDate(adapter.invalid(), false);
   });
+
+  it('should not throw when attempting to format a date with a year less than 1', () => {
+    expect(() => adapter.format(new Date(-1, 1, 1), {})).not.toThrow();
+  });
+
+  it('should not throw when attempting to format a date with a year greater than 9999', () => {
+    expect(() => adapter.format(new Date(10000, 1, 1), {})).not.toThrow();
+  });
 });
 
 


### PR DESCRIPTION
Avoids an error that can crash the consumer's app on IE11 and Edge when attempting to format a date whose year is less than 1 or greater than 9999.