### PR TITLE
chore(dgeni): fix missing parameter type warning

### DIFF
--- a/src/cdk/a11y/list-key-manager.ts
+++ b/src/cdk/a11y/list-key-manager.ts
@@ -74,7 +74,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
    * Configures whether the key manager should be able to move the selection vertically.
    * @param enabled Whether vertical selection should be enabled.
    */
-  withVerticalOrientation(enabled = true): this {
+  withVerticalOrientation(enabled: boolean = true): this {
     this._vertical = enabled;
     return this;
   }


### PR DESCRIPTION
* Fixes a Dgeni missing parameter type warning (`Missing parameter type information (enabled = true) in cdk/a11y/list-key-manager.ts`).