### PR TITLE
chore: additional files for examples are missing

### DIFF
--- a/src/material-examples/example-data.ts
+++ b/src/material-examples/example-data.ts
@@ -6,16 +6,27 @@ import {EXAMPLE_COMPONENTS} from './example-module';
  *   with information about Component name, selector, files used in example, and path to examples
  */
 export class ExampleData {
-  // TODO: figure out how do we get these variables.
-  description = 'Some description for material';
-  // TODO: use real example and delete the example/ folder.
-  examplePath = '/assets/example/';
-  exampleFiles = ['button-demo.html', 'button-demo.scss', 'button-demo.ts'];
 
-  // TODO: extract these variables from example code.
-  selectorName = 'button-demo';
-  indexFilename = 'button-demo';
-  componentName = 'ButtonDemo';
+  /** Description of the example. */
+  description: string;
+
+  /** Path to the example. This is based on the structure of the material.angular.io repo. */
+  examplePath: string;
+
+  /** List of files that are part of this example. */
+  exampleFiles: string[];
+
+  /** Selector name of the example component. */
+  selectorName: string;
+
+  /** Name of the file that contains the example component. */
+  indexFilename: string;
+
+  /**
+   * Name of the example component. For examples with multiple components, this property will
+   * include multiple components that are comma separated (e.g. dialog-overview)
+   */
+  componentName: string;
 
   constructor(example: string) {
     if (!example || !EXAMPLE_COMPONENTS.hasOwnProperty(example)) {
@@ -23,20 +34,14 @@ export class ExampleData {
     }
 
     const exampleConfig = EXAMPLE_COMPONENTS[example];
-    const exampleFilesSet = new Set(['html', 'ts', 'css'].map(extension => {
-      return `${example}-example.${extension}`;
-    }));
 
     // TODO(tinayuangao): Do not hard-code extensions
     this.exampleFiles = ['html', 'ts', 'css'].map(extension => `${example}-example.${extension}`);
     this.examplePath = `/assets/stackblitz/examples/${example}/`;
-    this.exampleFiles = Array.from(exampleFilesSet.values());
     this.selectorName = this.indexFilename = `${example}-example`;
 
     if (exampleConfig.additionalFiles) {
-      for (let file of exampleConfig.additionalFiles) {
-        exampleFilesSet.add(file);
-      }
+      this.exampleFiles.push(...exampleConfig.additionalFiles);
     }
 
     const exampleName = example.replace(/(?:^\w|\b\w)/g, letter => letter.toUpperCase());


### PR DESCRIPTION
* Due to recent changes to the `example-data` file, the `ExampleData` class accidentally no longer adds the additional files to the `exampleFiles` property. This means that those files aren't copied over to StackBlitz.
* Cleans up the example data file.

Fixes #9541.