### PR TITLE
Revert "fix(button): incorrect text color when no color is passed in …

### DIFF
--- a/src/lib/button/_button-theme.scss
+++ b/src/lib/button/_button-theme.scss
@@ -77,7 +77,6 @@
 
   .mat-button, .mat-icon-button {
     background: transparent;
-    color: mat-color($foreground, text);
 
     @include _mat-button-focus-color($theme);
     @include _mat-button-theme-color($theme, 'color');


### PR DESCRIPTION
…on dark theme"

This reverts commit cd2b6df2b1d75ee3ee635cdb1fbdcbea25670a91.


Temporarily reverting this so we can redo it with a fix for buttons inside toolbars (and possibly other colored backgrounds).