### PR TITLE
docs: add types to public methods and getters/setters

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -78,14 +78,21 @@ export class CdkDialogContainer extends BasePortalOutlet {
   // metadata is not inherited by child classes, instead the host binding data is defined in a way
   // that can be inherited.
   // tslint:disable:no-host-decorator-in-concrete
-  @HostBinding('attr.aria-label') get _ariaLabel() { return this._config.ariaLabel || null; }
+  @HostBinding('attr.aria-label')
+  get _ariaLabel(): string | null { return this._config.ariaLabel || null; }
 
   @HostBinding('attr.aria-describedby')
-  get _ariaDescribedBy() { return this._config ? this._config.ariaDescribedBy : null; }
+  get _ariaDescribedBy(): string | null | undefined {
+    return this._config ? this._config.ariaDescribedBy : null;
+  }
 
-  @HostBinding('attr.role') get _role() { return this._config ? this._config.role : null; }
+  @HostBinding('attr.role')
+  get _role(): string | null | undefined {
+    return this._config ? this._config.role : null;
+  }
 
-  @HostBinding('attr.tabindex') get _tabindex() { return -1; }
+  @HostBinding('attr.tabindex')
+  get _tabindex(): number { return -1; }
   // tslint:disable:no-host-decorator-in-concrete
 
   /** The portal host inside of this container into which the dialog content will be loaded. */

--- a/src/cdk/a11y/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor.ts
@@ -373,7 +373,7 @@ export class FocusMonitor implements OnDestroy {
 })
 export class CdkMonitorFocus implements OnDestroy {
   private _monitorSubscription: Subscription;
-  @Output() cdkFocusChange = new EventEmitter<FocusOrigin>();
+  @Output() cdkFocusChange: EventEmitter<FocusOrigin> = new EventEmitter<FocusOrigin>();
 
   constructor(private _elementRef: ElementRef, private _focusMonitor: FocusMonitor) {
     this._monitorSubscription = this._focusMonitor.monitor(

--- a/src/cdk/a11y/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap.ts
@@ -57,7 +57,7 @@ export class FocusTrap {
   }
 
   /** Destroys the focus trap by cleaning up the anchors. */
-  destroy() {
+  destroy(): void {
     if (this._startAnchor && this._startAnchor.parentNode) {
       this._startAnchor.parentNode.removeChild(this._startAnchor);
     }

--- a/src/cdk/a11y/list-key-manager.ts
+++ b/src/cdk/a11y/list-key-manager.ts
@@ -70,7 +70,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   tabOut: Subject<void> = new Subject<void>();
 
   /** Stream that emits whenever the active item of the list manager changes. */
-  change = new Subject<number>();
+  change: Subject<number> = new Subject<number>();
 
   /**
    * Turns on wrapping mode, which ensures that the active item will wrap to

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -50,16 +50,16 @@ export class CdkAccordionItem implements OnDestroy {
 
   /** Whether the AccordionItem is expanded. */
   @Input()
-  get expanded(): any { return this._expanded; }
-  set expanded(expanded: any) {
-    expanded = coerceBooleanProperty(expanded);
+  get expanded(): boolean { return this._expanded; }
+  set expanded(value: boolean) {
+    value = coerceBooleanProperty(value);
 
     // Only emit events and update the internal value if the value changes.
-    if (this._expanded !== expanded) {
-      this._expanded = expanded;
-      this.expandedChange.emit(expanded);
+    if (this._expanded !== value) {
+      this._expanded = value;
+      this.expandedChange.emit(value);
 
-      if (expanded) {
+      if (value) {
         this.opened.emit();
         /**
          * In the unique selection dispatcher, the id parameter is the id of the CdkAccordionItem,

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -21,7 +21,7 @@ let nextId = 0;
 })
 export class CdkAccordion {
   /** A readonly id value to use for unique selection coordination. */
-  readonly id = `cdk-accordion-${nextId++}`;
+  readonly id: string = `cdk-accordion-${nextId++}`;
 
   /** Whether the accordion should allow multiple expanded accordion items simulateously. */
   @Input()

--- a/src/cdk/bidi/dir.ts
+++ b/src/cdk/bidi/dir.ts
@@ -30,13 +30,11 @@ import {Direction, Directionality} from './directionality';
   exportAs: 'dir',
 })
 export class Dir implements Directionality, AfterContentInit, OnDestroy {
-  _dir: Direction = 'ltr';
-
   /** Whether the `value` has been set to its initial value. */
   private _isInitialized: boolean = false;
 
   /** Event emitted when the direction changes. */
-  @Output('dirChange') change = new EventEmitter<Direction>();
+  @Output('dirChange') change: EventEmitter<Direction> = new EventEmitter<Direction>();
 
   /** @docs-private */
   @Input()
@@ -48,6 +46,7 @@ export class Dir implements Directionality, AfterContentInit, OnDestroy {
       this.change.emit(this._dir);
     }
   }
+  _dir: Direction = 'ltr';
 
   /** Current layout direction of the element. */
   get value(): Direction { return this.dir; }

--- a/src/cdk/bidi/directionality.ts
+++ b/src/cdk/bidi/directionality.ts
@@ -39,7 +39,7 @@ export class Directionality {
   readonly value: Direction = 'ltr';
 
   /** Stream that emits whenever the 'ltr' / 'rtl' state changes. */
-  readonly change = new EventEmitter<Direction>();
+  readonly change: EventEmitter<Direction> = new EventEmitter<Direction>();
 
   constructor(@Optional() @Inject(DIR_DOCUMENT) _document?: any) {
     if (_document) {

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -44,7 +44,8 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
   private _observer: MutationObserver | null;
 
   /** Event emitted for each change in the element's content. */
-  @Output('cdkObserveContent') event = new EventEmitter<MutationRecord[]>();
+  @Output('cdkObserveContent') event: EventEmitter<MutationRecord[]> =
+      new EventEmitter<MutationRecord[]>();
 
   /** Used for debouncing the emitted values to the observeContent event. */
   private _debouncer = new Subject<MutationRecord[]>();

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -94,14 +94,11 @@ export class CdkOverlayOrigin {
   exportAs: 'cdkConnectedOverlay'
 })
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
-  private _overlayRef: OverlayRef;
-  private _templatePortal: TemplatePortal;
-  private _hasBackdrop = false;
-  private _backdropSubscription = Subscription.EMPTY;
-  private _positionSubscription = Subscription.EMPTY;
-  private _offsetX: number = 0;
-  private _offsetY: number = 0;
-  private _position: ConnectedPositionStrategy;
+private _overlayRef: OverlayRef;
+private _templatePortal: TemplatePortal;
+private _backdropSubscription = Subscription.EMPTY;
+private _positionSubscription = Subscription.EMPTY;
+private _position: ConnectedPositionStrategy;
 
   /** Origin for the connected overlay. */
   @Input('cdkConnectedOverlayOrigin') origin: CdkOverlayOrigin;
@@ -112,22 +109,24 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   /** The offset in pixels for the overlay connection point on the x-axis */
   @Input('cdkConnectedOverlayOffsetX')
   get offsetX(): number { return this._offsetX; }
-  set offsetX(offsetX: number) {
-    this._offsetX = offsetX;
+  set offsetX(value: number) {
+    this._offsetX = value;
     if (this._position) {
-      this._position.withOffsetX(offsetX);
+      this._position.withOffsetX(value);
     }
   }
+  private _offsetX: number = 0;
 
   /** The offset in pixels for the overlay connection point on the y-axis */
   @Input('cdkConnectedOverlayOffsetY')
-  get offsetY() { return this._offsetY; }
-  set offsetY(offsetY: number) {
-    this._offsetY = offsetY;
+  get offsetY(): number { return this._offsetY; }
+  set offsetY(value: number) {
+    this._offsetY = value;
     if (this._position) {
-      this._position.withOffsetY(offsetY);
+      this._position.withOffsetY(value);
     }
   }
+  private _offsetY: number = 0;
 
   /** The width of the overlay panel. */
   @Input('cdkConnectedOverlayWidth') width: number | string;
@@ -153,8 +152,9 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
 
   /** Whether or not the overlay should attach a backdrop. */
   @Input('cdkConnectedOverlayHasBackdrop')
-  get hasBackdrop() { return this._hasBackdrop; }
-  set hasBackdrop(value: any) { this._hasBackdrop = coerceBooleanProperty(value); }
+  get hasBackdrop(): boolean { return this._hasBackdrop; }
+  set hasBackdrop(value: boolean) { this._hasBackdrop = coerceBooleanProperty(value); }
+  private _hasBackdrop = false;
 
   /**
    * @deprecated
@@ -162,7 +162,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('origin')
   get _deprecatedOrigin(): CdkOverlayOrigin { return this.origin; }
-  set _deprecatedOrigin(_origin: CdkOverlayOrigin) { this.origin = _origin; }
+  set _deprecatedOrigin(value: CdkOverlayOrigin) { this.origin = value; }
 
   /**
    * @deprecated
@@ -170,7 +170,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('positions')
   get _deprecatedPositions(): ConnectionPositionPair[] { return this.positions; }
-  set _deprecatedPositions(_positions: ConnectionPositionPair[]) { this.positions = _positions; }
+  set _deprecatedPositions(value: ConnectionPositionPair[]) { this.positions = value; }
 
   /**
    * @deprecated
@@ -178,7 +178,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('offsetX')
   get _deprecatedOffsetX(): number { return this.offsetX; }
-  set _deprecatedOffsetX(_offsetX: number) { this.offsetX = _offsetX; }
+  set _deprecatedOffsetX(value: number) { this.offsetX = value; }
 
   /**
    * @deprecated
@@ -186,7 +186,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('offsetY')
   get _deprecatedOffsetY(): number { return this.offsetY; }
-  set _deprecatedOffsetY(_offsetY: number) { this.offsetY = _offsetY; }
+  set _deprecatedOffsetY(value: number) { this.offsetY = value; }
 
   /**
    * @deprecated
@@ -194,7 +194,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('width')
   get _deprecatedWidth(): number | string { return this.width; }
-  set _deprecatedWidth(_width: number | string) { this.width = _width; }
+  set _deprecatedWidth(value: number | string) { this.width = value; }
 
   /**
    * @deprecated
@@ -202,7 +202,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('height')
   get _deprecatedHeight(): number | string { return this.height; }
-  set _deprecatedHeight(_height: number | string) { this.height = _height; }
+  set _deprecatedHeight(value: number | string) { this.height = value; }
 
   /**
    * @deprecated
@@ -210,7 +210,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('minWidth')
   get _deprecatedMinWidth(): number | string { return this.minWidth; }
-  set _deprecatedMinWidth(_minWidth: number | string) { this.minWidth = _minWidth; }
+  set _deprecatedMinWidth(value: number | string) { this.minWidth = value; }
 
   /**
    * @deprecated
@@ -218,7 +218,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('minHeight')
   get _deprecatedMinHeight(): number | string { return this.minHeight; }
-  set _deprecatedMinHeight(_minHeight: number | string) { this.minHeight = _minHeight; }
+  set _deprecatedMinHeight(value: number | string) { this.minHeight = value; }
 
   /**
    * @deprecated
@@ -226,7 +226,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('backdropClass')
   get _deprecatedBackdropClass(): string { return this.backdropClass; }
-  set _deprecatedBackdropClass(_backdropClass: string) { this.backdropClass = _backdropClass; }
+  set _deprecatedBackdropClass(value: string) { this.backdropClass = value; }
 
   /**
    * @deprecated
@@ -234,9 +234,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('scrollStrategy')
   get _deprecatedScrollStrategy(): ScrollStrategy { return this.scrollStrategy; }
-  set _deprecatedScrollStrategy(_scrollStrategy: ScrollStrategy) {
-    this.scrollStrategy = _scrollStrategy;
-  }
+  set _deprecatedScrollStrategy(value: ScrollStrategy) { this.scrollStrategy = value; }
 
   /**
    * @deprecated
@@ -244,27 +242,28 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
    */
   @Input('open')
   get _deprecatedOpen(): boolean { return this.open; }
-  set _deprecatedOpen(_open: boolean) { this.open = _open; }
+  set _deprecatedOpen(value: boolean) { this.open = value; }
 
   /**
    * @deprecated
    * @deletion-target 6.0.0
    */
   @Input('hasBackdrop')
-  get _deprecatedHasBackdrop() { return this.hasBackdrop; }
-  set _deprecatedHasBackdrop(_hasBackdrop: any) { this.hasBackdrop = _hasBackdrop; }
+  get _deprecatedHasBackdrop(): boolean { return this.hasBackdrop; }
+  set _deprecatedHasBackdrop(value: boolean) { this.hasBackdrop = value; }
 
   /** Event emitted when the backdrop is clicked. */
-  @Output() backdropClick = new EventEmitter<void>();
+  @Output() backdropClick: EventEmitter<void> = new EventEmitter<void>();
 
   /** Event emitted when the position has changed. */
-  @Output() positionChange = new EventEmitter<ConnectedOverlayPositionChange>();
+  @Output() positionChange: EventEmitter<ConnectedOverlayPositionChange> =
+      new EventEmitter<ConnectedOverlayPositionChange>();
 
   /** Event emitted when the overlay has been attached. */
-  @Output() attach = new EventEmitter<void>();
+  @Output() attach: EventEmitter<void> = new EventEmitter<void>();
 
   /** Event emitted when the overlay has been detached. */
-  @Output() detach = new EventEmitter<void>();
+  @Output() detach: EventEmitter<void> = new EventEmitter<void>();
 
   // TODO(jelbourn): inputs for size, scroll behavior, animation, etc.
 
@@ -278,14 +277,10 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 
   /** The associated overlay reference. */
-  get overlayRef(): OverlayRef {
-    return this._overlayRef;
-  }
+  get overlayRef(): OverlayRef { return this._overlayRef; }
 
   /** The element's layout direction. */
-  get dir(): Direction {
-    return this._dir ? this._dir.value : 'ltr';
-  }
+  get dir(): Direction { return this._dir ? this._dir.value : 'ltr'; }
 
   ngOnDestroy() {
     this._destroyOverlay();

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -203,20 +203,20 @@ export class OverlayRef implements PortalOutlet {
   }
 
   /** Updates the position of the overlay based on the position strategy. */
-  updatePosition() {
+  updatePosition(): void {
     if (this._config.positionStrategy) {
       this._config.positionStrategy.apply();
     }
   }
 
   /** Update the size properties of the overlay. */
-  updateSize(sizeConfig: OverlaySizeConfig) {
+  updateSize(sizeConfig: OverlaySizeConfig): void {
     this._config = {...this._config, ...sizeConfig};
     this._updateElementSize();
   }
 
   /** Sets the LTR/RTL direction for the overlay. */
-  setDirection(dir: Direction) {
+  setDirection(dir: Direction): void {
     this._config = {...this._config, direction: dir};
     this._updateElementDirection();
   }

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -52,9 +52,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   private _resizeSubscription = Subscription.EMPTY;
 
   /** Whether the we're dealing with an RTL context */
-  get _isRtl() {
-    return this._dir === 'rtl';
-  }
+  get _isRtl() { return this._dir === 'rtl'; }
 
   /** Ordered list of preferred positions, from most to least desirable. */
   _preferredPositions: ConnectionPositionPair[] = [];
@@ -105,13 +103,13 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   }
 
   /** Disposes all resources used by the position strategy. */
-  dispose() {
+  dispose(): void {
     this._applied = false;
     this._resizeSubscription.unsubscribe();
   }
 
   /** @docs-private */
-  detach() {
+  detach(): void {
     this._applied = false;
     this._resizeSubscription.unsubscribe();
   }

--- a/src/cdk/overlay/scroll/block-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.ts
@@ -20,10 +20,10 @@ export class BlockScrollStrategy implements ScrollStrategy {
   constructor(private _viewportRuler: ViewportRuler) { }
 
   /** Attaches this scroll strategy to an overlay. */
-  attach() { }
+  attach(): void { }
 
   /** Blocks page-level scroll while the attached overlay is open. */
-  enable() {
+  enable(): void {
     if (this._canBeEnabled()) {
       const root = document.documentElement;
 
@@ -43,7 +43,7 @@ export class BlockScrollStrategy implements ScrollStrategy {
   }
 
   /** Unblocks page-level scroll while the attached overlay is open. */
-  disable() {
+  disable(): void {
     if (this._isEnabled) {
       const html = document.documentElement;
       const body = document.body;

--- a/src/cdk/overlay/scroll/close-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.ts
@@ -43,7 +43,7 @@ export class CloseScrollStrategy implements ScrollStrategy {
   }
 
   /** Enables the closing of the attached overlay on scroll. */
-  enable() {
+  enable(): void {
     if (this._scrollSubscription) {
       return;
     }
@@ -68,7 +68,7 @@ export class CloseScrollStrategy implements ScrollStrategy {
   }
 
   /** Disables the closing the attached overlay on scroll. */
-  disable() {
+  disable(): void {
     if (this._scrollSubscription) {
       this._scrollSubscription.unsubscribe();
       this._scrollSubscription = null;

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -73,22 +73,19 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
    * @deletion-target 6.0.0
    */
   @Input('portalHost')
-  get _deprecatedPortal() { return this.portal; }
-  set _deprecatedPortal(v) { this.portal = v; }
+  get _deprecatedPortal(): Portal<any> | null { return this.portal; }
+  set _deprecatedPortal(value: Portal<any> | null) { this.portal = value; }
 
   /**
    * @deprecated
    * @deletion-target 6.0.0
    */
   @Input('cdkPortalHost')
-  get _deprecatedPortalHost() { return this.portal; }
-  set _deprecatedPortalHost(v) { this.portal = v; }
+  get _deprecatedPortalHost(): Portal<any> | null { return this.portal; }
+  set _deprecatedPortalHost(value: Portal<any> | null) { this.portal = value; }
 
   /** Portal associated with the Portal outlet. */
-  get portal(): Portal<any> | null {
-    return this._attachedPortal;
-  }
-
+  get portal(): Portal<any> | null { return this._attachedPortal; }
   set portal(portal: Portal<any> | null) {
     // Ignore the cases where the `portal` is set to a falsy value before the lifecycle hooks have
     // run. This handles the cases where the user might do something like `<div cdkPortalOutlet>`
@@ -109,13 +106,11 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
     this._attachedPortal = portal;
   }
 
-  @Output('attached') attached: EventEmitter<CdkPortalOutletAttachedRef> =
+  @Output() attached: EventEmitter<CdkPortalOutletAttachedRef> =
       new EventEmitter<CdkPortalOutletAttachedRef>();
 
   /** Component or view reference that is attached to the portal. */
-  get attachedRef(): CdkPortalOutletAttachedRef {
-    return this._attachedRef;
-  }
+  get attachedRef(): CdkPortalOutletAttachedRef { return this._attachedRef; }
 
   ngOnInit() {
     this._isInitialized = true;

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -79,7 +79,7 @@ export class ViewportRuler implements OnDestroy {
   }
 
   /** Gets the (top, left) scroll position of the viewport. */
-  getViewportScrollPosition() {
+  getViewportScrollPosition(): {left: number, top: number} {
     // The top-left-corner of the viewport is determined by the scroll position of the document
     // body, normally just (scrollLeft, scrollTop). However, Chrome and Firefox disagree about
     // whether `document.body` or `document.documentElement` is the scrolled element, so reading

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -162,7 +162,7 @@ export class CdkStepper implements OnDestroy {
 
   /** The index of the selected step. */
   @Input()
-  get selectedIndex() { return this._selectedIndex; }
+  get selectedIndex(): number { return this._selectedIndex; }
   set selectedIndex(index: number) {
     if (this._steps) {
       if (this._anyControlsInvalidOrPending(index) || index < this._selectedIndex &&

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -645,7 +645,7 @@ interface TestData {
 class FakeDataSource extends DataSource<TestData> {
   isConnected = false;
 
-  get data() { return this._dataChange.getValue(); }
+  get data(): TestData[] { return this._dataChange.getValue(); }
   set data(data: TestData[]) { this._dataChange.next(data); }
   _dataChange = new BehaviorSubject<TestData[]>([]);
 

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -118,7 +118,6 @@ export function getMatAutocompleteMissingPanelError(): Error {
 export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   private _overlayRef: OverlayRef | null;
   private _portal: TemplatePortal;
-  private _panelOpen: boolean = false;
   private _componentDestroyed = false;
 
   /** Strategy that is used to position the panel. */
@@ -158,9 +157,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   /** Whether or not the autocomplete panel is open. */
-  get panelOpen(): boolean {
-    return this._panelOpen && this.autocomplete.showPanel;
-  }
+  get panelOpen(): boolean { return this._panelOpen && this.autocomplete.showPanel; }
+  private _panelOpen: boolean = false;
 
   /** Opens the autocomplete suggestion panel. */
   openPanel(): void {

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -75,12 +75,10 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   _keyManager: ActiveDescendantKeyManager<MatOption>;
 
   /** Whether the autocomplete panel should be visible, depending on option length. */
-  showPanel = false;
+  showPanel: boolean = false;
 
   /** Whether the autocomplete panel is open. */
-  get isOpen(): boolean {
-    return this._isOpen && this.showPanel;
-  }
+  get isOpen(): boolean { return this._isOpen && this.showPanel; }
   _isOpen: boolean = false;
 
   /** @docs-private */
@@ -107,9 +105,9 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
    * inside the overlay container to allow for easy styling.
    */
   @Input('class')
-  set classList(classList: string) {
-    if (classList && classList.length) {
-      classList.split(' ').forEach(className => this._classList[className.trim()] = true);
+  set classList(value: string) {
+    if (value && value.length) {
+      value.split(' ').forEach(className => this._classList[className.trim()] = true);
       this._elementRef.nativeElement.className = '';
     }
   }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -73,19 +73,6 @@ export class MatButtonToggleChange {
 })
 export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     implements ControlValueAccessor, CanDisable {
-
-  /** The value for the button toggle group. Should match currently selected button toggle. */
-  private _value: any = null;
-
-  /** The HTML name attribute applied to toggles in this group. */
-  private _name: string = `mat-button-toggle-group-${_uniqueIdCounter++}`;
-
-  /** Whether the button toggle group should be vertical. */
-  private _vertical: boolean = false;
-
-  /** The currently selected button toggle, should match the value. */
-  private _selected: MatButtonToggle | null = null;
-
   /**
    * The method to be called in order to update ngModel.
    * Now `ngModel` binding is not supported in multiple selection mode.
@@ -105,31 +92,34 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     this._name = value;
     this._updateButtonToggleNames();
   }
+  private _name: string = `mat-button-toggle-group-${_uniqueIdCounter++}`;
 
   /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean { return this._vertical; }
   set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
+  private _vertical: boolean = false;
 
   /** Value of the toggle group. */
   @Input()
   get value(): any { return this._value; }
-  set value(newValue: any) {
-    if (this._value != newValue) {
-      this._value = newValue;
-      this.valueChange.emit(newValue);
+  set value(value: any) {
+    if (this._value != value) {
+      this._value = value;
+      this.valueChange.emit(value);
       this._updateSelectedButtonToggleFromValue();
     }
   }
+  private _value: any = null;
 
   /**
    * Event that emits whenever the value of the group changes.
    * Used to facilitate two-way data binding.
    * @docs-private
    */
-  @Output() valueChange = new EventEmitter<any>();
+  @Output() valueChange: EventEmitter<any> = new EventEmitter<any>();
 
-  /** Whether the toggle group is selected. */
+  /** The currently selected button toggle, should match the value. */
   @Input()
   get selected(): MatButtonToggle | null { return this._selected; }
   set selected(selected: MatButtonToggle | null) {
@@ -140,6 +130,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
       selected.checked = true;
     }
   }
+  private _selected: MatButtonToggle | null = null;
 
   /** Event emitted when the group's value changes. */
   @Output() change: EventEmitter<MatButtonToggleChange> = new EventEmitter<MatButtonToggleChange>();
@@ -240,16 +231,11 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 })
 export class MatButtonToggleGroupMultiple extends _MatButtonToggleGroupMixinBase
     implements CanDisable {
-
-  /** Whether the button toggle group should be vertical. */
-  private _vertical: boolean = false;
-
   /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean { return this._vertical; }
-  set vertical(value) {
-    this._vertical = coerceBooleanProperty(value);
-  }
+  set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
+  private _vertical: boolean = false;
 }
 
 /** Single button inside of a toggle group. */
@@ -282,17 +268,8 @@ export class MatButtonToggle implements OnInit, OnDestroy {
    */
   @Input('aria-labelledby') ariaLabelledby: string | null = null;
 
-  /** Whether or not this button toggle is checked. */
-  private _checked: boolean = false;
-
   /** Type of the button toggle. Either 'radio' or 'checkbox'. */
   _type: ToggleType;
-
-  /** Whether or not this button toggle is disabled. */
-  private _disabled: boolean = false;
-
-  /** Value assigned to this button toggle. */
-  private _value: any = null;
 
   /** Whether or not the button toggle is a single selection. */
   private _isSingleSelector: boolean = false;
@@ -320,19 +297,20 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   /** Whether the button is checked. */
   @Input()
   get checked(): boolean { return this._checked; }
-  set checked(newCheckedState: boolean) {
-    if (this._isSingleSelector && newCheckedState) {
+  set checked(value: boolean) {
+    if (this._isSingleSelector && value) {
       // Notify all button toggles with the same name (in the same group) to un-check.
       this._buttonToggleDispatcher.notify(this.id, this.name);
       this._changeDetectorRef.markForCheck();
     }
 
-    this._checked = newCheckedState;
+    this._checked = value;
 
-    if (newCheckedState && this._isSingleSelector && this.buttonToggleGroup.value != this.value) {
+    if (value && this._isSingleSelector && this.buttonToggleGroup.value != this.value) {
       this.buttonToggleGroup.selected = this;
     }
   }
+  private _checked: boolean = false;
 
   /** MatButtonToggleGroup reads this to assign its own value. */
   @Input()
@@ -345,6 +323,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
       this._value = value;
     }
   }
+  private _value: any = null;
 
   /** Whether the button is disabled. */
   @Input()
@@ -352,9 +331,8 @@ export class MatButtonToggle implements OnInit, OnDestroy {
     return this._disabled || (this.buttonToggleGroup != null && this.buttonToggleGroup.disabled) ||
         (this.buttonToggleGroupMultiple != null && this.buttonToggleGroupMultiple.disabled);
   }
-  set disabled(value: boolean) {
-    this._disabled = coerceBooleanProperty(value);
-  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled: boolean = false;
 
   /** Event emitted when the group value changes. */
   @Output() change: EventEmitter<MatButtonToggleChange> = new EventEmitter<MatButtonToggleChange>();
@@ -401,7 +379,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   }
 
   /** Focuses the button. */
-  focus() {
+  focus(): void {
     this._inputElement.nativeElement.focus();
   }
 
@@ -452,7 +430,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   }
 
   // Unregister buttonToggleDispatcherListener on destroy
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this._removeUniqueSelectionListener();
   }
 

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -137,12 +137,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
-  private _required: boolean;
-
   /** Whether the checkbox is required. */
   @Input()
   get required(): boolean { return this._required; }
-  set required(value) { this._required = coerceBooleanProperty(value); }
+  set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  private _required: boolean;
 
   /**
    * Whether or not the checkbox should appear before or after the label.
@@ -155,8 +154,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
+  set align(value: 'start' | 'end') {
+    this.labelPosition = (value == 'start') ? 'after' : 'before';
   }
 
   /** Whether the label should appear after or before the checkbox. Defaults to 'after' */
@@ -184,15 +183,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor.
    * @docs-private
    */
-  onTouched: () => any = () => {};
+  _onTouched: () => any = () => {};
 
   private _currentAnimationClass: string = '';
 
   private _currentCheckState: TransitionCheckState = TransitionCheckState.Init;
-
-  private _checked: boolean = false;
-
-  private _indeterminate: boolean = false;
 
   private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
@@ -224,13 +219,14 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * Whether the checkbox is checked.
    */
   @Input()
-  get checked() { return this._checked; }
-  set checked(checked: boolean) {
-    if (checked != this.checked) {
-      this._checked = checked;
+  get checked(): boolean { return this._checked; }
+  set checked(value: boolean) {
+    if (value != this.checked) {
+      this._checked = value;
       this._changeDetectorRef.markForCheck();
     }
   }
+  private _checked: boolean = false;
 
   /**
    * Whether the checkbox is indeterminate. This is also known as "mixed" mode and can be used to
@@ -239,10 +235,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * set to false.
    */
   @Input()
-  get indeterminate() { return this._indeterminate; }
-  set indeterminate(indeterminate: boolean) {
-    let changed =  indeterminate != this._indeterminate;
-    this._indeterminate = indeterminate;
+  get indeterminate(): boolean { return this._indeterminate; }
+  set indeterminate(value: boolean) {
+    const changed = value != this._indeterminate;
+    this._indeterminate = value;
 
     if (changed) {
       if (this._indeterminate) {
@@ -254,6 +250,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       this.indeterminateChange.emit(this._indeterminate);
     }
   }
+  private _indeterminate: boolean = false;
 
   _isRippleDisabled() {
     return this.disableRipple || this.disabled;
@@ -290,7 +287,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * @param fn Callback to be triggered when the checkbox is touched.
    */
   registerOnTouched(fn: any) {
-    this.onTouched = fn;
+    this._onTouched = fn;
   }
 
   /**
@@ -341,7 +338,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       this._focusRipple = this.ripple.launch(0, 0, {persistent: true});
     } else if (!focusOrigin) {
       this._removeFocusRipple();
-      this.onTouched();
+      this._onTouched();
     }
   }
 

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -37,6 +37,7 @@ export interface MatChipInputEvent {
   }
 })
 export class MatChipInput {
+  /** Whether the control is focused. */
   focused: boolean = false;
   _chipList: MatChipList;
 
@@ -73,10 +74,7 @@ export class MatChipInput {
   @Input() placeholder: string = '';
 
   /** Whether the input is empty. */
-  get empty(): boolean {
-    let value: string | null = this._inputElement.value;
-    return (value == null || value === '');
-  }
+  get empty(): boolean { return !this._inputElement.value; }
 
   /** The native input element to which this directive is attached. */
   protected _inputElement: HTMLInputElement;
@@ -127,5 +125,6 @@ export class MatChipInput {
     this._chipList.stateChanges.next();
   }
 
+  /** Focuses the input. */
   focus(): void { this._inputElement.focus(); }
 }

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -50,6 +50,7 @@ export class MatChipListBase {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
+              /** @docs-private */
               public ngControl: NgControl) {}
 }
 export const _MatChipListMixinBase = mixinErrorState(MatChipListBase);
@@ -100,8 +101,12 @@ export class MatChipListChange {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MatChipList extends _MatChipListMixinBase implements MatFormFieldControl<any>,
-    ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
-  readonly controlType = 'mat-chip-list';
+  ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  readonly controlType: string = 'mat-chip-list';
 
   /** When a chip is destroyed, we track the index so we can focus the appropriate next chip. */
   protected _lastDestroyedIndex: number|null = null;
@@ -116,42 +121,22 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   private _changeSubscription: Subscription;
 
   /** Subscription to focus changes in the chips. */
-  private _chipFocusSubscription: Subscription|null;
+  private _chipFocusSubscription: Subscription | null;
 
   /** Subscription to blur changes in the chips. */
-  private _chipBlurSubscription: Subscription|null;
+  private _chipBlurSubscription: Subscription | null;
 
   /** Subscription to selection changes in chips. */
-  private _chipSelectionSubscription: Subscription|null;
+  private _chipSelectionSubscription: Subscription | null;
 
   /** Subscription to remove changes in chips. */
-  private _chipRemoveSubscription: Subscription|null;
-
-  /** Whether or not the chip is selectable. */
-  protected _selectable: boolean = true;
-
-  /** Whether the component is in multiple selection mode. */
-  private _multiple: boolean = false;
+  private _chipRemoveSubscription: Subscription | null;
 
   /** The chip input to add more chips */
   protected _chipInput: MatChipInput;
 
-  /** Id of the chip list */
-  protected _id: string;
-
   /** Uid of the chip list */
   protected _uid: string = `mat-chip-list-${nextUniqueId++}`;
-
-  /** Whether this is required */
-  protected _required: boolean = false;
-
-  /** Whether this is disabled */
-  protected _disabled: boolean = false;
-
-  protected _value: any;
-
-  /** Placeholder for the chip list. Alternatively, placeholder can be set on MatChipInput */
-  protected _placeholder: string;
 
   /** The aria-describedby attribute on the chip list for improved a11y. */
   _ariaDescribedby: string;
@@ -176,17 +161,13 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
   _selectionModel: SelectionModel<MatChip>;
 
-  /** Comparison function to specify which option is displayed. Defaults to object equality. */
-  private _compareWith = (o1: any, o2: any) => o1 === o2;
-
   /** The array of selected chips inside chip list. */
   get selected(): MatChip[] | MatChip {
     return this.multiple ? this._selectionModel.selected : this._selectionModel.selected[0];
   }
 
-  get role(): string|null {
-    return this.empty ? null : 'listbox';
-  }
+  /** The ARIA role applied to the chip list. */
+  get role(): string | null { return this.empty ? null : 'listbox'; }
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;
@@ -197,6 +178,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   set multiple(value: boolean) {
     this._multiple = coerceBooleanProperty(value);
   }
+  private _multiple: boolean = false;
 
   /**
    * A function to compare the option values with the selected values. The first argument
@@ -204,7 +186,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
    * should be returned.
    */
   @Input()
-  get compareWith() { return this._compareWith; }
+  get compareWith(): (o1: any, o2: any) => boolean { return this._compareWith; }
   set compareWith(fn: (o1: any, o2: any) => boolean) {
     this._compareWith = fn;
     if (this._selectionModel) {
@@ -212,32 +194,45 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
       this._initializeSelection();
     }
   }
+  private _compareWith = (o1: any, o2: any) => o1 === o2;
 
   /** Required for FormFieldControl */
   @Input()
-  get value() { return this._value; }
-  set value(newValue: any) {
-    this.writeValue(newValue);
-    this._value = newValue;
+  get value(): any { return this._value; }
+  set value(value: any) {
+    this.writeValue(value);
+    this._value = value;
   }
+  protected _value: any;
 
-  /** Required for FormFieldControl. The ID of the chip list */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get id(): string { return this._id || this._uid; }
   set id(value: string) {
     this._id = value;
     this.stateChanges.next();
   }
+  protected _id: string;
 
-  /** Required for FormFieldControl. Whether the chip list is required. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get required(): boolean { return this._required; }
   set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
+  protected _required: boolean = false;
 
-  /** For FormFieldControl. Use chip input's placholder if there's a chip input */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get placeholder(): string {
     return this._chipInput ? this._chipInput.placeholder : this._placeholder;
@@ -246,6 +241,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     this._placeholder = value;
     this.stateChanges.next();
   }
+  protected _placeholder: string;
 
   /** Whether any chips or the matChipInput inside of this chip-list has focus. */
   get focused(): boolean {
@@ -253,19 +249,28 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
       (this._chipInput && this._chipInput.focused);
   }
 
-  /** Whether this chip-list contains no chips and no matChipInput. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   get empty(): boolean {
     return (!this._chipInput || this._chipInput.empty) && this.chips.length === 0;
   }
 
-  /** @docs-private */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   get shouldLabelFloat(): boolean { return !this.empty || this.focused; }
 
-  /** Whether this chip-list is disabled. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
-  get disabled() { return this.ngControl ? this.ngControl.disabled : this._disabled; }
-  set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
-
+  get disabled(): boolean { return this.ngControl ? !!this.ngControl.disabled : this._disabled; }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  protected _disabled: boolean = false;
 
   /** Orientation of the chip list. */
   @Input('aria-orientation') ariaOrientation: 'horizontal' | 'vertical' = 'horizontal';
@@ -277,6 +282,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   @Input()
   get selectable(): boolean { return this._selectable; }
   set selectable(value: boolean) { this._selectable = coerceBooleanProperty(value); }
+  protected _selectable: boolean = true;
 
   @Input()
   set tabIndex(value: number) {
@@ -323,6 +329,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
               @Optional() _parentForm: NgForm,
               @Optional() _parentFormGroup: FormGroupDirective,
               _defaultErrorStateMatcher: ErrorStateMatcher,
+              /** @docs-private */
               @Optional() @Self() public ngControl: NgControl) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
     if (this.ngControl) {
@@ -330,8 +337,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     }
   }
 
-  ngAfterContentInit(): void {
-
+  ngAfterContentInit() {
     this._keyManager = new FocusKeyManager<MatChip>(this.chips).withWrap();
 
     // Prevents the chip list from capturing focus and redirecting
@@ -370,7 +376,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     }
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this._tabOutSubscription.unsubscribe();
 
     if (this._changeSubscription) {
@@ -382,7 +388,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
 
   /** Associates an HTML input element with this chip list. */
-  registerInput(inputElement: MatChipInput) {
+  registerInput(inputElement: MatChipInput): void {
     this._chipInput = inputElement;
   }
 
@@ -410,16 +416,17 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   }
 
   // Implemented as part of ControlValueAccessor
-  setDisabledState(disabled: boolean): void {
-    this.disabled = disabled;
-    this._elementRef.nativeElement.disabled = disabled;
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+    this._elementRef.nativeElement.disabled = isDisabled;
     this.stateChanges.next();
   }
 
-  /** @docs-private */
-  onContainerClick() {
-    this.focus();
-  }
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  onContainerClick() { this.focus(); }
 
   /**
    * Focuses the the first non-disabled chip in this chip list, or the associated input when there

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -83,15 +83,6 @@ export class MatBasicChip {
 })
 export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDestroy, CanColor,
     CanDisable {
-
-  protected _value: any;
-
-  protected _selected: boolean = false;
-
-  protected _selectable: boolean = true;
-
-  protected _removable: boolean = true;
-
   /** Whether the chip has focus. */
   _hasFocus: boolean = false;
 
@@ -106,6 +97,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       selected: value
     });
   }
+  protected _selected: boolean = false;
+
   /** The value of the chip. Defaults to the content inside <mat-chip> tags. */
   @Input()
   get value(): any {
@@ -113,9 +106,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       ? this._value
       : this._elementRef.nativeElement.textContent;
   }
-  set value(newValue: any) {
-    this._value = newValue;
-  }
+  set value(value: any) { this._value = value; }
+  protected _value: any;
 
   /**
    * Whether or not the chips are selectable. When a chip is not selectable,
@@ -126,6 +118,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   set selectable(value: boolean) {
     this._selectable = coerceBooleanProperty(value);
   }
+  protected _selectable: boolean = true;
 
   /**
    * Determines whether or not the chip displays the remove styling and emits (remove) events.
@@ -135,6 +128,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   set removable(value: boolean) {
     this._removable = coerceBooleanProperty(value);
   }
+  protected _removable: boolean = true;
 
   /** Emits when the chip is focused. */
   _onFocus = new Subject<MatChipEvent>();
@@ -147,7 +141,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       = new EventEmitter<MatChipSelectionChange>();
 
   /** Emitted when the chip is destroyed. */
-  @Output() destroyed = new EventEmitter<MatChipEvent>();
+  @Output() destroyed: EventEmitter<MatChipEvent> = new EventEmitter<MatChipEvent>();
 
   /**
    * Emitted when the chip is destroyed.
@@ -166,6 +160,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
    */
   @Output('remove') onRemove: EventEmitter<MatChipEvent> = this.removed;
 
+  /** The ARIA selected applied to the chip. */
   get ariaSelected(): string | null {
     return this.selectable ? this.selected.toString() : null;
   }
@@ -174,7 +169,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     super(_elementRef);
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this.destroyed.emit({chip: this});
   }
 

--- a/src/lib/core/common-behaviors/color.ts
+++ b/src/lib/core/common-behaviors/color.ts
@@ -27,8 +27,6 @@ export type ThemePalette = 'primary' | 'accent' | 'warn' | undefined;
 export function mixinColor<T extends Constructor<HasElementRef>>(base: T,
     defaultColor?: ThemePalette): Constructor<CanColor> & T {
   return class extends base {
-    private _color: ThemePalette;
-
     get color(): ThemePalette { return this._color; }
     set color(value: ThemePalette) {
       const colorPalette = value || defaultColor;
@@ -44,6 +42,7 @@ export function mixinColor<T extends Constructor<HasElementRef>>(base: T,
         this._color = colorPalette;
       }
     }
+    private _color: ThemePalette;
 
     constructor(...args: any[]) {
       super(...args);

--- a/src/lib/core/common-behaviors/disable-ripple.ts
+++ b/src/lib/core/common-behaviors/disable-ripple.ts
@@ -19,11 +19,10 @@ export interface CanDisableRipple {
 export function mixinDisableRipple<T extends Constructor<{}>>(base: T)
     : Constructor<CanDisableRipple> & T {
   return class extends base {
-    private _disableRipple: boolean = false;
-
     /** Whether the ripple effect is disabled or not. */
-    get disableRipple() { return this._disableRipple; }
-    set disableRipple(value: any) { this._disableRipple = coerceBooleanProperty(value); }
+    get disableRipple(): boolean { return this._disableRipple; }
+    set disableRipple(value: boolean) { this._disableRipple = coerceBooleanProperty(value); }
+    private _disableRipple: boolean = false;
 
     constructor(...args: any[]) { super(...args); }
   };

--- a/src/lib/core/common-behaviors/disabled.ts
+++ b/src/lib/core/common-behaviors/disabled.ts
@@ -18,10 +18,9 @@ export interface CanDisable {
 /** Mixin to augment a directive with a `disabled` property. */
 export function mixinDisabled<T extends Constructor<{}>>(base: T): Constructor<CanDisable> & T {
   return class extends base {
+    get disabled(): boolean { return this._disabled; }
+    set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
     private _disabled: boolean = false;
-
-    get disabled() { return this._disabled; }
-    set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
 
     constructor(...args: any[]) { super(...args); }
   };

--- a/src/lib/core/common-behaviors/error-state.ts
+++ b/src/lib/core/common-behaviors/error-state.ts
@@ -41,11 +41,11 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(base: T)
      * Stream that emits whenever the state of the input changes such that the wrapping
      * `MatFormField needs to run change detection.
      */
-    stateChanges = new Subject<void>();
+    stateChanges: Subject<void> = new Subject<void>();
 
     errorStateMatcher: ErrorStateMatcher;
 
-    updateErrorState() {
+    updateErrorState(): void {
       const oldState = this.errorState;
       const parent = this._parentFormGroup || this._parentForm;
       const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;

--- a/src/lib/core/common-behaviors/tabindex.ts
+++ b/src/lib/core/common-behaviors/tabindex.ts
@@ -19,13 +19,12 @@ export interface HasTabIndex {
 export function mixinTabIndex<T extends Constructor<CanDisable>>(base: T, defaultTabIndex = 0)
     : Constructor<HasTabIndex> & T {
   return class extends base {
-    private _tabIndex: number = defaultTabIndex;
-
     get tabIndex(): number { return this.disabled ? -1 : this._tabIndex; }
     set tabIndex(value: number) {
       // If the specified tabIndex value is null or undefined, fall back to the default value.
       this._tabIndex = value != null ? value : defaultTabIndex;
     }
+    private _tabIndex: number = defaultTabIndex;
 
     constructor(...args: any[]) {
       super(...args);

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -261,11 +261,11 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any) {
+  isDateInstance(obj: any): obj is Date {
     return obj instanceof Date;
   }
 
-  isValid(date: Date) {
+  isValid(date: Date): boolean {
     return !isNaN(date.getTime());
   }
 

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -85,34 +85,34 @@ export const MAT_OPTION_PARENT_COMPONENT =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatOption implements AfterViewChecked {
-  private _selected = false;
-  private _active = false;
-  private _disabled = false;
-  private _id = `mat-option-${_uniqueIdCounter++}`;
   private _mostRecentViewValue = '';
 
   /** Whether the wrapping component is in multiple selection mode. */
-  get multiple() { return this._parent && this._parent.multiple; }
+  get multiple(): boolean | undefined { return this._parent && this._parent.multiple; }
 
   /** The unique ID of the option. */
   get id(): string { return this._id; }
+  private _id = `mat-option-${_uniqueIdCounter++}`;
 
   /** Whether or not the option is currently selected. */
   get selected(): boolean { return this._selected; }
+  private _selected = false;
 
   /** The form value of the option. */
   @Input() value: any;
 
   /** Whether the option is disabled. */
   @Input()
-  get disabled() { return (this.group && this.group.disabled) || this._disabled; }
-  set disabled(value: any) { this._disabled = coerceBooleanProperty(value); }
+  get disabled(): boolean { return (this.group && this.group.disabled) || this._disabled; }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled: boolean = false;
 
   /** Whether ripples for the option are disabled. */
-  get disableRipple() { return this._parent && this._parent.disableRipple; }
+  get disableRipple(): boolean | undefined { return this._parent && this._parent.disableRipple; }
 
   /** Event emitted when the option is selected or deselected. */
-  @Output() onSelectionChange = new EventEmitter<MatOptionSelectionChange>();
+  @Output() onSelectionChange: EventEmitter<MatOptionSelectionChange> =
+      new EventEmitter<MatOptionSelectionChange>();
 
   /** Emits when the state of the option changes and any parents have to be notified. */
   _stateChanges = new Subject<void>();
@@ -129,9 +129,8 @@ export class MatOption implements AfterViewChecked {
    * focus is actually retained somewhere else. This comes in handy
    * for components like autocomplete where focus must remain on the input.
    */
-  get active(): boolean {
-    return this._active;
-  }
+  get active(): boolean { return this._active; }
+  private _active = false;
 
   /**
    * The displayed value of the option. It is necessary to show the selected option in the

--- a/src/lib/core/ripple/ripple-ref.ts
+++ b/src/lib/core/ripple/ripple-ref.ts
@@ -28,7 +28,7 @@ export class RippleRef {
   }
 
   /** Fades out the ripple element. */
-  fadeOut() {
+  fadeOut(): void {
     this._renderer.fadeOutRipple(this);
   }
 }

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -168,7 +168,7 @@ export class RippleRenderer {
   }
 
   /** Fades out a ripple reference. */
-  fadeOutRipple(rippleRef: RippleRef) {
+  fadeOutRipple(rippleRef: RippleRef): void {
     // For ripples that are not active anymore, don't re-un the fade-out animation.
     if (!this._activeRipples.delete(rippleRef)) {
       return;
@@ -190,12 +190,12 @@ export class RippleRenderer {
   }
 
   /** Fades out all currently active ripples. */
-  fadeOutAll() {
+  fadeOutAll(): void {
     this._activeRipples.forEach(ripple => ripple.fadeOut());
   }
 
   /** Sets up the trigger event listeners */
-  setupTriggerEvents(element: HTMLElement) {
+  setupTriggerEvents(element: HTMLElement): void {
     if (!element || element === this._triggerElement) {
       return;
     }

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -96,7 +96,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
    * by using the `launch()` method.
    */
   @Input('matRippleDisabled')
-  get disabled() { return this._disabled; }
+  get disabled(): boolean { return this._disabled; }
   set disabled(value: boolean) {
     this._disabled = value;
     this._setupTriggerEventsIfEnabled();
@@ -108,9 +108,9 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
    * Defaults to the directive's host element.
    */
   @Input('matRippleTrigger')
-  get trigger() { return this._trigger || this._elementRef.nativeElement; }
-  set trigger(trigger: HTMLElement) {
-    this._trigger = trigger;
+  get trigger(): HTMLElement { return this._trigger || this._elementRef.nativeElement; }
+  set trigger(value: HTMLElement) {
+    this._trigger = value;
     this._setupTriggerEventsIfEnabled();
   }
   private _trigger: HTMLElement;
@@ -148,7 +148,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   }
 
   /** Fades out all currently showing ripple elements. */
-  fadeOutAll() {
+  fadeOutAll(): void {
     this._rippleRenderer.fadeOutAll();
   }
 

--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -79,7 +79,7 @@ export class MatCalendarBody {
   @Input() cellAspectRatio = 1;
 
   /** Emits when a new value is selected. */
-  @Output() selectedValueChange = new EventEmitter<number>();
+  @Output() selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
   _cellClicked(cell: MatCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -105,10 +105,10 @@ export class MatCalendar<D> implements AfterContentInit, OnDestroy, OnChanges {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when the currently selected date changes. */
-  @Output() selectedChange = new EventEmitter<D>();
+  @Output() selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Emits when any date is selected. */
-  @Output() _userSelection = new EventEmitter<void>();
+  @Output() _userSelection: EventEmitter<void> = new EventEmitter<void>();
 
   /** Reference to the current month view component. */
   @ViewChild(MatMonthView) monthView: MatMonthView<D>;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -110,8 +110,8 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   /** Function that can be used to filter out dates within the datepicker. */
   @Input()
-  set matDatepickerFilter(filter: (date: D | null) => boolean) {
-    this._dateFilter = filter;
+  set matDatepickerFilter(value: (date: D | null) => boolean) {
+    this._dateFilter = value;
     this._validatorOnChange();
   }
   _dateFilter: (date: D | null) => boolean;
@@ -173,7 +173,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
       = new EventEmitter<MatDatepickerInputEvent<D>>();
 
   /** Emits when the value changes (either due to user input or programmatic change). */
-  _valueChange = new EventEmitter<D|null>();
+  _valueChange = new EventEmitter<D | null>();
 
   /** Emits when the disabled state has changed */
   _disabledChange = new EventEmitter<boolean>();
@@ -268,6 +268,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     this._validatorOnChange = fn;
   }
 
+  /** @docs-private */
   validate(c: AbstractControl): ValidationErrors | null {
     return this._validator ? this._validator(c) : null;
   }
@@ -304,8 +305,8 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   }
 
   // Implemented as part of ControlValueAccessor
-  setDisabledState(disabled: boolean): void {
-    this.disabled = disabled;
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
   }
 
   _onKeydown(event: KeyboardEvent) {

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -20,32 +20,32 @@ export class MatDatepickerIntl {
   changes: Subject<void> = new Subject<void>();
 
   /** A label for the calendar popup (used by screen readers). */
-  calendarLabel = 'Calendar';
+  calendarLabel: string = 'Calendar';
 
   /** A label for the button used to open the calendar popup (used by screen readers). */
-  openCalendarLabel = 'Open calendar';
+  openCalendarLabel: string = 'Open calendar';
 
   /** A label for the previous month button (used by screen readers). */
-  prevMonthLabel = 'Previous month';
+  prevMonthLabel: string = 'Previous month';
 
   /** A label for the next month button (used by screen readers). */
-  nextMonthLabel = 'Next month';
+  nextMonthLabel: string = 'Next month';
 
   /** A label for the previous year button (used by screen readers). */
-  prevYearLabel = 'Previous year';
+  prevYearLabel: string = 'Previous year';
 
   /** A label for the next year button (used by screen readers). */
-  nextYearLabel = 'Next year';
+  nextYearLabel: string = 'Next year';
 
   /** A label for the previous multi-year button (used by screen readers). */
-  prevMultiYearLabel = 'Previous 20 years';
+  prevMultiYearLabel: string = 'Previous 20 years';
 
   /** A label for the next multi-year button (used by screen readers). */
-  nextMultiYearLabel = 'Next 20 years';
+  nextMultiYearLabel: string = 'Next 20 years';
 
   /** A label for the 'switch to month view' button (used by screen readers). */
-  switchToMonthViewLabel = 'Choose date';
+  switchToMonthViewLabel: string = 'Choose date';
 
   /** A label for the 'switch to year view' button (used by screen readers). */
-  switchToMultiYearViewLabel = 'Choose month and year';
+  switchToMultiYearViewLabel: string = 'Choose month and year';
 }

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -58,9 +58,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   get disabled(): boolean {
     return this._disabled === undefined ? this.datepicker.disabled : !!this._disabled;
   }
-  set disabled(value: boolean) {
-    this._disabled = coerceBooleanProperty(value);
-  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
   private _disabled: boolean;
 
   /** Custom icon set by the consumer. */

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -122,8 +122,8 @@ export class MatDatepicker<D> implements OnDestroy {
     // selected value is.
     return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D | null) {
-    this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(date));
+  set startAt(value: D | null) {
+    this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
   private _startAt: D | null;
 
@@ -176,7 +176,7 @@ export class MatDatepicker<D> implements OnDestroy {
   /** Whether the calendar is open. */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(shouldOpen: boolean) { shouldOpen ? this.open() : this.close(); }
+  set opened(value: boolean) { value ? this.open() : this.close(); }
   private _opened = false;
 
   /** The id for the datepicker calendar. */

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -68,10 +68,10 @@ export class MatMonthView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new date is selected. */
-  @Output() selectedChange = new EventEmitter<D | null>();
+  @Output() selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
 
   /** Emits when any date is selected. */
-  @Output() _userSelection = new EventEmitter<void>();
+  @Output() _userSelection: EventEmitter<void> = new EventEmitter<void>();
 
   /** The label for this month (e.g. "January 2017"). */
   _monthLabel: string;
@@ -117,7 +117,7 @@ export class MatMonthView<D> implements AfterContentInit {
     this._activeDate = this._dateAdapter.today();
   }
 
-  ngAfterContentInit(): void {
+  ngAfterContentInit() {
     this._init();
   }
 

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -68,7 +68,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new month is selected. */
-  @Output() selectedChange = new EventEmitter<D>();
+  @Output() selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Grid of calendar cells representing the currently displayed years. */
   _years: MatCalendarCell[][];

--- a/src/lib/datepicker/year-view.ts
+++ b/src/lib/datepicker/year-view.ts
@@ -63,7 +63,7 @@ export class MatYearView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new month is selected. */
-  @Output() selectedChange = new EventEmitter<D>();
+  @Output() selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Grid of calendar cells representing the months of the year. */
   _months: MatCalendarCell[][];

--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -43,6 +43,7 @@ export class MatDialogClose implements OnInit, OnChanges {
   @Input('matDialogClose') _matDialogClose: any;
 
   constructor(
+    /** @docs-private */
     @Optional() public dialogRef: MatDialogRef<any>,
     private _elementRef: ElementRef,
     private _dialog: MatDialog) {}
@@ -79,7 +80,8 @@ export class MatDialogClose implements OnInit, OnChanges {
   },
 })
 export class MatDialogTitle implements OnInit {
-  @Input() id = `mat-dialog-title-${dialogElementUid++}`;
+  /** The unique ID for this dialog title. */
+  @Input() id: string = `mat-dialog-title-${dialogElementUid++}`;
 
   constructor(
     @Optional() private _dialogRef: MatDialogRef<any>,

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -52,6 +52,7 @@ export class MatDialogRef<T, R = any> {
     private _overlayRef: OverlayRef,
     public _containerInstance: MatDialogContainer,
     location?: Location,
+  /** The unique ID for this dialog ref. */
     readonly id: string = `mat-dialog-${uniqueId++}`) {
 
     // Pass the id along to the container.

--- a/src/lib/expansion/accordion.ts
+++ b/src/lib/expansion/accordion.ts
@@ -27,7 +27,7 @@ export class MatAccordion extends CdkAccordion {
   /** Whether the expansion indicator should be hidden. */
   @Input()
   get hideToggle(): boolean { return this._hideToggle; }
-  set hideToggle(show: boolean) { this._hideToggle = coerceBooleanProperty(show); }
+  set hideToggle(value: boolean) { this._hideToggle = coerceBooleanProperty(value); }
   private _hideToggle: boolean = false;
 
   /**

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -67,6 +67,7 @@ export class MatExpansionPanelHeader implements OnDestroy {
   private _parentChangeSubscription = Subscription.EMPTY;
 
   constructor(
+    /** @docs-private */
     @Host() public panel: MatExpansionPanel,
     private _element: ElementRef,
     private _focusMonitor: FocusMonitor,

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -93,9 +93,7 @@ export class MatExpansionPanel extends _MatExpansionPanelMixinBase
   /** Whether the toggle indicator should be hidden. */
   @Input()
   get hideToggle(): boolean { return this._hideToggle; }
-  set hideToggle(value: boolean) {
-    this._hideToggle = coerceBooleanProperty(value);
-  }
+  set hideToggle(value: boolean) { this._hideToggle = coerceBooleanProperty(value); }
   private _hideToggle = false;
 
   /** Stream that emits for changes in `@Input` properties. */

--- a/src/lib/form-field/error.ts
+++ b/src/lib/form-field/error.ts
@@ -22,5 +22,6 @@ let nextUniqueId = 0;
   }
 })
 export class MatError {
+  /** The unique ID for this error. */
   @Input() id: string = `mat-error-${nextUniqueId++}`;
 }

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -95,7 +95,7 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
    */
   @Input()
   get dividerColor(): 'primary' | 'accent' | 'warn' { return this.color; }
-  set dividerColor(value) { this.color = value; }
+  set dividerColor(value: 'primary' | 'accent' | 'warn') { this.color = value; }
 
   /** Whether the required marker should be hidden. */
   @Input()
@@ -109,12 +109,12 @@ export class MatFormField implements AfterViewInit, AfterContentInit, AfterConte
   private _showAlwaysAnimate = false;
 
   /** Whether the floating label should always float or not. */
-  get _shouldAlwaysFloat() {
+  get _shouldAlwaysFloat(): boolean {
     return this._floatLabel === 'always' && !this._showAlwaysAnimate;
   }
 
   /** Whether the label can float or not. */
-  get _canLabelFloat() { return this._floatLabel !== 'never'; }
+  get _canLabelFloat(): boolean { return this._floatLabel !== 'never'; }
 
   /** State of the mat-hint and mat-error animations. */
   _subscriptAnimationState: string = '';

--- a/src/lib/grid-list/tile-coordinator.ts
+++ b/src/lib/grid-list/tile-coordinator.ts
@@ -43,7 +43,7 @@ export class TileCoordinator {
    * Gets the total span of rows occupied by tiles.
    * Ex: A list with 1 row that contains a tile with rowspan 2 will have a total rowspan of 2.
    */
-  get rowspan() {
+  get rowspan(): number {
     let lastRowMax = Math.max(...this.tracker);
     // if any of the tiles has a rowspan that pushes it beyond the total row count,
     // add the difference to the rowcount

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -159,7 +159,7 @@ export class FixedTileStyler extends TileStyler {
 
   constructor(public fixedRowHeight: string) { super(); }
 
-  init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string) {
+  init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string): void {
     super.init(gutterSize, tracker, cols, direction);
     this.fixedRowHeight = normalizeUnits(this.fixedRowHeight);
   }
@@ -175,7 +175,7 @@ export class FixedTileStyler extends TileStyler {
     ];
   }
 
-  reset(list: MatGridList) {
+  reset(list: MatGridList): void {
     list._setListStyle(['height', null]);
 
     list._tiles.forEach(tile => {
@@ -220,7 +220,7 @@ export class RatioTileStyler extends TileStyler {
     ];
   }
 
-  reset(list: MatGridList) {
+  reset(list: MatGridList): void {
     list._setListStyle(['padding-bottom', null]);
 
     list._tiles.forEach(tile => {
@@ -263,7 +263,7 @@ export class FitTileStyler extends TileStyler {
     tile._setStyle('height', calc(this.getTileSize(baseTileHeight, tile.rowspan)));
   }
 
-  reset(list: MatGridList) {
+  reset(list: MatGridList): void {
     list._tiles.forEach(tile => {
       tile._setStyle('top', null);
       tile._setStyle('height', null);

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -40,16 +40,14 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   private _previousValue: string;
   private _destroyed = new Subject<void>();
 
-  private _minRows: number;
-  private _maxRows: number;
-
   /** Minimum amount of rows in the textarea. */
   @Input('matAutosizeMinRows')
+  get minRows(): number { return this._minRows; }
   set minRows(value: number) {
     this._minRows = value;
     this._setMinHeight();
   }
-  get minRows(): number { return this._minRows; }
+  private _minRows: number;
 
   /** Maximum amount of rows in the textarea. */
   @Input('matAutosizeMaxRows')
@@ -58,6 +56,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     this._maxRows = value;
     this._setMaxHeight();
   }
+  private _maxRows: number;
 
   /** Cached height of a textarea with a single row. */
   private _cachedLineHeight: number;
@@ -170,7 +169,7 @@ export class MatTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
    * @param force Whether to force a height recalculation. By default the height will be
    *    recalculated only if the value changed since the last call.
    */
-  resizeToFitContent(force: boolean = false) {
+  resizeToFitContent(force: boolean = false): void {
     this._cacheTextareaLineHeight();
 
     // If we haven't determined the line-height yet, we know we're still hidden and there's no point

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -48,6 +48,7 @@ export class MatInputBase {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
+              /** @docs-private */
               public ngControl: NgControl) {}
 }
 export const _MatInputMixinBase = mixinErrorState(MatInputBase);
@@ -77,19 +78,9 @@ export const _MatInputMixinBase = mixinErrorState(MatInputBase);
 })
 export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges,
     OnDestroy, DoCheck, CanUpdateErrorState {
-  /** Variables used as cache for getters and setters. */
-  protected _type = 'text';
-  protected _disabled = false;
-  protected _required = false;
-  protected _id: string;
   protected _uid = `mat-input-${nextUniqueId++}`;
   protected _previousNativeValue: any;
-  private _readonly = false;
   private _inputValueAccessor: {value: any};
-
-  /** Whether the input is focused. */
-  focused = false;
-
   /** The aria-describedby attribute on the input for improved a11y. */
   _ariaDescribedby: string;
 
@@ -97,15 +88,27 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   _isServer = false;
 
   /**
-   * Stream that emits whenever the state of the input changes such that the wrapping `MatFormField`
-   * needs to run change detection.
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
    */
-  stateChanges = new Subject<void>();
+  focused: boolean = false;
 
-  /** A name for this control that can be used by `mat-form-field`. */
-  controlType = 'mat-input';
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  stateChanges: Subject<void> = new Subject<void>();
 
-  /** Whether the element is disabled. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  controlType: string = 'mat-input';
+
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get disabled(): boolean {
     if (this.ngControl && this.ngControl.disabled !== null) {
@@ -123,19 +126,31 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
       this.stateChanges.next();
     }
   }
+  protected _disabled = false;
 
-  /** Unique id of the element. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get id(): string { return this._id; }
   set id(value: string) { this._id = value || this._uid; }
+  protected _id: string;
 
-  /** Placeholder attribute of the element. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input() placeholder: string = '';
 
-  /** Whether the element is required. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get required(): boolean { return this._required; }
   set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  protected _required = false;
 
   /** Input type of the element. */
   @Input()
@@ -151,6 +166,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
       this._elementRef.nativeElement.type = this._type;
     }
   }
+  protected _type = 'text';
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;
@@ -169,6 +185,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   @Input()
   get readonly(): boolean { return this._readonly; }
   set readonly(value: boolean) { this._readonly = coerceBooleanProperty(value); }
+  private _readonly = false;
 
   protected _neverEmptyInputTypes = [
     'date',
@@ -181,6 +198,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
 
   constructor(protected _elementRef: ElementRef,
               protected _platform: Platform,
+              /** @docs-private */
               @Optional() @Self() public ngControl: NgControl,
               @Optional() _parentForm: NgForm,
               @Optional() _parentFormGroup: FormGroupDirective,
@@ -237,7 +255,8 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     this._dirtyCheckNativeValue();
   }
 
-  focus() { this._elementRef.nativeElement.focus(); }
+  /** Focuses the input. */
+  focus(): void { this._elementRef.nativeElement.focus(); }
 
   /** Callback for the cases where the focused state of the input changes. */
   _focusChanged(isFocused: boolean) {
@@ -297,7 +316,10 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     return nodeName ? nodeName.toLowerCase() === 'textarea' : false;
   }
 
-  // Implemented as part of MatFormFieldControl.
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   get empty(): boolean {
     return !this._isNeverEmpty() && !this._elementRef.nativeElement.value && !this._isBadInput();
   }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -112,8 +112,6 @@ export class MatListOption extends _MatListOptionMixinBase
     implements AfterContentInit, OnDestroy, OnInit, FocusableOption, CanDisableRipple {
 
   private _lineSetter: MatLineSetter;
-  private _selected: boolean = false;
-  private _disabled: boolean = false;
 
   /** Whether the option has focus. */
   _hasFocus: boolean = false;
@@ -131,8 +129,10 @@ export class MatListOption extends _MatListOptionMixinBase
 
   /** Whether the option is disabled. */
   @Input()
-  get disabled() { return this._disabled || (this.selectionList && this.selectionList.disabled); }
-  set disabled(value: any) {
+  get disabled(): boolean {
+    return this._disabled || (this.selectionList && this.selectionList.disabled);
+  }
+  set disabled(value: boolean) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this._disabled) {
@@ -140,6 +140,7 @@ export class MatListOption extends _MatListOptionMixinBase
       this._changeDetector.markForCheck();
     }
   }
+  private _disabled: boolean = false;
 
   /** Whether the option is selected. */
   @Input()
@@ -152,6 +153,7 @@ export class MatListOption extends _MatListOptionMixinBase
       this.selectionList._reportValueChange();
     }
   }
+  private _selected: boolean = false;
 
   /**
    * Emits a change event whenever the selected state of an option changes.
@@ -183,7 +185,7 @@ export class MatListOption extends _MatListOptionMixinBase
     this._lineSetter = new MatLineSetter(this._lines, this._element);
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     if (this.selected) {
       // We have to delay this until the next tick in order
       // to avoid changed after checked errors.
@@ -322,7 +324,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
     this.tabIndex = parseInt(tabIndex) || 0;
   }
 
-  ngAfterContentInit(): void {
+  ngAfterContentInit() {
     this._keyManager = new FocusKeyManager<MatListOption>(this.options).withWrap().withTypeAhead();
 
     if (this._tempValues) {
@@ -332,18 +334,18 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
   }
 
   /** Focus the selection-list. */
-  focus() {
+  focus(): void {
     this._element.nativeElement.focus();
   }
 
   /** Selects all of the options. */
-  selectAll() {
+  selectAll(): void {
     this.options.forEach(option => option._setSelected(true));
     this._reportValueChange();
   }
 
   /** Deselects all of the options. */
-  deselectAll() {
+  deselectAll(): void {
     this.options.forEach(option => option._setSelected(false));
     this._reportValueChange();
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -82,8 +82,6 @@ const MAT_MENU_BASE_ELEVATION = 2;
 })
 export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
   private _keyManager: FocusKeyManager<MatMenuItem>;
-  private _xPosition: MenuPositionX = this._defaultOptions.xPosition;
-  private _yPosition: MenuPositionY = this._defaultOptions.yPosition;
   private _previousElevation: string;
 
   /** Subscription to tab events on the menu panel */
@@ -111,6 +109,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
     this._xPosition = value;
     this.setPositionClasses();
   }
+  private _xPosition: MenuPositionX = this._defaultOptions.xPosition;
 
   /** Position of the menu in the Y axis. */
   @Input()
@@ -122,6 +121,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
     this._yPosition = value;
     this.setPositionClasses();
   }
+  private _yPosition: MenuPositionY = this._defaultOptions.yPosition;
 
   /** @docs-private */
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
@@ -144,9 +144,9 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    * @param classes list of class names
    */
   @Input('class')
-  set panelClass(classes: string) {
-    if (classes && classes.length) {
-      this._classList = classes.split(' ').reduce((obj: any, className: string) => {
+  set panelClass(value: string) {
+    if (value && value.length) {
+      this._classList = value.split(' ').reduce((obj: any, className: string) => {
         obj[className] = true;
         return obj;
       }, {});
@@ -165,7 +165,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    */
   @Input()
   get classList(): string { return this.panelClass; }
-  set classList(classes: string) { this.panelClass = classes; }
+  set classList(value: string) { this.panelClass = value; }
 
   /** Event emitted when the menu is closed. */
   @Output() closed: EventEmitter<void | 'click' | 'keydown'>
@@ -242,7 +242,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    * Resets the active item in the menu. This is used when the menu is opened, allowing
    * the user to start from the first option when pressing the down arrow.
    */
-  resetActiveItem() {
+  resetActiveItem(): void {
     this._keyManager.setActiveItem(-1);
   }
 
@@ -250,7 +250,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
    * It's necessary to set position-based classes to ensure the menu panel animation
    * folds out from the correct direction.
    */
-  setPositionClasses(posX: MenuPositionX = this.xPosition, posY: MenuPositionY = this.yPosition) {
+  setPositionClasses(
+    posX: MenuPositionX = this.xPosition, posY: MenuPositionY = this.yPosition): void {
     this._classList['mat-menu-before'] = posX === 'before';
     this._classList['mat-menu-after'] = posX === 'after';
     this._classList['mat-menu-above'] = posY === 'above';

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -85,7 +85,6 @@ export const MENU_PANEL_TOP_PADDING = 8;
 export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _portal: TemplatePortal;
   private _overlayRef: OverlayRef | null = null;
-  private _menuOpen: boolean = false;
   private _closeSubscription = Subscription.EMPTY;
   private _positionSubscription = Subscription.EMPTY;
   private _hoverSubscription = Subscription.EMPTY;
@@ -99,13 +98,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * @deletion-target 6.0.0
    */
   @Input('mat-menu-trigger-for')
-  get _deprecatedMatMenuTriggerFor(): MatMenuPanel {
-    return this.menu;
-  }
-
-  set _deprecatedMatMenuTriggerFor(v: MatMenuPanel) {
-    this.menu = v;
-  }
+  get _deprecatedMatMenuTriggerFor(): MatMenuPanel { return this.menu; }
+  set _deprecatedMatMenuTriggerFor(value: MatMenuPanel) { this.menu = value; }
 
   /** References the menu instance that the trigger is associated with. */
   @Input('matMenuTriggerFor') menu: MatMenuPanel;
@@ -178,9 +172,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   }
 
   /** Whether the menu is open. */
-  get menuOpen(): boolean {
-    return this._menuOpen;
-  }
+  get menuOpen(): boolean { return this._menuOpen; }
+  private _menuOpen: boolean = false;
 
   /** The text direction of the containing app. */
   get dir(): Direction {
@@ -219,7 +212,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * Focuses the menu trigger.
    * @param origin Source of the menu trigger's focus.
    */
-  focus(origin: FocusOrigin = 'program') {
+  focus(origin: FocusOrigin = 'program'): void {
     if (this._focusMonitor) {
       this._focusMonitor.focusVia(this._element.nativeElement, origin);
     } else {

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -31,7 +31,7 @@ export class MatPaginatorIntl {
   previousPageLabel: string = 'Previous page';
 
   /** A label for the range of items within the current page and the length of the whole list. */
-  getRangeLabel = (page: number, pageSize: number, length: number) => {
+  getRangeLabel = (page: number, pageSize: number, length: number): string => {
     if (length == 0 || pageSize == 0) { return `0 of ${length}`; }
 
     length = Math.max(length, 0);

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -64,8 +64,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The zero-based page index of the displayed list of items. Defaulted to 0. */
   @Input()
   get pageIndex(): number { return this._pageIndex; }
-  set pageIndex(pageIndex: number) {
-    this._pageIndex = coerceNumberProperty(pageIndex);
+  set pageIndex(value: number) {
+    this._pageIndex = coerceNumberProperty(value);
     this._changeDetectorRef.markForCheck();
   }
   _pageIndex: number = 0;
@@ -73,8 +73,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
   @Input()
   get length(): number { return this._length; }
-  set length(length: number) {
-    this._length = coerceNumberProperty(length);
+  set length(value: number) {
+    this._length = coerceNumberProperty(value);
     this._changeDetectorRef.markForCheck();
   }
   _length: number = 0;
@@ -82,8 +82,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** Number of items to display on a page. By default set to 50. */
   @Input()
   get pageSize(): number { return this._pageSize; }
-  set pageSize(pageSize: number) {
-    this._pageSize = coerceNumberProperty(pageSize);
+  set pageSize(value: number) {
+    this._pageSize = coerceNumberProperty(value);
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSize: number;
@@ -91,8 +91,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The set of provided page size options to display to the user. */
   @Input()
   get pageSizeOptions(): number[] { return this._pageSizeOptions; }
-  set pageSizeOptions(pageSizeOptions: number[]) {
-    this._pageSizeOptions = (pageSizeOptions || []).map(p => coerceNumberProperty(p));
+  set pageSizeOptions(value: number[]) {
+    this._pageSizeOptions = (value || []).map(p => coerceNumberProperty(p));
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSizeOptions: number[] = [];
@@ -101,7 +101,7 @@ export class MatPaginator implements OnInit, OnDestroy {
   @Input() hidePageSize = false;
 
   /** Event emitted when the paginator changes the page size or page index. */
-  @Output() page = new EventEmitter<PageEvent>();
+  @Output() page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
 
   /** Displayed set of page size options. Will be sorted and include current page size. */
   _displayedPageSizeOptions: number[];

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -51,20 +51,16 @@ export const _MatProgressBarMixinBase = mixinColor(MatProgressBarBase, 'primary'
 })
 export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor {
 
-  constructor(public _elementRef: ElementRef) {
-    super(_elementRef);
-  }
-
   /** Value of the progress bar. Defaults to zero. Mirrored to aria-valuenow. */
   @Input()
   get value(): number { return this._value; }
-  set value(v: number) { this._value = clamp(v || 0); }
+  set value(value: number) { this._value = clamp(value || 0); }
   private _value: number = 0;
 
   /** Buffer value of the progress bar. Defaults to zero. */
   @Input()
   get bufferValue(): number { return this._bufferValue; }
-  set bufferValue(v: number) { this._bufferValue = clamp(v || 0); }
+  set bufferValue(value: number) { this._bufferValue = clamp(value || 0); }
   private _bufferValue: number = 0;
 
   /**
@@ -75,6 +71,10 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
    * Mirrored to mode attribute.
    */
   @Input() mode: 'determinate' | 'indeterminate' | 'buffer' | 'query' = 'determinate';
+
+  constructor(public _elementRef: ElementRef) {
+    super(_elementRef);
+  }
 
   /** Gets the current transform value for the progress bar's primary indicator. */
   _primaryTransform() {

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -95,8 +95,6 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
 export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements CanColor,
   OnChanges {
 
-  private _value = 0;
-  private _strokeWidth: number;
   private _fallbackAnimation = false;
 
   /** The width and height of the host element. Will grow with stroke width. */
@@ -114,8 +112,8 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   /** The diameter of the progress spinner (will set width and height of svg). */
   @Input()
   get diameter(): number { return this._diameter; }
-  set diameter(size: number) {
-    this._diameter = coerceNumberProperty(size);
+  set diameter(value: number) {
+    this._diameter = coerceNumberProperty(value);
 
     if (!this._fallbackAnimation && !MatProgressSpinner.diameters.has(this._diameter)) {
       this._attachStyleNode();
@@ -132,19 +130,18 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   set strokeWidth(value: number) {
     this._strokeWidth = coerceNumberProperty(value);
   }
-
+  private _strokeWidth: number;
 
   /** Mode of the progress circle */
   @Input() mode: ProgressSpinnerMode = 'determinate';
 
   /** Value of the progress circle. */
   @Input()
-  get value(): number {
-    return this.mode === 'determinate' ? this._value : 0;
+  get value(): number { return this.mode === 'determinate' ? this._value : 0; }
+  set value(value: number) {
+    this._value = Math.max(0, Math.min(100, coerceNumberProperty(value)));
   }
-  set value(newValue: number) {
-    this._value = Math.max(0, Math.min(100, coerceNumberProperty(newValue)));
-  }
+  private _value = 0;
 
   constructor(public _elementRef: ElementRef,
               platform: Platform,
@@ -168,12 +165,12 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   }
 
   /** The radius of the spinner, adjusted for stroke width. */
-  get _circleRadius() {
+  get _circleRadius(): number {
     return (this.diameter - BASE_STROKE_WIDTH) / 2;
   }
 
   /** The view box of the spinner's svg element. */
-  get _viewBox() {
+  get _viewBox(): string {
     const viewBox = this._circleRadius * 2 + this.strokeWidth;
     return `0 0 ${viewBox} ${viewBox}`;
   }
@@ -184,7 +181,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   }
 
   /** The dash offset of the svg circle. */
-  get _strokeDashOffset() {
+  get _strokeDashOffset(): number | null {
     if (this.mode === 'determinate') {
       return this._strokeCircumference * (100 - this._value) / 100;
     }
@@ -198,7 +195,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   }
 
   /** Stroke width of the circle in percent. */
-  get _circleStrokeWidth() {
+  get _circleStrokeWidth(): number {
     return this.strokeWidth / this._elementSize * 100;
   }
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -86,31 +86,8 @@ export const _MatRadioGroupMixinBase = mixinDisabled(MatRadioGroupBase);
 })
 export class MatRadioGroup extends _MatRadioGroupMixinBase
     implements AfterContentInit, ControlValueAccessor, CanDisable {
-  /**
-   * Selected value for group. Should equal the value of the selected radio button if there *is*
-   * a corresponding radio button with a matching value. If there is *not* such a corresponding
-   * radio button, this value persists to be applied in case a new radio button is added with a
-   * matching value.
-   */
-  private _value: any = null;
-
-  /** The HTML name attribute applied to radio buttons in this group. */
-  private _name: string = `mat-radio-group-${nextUniqueId++}`;
-
-  /** The currently selected radio button. Should match value. */
-  private _selected: MatRadioButton | null = null;
-
   /** Whether the `value` has been set to its initial value. */
   private _isInitialized: boolean = false;
-
-  /** Whether the labels should appear after or before the radio-buttons. Defaults to 'after' */
-  private _labelPosition: 'before' | 'after' = 'after';
-
-  /** Whether the radio group is disabled. */
-  private _disabled: boolean = false;
-
-  /** Whether the radio group is required. */
-  private _required: boolean = false;
 
   /** The method to be called in order to update ngModel */
   _controlValueAccessorChangeFn: (value: any) => void = () => {};
@@ -119,7 +96,7 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
    * onTouch function registered via registerOnTouch (ControlValueAccessor).
    * @docs-private
    */
-  onTouched: () => any = () => {};
+  _onTouched: () => any = () => {};
 
   /**
    * Event emitted when the group value changes.
@@ -139,6 +116,7 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     this._name = value;
     this._updateRadioButtonNames();
   }
+  private _name: string = `mat-radio-group-${nextUniqueId++}`;
 
   /**
    * Alignment of the radio-buttons relative to their labels. Can be 'before' or 'after'.
@@ -151,33 +129,37 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
+  set align(value: 'start' | 'end') {
+    this.labelPosition = (value == 'start') ? 'after' : 'before';
   }
-
 
   /** Whether the labels should appear after or before the radio-buttons. Defaults to 'after' */
   @Input()
-  get labelPosition(): 'before' | 'after' {
-    return this._labelPosition;
-  }
-  set labelPosition(v) {
-    this._labelPosition = (v == 'before') ? 'before' : 'after';
+  get labelPosition(): 'before' | 'after' { return this._labelPosition; }
+  set labelPosition(value: 'before' | 'after') {
+    this._labelPosition = (value == 'before') ? 'before' : 'after';
     this._markRadiosForCheck();
   }
+  private _labelPosition: 'before' | 'after' = 'after';
 
-  /** Value of the radio button. */
+  /**
+   * Selected value for group. Should equal the value of the selected radio button if there *is*
+   * a corresponding radio button with a matching value. If there is *not* such a corresponding
+   * radio button, this value persists to be applied in case a new radio button is added with a
+   * matching value.
+   */
   @Input()
   get value(): any { return this._value; }
-  set value(newValue: any) {
-    if (this._value != newValue) {
+  set value(value: any) {
+    if (this._value != value) {
       // Set this before proceeding to ensure no circular loop occurs with selection.
-      this._value = newValue;
+      this._value = value;
 
       this._updateSelectedRadioFromValue();
       this._checkSelectedRadioButton();
     }
   }
+  private _value: any = null;
 
   _checkSelectedRadioButton() {
     if (this._selected && !this._selected.checked) {
@@ -185,22 +167,24 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     }
   }
 
-  /** Whether the radio button is selected. */
+  /** The currently selected radio button. Should match value. */
   @Input()
-  get selected() { return this._selected; }
+  get selected(): MatRadioButton | null { return this._selected; }
   set selected(selected: MatRadioButton | null) {
     this._selected = selected;
     this.value = selected ? selected.value : null;
     this._checkSelectedRadioButton();
   }
+  private _selected: MatRadioButton | null = null;
 
   /** Whether the radio group is disabled */
   @Input()
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) {
+  set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
     this._markRadiosForCheck();
   }
+  private _disabled: boolean = false;
 
   /** Whether the radio group is required */
   @Input()
@@ -209,6 +193,7 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     this._required = coerceBooleanProperty(value);
     this._markRadiosForCheck();
   }
+  private _required: boolean = false;
 
   constructor(private _changeDetector: ChangeDetectorRef) {
     super();
@@ -230,8 +215,8 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
    * radio buttons upon their blur.
    */
   _touch() {
-    if (this.onTouched) {
-      this.onTouched();
+    if (this._onTouched) {
+      this._onTouched();
     }
   }
 
@@ -299,7 +284,7 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
    * @param fn Callback to be registered.
    */
   registerOnTouched(fn: any) {
-    this.onTouched = fn;
+    this._onTouched = fn;
   }
 
   /**
@@ -392,6 +377,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
       this._changeDetector.markForCheck();
     }
   }
+  private _checked: boolean = false;
 
   /** The value of this radio button. */
   @Input()
@@ -410,6 +396,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
       }
     }
   }
+  private _value: any = null;
 
   /**
    * Whether or not the radio-button should appear before or after the label.
@@ -422,38 +409,33 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
+  set align(value: 'start' | 'end') {
+    this.labelPosition = (value == 'start') ? 'after' : 'before';
   }
-
-  private _labelPosition: 'before' | 'after';
 
   /** Whether the label should appear after or before the radio button. Defaults to 'after' */
   @Input()
   get labelPosition(): 'before' | 'after' {
     return this._labelPosition || (this.radioGroup && this.radioGroup.labelPosition) || 'after';
   }
-  set labelPosition(value) {
-    this._labelPosition = value;
-  }
+  set labelPosition(value: 'before' | 'after') { this._labelPosition = value; }
+  private _labelPosition: 'before' | 'after';
 
   /** Whether the radio button is disabled. */
   @Input()
   get disabled(): boolean {
     return this._disabled || (this.radioGroup != null && this.radioGroup.disabled);
   }
-  set disabled(value: boolean) {
-    this._disabled = coerceBooleanProperty(value);
-  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled: boolean;
 
   /** Whether the radio button is required. */
   @Input()
   get required(): boolean {
     return this._required || (this.radioGroup && this.radioGroup.required);
   }
-  set required(value: boolean) {
-    this._required = coerceBooleanProperty(value);
-  }
+  set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  private _required: boolean;
 
   /**
    * Event emitted when the checked state of this radio button changes.
@@ -467,18 +449,6 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   /** ID of the native input element inside `<mat-radio-button>` */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
-
-  /** Whether this radio is checked. */
-  private _checked: boolean = false;
-
-  /** Whether this radio is disabled. */
-  private _disabled: boolean;
-
-  /** Whether this radio is required. */
-  private _required: boolean;
-
-  /** Value assigned to this radio. */
-  private _value: any = null;
 
   /** The child ripple instance. */
   @ViewChild(MatRipple) _ripple: MatRipple;

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -154,6 +154,7 @@ export class MatSelectBase {
               public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
+              /** @docs-private */
               public ngControl: NgControl) {}
 }
 export const _MatSelectMixinBase = mixinDisableRipple(
@@ -212,23 +213,8 @@ export class MatSelectTrigger {}
 export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges,
     OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable, HasTabIndex,
     MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
-  /** Whether or not the overlay panel is open. */
-  private _panelOpen = false;
-
-  /** Whether filling out the select is required in the form. */
-  private _required: boolean = false;
-
   /** The scroll position of the overlay panel, calculated to center the selected option. */
   private _scrollTop = 0;
-
-  /** The placeholder displayed in the trigger of the select. */
-  private _placeholder: string;
-
-  /** Whether the component is in multiple selection mode. */
-  private _multiple: boolean = false;
-
-  /** Comparison function to specify which option is displayed. Defaults to object equality. */
-  private _compareWith = (o1: any, o2: any) => o1 === o2;
 
   /** Unique id for this input. */
   private _uid = `mat-select-${nextUniqueId++}`;
@@ -297,11 +283,17 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     },
   ];
 
-  /** Whether the select is focused. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   focused: boolean = false;
 
-  /** A name for this control that can be used by `mat-form-field`. */
-  controlType = 'mat-select';
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  controlType: string = 'mat-select';
 
   /** Trigger that opens the select. */
   @ViewChild('trigger') trigger: ElementRef;
@@ -324,21 +316,29 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** User-supplied override of the trigger element. */
   @ContentChild(MatSelectTrigger) customTrigger: MatSelectTrigger;
 
-  /** Placeholder to be shown if no value has been selected. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get placeholder(): string { return this._placeholder; }
   set placeholder(value: string) {
     this._placeholder = value;
     this.stateChanges.next();
   }
+  private _placeholder: string;
 
-  /** Whether the component is required. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get required(): boolean { return this._required; }
   set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
+  private _required: boolean = false;
 
   /** Whether the user should be allowed to select multiple options. */
   @Input()
@@ -350,6 +350,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
     this._multiple = coerceBooleanProperty(value);
   }
+  private _multiple: boolean = false;
 
   /**
    * A function to compare the option values with the selected values. The first argument
@@ -357,7 +358,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    * should be returned.
    */
   @Input()
-  get compareWith() { return this._compareWith; }
+  get compareWith(): (o1: any, o2: any) => boolean { return this._compareWith; }
   set compareWith(fn: (o1: any, o2: any) => boolean) {
     if (typeof fn !== 'function') {
       throw getMatSelectNonFunctionValueError();
@@ -368,14 +369,15 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       this._initializeSelection();
     }
   }
+  private _compareWith = (o1: any, o2: any) => o1 === o2;
 
   /** Value of the select control. */
   @Input()
   get value(): any { return this._value; }
-  set value(newValue: any) {
-    if (newValue !== this._value) {
-      this.writeValue(newValue);
-      this._value = newValue;
+  set value(value: any) {
+    if (value !== this._value) {
+      this.writeValue(value);
+      this._value = value;
     }
   }
   private _value: any;
@@ -389,7 +391,10 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;
 
-  /** Unique id of the element. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get id(): string { return this._id; }
   set id(value: string) {
@@ -465,6 +470,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     @Optional() _parentForm: NgForm,
     @Optional() _parentFormGroup: FormGroupDirective,
     @Optional() private _parentFormField: MatFormField,
+    /** @docs-private */
     @Self() @Optional() public ngControl: NgControl,
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SELECT_SCROLL_STRATEGY) private _scrollStrategyFactory) {
@@ -603,9 +609,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   }
 
   /** Whether or not the overlay panel is open. */
-  get panelOpen(): boolean {
-    return this._panelOpen;
-  }
+  get panelOpen(): boolean { return this._panelOpen; }
+  private _panelOpen = false;
 
   /** The currently selected option. */
   get selected(): MatOption | MatOption[] {
@@ -749,7 +754,10 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     return this._parentFormField ? `mat-${this._parentFormField.color}` : '';
   }
 
-  /** Whether the select has a value. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   get empty(): boolean {
     return !this._selectionModel || this._selectionModel.isEmpty();
   }

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -176,9 +176,6 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
   set disableClose(value: boolean) { this._disableClose = coerceBooleanProperty(value); }
   private _disableClose: boolean = false;
 
-  /** Whether the drawer is opened. */
-  private _opened: boolean = false;
-
   /** How the sidenav was opened (keypress, mouse click etc.) */
   private _openedVia: FocusOrigin | null;
 
@@ -335,7 +332,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
    */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(v: boolean) { this.toggle(coerceBooleanProperty(v)); }
+  set opened(value: boolean) { this.toggle(coerceBooleanProperty(value)); }
+  private _opened: boolean = false;
 
   /**
    * Open the drawer.
@@ -388,7 +386,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
    * Handles the keyboard events.
    * @docs-private
    */
-  handleKeydown(event: KeyboardEvent) {
+  handleKeydown(event: KeyboardEvent): void {
     if (event.keyCode === ESCAPE && !this.disableClose) {
       this.close();
       event.stopPropagation();
@@ -408,7 +406,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     }
   }
 
-  get _width() {
+  get _width(): number {
     return this._elementRef.nativeElement ? (this._elementRef.nativeElement.offsetWidth || 0) : 0;
   }
 }
@@ -457,7 +455,7 @@ export class MatDrawerContainer implements AfterContentInit, OnDestroy {
   private _autosize: boolean;
 
   /** Event emitted when the drawer backdrop is clicked. */
-  @Output() backdropClick = new EventEmitter<void>();
+  @Output() backdropClick: EventEmitter<void> = new EventEmitter<void>();
 
   /** The drawer at the start/end position, independent of direction. */
   private _start: MatDrawer | null;

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -76,7 +76,7 @@ export class MatSidenav extends MatDrawer {
   /** Whether the sidenav is fixed in the viewport. */
   @Input()
   get fixedInViewport(): boolean { return this._fixedInViewport; }
-  set fixedInViewport(value) { this._fixedInViewport = coerceBooleanProperty(value); }
+  set fixedInViewport(value: boolean) { this._fixedInViewport = coerceBooleanProperty(value); }
   private _fixedInViewport = false;
 
   /**
@@ -85,7 +85,7 @@ export class MatSidenav extends MatDrawer {
    */
   @Input()
   get fixedTopGap(): number { return this._fixedTopGap; }
-  set fixedTopGap(value) { this._fixedTopGap = coerceNumberProperty(value); }
+  set fixedTopGap(value: number) { this._fixedTopGap = coerceNumberProperty(value); }
   private _fixedTopGap = 0;
 
   /**
@@ -94,7 +94,7 @@ export class MatSidenav extends MatDrawer {
    */
   @Input()
   get fixedBottomGap(): number { return this._fixedBottomGap; }
-  set fixedBottomGap(value) { this._fixedBottomGap = coerceNumberProperty(value); }
+  set fixedBottomGap(value: number) { this._fixedBottomGap = coerceNumberProperty(value); }
   private _fixedBottomGap = 0;
 }
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -94,8 +94,6 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
 
   private _uniqueId: string = `mat-slide-toggle-${++nextUniqueId}`;
   private _slideRenderer: SlideToggleRenderer;
-  private _required: boolean = false;
-  private _checked: boolean = false;
 
   /** Reference to the focus state ripple. */
   private _focusRipple: RippleRef | null;
@@ -120,15 +118,18 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   /** Whether the slide-toggle is required. */
   @Input()
   get required(): boolean { return this._required; }
-  set required(value) { this._required = coerceBooleanProperty(value); }
+  set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  private _required: boolean = false;
 
   /** Whether the slide-toggle element is checked or not */
   @Input()
   get checked(): boolean { return this._checked; }
-  set checked(value) {
+  set checked(value: boolean) {
     this._checked = coerceBooleanProperty(value);
     this._changeDetectorRef.markForCheck();
   }
+  private _checked: boolean = false;
+
   /** An event will be dispatched each time the slide-toggle changes its value. */
   @Output() change: EventEmitter<MatSlideToggleChange> = new EventEmitter<MatSlideToggleChange>();
 

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -147,8 +147,8 @@ export class MatSlider extends _MatSliderMixinBase
   /** The maximum value that the slider can have. */
   @Input()
   get max(): number { return this._max; }
-  set max(v: number) {
-    this._max = coerceNumberProperty(v, this._max);
+  set max(value: number) {
+    this._max = coerceNumberProperty(value, this._max);
     this._percent = this._calculatePercentage(this._value);
 
     // Since this also modifies the percentage, we need to let the change detection know.
@@ -159,8 +159,8 @@ export class MatSlider extends _MatSliderMixinBase
   /** The minimum value that the slider can have. */
   @Input()
   get min(): number { return this._min; }
-  set min(v: number) {
-    this._min = coerceNumberProperty(v, this._min);
+  set min(value: number) {
+    this._min = coerceNumberProperty(value, this._min);
 
     // If the value wasn't explicitly set by the user, set it to the min.
     if (this._value === null) {
@@ -176,8 +176,8 @@ export class MatSlider extends _MatSliderMixinBase
   /** The values at which the thumb will snap. */
   @Input()
   get step(): number { return this._step; }
-  set step(v: number) {
-    this._step = coerceNumberProperty(v, this._step);
+  set step(value: number) {
+    this._step = coerceNumberProperty(value, this._step);
 
     if (this._step % 1 !== 0) {
       this._roundLabelTo = this._step.toString().split('.').pop()!.length;
@@ -200,14 +200,14 @@ export class MatSlider extends _MatSliderMixinBase
    */
   @Input('thumb-label')
   get _thumbLabelDeprecated(): boolean { return this._thumbLabel; }
-  set _thumbLabelDeprecated(value) { this._thumbLabel = value; }
+  set _thumbLabelDeprecated(value: boolean) { this._thumbLabel = value; }
 
   /**
    * How often to show ticks. Relative to the step so that a tick always appears on a step.
    * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
    */
   @Input()
-  get tickInterval() { return this._tickInterval; }
+  get tickInterval(): 'auto' | number { return this._tickInterval; }
   set tickInterval(value: 'auto' | number) {
     if (value === 'auto') {
       this._tickInterval = 'auto';
@@ -224,8 +224,8 @@ export class MatSlider extends _MatSliderMixinBase
    * @deletion-target 6.0.0
    */
   @Input('tick-interval')
-  get _tickIntervalDeprecated() { return this.tickInterval; }
-  set _tickIntervalDeprecated(v) { this.tickInterval = v; }
+  get _tickIntervalDeprecated(): 'auto' | number { return this.tickInterval; }
+  set _tickIntervalDeprecated(value: 'auto' | number) { this.tickInterval = value; }
 
   /** Value of the slider. */
   @Input()
@@ -236,9 +236,9 @@ export class MatSlider extends _MatSliderMixinBase
     }
     return this._value;
   }
-  set value(v: number | null) {
-    if (v !== this._value) {
-      this._value = coerceNumberProperty(v, this._value || 0);
+  set value(value: number | null) {
+    if (value !== this._value) {
+      this._value = coerceNumberProperty(value, this._value || 0);
       this._percent = this._calculatePercentage(this._value);
 
       // Since this also modifies the percentage, we need to let the change detection know.
@@ -250,9 +250,7 @@ export class MatSlider extends _MatSliderMixinBase
   /** Whether the slider is vertical. */
   @Input()
   get vertical(): boolean { return this._vertical; }
-  set vertical(value: boolean) {
-    this._vertical = coerceBooleanProperty(value);
-  }
+  set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
   private _vertical = false;
 
   /** Event emitted when the slider value has changed. */
@@ -273,18 +271,14 @@ export class MatSlider extends _MatSliderMixinBase
     return this.value || 0;
   }
 
-  /** set focus to the host element */
-  focus() {
-    this._focusHostElement();
-  }
+  /** Set focus to the host element */
+  focus(): void { this._focusHostElement(); }
 
-  /** blur the host element */
-  blur() {
-    this._blurHostElement();
-  }
+  /** Blur the host element */
+  blur(): void { this._blurHostElement(); }
 
   /** onTouch function registered via registerOnTouch (ControlValueAccessor). */
-  onTouched: () => any = () => {};
+  _onTouched: () => any = () => {};
 
   /** The percentage of the slider that coincides with the value. */
   get percent(): number { return this._clamp(this._percent); }
@@ -306,7 +300,7 @@ export class MatSlider extends _MatSliderMixinBase
    * Whether the axis of the slider is inverted.
    * (i.e. whether moving the thumb in the positive x or y direction decreases the slider's value).
    */
-  get _invertAxis() {
+  get _invertAxis(): boolean {
     // Standard non-inverted mode for a vertical slider should be dragging the thumb from bottom to
     // top. However from a y-axis standpoint this is inverted.
     return this.vertical ? !this.invert : this.invert;
@@ -314,15 +308,13 @@ export class MatSlider extends _MatSliderMixinBase
 
 
   /** Whether the slider is at its minimum value. */
-  get _isMinValue() {
-    return this.percent === 0;
-  }
+  get _isMinValue(): boolean { return this.percent === 0; }
 
   /**
    * The amount of space to leave between the slider thumb and the track fill & track background
    * elements.
    */
-  get _thumbGap() {
+  get _thumbGap(): number {
     if (this.disabled) {
       return DISABLED_THUMB_GAP;
     }
@@ -424,12 +416,12 @@ export class MatSlider extends _MatSliderMixinBase
    * Whether mouse events should be converted to a slider position by calculating their distance
    * from the right or bottom edge of the slider as opposed to the top or left.
    */
-  private get _invertMouseCoords() {
+  private get _invertMouseCoords(): boolean {
     return (this._direction == 'rtl' && !this.vertical) ? !this._invertAxis : this._invertAxis;
   }
 
   /** The language direction for this slider element. */
-  private get _direction() {
+  private get _direction(): 'ltr' | 'rtl' {
     return (this._dir && this._dir.value == 'rtl') ? 'rtl' : 'ltr';
   }
 
@@ -548,7 +540,7 @@ export class MatSlider extends _MatSliderMixinBase
   }
 
   _onBlur() {
-    this.onTouched();
+    this._onTouched();
   }
 
   _onKeydown(event: KeyboardEvent) {
@@ -735,7 +727,7 @@ export class MatSlider extends _MatSliderMixinBase
    * @param fn Callback to be registered.
    */
   registerOnTouched(fn: any) {
-    this.onTouched = fn;
+    this._onTouched = fn;
   }
 
   /**

--- a/src/lib/slider/test-gesture-config.ts
+++ b/src/lib/slider/test-gesture-config.ts
@@ -24,7 +24,7 @@ export class TestGestureConfig extends GestureConfig {
   /**
    * Create a mapping of Hammer instances to element so that events can be emitted during testing.
    */
-  buildHammer(element: HTMLElement) {
+  buildHammer(element: HTMLElement): HammerManager {
     let mc = super.buildHammer(element) as HammerManager;
     let instance = this.hammerInstances.get(element);
 
@@ -41,7 +41,7 @@ export class TestGestureConfig extends GestureConfig {
    * The Angular event plugin for Hammer creates a new HammerManager instance for each listener,
    * so we need to apply our event on all instances to hit the correct listener.
    */
-  emitEventForElement(eventType: string, element: HTMLElement, eventData = {}) {
+  emitEventForElement(eventType: string, element: HTMLElement, eventData = {}): void {
     let instances = this.hammerInstances.get(element);
 
     if (instances) {

--- a/src/lib/snack-bar/simple-snack-bar.ts
+++ b/src/lib/snack-bar/simple-snack-bar.ts
@@ -35,6 +35,7 @@ export class SimpleSnackBar {
   data: { message: string, action: string };
 
   constructor(
+    /** @docs-private */
     public snackBarRef: MatSnackBarRef<SimpleSnackBar>,
     @Inject(MAT_SNACK_BAR_DATA) data: any) {
     this.data = data;

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -106,7 +106,7 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   }
 
   /** Handle end of animations, updating the state of the snackbar. */
-  onAnimationEnd(event: AnimationEvent) {
+  onAnimationEnd(event: AnimationEvent): void {
     const {fromState, toState} = event;
 
     if ((toState === 'void' && fromState !== 'void') || toState.startsWith('hidden')) {

--- a/src/lib/sort/sort-header-intl.ts
+++ b/src/lib/sort/sort-header-intl.ts
@@ -23,12 +23,12 @@ export class MatSortHeaderIntl {
   changes: Subject<void> = new Subject<void>();
 
   /** ARIA label for the sorting button. */
-  sortButtonLabel = (id: string) => {
+  sortButtonLabel = (id: string): string => {
     return `Change sorting for ${id}`;
   }
 
   /** A label to describe the current sort (visible only to screenreaders). */
-  sortDescriptionLabel = (id: string, direction: SortDirection) => {
+  sortDescriptionLabel = (id: string, direction: SortDirection): string => {
     return `Sorted by ${id} ${direction == 'asc' ? 'ascending' : 'descending'}`;
   }
 }

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -79,7 +79,7 @@ export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortabl
   /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
   @Input()
   get disableClear(): boolean { return this._disableClear; }
-  set disableClear(v) { this._disableClear = coerceBooleanProperty(v); }
+  set disableClear(value: boolean) { this._disableClear = coerceBooleanProperty(value); }
   private _disableClear: boolean;
 
   constructor(public _intl: MatSortHeaderIntl,

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -59,7 +59,7 @@ export const _MatSortMixinBase = mixinDisabled(MatSortBase);
 })
 export class MatSort extends _MatSortMixinBase implements CanDisable, OnChanges, OnDestroy {
   /** Collection of all registered sortables that this directive manages. */
-  sortables = new Map<string, MatSortable>();
+  sortables: Map<string, MatSortable> = new Map<string, MatSortable>();
 
   /** Used to notify any child components listening to state changes. */
   _stateChanges = new Subject<void>();
@@ -76,11 +76,11 @@ export class MatSort extends _MatSortMixinBase implements CanDisable, OnChanges,
   /** The sort direction of the currently active MatSortable. */
   @Input('matSortDirection')
   get direction(): SortDirection { return this._direction; }
-  set direction(direction: SortDirection) {
-    if (isDevMode() && direction && direction !== 'asc' && direction !== 'desc') {
-      throw getSortInvalidDirectionError(direction);
+  set direction(value: SortDirection) {
+    if (isDevMode() && value && value !== 'asc' && value !== 'desc') {
+      throw getSortInvalidDirectionError(value);
     }
-    this._direction = direction;
+    this._direction = value;
   }
   private _direction: SortDirection = '';
 
@@ -90,7 +90,7 @@ export class MatSort extends _MatSortMixinBase implements CanDisable, OnChanges,
    */
   @Input('matSortDisableClear')
   get disableClear(): boolean { return this._disableClear; }
-  set disableClear(v: boolean) { this._disableClear = coerceBooleanProperty(v); }
+  set disableClear(value: boolean) { this._disableClear = coerceBooleanProperty(value); }
   private _disableClear: boolean;
 
   /** Event emitted when the user changes either the active sort or sort direction. */

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -50,26 +50,26 @@ export class MatTableDataSource<T> implements DataSource<T> {
   filteredData: T[];
 
   /** Array of data that should be rendered by the table, where each object represents one row. */
-  get data() { return this._data.value; }
-  set data(data: T[]) { this._data.next(data); }
+  get data(): T[] { return this._data.value; }
+  set data(value: T[]) { this._data.next(value); }
 
   /**
    * Filter term that should be used to filter out objects from the data array. To override how
    * data objects match to this filter string, provide a custom function for filterPredicate.
    */
   get filter(): string { return this._filter.value; }
-  set filter(filter: string) { this._filter.next(filter); }
+  set filter(value: string) { this._filter.next(value); }
 
   /**
    * Instance of the MatSort directive used by the table to control its sorting. Sort changes
    * emitted by the MatSort will trigger an update to the table's rendered data.
    */
   get sort(): MatSort | null { return this._sort; }
-  set sort(sort: MatSort|null) {
-    this._sort = sort;
+  set sort(value: MatSort | null) {
+    this._sort = value;
     this._updateChangeSubscription();
   }
-  private _sort: MatSort|null;
+  private _sort: MatSort | null;
 
   /**
    * Instance of the MatPaginator component used by the table to control what page of the data is
@@ -82,11 +82,11 @@ export class MatTableDataSource<T> implements DataSource<T> {
    * initialized before assigning it to this data source.
    */
   get paginator(): MatPaginator | null { return this._paginator; }
-  set paginator(paginator: MatPaginator|null) {
-    this._paginator = paginator;
+  set paginator(value: MatPaginator | null) {
+    this._paginator = value;
     this._updateChangeSubscription();
   }
-  private _paginator: MatPaginator|null;
+  private _paginator: MatPaginator | null;
 
   /**
    * Data accessor function that is used for accessing data properties for sorting through

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -285,9 +285,9 @@ interface TestData {
 }
 
 class FakeDataSource extends DataSource<TestData> {
-  _dataChange = new BehaviorSubject<TestData[]>([]);
+  get data(): TestData[] { return this._dataChange.getValue(); }
   set data(data: TestData[]) { this._dataChange.next(data); }
-  get data() { return this._dataChange.getValue(); }
+  _dataChange = new BehaviorSubject<TestData[]>([]);
 
   constructor() {
     super();

--- a/src/lib/tabs/ink-bar.ts
+++ b/src/lib/tabs/ink-bar.ts
@@ -29,7 +29,7 @@ export class MatInkBar {
    * Shows the ink bar if previously set as hidden.
    * @param element
    */
-  alignToElement(element: HTMLElement) {
+  alignToElement(element: HTMLElement): void {
     this.show();
 
     if (typeof requestAnimationFrame !== 'undefined') {

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -71,7 +71,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   }
 
   /** Set initial visibility or set up subscription for changing visibility. */
-  ngOnInit(): void {
+  ngOnInit() {
     if (this._host._isCenterPosition(this._host._position)) {
       this.attach(this._host._content);
     }
@@ -89,7 +89,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   }
 
   /** Clean up centering subscription. */
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     if (this._centeringSub && !this._centeringSub.closed) {
       this._centeringSub.unsubscribe();
     }
@@ -135,10 +135,10 @@ export class MatTabBody implements OnInit {
 
   /** The shifted index position of the tab body, where zero represents the active center tab. */
   @Input()
-  set position(position: number) {
-    if (position < 0) {
+  set position(value: number) {
+    if (value < 0) {
       this._position = this._getLayoutDirection() == 'ltr' ? 'left' : 'right';
-    } else if (position > 0) {
+    } else if (value > 0) {
       this._position = this._getLayoutDirection() == 'ltr' ? 'right' : 'left';
     } else {
       this._position = 'center';
@@ -148,11 +148,11 @@ export class MatTabBody implements OnInit {
 
   /** The origin position from which this tab should appear when it is centered into view. */
   @Input()
-  set origin(origin: number) {
-    if (origin == null) { return; }
+  set origin(value: number) {
+    if (value == null) { return; }
 
     const dir = this._getLayoutDirection();
-    if ((dir == 'ltr' && origin <= 0) || (dir == 'rtl' && origin > 0)) {
+    if ((dir == 'ltr' && value <= 0) || (dir == 'rtl' && value > 0)) {
       this._origin = 'left';
     } else {
       this._origin = 'right';

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -139,7 +139,7 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   private _backgroundColor: ThemePalette;
 
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
-  @Output() selectedIndexChange: EventEmitter<number> = new EventEmitter();
+  @Output() selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
   /** Event emitted when focus has changed within a tab group. */
   @Output() focusChange: EventEmitter<MatTabChangeEvent> = new EventEmitter<MatTabChangeEvent>();
@@ -172,7 +172,7 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
    * each tab should be in according to the new selected index, and additionally we know how
    * a new selected tab should transition in (from the left or right).
    */
-  ngAfterContentChecked(): void {
+  ngAfterContentChecked() {
     // Clamp the next selected index to the boundsof 0 and the tabs length.
     // Note the `|| 0`, which ensures that values like NaN can't get through
     // and which would otherwise throw the component into an infinite loop

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -113,8 +113,6 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
   /** Whether the scroll distance has changed and should be applied after the view is checked. */
   private _scrollDistanceChanged: boolean;
 
-  private _selectedIndex: number = 0;
-
   /** The index of the active tab. */
   @Input()
   get selectedIndex(): number { return this._selectedIndex; }
@@ -124,12 +122,13 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this._selectedIndex = value;
     this._focusIndex = value;
   }
+  private _selectedIndex: number = 0;
 
   /** Event emitted when the option is selected. */
-  @Output() selectFocusedIndex = new EventEmitter();
+  @Output() selectFocusedIndex: EventEmitter<number> = new EventEmitter<number>();
 
   /** Event emitted when a label is focused. */
-  @Output() indexFocused = new EventEmitter();
+  @Output() indexFocused: EventEmitter<number> = new EventEmitter<number>();
 
   constructor(private _elementRef: ElementRef,
               private _changeDetectorRef: ChangeDetectorRef,
@@ -138,7 +137,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     super();
   }
 
-  ngAfterContentChecked(): void {
+  ngAfterContentChecked() {
     // If the number of tab labels have changed, check if scrolling should be enabled
     if (this._tabLabelCount != this._labelWrappers.length) {
       this._updatePagination();
@@ -220,6 +219,8 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this._updateTabScrollPosition();
   }
 
+  /** Tracks which element has focus; used for keyboard navigation */
+  get focusIndex(): number { return this._focusIndex; }
   /** When the focus index is set, we must manually send focus to the correct label */
   set focusIndex(value: number) {
     if (!this._isValidIndex(value) || this._focusIndex == value) { return; }
@@ -228,9 +229,6 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this.indexFocused.emit(value);
     this._setTabFocus(value);
   }
-
-  /** Tracks which element has focus; used for keyboard navigation */
-  get focusIndex(): number { return this._focusIndex; }
 
   /**
    * Determines if an index is valid.  If the tabs are not ready yet, we assume that the user is
@@ -311,8 +309,8 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
 
   /** Sets the distance in pixels that the tab header should be transformed in the X-axis. */
   get scrollDistance(): number { return this._scrollDistance; }
-  set scrollDistance(v: number) {
-    this._scrollDistance = Math.max(0, Math.min(this._getMaxScrollDistance(), v));
+  set scrollDistance(value: number) {
+    this._scrollDistance = Math.max(0, Math.min(this._getMaxScrollDistance(), value));
 
     // Mark that the scroll distance has changed so that after the view is checked, the CSS
     // transformation can move the header.

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -106,7 +106,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
 
   /** Whether ripples should be disabled for all links or not. */
   @Input()
-  get disableRipple() { return this._disableRipple; }
+  get disableRipple(): boolean { return this._disableRipple; }
   set disableRipple(value: boolean) {
     this._disableRipple = coerceBooleanProperty(value);
     this._setLinkDisableRipple();
@@ -122,7 +122,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
   }
 
   /** Notifies the component that the active link has been changed. */
-  updateActiveLink(element: ElementRef) {
+  updateActiveLink(element: ElementRef): void {
     this._activeLinkChanged = this._activeLinkElement != element;
     this._activeLinkElement = element;
 
@@ -131,7 +131,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
     }
   }
 
-  ngAfterContentInit(): void {
+  ngAfterContentInit() {
     this._ngZone.runOutsideAngular(() => {
       const dirChange = this._dir ? this._dir.change : observableOf(null);
 
@@ -143,7 +143,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
   }
 
   /** Checks if the active link has been changed and, if so, will update the ink bar. */
-  ngAfterContentChecked(): void {
+  ngAfterContentChecked() {
     if (this._activeLinkChanged) {
       this._alignInkBar();
       this._activeLinkChanged = false;

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -55,9 +55,7 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
   private _contentPortal: TemplatePortal | null = null;
 
   /** @docs-private */
-  get content(): TemplatePortal | null {
-    return this._contentPortal;
-  }
+  get content(): TemplatePortal | null { return this._contentPortal; }
 
   /** Emits whenever the label changes. */
   _labelChange = new Subject<void>();
@@ -77,10 +75,8 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
    */
   origin: number | null = null;
 
-  /**
-   * Whether the tab is currently active.
-   */
-  isActive = false;
+  /** Whether the tab is currently active. */
+  isActive: boolean = false;
 
   constructor(private _viewContainerRef: ViewContainerRef) {
     super();
@@ -96,12 +92,12 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
     }
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this._disableChange.complete();
     this._labelChange.complete();
   }
 
-  ngOnInit(): void {
+  ngOnInit() {
     this._contentPortal = new TemplatePortal(this._content, this._viewContainerRef);
   }
 }

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -107,10 +107,6 @@ export class MatTooltip implements OnDestroy {
   _overlayRef: OverlayRef | null;
   _tooltipInstance: TooltipComponent | null;
 
-  private _position: TooltipPosition = 'below';
-  private _disabled: boolean = false;
-  private _tooltipClass: string|string[]|Set<string>|{[key: string]: any};
-
   /** Allows the user to define the position of the tooltip relative to the parent element */
   @Input('matTooltipPosition')
   get position(): TooltipPosition { return this._position; }
@@ -125,11 +121,12 @@ export class MatTooltip implements OnDestroy {
       }
     }
   }
+  private _position: TooltipPosition = 'below';
 
   /** Disables the display of the tooltip. */
   @Input('matTooltipDisabled')
   get disabled(): boolean { return this._disabled; }
-  set disabled(value) {
+  set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
 
     // If tooltip is disabled, hide immediately.
@@ -137,6 +134,7 @@ export class MatTooltip implements OnDestroy {
       this.hide(0);
     }
   }
+  private _disabled: boolean = false;
 
   /**
    * @deprecated
@@ -158,7 +156,7 @@ export class MatTooltip implements OnDestroy {
 
   /** The message to be displayed in the tooltip */
   @Input('matTooltip')
-  get message() { return this._message; }
+  get message(): string { return this._message; }
   set message(value: string) {
     this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message);
 
@@ -175,13 +173,16 @@ export class MatTooltip implements OnDestroy {
 
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */
   @Input('matTooltipClass')
-  get tooltipClass() { return this._tooltipClass; }
-  set tooltipClass(value: string|string[]|Set<string>|{[key: string]: any}) {
+  get tooltipClass(): string | string[] | Set<string> | { [key: string]: any } {
+    return this._tooltipClass;
+  }
+  set tooltipClass(value: string | string[] | Set<string> | {[key: string]: any}) {
     this._tooltipClass = value;
     if (this._tooltipInstance) {
       this._setTooltipClass(this._tooltipClass);
     }
   }
+  private _tooltipClass: string | string[] | Set<string> | { [key: string]: any };
 
   private _manualListeners = new Map<string, Function>();
 

--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
@@ -39,37 +39,37 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
 
   controlType = 'my-tel-input';
 
-  get empty() {
+  get empty(): boolean {
     let n = this.parts.value;
     return !n.area && !n.exchange && !n.subscriber;
   }
 
-  get shouldLabelFloat() { return this.focused || !this.empty; }
+  get shouldLabelFloat(): boolean { return this.focused || !this.empty; }
 
   id = `my-tel-input-${MyTelInput.nextId++}`;
 
   describedBy = '';
 
   @Input()
-  get placeholder() { return this._placeholder; }
-  set placeholder(plh) {
-    this._placeholder = plh;
+  get placeholder(): string { return this._placeholder; }
+  set placeholder(value: string) {
+    this._placeholder = value;
     this.stateChanges.next();
   }
   private _placeholder: string;
 
   @Input()
-  get required() { return this._required; }
-  set required(req) {
-    this._required = coerceBooleanProperty(req);
+  get required(): boolean { return this._required; }
+  set required(value: boolean) {
+    this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
   private _required = false;
 
   @Input()
-  get disabled() { return this._disabled; }
-  set disabled(dis) {
-    this._disabled = coerceBooleanProperty(dis);
+  get disabled(): boolean { return this._disabled; }
+  set disabled(value: boolean) {
+    this._disabled = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
   private _disabled = false;
@@ -90,9 +90,9 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
 
   constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef) {
     this.parts = fb.group({
-      'area': '',
-      'exchange': '',
-      'subscriber': '',
+      area: '',
+      exchange: '',
+      subscriber: '',
     });
 
     fm.monitor(elRef.nativeElement, true).subscribe((origin) => {

--- a/src/material-examples/slider-configurable/slider-configurable-example.ts
+++ b/src/material-examples/slider-configurable/slider-configurable-example.ts
@@ -22,11 +22,11 @@ export class SliderConfigurableExample {
   value = 0;
   vertical = false;
 
-  get tickInterval(): number | 'auto' {
+  get tickInterval(): 'auto' | number {
     return this.showTicks ? (this.autoTicks ? 'auto' : this._tickInterval) : 0;
   }
-  set tickInterval(v) {
-    this._tickInterval = Number(v);
+  set tickInterval(value: 'auto' | number) {
+    this._tickInterval = Number(value);
   }
   private _tickInterval = 1;
 }

--- a/tools/screenshot-test/src/app/result/result.component.ts
+++ b/tools/screenshot-test/src/app/result/result.component.ts
@@ -32,23 +32,21 @@ export class ResultComponent {
    * Test result, auto set collapse to be the same as the result value
    */
   @Input()
-  get result() { return this._result; }
+  get result(): boolean { return this._result; }
   set result(value: boolean) {
     this._result = value;
     this.collapse = value;
   }
   _result: boolean;
 
-  get resultText() {
-    return this._result ? 'Passed' : 'Failed';
-  }
+  get resultText(): string { return this._result ? 'Passed' : 'Failed'; }
 
   /** Collapse: whether collapse or expand the card to show images */
   @Input() collapse: boolean = true;
 
   /** Mode: the result card has three modes, flip, side by side, and diff */
   @Input()
-  get mode() { return this._mode; }
+  get mode(): 'flip' | 'side-by-side' | 'diff' { return this._mode; }
   set mode(value: 'flip' | 'side-by-side' | 'diff') {
     this._mode = value;
     this.modeEvent.emit(value);
@@ -58,7 +56,7 @@ export class ResultComponent {
 
   /** When mode is "flip" whether we show the test image or the golden image */
   @Input()
-  get flipping() { return this._flipping; }
+  get flipping(): boolean { return this._flipping; }
   set flipping(value: boolean) {
     this._flipping = value;
     this.flippingEvent.emit(value);


### PR DESCRIPTION
Basically, this PR adds the missing types/docs for leftovers after #7711.

Fixes #8832.

**PS**: It'd be great to use something like [typedef](https://palantir.github.io/tslint/rules/typedef/) to ensure types for getters and setters are specified.