### PR TITLE
chore(expansion): revert pull #9313

### DIFF
--- a/src/lib/expansion/expansion-animations.ts
+++ b/src/lib/expansion/expansion-animations.ts
@@ -35,12 +35,12 @@ export const matExpansionAnimations: {
     state('collapsed', style({
       height: '{{collapsedHeight}}',
     }), {
-      params: {collapsedHeight: '*'},
+      params: {collapsedHeight: '48px'},
     }),
     state('expanded', style({
       height: '{{expandedHeight}}'
     }), {
-      params: {expandedHeight: '*'}
+      params: {expandedHeight: '64px'}
     }),
     transition('expanded <=> collapsed', animate(EXPANSION_PANEL_ANIMATION_TIMING)),
   ]),

--- a/src/lib/expansion/expansion-panel-header.scss
+++ b/src/lib/expansion/expansion-panel-header.scss
@@ -2,13 +2,8 @@
 .mat-expansion-panel-header {
   display: flex;
   flex-direction: row;
-  height: 48px;
   align-items: center;
   padding: 0 24px;
-
-  &.mat-expanded {
-    height: 64px;
-  }
 
   &:focus,
   &:hover {


### PR DESCRIPTION
Reverting change as angular animations is not able to animate between end states which are defined by a difference in computed styles from the presence of a class.