### PR TITLE
chore: fix warning about unconfigurable property

### DIFF
--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -346,9 +346,12 @@ describe('InteractivityChecker', () => {
         iframe.setAttribute('tabindex', '-1');
         iframe.contentDocument.body.appendChild(button);
 
-        Object.defineProperty(iframe.contentWindow, 'frameElement', {
-          get: () => { throw 'Access Denied!'; }
-        });
+        // Some browsers explicitly prevent overwriting of properties on a `Window` object.
+        if (!platform.SAFARI) {
+          Object.defineProperty(iframe.contentWindow, 'frameElement', {
+            get: () => { throw 'Access Denied!'; }
+          });
+        }
 
         expect(() => checker.isTabbable(button)).not.toThrow();
       });


### PR DESCRIPTION
Fixes that some browsers in Browserstack or Saucelabs warn about the `defineProperty` call in the interactivity checker tests.

`LOG: 'Attempting to configure 'frameElement' with descriptor '{}' on object '[object Window]' and got error, giving up: TypeError: Attempting to change the getter of an unconfigurable property.'`.

This happens because some browsers explicitly set all properties to `configurable: false` on `window` objects. To avoid such warnings, we can just check if the properties is configurable (or doesn't exist).