### PR TITLE
test(paginator): fix off-by-one error

### DIFF
--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -125,17 +125,17 @@ describe('MatPaginator', () => {
       expect(component.latestPageEvent ? component.latestPageEvent.pageIndex : null).toBe(0);
     });
 
-    it('should disable navigating to the next page if at first page', () => {
+    it('should disable navigating to the next page if at last page', () => {
       component.goToLastPage();
       fixture.detectChanges();
-      expect(paginator.pageIndex).toBe(10);
+      expect(paginator.pageIndex).toBe(9);
       expect(paginator.hasNextPage()).toBe(false);
 
       component.latestPageEvent = null;
       dispatchMouseEvent(getNextButton(fixture), 'click');
 
       expect(component.latestPageEvent).toBe(null);
-      expect(paginator.pageIndex).toBe(10);
+      expect(paginator.pageIndex).toBe(9);
     });
 
     it('should disable navigating to the previous page if at first page', () => {
@@ -310,7 +310,7 @@ class MatPaginatorApp {
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
   goToLastPage() {
-    this.pageIndex = Math.ceil(this.length / this.pageSize);
+    this.pageIndex = Math.ceil(this.length / this.pageSize) - 1;
   }
 }
 


### PR DESCRIPTION
Whilst there are 10 pages they are starting from index 0 and therefore the last page is in fact index 9.
This error was repeated both in the length calculation and in the assertion statements, therefore the
test passed when it should have failed.

Discovered in #9278, currently blocked by #9584 as it includes that fix