### PR TITLE
fix(scrolling): implement ngOnDestroy in ScrollDispatcher

### DIFF
--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -180,6 +180,22 @@ describe('Scroll Dispatcher', () => {
           .toBe(4, 'Expected scrollable count to stay the same');
     });
 
+    it('should remove the global subscription on destroy', () => {
+      expect(scroll._globalSubscription).toBeNull('Expected no global listeners on init.');
+
+      const subscription = scroll.scrolled(0).subscribe(() => {});
+
+      expect(scroll._globalSubscription).toBeTruthy(
+          'Expected global listeners after a subscription has been added.');
+
+      scroll.ngOnDestroy();
+
+      expect(scroll._globalSubscription).toBeNull(
+          'Expected global listeners to have been removed after the subscription has stopped.');
+
+      subscription.unsubscribe();
+    });
+
   });
 });
 


### PR DESCRIPTION
Sets up some cleanup logic in the `ScrollDispatcher` in case the module is unloaded.