### PR TITLE
refactor: use emit instead of next for event emitters

### DIFF
--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -190,7 +190,7 @@ export class MatPaginator implements OnInit, OnDestroy {
 
   /** Emits an event notifying that a change of the paginator's properties has been triggered. */
   private _emitPageEvent() {
-    this.page.next({
+    this.page.emit({
       pageIndex: this.pageIndex,
       pageSize: this.pageSize,
       length: this.length

--- a/src/lib/sort/sort.ts
+++ b/src/lib/sort/sort.ts
@@ -128,7 +128,7 @@ export class MatSort extends _MatSortMixinBase implements CanDisable, OnChanges,
       this.direction = this.getNextSortDirection(sortable);
     }
 
-    this.sortChange.next({active: this.active, direction: this.direction});
+    this.sortChange.emit({active: this.active, direction: this.direction});
   }
 
   /** Returns the next sort direction of the active sortable, checking for potential overrides. */


### PR DESCRIPTION
We should use `emit` instead of `next`. PR [@angular/angular#5302](https://github.com/angular/angular/pull/5302) had deprecated `next` method.