### PR TITLE
docs: add types to public methods and getters/setters

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -118,7 +118,6 @@ export function getMatAutocompleteMissingPanelError(): Error {
 export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   private _overlayRef: OverlayRef | null;
   private _portal: TemplatePortal;
-  private _panelOpen: boolean = false;
   private _componentDestroyed = false;
 
   /** Strategy that is used to position the panel. */
@@ -158,9 +157,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   }
 
   /** Whether or not the autocomplete panel is open. */
-  get panelOpen(): boolean {
-    return this._panelOpen && this.autocomplete.showPanel;
-  }
+  get panelOpen(): boolean { return this._panelOpen && this.autocomplete.showPanel; }
+  private _panelOpen: boolean = false;
 
   /** Opens the autocomplete suggestion panel. */
   openPanel(): void {
@@ -252,42 +250,22 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     }));
   }
 
-  /**
-   * Sets the autocomplete's value. Part of the ControlValueAccessor interface
-   * required to integrate with Angular's core forms API.
-   *
-   * @param value New value to be written to the model.
-   */
+  // Implemented as part of ControlValueAccessor.
   writeValue(value: any): void {
     Promise.resolve(null).then(() => this._setTriggerValue(value));
   }
 
-  /**
-   * Saves a callback function to be invoked when the autocomplete's value
-   * changes from user input. Part of the ControlValueAccessor interface
-   * required to integrate with Angular's core forms API.
-   *
-   * @param fn Callback to be triggered when the value changes.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnChange(fn: (value: any) => {}): void {
     this._onChange = fn;
   }
 
-  /**
-   * Saves a callback function to be invoked when the autocomplete is blurred
-   * by the user. Part of the ControlValueAccessor interface required
-   * to integrate with Angular's core forms API.
-   *
-   * @param fn Callback to be triggered when the component has been touched.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnTouched(fn: () => {}) {
     this._onTouched = fn;
   }
 
-  /**
-   * Disables the input. Implemented as a part of `ControlValueAccessor`.
-   * @param isDisabled Whether the component should be disabled.
-   */
+  // Implemented as part of ControlValueAccessor.
   setDisabledState(isDisabled: boolean) {
     this._element.nativeElement.disabled = isDisabled;
   }

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -89,12 +89,10 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   _keyManager: ActiveDescendantKeyManager<MatOption>;
 
   /** Whether the autocomplete panel should be visible, depending on option length. */
-  showPanel = false;
+  showPanel: boolean = false;
 
   /** Whether the autocomplete panel is open. */
-  get isOpen(): boolean {
-    return this._isOpen && this.showPanel;
-  }
+  get isOpen(): boolean { return this._isOpen && this.showPanel; }
   _isOpen: boolean = false;
 
   /** @docs-private */
@@ -133,9 +131,9 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
    * inside the overlay container to allow for easy styling.
    */
   @Input('class')
-  set classList(classList: string) {
-    if (classList && classList.length) {
-      classList.split(' ').forEach(className => this._classList[className.trim()] = true);
+  set classList(value: string) {
+    if (value && value.length) {
+      value.split(' ').forEach(className => this._classList[className.trim()] = true);
       this._elementRef.nativeElement.className = '';
     }
   }

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -73,19 +73,6 @@ export class MatButtonToggleChange {
 })
 export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     implements ControlValueAccessor, CanDisable {
-
-  /** The value for the button toggle group. Should match currently selected button toggle. */
-  private _value: any = null;
-
-  /** The HTML name attribute applied to toggles in this group. */
-  private _name: string = `mat-button-toggle-group-${_uniqueIdCounter++}`;
-
-  /** Whether the button toggle group should be vertical. */
-  private _vertical: boolean = false;
-
-  /** The currently selected button toggle, should match the value. */
-  private _selected: MatButtonToggle | null = null;
-
   /**
    * The method to be called in order to update ngModel.
    * Now `ngModel` binding is not supported in multiple selection mode.
@@ -105,22 +92,25 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     this._name = value;
     this._updateButtonToggleNames();
   }
+  private _name: string = `mat-button-toggle-group-${_uniqueIdCounter++}`;
 
   /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean { return this._vertical; }
   set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
+  private _vertical: boolean = false;
 
   /** Value of the toggle group. */
   @Input()
   get value(): any { return this._value; }
-  set value(newValue: any) {
-    if (this._value != newValue) {
-      this._value = newValue;
-      this.valueChange.emit(newValue);
+  set value(value: any) {
+    if (this._value != value) {
+      this._value = value;
+      this.valueChange.emit(value);
       this._updateSelectedButtonToggleFromValue();
     }
   }
+  private _value: any = null;
 
   /**
    * Event that emits whenever the value of the group changes.
@@ -129,7 +119,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
    */
   @Output() readonly valueChange = new EventEmitter<any>();
 
-  /** Whether the toggle group is selected. */
+  /** The currently selected button toggle, should match the value. */
   @Input()
   get selected(): MatButtonToggle | null { return this._selected; }
   set selected(selected: MatButtonToggle | null) {
@@ -140,6 +130,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
       selected.checked = true;
     }
   }
+  private _selected: MatButtonToggle | null = null;
 
   /** Event emitted when the group's value changes. */
   @Output() readonly change: EventEmitter<MatButtonToggleChange> =
@@ -185,37 +176,23 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
     this.change.emit(event);
   }
 
-  /**
-   * Sets the model value. Implemented as part of ControlValueAccessor.
-   * @param value Value to be set to the model.
-   */
+  // Implemented as part of ControlValueAccessor.
   writeValue(value: any) {
     this.value = value;
     this._changeDetector.markForCheck();
   }
 
-  /**
-   * Registers a callback that will be triggered when the value has changed.
-   * Implemented as part of ControlValueAccessor.
-   * @param fn On change callback function.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Registers a callback that will be triggered when the control has been touched.
-   * Implemented as part of ControlValueAccessor.
-   * @param fn On touch callback function.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnTouched(fn: any) {
     this._onTouched = fn;
   }
 
-  /**
-   * Toggles the disabled state of the component. Implemented as part of ControlValueAccessor.
-   * @param isDisabled Whether the component should be disabled.
-   */
+  // Implemented as part of ControlValueAccessor.
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
     this._markButtonTogglesForCheck();
@@ -241,16 +218,11 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 })
 export class MatButtonToggleGroupMultiple extends _MatButtonToggleGroupMixinBase
     implements CanDisable {
-
-  /** Whether the button toggle group should be vertical. */
-  private _vertical: boolean = false;
-
   /** Whether the toggle group is vertical. */
   @Input()
   get vertical(): boolean { return this._vertical; }
-  set vertical(value) {
-    this._vertical = coerceBooleanProperty(value);
-  }
+  set vertical(value: boolean) { this._vertical = coerceBooleanProperty(value); }
+  private _vertical: boolean = false;
 }
 
 /** Single button inside of a toggle group. */
@@ -283,17 +255,8 @@ export class MatButtonToggle implements OnInit, OnDestroy {
    */
   @Input('aria-labelledby') ariaLabelledby: string | null = null;
 
-  /** Whether or not this button toggle is checked. */
-  private _checked: boolean = false;
-
   /** Type of the button toggle. Either 'radio' or 'checkbox'. */
   _type: ToggleType;
-
-  /** Whether or not this button toggle is disabled. */
-  private _disabled: boolean = false;
-
-  /** Value assigned to this button toggle. */
-  private _value: any = null;
 
   /** Whether or not the button toggle is a single selection. */
   private _isSingleSelector: boolean = false;
@@ -321,19 +284,20 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   /** Whether the button is checked. */
   @Input()
   get checked(): boolean { return this._checked; }
-  set checked(newCheckedState: boolean) {
-    if (this._isSingleSelector && newCheckedState) {
+  set checked(value: boolean) {
+    if (this._isSingleSelector && value) {
       // Notify all button toggles with the same name (in the same group) to un-check.
       this._buttonToggleDispatcher.notify(this.id, this.name);
       this._changeDetectorRef.markForCheck();
     }
 
-    this._checked = newCheckedState;
+    this._checked = value;
 
-    if (newCheckedState && this._isSingleSelector && this.buttonToggleGroup.value != this.value) {
+    if (value && this._isSingleSelector && this.buttonToggleGroup.value != this.value) {
       this.buttonToggleGroup.selected = this;
     }
   }
+  private _checked: boolean = false;
 
   /** MatButtonToggleGroup reads this to assign its own value. */
   @Input()
@@ -346,6 +310,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
       this._value = value;
     }
   }
+  private _value: any = null;
 
   /** Whether the button is disabled. */
   @Input()
@@ -353,9 +318,8 @@ export class MatButtonToggle implements OnInit, OnDestroy {
     return this._disabled || (this.buttonToggleGroup != null && this.buttonToggleGroup.disabled) ||
         (this.buttonToggleGroupMultiple != null && this.buttonToggleGroupMultiple.disabled);
   }
-  set disabled(value: boolean) {
-    this._disabled = coerceBooleanProperty(value);
-  }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled: boolean = false;
 
   /** Event emitted when the group value changes. */
   @Output() readonly change: EventEmitter<MatButtonToggleChange> =
@@ -403,7 +367,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   }
 
   /** Focuses the button. */
-  focus() {
+  focus(): void {
     this._inputElement.nativeElement.focus();
   }
 
@@ -454,7 +418,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
   }
 
   // Unregister buttonToggleDispatcherListener on destroy
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this._removeUniqueSelectionListener();
   }
 

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -137,12 +137,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
-  private _required: boolean;
-
   /** Whether the checkbox is required. */
   @Input()
   get required(): boolean { return this._required; }
-  set required(value) { this._required = coerceBooleanProperty(value); }
+  set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  private _required: boolean;
 
   /**
    * Whether or not the checkbox should appear before or after the label.
@@ -155,8 +154,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     // label relative to the checkbox. As such, they are inverted.
     return this.labelPosition == 'after' ? 'start' : 'end';
   }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
+  set align(value: 'start' | 'end') {
+    this.labelPosition = (value == 'start') ? 'after' : 'before';
   }
 
   /** Whether the label should appear after or before the checkbox. Defaults to 'after' */
@@ -185,15 +184,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor.
    * @docs-private
    */
-  onTouched: () => any = () => {};
+  _onTouched: () => any = () => {};
 
   private _currentAnimationClass: string = '';
 
   private _currentCheckState: TransitionCheckState = TransitionCheckState.Init;
-
-  private _checked: boolean = false;
-
-  private _indeterminate: boolean = false;
 
   private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
@@ -225,13 +220,14 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * Whether the checkbox is checked.
    */
   @Input()
-  get checked() { return this._checked; }
-  set checked(checked: boolean) {
-    if (checked != this.checked) {
-      this._checked = checked;
+  get checked(): boolean { return this._checked; }
+  set checked(value: boolean) {
+    if (value != this.checked) {
+      this._checked = value;
       this._changeDetectorRef.markForCheck();
     }
   }
+  private _checked: boolean = false;
 
   /**
    * Whether the checkbox is indeterminate. This is also known as "mixed" mode and can be used to
@@ -240,10 +236,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    * set to false.
    */
   @Input()
-  get indeterminate() { return this._indeterminate; }
-  set indeterminate(indeterminate: boolean) {
-    let changed =  indeterminate != this._indeterminate;
-    this._indeterminate = indeterminate;
+  get indeterminate(): boolean { return this._indeterminate; }
+  set indeterminate(value: boolean) {
+    const changed = value != this._indeterminate;
+    this._indeterminate = value;
 
     if (changed) {
       if (this._indeterminate) {
@@ -255,6 +251,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       this.indeterminateChange.emit(this._indeterminate);
     }
   }
+  private _indeterminate: boolean = false;
 
   _isRippleDisabled() {
     return this.disableRipple || this.disabled;
@@ -268,36 +265,22 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     this._changeDetectorRef.markForCheck();
   }
 
-  /**
-   * Sets the model value. Implemented as part of ControlValueAccessor.
-   * @param value Value to be set to the model.
-   */
+  // Implemented as part of ControlValueAccessor.
   writeValue(value: any) {
     this.checked = !!value;
   }
 
-  /**
-   * Registers a callback to be triggered when the value has changed.
-   * Implemented as part of ControlValueAccessor.
-   * @param fn Function to be called on change.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnChange(fn: (value: any) => void) {
     this._controlValueAccessorChangeFn = fn;
   }
 
-  /**
-   * Registers a callback to be triggered when the control has been touched.
-   * Implemented as part of ControlValueAccessor.
-   * @param fn Callback to be triggered when the checkbox is touched.
-   */
+  // Implemented as part of ControlValueAccessor.
   registerOnTouched(fn: any) {
-    this.onTouched = fn;
+    this._onTouched = fn;
   }
 
-  /**
-   * Sets the checkbox's disabled state. Implemented as a part of ControlValueAccessor.
-   * @param isDisabled Whether the checkbox should be disabled.
-   */
+  // Implemented as part of ControlValueAccessor.
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
     this._changeDetectorRef.markForCheck();
@@ -342,7 +325,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       this._focusRipple = this.ripple.launch(0, 0, {persistent: true});
     } else if (!focusOrigin) {
       this._removeFocusRipple();
-      this.onTouched();
+      this._onTouched();
     }
   }
 

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -37,6 +37,7 @@ export interface MatChipInputEvent {
   }
 })
 export class MatChipInput {
+  /** Whether the control is focused. */
   focused: boolean = false;
   _chipList: MatChipList;
 
@@ -73,10 +74,7 @@ export class MatChipInput {
   @Input() placeholder: string = '';
 
   /** Whether the input is empty. */
-  get empty(): boolean {
-    let value: string | null = this._inputElement.value;
-    return (value == null || value === '');
-  }
+  get empty(): boolean { return !this._inputElement.value; }
 
   /** The native input element to which this directive is attached. */
   protected _inputElement: HTMLInputElement;
@@ -127,5 +125,6 @@ export class MatChipInput {
     this._chipList.stateChanges.next();
   }
 
+  /** Focuses the input. */
   focus(): void { this._inputElement.focus(); }
 }

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -83,15 +83,6 @@ export class MatBasicChip {
 })
 export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDestroy, CanColor,
     CanDisable {
-
-  protected _value: any;
-
-  protected _selected: boolean = false;
-
-  protected _selectable: boolean = true;
-
-  protected _removable: boolean = true;
-
   /** Whether the chip has focus. */
   _hasFocus: boolean = false;
 
@@ -106,6 +97,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       selected: value
     });
   }
+  protected _selected: boolean = false;
+
   /** The value of the chip. Defaults to the content inside `<mat-chip>` tags. */
   @Input()
   get value(): any {
@@ -113,9 +106,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       ? this._value
       : this._elementRef.nativeElement.textContent;
   }
-  set value(newValue: any) {
-    this._value = newValue;
-  }
+  set value(value: any) { this._value = value; }
+  protected _value: any;
 
   /**
    * Whether or not the chips are selectable. When a chip is not selectable,
@@ -126,6 +118,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   set selectable(value: boolean) {
     this._selectable = coerceBooleanProperty(value);
   }
+  protected _selectable: boolean = true;
 
   /**
    * Determines whether or not the chip displays the remove styling and emits (remove) events.
@@ -135,6 +128,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   set removable(value: boolean) {
     this._removable = coerceBooleanProperty(value);
   }
+  protected _removable: boolean = true;
 
   /** Emits when the chip is focused. */
   readonly _onFocus = new Subject<MatChipEvent>();
@@ -147,7 +141,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
       new EventEmitter<MatChipSelectionChange>();
 
   /** Emitted when the chip is destroyed. */
-  @Output() readonly destroyed = new EventEmitter<MatChipEvent>();
+  @Output() readonly destroyed: EventEmitter<MatChipEvent> = new EventEmitter<MatChipEvent>();
 
   /**
    * Emitted when the chip is destroyed.
@@ -166,6 +160,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
    */
   @Output('remove') onRemove: EventEmitter<MatChipEvent> = this.removed;
 
+  /** The ARIA selected applied to the chip. */
   get ariaSelected(): string | null {
     return this.selectable ? this.selected.toString() : null;
   }
@@ -174,7 +169,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     super(_elementRef);
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this.destroyed.emit({chip: this});
   }
 

--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -79,7 +79,7 @@ export class MatCalendarBody {
   @Input() cellAspectRatio = 1;
 
   /** Emits when a new value is selected. */
-  @Output() readonly selectedValueChange = new EventEmitter<number>();
+  @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
   _cellClicked(cell: MatCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -105,10 +105,10 @@ export class MatCalendar<D> implements AfterContentInit, OnDestroy, OnChanges {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when the currently selected date changes. */
-  @Output() readonly selectedChange = new EventEmitter<D>();
+  @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Emits when any date is selected. */
-  @Output() readonly _userSelection = new EventEmitter<void>();
+  @Output() readonly _userSelection: EventEmitter<void> = new EventEmitter<void>();
 
   /** Reference to the current month view component. */
   @ViewChild(MatMonthView) monthView: MatMonthView<D>;

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -110,8 +110,8 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   /** Function that can be used to filter out dates within the datepicker. */
   @Input()
-  set matDatepickerFilter(filter: (date: D | null) => boolean) {
-    this._dateFilter = filter;
+  set matDatepickerFilter(value: (date: D | null) => boolean) {
+    this._dateFilter = value;
     this._validatorOnChange();
   }
   _dateFilter: (date: D | null) => boolean;
@@ -173,7 +173,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
       new EventEmitter<MatDatepickerInputEvent<D>>();
 
   /** Emits when the value changes (either due to user input or programmatic change). */
-  _valueChange = new EventEmitter<D|null>();
+  _valueChange = new EventEmitter<D | null>();
 
   /** Emits when the disabled state has changed */
   _disabledChange = new EventEmitter<boolean>();
@@ -268,6 +268,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     this._validatorOnChange = fn;
   }
 
+  /** @docs-private */
   validate(c: AbstractControl): ValidationErrors | null {
     return this._validator ? this._validator(c) : null;
   }
@@ -288,24 +289,24 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     return this._formField ? -this._formField._inputContainerRef.nativeElement.clientHeight : 0;
   }
 
-  // Implemented as part of ControlValueAccessor
+  // Implemented as part of ControlValueAccessor.
   writeValue(value: D): void {
     this.value = value;
   }
 
-  // Implemented as part of ControlValueAccessor
+  // Implemented as part of ControlValueAccessor.
   registerOnChange(fn: (value: any) => void): void {
     this._cvaOnChange = fn;
   }
 
-  // Implemented as part of ControlValueAccessor
+  // Implemented as part of ControlValueAccessor.
   registerOnTouched(fn: () => void): void {
     this._onTouched = fn;
   }
 
-  // Implemented as part of ControlValueAccessor
-  setDisabledState(disabled: boolean): void {
-    this.disabled = disabled;
+  // Implemented as part of ControlValueAccessor.
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
   }
 
   _onKeydown(event: KeyboardEvent) {

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -20,32 +20,32 @@ export class MatDatepickerIntl {
   readonly changes: Subject<void> = new Subject<void>();
 
   /** A label for the calendar popup (used by screen readers). */
-  calendarLabel = 'Calendar';
+  calendarLabel: string = 'Calendar';
 
   /** A label for the button used to open the calendar popup (used by screen readers). */
-  openCalendarLabel = 'Open calendar';
+  openCalendarLabel: string = 'Open calendar';
 
   /** A label for the previous month button (used by screen readers). */
-  prevMonthLabel = 'Previous month';
+  prevMonthLabel: string = 'Previous month';
 
   /** A label for the next month button (used by screen readers). */
-  nextMonthLabel = 'Next month';
+  nextMonthLabel: string = 'Next month';
 
   /** A label for the previous year button (used by screen readers). */
-  prevYearLabel = 'Previous year';
+  prevYearLabel: string = 'Previous year';
 
   /** A label for the next year button (used by screen readers). */
-  nextYearLabel = 'Next year';
+  nextYearLabel: string = 'Next year';
 
   /** A label for the previous multi-year button (used by screen readers). */
-  prevMultiYearLabel = 'Previous 20 years';
+  prevMultiYearLabel: string = 'Previous 20 years';
 
   /** A label for the next multi-year button (used by screen readers). */
-  nextMultiYearLabel = 'Next 20 years';
+  nextMultiYearLabel: string = 'Next 20 years';
 
   /** A label for the 'switch to month view' button (used by screen readers). */
-  switchToMonthViewLabel = 'Choose date';
+  switchToMonthViewLabel: string = 'Choose date';
 
   /** A label for the 'switch to year view' button (used by screen readers). */
-  switchToMultiYearViewLabel = 'Choose month and year';
+  switchToMultiYearViewLabel: string = 'Choose month and year';
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -122,8 +122,8 @@ export class MatDatepicker<D> implements OnDestroy {
     // selected value is.
     return this._startAt || (this._datepickerInput ? this._datepickerInput.value : null);
   }
-  set startAt(date: D | null) {
-    this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(date));
+  set startAt(value: D | null) {
+    this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
   private _startAt: D | null;
 
@@ -176,7 +176,7 @@ export class MatDatepicker<D> implements OnDestroy {
   /** Whether the calendar is open. */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(shouldOpen: boolean) { shouldOpen ? this.open() : this.close(); }
+  set opened(value: boolean) { value ? this.open() : this.close(); }
   private _opened = false;
 
   /** The id for the datepicker calendar. */

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -68,10 +68,10 @@ export class MatMonthView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new date is selected. */
-  @Output() readonly selectedChange = new EventEmitter<D | null>();
+  @Output() readonly selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
 
   /** Emits when any date is selected. */
-  @Output() readonly _userSelection = new EventEmitter<void>();
+  @Output() readonly _userSelection: EventEmitter<void> = new EventEmitter<void>();
 
   /** The label for this month (e.g. "January 2017"). */
   _monthLabel: string;
@@ -117,7 +117,7 @@ export class MatMonthView<D> implements AfterContentInit {
     this._activeDate = this._dateAdapter.today();
   }
 
-  ngAfterContentInit(): void {
+  ngAfterContentInit() {
     this._init();
   }
 

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -68,7 +68,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new month is selected. */
-  @Output() readonly selectedChange = new EventEmitter<D>();
+  @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Grid of calendar cells representing the currently displayed years. */
   _years: MatCalendarCell[][];

--- a/src/lib/datepicker/year-view.ts
+++ b/src/lib/datepicker/year-view.ts
@@ -63,7 +63,7 @@ export class MatYearView<D> implements AfterContentInit {
   @Input() dateFilter: (date: D) => boolean;
 
   /** Emits when a new month is selected. */
-  @Output() readonly selectedChange = new EventEmitter<D>();
+  @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Grid of calendar cells representing the months of the year. */
   _months: MatCalendarCell[][];

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -121,12 +121,12 @@ export class MatFormField extends _MatFormFieldMixinBase
   private _showAlwaysAnimate = false;
 
   /** Whether the floating label should always float or not. */
-  get _shouldAlwaysFloat() {
+  get _shouldAlwaysFloat(): boolean {
     return this._floatLabel === 'always' && !this._showAlwaysAnimate;
   }
 
   /** Whether the label can float or not. */
-  get _canLabelFloat() { return this._floatLabel !== 'never'; }
+  get _canLabelFloat(): boolean { return this._floatLabel !== 'never'; }
 
   /** State of the mat-hint and mat-error animations. */
   _subscriptAnimationState: string = '';

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -48,6 +48,7 @@ export class MatInputBase {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
+              /** @docs-private */
               public ngControl: NgControl) {}
 }
 export const _MatInputMixinBase = mixinErrorState(MatInputBase);
@@ -77,19 +78,9 @@ export const _MatInputMixinBase = mixinErrorState(MatInputBase);
 })
 export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges,
     OnDestroy, DoCheck, CanUpdateErrorState {
-  /** Variables used as cache for getters and setters. */
-  protected _type = 'text';
-  protected _disabled = false;
-  protected _required = false;
-  protected _id: string;
   protected _uid = `mat-input-${nextUniqueId++}`;
   protected _previousNativeValue: any;
-  private _readonly = false;
   private _inputValueAccessor: {value: any};
-
-  /** Whether the input is focused. */
-  focused = false;
-
   /** The aria-describedby attribute on the input for improved a11y. */
   _ariaDescribedby: string;
 
@@ -97,15 +88,27 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   _isServer = false;
 
   /**
-   * Stream that emits whenever the state of the input changes such that the wrapping `MatFormField`
-   * needs to run change detection.
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
    */
-  readonly stateChanges = new Subject<void>();
+  focused: boolean = false;
 
-  /** A name for this control that can be used by `mat-form-field`. */
-  controlType = 'mat-input';
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  readonly stateChanges: Subject<void> = new Subject<void>();
 
-  /** Whether the element is disabled. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  controlType: string = 'mat-input';
+
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get disabled(): boolean {
     if (this.ngControl && this.ngControl.disabled !== null) {
@@ -123,19 +126,31 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
       this.stateChanges.next();
     }
   }
+  protected _disabled = false;
 
-  /** Unique id of the element. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get id(): string { return this._id; }
   set id(value: string) { this._id = value || this._uid; }
+  protected _id: string;
 
-  /** Placeholder attribute of the element. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input() placeholder: string = '';
 
-  /** Whether the element is required. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get required(): boolean { return this._required; }
   set required(value: boolean) { this._required = coerceBooleanProperty(value); }
+  protected _required = false;
 
   /** Input type of the element. */
   @Input()
@@ -151,11 +166,15 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
       this._elementRef.nativeElement.type = this._type;
     }
   }
+  protected _type = 'text';
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;
 
-  /** The input element's value. */
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   @Input()
   get value(): string { return this._inputValueAccessor.value; }
   set value(value: string) {
@@ -169,6 +188,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   @Input()
   get readonly(): boolean { return this._readonly; }
   set readonly(value: boolean) { this._readonly = coerceBooleanProperty(value); }
+  private _readonly = false;
 
   protected _neverEmptyInputTypes = [
     'date',
@@ -181,6 +201,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
 
   constructor(protected _elementRef: ElementRef,
               protected _platform: Platform,
+              /** @docs-private */
               @Optional() @Self() public ngControl: NgControl,
               @Optional() _parentForm: NgForm,
               @Optional() _parentFormGroup: FormGroupDirective,
@@ -237,7 +258,8 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     this._dirtyCheckNativeValue();
   }
 
-  focus() { this._elementRef.nativeElement.focus(); }
+  /** Focuses the input. */
+  focus(): void { this._elementRef.nativeElement.focus(); }
 
   /** Callback for the cases where the focused state of the input changes. */
   _focusChanged(isFocused: boolean) {
@@ -297,7 +319,10 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     return nodeName ? nodeName.toLowerCase() === 'textarea' : false;
   }
 
-  // Implemented as part of MatFormFieldControl.
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
   get empty(): boolean {
     return !this._isNeverEmpty() && !this._elementRef.nativeElement.value && !this._isBadInput();
   }

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -64,8 +64,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The zero-based page index of the displayed list of items. Defaulted to 0. */
   @Input()
   get pageIndex(): number { return this._pageIndex; }
-  set pageIndex(pageIndex: number) {
-    this._pageIndex = coerceNumberProperty(pageIndex);
+  set pageIndex(value: number) {
+    this._pageIndex = coerceNumberProperty(value);
     this._changeDetectorRef.markForCheck();
   }
   _pageIndex: number = 0;
@@ -73,8 +73,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
   @Input()
   get length(): number { return this._length; }
-  set length(length: number) {
-    this._length = coerceNumberProperty(length);
+  set length(value: number) {
+    this._length = coerceNumberProperty(value);
     this._changeDetectorRef.markForCheck();
   }
   _length: number = 0;
@@ -82,8 +82,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** Number of items to display on a page. By default set to 50. */
   @Input()
   get pageSize(): number { return this._pageSize; }
-  set pageSize(pageSize: number) {
-    this._pageSize = coerceNumberProperty(pageSize);
+  set pageSize(value: number) {
+    this._pageSize = coerceNumberProperty(value);
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSize: number;
@@ -91,8 +91,8 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** The set of provided page size options to display to the user. */
   @Input()
   get pageSizeOptions(): number[] { return this._pageSizeOptions; }
-  set pageSizeOptions(pageSizeOptions: number[]) {
-    this._pageSizeOptions = (pageSizeOptions || []).map(p => coerceNumberProperty(p));
+  set pageSizeOptions(value: number[]) {
+    this._pageSizeOptions = (value || []).map(p => coerceNumberProperty(p));
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSizeOptions: number[] = [];
@@ -101,7 +101,7 @@ export class MatPaginator implements OnInit, OnDestroy {
   @Input() hidePageSize = false;
 
   /** Event emitted when the paginator changes the page size or page index. */
-  @Output() readonly page = new EventEmitter<PageEvent>();
+  @Output() readonly page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
 
   /** Displayed set of page size options. Will be sorted and include current page size. */
   _displayedPageSizeOptions: number[];

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -176,9 +176,6 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
   set disableClose(value: boolean) { this._disableClose = coerceBooleanProperty(value); }
   private _disableClose: boolean = false;
 
-  /** Whether the drawer is opened. */
-  private _opened: boolean = false;
-
   /** How the sidenav was opened (keypress, mouse click etc.) */
   private _openedVia: FocusOrigin | null;
 
@@ -335,7 +332,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
    */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(v: boolean) { this.toggle(coerceBooleanProperty(v)); }
+  set opened(value: boolean) { this.toggle(coerceBooleanProperty(value)); }
+  private _opened: boolean = false;
 
   /**
    * Open the drawer.
@@ -388,7 +386,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
    * Handles the keyboard events.
    * @docs-private
    */
-  handleKeydown(event: KeyboardEvent) {
+  handleKeydown(event: KeyboardEvent): void {
     if (event.keyCode === ESCAPE && !this.disableClose) {
       this.close();
       event.stopPropagation();
@@ -408,7 +406,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     }
   }
 
-  get _width() {
+  get _width(): number {
     return this._elementRef.nativeElement ? (this._elementRef.nativeElement.offsetWidth || 0) : 0;
   }
 }
@@ -457,7 +455,7 @@ export class MatDrawerContainer implements AfterContentInit, OnDestroy {
   private _autosize: boolean;
 
   /** Event emitted when the drawer backdrop is clicked. */
-  @Output() readonly backdropClick = new EventEmitter<void>();
+  @Output() readonly backdropClick: EventEmitter<void> = new EventEmitter<void>();
 
   /** The drawer at the start/end position, independent of direction. */
   private _start: MatDrawer | null;

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -139,7 +139,7 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   private _backgroundColor: ThemePalette;
 
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
-  @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter();
+  @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
   /** Event emitted when focus has changed within a tab group. */
   @Output() readonly focusChange: EventEmitter<MatTabChangeEvent> =
@@ -173,7 +173,7 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
    * each tab should be in according to the new selected index, and additionally we know how
    * a new selected tab should transition in (from the left or right).
    */
-  ngAfterContentChecked(): void {
+  ngAfterContentChecked() {
     // Clamp the next selected index to the boundsof 0 and the tabs length.
     // Note the `|| 0`, which ensures that values like NaN can't get through
     // and which would otherwise throw the component into an infinite loop


### PR DESCRIPTION
Part of #9558.

This:

- Changes some incorrect docs;
- Marks some inherited methods/variables' docs as `private-docs` as they can be caught by parent class after #9299;
- Put getters/setters and properties together to avoid duplicated docs;
- Removes unnecessary docs for `ControlValueAccessor` methods API;
- Removes unnecessary types for lifecycle hooks;
- Adds missing types for methods/variables;

Relates to #8832.

cc @jelbourn.

I'm open to rephrase the title of this PR, feel free to suggest.