### PR TITLE
chore(dgeni): add @deletion-target to valid tags

### DIFF
--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -87,7 +87,8 @@ apiDocsPackage.config((computePathsProcessor: any) => {
 // Configure custom JsDoc tags.
 apiDocsPackage.config((parseTagsProcessor: any) => {
   parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat([
-    {name: 'docs-private'}
+    {name: 'docs-private'},
+    {name: 'deletion-target'}
   ]);
 });
 


### PR DESCRIPTION
* Currently Dgeni always shows warnings about the `@deletion-target` tag, because it considers non-jsdoc tags as invalid by default.