### PR TITLE
build: show deletion target in docs

### DIFF
--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -1,13 +1,25 @@
+import {ApiDoc} from 'dgeni-packages/typescript/api-doc-types/ApiDoc';
 import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
 import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
+import {ParsedDecorator} from 'dgeni-packages/typescript/services/TsParser/getDecorators';
 import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
 
+/** Interface that describes categorized docs that can be deprecated. */
+export interface DeprecationDoc extends ApiDoc {
+  isDeprecated: boolean;
+  deletionTarget: string | null;
+}
+
+/** Interface that describes Dgeni documents that have decorators. */
+export interface HasDecoratorsDoc {
+  decorators?: ParsedDecorator[] | undefined;
+}
+
 /** Extended Dgeni class-like document that includes separated class members. */
-export interface CategorizedClassLikeDoc extends ClassLikeExportDoc {
+export interface CategorizedClassLikeDoc extends ClassLikeExportDoc, DeprecationDoc {
   methods: CategorizedMethodMemberDoc[];
   properties: CategorizedPropertyMemberDoc[];
-  isDeprecated: boolean;
 }
 
 /** Extended Dgeni class document that includes extracted Angular metadata. */
@@ -22,9 +34,8 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
 }
 
 /** Extended Dgeni property-member document that includes extracted Angular metadata. */
-export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc {
+export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc, DeprecationDoc {
   description: string;
-  isDeprecated: boolean;
   isDirectiveInput: boolean;
   isDirectiveOutput: boolean;
   directiveInputAlias: string;
@@ -32,7 +43,6 @@ export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc {
 }
 
 /** Extended Dgeni method-member document that simplifies logic for the Dgeni template. */
-export interface CategorizedMethodMemberDoc extends NormalizedMethodMemberDoc {
+export interface CategorizedMethodMemberDoc extends NormalizedMethodMemberDoc, DeprecationDoc {
   showReturns: boolean;
-  isDeprecated: boolean;
 }

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -1,3 +1,5 @@
+{% import "macros.html" as macros %}
+
 <h4 id="{$ class.name $}" class="docs-header-link docs-api-h4 docs-api-class-name">
   <span header-link="{$ class.name $}"></span>
   <code>{$ class.name $}</code>
@@ -28,7 +30,9 @@
 {%- endif -%}
 
 {%- if class.isDeprecated -%}
-<div class="docs-api-class-deprecated-marker">Deprecated</div>
+<div class="docs-api-class-deprecated-marker" {$ macros.deprecationTitle(class) $}>
+  Deprecated
+</div>
 {%- endif -%}
 
 {$ propertyList(class.properties) $}

--- a/tools/dgeni/templates/interface.template.html
+++ b/tools/dgeni/templates/interface.template.html
@@ -1,3 +1,5 @@
+{% import "macros.html" as macros %}
+
 <h4 id="{$ interface.name $}" class="docs-header-link docs-api-h4 docs-api-interface-name">
   <span header-link="{$ interface.name $}"></span>
   <code>{$ interface.name $}</code>
@@ -8,7 +10,9 @@
 {%- endif -%}
 
 {%- if interface.isDeprecated -%}
-<div class="docs-api-interface-deprecated-marker">Deprecated</div>
+<div class="docs-api-interface-deprecated-marker" {$ macros.deprecationTitle(interface) $}>
+  Deprecated
+</div>
 {%- endif -%}
 
 {$ propertyList(interface.properties) $}

--- a/tools/dgeni/templates/macros.html
+++ b/tools/dgeni/templates/macros.html
@@ -1,0 +1,5 @@
+{% macro deprecationTitle(doc) %}
+  {%- if doc.deletionTarget -%}
+    title="Will be deleted in v{$ doc.deletionTarget $}"
+  {%- endif -%}
+{% endmacro %}

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -1,9 +1,13 @@
+{% import "macros.html" as macros %}
+
 <table class="docs-api-method-table">
   <thead>
     <tr class="docs-api-method-name-row">
       <th colspan="2" class="docs-api-method-name-cell">
         {%- if method.isDeprecated -%}
-          <div class="docs-api-deprecated-marker">Deprecated</div>
+          <div class="docs-api-deprecated-marker" {$ macros.deprecationTitle(method) $}>
+            Deprecated
+          </div>
         {%- endif -%}   
         {$ method.name $}
       </th>

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -1,3 +1,5 @@
+{% import "macros.html" as macros %}
+
 <tr class="docs-api-properties-row">
   <td class="docs-api-properties-name-cell">
     {%- if property.isDirectiveInput -%}
@@ -19,7 +21,9 @@
       </div>
     {%- endif -%}
     {%- if property.isDeprecated -%}
-      <div class="docs-api-deprecated-marker">Deprecated</div>
+      <div class="docs-api-deprecated-marker" {$ macros.deprecationTitle(property) $}>
+        Deprecated
+      </div>
     {%- endif -%}   
 
     <p class="docs-api-property-name">


### PR DESCRIPTION
* Surfaces the @deletion-target JSDoc information into the Dgeni HTML output. Currently it will add a title to the deprecation marker.

Closes #9641