### PR TITLE
fix(chips): chip list capturing keyboard events from input

### DIFF
--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -212,6 +212,18 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(1);
         });
 
+        it('should not handle arrow key events from non-chip elements', () => {
+          const event: KeyboardEvent =
+              createKeyboardEvent('keydown', RIGHT_ARROW, chipListNativeElement);
+          const initialActiveIndex = manager.activeItemIndex;
+
+          chipListInstance._keydown(event);
+          fixture.detectChanges();
+
+          expect(manager.activeItemIndex)
+              .toBe(initialActiveIndex, 'Expected focused item not to have changed.');
+        });
+
       });
 
       describe('RTL', () => {

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -459,7 +459,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     if (event.keyCode === BACKSPACE && this._isInputEmpty(target)) {
       this._keyManager.setLastItemActive();
       event.preventDefault();
-    } else {
+    } else if (target && target.classList.contains('mat-chip')) {
       this._keyManager.onKeydown(event);
       this.stateChanges.next();
     }


### PR DESCRIPTION
* Fixes the chip list reacting to keyboard events from inside the input, which ends up moving focus away and creating a new chip. This appears to be a regression introduced in 5a055a70d4a5e05dc3fcdca6210054d1dc21514e.
* Adds a test to ensure that we don't re-introduce the issue in the future.