### PR TITLE
chore(dgeni): fix duplicate api doc entries

### DIFF
--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -1,6 +1,7 @@
 import {Package} from 'dgeni';
 import {DocsPrivateFilter} from './processors/docs-private-filter';
 import {Categorizer} from './processors/categorizer';
+import {FilterDuplicateExports} from './processors/filter-duplicate-exports';
 import {FilterExportAliases} from './processors/filter-export-aliases';
 import {MergeInheritedProperties} from './processors/merge-inherited-properties';
 import {ComponentGrouper} from './processors/component-grouper';
@@ -48,6 +49,9 @@ const materialPackages = globSync(path.join(sourceDir, 'lib', '*/'))
   .map(packagePath => path.basename(packagePath));
 
 export const apiDocsPackage = new Package('material2-api-docs', dgeniPackageDeps);
+
+// Processor that filters out duplicate exports that should not be shown in the docs.
+apiDocsPackage.processor(new FilterDuplicateExports());
 
 // Processor that filters out aliased exports that should not be shown in the docs.
 apiDocsPackage.processor(new FilterExportAliases());

--- a/tools/dgeni/processors/filter-duplicate-exports.ts
+++ b/tools/dgeni/processors/filter-duplicate-exports.ts
@@ -1,0 +1,42 @@
+import {DocCollection, Processor} from 'dgeni';
+import {ExportDoc} from 'dgeni-packages/typescript/api-doc-types/ExportDoc';
+
+/**
+ * Processor to filter out Dgeni documents that are exported multiple times. This is necessary
+ * to avoid that API entries are showing up multiple times in the docs.
+ *
+ * ```ts
+ *   // Some file in @angular/cdk/scrolling
+ *   export {ScrollDispatcher} from './scroll-dispatcher.ts';
+ *
+ *   // Other file in @angular/cdk/overlay
+ *   export {ScrollDispatcher} from '@angular/cdk/scrolling';
+ * ```
+ *
+ * This issue occurs sometimes in the Angular Material repository, if specific imports are
+ * re-exported from a different secondary entry-point (e.g. ScrollDispatcher in the overlay).
+ */
+export class FilterDuplicateExports implements Processor {
+  name = 'filter-duplicate-exports';
+  $runBefore = ['filter-export-aliases'];
+
+  $process(docs: DocCollection) {
+    return docs.forEach(this.checkForDuplicateExports);
+  }
+
+  checkForDuplicateExports = (doc: ExportDoc, index: number, docs: DocCollection) => {
+    if (!(doc instanceof ExportDoc)) {
+      return;
+    }
+
+    // Checks for export documents that have the same name, originate from the same module, but
+    // have a different Dgeni document id. Those documents can be considered as duplicates.
+    const duplicateDocs = docs.filter(d => doc.name === d.name &&
+        doc.originalModule === d.originalModule && doc.id !== d.id);
+
+    if (duplicateDocs.length > 0) {
+      docs.splice(index, 1);
+    }
+  }
+
+}


### PR DESCRIPTION
* Fixes that some API document entries are showing up twice (e.g. https://material.angular.io/cdk/scrolling/api). This happens because the `ScrollDispatcher` is exported multiple times across different packages (`cdk/scrolling` and `cdk/overlay`).