### PR TITLE
docs(theming): Document hue options available for mat-color sass function

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -63,8 +63,13 @@ You can use the `mat-color` function to extract a specific color from a palette.
 @import 'src/unicorn-app-theme.scss';
 
 // Use mat-color to extract individual colors from a palette as necessary.
+// The hue can be one of the standard values (500, A400, etc.), one of the three preconfigured
+// hues (default, lighter, darker), or any of the aforementioned prefixed with "-contrast".
+// For example a hue of "darker-constrast" gives a light color to contrast with a "darker" hue
+// Available color palettes: https://www.google.com/design/spec/style/color.html
 .candy-carousel {
   background-color: mat-color($candy-app-primary);
   border-color: mat-color($candy-app-accent, A400);
+  color: mat-color($candy-app-primary, darker);
 }
 ```

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -65,7 +65,7 @@ You can use the `mat-color` function to extract a specific color from a palette.
 // Use mat-color to extract individual colors from a palette as necessary.
 // The hue can be one of the standard values (500, A400, etc.), one of the three preconfigured
 // hues (default, lighter, darker), or any of the aforementioned prefixed with "-contrast".
-// For example a hue of "darker-constrast" gives a light color to contrast with a "darker" hue
+// For example a hue of "darker-contrast" gives a light color to contrast with a "darker" hue
 // Available color palettes: https://www.google.com/design/spec/style/color.html
 .candy-carousel {
   background-color: mat-color($candy-app-primary);

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -75,10 +75,7 @@ A typical theme file will look something like this:
 
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
-// hue.
-// Primary hue values(lightest to darkest): 50, 100, 200, 300, 400, 500, 600, 700, 800, or 900
-// Accent hue values (lightest to darkest): A100, A200, A400, A700
-// For full palette see https://www.google.com/design/spec/style/color.html
+// hue. Available color palettes: https://www.google.com/design/spec/style/color.html
 $candy-app-primary: mat-palette($mat-indigo);
 $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
 

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -76,6 +76,9 @@ A typical theme file will look something like this:
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue.
+// Primary hue values(lightest to darkest): 50, 100, 200, 300, 400, 500, 600, 700, 800, or 900
+// Accent hue values (lightest to darkest): A100, A200, A400, A700
+// For full palette see https://www.google.com/design/spec/style/color.html
 $candy-app-primary: mat-palette($mat-indigo);
 $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
 


### PR DESCRIPTION
Addresses #9539 

Adds documentation to how to use mat-color in the guides/theming-your-components.md file.

Also adds link to the colors page of the Material Design Spec.