### PR TITLE
fix(autocomplete): expose MatAutocompleteTrigger in template

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -113,6 +113,7 @@ export function getMatAutocompleteMissingPanelError(): Error {
     '(input)': '_handleInput($event)',
     '(keydown)': '_handleKeydown($event)',
   },
+  exportAs: 'matAutocompleteTrigger',
   providers: [MAT_AUTOCOMPLETE_VALUE_ACCESSOR]
 })
 export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {


### PR DESCRIPTION
Adds an `exportAs` to the `MatAutocompleteTrigger` so it can be accessed through templates and because the methods for toggling the panel are on it.

Fixes #9687.