### PR TITLE
chore: fix lint warning

### DIFF
--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -24,7 +24,7 @@ export abstract class DateAdapter<D> {
 
   /** A stream that emits when the locale changes. */
   get localeChanges(): Observable<void> { return this._localeChanges; }
-  protected _localeChanges= new Subject<void>();
+  protected _localeChanges = new Subject<void>();
 
   /**
    * Gets the year component of the given date.

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -41,7 +41,7 @@ export const _MatSortHeaderMixinBase = mixinDisabled(MatSortHeaderBase);
 export type ArrowViewState = SortDirection | 'hint' | 'active';
 
 /**
- * States describing the arrow's animated position (animating fromState -> toState).
+ * States describing the arrow's animated position (animating fromState to toState).
  * If the fromState is not defined, there will be no animated transition to the toState.
  * @docs-private
  */


### PR DESCRIPTION
Fixes a lint warning due to a PR that was opened after the HTML escaping rule was introduced.

Side note: it seems like the rule catches things like `->` as HTML tags.