### PR TITLE
build: prevent beta publishing to latest tag

### DIFF
--- a/tools/gulp/tasks/publish.ts
+++ b/tools/gulp/tasks/publish.ts
@@ -42,22 +42,30 @@ task(':publish:whoami', execTask('npm', ['whoami'], {
 task(':publish:logout', execTask('npm', ['logout']));
 
 task(':publish', async () => {
-  const label = argv['tag'];
+  const tag = argv['tag'];
   const version = buildConfig.projectVersion;
   const currentDir = process.cwd();
 
   console.log('');
-  if (!label) {
-    console.log(grey('> You can use a label with --tag=labelName.\n'));
-    console.log(green(`Publishing version "${version}" using the latest tag...`));
+  if (!tag) {
+    console.log(grey('> You can specify the tag by passing --tag=labelName.\n'));
+    console.log(green(`Publishing version "${version}" to the latest tag...`));
   } else {
-    console.log(yellow(`Publishing version "${version}" using the ${label} tag...`));
+    console.log(yellow(`Publishing version "${version}" to the ${tag} tag...`));
   }
   console.log('');
 
+
+  if (version.match(/(alpha|beta|rc)/) && (!tag || tag === 'latest')) {
+    console.log(red(`Publishing ${version} to the "latest" tag is not allowed.`));
+    console.log(red(`Alpha, Beta or RC versions shouldn't be published to "latest".`));
+    console.log();
+    return;
+  }
+
   if (releasePackages.length > 1) {
     console.warn(red('Warning: Multiple packages will be released if proceeding.'));
-    console.warn(red('Warning: Packages to be released: ', releasePackages.join(', ')));
+    console.warn(red('Warning: Packages to be released:', releasePackages.join(', ')));
     console.log();
   }
 
@@ -67,13 +75,13 @@ task(':publish', async () => {
 
   // Iterate over every declared release package and publish it on NPM.
   for (const packageName of releasePackages) {
-    await _execNpmPublish(label, packageName);
+    await _execNpmPublish(tag, packageName);
   }
 
   process.chdir(currentDir);
 });
 
-function _execNpmPublish(label: string, packageName: string): Promise<{}> | undefined {
+function _execNpmPublish(tag: string, packageName: string): Promise<{}> | undefined {
   const packageDir = join(buildConfig.outputDir, 'releases', packageName);
 
   if (!statSync(packageDir).isDirectory()) {
@@ -94,8 +102,8 @@ function _execNpmPublish(label: string, packageName: string): Promise<{}> | unde
   const command = 'npm';
   const args = ['publish', '--access', 'public'];
 
-  if (label) {
-    args.push('--tag', label);
+  if (tag) {
+    args.push('--tag', tag);
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
* No longer allows publishing versions that include "beta" to the "latest" tag on NPM. This safeguard can be still removed temporarily, if there is a real need to publish a beta in the latest tag.

Closes #9699.