### PR TITLE
fix(overlay): expose event object in backdropClick stream

### DIFF
--- a/src/cdk-experimental/dialog/dialog-ref.ts
+++ b/src/cdk-experimental/dialog/dialog-ref.ts
@@ -62,7 +62,7 @@ export class DialogRef<T, R = any> {
   }
 
   /** Gets an observable that emits when the overlay's backdrop has been clicked. */
-  backdropClick(): Observable<void> {
+  backdropClick(): Observable<MouseEvent> {
     return this._overlayRef.backdropClick();
   }
 

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -27,7 +27,7 @@ export type ImmutableObject<T> = {
  */
 export class OverlayRef implements PortalOutlet {
   private _backdropElement: HTMLElement | null = null;
-  private _backdropClick: Subject<any> = new Subject();
+  private _backdropClick: Subject<MouseEvent> = new Subject();
   private _attachments = new Subject<void>();
   private _detachments = new Subject<void>();
 
@@ -181,7 +181,7 @@ export class OverlayRef implements PortalOutlet {
   }
 
   /** Gets an observable that emits when the backdrop has been clicked. */
-  backdropClick(): Observable<void> {
+  backdropClick(): Observable<MouseEvent> {
     return this._backdropClick.asObservable();
   }
 
@@ -278,7 +278,8 @@ export class OverlayRef implements PortalOutlet {
 
     // Forward backdrop clicks such that the consumer of the overlay can perform whatever
     // action desired when such a click occurs (usually closing the overlay).
-    this._backdropElement.addEventListener('click', () => this._backdropClick.next(null));
+    this._backdropElement.addEventListener('click',
+        (event: MouseEvent) => this._backdropClick.next(event));
 
     // Add class to fade-in the backdrop after one frame.
     if (typeof requestAnimationFrame !== 'undefined') {

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -388,7 +388,7 @@ describe('Overlay', () => {
       overlayRef.backdropClick().subscribe(backdropClickHandler);
 
       backdrop.click();
-      expect(backdropClickHandler).toHaveBeenCalled();
+      expect(backdropClickHandler).toHaveBeenCalledWith(jasmine.any(MouseEvent));
     });
 
     it('should complete the backdrop click stream once the overlay is destroyed', () => {

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -141,7 +141,7 @@ export class MatDialogRef<T, R = any> {
   /**
    * Gets an observable that emits when the overlay's backdrop has been clicked.
    */
-  backdropClick(): Observable<void> {
+  backdropClick(): Observable<MouseEvent> {
     return this._overlayRef.backdropClick();
   }
 

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -41,7 +41,7 @@ export const _MatSortHeaderMixinBase = mixinDisabled(MatSortHeaderBase);
 export type ArrowViewState = SortDirection | 'hint' | 'active';
 
 /**
- * States describing the arrow's animated position (animating fromState -> toState).
+ * States describing the arrow's animated position (animating fromState to toState).
  * If the fromState is not defined, there will be no animated transition to the toState.
  * @docs-private
  */


### PR DESCRIPTION
Exposes the click event object when subscribing to the `OverlayRef.backdropClick` stream.

Fixes #9713.