### PR TITLE
chore: add bazel test rules for the cdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       # This may be unnecessary once rules_nodejs uses nodejs 8
       - run: bazel run @nodejs//:npm run postinstall
       - run: bazel build src/...
+      - run: bazel test src/...
       - save_cache:
           key: material2-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,22 +14,67 @@ filegroup(
   # TODO(alexeagle): figure out what to do
   srcs = glob(["/".join(["node_modules", pkg, "**", ext]) for pkg in [
     "@angular",
-    "jasmine",
-    "typescript",
-    "tslib",
-    "zone.js",
     "@types",
-    "tsickle",
-    "hammerjs",
-    "protobufjs",
     "bytebuffer",
-    "reflect-metadata",
+    "hammerjs",
+    "jasmine",
     "minimist",
     "moment",
+    "protobufjs",
+    "protractor",
+    "reflect-metadata",
+    "tsickle",
+    "tslib",
+    "tsutils",
+    "typescript",
+    "zone.js",
   ] for ext in [
     "*.js",
     "*.json",
     "*.d.ts",
-  ]]),
+  ]] + [
+    "node_modules/http-server/**",
+  ]),
 )
 
+
+# Glob pattern that matches all Angular testing bundles.
+ANGULAR_TESTING = [
+  "node_modules/@angular/*/bundles/*-testing.umd.js",
+  # The compiler and the dynamic platform-browser should be visible only in tests
+  "node_modules/@angular/compiler/bundles/*.umd.js",
+  "node_modules/@angular/platform-browser-dynamic/bundles/*.umd.js",
+]
+
+filegroup(
+  name = "angular_bundles",
+  srcs = glob(["node_modules/@angular/*/bundles/*.umd.js"], exclude = ANGULAR_TESTING),
+)
+
+filegroup(
+  name = "angular_test_bundles",
+  testonly = 1,
+  srcs = glob(ANGULAR_TESTING),
+)
+
+filegroup(
+  name = "tslib_bundle",
+  testonly = 1,
+  srcs = glob(["node_modules/tslib/tslib.js"]),
+)
+
+# Files necessary for unit tests that use zonejs
+filegroup(
+  name = "web_test_bootstrap_scripts",
+  # The order of these deps is important.
+  # Do not sort.
+  srcs = [
+    "//:node_modules/reflect-metadata/Reflect.js",
+    "//:node_modules/zone.js/dist/zone.js",
+    "//:node_modules/zone.js/dist/async-test.js",
+    "//:node_modules/zone.js/dist/sync-test.js",
+    "//:node_modules/zone.js/dist/fake-async-test.js",
+    "//:node_modules/zone.js/dist/proxy.js",
+    "//:node_modules/zone.js/dist/jasmine-patch.js",
+  ],
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,17 @@
   "requires": true,
   "dependencies": {
     "@angular/animations": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.3.tgz",
-      "integrity": "sha512-K9rOsRGwt7Zmp/rNdvBmgBKqvEdgCyZF0kvwxrmZfq1Zj0GAkfTAKPL007493O6XFd+icfu/+kmYeqXBGB4gKA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.4.tgz",
+      "integrity": "sha512-kLOUORV/2GdYsNSwmUsB3eEL+nAoBZYKgibYLkVy6oecrIbdFMWiNzLcFjX/avcMnb1UNMk24Hd7Of4C2UawPA==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/bazel": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/bazel/-/bazel-5.2.3.tgz",
-      "integrity": "sha512-dsUFoG1jyDglC3FX/3XDSblkSXAMJ392RuIisxs8eT4zrCnUVwnp3iBqn7wu4iGqmj4+8ryI3FLXZjpI4A8n5g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/bazel/-/bazel-5.2.4.tgz",
+      "integrity": "sha512-fXhjUvSjierIZBYDGaa8nNBqh3LN399xjX/6qY/g8idc6jFAmeSuDGGJCaV90O+3vCjzWaMBuAZV+uuwAbbXww==",
       "dev": true,
       "requires": {
         "@types/node": "6.0.84"
@@ -30,25 +30,25 @@
       }
     },
     "@angular/common": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.3.tgz",
-      "integrity": "sha512-RwQ/IjmpDdMecTz/wwQlKpHgF4Crr8kyqV9FJ+c+cHR8Riqlu2DOXSU7LIfDdGoo6Mpixdxd1rtHYfs7l9YBSA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.4.tgz",
+      "integrity": "sha512-PNtg7lzCBUgYo5Rj+/j11EVKhLfrUkkh81ecBwexk6VcDJebmvBO1HdGppV5UPzEH/StL1mTwLc95dOI0hHSJA==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.3.tgz",
-      "integrity": "sha512-OynSzUdEHwajQMoV2JuYq5IdiR2dlTCTAHhTLzrym85wOihvTvovEQwVhYYHyKERu85JIoaF1sXA42KIjMGfkw==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.4.tgz",
+      "integrity": "sha512-KFaGcm/5OKJRxXIxrS53IYPtqta9u2xLLedrWspxIvI59ImfzeZGnLGPhfrI0pbK7wY0rJ5YdGYQnzq33dh01A==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.3.tgz",
-      "integrity": "sha512-uoCxeyQSd8R/cwEbd0FIUXjnbPq0HXEsyu3WSu9Ek2jt52HL+x/gZQdFCRtjW/mvQNOqxrgrTtEkhJ398+VkXg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.4.tgz",
+      "integrity": "sha512-nODdd7EuGzk1ME5UzpVa/lN1oKNypRt2oZoNYOkgNO2TQWD1jqOcozruit1eOEFHQhXO2JvPTzlt1dd6viHSCQ==",
       "dev": true,
       "requires": {
         "chokidar": "1.7.0",
@@ -72,151 +72,197 @@
       }
     },
     "@angular/core": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.3.tgz",
-      "integrity": "sha512-tL9O8KA6KGjnlxqjuTytpC2OeKbxe/yHev0kmwo5CK0lDZU4UFetcItAzUXU1dyRuILTcBkbnFt9+nr1SZs/cQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.4.tgz",
+      "integrity": "sha512-GPnxUf7g8Mz0AUttKKcqaw0m2xZujwwzojkg3xUIvHrNFFF5/HH5549PfnE1jD7qkmnDFx5j3IPuNkwYHW6XvA==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/forms": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.3.tgz",
-      "integrity": "sha512-PsMGbj/Slvsxxyl61QSSSFDCGHN1XK6kNxVQTVmAlVhP1LlaYqBOIgQy4K9CYWUeHqU/YCdhVaFb5quzZLtPYA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.4.tgz",
+      "integrity": "sha512-0k6rs2k85wcBq0WPAjxNbtBu1wq/1fUSFaBLbpnrwwHeCLJI5aAjG2/f3jv/17a/ek7/WZ3lxXtHzNMMdaD/Iw==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/http": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.2.3.tgz",
-      "integrity": "sha512-3kAj7YYws8J2zRu46fEXk6lYrgSK9s5YA6O4REZkLox/suK0wb6TsDIIhoMzScGctSzZESVyuWsvYMrDYCflPA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.2.4.tgz",
+      "integrity": "sha512-WjZTNqHw9cT/mIRenIGKKlJRdm9ZdDl7IqnX+OnAdO/c6hmoQwy9fkSLRLmcXw4FBM+ASfjWu4ybodaZ8Tv6xQ==",
       "dev": true,
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.3.tgz",
-      "integrity": "sha512-60LgA4KK3BufBR7vwwcn3zTYuLlfDG3jFip7bvdgsDpURrUB0j6/pL5cbGElww4jnnxZ72uJzJRzSiGEofjc3g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.4.tgz",
+      "integrity": "sha512-chv6h2aHQ/QoVA4Y6rpPpSju7vyLg/iMh516GxpGYVk6bHEdrH9pHJPulPcrt/LTd7lMAAHE3YmvYWVU6aDsaQ==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.3.tgz",
-      "integrity": "sha512-PheS+KJQJiyvQg1lr+eX0/1b/rjLnDjgI1qvzwikrvGYymb2JdZ+rjllHBs1iotzQ+tG+hRnlktvgdFN134x/g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.4.tgz",
+      "integrity": "sha512-B3pv6FUTWA1daDYhx6b77FCFCzHQPuCyrsJQwMSSu6Xt+CYn2gc3dS0ph3B6cV6mnt1qIbEpML+Vp5Bi9x0Mkw==",
       "dev": true,
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-5.2.3.tgz",
-      "integrity": "sha512-rFeKYyHO2JSH2RfVHCX/hYFEsaGhwLbYdPbI2UV62ZNSMdeaFXCgXx7RUXVlLeVSG210G3+sZIvHea8bBwx7Dg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-5.2.4.tgz",
+      "integrity": "sha512-SxepfNo5pfo/fyYQMDXXxzSp6ssdoejN2n+2IGGeJ+v92ZnZ/f2QCVgeQLnUaWu3xlziaFrg8eyqd09iCfIzYg==",
       "dev": true,
       "requires": {
         "domino": "1.0.30",
-        "tslib": "1.8.0",
+        "tslib": "1.9.0",
         "xhr2": "0.1.4"
       }
     },
     "@angular/router": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.2.3.tgz",
-      "integrity": "sha512-XVEpwNZta76FYas1gZSSGvkQoiGgQjvXfab6CwOh958d4c0C+9pJsykqsv6X/n8TSTShQt7wjs/vp/copXeuoA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.2.4.tgz",
+      "integrity": "sha512-sg3iCThhbfv/6zARdKbHNLc7Xe1Rt1deit55b3K+WlrHX7GhsuJPLcitrNaADIcgDKbNT9XrwBaNirAEip9hxA==",
       "dev": true,
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/upgrade": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/upgrade/-/upgrade-5.0.5.tgz",
-      "integrity": "sha1-RvIn1cTLqw1F93UuxK/UVS10BVA=",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/upgrade/-/upgrade-5.2.4.tgz",
+      "integrity": "sha512-rNfcZ80n/MJKIj9WeJ711uDzMufXU9VNpyzL4s9M6mT571TKcGm79akngOcih0zto0IosVq7DzhoeFYs9lCf1g==",
       "dev": true,
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "@bazel/ibazel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bazel/ibazel/-/ibazel-0.1.1.tgz",
-      "integrity": "sha1-+XDAi05O+wqxfgSt48xhBVTzO+0=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@bazel/ibazel/-/ibazel-0.3.1.tgz",
+      "integrity": "sha1-XwLyCPE45YG72xU01cAT16Csl5k=",
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.3.tgz",
-      "integrity": "sha512-6fUnuPMMnctCybf6QktUifKmS3/GPrp8LRcM1/pS/CjEu+RULU+6wRBBtHIxIK+PTZ18Zfuw7rgAYI2E9Rx5HQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.1.8.tgz",
+      "integrity": "sha512-LkXMugZ2Z2S0r9zH62YNRhCscstFqJuufEjJmb/XWCTjCKzJZKdbE/6A+WNTitNSHgAkKEF0NoGsIuyhYAubkg==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.3"
+        "@firebase/app-types": "0.1.1",
+        "@firebase/util": "0.1.8"
       }
     },
+    "@firebase/app-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.1.1.tgz",
+      "integrity": "sha512-0CmY/orojHIJiTyDXUqrAtCSmk2nWw7h7qamJUPcBRgAIfc3ZsjFBLo1zj0sRVzZYbTWS9cKBC8tnpFZlEMLPw==",
+      "dev": true
+    },
     "@firebase/auth": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.2.2.tgz",
-      "integrity": "sha512-/qUnCjil7Eb0KQVErkziuyIbG1FrszD6+ttGY7+DTTbN+/QGjyqwTizwGLQDF8Itvf29O7YWKEdsoJyiwn/F4Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.3.3.tgz",
+      "integrity": "sha512-ysp6A71pxHzSQ81VERtOcPMsEUEHEFSvG2ifZ57GI8rDLwgW0ViwOR9Vc53vzdq/+MbgVXPanX8bBzufoixb7A==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.1.1"
+      }
+    },
+    "@firebase/auth-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.1.1.tgz",
+      "integrity": "sha512-GN/PotaK7GawoGf08P+nyFIrVjUwr6xaA1T8g6kB9WSA0/pKHkR8qS0eeKOJbx4iycn+SybdXIbtm/c2juGLdQ==",
       "dev": true
     },
     "@firebase/database": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.4.tgz",
-      "integrity": "sha512-qUkcWTZcN5anNxpF251LL0kqnaQQkc6lKzthzKlp41PIoan/PbEduJ7mDitoT/BIk0lwid+di+ibY58TEQ6t2g==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.1.9.tgz",
+      "integrity": "sha512-w7bsItAvUDMGDX7v2NTIHmt5yRYDWAdUKqC7p152dopGw6AAFgxhR5jAikq7qB2UOPB1vRy8KHlcMk3RnF6cXw==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.3",
+        "@firebase/database-types": "0.1.1",
+        "@firebase/util": "0.1.8",
         "faye-websocket": "0.11.1"
       }
     },
+    "@firebase/database-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.1.1.tgz",
+      "integrity": "sha512-LbLnwXFeQuxQrsuUccbiXX4j3wdajLPNcbivzypJhww+VU4W/4grnbVn/zPlRlMcG6jTwSyBnjdtJFKMSeNU+A==",
+      "dev": true
+    },
     "@firebase/firestore": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.2.0.tgz",
-      "integrity": "sha512-oppGPi8N6teu/VjNJ98ggUB9CnxepwB+wr3Ozbu5VyP2slPE+Y/adwRj0jPT82EmhnKb4Yx4FLsBBEWSqOQUjw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.3.2.tgz",
+      "integrity": "sha512-hUd70L5OD2vQwkizTVhVQkBSBsFAH9F2IsLZuNtXx3ZoL5zJ8ob5/iatIBxcTRvgAAdxDjoChf30rh3vFLVeXg==",
       "dev": true,
       "requires": {
-        "@firebase/webchannel-wrapper": "0.2.4",
-        "grpc": "1.7.2"
+        "@firebase/firestore-types": "0.2.1",
+        "@firebase/webchannel-wrapper": "0.2.6",
+        "grpc": "1.9.0"
       }
+    },
+    "@firebase/firestore-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-0.2.1.tgz",
+      "integrity": "sha512-f6wR2Ct2NfyH9xmY7VJXgzBH8bMYxLUm3ceeUQ+JdoXtHvpdON9LOZzgY19cSp91z3fQ5I8+n5X15VLoze4oWw==",
+      "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.1.4.tgz",
-      "integrity": "sha512-0b0HuYPKQvrYkIhD7cbrk7evDpv0QF4nz/cupEGA8x6LeeQnIr4wnBaMpWFMhdE7cEwGbTSugkFT+sUxJdjiyw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.1.9.tgz",
+      "integrity": "sha512-fJ8heEhz4Cdbyx1DeZQzNPEAlxrSsFlGKAR4zK7vpwv3cTCgufbsK1jCCLdVonYWF/Jv6G61r3kJyVF02OuW1A==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.1.3"
+        "@firebase/messaging-types": "0.1.1",
+        "@firebase/util": "0.1.8"
       }
     },
+    "@firebase/messaging-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.1.1.tgz",
+      "integrity": "sha512-MDAB2Il/HhhQnlYvfvqbd7SYFk30wWSLehcp+8LEdRGn1mctQJHQUT3Y1gRChUFbA4a94enGfR5NPOBKbTMbkA==",
+      "dev": true
+    },
     "@firebase/polyfill": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.1.2.tgz",
-      "integrity": "sha512-5oneu9nOYDZkZWyfvBXFa+ORWj9HeOYhwWy4HSJzCLKLnOvQSSZRcNBD2cVrysGR8tZCEfyKqq3fnwtODCvIQg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.1.4.tgz",
+      "integrity": "sha512-Ega4DpDDUjHCa9UDp9LafY/FN7ATiohFRfqHM0ikbMB0i+eDkw9TJjiaXFaC+xLQbq0J3WxbaAhdvD81IEsRWQ==",
       "dev": true,
       "requires": {
         "promise-polyfill": "6.1.0"
       }
     },
     "@firebase/storage": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.1.3.tgz",
-      "integrity": "sha512-zqgebR8dwMtv/r6QfABWNIxeK9lvWgYy9D8R5Vjflelggm0ylon/Z9h86HsSxW0VmUE4486uoX9kBlk+SW+6Ow==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.1.6.tgz",
+      "integrity": "sha512-BefvT57XRoCABgPmYbWjVNRIr8rsGNrBvnP1Wa4ya39FJEWhnzMrom+DQDukBFaq4QpjaIfbqYo7mC67g+j/Sw==",
+      "dev": true,
+      "requires": {
+        "@firebase/storage-types": "0.1.1"
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.1.1.tgz",
+      "integrity": "sha512-5xFcXUCu9MF0stI8ZN6C8B3d5+GWY+DU0h0Itz3Xy+kexGP93i6tdw8HlKhKvPsT2rLmP5Y2nmOI5/tcCt+GGw==",
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.3.tgz",
-      "integrity": "sha512-rnLhQN6q/uk15Zi4dNqYel6uowlqPeL35FLqyyVDaoMLZDigIy/bwlM0KaBGToR+FcJ6X3BFFm/9WC0wnFQ7YQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.1.8.tgz",
+      "integrity": "sha512-SfWLSfp1MXb5ItG3wGfdxxIDzFMcjq2E0iz9C7sstzD3mJ8/q55Sd8esAL3VQx5jD/hbfKUypsBczr5A0ML7Tw==",
       "dev": true
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.4.tgz",
-      "integrity": "sha512-jEpglcwMlwdXc/JgvJaJtCSkPMktnFeI0gAZxPrmbJxKVzMZJ2zM582NbW/r6M22pSdNWjcWeg1I2LRg3jQGQA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.6.tgz",
+      "integrity": "sha512-Uv9ieuHVogIOOzpGmdjV3/0asMJPdssq2vrOYJ/UTlvekT6aGdv+sx2WWvIrGRWfFxWIkOxCqpqaGMYbhc88Pg==",
       "dev": true
     },
     "@google-cloud/common": {
@@ -229,139 +275,98 @@
         "arrify": "1.0.1",
         "concat-stream": "1.6.0",
         "create-error-class": "3.0.2",
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "ent": "2.2.0",
         "extend": "3.0.1",
-        "google-auto-auth": "0.8.1",
+        "google-auto-auth": "0.8.2",
         "is": "3.2.1",
-        "log-driver": "1.2.5",
+        "log-driver": "1.2.6",
         "methmeth": "1.1.0",
-        "modelo": "4.2.0",
+        "modelo": "4.2.3",
         "request": "2.83.0",
-        "retry-request": "3.3.0",
+        "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
         "stream-events": "1.0.2",
-        "string-format-obj": "1.1.0",
+        "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
     },
     "@google-cloud/common-grpc": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.5.1.tgz",
-      "integrity": "sha512-K42YaV6d1+zxdWQTdnDXmxmfhXPoRxwibqUWBOb7wS7wAJsmVvAtfj9WocRu2cfbHno3JPCZU9ahyFg3p2ZbBQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.5.5.tgz",
+      "integrity": "sha512-wgtuBcgTZ7cUMGQV9MSz4y0+FReLqdsOOgzOifu+lsnRh9qsMEZJ9sBDLB6NrRxrvcAHZc4ayiBx7B7i5cDYoA==",
       "dev": true,
       "requires": {
-        "@google-cloud/common": "0.13.6",
-        "dot-prop": "2.4.0",
-        "duplexify": "3.5.1",
+        "@google-cloud/common": "0.16.1",
+        "dot-prop": "4.2.0",
+        "duplexify": "3.5.3",
         "extend": "3.0.1",
-        "grpc": "1.7.2",
+        "grpc": "1.7.3",
         "is": "3.2.1",
-        "modelo": "4.2.0",
+        "modelo": "4.2.3",
         "retry-request": "3.3.1",
         "through2": "2.0.3"
       },
       "dependencies": {
         "@google-cloud/common": {
-          "version": "0.13.6",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
-          "integrity": "sha1-qdjhN7xCmkSrqWif5qDkMxeE+FM=",
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.16.1.tgz",
+          "integrity": "sha512-1sufDsSfgJ7fuBLq+ux8t3TlydMlyWl9kPZx2WdLINkGtf5RjvXX6EWYZiCMKe8flJ3oC0l95j5atN2uX5n3rg==",
           "dev": true,
           "requires": {
             "array-uniq": "1.0.3",
             "arrify": "1.0.1",
             "concat-stream": "1.6.0",
             "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "ent": "2.2.0",
             "extend": "3.0.1",
-            "google-auto-auth": "0.7.2",
+            "google-auto-auth": "0.9.3",
             "is": "3.2.1",
             "log-driver": "1.2.5",
             "methmeth": "1.1.0",
-            "modelo": "4.2.0",
+            "modelo": "4.2.3",
             "request": "2.83.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
             "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
+            "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           }
         },
-        "dot-prop": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
-          "integrity": "sha1-hI4o9/HVB0DGdHqzywdnBGK2+Jw=",
+        "gcp-metadata": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
+          "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
-          "dev": true,
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
+            "extend": "3.0.1",
+            "retry-request": "3.3.1"
           }
         },
         "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.3.tgz",
+          "integrity": "sha512-TbOZZs0WJOolrRmdQLK5qmWdOJQFG1oPnxcIBbAwL7XCWcv3XgZ9gHJ6W4byrdEZT8TahNFgMfkHd73mqxM9dw==",
           "dev": true,
           "requires": {
             "async": "2.6.0",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
+            "gcp-metadata": "0.4.1",
+            "google-auth-library": "0.12.0",
             "request": "2.83.0"
           }
         },
-        "retry-request": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
-          "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
-          "dev": true,
-          "requires": {
-            "request": "2.83.0",
-            "through2": "2.0.3"
-          }
-        }
-      }
-    },
-    "@google-cloud/firestore": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.10.1.tgz",
-      "integrity": "sha512-l9AzPoc2fIvFzI6KWyRhWUYQBpnQjaA6ZACILAslppC4wJv9SqYc7O5gUfxeWq5yV6XCo7e7/n7apPvf91T1IA==",
-      "dev": true,
-      "requires": {
-        "@google-cloud/common": "0.15.1",
-        "@google-cloud/common-grpc": "0.5.1",
-        "bun": "0.0.12",
-        "extend": "3.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "google-gax": "0.14.2",
-        "grpc": "1.7.1",
-        "is": "3.2.1",
-        "safe-buffer": "5.1.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
         "grpc": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.1.tgz",
-          "integrity": "sha512-lMgjZUzJx09VL5iCfs7rFagE5htikdv/9VzX/ji3zuwlzAhijqcU47bi5N5lbVw/UB2fxneeYg8sBTfQfd0c4A==",
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
+          "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
           "dev": true,
           "requires": {
             "arguejs": "0.2.3",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "nan": "2.8.0",
             "node-pre-gyp": "0.6.39",
-            "protobufjs": "5.0.0"
+            "protobufjs": "5.0.2"
           },
           "dependencies": {
             "abbrev": {
@@ -1186,38 +1191,61 @@
               "dev": true
             }
           }
+        },
+        "log-driver": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+          "dev": true
         }
       }
     },
+    "@google-cloud/firestore": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.11.2.tgz",
+      "integrity": "sha512-Dp5Im5y6LfJ2OuuGN/PX/w7+LdKPRhKbhgNOaUjreIULo7Ya9AyRMYn/E+w8Rm+b3CZXM7fzVpkkdg9Thq8uUQ==",
+      "dev": true,
+      "requires": {
+        "@google-cloud/common": "0.15.1",
+        "@google-cloud/common-grpc": "0.5.5",
+        "bun": "0.0.12",
+        "extend": "3.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "google-gax": "0.14.5",
+        "is": "3.2.1",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.3"
+      }
+    },
     "@google-cloud/functions-emulator": {
-      "version": "1.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.27.tgz",
-      "integrity": "sha1-0iEKArtKCQN95jpRLn1amMKBI+c=",
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-emulator/-/functions-emulator-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-rLysQK3DFWetXgZr41SG3+qcpsanNgKjYQulmFytGXdQGhiP1Tn3qe7e+H905nBqZMR2u+L0amw0/6Sw9uouhg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@google-cloud/storage": "1.4.0",
+        "@google-cloud/storage": "1.2.1",
         "adm-zip": "0.4.7",
-        "ajv": "5.3.0",
-        "body-parser": "1.18.2",
+        "ajv": "5.2.2",
+        "body-parser": "1.17.2",
         "cli-table2": "0.2.0",
         "colors": "1.1.2",
         "configstore": "3.1.1",
-        "express": "4.16.2",
-        "google-proto-files": "0.14.1",
-        "googleapis": "22.2.0",
+        "express": "4.15.4",
+        "google-proto-files": "0.12.1",
+        "googleapis": "20.1.0",
         "got": "7.1.0",
-        "grpc": "1.7.1",
+        "grpc": "1.4.1",
         "http-proxy": "1.16.2",
         "lodash": "4.17.4",
         "prompt": "1.0.0",
-        "rimraf": "2.6.2",
+        "rimraf": "2.6.1",
         "semver": "5.4.1",
         "serializerr": "1.0.3",
-        "tmp": "0.0.33",
+        "tmp": "0.0.31",
         "uuid": "3.1.0",
-        "winston": "2.4.0",
-        "yargs": "10.0.3"
+        "winston": "2.3.1",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "@google-cloud/common": {
@@ -1231,26 +1259,26 @@
             "arrify": "1.0.1",
             "concat-stream": "1.6.0",
             "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "ent": "2.2.0",
             "extend": "3.0.1",
             "google-auto-auth": "0.7.2",
             "is": "3.2.1",
-            "log-driver": "1.2.5",
+            "log-driver": "1.2.6",
             "methmeth": "1.1.0",
-            "modelo": "4.2.0",
+            "modelo": "4.2.3",
             "request": "2.83.0",
-            "retry-request": "3.3.0",
+            "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
             "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
+            "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           }
         },
         "@google-cloud/storage": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.4.0.tgz",
-          "integrity": "sha512-vt1NU7D12OGYPhWfwBD1Q2qFS6Suykorlp3NLaES2W9CW6sEBWLwScxElXt8nPvonYBCFt99jP4g1AqY+0hefw==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.2.1.tgz",
+          "integrity": "sha1-oPLiCHG4YvDqZKkKxI/AiEXPlQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1259,48 +1287,43 @@
             "async": "2.6.0",
             "concat-stream": "1.6.0",
             "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "extend": "3.0.1",
             "gcs-resumable-upload": "0.8.2",
             "hash-stream-validation": "0.2.1",
             "is": "3.2.1",
             "mime-types": "2.1.17",
             "once": "1.4.0",
-            "pumpify": "1.3.5",
-            "safe-buffer": "5.1.1",
-            "snakeize": "0.1.0",
+            "pumpify": "1.4.0",
             "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
+            "string-format-obj": "1.1.1",
             "through2": "2.0.3"
           }
         },
-        "@types/node": {
-          "version": "8.0.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.54.tgz",
-          "integrity": "sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/events": "1.1.0"
-          }
-        },
         "ajv": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
           "dev": true,
           "optional": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true,
           "optional": true
         },
@@ -1338,945 +1361,1111 @@
           }
         },
         "google-proto-files": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.1.tgz",
-          "integrity": "sha1-bl8V+L1mFdc8o/3QjN7DM2P5r4k=",
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.12.1.tgz",
+          "integrity": "sha512-d+BiTMpYP4/pN+Kgi0lWE+2/GaVN4jy8LCabjo2Wd16Ykm5oRO5bI40bo8u2U4rN/GpZkMyfxZAjWVPRjGe3nQ==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "globby": "6.1.0",
-            "protobufjs": "6.8.3"
-          }
+          "optional": true
         },
         "grpc": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.1.tgz",
-          "integrity": "sha512-lMgjZUzJx09VL5iCfs7rFagE5htikdv/9VzX/ji3zuwlzAhijqcU47bi5N5lbVw/UB2fxneeYg8sBTfQfd0c4A==",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.4.1.tgz",
+          "integrity": "sha1-PuSoNGphPygjkoyfj5kIG2No7Hw=",
           "dev": true,
           "optional": true,
           "requires": {
             "arguejs": "0.2.3",
             "lodash": "4.17.4",
             "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39",
+            "node-pre-gyp": "0.6.36",
             "protobufjs": "5.0.2"
           },
           "dependencies": {
-            "abbrev": {
-              "version": "1.0.9",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true,
-              "dev": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true,
-              "dev": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true,
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
             "node-pre-gyp": {
-              "version": "0.6.39",
+              "version": "0.6.36",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.2",
-                "hawk": "3.1.3",
                 "mkdirp": "0.5.1",
                 "nopt": "4.0.1",
                 "npmlog": "4.1.2",
-                "rc": "1.2.2",
+                "rc": "1.2.1",
                 "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.4.1",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
                 "tar": "2.2.1",
-                "tar-pack": "3.4.1"
+                "tar-pack": "3.4.0"
               },
               "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
                 "nopt": {
                   "version": "4.0.1",
                   "bundled": true,
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "abbrev": "1.0.9",
+                    "abbrev": "1.1.0",
                     "osenv": "0.1.4"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "osenv": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                      },
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "os-tmpdir": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  },
+                  "dependencies": {
+                    "are-we-there-yet": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.2"
+                      },
+                      "dependencies": {
+                        "delegates": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "readable-stream": {
+                          "version": "2.3.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "core-util-is": "1.0.2",
+                            "inherits": "2.0.3",
+                            "isarray": "1.0.0",
+                            "process-nextick-args": "1.0.7",
+                            "safe-buffer": "5.1.1",
+                            "string_decoder": "1.0.3",
+                            "util-deprecate": "1.0.2"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "string_decoder": {
+                              "version": "1.0.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "safe-buffer": "5.1.1"
+                              }
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "gauge": {
+                      "version": "2.7.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "aproba": "1.1.2",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                      },
+                      "dependencies": {
+                        "aproba": {
+                          "version": "1.1.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "has-unicode": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "object-assign": {
+                          "version": "4.1.1",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "wide-align": {
+                          "version": "1.1.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "string-width": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.4",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.4.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.1.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.1.0"
+                  },
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "aws4": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "delayed-stream": "1.0.0"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                      },
+                      "dependencies": {
+                        "asynckit": {
+                          "version": "0.4.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                      },
+                      "dependencies": {
+                        "ajv": {
+                          "version": "4.11.8",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "co": "4.6.0",
+                            "json-stable-stringify": "1.0.1"
+                          },
+                          "dependencies": {
+                            "co": {
+                              "version": "4.6.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "json-stable-stringify": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsonify": "0.0.0"
+                              },
+                              "dependencies": {
+                                "jsonify": {
+                                  "version": "0.0.0",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-schema": {
+                          "version": "1.0.5",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                      },
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "hoek": "2.16.3"
+                          }
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "boom": "2.10.1"
+                          }
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "hoek": "2.16.3"
+                          }
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.1"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "jsprim": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0",
+                            "extsprintf": "1.0.2",
+                            "json-schema": "0.2.3",
+                            "verror": "1.3.6"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "extsprintf": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "json-schema": {
+                              "version": "0.2.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "verror": {
+                              "version": "1.3.6",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "extsprintf": "1.0.2"
+                              }
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.13.1",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "asn1": "0.2.3",
+                            "assert-plus": "1.0.0",
+                            "bcrypt-pbkdf": "1.0.1",
+                            "dashdash": "1.14.1",
+                            "ecc-jsbn": "0.1.1",
+                            "getpass": "0.1.7",
+                            "jsbn": "0.1.1",
+                            "tweetnacl": "0.14.5"
+                          },
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true
+                            },
+                            "bcrypt-pbkdf": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "tweetnacl": "0.14.5"
+                              }
+                            },
+                            "dashdash": {
+                              "version": "1.14.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsbn": "0.1.1"
+                              }
+                            },
+                            "getpass": {
+                              "version": "0.1.7",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.1",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.5",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.27.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "punycode": "1.4.1"
+                      },
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "safe-buffer": "5.1.1"
+                      }
+                    },
+                    "uuid": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      },
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "inflight": {
+                          "version": "1.0.6",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "once": "1.4.0",
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "brace-expansion": "1.1.8"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.8",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "dev": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  },
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "inherits": "2.0.3"
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "2.6.8",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.3.2",
+                    "rimraf": "2.6.1",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.6.8",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                      },
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "minimatch": {
+                          "version": "3.0.4",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "brace-expansion": "1.1.8"
+                          },
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.8",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.3.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "safe-buffer": "5.1.1"
+                          }
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
                   }
                 }
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true,
-              "dev": true
-            },
-            "protobufjs": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-              "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ascli": "1.0.1",
-                "bytebuffer": "5.0.1",
-                "glob": "7.1.1",
-                "yargs": "3.32.0"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "7.1.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "5.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.3",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs": {
-              "version": "3.32.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-              "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "2.1.1",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "os-locale": "1.4.0",
-                "string-width": "1.0.2",
-                "window-size": "0.1.4",
-                "y18n": "3.2.1"
               }
             }
           }
@@ -2288,27 +2477,40 @@
           "dev": true,
           "optional": true
         },
-        "protobufjs": {
-          "version": "6.8.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.3.tgz",
-          "integrity": "sha512-/iQhTYnSniRNmdRF9Kvw8odMSokwNOWVDOmMJjW64+EVE6igcdj/82Op/4MJ/WimgMRNac7gChlSVX4Gep/tHg==",
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "@protobufjs/aspromise": "1.1.2",
-            "@protobufjs/base64": "1.1.2",
-            "@protobufjs/codegen": "2.0.4",
-            "@protobufjs/eventemitter": "1.1.0",
-            "@protobufjs/fetch": "1.1.0",
-            "@protobufjs/float": "1.0.2",
-            "@protobufjs/inquire": "1.1.0",
-            "@protobufjs/path": "1.1.2",
-            "@protobufjs/pool": "1.1.0",
-            "@protobufjs/utf8": "1.1.0",
-            "@types/long": "3.0.32",
-            "@types/node": "8.0.54",
-            "long": "3.2.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "2.1.1",
@@ -2332,56 +2534,81 @@
           }
         },
         "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+          "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
           "dev": true,
           "optional": true,
           "requires": {
             "os-tmpdir": "1.0.2"
           }
         },
-        "yargs": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true,
+          "optional": true
+        },
+        "winston": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+          "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
           "dev": true,
           "optional": true,
           "requires": {
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "stack-trace": "0.0.10"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+              "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+              "dev": true,
+              "optional": true
+            },
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
-            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
-          },
-          "dependencies": {
-            "os-locale": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
-              }
-            }
+            "yargs-parser": "7.0.0"
           }
         }
       }
     },
     "@google-cloud/storage": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.5.0.tgz",
-      "integrity": "sha512-0R9+quyMvd3e1GEqzONOrI0083ExBQq4+Zj8zzQIchzWvthdQDfoSBs+/a4Ol7SOu4kBK75p2SH5Q5BLE0a9og==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.5.2.tgz",
+      "integrity": "sha512-E97x2oZr9w0N26H0LtyjR3XLFSLYXH5D8y8HwEZRWQnNVF9sO+x16MEhdHFdFclgdx687eGeCYbDVKpP+dKb6w==",
       "dev": true,
       "requires": {
         "@google-cloud/common": "0.15.1",
@@ -2389,19 +2616,19 @@
         "async": "2.6.0",
         "concat-stream": "1.6.0",
         "create-error-class": "3.0.2",
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "extend": "3.0.1",
         "gcs-resumable-upload": "0.8.2",
         "hash-stream-validation": "0.2.1",
         "is": "3.2.1",
         "mime-types": "2.1.17",
         "once": "1.4.0",
-        "pumpify": "1.3.5",
+        "pumpify": "1.4.0",
         "request": "2.83.0",
         "safe-buffer": "5.1.1",
         "snakeize": "0.1.0",
         "stream-events": "1.0.2",
-        "string-format-obj": "1.1.0",
+        "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
     },
@@ -2479,26 +2706,26 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
       "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/fs-extra": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.5.tgz",
-      "integrity": "sha512-tIG0GpHum5IFb8Qze/cSv0w/0gNzHB+MUDftTQaxenx46z50g51/MPkNLssLz9+uZLzCDd35bT9qtWOTXZ21Gw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.7.tgz",
+      "integrity": "sha512-BN48b/2F3kL0Ual7tjcHjj0Fl+nuYKtHa0G/xT3Q43HuCpN7rQD5vIx6Aqnl9x10oBI5xMJh8Ly+FQpP205JlA==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48"
+        "@types/node": "7.0.54"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "7.0.48"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "7.0.54"
       }
     },
     "@types/google-cloud__storage": {
@@ -2507,7 +2734,7 @@
       "integrity": "sha512-010Llp+5ze+XWWmZuLDxs0pZgFjOgtJQVt9icJ0Ed67ZFLq7PnXkYx8x/k9nwDojR5/X4XoLPNqB1F627TScdQ==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48"
+        "@types/node": "7.0.54"
       }
     },
     "@types/gulp": {
@@ -2516,9 +2743,9 @@
       "integrity": "sha1-g8WcaBzCM9Hsf4LSaVVVZvoTMVY=",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48",
+        "@types/node": "7.0.54",
         "@types/orchestrator": "0.3.2",
-        "@types/vinyl": "2.0.1"
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/hammerjs": {
@@ -2528,19 +2755,10 @@
       "dev": true
     },
     "@types/jasmine": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.2.tgz",
-      "integrity": "sha512-RabEJPjYMpjWqW1qYj4k0rlgP5uzyguoc0yxedJdq7t5h19MYvqhjCR1evM3raZ/peHRxp1Qfl24iawvkibSug==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.6.tgz",
+      "integrity": "sha512-clg9raJTY0EOo5pVZKX3ZlMjlYzVU73L71q5OV1jhE2Uezb7oF94jh4CvwrW6wInquQAdhOxJz5VDF2TLUGmmA==",
       "dev": true
-    },
-    "@types/jsonwebtoken": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
-      "integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "7.0.48"
-      }
     },
     "@types/long": {
       "version": "3.0.32",
@@ -2554,13 +2772,13 @@
       "integrity": "sha1-njnQT2/k82+nR3VmytH6+AsqZx8=",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48"
+        "@types/node": "7.0.54"
       }
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
@@ -2570,9 +2788,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.48.tgz",
-      "integrity": "sha512-LLlXafM3BD52MH056tHxTXO8JFCnpJJQkdzIU3+m8ew+CXJY/5zIXgDNb4TK/QFvlI8QexLS5tL+sE0Qhegr1w==",
+      "version": "7.0.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.54.tgz",
+      "integrity": "sha512-w5PYRbRlUOUqHziUzmSeKhIAV9ogBb/sJQxsR8DsYFY30/xJ2RIIuee6gNNl3TgPEFON8vkOR/qKbQr5/XF7/A==",
       "dev": true
     },
     "@types/orchestrator": {
@@ -2581,14 +2799,14 @@
       "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48",
-        "@types/q": "1.0.6"
+        "@types/node": "7.0.54",
+        "@types/q": "1.0.7"
       }
     },
     "@types/q": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.6.tgz",
-      "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.7.tgz",
+      "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ==",
       "dev": true
     },
     "@types/run-sequence": {
@@ -2598,7 +2816,7 @@
       "dev": true,
       "requires": {
         "@types/gulp": "3.8.32",
-        "@types/node": "7.0.48"
+        "@types/node": "7.0.54"
       }
     },
     "@types/selenium-webdriver": {
@@ -2608,18 +2826,18 @@
       "dev": true
     },
     "@types/vinyl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.1.tgz",
-      "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.2.tgz",
+      "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.48"
+        "@types/node": "7.0.54"
       }
     },
     "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
         "jsonparse": "1.3.1",
@@ -2655,9 +2873,15 @@
       }
     },
     "acorn": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "dev": true
+    },
+    "acorn-es7-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
+      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
       "dev": true
     },
     "acorn-globals": {
@@ -2667,6 +2891,14 @@
       "dev": true,
       "requires": {
         "acorn": "2.7.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+          "dev": true
+        }
       }
     },
     "add-stream": {
@@ -2688,27 +2920,19 @@
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -2748,21 +2972,64 @@
         "string-width": "1.0.2"
       }
     },
+    "ansi-colors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
+      "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "any-promise": {
@@ -2794,17 +3061,17 @@
       "dev": true
     },
     "archiver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
-      "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
         "archiver-utils": "1.3.0",
         "async": "2.6.0",
         "buffer-crc32": "0.2.13",
         "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "readable-stream": "2.3.3",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.4",
         "tar-stream": "1.5.5",
         "zip-stream": "1.2.0"
       }
@@ -2818,9 +3085,9 @@
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "lazystream": "1.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "archy": {
@@ -2836,7 +3103,7 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "argparse": {
@@ -2851,7 +3118,8 @@
     "arguejs": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
-      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
+      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc=",
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -2866,6 +3134,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-differ": {
@@ -2884,6 +3158,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
     "array-find-index": {
@@ -2940,7 +3220,8 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
@@ -2957,7 +3238,8 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "as-array": {
       "version": "2.0.0",
@@ -2975,6 +3257,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "dev": true,
       "requires": {
         "colour": "0.7.1",
         "optjs": "3.2.2"
@@ -2983,12 +3266,20 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
     },
     "ast-module-types": {
       "version": "2.3.2",
@@ -3000,8 +3291,9 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "async-each": {
@@ -3019,7 +3311,14 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "dev": true
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -3028,7 +3327,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000808",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -3038,26 +3337,28 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
     },
     "axe-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.5.0.tgz",
-      "integrity": "sha512-onOXxjT3lXT3FfIBH5AIDxug+28Xw4q4XY66v+2rTRWg9o8dSiKr58ZWlCveh1cmE2kL5bT1KlO9PsSr7pWClA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
       "dev": true
     },
     "axe-webdriverjs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-1.2.0.tgz",
-      "integrity": "sha512-5ONeCl65pIjxZ6CvfYf1SZclHBWBBklGis3jVrsOu/bpyWaJgtNYu8VEaXHWbO8g5xBUl4v5zvIrthRFkhqhsQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-1.3.0.tgz",
+      "integrity": "sha512-DGjz5DqQ+btGCj49cFSF+ZK9UWcYCwXiYqIlfBDBbPAen2u/plEUsHBiQODpkhTpbFdnUgCwxf6cwaP8Ku6hCw==",
       "dev": true,
       "requires": {
-        "axe-core": "2.5.0",
+        "axe-core": "2.6.1",
         "selenium-webdriver": "3.6.0"
       }
     },
@@ -3078,8 +3379,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babylon": {
@@ -3103,7 +3404,31 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -3154,6 +3479,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -3191,12 +3517,38 @@
       "dev": true
     },
     "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
       }
     },
     "blob": {
@@ -3215,9 +3567,9 @@
       }
     },
     "blocking-proxy": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-0.0.5.tgz",
-      "integrity": "sha1-RikF4Nz76pcPQao3Ij3anAexkSs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-1.0.1.tgz",
+      "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
       "dev": true,
       "requires": {
         "minimist": "1.2.0"
@@ -3230,27 +3582,42 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "dev": true,
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "2.4.0",
         "content-type": "1.0.4",
-        "debug": "2.6.9",
-        "depd": "1.1.1",
+        "debug": "2.6.7",
+        "depd": "1.1.2",
         "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
         "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        }
       }
     },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -3273,9 +3640,10 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -3292,31 +3660,14 @@
         "repeat-element": "1.1.2"
       }
     },
-    "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-db": "1.0.30000808",
+        "electron-to-chromium": "1.3.33"
       }
     },
     "browserstack": {
@@ -3326,6 +3677,35 @@
       "dev": true,
       "requires": {
         "https-proxy-agent": "1.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.7",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "browserstacktunnel-wrapper": {
@@ -3336,6 +3716,35 @@
       "requires": {
         "https-proxy-agent": "1.0.0",
         "unzip": "0.1.11"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.7",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "buffer-crc32": {
@@ -3374,30 +3783,12 @@
       "dev": true
     },
     "bufferstreams": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.2.tgz",
-      "integrity": "sha512-S2y8glT5dGiZEt9IExGShLUIFEE7kW6wUUapwPaqs+MBoS4jIfbRfLnSCv1UttLEPojanU4InDCmrDkiErudJg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.3.tgz",
+      "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
       "dev": true,
       "requires": {
-        "debug": "2.6.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-          "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
+        "readable-stream": "2.3.4"
       }
     },
     "builtin-modules": {
@@ -3445,14 +3836,46 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "dev": true,
       "requires": {
         "long": "3.2.0"
       }
     },
     "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "call-signature": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
     "callsite": {
@@ -3474,7 +3897,8 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -3487,15 +3911,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000783",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz",
-      "integrity": "sha1-m1SZ+xtQPSNF0SqmuGEoUvQnb/0=",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
+      "integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==",
       "dev": true
     },
     "canonical-path": {
@@ -3507,12 +3931,14 @@
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "catharsis": {
       "version": "0.8.9",
@@ -3537,6 +3963,14 @@
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true
+        }
       }
     },
     "chainsaw": {
@@ -3546,6 +3980,14 @@
       "dev": true,
       "requires": {
         "traverse": "0.3.9"
+      },
+      "dependencies": {
+        "traverse": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+          "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+          "dev": true
+        }
       }
     },
     "chalk": {
@@ -3663,6 +4105,92 @@
         "json-parse-helpfulerror": "1.0.3"
       }
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "clean-css": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
@@ -3740,6 +4268,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
@@ -3783,23 +4312,245 @@
         "inherits": "2.0.3",
         "process-nextick-args": "1.0.7",
         "through2": "2.0.3"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
       }
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "codecov.io": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.0.1.tgz",
+      "integrity": "sha1-JeorCV4enqEYcr36WEIRgTDfeLE=",
+      "dev": true,
+      "requires": {
+        "request": "2.42.0",
+        "urlgrey": "0.4.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+          "dev": true,
+          "optional": true
+        },
+        "boom": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+          "dev": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "caseless": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
+          "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "dev": true,
+          "optional": true
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.9.2",
+            "combined-stream": "0.0.7",
+            "mime": "1.2.11"
+          }
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2",
+            "cryptiles": "0.2.2",
+            "hoek": "0.9.1",
+            "sntp": "0.2.4"
+          }
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+          "dev": true,
+          "optional": true
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
+          "integrity": "sha1-8ilW8x6nFRqCHl8vsywRPK2Ln2k=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.42.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+          "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.5.0",
+            "bl": "0.9.5",
+            "caseless": "0.6.0",
+            "forever-agent": "0.5.2",
+            "form-data": "0.1.4",
+            "hawk": "1.1.1",
+            "http-signature": "0.10.1",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "1.0.2",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.4.0",
+            "qs": "1.2.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
     },
     "collapse-white-space": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
       "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
     },
     "color-convert": {
       "version": "1.9.1",
@@ -3816,6 +4567,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -3825,7 +4582,8 @@
     "colour": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
+      "dev": true
     },
     "combine-lists": {
       "version": "1.0.1",
@@ -3833,21 +4591,22 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
     },
     "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
       "dev": true
     },
     "commondir": {
@@ -3883,7 +4642,7 @@
       "integrity": "sha1-fAp5onu4C2xplERfgpWCWdPQIVM=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "component-bind": {
@@ -3893,9 +4652,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "component-inherit": {
@@ -3913,7 +4672,7 @@
         "buffer-crc32": "0.2.13",
         "crc32-stream": "2.0.0",
         "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "compressible": {
@@ -3938,20 +4697,45 @@
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
         "vary": "1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -3981,25 +4765,25 @@
         "utils-merge": "1.0.1"
       },
       "dependencies": {
-        "finalhandler": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "ms": "2.0.0"
           }
         },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "dev": true
         }
       }
@@ -4102,27 +4886,28 @@
       "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
-      "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.12.tgz",
+      "integrity": "sha512-e8RZ7l9PDiBkALSqxTgdzufaCy0NPXqatdQ3PDteq+65SSQhx8a+8fTGzhWmZhRxXGP5HZmoAiMCIJaw5NWDWQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.5.2",
-        "conventional-changelog-atom": "0.1.2",
-        "conventional-changelog-codemirror": "0.2.1",
-        "conventional-changelog-core": "1.9.3",
-        "conventional-changelog-ember": "0.2.9",
-        "conventional-changelog-eslint": "0.2.1",
-        "conventional-changelog-express": "0.2.1",
+        "conventional-changelog-angular": "1.6.2",
+        "conventional-changelog-atom": "0.2.0",
+        "conventional-changelog-codemirror": "0.3.0",
+        "conventional-changelog-core": "2.0.1",
+        "conventional-changelog-ember": "0.3.2",
+        "conventional-changelog-eslint": "1.0.0",
+        "conventional-changelog-express": "0.3.0",
         "conventional-changelog-jquery": "0.1.0",
         "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.2.1"
+        "conventional-changelog-jshint": "0.3.0",
+        "conventional-changelog-preset-loader": "1.1.2"
       }
     },
     "conventional-changelog-angular": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.2.tgz",
-      "integrity": "sha1-Kzj2Zf6cWSCvGi+C9Uf0ur5t5Xw=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.2.tgz",
+      "integrity": "sha512-LiGZkMJOCJFLNzDlZo3f+DpblcDSzsaYHUWhC+kzsqq+no4qwDP3uW0HVIHueXT4jJDhYNaE9t/XCD7vu7xR1g==",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -4130,37 +4915,37 @@
       }
     },
     "conventional-changelog-atom": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
-      "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.0.tgz",
+      "integrity": "sha1-cvGOXHTj2IB0ESUv4BOBjd/6cVc=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
-      "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.0.tgz",
+      "integrity": "sha1-TdirufUhpjjKtJ9oNJbCa4pcbTE=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.3.tgz",
-      "integrity": "sha1-KJn+d5OJoynw7EsnRsNt3vuY2i0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.1.tgz",
+      "integrity": "sha512-XxgSDsCUGXT4j3uVpYkz17D1AoWzO8BOC0VO1fSwvvXJB5Q32zhPGXObvu7vTb0GE0OS15eDgzYN32fU3mOzYA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "2.0.2",
-        "conventional-commits-parser": "2.0.1",
+        "conventional-changelog-writer": "3.0.0",
+        "conventional-commits-parser": "2.1.1",
         "dateformat": "1.0.12",
         "get-pkg-repo": "1.4.0",
         "git-raw-commits": "1.3.0",
         "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.2.3",
-        "lodash": "4.17.4",
+        "git-semver-tags": "1.3.0",
+        "lodash": "4.17.5",
         "normalize-package-data": "2.4.0",
         "q": "1.4.1",
         "read-pkg": "1.1.0",
@@ -4177,31 +4962,110 @@
             "get-stdin": "4.0.1",
             "meow": "3.7.0"
           }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         }
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.9.tgz",
-      "integrity": "sha1-jsc8wFTjqwZGZ/sf61L+jvGxZDg=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.2.tgz",
+      "integrity": "sha512-ZigC7cz6rLzHk4YHnhfd85mxCyRQqiI8CMwalCVC8jIsplxswm+u3F16dIx5Z/P/A5VYFtv4H4ndhccTKS13jw==",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
-      "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.0.tgz",
+      "integrity": "sha1-xjzZ1vCdTiBFMK5zadeiChZ7xrw=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
-      "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.0.tgz",
+      "integrity": "sha1-XtAG9IaC2GFe4KtfU8rLJvvT4cg=",
       "dev": true,
       "requires": {
         "q": "1.4.1"
@@ -4226,29 +5090,35 @@
       }
     },
     "conventional-changelog-jshint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
-      "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.0.tgz",
+      "integrity": "sha1-A5P9RoETuvc8upEdF8WCZCM2aig=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
         "q": "1.4.1"
       }
     },
+    "conventional-changelog-preset-loader": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.2.tgz",
+      "integrity": "sha512-uQiqFzPb38JPOOcGDfrIAQzMHlbJdYxnlGy3yzdGmNMihXJLRPJE+KuZEiQp519/i0gSCqF85upWL4wuzJmwsQ==",
+      "dev": true
+    },
     "conventional-changelog-writer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.2.tgz",
-      "integrity": "sha1-tYV97RsAHa+aeLnNQJJvRcE0lJs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.0.tgz",
+      "integrity": "sha1-4QYVTtlDQeOH1xe2G+IYH/UyVMw=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.0",
+        "conventional-commits-filter": "1.1.1",
         "dateformat": "1.0.12",
         "handlebars": "4.0.11",
         "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "meow": "3.7.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "split": "1.0.1",
         "through2": "2.0.3"
       },
@@ -4275,9 +5145,9 @@
       }
     },
     "conventional-commits-filter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.0.tgz",
-      "integrity": "sha1-H8Ka8wte2rdvVOIpxBGwxmPQ+es=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
+      "integrity": "sha512-bQyatySNKHhcaeKVr9vFxYWA1W1Tdz6ybVMYDmv4/FhOXY1+fchiW07TzRbIQZhVa4cvBwrEaEUQBbCncFSdJQ==",
       "dev": true,
       "requires": {
         "is-subset": "0.1.1",
@@ -4285,14 +5155,14 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.1.tgz",
-      "integrity": "sha1-HxXOa4RPfKQUlcgZDAgzwwuLFpM=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.1.tgz",
+      "integrity": "sha512-Qqxaul7TELPnTrm7KhWGjVTFTs7T9yUblzXugtXEff2C2uXFK4S0uVGqsyX7feQZzoFbXnJ1KdEs+IMmSxGbqQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
+        "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "meow": "3.7.0",
         "split2": "2.2.0",
         "through2": "2.0.3",
@@ -4329,6 +5199,12 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "copy-props": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-1.6.0.tgz",
@@ -4340,14 +5216,15 @@
       }
     },
     "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "3.1.0",
@@ -4385,13 +5262,14 @@
       "dev": true,
       "requires": {
         "crc": "3.5.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "1.0.0"
       }
@@ -4428,6 +5306,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -4436,6 +5315,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
           "requires": {
             "hoek": "4.2.0"
           }
@@ -4513,6 +5393,12 @@
         "through2": "2.0.1"
       },
       "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
@@ -4545,6 +5431,13 @@
         }
       }
     },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true,
+      "optional": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4572,7 +5465,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "dargs": {
@@ -4588,6 +5481,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -4599,9 +5493,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -4618,7 +5512,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -4629,6 +5524,12 @@
         "decamelize": "1.2.0",
         "map-obj": "1.0.1"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -4641,11 +5542,10 @@
       }
     },
     "deep-equal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-      "dev": true,
-      "optional": true
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -4681,6 +5581,31 @@
           "dev": true
         }
       }
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2"
+      }
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
     },
     "del": {
       "version": "2.2.2",
@@ -4722,7 +5647,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -4731,9 +5657,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "dependency-graph": {
@@ -4748,9 +5674,9 @@
       "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
-        "debug": "2.6.9",
-        "filing-cabinet": "1.12.0",
+        "commander": "2.14.1",
+        "debug": "2.6.7",
+        "filing-cabinet": "1.13.1",
         "precinct": "3.8.0"
       }
     },
@@ -4767,13 +5693,10 @@
       "dev": true
     },
     "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true,
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
     },
     "detective-amd": {
       "version": "2.4.0",
@@ -4972,14 +5895,14 @@
         "estraverse": "4.2.0",
         "glob": "7.1.2",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "lodash": "4.17.5",
+        "marked": "0.3.12",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "mkdirp-promise": "5.0.1",
         "node-html-encoder": "0.0.2",
         "nunjucks": "3.0.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "shelljs": "0.7.8",
         "source-map-support": "0.4.18",
         "spdx-license-list": "2.1.0",
@@ -5014,6 +5937,12 @@
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "dev": true
+    },
     "dir-glob": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
@@ -5022,17 +5951,6 @@
       "requires": {
         "arrify": "1.0.1",
         "path-type": "3.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        }
       }
     },
     "dom-serialize": {
@@ -5093,9 +6011,9 @@
       "dev": true
     },
     "domutils": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
-      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
         "dom-serializer": "0.1.0",
@@ -5138,7 +6056,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "duplexer3": {
@@ -5149,13 +6067,14 @@
       "optional": true
     },
     "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+      "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "stream-shift": "1.0.0"
       }
     },
@@ -5169,10 +6088,17 @@
         "object.defaults": "1.1.0"
       }
     },
+    "eastasianwidth": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
+      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -5195,21 +6121,42 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
       "dev": true
     },
+    "empower": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
+      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "empower-core": "0.6.2"
+      }
+    },
+    "empower-core": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+      "dev": true,
+      "requires": {
+        "call-signature": "0.0.2",
+        "core-js": "2.5.3"
+      }
+    },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -5275,12 +6222,6 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
@@ -5313,9 +6254,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.0.3.tgz",
-      "integrity": "sha1-3xTAa1/F7sreEJTJxaErSz7cC2I=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -5327,7 +6268,8 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
     },
     "entities": {
       "version": "1.1.1",
@@ -5342,12 +6284,12 @@
       "dev": true
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -5370,9 +6312,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -5386,7 +6328,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -5402,13 +6344,13 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.1.1"
+        "es6-promise": "4.2.4"
       },
       "dependencies": {
         "es6-promise": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
           "dev": true
         }
       }
@@ -5420,7 +6362,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -5433,7 +6375,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "escape-html": {
@@ -5475,6 +6417,15 @@
       "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
       "dev": true
     },
+    "espurify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3"
+      }
+    },
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
@@ -5500,7 +6451,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "event-stream": {
@@ -5516,6 +6467,17 @@
         "split": "0.3.3",
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        }
       }
     },
     "eventemitter3": {
@@ -5529,7 +6491,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -5545,7 +6506,6 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "lru-cache": "4.1.1",
             "shebang-command": "1.2.0",
@@ -5650,57 +6610,72 @@
       }
     },
     "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
       "dev": true,
       "optional": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "debug": "2.6.8",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.1.0",
-        "fresh": "0.5.2",
+        "finalhandler": "1.0.6",
+        "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
-        "qs": "6.5.1",
+        "proxy-addr": "1.1.5",
+        "qs": "6.5.0",
         "range-parser": "1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
-        "setprototypeof": "1.1.0",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
+        "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.1",
+        "utils-merge": "1.0.0",
         "vary": "1.1.2"
       },
       "dependencies": {
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
           "dev": true,
           "optional": true
         },
@@ -5771,19 +6746,23 @@
           "requires": {
             "base64-url": "1.2.1"
           }
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-          "dev": true
         }
       }
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
     },
     "extglob": {
       "version": "0.3.2",
@@ -5797,7 +6776,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -5806,24 +6786,27 @@
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5882,30 +6865,46 @@
       "dev": true
     },
     "filesize": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.0.tgz",
+      "integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw==",
       "dev": true
     },
     "filing-cabinet": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.12.0.tgz",
-      "integrity": "sha1-b7k/2WjoO+3xtCmPKCNqiq/ffXg=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.13.1.tgz",
+      "integrity": "sha512-uK8bwNArVOuC38LqajIJEs1lpGMtShfGwdM+GuMZVWSaEgO/I9NSh1v8uFTaJL0gTHVT9HJASyTwj8LZONogiA==",
       "dev": true,
       "requires": {
         "app-module-path": "1.1.0",
-        "commander": "2.12.2",
-        "debug": "2.6.9",
-        "enhanced-resolve": "3.0.3",
+        "commander": "2.14.1",
+        "debug": "3.1.0",
+        "enhanced-resolve": "3.4.1",
         "is-relative-path": "1.0.2",
         "module-definition": "2.2.4",
         "module-lookup-amd": "4.0.5",
-        "object-assign": "4.1.1",
         "resolve": "1.5.0",
         "resolve-dependency-path": "1.0.2",
         "sass-lookup": "1.1.0",
         "stylus-lookup": "1.0.2",
         "typescript": "2.5.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "fill-range": {
@@ -5928,14 +6927,13 @@
       "dev": true
     },
     "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -5943,12 +6941,26 @@
         "unpipe": "1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5983,15 +6995,229 @@
       }
     },
     "findup-sync": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.5",
+        "resolve-dir": "1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+          "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.1"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.7",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
+          "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.0",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.7",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          }
+        }
       }
     },
     "fined": {
@@ -6004,99 +7230,47 @@
         "is-plain-object": "2.0.4",
         "object.defaults": "1.1.0",
         "object.pick": "1.3.0",
-        "parse-filepath": "1.0.1"
-      },
-      "dependencies": {
-        "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        }
+        "parse-filepath": "1.0.2"
       }
     },
     "firebase": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.7.0.tgz",
-      "integrity": "sha512-iffGyUW5PjB3fRVkKzGWnCHnU/3fi8Em+Gekr0K7GnRlXFmQG/QX1wdqGug8CEoFRXXNBz4DSamiDSKzlh+g4A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.9.1.tgz",
+      "integrity": "sha512-PMZCkju+Fs2DvtKxuuQPRxWq2fvlgmGXeNF2kHVNeZ1x+cA2OKrC3+HzbmjrgMChFejvFJrqPiPGPv/I3odhrQ==",
       "dev": true,
       "requires": {
-        "@firebase/app": "0.1.3",
-        "@firebase/auth": "0.2.2",
-        "@firebase/database": "0.1.4",
-        "@firebase/firestore": "0.2.0",
-        "@firebase/messaging": "0.1.4",
-        "@firebase/polyfill": "0.1.2",
-        "@firebase/storage": "0.1.3",
+        "@firebase/app": "0.1.8",
+        "@firebase/auth": "0.3.3",
+        "@firebase/database": "0.1.9",
+        "@firebase/firestore": "0.3.2",
+        "@firebase/messaging": "0.1.9",
+        "@firebase/polyfill": "0.1.4",
+        "@firebase/storage": "0.1.6",
         "dom-storage": "2.0.2",
         "xmlhttprequest": "1.8.0"
       }
     },
     "firebase-admin": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-5.5.1.tgz",
-      "integrity": "sha1-uvmMjJw3vWdwor4yW3B1kS1JPpA=",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-5.8.2.tgz",
+      "integrity": "sha1-TDkN87b9MlZ9jUVYrASXS+vRV0k=",
       "dev": true,
       "requires": {
-        "@firebase/app": "0.1.3",
-        "@firebase/database": "0.1.4",
-        "@google-cloud/firestore": "0.10.1",
-        "@google-cloud/storage": "1.5.0",
+        "@firebase/app": "0.1.8",
+        "@firebase/database": "0.1.9",
+        "@google-cloud/firestore": "0.11.2",
+        "@google-cloud/storage": "1.5.2",
         "@types/google-cloud__storage": "1.1.7",
-        "@types/jsonwebtoken": "7.2.5",
-        "@types/node": "8.5.2",
+        "@types/node": "8.9.3",
         "faye-websocket": "0.9.3",
-        "google-auth-library": "0.10.0",
-        "jsonwebtoken": "7.4.3",
+        "jsonwebtoken": "8.1.0",
         "node-forge": "0.7.1"
       },
       "dependencies": {
-        "@google-cloud/common": {
-          "version": "0.13.6",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
-          "integrity": "sha1-qdjhN7xCmkSrqWif5qDkMxeE+FM=",
-          "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.1",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "is": "3.2.1",
-            "log-driver": "1.2.5",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.0",
-            "request": "2.83.0",
-            "retry-request": "3.3.0",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.0",
-            "through2": "2.0.3"
-          }
-        },
-        "@google-cloud/common-grpc": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.4.1.tgz",
-          "integrity": "sha1-CSZGB++4k0MJr/1jhJmG+7gPkhg=",
-          "requires": {
-            "@google-cloud/common": "0.13.6",
-            "duplexify": "3.5.1",
-            "extend": "3.0.1",
-            "grpc": "1.7.2",
-            "is": "3.2.1",
-            "modelo": "4.2.0",
-            "retry-request": "3.3.0",
-            "through2": "2.0.3"
-          }
-        },
         "@types/node": {
-          "version": "8.5.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-          "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
           "dev": true
         },
         "faye-websocket": {
@@ -6108,40 +7282,46 @@
             "websocket-driver": "0.7.0"
           }
         },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
+        "jsonwebtoken": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
+          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
           "dev": true,
           "requires": {
-            "gtoken": "1.2.3",
             "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
+            "lodash.includes": "4.3.0",
+            "lodash.isboolean": "3.0.3",
+            "lodash.isinteger": "4.0.4",
+            "lodash.isnumber": "3.0.3",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.isstring": "4.0.1",
+            "lodash.once": "4.1.1",
+            "ms": "2.1.1",
+            "xtend": "4.0.1"
           }
         }
       }
     },
     "firebase-tools": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.16.0.tgz",
-      "integrity": "sha1-E4n8FgIV7CQRRUQcdqhIz86beUE=",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.17.4.tgz",
+      "integrity": "sha1-3eFe4SpvqZMKQUK32v0SMT9lVdg=",
       "dev": true,
       "requires": {
-        "@google-cloud/functions-emulator": "1.0.0-alpha.27",
-        "JSONStream": "1.3.1",
-        "archiver": "2.1.0",
+        "@google-cloud/functions-emulator": "1.0.0-alpha.23",
+        "JSONStream": "1.3.2",
+        "archiver": "2.1.1",
         "chalk": "1.1.3",
         "cjson": "0.3.3",
         "cli-table": "0.3.1",
-        "commander": "2.12.2",
+        "commander": "2.14.1",
         "configstore": "1.4.0",
         "cross-spawn": "4.0.2",
         "csv-streamify": "3.0.4",
         "didyoumean": "1.2.1",
         "es6-set": "0.1.5",
         "exit-code": "1.0.2",
-        "filesize": "3.5.11",
+        "filesize": "3.6.0",
         "firebase": "2.4.2",
         "fs-extra": "0.23.1",
         "fstream-ignore": "1.0.5",
@@ -6149,23 +7329,23 @@
         "google-auto-auth": "0.7.2",
         "inquirer": "0.12.0",
         "is": "3.2.1",
-        "jsonschema": "1.2.0",
+        "jsonschema": "1.2.2",
         "jsonwebtoken": "7.4.3",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "open": "0.0.5",
         "ora": "0.2.3",
         "portfinder": "0.4.0",
         "progress": "2.0.0",
         "request": "2.83.0",
         "rsvp": "3.6.2",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "superstatic": "5.0.1",
         "tar": "3.2.1",
         "tmp": "0.0.33",
         "universal-analytics": "0.3.11",
         "update-notifier": "0.5.0",
         "user-home": "2.0.0",
-        "uuid": "3.1.0",
+        "uuid": "3.2.1",
         "winston": "1.1.2"
       },
       "dependencies": {
@@ -6335,9 +7515,9 @@
       "dev": true
     },
     "flagged-respawn": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
       "dev": true
     },
     "flat-arguments": {
@@ -6441,10 +7621,17 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "fork-stream": {
       "version": "0.0.4",
@@ -6456,6 +7643,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -6469,10 +7657,19 @@
       "dev": true,
       "optional": true
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
     "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
     "from": {
@@ -6489,12 +7686,6 @@
       "requires": {
         "null-check": "1.0.0"
       }
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -7489,7 +8680,7 @@
       "dev": true,
       "requires": {
         "extend": "3.0.1",
-        "retry-request": "3.3.0"
+        "retry-request": "3.3.1"
       }
     },
     "gcs-resumable-upload": {
@@ -7501,7 +8692,7 @@
         "buffer-equal": "1.0.0",
         "configstore": "3.1.1",
         "google-auto-auth": "0.7.2",
-        "pumpify": "1.3.5",
+        "pumpify": "1.4.0",
         "request": "2.83.0",
         "stream-events": "1.0.2",
         "through2": "2.0.3"
@@ -7589,10 +8780,17 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -7650,13 +8848,13 @@
       }
     },
     "git-semver-tags": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
-      "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.0.tgz",
+      "integrity": "sha1-sVSDOmq1w2DArTsaqbjxLqBt6Rk=",
       "dev": true,
       "requires": {
         "meow": "3.7.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "gitconfiglocal": {
@@ -7677,49 +8875,15 @@
         "dotenv": "4.0.0",
         "follow-redirects": "1.2.6",
         "https-proxy-agent": "2.1.1",
-        "lodash": "4.17.4",
-        "mime": "2.0.3",
+        "lodash": "4.17.5",
+        "mime": "2.2.0",
         "netrc": "0.1.4"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-          "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-          "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
-          "dev": true,
-          "requires": {
-            "agent-base": "4.1.2",
-            "debug": "3.1.0"
-          }
-        },
         "mime": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-          "integrity": "sha1-Q1MzeFR0fEjqSYMw3ANPn0u7zAs=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
+          "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
           "dev": true
         }
       }
@@ -7812,7 +8976,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -7864,46 +9028,41 @@
       }
     },
     "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.1",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
+        "expand-tilde": "2.0.2",
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.5",
-        "is-windows": "0.2.0",
+        "is-windows": "1.0.1",
         "which": "1.3.0"
       }
     },
     "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
         "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
         "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
+        "ignore": "3.3.7",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "globjoin": {
@@ -7980,9 +9139,9 @@
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
@@ -8042,14 +9201,14 @@
         "gtoken": "1.2.3",
         "jws": "3.1.4",
         "lodash.isstring": "4.0.1",
-        "lodash.merge": "4.6.0",
+        "lodash.merge": "4.6.1",
         "request": "2.83.0"
       }
     },
     "google-auto-auth": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.1.tgz",
-      "integrity": "sha512-v5a4mHIkhvbtKNILxnOYgOw+cin/jfLR0pEj1ids2jn9p0OyxYUXjSJbCEciuAorQao9Y55w0zJIc8yW1rIPaA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.2.tgz",
+      "integrity": "sha512-W91J1paFbyG45gpDWdTu9tKDxbiTDWYkOAxytNVF4oHVVgTCBV/8+lWdjj/6ldjN3eb+sEd9PKJBjm0kmCxvcw==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -8070,58 +9229,903 @@
       }
     },
     "google-gax": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.2.tgz",
-      "integrity": "sha1-Kx8rhui+mKYgBBzucQ5PTOYbbis=",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.5.tgz",
+      "integrity": "sha512-3A6KbrtLDavrqZnnzurnSydRIJnyH+2Sm56fAvXciQ/62aEnSDaR43MCgWhtReCLVjeFjBiCEIdX5zV0LVLVBg==",
       "dev": true,
       "requires": {
         "extend": "3.0.1",
-        "globby": "6.1.0",
-        "google-auto-auth": "0.7.2",
-        "google-proto-files": "0.13.1",
-        "grpc": "1.7.2",
+        "globby": "7.1.1",
+        "google-auto-auth": "0.9.3",
+        "google-proto-files": "0.14.2",
+        "grpc": "1.7.3",
         "is-stream-ended": "0.1.3",
-        "lodash": "4.17.4",
-        "process-nextick-args": "1.0.7",
-        "protobufjs": "6.8.3",
-        "readable-stream": "2.3.3",
+        "lodash": "4.17.5",
+        "protobufjs": "6.8.4",
+        "readable-stream": "2.3.4",
         "through2": "2.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.5.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-          "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
           "dev": true
         },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
+        "gcp-metadata": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
+          "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
           "dev": true,
           "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
+            "extend": "3.0.1",
+            "retry-request": "3.3.1"
           }
         },
         "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.3.tgz",
+          "integrity": "sha512-TbOZZs0WJOolrRmdQLK5qmWdOJQFG1oPnxcIBbAwL7XCWcv3XgZ9gHJ6W4byrdEZT8TahNFgMfkHd73mqxM9dw==",
           "dev": true,
           "requires": {
             "async": "2.6.0",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
+            "gcp-metadata": "0.4.1",
+            "google-auth-library": "0.12.0",
             "request": "2.83.0"
           }
         },
+        "grpc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
+          "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
+          "dev": true,
+          "requires": {
+            "arguejs": "0.2.3",
+            "lodash": "4.17.5",
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39",
+            "protobufjs": "5.0.2"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.9",
+              "bundled": true,
+              "dev": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "dev": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "dev": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "detect-libc": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true,
+              "dev": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true,
+              "dev": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "dev": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true,
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.39",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "detect-libc": "1.0.2",
+                "hawk": "3.1.3",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.2",
+                "rc": "1.2.2",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.4.1",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.1"
+              },
+              "dependencies": {
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1.0.9",
+                    "osenv": "0.1.4"
+                  }
+                }
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "protobufjs": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
+              "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
+              "dev": true,
+              "requires": {
+                "ascli": "1.0.1",
+                "bytebuffer": "5.0.1",
+                "glob": "7.1.1",
+                "yargs": "3.32.0"
+              }
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "rc": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "7.1.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "5.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.3.3",
+                "rimraf": "2.6.2",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
         "protobufjs": {
-          "version": "6.8.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.3.tgz",
-          "integrity": "sha512-/iQhTYnSniRNmdRF9Kvw8odMSokwNOWVDOmMJjW64+EVE6igcdj/82Op/4MJ/WimgMRNac7gChlSVX4Gep/tHg==",
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
+          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
           "dev": true,
           "requires": {
             "@protobufjs/aspromise": "1.1.2",
@@ -8135,7 +10139,7 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.5.2",
+            "@types/node": "8.9.3",
             "long": "3.2.0"
           }
         }
@@ -8151,15 +10155,50 @@
       }
     },
     "google-proto-files": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.13.1.tgz",
-      "integrity": "sha512-CivI3rZ85dMPTCAyxq6lq9s7vDkeWEIFxweopC1vEjjRmFMJwOX/MOmFZ90a0BGal/Dsb63vq7Ael9ryeokz0g==",
-      "dev": true
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.2.tgz",
+      "integrity": "sha512-wwm2TIlfTgAjDbjrxAb3akznO7vBM0PRLS6Xf2QfR3L7b0p+szD3iwOW0wMSFl3B0UbLv27hUVk+clePqCVmXA==",
+      "dev": true,
+      "requires": {
+        "globby": "7.1.1",
+        "power-assert": "1.4.4",
+        "prettier": "1.10.2",
+        "protobufjs": "6.8.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.4.tgz",
+          "integrity": "sha512-d+WZqUDXKM+oZhr8yprAtQW07q08p9/V35AJ2J1fds+r903S/aH9P8uO1gmTwozOKugt2XCjdrre3OxuPRGkGg==",
+          "dev": true,
+          "requires": {
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/base64": "1.1.2",
+            "@protobufjs/codegen": "2.0.4",
+            "@protobufjs/eventemitter": "1.1.0",
+            "@protobufjs/fetch": "1.1.0",
+            "@protobufjs/float": "1.0.2",
+            "@protobufjs/inquire": "1.1.0",
+            "@protobufjs/path": "1.1.2",
+            "@protobufjs/pool": "1.1.0",
+            "@protobufjs/utf8": "1.1.0",
+            "@types/long": "3.0.32",
+            "@types/node": "8.9.3",
+            "long": "3.2.0"
+          }
+        }
+      }
     },
     "googleapis": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-22.2.0.tgz",
-      "integrity": "sha1-/XnDwm5+caT1ouwafaX7EV2IU9I=",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-20.1.0.tgz",
+      "integrity": "sha512-UZYpUKPcwt28tZIvC+sT7yHtl56bMxnePNJBtZ3tG0OrQ1KegukirKRRuIxPavNCOcVC/ka5j/RRDhEIrYf5UA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8175,7 +10214,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
         },
         "google-auth-library": {
@@ -8238,24 +10277,26 @@
       }
     },
     "grpc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.2.tgz",
-      "integrity": "sha512-GH6xziNGjW8LAtqQ3HmYI7Tx8BIlr46iaMRXHfh46kkaOP6PNWUx47ULNTUlXSYR3P00d0Pl8uzodTLwPk805w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.9.0.tgz",
+      "integrity": "sha512-F4j7ireH/ssXcBNTGR3yFjRHTWdJmtg6Czm5tnQYwIuhZh4znx8KhA50dpAkjNqrrbzt97N6hd/TXOPTZGmvtQ==",
+      "dev": true,
       "requires": {
-        "arguejs": "0.2.3",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "nan": "2.8.0",
         "node-pre-gyp": "0.6.39",
-        "protobufjs": "5.0.0"
+        "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "bundled": true
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
         },
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -8263,15 +10304,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.3"
@@ -8279,31 +10323,38 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -8312,6 +10363,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -8319,6 +10371,7 @@
         "boom": {
           "version": "2.10.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -8326,6 +10379,7 @@
         "brace-expansion": {
           "version": "1.1.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -8333,38 +10387,46 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -8372,42 +10434,50 @@
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -8415,19 +10485,23 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -8436,11 +10510,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -8451,6 +10527,7 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -8460,6 +10537,7 @@
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -8474,19 +10552,22 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "glob": {
-          "version": "7.1.1",
+          "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -8498,15 +10579,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -8514,11 +10598,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -8528,11 +10614,13 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.1",
@@ -8542,6 +10630,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -8549,58 +10638,70 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
-          "version": "1.3.4",
-          "bundled": true
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -8610,17 +10711,20 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "mime-db": {
           "version": "1.30.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.17",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mime-db": "1.30.0"
           }
@@ -8628,55 +10732,60 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "1.0.3",
             "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.2",
+            "rc": "1.2.4",
             "request": "2.81.0",
             "rimraf": "2.6.2",
-            "semver": "5.4.1",
+            "semver": "5.5.0",
             "tar": "2.2.1",
             "tar-pack": "3.4.1"
-          },
-          "dependencies": {
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1.0.9",
-                "osenv": "0.1.4"
-              }
-            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -8686,34 +10795,41 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -8721,43 +10837,51 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rc": {
-          "version": "1.2.2",
+          "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "deep-extend": "0.4.2",
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -8771,6 +10895,7 @@
         "request": {
           "version": "2.81.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -8793,35 +10918,41 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
-          "version": "5.4.1",
-          "bundled": true
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -8829,6 +10960,7 @@
         "sshpk": {
           "version": "1.13.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -8842,13 +10974,15 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -8858,28 +10992,33 @@
         "string_decoder": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -8889,8 +11028,9 @@
         "tar-pack": {
           "version": "3.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "fstream": "1.0.11",
             "fstream-ignore": "1.0.5",
             "once": "1.4.0",
@@ -8903,6 +11043,7 @@
         "tough-cookie": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -8910,6 +11051,7 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8917,23 +11059,28 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uuid": {
-          "version": "3.1.0",
-          "bundled": true
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
@@ -8942,20 +11089,23 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -8982,7 +11132,7 @@
         "deprecated": "0.0.1",
         "gulp-util": "3.0.8",
         "interpret": "1.1.0",
-        "liftoff": "2.3.0",
+        "liftoff": "2.5.0",
         "minimist": "1.2.0",
         "orchestrator": "0.3.8",
         "pretty-hrtime": "1.0.3",
@@ -9143,6 +11293,12 @@
           "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
           "dev": true
         },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -9215,13 +11371,13 @@
       }
     },
     "gulp-clean-css": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.0.tgz",
-      "integrity": "sha512-CsqaSO2ZTMQI/WwbWloZWBudhsRMKgxBthzxt4bbcbWrjOY4pRFziyK9IH6YbTpaWAPKEwWpopPkpiAEoDofxw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.2.tgz",
+      "integrity": "sha512-NaBtCOmhk2FP1D1pgv5jEvZaKr+6FZHvEgsl1iPGmTpyUOWpECR3Mzdciwo+hEWwtlnkZSueoAf74YCMtar48A==",
       "dev": true,
       "requires": {
         "clean-css": "4.1.9",
-        "gulp-util": "3.0.8",
+        "plugin-error": "0.1.2",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
@@ -9235,11 +11391,11 @@
         "archy": "1.0.0",
         "chalk": "1.1.3",
         "copy-props": "1.6.0",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "interpret": "1.1.0",
-        "liftoff": "2.3.0",
-        "lodash.isfunction": "3.0.8",
+        "liftoff": "2.5.0",
+        "lodash.isfunction": "3.0.9",
         "lodash.isplainobject": "4.0.6",
         "lodash.sortby": "4.7.0",
         "matchdep": "1.0.1",
@@ -9253,15 +11409,17 @@
       }
     },
     "gulp-connect": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-5.0.0.tgz",
-      "integrity": "sha1-8v3zBq6RFGg2jCKF8teC8T7dr04=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-5.2.0.tgz",
+      "integrity": "sha512-m4n11rFZ1SSTc7zTqLYenyn7hO//zWpzALBkoOYimd3IMRbTgvwvYIT7SZaAefBUVCGRWABJ7ChiskwndYuaQg==",
       "dev": true,
       "requires": {
+        "ansi-colors": "1.0.1",
         "connect": "2.30.2",
         "connect-livereload": "0.5.4",
         "event-stream": "3.3.4",
-        "gulp-util": "3.0.8",
+        "fancy-log": "1.3.2",
+        "send": "0.13.2",
         "tiny-lr": "0.2.1"
       },
       "dependencies": {
@@ -9500,7 +11658,7 @@
           "dev": true,
           "requires": {
             "debug": "2.2.0",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "destroy": "1.0.4",
             "escape-html": "1.0.3",
             "etag": "1.7.0",
@@ -9514,9 +11672,9 @@
           },
           "dependencies": {
             "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
               "dev": true
             },
             "escape-html": {
@@ -9552,12 +11710,6 @@
             }
           }
         },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-          "dev": true
-        },
         "vary": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
@@ -9567,17 +11719,57 @@
       }
     },
     "gulp-conventional-changelog": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.7.tgz",
-      "integrity": "sha1-Azf2hLSeKTWOYj4W6UtJ8FotK/E=",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.12.tgz",
+      "integrity": "sha512-efXp/cwisaPGCMhCLeAN4tzQ9TaBwzNIt9nY8ysvZ2d0LPMk7iMyGapjnd2Ejw0yIZIJrIS15OLSpwrNIErHAA==",
       "dev": true,
       "requires": {
         "add-stream": "1.0.0",
         "concat-stream": "1.6.0",
-        "conventional-changelog": "1.1.7",
-        "gulp-util": "3.0.8",
+        "conventional-changelog": "1.1.12",
+        "fancy-log": "1.3.2",
         "object-assign": "4.1.1",
+        "plugin-error": "1.0.1",
         "through2": "2.0.3"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "1.0.1",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
+          }
+        }
       }
     },
     "gulp-dom": {
@@ -9624,7 +11816,7 @@
             "beeper": "1.1.1",
             "chalk": "1.1.3",
             "dateformat": "1.0.12",
-            "fancy-log": "1.3.0",
+            "fancy-log": "1.3.2",
             "gulplog": "1.0.0",
             "has-gulplog": "0.1.0",
             "lodash._reescape": "3.0.0",
@@ -9643,6 +11835,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "readable-stream": {
@@ -9721,11 +11919,11 @@
       "integrity": "sha1-GeqAAtEjHWsfGKEtIPKmand3D7M=",
       "dev": true,
       "requires": {
-        "bufferstreams": "1.1.2",
+        "bufferstreams": "1.1.3",
         "gulp-util": "3.0.8",
-        "html-minifier": "3.5.7",
+        "html-minifier": "3.5.9",
         "object-assign": "4.1.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "tryit": "1.0.3"
       }
     },
@@ -9747,7 +11945,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
-        "marked": "0.3.7",
+        "marked": "0.3.12",
         "through2": "2.0.3"
       }
     },
@@ -9786,7 +11984,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "gulp-util": {
@@ -9800,7 +11998,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "2.2.0",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -9858,7 +12056,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "hammerjs": {
@@ -9899,14 +12097,16 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
       }
     },
@@ -9980,6 +12180,66 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "hash-stream-validation": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
@@ -9993,6 +12253,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -10025,7 +12286,8 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
     },
     "home-dir": {
       "version": "1.0.0",
@@ -10058,19 +12320,19 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.7.tgz",
-      "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.9.tgz",
+      "integrity": "sha512-EZqO91XJwkj8BeLx9C12sKB/AHoTANaZax39vEOP9f/X/9jgJ3r1O2+neabuHqpz5kJO71TapP9JrtCY39su1A==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.9",
-        "commander": "2.12.2",
+        "commander": "2.14.1",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.2.1"
+        "uglify-js": "3.3.10"
       },
       "dependencies": {
         "source-map": {
@@ -10080,12 +12342,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.1.tgz",
-          "integrity": "sha512-BhZTJPmOKPSUcjnx2nlfaOQKHLyjjT4HFyzFWF1BUErx9knJNpdW94ql5o8qVxeNL+8IAWjEjnPvASH2yZnkMg==",
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.10.tgz",
+          "integrity": "sha512-dNib7aUDNZFJNTXFyq0CDmLRVOsnY1F+IQgt2FAOdZFx2+LvKVLbbIb/fL+BYKCv3YH3bPCE/6M/JaxChtQLHQ==",
           "dev": true,
           "requires": {
-            "commander": "2.12.2",
+            "commander": "2.14.1",
             "source-map": "0.6.1"
           }
         }
@@ -10105,10 +12367,10 @@
       "requires": {
         "domelementtype": "1.3.0",
         "domhandler": "2.4.1",
-        "domutils": "1.6.2",
+        "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "http-errors": {
@@ -10121,12 +12383,20 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        }
       }
     },
     "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy": {
@@ -10149,6 +12419,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -10156,14 +12427,30 @@
       }
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "i": {
@@ -10277,6 +12564,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -10285,7 +12573,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -10305,7 +12594,7 @@
         "cli-cursor": "1.0.2",
         "cli-width": "2.2.0",
         "figures": "1.7.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "readline2": "1.0.1",
         "run-async": "0.1.0",
         "rx-lite": "3.1.2",
@@ -10323,28 +12612,47 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
       "dev": true,
       "optional": true
     },
     "is": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+      "dev": true
     },
     "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
       }
     },
     "is-alphabetical": {
@@ -10399,11 +12707,47 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
     "is-decimal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
       "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
       "dev": true
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
     },
     "is-directory": {
       "version": "0.3.1",
@@ -10451,6 +12795,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -10486,9 +12831,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -10524,6 +12869,26 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true,
       "optional": true
+    },
+    "is-odd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -10603,12 +12968,12 @@
       "dev": true
     },
     "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-relative-path": {
@@ -10632,7 +12997,8 @@
     "is-stream-ended": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
-      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+      "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -10658,12 +13024,13 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
         "unc-path-regex": "0.1.2"
@@ -10697,9 +13064,9 @@
       "dev": true
     },
     "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
     "is-word-character": {
@@ -10711,7 +13078,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -10743,7 +13111,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul": {
       "version": "0.4.5",
@@ -10861,12 +13230,20 @@
         "exit": "0.1.2",
         "glob": "7.1.2",
         "jasmine-core": "2.8.0"
+      },
+      "dependencies": {
+        "jasmine-core": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+          "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+          "dev": true
+        }
       }
     },
     "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "jasminewd2": {
@@ -10889,7 +13266,7 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.19.3",
+        "moment": "2.20.1",
         "topo": "1.1.0"
       },
       "dependencies": {
@@ -10913,9 +13290,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
     "js-tokens": {
@@ -10946,6 +13323,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -10974,6 +13352,14 @@
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "3.1.0",
         "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+          "dev": true
+        }
       }
     },
     "json-parse-better-errors": {
@@ -10994,17 +13380,30 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -11021,6 +13420,12 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -11034,9 +13439,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
-      "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -11056,6 +13461,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -11080,6 +13486,12 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
           "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "readable-stream": {
@@ -11134,12 +13546,12 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "body-parser": "1.18.2",
+        "body-parser": "1.17.2",
         "chokidar": "1.7.0",
         "colors": "1.1.2",
         "combine-lists": "1.0.1",
         "connect": "3.6.5",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
@@ -11159,7 +13571,7 @@
         "socket.io": "1.7.3",
         "source-map": "0.5.7",
         "tmp": "0.0.31",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       },
       "dependencies": {
         "colors": {
@@ -11246,9 +13658,9 @@
       }
     },
     "karma-firefox-launcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.0.1.tgz",
-      "integrity": "sha1-zlj0fCATqIFW1VpdYTN8CZz1u1E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
+      "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
       "dev": true
     },
     "karma-jasmine": {
@@ -11320,10 +13732,13 @@
       }
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "0.1.0"
+      }
     },
     "lazy-req": {
       "version": "1.1.0",
@@ -11337,13 +13752,14 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -11368,55 +13784,46 @@
       }
     },
     "liftoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
         "extend": "3.0.1",
-        "findup-sync": "0.4.3",
+        "findup-sync": "2.0.0",
         "fined": "1.1.0",
-        "flagged-respawn": "0.3.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mapvalues": "4.6.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
         "rechoir": "0.6.2",
         "resolve": "1.5.0"
       }
     },
     "livereload-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
       "dev": true
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "optional": true
         }
       }
     },
@@ -11431,9 +13838,10 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -11572,6 +13980,12 @@
         "lodash._root": "3.0.1"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -11584,10 +13998,28 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
     "lodash.isfunction": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
-      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs=",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "dev": true
     },
     "lodash.isobject": {
@@ -11622,22 +14054,16 @@
         "lodash.isobject": "2.4.1"
       }
     },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-      "dev": true
-    },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
     "lodash.noop": {
@@ -11729,9 +14155,13 @@
       }
     },
     "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.6.tgz",
+      "integrity": "sha512-iUHz4WAGsXwUmL1UergWrkFD2iTUrGLMsQDRYUWtS9FI+wSyM76vIL+THQt7vrQq5fZDGdrPSCFUfIlqII28tg==",
+      "dev": true,
+      "requires": {
+        "codecov.io": "0.0.1"
+      }
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -11787,7 +14217,8 @@
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -11907,7 +14338,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "ora": {
@@ -11971,10 +14402,19 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
+      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg==",
       "dev": true
+    },
+    "make-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+      "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -11994,6 +14434,15 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
     "markdown-escapes": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
@@ -12007,9 +14456,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "match-stream": {
@@ -12123,9 +14572,8 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -12134,8 +14582,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "0.1.6",
+        "readable-stream": "2.3.4"
       }
     },
     "meow": {
@@ -12154,6 +14602,87 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
       }
     },
     "merge-descriptors": {
@@ -12169,13 +14698,14 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "methmeth": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
-      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk="
+      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk=",
+      "dev": true
     },
     "method-override": {
       "version": "2.3.10",
@@ -12187,6 +14717,23 @@
         "methods": "1.1.2",
         "parseurl": "1.3.2",
         "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "methods": {
@@ -12225,20 +14772,22 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "mimic-response": {
@@ -12252,8 +14801,9 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -12289,12 +14839,33 @@
       }
     },
     "minizlib": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
-      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "dev": true,
       "requires": {
         "minipass": "2.2.1"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "mkdirp": {
@@ -12322,9 +14893,10 @@
       }
     },
     "modelo": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.0.tgz",
-      "integrity": "sha1-O0tCACOmbKfjK9uhbnEJN+FNGws="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",
+      "integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA==",
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.0",
@@ -12348,7 +14920,7 @@
       "integrity": "sha1-WONT+dwB7OwFexzN0A7QWUhKzKU=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.14.1",
         "debug": "3.1.0",
         "file-exists": "1.0.0",
         "find": "0.2.6",
@@ -12374,9 +14946,9 @@
       }
     },
     "moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
       "dev": true
     },
     "morgan": {
@@ -12387,9 +14959,26 @@
       "requires": {
         "basic-auth": "2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -12505,7 +15094,47 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
+      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
     },
     "nash": {
       "version": "2.0.4",
@@ -12534,9 +15163,9 @@
       }
     },
     "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
       "dev": true
     },
     "ncname": {
@@ -12652,7 +15281,7 @@
         "in-publish": "2.0.0",
         "lodash.assign": "4.2.0",
         "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
+        "lodash.mergewith": "4.6.1",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
         "nan": "2.8.0",
@@ -12737,7 +15366,7 @@
           "dev": true,
           "requires": {
             "glob": "7.1.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4"
           }
         },
@@ -12748,8 +15377,8 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.16.1",
+            "commander": "2.14.1",
+            "is-my-json-valid": "2.17.1",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -12813,7 +15442,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -12865,7 +15494,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -12895,7 +15524,6 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -12927,7 +15555,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nunjucks": {
       "version": "3.0.1",
@@ -12950,7 +15579,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12964,11 +15594,87 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "object.defaults": {
       "version": "1.1.0",
@@ -12996,6 +15702,27 @@
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
+        }
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
         }
       }
     },
@@ -13051,6 +15778,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -13116,7 +15844,8 @@
     "optjs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
+      "dev": true
     },
     "ora": {
       "version": "0.2.3",
@@ -13177,6 +15906,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "requires": {
         "lcid": "1.0.0"
       }
@@ -13217,10 +15947,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -13228,7 +15961,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-timeout": {
@@ -13241,6 +15974,12 @@
         "p-finally": "1.0.0"
       }
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "package-json": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
@@ -13248,9 +15987,9 @@
       "dev": true,
       "requires": {
         "got": "5.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -13270,7 +16009,7 @@
             "parse-json": "2.2.0",
             "pinkie-promise": "2.0.1",
             "read-all-stream": "3.1.0",
-            "readable-stream": "2.3.3",
+            "readable-stream": "2.3.4",
             "timed-out": "3.1.3",
             "unzip-response": "1.0.2",
             "url-parse-lax": "1.0.0"
@@ -13314,12 +16053,12 @@
       }
     },
     "parse-filepath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "0.2.6",
+        "is-absolute": "1.0.0",
         "map-cache": "0.2.2",
         "path-root": "0.1.1"
       }
@@ -13412,6 +16151,12 @@
         "upper-case-first": "1.1.2"
       }
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
     "path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
@@ -13430,7 +16175,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -13442,8 +16188,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -13473,22 +16218,12 @@
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
+        "pify": "3.0.0"
       }
     },
     "pause": {
@@ -13509,7 +16244,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -13538,6 +16274,58 @@
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true,
       "optional": true
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
+      }
     },
     "plur": {
       "version": "1.0.0",
@@ -13569,6 +16357,12 @@
         }
       }
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
     "postcss": {
       "version": "5.2.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -13576,7 +16370,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.3",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       }
@@ -13613,10 +16407,10 @@
       "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
-        "log-symbols": "2.1.0",
-        "postcss": "6.0.14"
+        "chalk": "2.3.1",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13629,40 +16423,40 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "log-symbols": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0"
+            "chalk": "2.3.1"
           }
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -13672,12 +16466,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13694,7 +16488,7 @@
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13707,31 +16501,31 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -13741,12 +16535,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13758,7 +16552,7 @@
       "dev": true,
       "requires": {
         "gonzales-pe": "4.2.3",
-        "postcss": "6.0.14"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13771,14 +16565,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "gonzales-pe": {
@@ -13791,9 +16585,9 @@
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "minimist": {
@@ -13803,14 +16597,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -13820,23 +16614,23 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "postcss-scss": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
-      "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
+      "integrity": "sha512-N2ZPDOV5PGEGVwdiB7b1QppxKkmkHodNWkemja7PV+/mHqbUlA6ZcYRreden5Ag5nwBBX8/aRE7lfg1xjdszyg==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13849,31 +16643,31 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -13883,12 +16677,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13910,13 +16704,133 @@
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
+    "power-assert": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
+      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "empower": "1.2.3",
+        "power-assert-formatter": "1.4.1",
+        "universal-deep-strict-equal": "1.2.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "power-assert-context-formatter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
+      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "power-assert-context-traversal": "1.1.1"
+      }
+    },
+    "power-assert-context-reducer-ast": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
+      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13",
+        "acorn-es7-plugin": "1.1.7",
+        "core-js": "2.5.3",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "power-assert-context-traversal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
+      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "estraverse": "4.2.0"
+      }
+    },
+    "power-assert-formatter": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
+      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "power-assert-context-formatter": "1.1.1",
+        "power-assert-context-reducer-ast": "1.1.2",
+        "power-assert-renderer-assertion": "1.1.1",
+        "power-assert-renderer-comparison": "1.1.1",
+        "power-assert-renderer-diagram": "1.1.2",
+        "power-assert-renderer-file": "1.1.1"
+      }
+    },
+    "power-assert-renderer-assertion": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
+      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
+      "dev": true,
+      "requires": {
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.1.1"
+      }
+    },
+    "power-assert-renderer-base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
+      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s=",
+      "dev": true
+    },
+    "power-assert-renderer-comparison": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
+      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "diff-match-patch": "1.0.0",
+        "power-assert-renderer-base": "1.1.1",
+        "stringifier": "1.3.0",
+        "type-name": "2.0.2"
+      }
+    },
+    "power-assert-renderer-diagram": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
+      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.1.1",
+        "stringifier": "1.3.0"
+      }
+    },
+    "power-assert-renderer-file": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
+      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
+      "dev": true,
+      "requires": {
+        "power-assert-renderer-base": "1.1.1"
+      }
+    },
+    "power-assert-util-string-width": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
+      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
+      "dev": true,
+      "requires": {
+        "eastasianwidth": "0.1.1"
+      }
+    },
     "precinct": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
       "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.14.1",
         "debug": "3.1.0",
         "detective-amd": "2.4.0",
         "detective-cjs": "2.0.0",
@@ -13965,6 +16879,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
@@ -13989,9 +16909,10 @@
       }
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
@@ -14000,9 +16921,9 @@
       "dev": true
     },
     "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+      "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "dev": true,
       "requires": {
         "asap": "2.0.6"
@@ -14078,28 +16999,15 @@
       }
     },
     "protobufjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.0.tgz",
-      "integrity": "sha1-QiMGMjPqlqwGPKK1VANSBNtST6E=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
+      "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
+      "dev": true,
       "requires": {
         "ascli": "1.0.1",
         "bytebuffer": "5.0.1",
-        "glob": "5.0.15",
+        "glob": "7.1.2",
         "yargs": "3.32.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "protochain": {
@@ -14110,15 +17018,15 @@
       "optional": true
     },
     "protractor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.2.0.tgz",
-      "integrity": "sha1-0/ObGV6F81Oa2djLZWCp0rYyl8Q=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.0.tgz",
+      "integrity": "sha512-8z1TWtc/I9Kn4fkfg87DhkSAi0arul7DHBEeJ70sy66teQAeffjQED1s0Gduigme7hxHRYdYEKbhHYz28fpv5w==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92",
+        "@types/node": "6.0.100",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.43",
-        "blocking-proxy": "0.0.5",
+        "blocking-proxy": "1.0.1",
         "chalk": "1.1.3",
         "glob": "7.1.2",
         "jasmine": "2.8.0",
@@ -14133,9 +17041,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.92",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-          "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+          "version": "6.0.100",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.100.tgz",
+          "integrity": "sha512-LeTv/2eb37puibsq5982HXkKJBpu7Xc01WaGjEfncb+iE159nYOKkcaCCAsVoXBPD/7jAPdJt4J0+R9bqMndgg==",
           "dev": true
         },
         "@types/q": {
@@ -14143,6 +17051,27 @@
           "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
           "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
           "dev": true
+        },
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.7",
+            "extend": "3.0.1"
+          }
         },
         "saucelabs": {
           "version": "1.3.0",
@@ -14152,6 +17081,12 @@
           "requires": {
             "https-proxy-agent": "1.0.0"
           }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
         },
         "webdriver-manager": {
           "version": "12.0.6",
@@ -14168,27 +17103,35 @@
             "q": "1.4.1",
             "request": "2.83.0",
             "rimraf": "2.6.2",
-            "semver": "5.4.1",
+            "semver": "5.5.0",
             "xml2js": "0.4.19"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
+            }
           }
         }
       }
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "dev": true,
       "optional": true,
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
+        "ipaddr.js": "1.4.0"
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -14236,30 +17179,31 @@
       }
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
     "pumpify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "inherits": "2.0.3",
-        "pump": "1.0.3"
+        "pump": "2.0.1"
       }
     },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "q": {
       "version": "1.4.1",
@@ -14276,7 +17220,8 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -14338,21 +17283,28 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
       "dev": true,
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+          "dev": true
+        }
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -14378,60 +17330,61 @@
       "dev": true,
       "requires": {
         "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "load-json-file": "1.1.0",
+        "load-json-file": "2.0.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "path-type": "2.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "pify": "2.3.0"
           }
         },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "optional": true
         }
       }
     },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      }
+    },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -14445,7 +17398,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -14494,9 +17447,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -14508,13 +17461,22 @@
         "is-equal-shallow": "0.1.3"
       }
     },
-    "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+    "regex-not": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2",
+        "extend-shallow": "2.0.1"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -14524,7 +17486,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.5"
       }
     },
     "relateurl": {
@@ -14626,6 +17588,7 @@
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -14648,7 +17611,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "require-directory": {
@@ -14761,13 +17724,13 @@
       "dev": true
     },
     "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -14776,13 +17739,19 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "response-time": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
       "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
       "dev": true,
       "requires": {
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "on-headers": "1.0.1"
       }
     },
@@ -14796,10 +17765,20 @@
         "onetime": "1.1.0"
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "retry-request": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.0.tgz",
-      "integrity": "sha512-bCbvtnZkfgB2TnbKMUUxzSR5W4AJQyMD6D6UcCsE/wBTVmlsS59OrDQr4RKV/Kq1hiIBmUYlbxd9MZ0cfpjrAQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
+      "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
+      "dev": true,
       "requires": {
         "request": "2.83.0",
         "through2": "2.0.3"
@@ -14855,12 +17834,11 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
-      "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz",
+      "integrity": "sha512-ZwmMip/yqw6cmDQJuCQJ1G7gw2z11iGUtQNFYrFZHmqadRHU+OZGC3nOXwXu+UTvcm5lzDspB1EYWrkTgPWybw==",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.2",
         "builtin-modules": "1.1.1",
         "is-module": "1.0.0",
         "resolve": "1.5.0"
@@ -14887,10 +17865,31 @@
           "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "dev": true
         }
       }
@@ -14927,9 +17926,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
-      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -14937,7 +17936,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "sander": {
       "version": "0.5.1",
@@ -14966,7 +17966,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -14976,6 +17976,85 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "which-module": {
           "version": "1.0.0",
@@ -15045,8 +18124,37 @@
         "adm-zip": "0.4.7",
         "async": "2.6.0",
         "https-proxy-agent": "1.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.7",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "saucelabs": {
@@ -15056,6 +18164,35 @@
       "dev": true,
       "requires": {
         "https-proxy-agent": "1.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.7",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "sax": {
@@ -15065,72 +18202,126 @@
       "dev": true
     },
     "scss-bundle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scss-bundle/-/scss-bundle-2.1.0.tgz",
-      "integrity": "sha512-8TJaz8f5FMyyH2Se0mxfQY6CKaFb8gxyIE0qPHxk4Dfx7x8IhnvIIXyZwh0O5XK+uD0L4/gQkkRVT5zW+GcJcw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/scss-bundle/-/scss-bundle-2.1.2.tgz",
+      "integrity": "sha512-0Gobwz+3xh38dLxDhP0/QU5L6fF5eRDCmeRCkpKkq219fTHfu/A//x+akqpERIhFKywmANNx7cZmOjqrCIt6LA==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
+        "fs-extra": "5.0.0",
         "globs": "0.1.3",
-        "mkdirp": "0.5.1",
-        "mz": "2.7.0",
         "node-sass": "4.7.2",
         "pretty-bytes": "4.0.2",
-        "promise": "7.3.1",
-        "yargs": "7.1.0"
+        "promise": "8.0.1",
+        "yargs": "10.1.2"
       },
       "dependencies": {
-        "camelcase": {
+        "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "mz": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-          "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "any-promise": "1.3.0",
-            "object-assign": "4.1.1",
-            "thenify-all": "1.6.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
+            "os-locale": "2.1.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "yargs-parser": "8.1.0"
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -15141,7 +18332,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.3",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -15169,9 +18360,9 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "semver-diff": {
@@ -15180,7 +18371,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "semver-greatest-satisfied-range": {
@@ -15193,30 +18384,39 @@
       }
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "depd": "1.1.1",
+        "debug": "2.6.8",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "fresh": "0.5.2",
+        "fresh": "0.5.0",
         "http-errors": "1.6.2",
-        "mime": "1.4.1",
+        "mime": "1.3.4",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
           "dev": true
         },
         "ms": {
@@ -15350,16 +18550,16 @@
       }
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
       "dev": true,
       "optional": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.16.1"
+        "send": "0.15.4"
       }
     },
     "set-blocking": {
@@ -15368,11 +18568,32 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -15391,7 +18612,6 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
-      "optional": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -15400,8 +18620,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "shelljs": {
       "version": "0.7.8",
@@ -15505,10 +18724,123 @@
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.7",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -15597,12 +18929,6 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
@@ -15632,6 +18958,12 @@
         "json3": "3.3.2"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "dev": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -15664,13 +18996,26 @@
         "buffer-crc32": "0.2.13",
         "minimist": "1.2.0",
         "sander": "0.5.1",
-        "sourcemap-codec": "1.3.1"
+        "sourcemap-codec": "1.4.0"
       }
     },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.4.18",
@@ -15680,13 +19025,27 @@
         "source-map": "0.5.7"
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
     "sourcemap-codec": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz",
-      "integrity": "sha1-mtb5vb1pGTEBbjCTnbyGhnMyMUY=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.0.tgz",
+      "integrity": "sha512-66s3CwUASiYGiwQxkr34IctPs/LDkaJ8qNqVK6bBektymq3Sx1rX9qDZ8MNXFwiXqKuM3JYwzG3NAhI1ivqkjA==",
       "dev": true,
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "1.0.0"
+      },
+      "dependencies": {
+        "vlq": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+          "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
+          "dev": true
+        }
       }
     },
     "sparkles": {
@@ -15729,9 +19088,9 @@
       "dev": true
     },
     "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "dev": true,
       "requires": {
         "through": "2.3.8"
@@ -15741,9 +19100,40 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
+      "dev": true,
       "requires": {
         "async": "2.6.0",
         "is-stream-ended": "0.1.3"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "split2": {
@@ -15765,6 +19155,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -15788,6 +19179,84 @@
       "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
       "dev": true
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -15800,7 +19269,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "stream-combiner": {
@@ -15857,6 +19326,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
       "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
+      "dev": true,
       "requires": {
         "stubs": "3.0.0"
       }
@@ -15864,12 +19334,14 @@
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
     },
     "string-format-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
-      "integrity": "sha1-djVhCx7zlwE+hHi+mKFw4EmD0Gg="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
+      "integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q==",
+      "dev": true
     },
     "string-length": {
       "version": "1.0.1",
@@ -15891,6 +19363,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -15901,8 +19374,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
+      }
+    },
+    "stringifier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
+      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "traverse": "0.6.6",
+        "type-name": "2.0.2"
       }
     },
     "stringify-entities": {
@@ -15932,32 +19417,29 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-      "dev": true,
-      "requires": {
-        "first-chunk-stream": "1.0.0",
-        "is-utf8": "0.2.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -15977,7 +19459,8 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "dev": true
     },
     "style-search": {
       "version": "0.1.0",
@@ -15991,9 +19474,9 @@
       "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
       "dev": true,
       "requires": {
-        "autoprefixer": "7.2.3",
+        "autoprefixer": "7.2.6",
         "balanced-match": "1.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "cosmiconfig": "3.1.0",
         "debug": "3.1.0",
         "execall": "1.0.0",
@@ -16005,14 +19488,14 @@
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "known-css-properties": "0.5.0",
-        "lodash": "4.17.4",
-        "log-symbols": "2.1.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
         "mathml-tag-names": "2.0.1",
         "meow": "4.0.0",
         "micromatch": "2.3.11",
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
-        "postcss": "6.0.14",
+        "postcss": "6.0.17",
         "postcss-html": "0.12.0",
         "postcss-less": "1.1.3",
         "postcss-media-query-parser": "0.2.3",
@@ -16020,7 +19503,7 @@
         "postcss-resolve-nested-selector": "0.1.1",
         "postcss-safe-parser": "3.0.1",
         "postcss-sass": "0.2.0",
-        "postcss-scss": "1.0.2",
+        "postcss-scss": "1.0.3",
         "postcss-selector-parser": "3.1.1",
         "postcss-value-parser": "3.3.0",
         "resolve-from": "4.0.0",
@@ -16048,27 +19531,27 @@
           }
         },
         "autoprefixer": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.3.tgz",
-          "integrity": "sha512-dqzVGiz3v934+s3YZA6nk7tAs9xuTz5wMJbX1M+L4cY/MTNkOUqP61c1GWkEVlUL/PEy1pKRSCFuoRZrXYx9qA==",
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+          "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
           "dev": true,
           "requires": {
-            "browserslist": "2.10.0",
-            "caniuse-lite": "1.0.30000783",
+            "browserslist": "2.11.3",
+            "caniuse-lite": "1.0.30000808",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.14",
+            "postcss": "6.0.17",
             "postcss-value-parser": "3.3.0"
           }
         },
         "browserslist": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
-          "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000783",
-            "electron-to-chromium": "1.3.28"
+            "caniuse-lite": "1.0.30000808",
+            "electron-to-chromium": "1.3.33"
           }
         },
         "camelcase": {
@@ -16089,14 +19572,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "debug": {
@@ -16108,36 +19591,16 @@
             "ms": "2.0.0"
           }
         },
-        "electron-to-chromium": {
-          "version": "1.3.28",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-          "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
-          "dev": true
-        },
         "get-stdin": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
           "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
           "dev": true
         },
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "glob": "7.1.2",
-            "ignore": "3.3.7",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
-          }
-        },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "indent-string": {
@@ -16165,12 +19628,12 @@
           }
         },
         "log-symbols": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0"
+            "chalk": "2.3.1"
           }
         },
         "map-obj": {
@@ -16212,24 +19675,15 @@
             "json-parse-better-errors": "1.0.1"
           }
         },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "read-pkg": {
@@ -16288,12 +19742,6 @@
             "ansi-regex": "3.0.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
         "strip-indent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
@@ -16301,12 +19749,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "trim-newlines": {
@@ -16360,7 +19808,7 @@
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -16373,31 +19821,31 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -16407,12 +19855,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16440,7 +19888,7 @@
         "home-dir": "1.0.0",
         "is-url": "1.2.2",
         "join-path": "1.1.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mime-types": "2.1.17",
         "minimatch": "3.0.4",
         "morgan": "1.9.0",
@@ -16619,10 +20067,10 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "chalk": "2.3.1",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
@@ -16643,20 +20091,20 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -16685,12 +20133,12 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16701,6 +20149,22 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "tape": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
+      "integrity": "sha1-Df7scJIn+8yRcKvn8EaWKycUMds=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "0.1.2",
+        "defined": "0.0.0",
+        "inherits": "2.0.3",
+        "jsonify": "0.0.0",
+        "resumer": "0.0.0",
+        "split": "0.2.10",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
+    },
     "tar": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-3.2.1.tgz",
@@ -16709,7 +20173,7 @@
       "requires": {
         "chownr": "1.0.1",
         "minipass": "2.2.1",
-        "minizlib": "1.0.4",
+        "minizlib": "1.1.0",
         "mkdirp": "0.5.1",
         "yallist": "3.0.2"
       },
@@ -16729,9 +20193,20 @@
       "dev": true,
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.4",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.4"
+          }
+        }
       }
     },
     "temp": {
@@ -16746,7 +20221,7 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "fork-stream": "0.0.4",
         "merge-stream": "1.0.1",
         "through2": "2.0.3"
@@ -16786,8 +20261,9 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "xtend": "4.0.1"
       }
     },
@@ -16822,7 +20298,7 @@
         "body-parser": "1.14.2",
         "debug": "2.2.0",
         "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
+        "livereload-js": "2.3.0",
         "parseurl": "1.3.2",
         "qs": "5.1.0"
       },
@@ -16836,7 +20312,7 @@
             "bytes": "2.2.0",
             "content-type": "1.0.4",
             "debug": "2.2.0",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "http-errors": "1.3.1",
             "iconv-lite": "0.4.13",
             "on-finished": "2.3.0",
@@ -16951,6 +20427,115 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
     "topo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
@@ -16972,6 +20557,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -17000,9 +20586,9 @@
       "dev": true
     },
     "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
     "traverse-chain": {
@@ -17084,9 +20670,9 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "diff": "3.4.0",
-        "make-error": "1.3.0",
+        "make-error": "1.3.3",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18",
@@ -17105,29 +20691,29 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "v8flags": {
@@ -17149,33 +20735,17 @@
       "requires": {
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "tsconfig-paths": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-2.4.0.tgz",
-      "integrity": "sha512-cfVaUy28o81n1A3uIXkt2NvoCN3ryIhZNql/ThWwjIW4huCALfaRD/shdLYxpAWW7tD9aUUSGeJi3iMyxeNQ/w==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-2.7.3.tgz",
+      "integrity": "sha512-PZWk7GDkXPGdnio/CzLJnaUdOBTIBdPuA77LK9u5XOpMk2RZnSk3k+wSefcbP7eSTJi4VZ0hXM+Vdf0YqR/qWg==",
       "dev": true,
       "requires": {
         "deepmerge": "2.0.1",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "tsickle": {
@@ -17190,9 +20760,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "tslint": {
       "version": "5.9.1",
@@ -17202,16 +20772,16 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
-        "chalk": "2.3.0",
-        "commander": "2.12.2",
+        "chalk": "2.3.1",
+        "commander": "2.14.1",
         "diff": "3.4.0",
         "glob": "7.1.2",
         "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
-        "tslib": "1.8.0",
-        "tsutils": "2.13.0"
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.21.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17224,29 +20794,29 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17258,18 +20828,19 @@
       "dev": true
     },
     "tsutils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
-      "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.21.1.tgz",
+      "integrity": "sha512-heMkdeQ9iUc90ynfiNo5Y+GXrEEGy86KMvnSTfHO+Q40AuNQ1lZGXcv58fuU9XTUxI0V7YIN9xPN+CO9b1Gn3w==",
       "dev": true,
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.9.0"
       }
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -17278,6 +20849,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -17299,10 +20871,17 @@
         "mime-types": "2.1.17"
       }
     },
+    "type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "2.5.3",
@@ -17452,6 +21031,32 @@
         "x-is-string": "0.1.0"
       }
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -17547,6 +21152,17 @@
         }
       }
     },
+    "universal-deep-strict-equal": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
+      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
+      "dev": true,
+      "requires": {
+        "array-filter": "1.0.0",
+        "indexof": "0.0.1",
+        "object-keys": "1.0.11"
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -17558,6 +21174,52 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "unzip": {
       "version": "0.1.11",
@@ -17591,7 +21253,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "1.1.1"
           }
         },
         "isarray": {
@@ -17663,7 +21325,7 @@
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "infinity-agent": "2.0.3",
             "is-redirect": "1.0.0",
             "is-stream": "1.1.0",
@@ -17760,6 +21422,12 @@
         "upper-case": "1.1.3"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
     "url-join": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
@@ -17791,6 +21459,100 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "urlgrey": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
+      "integrity": "sha1-8GU1cED7NcOzEdTl3DZITZbb6gY=",
+      "dev": true,
+      "requires": {
+        "tape": "2.3.0"
+      }
+    },
+    "use": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -17801,27 +21563,20 @@
       }
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
+        "lru-cache": "4.1.1",
         "tmp": "0.0.30"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-          "dev": true
-        }
       }
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utile": {
       "version": "0.3.0",
@@ -17844,19 +21599,27 @@
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true,
           "optional": true
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
@@ -17913,6 +21676,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -18000,7 +21764,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.0"
+            "natives": "1.1.1"
           }
         },
         "isarray": {
@@ -18026,6 +21790,16 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "1.0.0",
+            "is-utf8": "0.2.1"
+          }
         },
         "through2": {
           "version": "0.6.5",
@@ -18103,7 +21877,7 @@
             "buffer-crc32": "0.2.13",
             "glob": "7.1.2",
             "lodash": "4.16.2",
-            "readable-stream": "2.3.3",
+            "readable-stream": "2.3.4",
             "tar-stream": "1.5.5",
             "walkdir": "0.0.11",
             "zip-stream": "1.2.0"
@@ -18172,8 +21946,8 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.16.1",
+            "commander": "2.14.1",
+            "is-my-json-valid": "2.17.1",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -18243,7 +22017,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -18317,7 +22091,7 @@
           "dev": true,
           "requires": {
             "sax": "0.6.1",
-            "xmlbuilder": "9.0.4"
+            "xmlbuilder": "9.0.7"
           }
         }
       }
@@ -18334,7 +22108,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.9",
+        "http-parser-js": "0.4.10",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -18381,8 +22155,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.2",
@@ -18405,7 +22178,8 @@
     "window-size": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
     },
     "winston": {
       "version": "2.4.0",
@@ -18439,6 +22213,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -18447,7 +22222,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "wreck": {
       "version": "6.3.0",
@@ -18555,13 +22331,13 @@
       "dev": true,
       "requires": {
         "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xmlhttprequest": {
@@ -18579,12 +22355,14 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -18596,6 +22374,7 @@
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "dev": true,
       "requires": {
         "camelcase": "2.1.1",
         "cliui": "3.2.0",
@@ -18607,9 +22386,9 @@
       }
     },
     "yargs-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -18645,14 +22424,14 @@
       "requires": {
         "archiver-utils": "1.3.0",
         "compress-commons": "1.2.2",
-        "lodash": "4.17.4",
-        "readable-stream": "2.3.3"
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.4"
       }
     },
     "zone.js": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
-      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q=="
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.20.tgz",
+      "integrity": "sha512-FXlA37ErSXCMy5RNBcGFgCI/Zivqzr0D19GuvDxhcYIJc7xkFp6c29DKyODJu0Zo+EMyur/WPPgcBh1EHjB9jA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@angular/platform-server": "^5.2.3",
     "@angular/router": "^5.2.3",
     "@angular/upgrade": "^5.0.1",
-    "@bazel/ibazel": "^0.1.1",
+    "@bazel/ibazel": "0.3.1",
     "@google-cloud/storage": "^1.1.1",
     "@types/chalk": "^0.4.31",
     "@types/fs-extra": "^4.0.3",

--- a/src/cdk/BUILD.bazel
+++ b/src/cdk/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility=["//visibility:public"])
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_config")
 
+exports_files(["tsconfig-build.json"])
 
 ts_library(
   name = "cdk",
@@ -8,4 +9,10 @@ ts_library(
   module_name = "@angular/cdk",
   deps = [],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_config(
+  name ="tsconfig_tests",
+  src = "tsconfig-tests.json",
+  deps = ["tsconfig-build.json"],
 )

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -1,11 +1,13 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
 
 sass_library(
   name = "a11y_scss_lib",
   srcs = glob(["**/_*.scss"]),
 )
+
 
 ng_module(
   name = "a11y",
@@ -18,4 +20,34 @@ ng_module(
     "@rxjs",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "a11y_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":a11y",
+    "//src/cdk/keycodes",
+    "//src/cdk/platform",
+    "//src/cdk/testing",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = [
+    "//:web_test_bootstrap_scripts",
+  ],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":a11y_test_sources",
+  ],
 )

--- a/src/cdk/accordion/BUILD.bazel
+++ b/src/cdk/accordion/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "accordion",
@@ -10,4 +12,29 @@ ng_module(
     "//src/cdk/collections",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "accordion_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":accordion",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":accordion_test_sources",
+  ],
 )

--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -1,5 +1,6 @@
 package(default_visibility=["//visibility:public"])
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
 
 # Note: this will need to ng_module if any Angular-specific stuff is added to coercion.
 ts_library(
@@ -8,4 +9,17 @@ ts_library(
   module_name = "@angular/cdk/coercion",
   deps = [],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "coercion_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [":coercion"],
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+  deps = [":coercion_test_sources"],
 )

--- a/src/cdk/coercion/boolean-property.spec.ts
+++ b/src/cdk/coercion/boolean-property.spec.ts
@@ -45,5 +45,4 @@ describe('coerceBooleanProperty', () => {
   it('should coerce an array to true', () => {
     expect(coerceBooleanProperty([])).toBe(true);
   });
-
 });

--- a/src/cdk/collections/BUILD.bazel
+++ b/src/cdk/collections/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "collections",
@@ -7,4 +9,29 @@ ng_module(
   module_name = "@angular/cdk/collections",
   deps = ["@rxjs"],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "collections_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":collections",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":collections_test_sources",
+  ],
 )

--- a/src/cdk/layout/BUILD.bazel
+++ b/src/cdk/layout/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "layout",
@@ -11,4 +13,30 @@ ng_module(
     "@rxjs",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "layout_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":layout",
+    "//src/cdk/platform",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":layout_test_sources",
+  ],
 )

--- a/src/cdk/observers/BUILD.bazel
+++ b/src/cdk/observers/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "observers",
@@ -7,4 +9,29 @@ ng_module(
   module_name = "@angular/cdk/observers",
   deps = ["@rxjs", "//src/cdk/coercion"],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "observers_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":observers",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":observers_test_sources",
+  ],
 )

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,5 +1,6 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
 
 ng_module(
   name = "overlay",
@@ -15,4 +16,40 @@ ng_module(
     "@rxjs",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "overlay_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":overlay",
+    "//src/cdk/bidi",
+    "//src/cdk/keycodes",
+    "//src/cdk/platform",
+    "//src/cdk/portal",
+    "//src/cdk/scrolling",
+    "//src/cdk/testing",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  # TODO(jelbourn): re-enable this when we can specify browser flags
+  # in order to fix the window size.
+  tags = ["manual"],
+  bootstrap = [
+    "//:web_test_bootstrap_scripts",
+  ],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":overlay_test_sources",
+  ],
 )

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -330,7 +330,10 @@ describe('Overlay directives', () => {
         originX: 'end',
         originY: 'bottom',
         overlayX: 'start',
-        overlayY: 'top'
+        overlayY: 'top',
+        // TODO(jelbourn) figure out why, when compiling with bazel, these offsets are required.
+        offsetX: 0,
+        offsetY: 0,
       }];
 
       fixture.componentInstance.isOpen = true;

--- a/src/cdk/portal/BUILD.bazel
+++ b/src/cdk/portal/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "portal",
@@ -7,4 +9,28 @@ ng_module(
   module_name = "@angular/cdk/portal",
   deps = ["@rxjs"],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "portal_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":portal",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":portal_test_sources",
+  ],
 )

--- a/src/cdk/scrolling/BUILD.bazel
+++ b/src/cdk/scrolling/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "scrolling",
@@ -10,4 +12,32 @@ ng_module(
     "@rxjs",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "scrolling_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":scrolling",
+    "//src/cdk/testing",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = [
+    "//:web_test_bootstrap_scripts",
+  ],
+
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":scrolling_test_sources",
+  ],
 )

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility=["//visibility:public"])
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+
 
 ng_module(
   name = "table",
@@ -10,4 +12,29 @@ ng_module(
     "@rxjs",
   ],
   tsconfig = ":tsconfig-build.json",
+)
+
+ts_library(
+  name = "table_test_sources",
+  testonly = 1,
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":table",
+    "//src/cdk/collections",
+    "@rxjs",
+  ],
+  tsconfig = ":tsconfig-build.json",
+)
+
+ts_web_test(
+  name = "unit_tests",
+  bootstrap = ["//:web_test_bootstrap_scripts"],
+  # Do not sort
+  deps = [
+    "//:tslib_bundle",
+    "//:angular_bundles",
+    "//:angular_test_bundles",
+    "//test:angular_test_init",
+    ":table_test_sources",
+  ],
 )

--- a/src/cdk/testing/BUILD.bazel
+++ b/src/cdk/testing/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility=["//visibility:public"])
+load("@angular//:index.bzl", "ng_module")
+
+ng_module(
+  name = "testing",
+  srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
+  module_name = "@angular/cdk/testing",
+  tsconfig = ":tsconfig-test.json",
+  deps = ["@rxjs"],
+)

--- a/src/cdk/testing/tsconfig-test.json
+++ b/src/cdk/testing/tsconfig-test.json
@@ -1,0 +1,15 @@
+// This file exists to be consumed by bazel
+{
+  "extends": "../tsconfig-build",
+  "files": [
+    "public-api.ts",
+    "../typings.d.ts"
+  ],
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "flatModuleOutFile": "index.js",
+    "flatModuleId": "@angular/cdk/testing",
+    "skipTemplateCodegen": true
+  }
+}

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -22,7 +22,7 @@
     "target": "es2015",
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
-    "types": [],
+    "types": ["jasmine", "tslib"],
     "paths": {
       "@angular/cdk/*": ["../../dist/packages/cdk/*"]
     }

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility=["//visibility:public"])
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+
+
+# Common set-up for all Angular Material and CDK tests.
+ts_library(
+  name = "angular_test_init",
+  testonly = 1,
+  # This file *must* end with "spec" in order for ts_web_test to load it.
+  srcs = ["angular-test-init-spec.ts"],
+)

--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -1,0 +1,56 @@
+import {TestBed} from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+
+/* Common setup / initialization for all unit tests in Angular Material and CDK. */
+
+
+const testBed = TestBed.initTestEnvironment(
+    [BrowserDynamicTestingModule], platformBrowserDynamicTesting());
+patchTestBedToDestroyFixturesAfterEveryTest(testBed);
+
+(window as any).module = {};
+(window as any).isNode = false;
+(window as any).isBrowser = true;
+(window as any).global = window;
+
+
+/**
+ * Monkey-patches TestBed.resetTestingModule such that any errors that occur during component
+ * destruction are thrown instead of silently logged. Also runs TestBed.resetTestingModule after
+ * each unit test.
+ *
+ * Without this patch, the combination of two behaviors is problematic for Angular Material:
+ * - TestBed.resetTestingModule catches errors thrown on fixture destruction and logs them without
+ *     the errors ever being thrown. This means that any component errors that occur in ngOnDestroy
+ *     can encounter errors silently and still pass unit tests.
+ * - TestBed.resetTestingModule is only called *before* a test is run, meaning that even *if* the
+ *    aforementioned errors were thrown, they would be reported for the wrong test (the test that's
+ *    about to start, not the test that just finished).
+ */
+function patchTestBedToDestroyFixturesAfterEveryTest(testBed) {
+  // Original resetTestingModule function of the TestBed.
+  const _resetTestingModule = testBed.resetTestingModule;
+
+  // Monkey-patch the resetTestingModule to destroy fixtures outside of a try/catch block.
+  // With https://github.com/angular/angular/commit/2c5a67134198a090a24f6671dcdb7b102fea6eba
+  // errors when destroying components are no longer causing Jasmine to fail.
+  testBed.resetTestingModule = function() {
+    try {
+      this._activeFixtures.forEach(fixture => fixture.destroy());
+    } finally {
+      this._activeFixtures = [];
+      // Regardless of errors or not, run the original reset testing module function.
+      _resetTestingModule.call(this);
+    }
+  };
+
+  // Angular's testing package resets the testing module before each test. This doesn't work well
+  // for us because it doesn't allow developers to see what test actually failed.
+  // Fixing this by resetting the testing module after each test.
+  // https://github.com/angular/angular/blob/master/packages/core/testing/src/before_each.ts#L25
+  afterEach(() => testBed.resetTestingModule());
+}


### PR DESCRIPTION
This adds bazel test rules for everything under cdk/ and sets CircleCI to run them. Overlay tests don't work because there's not yet a way to pass through flags to the browser. These issues will be addressed in a follow-up PR.