### PR TITLE
fix(global-position-strategy): ignoring width and height from OverlayConfig

### DIFF
--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -20,15 +20,15 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /** The overlay to which this strategy is attached. */
   private _overlayRef: OverlayRef;
 
-  private _cssPosition: string = 'static';
-  private _topOffset: string = '';
-  private _bottomOffset: string = '';
-  private _leftOffset: string = '';
-  private _rightOffset: string = '';
-  private _alignItems: string = '';
-  private _justifyContent: string = '';
-  private _width: string = '';
-  private _height: string = '';
+  private _cssPosition = 'static';
+  private _topOffset = '';
+  private _bottomOffset = '';
+  private _leftOffset = '';
+  private _rightOffset = '';
+  private _alignItems = '';
+  private _justifyContent = '';
+  private _width = '';
+  private _height = '';
 
   /** A lazily-created wrapper for the overlay element that is used as a flex container. */
   private _wrapper: HTMLElement | null = null;
@@ -36,7 +36,17 @@ export class GlobalPositionStrategy implements PositionStrategy {
   constructor(private _document: any) {}
 
   attach(overlayRef: OverlayRef): void {
+    const config = overlayRef.getConfig();
+
     this._overlayRef = overlayRef;
+
+    if (this._width && !config.width) {
+      overlayRef.updateSize({width: this._width});
+    }
+
+    if (this._height && !config.height) {
+      overlayRef.updateSize({height: this._height});
+    }
   }
 
   /**
@@ -86,14 +96,14 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the overlay width and clears any previously set width.
    * @param value New width for the overlay
+   * @deprecated Pass the `width` through the `OverlayConfig`.
+   * @deletion-target 7.0.0
    */
   width(value: string = ''): this {
-    this._width = value;
-
-    // When the width is 100%, we should reset the `left` and the offset,
-    // in order to ensure that the element is flush against the viewport edge.
-    if (value === '100%') {
-      this.left('0px');
+    if (this._overlayRef) {
+      this._overlayRef.updateSize({width: value});
+    } else {
+      this._width = value;
     }
 
     return this;
@@ -102,14 +112,14 @@ export class GlobalPositionStrategy implements PositionStrategy {
   /**
    * Sets the overlay height and clears any previously set height.
    * @param value New height for the overlay
+   * @deprecated Pass the `height` through the `OverlayConfig`.
+   * @deletion-target 7.0.0
    */
   height(value: string = ''): this {
-    this._height = value;
-
-    // When the height is 100%, we should reset the `top` and the offset,
-    // in order to ensure that the element is flush against the viewport edge.
-    if (value === '100%') {
-      this.top('0px');
+    if (this._overlayRef) {
+      this._overlayRef.updateSize({height: value});
+    } else {
+      this._height = value;
     }
 
     return this;
@@ -162,19 +172,18 @@ export class GlobalPositionStrategy implements PositionStrategy {
       this._wrapper!.appendChild(element);
     }
 
-    let styles = element.style;
-    let parentStyles = (element.parentNode as HTMLElement).style;
+    const styles = element.style;
+    const parentStyles = (element.parentNode as HTMLElement).style;
+    const config = this._overlayRef.getConfig();
 
     styles.position = this._cssPosition;
-    styles.marginTop = this._topOffset;
-    styles.marginLeft = this._leftOffset;
+    styles.marginLeft = config.width === '100%' ? '0' : this._leftOffset;
+    styles.marginTop = config.height === '100%' ? '0' : this._topOffset;
     styles.marginBottom = this._bottomOffset;
     styles.marginRight = this._rightOffset;
-    styles.width = this._width;
-    styles.height = this._height;
 
-    parentStyles.justifyContent = this._justifyContent;
-    parentStyles.alignItems = this._alignItems;
+    parentStyles.justifyContent = config.width === '100%' ? 'flex-start' : this._justifyContent;
+    parentStyles.alignItems = config.height === '100%' ? 'flex-start' : this._alignItems;
   }
 
   /** Removes the wrapper element from the DOM. */


### PR DESCRIPTION
* Switches to using the `width` and `height` from the `OverlayConfig`, rather than the properties on the `GlobalPositionStrategy`.
* Deprecates the `GlobalPositionStrategy.width` and `GlobalPositionStrategy.height` methods in favor of passing the dimensions through the config.
* Reworks the `GlobalPositionStrategy` testing setup to make it less prone to breaking if any of the `OverlayRef` internals change.

Fixes #9715.