### PR TITLE
refactor(datepicker): move keyboard events handlers into the views

### DIFF
--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -83,9 +83,7 @@ export class MatCalendarBody {
   /** Emits when a new value is selected. */
   @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
-  constructor(private _elementRef: ElementRef,
-              private _ngZone: NgZone) {
-  }
+  constructor(private _elementRef: ElementRef, private _ngZone: NgZone) { }
 
   _cellClicked(cell: MatCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {

--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -9,12 +9,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
   Output,
-  ViewEncapsulation
+  ViewEncapsulation,
+  NgZone,
 } from '@angular/core';
-
+import {take} from 'rxjs/operators/take';
 
 /**
  * An internal class that represents the data corresponding to a single calendar cell.
@@ -81,6 +83,10 @@ export class MatCalendarBody {
   /** Emits when a new value is selected. */
   @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
+  constructor(private _elementRef: ElementRef,
+              private _ngZone: NgZone) {
+  }
+
   _cellClicked(cell: MatCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {
       return;
@@ -103,5 +109,14 @@ export class MatCalendarBody {
     }
 
     return cellNumber == this.activeCell;
+  }
+
+  /** Focuses the active cell after the microtask queue is empty. */
+  _focusActiveCell() {
+    this._ngZone.runOutsideAngular(() => {
+      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+        this._elementRef.nativeElement.querySelector('.mat-calendar-body-active').focus();
+      });
+    });
   }
 }

--- a/src/lib/datepicker/calendar.html
+++ b/src/lib/datepicker/calendar.html
@@ -20,11 +20,10 @@
   </div>
 </div>
 
-<div class="mat-calendar-content" (keydown)="_handleCalendarBodyKeydown($event)"
-    [ngSwitch]="_currentView" cdkMonitorSubtreeFocus tabindex="-1">
+<div class="mat-calendar-content" [ngSwitch]="_currentView" cdkMonitorSubtreeFocus tabindex="-1">
   <mat-month-view
       *ngSwitchCase="'month'"
-      [activeDate]="_activeDate"
+      [(activeDate)]="_activeDate"
       [selected]="selected"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"

--- a/src/lib/datepicker/calendar.html
+++ b/src/lib/datepicker/calendar.html
@@ -48,16 +48,10 @@
       *ngSwitchCase="'multi-year'"
       [activeDate]="_activeDate"
       [selected]="selected"
-<<<<<<< HEAD
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
       (yearSelected)="_yearSelectedInMultiYearView($event)"
-=======
-      [dateFilter]="_dateFilterForViews"
-      [maxDate]="maxDate"
-      [minDate]="minDate"
->>>>>>> add max/min filter to multi year and year views
       (selectedChange)="_goToDateInView($event, 'year')">
   </mat-multi-year-view>
 </div>

--- a/src/lib/datepicker/calendar.html
+++ b/src/lib/datepicker/calendar.html
@@ -48,10 +48,16 @@
       *ngSwitchCase="'multi-year'"
       [activeDate]="_activeDate"
       [selected]="selected"
+<<<<<<< HEAD
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
       (yearSelected)="_yearSelectedInMultiYearView($event)"
+=======
+      [dateFilter]="_dateFilterForViews"
+      [maxDate]="maxDate"
+      [minDate]="minDate"
+>>>>>>> add max/min filter to multi year and year views
       (selectedChange)="_goToDateInView($event, 'year')">
   </mat-multi-year-view>
 </div>

--- a/src/lib/datepicker/calendar.spec.ts
+++ b/src/lib/datepicker/calendar.spec.ts
@@ -1,31 +1,11 @@
 import {
-  DOWN_ARROW,
-  END,
   ENTER,
-  HOME,
-  LEFT_ARROW,
-  PAGE_DOWN,
-  PAGE_UP,
   RIGHT_ARROW,
-  UP_ARROW,
 } from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
-import {
-  AUG,
-  DEC,
-  FEB,
-  JAN,
-  JUL,
-  JUN,
-  MAR,
-  MatNativeDateModule,
-  MAY,
-  NOV,
-  OCT,
-  SEP,
-} from '@angular/material/core';
+import {ComponentFixture, TestBed, async, inject} from '@angular/core/testing';
+import {DEC, FEB, JAN, MatNativeDateModule, NOV} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {MatButtonModule} from '../button/index';
@@ -33,7 +13,7 @@ import {MatCalendar} from './calendar';
 import {MatCalendarBody} from './calendar-body';
 import {MatDatepickerIntl} from './datepicker-intl';
 import {MatMonthView} from './month-view';
-import {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';
+import {MatMultiYearView, yearsPerPage} from './multi-year-view';
 import {MatYearView} from './year-view';
 
 
@@ -240,7 +220,9 @@ describe('MatCalendar', () => {
         fixture.detectChanges();
 
         expect(button.getAttribute('aria-label')).toBe('Go to multi-year view?');
-      }));
+      })
+    );
+
 
     describe('a11y', () => {
       describe('calendar body', () => {
@@ -262,155 +244,6 @@ describe('MatCalendar', () => {
           expect(calendarBodyEl.getAttribute('tabindex')).toBe('-1');
         });
 
-        describe('month view', () => {
-          it('should decrement date on left arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 30));
-
-            calendarInstance._activeDate = new Date(2017, JAN, 1);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-          });
-
-          it('should increment date on left arrow press in rtl', () => {
-            dir.value = 'rtl';
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 1));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 2));
-          });
-
-          it('should increment date on right arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 1));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 2));
-          });
-
-          it('should decrement date on right arrow press in rtl', () => {
-            dir.value = 'rtl';
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 30));
-
-            calendarInstance._activeDate = new Date(2017, JAN, 1);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-          });
-
-          it('should go up a row on up arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 24));
-
-            calendarInstance._activeDate = new Date(2017, JAN, 7);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-          });
-
-          it('should go down a row on down arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 7));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 14));
-          });
-
-          it('should go to beginning of the month on home press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 1));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 1));
-          });
-
-          it('should go to end of the month on end press', () => {
-            calendarInstance._activeDate = new Date(2017, JAN, 10);
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 31));
-          });
-
-          it('should go back one month on page up press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, NOV, 30));
-          });
-
-          it('should go forward one month on page down press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 28));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, MAR, 28));
-          });
-
-          it('should select active date on enter', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(testComponent.selected).toBeUndefined();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
-            fixture.detectChanges();
-
-            expect(testComponent.selected).toEqual(new Date(2017, JAN, 30));
-          });
-        });
-
         describe('year view', () => {
           beforeEach(() => {
             dispatchMouseEvent(periodButton, 'click');
@@ -424,166 +257,13 @@ describe('MatCalendar', () => {
             expect(calendarInstance._currentView).toBe('year');
           });
 
-          it('should decrement month on left arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, NOV, 30));
-          });
-
-          it('should increment month on left arrow press in rtl', () => {
-            dir.value = 'rtl';
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 28));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, MAR, 28));
-          });
-
-          it('should increment month on right arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 28));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, MAR, 28));
-          });
-
-          it('should decrement month on right arrow press in rtl', () => {
-            dir.value = 'rtl';
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, DEC, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, NOV, 30));
-          });
-
-          it('should go up a row on up arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, SEP, 30));
-
-            calendarInstance._activeDate = new Date(2017, JUL, 1);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, MAR, 1));
-
-            calendarInstance._activeDate = new Date(2017, DEC, 10);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, AUG, 10));
-          });
-
-          it('should go down a row on down arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, MAY, 31));
-
-            calendarInstance._activeDate = new Date(2017, JUN, 1);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, OCT, 1));
-
-            calendarInstance._activeDate = new Date(2017, SEP, 30);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2018, JAN, 30));
-          });
-
-          it('should go to first month of the year on home press', () => {
-            calendarInstance._activeDate = new Date(2017, SEP, 30);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 30));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 30));
-          });
-
-          it('should go to last month of the year on end press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, DEC, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, DEC, 31));
-          });
-
-          it('should go back one year on page up press', () => {
-            calendarInstance._activeDate = new Date(2016, FEB, 29);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2015, FEB, 28));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2014, FEB, 28));
-          });
-
-          it('should go forward one year on page down press', () => {
-            calendarInstance._activeDate = new Date(2016, FEB, 29);
-            fixture.detectChanges();
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017, FEB, 28));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2018, FEB, 28));
-          });
-
           it('should return to month view on enter', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+            const tableBodyEl = calendarBodyEl.querySelector('.mat-calendar-body') as HTMLElement;
+
+            dispatchKeyboardEvent(tableBodyEl, 'keydown', RIGHT_ARROW);
             fixture.detectChanges();
 
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
+            dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
             fixture.detectChanges();
 
             expect(calendarInstance._currentView).toBe('month');
@@ -600,109 +280,13 @@ describe('MatCalendar', () => {
             expect(calendarInstance._currentView).toBe('multi-year');
           });
 
-          it('should decrement year on left arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2015, JAN, 31));
-          });
-
-          it('should increment year on right arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2018, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2019, JAN, 31));
-          });
-
-          it('should go up a row on up arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 - yearsPerRow, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 - yearsPerRow * 2, JAN, 31));
-          });
-
-          it('should go down a row on down arrow press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 + yearsPerRow, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 + yearsPerRow * 2, JAN, 31));
-          });
-
-          it('should go to first year in current range on home press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2016, JAN, 31));
-          });
-
-          it('should go to last year in current range on end press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2039, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2039, JAN, 31));
-          });
-
-          it('should go to same index in previous year range page up press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 - yearsPerPage, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate)
-                .toEqual(new Date(2017 - yearsPerPage * 2, JAN, 31));
-          });
-
-          it('should go to same index in next year range on page down press', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate).toEqual(new Date(2017 + yearsPerPage, JAN, 31));
-
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
-            fixture.detectChanges();
-
-            expect(calendarInstance._activeDate)
-                .toEqual(new Date(2017 + yearsPerPage * 2, JAN, 31));
-          });
-
           it('should go to year view on enter', () => {
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+            const tableBodyEl = calendarBodyEl.querySelector('.mat-calendar-body') as HTMLElement;
+
+            dispatchKeyboardEvent(tableBodyEl, 'keydown', RIGHT_ARROW);
             fixture.detectChanges();
 
-            dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
+            dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
             fixture.detectChanges();
 
             expect(calendarInstance._currentView).toBe('year');
@@ -710,8 +294,10 @@ describe('MatCalendar', () => {
             expect(testComponent.selected).toBeUndefined();
           });
         });
+
       });
     });
+
   });
 
   describe('calendar with min and max date', () => {
@@ -904,13 +490,13 @@ describe('MatCalendar', () => {
     });
 
     describe('a11y', () => {
-      let calendarBodyEl: HTMLElement;
+      let tableBodyEl: HTMLElement;
 
       beforeEach(() => {
-        calendarBodyEl = calendarElement.querySelector('.mat-calendar-content') as HTMLElement;
-        expect(calendarBodyEl).not.toBeNull();
+        tableBodyEl = calendarElement.querySelector('.mat-calendar-body') as HTMLElement;
+        expect(tableBodyEl).not.toBeNull();
 
-        dispatchFakeEvent(calendarBodyEl, 'focus');
+        dispatchFakeEvent(tableBodyEl, 'focus');
         fixture.detectChanges();
       });
 
@@ -918,7 +504,7 @@ describe('MatCalendar', () => {
         expect(calendarInstance._currentView).toBe('month');
         expect(calendarInstance._activeDate).toEqual(new Date(2017, JAN, 1));
 
-        dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
+        dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
         fixture.detectChanges();
 
         expect(testComponent.selected).toBeUndefined();
@@ -938,13 +524,15 @@ describe('MatCalendar', () => {
 
         expect(calendarInstance._currentView).toBe('year');
 
-        dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
+        tableBodyEl = calendarElement.querySelector('.mat-calendar-body') as HTMLElement;
+        dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
         fixture.detectChanges();
 
         expect(calendarInstance._currentView).toBe('month');
         expect(testComponent.selected).toBeUndefined();
       });
     });
+
   });
 });
 
@@ -989,6 +577,6 @@ class CalendarWithDateFilter {
   startDate = new Date(2017, JAN, 1);
 
   dateFilter (date: Date) {
-    return date.getDate() % 2 == 0 && date.getMonth() != NOV;
+    return !(date.getDate() % 2) && date.getMonth() !== NOV;
   }
 }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -234,7 +234,7 @@ describe('MatDatepicker', () => {
         expect(document.querySelector('mat-dialog-container')).not.toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
 
-        let calendarBodyEl = document.querySelector('.mat-calendar-content') as HTMLElement;
+        let calendarBodyEl = document.querySelector('.mat-calendar-body') as HTMLElement;
 
         dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
         fixture.detectChanges();
@@ -279,7 +279,7 @@ describe('MatDatepicker', () => {
         testComponent.datepicker.open();
         fixture.detectChanges();
 
-        let calendarBodyEl = document.querySelector('.mat-calendar-content') as HTMLElement;
+        let calendarBodyEl = document.querySelector('.mat-calendar-body') as HTMLElement;
         expect(calendarBodyEl).not.toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
 
@@ -402,7 +402,8 @@ describe('MatDatepicker', () => {
           fixture.detectChanges();
 
           expect(testComponent.datepicker.opened).toBe(false);
-        })));
+        }))
+      );
     });
 
     describe('datepicker with too many inputs', () => {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -21,9 +21,11 @@ import {ComponentPortal} from '@angular/cdk/portal';
 import {take} from 'rxjs/operators/take';
 import {filter} from 'rxjs/operators/filter';
 import {
+  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
   ComponentRef,
+  ElementRef,
   EventEmitter,
   Inject,
   InjectionToken,
@@ -32,11 +34,11 @@ import {
   OnDestroy,
   Optional,
   Output,
+  ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-  ElementRef,
 } from '@angular/core';
-import {DateAdapter} from '@angular/material/core';
+import {CanColor, DateAdapter, mixinColor, ThemePalette} from '@angular/material/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {DOCUMENT} from '@angular/common';
 import {Subject} from 'rxjs/Subject';
@@ -44,7 +46,7 @@ import {Subscription} from 'rxjs/Subscription';
 import {merge} from 'rxjs/observable/merge';
 import {createMissingDateImplError} from './datepicker-errors';
 import {MatDatepickerInput} from './datepicker-input';
-import {CanColor, mixinColor, ThemePalette} from '@angular/material/core';
+import {MatCalendar} from './calendar';
 
 
 /** Used to generate a unique ID for each datepicker instance. */
@@ -70,7 +72,7 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER = {
 // Boilerplate for applying mixins to MatDatepickerContent.
 /** @docs-private */
 export class MatDatepickerContentBase {
-  constructor(public _elementRef: ElementRef) {}
+  constructor(public _elementRef: ElementRef) { }
 }
 export const _MatDatepickerContentMixinBase = mixinColor(MatDatepickerContentBase);
 
@@ -102,12 +104,21 @@ export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
 
   @ViewChild(MatCalendar) _calendar: MatCalendar<D>;
 
-  constructor(elementRef: ElementRef) {
+  constructor(elementRef: ElementRef, private _ngZone: NgZone) {
     super(elementRef);
   }
 
   ngAfterContentInit() {
-    this._calendar._focusActiveCell();
+    this._focusActiveCell();
+  }
+
+  /** Focuses the active cell after the microtask queue is empty. */
+  private _focusActiveCell() {
+    this._ngZone.runOutsideAngular(() => {
+      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+        this._elementRef.nativeElement.querySelector('.mat-calendar-body-active').focus();
+      });
+    });
   }
 }
 
@@ -367,20 +378,23 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
 
   /** Open the calendar as a dialog. */
   private _openAsDialog(): void {
-    this._dialogRef = this._dialog.open(MatDatepickerContent, {
+    this._dialogRef = this._dialog.open<MatDatepickerContent<D>>(MatDatepickerContent, {
       direction: this._dir ? this._dir.value : 'ltr',
       viewContainerRef: this._viewContainerRef,
       panelClass: 'mat-datepicker-dialog',
     });
-    this._dialogRef.afterClosed().subscribe(() => this.close());
-    this._dialogRef.componentInstance.datepicker = this;
+    if (this._dialogRef) {
+      this._dialogRef.afterClosed().subscribe(() => this.close());
+      this._dialogRef.componentInstance.datepicker = this;
+    }
     this._setColor();
   }
 
   /** Open the calendar as a popup. */
   private _openAsPopup(): void {
     if (!this._calendarPortal) {
-      this._calendarPortal = new ComponentPortal(MatDatepickerContent, this._viewContainerRef);
+      this._calendarPortal = new ComponentPortal<MatDatepickerContent<D>>(MatDatepickerContent,
+                                                                          this._viewContainerRef);
     }
 
     if (!this._popupRef) {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -21,7 +21,6 @@ import {ComponentPortal} from '@angular/cdk/portal';
 import {take} from 'rxjs/operators/take';
 import {filter} from 'rxjs/operators/filter';
 import {
-  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
   ComponentRef,
@@ -33,7 +32,6 @@ import {
   OnDestroy,
   Optional,
   Output,
-  ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
   ElementRef,
@@ -44,7 +42,6 @@ import {DOCUMENT} from '@angular/common';
 import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {merge} from 'rxjs/observable/merge';
-import {MatCalendar} from './calendar';
 import {createMissingDateImplError} from './datepicker-errors';
 import {MatDatepickerInput} from './datepicker-input';
 import {CanColor, mixinColor, ThemePalette} from '@angular/material/core';

--- a/src/lib/datepicker/month-view.html
+++ b/src/lib/datepicker/month-view.html
@@ -10,6 +10,7 @@
          [selectedValue]="_selectedDate"
          [labelMinRequiredCells]="3"
          [activeCell]="_dateAdapter.getDate(activeDate) - 1"
-         (selectedValueChange)="_dateSelected($event)">
+         (selectedValueChange)="_dateSelected($event)"
+         (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/src/lib/datepicker/month-view.spec.ts
+++ b/src/lib/datepicker/month-view.spec.ts
@@ -1,12 +1,27 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {
+  DOWN_ARROW,
+  END,
+  ENTER,
+  HOME,
+  LEFT_ARROW,
+  PAGE_DOWN,
+  PAGE_UP,
+  RIGHT_ARROW,
+  UP_ARROW,
+} from '@angular/cdk/keycodes';
 import {By} from '@angular/platform-browser';
-import {MatMonthView} from './month-view';
+import {Component} from '@angular/core';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {JAN, MAR, NOV, FEB} from '@angular/material/core';
 import {MatCalendarBody} from './calendar-body';
-import {MatNativeDateModule} from '@angular/material/core';
-import {JAN, MAR} from '@angular/material/core';
+import {MatMonthView} from './month-view';
+import {MatNativeDateModule, DEC} from '@angular/material/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {dispatchKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
 
 describe('MatMonthView', () => {
+  let dir: {value: Direction};
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -20,6 +35,9 @@ describe('MatMonthView', () => {
         StandardMonthView,
         MonthViewWithDateFilter,
       ],
+      providers: [
+        {provide: Directionality, useFactory: () => dir = {value: 'ltr'}}
+      ]
     });
 
     TestBed.compileComponents();
@@ -76,6 +94,170 @@ describe('MatMonthView', () => {
       expect((cellEls[4] as HTMLElement).innerText.trim()).toBe('5');
       expect(cellEls[4].classList).toContain('mat-calendar-body-active');
     });
+
+    describe('a11y', () => {
+      describe('calendar body', () => {
+        let calendarBodyEl: HTMLElement;
+        let calendarInstance: StandardMonthView;
+
+        beforeEach(() => {
+          calendarInstance = fixture.componentInstance;
+          calendarBodyEl =
+            fixture.debugElement.nativeElement.querySelector('.mat-calendar-body') as HTMLElement;
+          expect(calendarBodyEl).not.toBeNull();
+          dir.value = 'ltr';
+          fixture.componentInstance.date = new Date(2017, JAN, 5);
+          dispatchFakeEvent(calendarBodyEl, 'focus');
+          fixture.detectChanges();
+        });
+
+        it('should decrement date on left arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 4));
+
+          calendarInstance.date = new Date(2017, JAN, 1);
+          fixture.detectChanges();
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, DEC, 31));
+        });
+
+        it('should increment date on left arrow press in rtl', () => {
+          dir.value = 'rtl';
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 6));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 7));
+        });
+
+        it('should increment date on right arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 6));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 7));
+        });
+
+        it('should decrement date on right arrow press in rtl', () => {
+          dir.value = 'rtl';
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 4));
+
+          calendarInstance.date = new Date(2017, JAN, 1);
+          fixture.detectChanges();
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, DEC, 31));
+        });
+
+        it('should go up a row on up arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, DEC, 29));
+
+          calendarInstance.date = new Date(2017, JAN, 7);
+          fixture.detectChanges();
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, DEC, 31));
+        });
+
+        it('should go down a row on down arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 12));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 19));
+        });
+
+        it('should go to beginning of the month on home press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 1));
+        });
+
+        it('should go to end of the month on end press', () => {
+          calendarInstance.date = new Date(2017, JAN, 10);
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 31));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 31));
+        });
+
+        it('should go back one month on page up press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, DEC, 5));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2016, NOV, 5));
+        });
+
+        it('should go forward one month on page down press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, FEB, 5));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, MAR, 5));
+        });
+
+        it('should select active date on enter', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(testComponent.selected).toEqual(new Date(2017, JAN, 10));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
+          fixture.detectChanges();
+
+          expect(testComponent.selected).toEqual(new Date(2017, JAN, 4));
+        });
+      });
+    });
   });
 
   describe('month view with date filter', () => {
@@ -102,7 +284,7 @@ describe('MatMonthView', () => {
 
 
 @Component({
-  template: `<mat-month-view [activeDate]="date" [(selected)]="selected"></mat-month-view>`,
+  template: `<mat-month-view [(activeDate)]="date" [(selected)]="selected"></mat-month-view>`,
 })
 class StandardMonthView {
   date = new Date(2017, JAN, 5);

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -66,9 +66,6 @@ export class MatMonthView<D> implements AfterContentInit {
     if (!this._hasSameMonthAndYear(oldActiveDate, this._activeDate)) {
       this._init();
     }
-    if (this._dateAdapter.compareDate(oldActiveDate, this._activeDate)) {
-      this.activeDateChange.emit(this._activeDate);
-    }
   }
   private _activeDate: D;
 
@@ -181,6 +178,8 @@ export class MatMonthView<D> implements AfterContentInit {
     // disabled ones from being selected. This may not be ideal, we should look into whether
     // navigation should skip over disabled dates, and if so, how to implement that efficiently.
 
+    const oldActiveDate = this._activeDate;
+
     const isRtl = this._isRtl();
     switch (event.keyCode) {
       case LEFT_ARROW:
@@ -225,6 +224,10 @@ export class MatMonthView<D> implements AfterContentInit {
       default:
         // Don't prevent default or focus active cell on keys that we don't explicitly handle.
         return;
+    }
+
+    if (this._dateAdapter.compareDate(oldActiveDate, this.activeDate)) {
+      this.activeDateChange.emit(this.activeDate);
     }
 
     this._focusActiveCell();

--- a/src/lib/datepicker/multi-year-view.html
+++ b/src/lib/datepicker/multi-year-view.html
@@ -10,6 +10,7 @@
          [numCols]="4"
          [cellAspectRatio]="4 / 7"
          [activeCell]="_getActiveCell()"
-         (selectedValueChange)="_yearSelected($event)">
+         (selectedValueChange)="_yearSelected($event)"
+         (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/src/lib/datepicker/multi-year-view.spec.ts
+++ b/src/lib/datepicker/multi-year-view.spec.ts
@@ -1,13 +1,26 @@
-import {Component, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {JAN, MatNativeDateModule} from '@angular/material/core';
+import {
+  DOWN_ARROW,
+  END,
+  HOME,
+  LEFT_ARROW,
+  PAGE_DOWN,
+  PAGE_UP,
+  RIGHT_ARROW,
+  UP_ARROW,
+} from '@angular/cdk/keycodes';
 import {By} from '@angular/platform-browser';
+import {Component, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {JAN, MatNativeDateModule} from '@angular/material/core';
 import {MatCalendarBody} from './calendar-body';
-import {MatMultiYearView, yearsPerPage} from './multi-year-view';
-import {MatYearView} from './year-view';
+import {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';
+import {dispatchKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
 
 describe('MatMultiYearView', () => {
-  beforeEach(() => {
+  let dir: {value: Direction};
+
+  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,
@@ -20,10 +33,13 @@ describe('MatMultiYearView', () => {
         StandardMultiYearView,
         MultiYearViewWithDateFilter,
       ],
+      providers: [
+        {provide: Directionality, useFactory: () => dir = {value: 'ltr'}}
+      ]
     });
 
     TestBed.compileComponents();
-  });
+  }));
 
   describe('standard multi-year view', () => {
     let fixture: ComponentFixture<StandardMultiYearView>;
@@ -81,6 +97,130 @@ describe('MatMultiYearView', () => {
       expect((cellEls[1] as HTMLElement).innerText.trim()).toBe('2017');
       expect(cellEls[1].classList).toContain('mat-calendar-body-active');
     });
+
+    describe('a11y', () => {
+      describe('calendar body', () => {
+        let calendarBodyEl: HTMLElement;
+        let calendarInstance: StandardMultiYearView;
+
+        beforeEach(() => {
+          calendarInstance = fixture.componentInstance;
+          calendarBodyEl =
+            fixture.debugElement.nativeElement.querySelector('.mat-calendar-body') as HTMLElement;
+          expect(calendarBodyEl).not.toBeNull();
+          dir.value = 'ltr';
+          fixture.componentInstance.date = new Date(2017, JAN, 1);
+          dispatchFakeEvent(calendarBodyEl, 'focus');
+          fixture.detectChanges();
+        });
+
+        it('should decrement year on left arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2016, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2015, JAN, 1));
+        });
+
+        it('should increment year on right arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2018, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2019, JAN, 1));
+        });
+
+        it('should go up a row on up arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 - yearsPerRow, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 - yearsPerRow * 2, JAN, 1));
+        });
+
+        it('should go down a row on down arrow press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 + yearsPerRow, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 + yearsPerRow * 2, JAN, 1));
+        });
+
+        it('should go to first year in current range on home press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2016, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2016, JAN, 1));
+        });
+
+        it('should go to last year in current range on end press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2039, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate).toEqual(new Date(2039, JAN, 1));
+        });
+
+        it('should go to same index in previous year range page up press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 - yearsPerPage, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+              .toEqual(new Date(2017 - yearsPerPage * 2, JAN, 1));
+        });
+
+        it('should go to same index in next year range on page down press', () => {
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 + yearsPerPage, JAN, 1));
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
+          fixture.detectChanges();
+
+          expect(calendarInstance.multiYearView.activeDate)
+            .toEqual(new Date(2017 + yearsPerPage * 2, JAN, 1));
+        });
+
+      });
+    });
+
   });
 
   describe('multi year view with date filter', () => {
@@ -116,7 +256,7 @@ class StandardMultiYearView {
   selected = new Date(2020, JAN, 1);
   selectedYear: Date;
 
-  @ViewChild(MatYearView) yearView: MatYearView<Date>;
+  @ViewChild(MatMultiYearView) multiYearView: MatMultiYearView<Date>;
 }
 
 @Component({

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -96,7 +96,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter: (date: D) => boolean;
 
-  /** Emits when a new month is selected. */
+  /** Emits when a new year is selected. */
   @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** Emits the selected year. This doesn't imply a change on the selected date */

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -161,20 +161,6 @@ export class MatMultiYearView<D> implements AfterContentInit {
       return true;
     }
 
-    // disable if the year is greater than maxDate
-    if (this.maxDate) {
-      if (year > this._dateAdapter.getYear(this.maxDate)) {
-        return false;
-      }
-    }
-
-    // disable if the year is lower than maxDate
-    if (this.minDate) {
-      if (year < this._dateAdapter.getYear(this.minDate)) {
-        return false;
-      }
-    }
-
     const firstOfYear = this._dateAdapter.createDate(year, 0, 1);
 
     // If any date in the year is enabled count the year as enabled.

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -161,6 +161,20 @@ export class MatMultiYearView<D> implements AfterContentInit {
       return true;
     }
 
+    // disable if the year is greater than maxDate
+    if (this.maxDate) {
+      if (year > this._dateAdapter.getYear(this.maxDate)) {
+        return false;
+      }
+    }
+
+    // disable if the year is lower than maxDate
+    if (this.minDate) {
+      if (year < this._dateAdapter.getYear(this.minDate)) {
+        return false;
+      }
+    }
+
     const firstOfYear = this._dateAdapter.createDate(year, 0, 1);
 
     // If any date in the year is enabled count the year as enabled.

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -7,20 +7,34 @@
  */
 
 import {
+  DOWN_ARROW,
+  END,
+  ENTER,
+  HOME,
+  LEFT_ARROW,
+  PAGE_DOWN,
+  PAGE_UP,
+  RIGHT_ARROW,
+  UP_ARROW,
+} from '@angular/cdk/keycodes';
+import {
   AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
+  NgZone,
   Optional,
   Output,
   ViewEncapsulation
 } from '@angular/core';
 import {DateAdapter} from '@angular/material/core';
+import {Directionality} from '@angular/cdk/bidi';
 import {MatCalendarCell} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
-
+import {take} from 'rxjs/operators/take';
 
 export const yearsPerPage = 24;
 
@@ -38,7 +52,7 @@ export const yearsPerRow = 4;
   exportAs: 'matMultiYearView',
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MatMultiYearView<D> implements AfterContentInit {
   /** The date to display in this multi-year view (everything other than the year is ignored). */
@@ -46,8 +60,9 @@ export class MatMultiYearView<D> implements AfterContentInit {
   get activeDate(): D { return this._activeDate; }
   set activeDate(value: D) {
     let oldActiveDate = this._activeDate;
-    this._activeDate =
+    const validDate =
         this._getValidDateOrNull(this._dateAdapter.deserialize(value)) || this._dateAdapter.today();
+    this._activeDate = this._dateAdapter.clampDate(validDate, this.minDate, this.maxDate);
     if (Math.floor(this._dateAdapter.getYear(oldActiveDate) / yearsPerPage) !=
         Math.floor(this._dateAdapter.getYear(this._activeDate) / yearsPerPage)) {
       this._init();
@@ -98,8 +113,11 @@ export class MatMultiYearView<D> implements AfterContentInit {
   /** The year of the selected date. Null if the selected date is null. */
   _selectedYear: number | null;
 
-  constructor(@Optional() public _dateAdapter: DateAdapter<D>,
-              private _changeDetectorRef: ChangeDetectorRef) {
+  constructor(private _changeDetectorRef: ChangeDetectorRef,
+              private _elementRef: ElementRef,
+              private _ngZone: NgZone,
+              @Optional() public _dateAdapter: DateAdapter<D>,
+              @Optional() private _dir?: Directionality) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }
@@ -109,6 +127,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
 
   ngAfterContentInit() {
     this._init();
+    this._focusActiveCell();
   }
 
   /** Initializes this multi-year view. */
@@ -135,6 +154,67 @@ export class MatMultiYearView<D> implements AfterContentInit {
         this._dateAdapter.getNumDaysInMonth(this._dateAdapter.createDate(year, month, 1));
     this.selectedChange.emit(this._dateAdapter.createDate(year, month,
         Math.min(this._dateAdapter.getDate(this.activeDate), daysInMonth)));
+  }
+
+  /** Focuses the active cell after the microtask queue is empty. */
+  _focusActiveCell() {
+    this._ngZone.runOutsideAngular(() => {
+      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+        this._elementRef.nativeElement.querySelector('.mat-calendar-body-active').focus();
+      });
+    });
+  }
+
+  /** Handles keydown events on the calendar body when calendar is in multi-year view. */
+  _handleCalendarBodyKeydown(event: KeyboardEvent): void {
+    // TODO(mmalerba): We currently allow keyboard navigation to disabled dates, but just prevent
+    // disabled ones from being selected. This may not be ideal, we should look into whether
+    // navigation should skip over disabled dates, and if so, how to implement that efficiently.
+
+    const isRtl = this._isRtl();
+
+    switch (event.keyCode) {
+      case LEFT_ARROW:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate, isRtl ? 1 : -1);
+        break;
+      case RIGHT_ARROW:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate, isRtl ? -1 : 1);
+        break;
+      case UP_ARROW:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate, -yearsPerRow);
+        break;
+      case DOWN_ARROW:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate, yearsPerRow);
+        break;
+      case HOME:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate,
+            -this._dateAdapter.getYear(this._activeDate) % yearsPerPage);
+        break;
+      case END:
+        this.activeDate = this._dateAdapter.addCalendarYears(this._activeDate,
+            yearsPerPage - this._dateAdapter.getYear(this._activeDate) % yearsPerPage - 1);
+        break;
+      case PAGE_UP:
+        this.activeDate =
+            this._dateAdapter.addCalendarYears(
+                this._activeDate, event.altKey ? -yearsPerPage * 10 : -yearsPerPage);
+        break;
+      case PAGE_DOWN:
+        this.activeDate =
+            this._dateAdapter.addCalendarYears(
+                this._activeDate, event.altKey ? yearsPerPage * 10 : yearsPerPage);
+        break;
+      case ENTER:
+        this._yearSelected(this._dateAdapter.getYear(this._activeDate));
+        break;
+      default:
+        // Don't prevent default or focus active cell on keys that we don't explicitly handle.
+        return;
+    }
+
+    this._focusActiveCell();
+    // Prevent unexpected default actions such as form submission.
+    event.preventDefault();
   }
 
   _getActiveCell(): number {
@@ -180,5 +260,10 @@ export class MatMultiYearView<D> implements AfterContentInit {
    */
   private _getValidDateOrNull(obj: any): D | null {
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /** Determines whether the user has the RTL layout direction. */
+  private _isRtl() {
+    return this._dir && this._dir.value === 'rtl';
   }
 }

--- a/src/lib/datepicker/year-view.html
+++ b/src/lib/datepicker/year-view.html
@@ -12,6 +12,7 @@
          [numCols]="4"
          [cellAspectRatio]="4 / 7"
          [activeCell]="_dateAdapter.getMonth(activeDate)"
-         (selectedValueChange)="_monthSelected($event)">
+         (selectedValueChange)="_monthSelected($event)"
+         (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>


### PR DESCRIPTION
<strike>This should be blocked until #9727 is merged.

@mmalerba, as #9727 hasn't been merged yet, I can merge this into that one.</strike>

There are a few things to discuss before though. Originally the keyboard events (basically `(keydown)`) were listened to at this markup:

https://github.com/angular/material2/blob/c7201984d4570e2bf17fbf4afce0dc4400f863f5/src/lib/datepicker/calendar.html#L23-L24

As now the events are being handled inside each view, I moved the listening part to each view markup, like the snippet below, from `month-view.html`

```html
<table class="mat-calendar-table">
  <thead class="mat-calendar-table-header">
    <tr><th *ngFor="let day of _weekdays" [attr.aria-label]="day.long">{{day.narrow}}</th></tr>
    <tr><th class="mat-calendar-table-header-divider" colspan="7" aria-hidden="true"></th></tr>
  </thead>
  <tbody mat-calendar-body
         [label]="_monthLabel"
         [rows]="_weeks"
         [todayValue]="_todayDate"
         [selectedValue]="_selectedDate"
         [labelMinRequiredCells]="3"
         [activeCell]="_dateAdapter.getDate(activeDate) - 1"
         (selectedValueChange)="_dateSelected($event)"
         (keydown)="_handleCalendarBodyKeydown($event)"> <------- HERE IS THE LISTENER NOW
  </tbody>
</table>
```

Also, I thought it'd be better to move the `a11y` tests from `calendar.spec.ts` to each view spec file.

As a consequence... well, I'm with this feeling that we're replicating too much code (just a feeling).

Another possible approach would be to keep the listener in `calendar.html` (its original place)  and pass  through `keydown` event to each view, but I thought it'd be a little bit awkward.