### PR TITLE
fix(menu): close nested menu chain when the user tabs out

### DIFF
--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -21,7 +21,7 @@ export interface MatMenuPanel {
   yPosition: MenuPositionY;
   overlapTrigger: boolean;
   templateRef: TemplateRef<any>;
-  close: EventEmitter<void | 'click' | 'keydown'>;
+  close: EventEmitter<Event | void>;
   parentMenu?: MatMenuPanel | undefined;
   direction?: Direction;
   focusFirstItem: (origin?: FocusOrigin) => void;

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -8,7 +8,7 @@
 
 import {isFakeMousedownFromScreenReader} from '@angular/cdk/a11y';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
+import {LEFT_ARROW, RIGHT_ARROW, TAB} from '@angular/cdk/keycodes';
 import {
   ConnectedPositionStrategy,
   HorizontalConnectionPos,
@@ -150,19 +150,23 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   ngAfterContentInit() {
     this._checkMenu();
 
-    this.menu.close.subscribe(reason => {
+    this.menu.close.subscribe((event?: Event) => {
       this._destroyMenu();
 
-      // If a click closed the menu, we should close the entire chain of nested menus.
-      if (reason === 'click' && this._parentMenu) {
-        this._parentMenu.closed.emit(reason);
+      const isClickEvent = event && event.type === 'click';
+      const isTabbingOut = event && event.type.indexOf('key') === 0 &&
+                           (event as KeyboardEvent).keyCode === TAB;
+
+      // If a click or a tab closed the menu, we should close the entire chain of nested menus.
+      if (this._parentMenu && (isClickEvent || isTabbingOut)) {
+        this._parentMenu.closed.emit(event);
       }
     });
 
     if (this.triggersSubmenu()) {
       // Subscribe to changes in the hovered item in order to toggle the panel.
       this._hoverSubscription = this._parentMenu._hovered()
-          .pipe(filter(active => active === this._menuItemInstance))
+          .pipe(filter(activeItem => activeItem === this._menuItemInstance))
           .subscribe(() => {
             this._openedByMouse = true;
             this.openMenu();

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -3,7 +3,7 @@
     class="mat-menu-panel"
     [ngClass]="_classList"
     (keydown)="_handleKeydown($event)"
-    (click)="closed.emit('click')"
+    (click)="closed.emit($event)"
     [@transformMenu]="_panelAnimationState"
     (@transformMenu.done)="_onAnimationDone($event)"
     tabindex="-1"

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {OverlayContainer, Overlay} from '@angular/cdk/overlay';
-import {ESCAPE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
+import {ESCAPE, LEFT_ARROW, RIGHT_ARROW, TAB} from '@angular/cdk/keycodes';
 import {
   MAT_MENU_DEFAULT_OPTIONS,
   MatMenu,
@@ -726,7 +726,7 @@ describe('MatMenu', () => {
       menuItem.click();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.closeCallback).toHaveBeenCalledWith('click');
+      expect(fixture.componentInstance.closeCallback).toHaveBeenCalledWith(jasmine.any(MouseEvent));
       expect(fixture.componentInstance.closeCallback).toHaveBeenCalledTimes(1);
     });
 
@@ -747,7 +747,8 @@ describe('MatMenu', () => {
       dispatchKeyboardEvent(menu, 'keydown', ESCAPE);
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.closeCallback).toHaveBeenCalledWith('keydown');
+      expect(fixture.componentInstance.closeCallback)
+          .toHaveBeenCalledWith(jasmine.any(KeyboardEvent));
       expect(fixture.componentInstance.closeCallback).toHaveBeenCalledTimes(1);
     });
 
@@ -1124,6 +1125,28 @@ describe('MatMenu', () => {
       expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(0, 'Expected no open menus');
     }));
 
+    it('should close all of the menus when tabbing out', fakeAsync(() => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      instance.levelOneTrigger.openMenu();
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.openMenu();
+      fixture.detectChanges();
+
+      const menus = overlay.querySelectorAll('.mat-menu-panel');
+
+      expect(menus.length).toBe(3, 'Expected three open menus');
+
+      dispatchKeyboardEvent(menus[2], 'keydown', TAB);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(overlay.querySelectorAll('.mat-menu-panel').length).toBe(0, 'Expected no open menus');
+    }));
+
     it('should set a class on the menu items that trigger a sub-menu', () => {
       compileTestComponent();
       instance.rootTrigger.openMenu();
@@ -1405,7 +1428,7 @@ class CustomMenuPanel implements MatMenuPanel {
   parentMenu: MatMenuPanel;
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
-  @Output() close = new EventEmitter<void | 'click' | 'keydown'>();
+  @Output() close = new EventEmitter<Event | void>();
   focusFirstItem = () => {};
   resetActiveItem = () => {};
   setPositionClasses = () => {};


### PR DESCRIPTION
Fixes the chain of nested menu not being closed when the user tabs out. Currently only the last menu is closed, which goes against the accessibility guidelines.

BREAKING CHANGE: The signature of the `MatMenuPanel.close` has changed from `EventEmitter<void | 'click' | 'keydown'>` to `EventEmitter<Event | void>`.