### PR TITLE
feat(bottom-sheet): add result param when dismissing bottom sheet

### DIFF
--- a/src/lib/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.spec.ts
@@ -295,6 +295,34 @@ describe('MatBottomSheet', () => {
       tick(500);
     }));
 
+  it('should emit after being dismissed', fakeAsync(() => {
+    const bottomSheetRef = bottomSheet.open(PizzaMsg);
+    const spy = jasmine.createSpy('afterDismissed spy');
+
+    bottomSheetRef.afterDismissed().subscribe(spy);
+    viewContainerFixture.detectChanges();
+
+    bottomSheetRef.dismiss();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should be able to pass a result back to the dismissed stream', fakeAsync(() => {
+    const bottomSheetRef = bottomSheet.open<PizzaMsg, any, number>(PizzaMsg);
+    const spy = jasmine.createSpy('afterDismissed spy');
+
+    bottomSheetRef.afterDismissed().subscribe(spy);
+    viewContainerFixture.detectChanges();
+
+    bottomSheetRef.dismiss(1337);
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(spy).toHaveBeenCalledWith(1337);
+  }));
+
   describe('passing in data', () => {
     it('should be able to pass in data', () => {
       const config = {

--- a/src/lib/bottom-sheet/bottom-sheet.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.ts
@@ -39,18 +39,18 @@ export class MatBottomSheet {
       private _injector: Injector,
       @Optional() @SkipSelf() private _parentBottomSheet: MatBottomSheet) {}
 
-  open<T, D = any>(component: ComponentType<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T>;
-  open<T, D = any>(template: TemplateRef<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T>;
+  open<T, D = any, R = any>(component: ComponentType<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
+  open<T, D = any, R = any>(template: TemplateRef<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
 
-  open<T, D = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T> {
+  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R> {
 
     const _config = _applyConfigDefaults(config);
     const overlayRef = this._createOverlay(_config);
     const container = this._attachContainer(overlayRef, _config);
-    const ref = new MatBottomSheetRef<T>(container, overlayRef);
+    const ref = new MatBottomSheetRef<T, R>(container, overlayRef);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       container.attachTemplatePortal(new TemplatePortal<T>(componentOrTemplateRef, null!, {


### PR DESCRIPTION
Something that came up while doing the docs. Adds the ability for the consumer to pass back a result from a bottom sheet. Also adds a test for `afterDismissed` since it didn't have one.