### PR TITLE
refactor(live-announcer): expose promise when announcing a message

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -70,6 +70,15 @@ describe('LiveAnnouncer', () => {
       expect(document.body.querySelector('[aria-live]'))
           .toBeFalsy('Expected that the aria-live element was remove from the DOM.');
     }));
+
+    it('should return a promise that resolves after the text has been announced', fakeAsync(() => {
+      const spy = jasmine.createSpy('announce spy');
+      const promise = announcer.announce('something').then(spy);
+
+      expect(spy).not.toHaveBeenCalled();
+      tick(100);
+      expect(spy).toHaveBeenCalled();
+    }));
   });
 
   describe('with a custom element', () => {

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -40,8 +40,9 @@ export class LiveAnnouncer implements OnDestroy {
    * Announces a message to screenreaders.
    * @param message Message to be announced to the screenreader
    * @param politeness The politeness of the announcer element
+   * @returns Promise that will be resolved when the message is added to the DOM.
    */
-  announce(message: string, politeness: AriaLivePoliteness = 'polite'): void {
+  announce(message: string, politeness: AriaLivePoliteness = 'polite'): Promise<void> {
     this._liveElement.textContent = '';
 
     // TODO: ensure changing the politeness works on all environments we support.
@@ -52,7 +53,12 @@ export class LiveAnnouncer implements OnDestroy {
     // - With Chrome and IE11 with NVDA or JAWS, a repeated (identical) message won't be read a
     //   second time without clearing and then using a non-zero delay.
     // (using JAWS 17 at time of this writing).
-    setTimeout(() => this._liveElement.textContent = message, 100);
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this._liveElement.textContent = message;
+        resolve();
+      }, 100);
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Since there's a timeout when announcing something through the `LiveAnnouncer.announce` method, it may be hard/prone to race conditions for the consumer to coordinate it with some other action. These changes expose a promise that will be resolved once the message has been added to the DOM.