### PR TITLE
refactor(tabs): use common logic for handling keyboard focus

### DIFF
--- a/src/lib/tabs/BUILD.bazel
+++ b/src/lib/tabs/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
   ] + glob(["**/*.html"]),
   deps = [
     "//src/lib/core",
+    "//src/cdk/a11y",
     "//src/cdk/bidi",
     "//src/cdk/coercion",
     "//src/cdk/observers",

--- a/src/lib/tabs/tab-header.spec.ts
+++ b/src/lib/tabs/tab-header.spec.ts
@@ -47,11 +47,14 @@ describe('MatTabHeader', () => {
   }));
 
   describe('focusing', () => {
+    let tabListContainer: HTMLElement;
+
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleTabHeaderApp);
       fixture.detectChanges();
 
       appComponent = fixture.componentInstance;
+      tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
     });
 
     it('should initialize to the selected index', () => {
@@ -83,12 +86,12 @@ describe('MatTabHeader', () => {
 
       // Move focus right, verify that the disabled tab is 1 and should be skipped
       expect(appComponent.disabledTabIndex).toBe(1);
-      appComponent.tabHeader._focusNextTab();
+      dispatchKeyboardEvent(tabListContainer, 'keydown', RIGHT_ARROW);
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(2);
 
       // Move focus right to index 3
-      appComponent.tabHeader._focusNextTab();
+      dispatchKeyboardEvent(tabListContainer, 'keydown', RIGHT_ARROW);
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(3);
     });
@@ -99,13 +102,13 @@ describe('MatTabHeader', () => {
       expect(appComponent.tabHeader.focusIndex).toBe(3);
 
       // Move focus left to index 3
-      appComponent.tabHeader._focusPreviousTab();
+      dispatchKeyboardEvent(tabListContainer, 'keydown', LEFT_ARROW);
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(2);
 
       // Move focus left, verify that the disabled tab is 1 and should be skipped
       expect(appComponent.disabledTabIndex).toBe(1);
-      appComponent.tabHeader._focusPreviousTab();
+      dispatchKeyboardEvent(tabListContainer, 'keydown', LEFT_ARROW);
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(0);
     });
@@ -114,8 +117,6 @@ describe('MatTabHeader', () => {
       appComponent.tabHeader.focusIndex = 0;
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(0);
-
-      let tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
 
       // Move focus right to 2
       dispatchKeyboardEvent(tabListContainer, 'keydown', RIGHT_ARROW);
@@ -147,7 +148,6 @@ describe('MatTabHeader', () => {
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(3);
 
-      const tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
       const event = dispatchKeyboardEvent(tabListContainer, 'keydown', HOME);
       fixture.detectChanges();
 
@@ -161,7 +161,6 @@ describe('MatTabHeader', () => {
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(3);
 
-      const tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
       dispatchKeyboardEvent(tabListContainer, 'keydown', HOME);
       fixture.detectChanges();
 
@@ -174,7 +173,6 @@ describe('MatTabHeader', () => {
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(0);
 
-      const tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
       const event = dispatchKeyboardEvent(tabListContainer, 'keydown', END);
       fixture.detectChanges();
 
@@ -188,7 +186,6 @@ describe('MatTabHeader', () => {
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(0);
 
-      const tabListContainer = appComponent.tabHeader._tabListContainer.nativeElement;
       dispatchKeyboardEvent(tabListContainer, 'keydown', END);
       fixture.detectChanges();
 


### PR DESCRIPTION
Switches the tab header component to use the `FocusKeyManager` to manage the focused item, rather than implementing the logic itself.