### PR TITLE
fix(overlay): expose backdropClick mouse event in ConnectedOverlayDirective

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -320,7 +320,8 @@ describe('Overlay directives', () => {
       backdrop.click();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.backdropClicked).toBe(true);
+      expect(fixture.componentInstance.backdropClickHandler)
+          .toHaveBeenCalledWith(jasmine.any(MouseEvent));
     });
 
     it('should emit positionChange appropriately', () => {
@@ -365,7 +366,7 @@ describe('Overlay directives', () => {
   <ng-template cdk-connected-overlay [open]="isOpen" [width]="width" [height]="height"
             [cdkConnectedOverlayOrigin]="triggerOverride || trigger"
             [hasBackdrop]="hasBackdrop" backdropClass="mat-test-class"
-            (backdropClick)="backdropClicked=true" [offsetX]="offsetX" [offsetY]="offsetY"
+            (backdropClick)="backdropClickHandler($event)" [offsetX]="offsetX" [offsetY]="offsetY"
             (positionChange)="positionChangeHandler($event)" (attach)="attachHandler()"
             (detach)="detachHandler()" [minWidth]="minWidth" [minHeight]="minHeight"
             [cdkConnectedOverlayPositions]="positionOverrides">
@@ -386,7 +387,7 @@ class ConnectedOverlayDirectiveTest {
   offsetY = 0;
   triggerOverride: CdkOverlayOrigin;
   hasBackdrop: boolean;
-  backdropClicked = false;
+  backdropClickHandler = jasmine.createSpy('backdropClick handler');
   positionChangeHandler = jasmine.createSpy('positionChangeHandler');
   positionOverrides: ConnectionPositionPair[];
   attachHandler = jasmine.createSpy('attachHandler').and.callFake(() => {

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -254,7 +254,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   set _deprecatedHasBackdrop(_hasBackdrop: any) { this.hasBackdrop = _hasBackdrop; }
 
   /** Event emitted when the backdrop is clicked. */
-  @Output() backdropClick = new EventEmitter<void>();
+  @Output() backdropClick = new EventEmitter<MouseEvent>();
 
   /** Event emitted when the position has changed. */
   @Output() positionChange = new EventEmitter<ConnectedOverlayPositionChange>();
@@ -394,8 +394,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     }
 
     if (this.hasBackdrop) {
-      this._backdropSubscription = this._overlayRef.backdropClick().subscribe(() => {
-        this.backdropClick.emit();
+      this._backdropSubscription = this._overlayRef.backdropClick().subscribe(event => {
+        this.backdropClick.emit(event);
       });
     }
   }


### PR DESCRIPTION
Exposes the `MouseEvent` from the backdrop click in the `ConnectedOverlayDirective.backdropClick` emitter.

Relates to #9713.