### PR TITLE
refactor(selection-model): avoid unnecessary null checks in change event

### DIFF
--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -122,10 +122,12 @@ export class SelectionModel<T> {
     this._selected = null;
 
     if (this._selectedToEmit.length || this._deselectedToEmit.length) {
-      const eventData = new SelectionChange<T>(this, this._selectedToEmit, this._deselectedToEmit);
-
       if (this.onChange) {
-        this.onChange.next(eventData);
+        this.onChange.next({
+          source: this,
+          added: this._selectedToEmit,
+          removed: this._deselectedToEmit
+        });
       }
 
       this._deselectedToEmit = [];
@@ -181,14 +183,13 @@ export class SelectionModel<T> {
  * Event emitted when the value of a MatSelectionModel has changed.
  * @docs-private
  */
-export class SelectionChange<T> {
-  constructor(
-    /** Model that dispatched the event. */
-    public source: SelectionModel<T>,
-    /** Options that were added to the model. */
-    public added?: T[],
-    /** Options that were removed from the model. */
-    public removed?: T[]) {}
+export interface SelectionChange<T> {
+  /** Model that dispatched the event. */
+  source: SelectionModel<T>;
+  /** Options that were added to the model. */
+  added: T[];
+  /** Options that were removed from the model. */
+  removed: T[];
 }
 
 /**


### PR DESCRIPTION
* Makes the `added` and `removed` properties on the `SelectionChange` event required since they're guaranteed to be an empty array. This makes it more convenient to consume, because it avoids having to null check them every time.
* Turns the `SelectionChange` into an interface to reduce the amount of code being generated.