### PR TITLE
updated Creating a Custom Form Field doc ngControl section

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -177,7 +177,7 @@ constructor(
 
 Note that if your component implements `ControlValueAccessor`, it may already be set up to provide `NG_VALUE_ACCESSOR` (in the `providers` part of the component's decorator, or possibly in a module declaration). If so you may get a *cannot instantiate cyclic dependency* error. 
 
-To resolve this, remove the `NG_VALUE_ACCESSOR` and instead set the value accessor directly:
+To resolve this, remove the `NG_VALUE_ACCESSOR` provider and instead set the value accessor directly:
 
 ```ts
 constructor(

--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -159,20 +159,47 @@ private _placeholder: string;
 
 This property allows the form field control to specify the `@angular/forms` control that is bound to
 this component. Since we haven't set up our component to act as a `ControlValueAccessor`, we'll just
-set this to `null` in our component. In any real component, you would probably want to implement
-`ControlValueAccessor` so that your component can work with `formControl` and `ngModel`.
+set this to `null` in our component. 
 
 ```ts
-ngControl = null;
+ngControl: NgControl = null;
 ```
 
-If you did implement `ControlValueAccessor`, you could simply inject the `NgControl` and make it
-publicly available. (For additional information about `ControlValueAccessor` see the
-[API docs](https://angular.io/api/forms/ControlValueAccessor).)
+In any real component, you would probably want to implement `ControlValueAccessor` so that your component 
+can work with `formControl` and `ngModel`. If you do implement `ControlValueAccessor`, you will need to get
+a reference to the `NgControl` associated with yoru control, and make it publicly available. 
+
+One way to do this is to inject it:
 
 ```ts
 constructor(..., @Optional() @Self() public ngControl: NgControl) { ... }
 ```
+
+...however, if your component implements `ControlValueAccessor`, it may already provide `NG_VALUE_ACCESSOR` and attempting to inject `NgControl` this may cause a dependency injection error ("Cannot instantiate cyclic dependency"). 
+
+If necessary, inject the `Injector` itself and use it to get the `NgControl` directly:
+
+```ts
+
+ngControl: NgControl;
+
+constructor(
+    private readonly _injector: Injector,
+    // ...
+) { }
+
+// ... 
+
+ngAfterViewInit() {
+    this.ngControl = this._injector.get(NgControl);
+}
+
+```
+
+Note that this approach, called *service location*, is considered an anti-pattern except in cases where specifically necessary (as it may be here).
+
+For additional information about `ControlValueAccessor` see the [API docs](https://angular.io/api/forms/ControlValueAccessor).
+
 
 #### `focused`
 


### PR DESCRIPTION
If the component already implements ControlValueAccessor, injecting NgControl in the constructor (as described in the docs) may fail.  Added an alternate approach to get past this problem.