### PR TITLE
chore: fewer warnings for docs generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "axe-webdriverjs": "^1.1.1",
     "chalk": "^1.1.3",
     "dgeni": "^0.4.9",
-    "dgeni-packages": "^0.22.0",
+    "dgeni-packages": "^0.24.1",
     "firebase": "^4.0.0",
     "firebase-admin": "^5.0.0",
     "firebase-tools": "^3.11.0",

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -280,7 +280,10 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     return this._validator ? this._validator(c) : null;
   }
 
-  /** @deletion-target 7.0.0 Use `getConnectedOverlayOrigin` instead */
+  /**
+   * @deprecated
+   * @deletion-target 7.0.0 Use `getConnectedOverlayOrigin` instead
+   */
   getPopupConnectionElementRef(): ElementRef {
     return this.getConnectedOverlayOrigin();
   }

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -200,7 +200,10 @@ export class MatFormField extends _MatFormFieldMixinBase
 
   _outlineGapStart = 0;
 
-  /** @deletion-target 7.0.0 */
+  /**
+   * @deprecated
+   * @deletion-target 7.0.0
+   */
   @ViewChild('underline') underlineRef: ElementRef;
 
   @ViewChild('connectionContainer') _connectionContainerRef: ElementRef;

--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -1,4 +1,5 @@
 import {Package} from 'dgeni';
+import {patchLogService} from './patch-log-service';
 import {DocsPrivateFilter} from './processors/docs-private-filter';
 import {Categorizer} from './processors/categorizer';
 import {FilterDuplicateExports} from './processors/filter-duplicate-exports';
@@ -78,6 +79,9 @@ apiDocsPackage.config((readFilesProcessor: any, writeFilesProcessor: any) => {
 
   writeFilesProcessor.outputFolder = outputDir;
 });
+
+// Patches Dgeni's log service to not print warnings about unresolved mixin base symbols.
+apiDocsPackage.config((log: any) => patchLogService(log));
 
 // Configure the output path for written files (i.e., file names).
 apiDocsPackage.config((computePathsProcessor: any) => {

--- a/tools/dgeni/patch-log-service.ts
+++ b/tools/dgeni/patch-log-service.ts
@@ -1,0 +1,24 @@
+
+/**
+ * Function that patches Dgeni's instantiated log service. The patch will hide warnings about
+ * unresolved TypeScript symbols for the mixin base classes.
+ *
+ * ```
+ * warn:    Unresolved TypeScript symbol(s): _MatToolbarMixinBase - doc "lib/toolbar/MatToolbar"
+ *    (class)  - from file "lib/toolbar/toolbar.ts" - starting at line 37, ending at line 98
+ * ```
+ *
+ * Those warnings are valid, but are not fixable because the base class is created dynamically
+ * through mixin functions and will be stored as a constant.
+ */
+export function patchLogService(log: any) {
+  const _warnFn = log.warn;
+
+  log.warn = function(message: string) {
+    if (message.includes('Unresolved TypeScript symbol') && message.includes('MixinBase')) {
+      return;
+    }
+
+    _warnFn.apply(this, [message]);
+  };
+}


### PR DESCRIPTION
* Hides the warnings about unresolved TypeScript symbols for the mixin base classes. Those warnings are not fixable and are polluting the Dgeni output.
* Adds missing `@deprecated` tags to entries that already have the  `@deletion-target` set.
* Updates to the latest version of dgeni-packages because https://github.com/angular/dgeni-packages/commit/3a4e5685589b99b85dfb88e8fd8dbf46aab24088 landed.