### PR TITLE
fix(viewport-ruler): server-side rendering errors when attempting to measure the viewport

### DIFF
--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -42,8 +42,7 @@ import {
   CdkTableModule,
   DataSource
 } from '@angular/cdk/table';
-import {Overlay} from '@angular/cdk/overlay';
-
+import {ViewportRuler} from '@angular/cdk/scrolling';
 import {of as observableOf} from 'rxjs/observable/of';
 import {Observable} from 'rxjs/Observable';
 
@@ -75,13 +74,17 @@ export class KitchenSink {
   /** Data source for the CDK and Material table. */
   tableDataSource = new TableDataSource();
 
-  constructor(snackBar: MatSnackBar, dialog: MatDialog, overlay: Overlay) {
-    // Open a snack bar to do a basic sanity check of the overlays.
+  constructor(
+    snackBar: MatSnackBar,
+    dialog: MatDialog,
+    viewportRuler: ViewportRuler) {
     snackBar.open('Hello there');
+    dialog.open(TestDialog);
 
-    // TODO(crisbeto): use the noop scroll strategy until
-    // the fixes for the block scroll strategy get in.
-    dialog.open(TestDialog, {scrollStrategy: overlay.scrollStrategies.noop()});
+    // Do a sanity check on the viewport ruler.
+    viewportRuler.getViewportRect();
+    viewportRuler.getViewportSize();
+    viewportRuler.getViewportScrollPosition();
   }
 }
 


### PR DESCRIPTION
Fixes some errors being thrown by the `ViewportRuler` when attempting to measure the viewport or to get the scroll position while rendering on the server.

Relates to #9066.