### PR TITLE
refactor: clean out variables that are being assigned to but not being read

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -76,12 +76,10 @@ describe('FocusTrap', () => {
 
   describe('with bindings', () => {
     let fixture: ComponentFixture<FocusTrapWithBindings>;
-    let focusTrapInstance: FocusTrap;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(FocusTrapWithBindings);
       fixture.detectChanges();
-      focusTrapInstance = fixture.componentInstance.focusTrapDirective.focusTrap;
     });
 
     it('should clean up its anchor sibling elements on destroy', () => {

--- a/src/cdk/layout/media-matcher.spec.ts
+++ b/src/cdk/layout/media-matcher.spec.ts
@@ -5,13 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {LayoutModule, BreakpointObserver} from './index';
+import {LayoutModule} from './index';
 import {MediaMatcher} from './media-matcher';
 import {async, TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 
 describe('MediaMatcher', () => {
-  let breakpointManager: BreakpointObserver;
   let mediaMatcher: MediaMatcher;
 
   beforeEach(async(() => {
@@ -20,12 +19,9 @@ describe('MediaMatcher', () => {
     });
   }));
 
-  beforeEach(inject(
-    [BreakpointObserver, MediaMatcher],
-    (bm: BreakpointObserver, mm: MediaMatcher) => {
-      breakpointManager = bm;
-      mediaMatcher = mm;
-    }));
+  beforeEach(inject([MediaMatcher], (mm: MediaMatcher) => {
+    mediaMatcher = mm;
+  }));
 
   it('correctly returns a MediaQueryList to check for matches', () => {
     expect(mediaMatcher.matchMedia('(min-width: 1px)').matches).toBeTruthy();

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -35,9 +35,6 @@ import {OverlayRef} from '../overlay-ref';
  * of the overlay.
  */
 export class ConnectedPositionStrategy implements PositionStrategy {
-  /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayRef;
-
   /** Layout direction of the position strategy. */
   private _dir = 'ltr';
 
@@ -100,7 +97,6 @@ export class ConnectedPositionStrategy implements PositionStrategy {
 
   /** Attach this position strategy to an overlay. */
   attach(overlayRef: OverlayRef): void {
-    this._overlayRef = overlayRef;
     this._pane = overlayRef.overlayElement;
     this._resizeSubscription.unsubscribe();
     this._resizeSubscription = this._viewportRuler.change().subscribe(() => this.apply());

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -139,9 +139,6 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
   /** Subject that emits when the component has been destroyed. */
   private _onDestroy = new Subject<void>();
 
-  /** Latest data provided by the data source through the connect interface. */
-  private _data = new Array<T>();
-
   /** Differ used to find the changes in the data provided by the data source. */
   private _dataDiffer: IterableDiffer<T>;
 
@@ -231,8 +228,6 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
    * clearing the node outlet. Otherwise start listening for new data.
    */
   private _switchDataSource(dataSource: DataSource<T> | Observable<T[]> | T[]) {
-    this._data = new Array<T>();
-
     if (this._dataSource && typeof (this._dataSource as DataSource<T>).disconnect === 'function') {
       (this.dataSource as DataSource<T>).disconnect(this);
     }
@@ -269,10 +264,7 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
 
     if (dataStream) {
       this._dataSubscription = dataStream.pipe(takeUntil(this._onDestroy))
-        .subscribe(data => {
-          this._data = data;
-          this._renderNodeChanges(data);
-        });
+        .subscribe(data => this._renderNodeChanges(data));
     } else {
       throw getTreeNoValidDataSourceError();
     }

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1468,6 +1468,7 @@ describe('MatAutocomplete', () => {
       zone.simulateZoneExit();
 
       expect(spy).toHaveBeenCalledWith(jasmine.any(MatOptionSelectionChange));
+      subscription!.unsubscribe();
     }));
 
   });

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -81,9 +81,7 @@ describe('MatButtonToggle with forms', () => {
   describe('button toggle group with ngModel and change event', () => {
     let fixture: ComponentFixture<ButtonToggleGroupWithNgModel>;
     let groupDebugElement: DebugElement;
-    let groupNativeElement: HTMLElement;
     let buttonToggleDebugElements: DebugElement[];
-    let buttonToggleNativeElements: HTMLElement[];
     let groupInstance: MatButtonToggleGroup;
     let buttonToggleInstances: MatButtonToggle[];
     let testComponent: ButtonToggleGroupWithNgModel;
@@ -96,13 +94,10 @@ describe('MatButtonToggle with forms', () => {
       testComponent = fixture.debugElement.componentInstance;
 
       groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
-      groupNativeElement = groupDebugElement.nativeElement;
       groupInstance = groupDebugElement.injector.get<MatButtonToggleGroup>(MatButtonToggleGroup);
       groupNgModel = groupDebugElement.injector.get<NgModel>(NgModel);
 
       buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
-      buttonToggleNativeElements =
-        buttonToggleDebugElements.map(debugEl => debugEl.nativeElement);
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
       buttonToggleLabels = buttonToggleDebugElements.map(
         debugEl => debugEl.query(By.css('label')).nativeElement);
@@ -545,13 +540,10 @@ describe('MatButtonToggle without forms', () => {
     let buttonToggleNativeElement: HTMLElement;
     let buttonToggleLabelElement: HTMLLabelElement;
     let buttonToggleInstance: MatButtonToggle;
-    let testComponent: StandaloneButtonToggle;
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(StandaloneButtonToggle);
       fixture.detectChanges();
-
-      testComponent = fixture.debugElement.componentInstance;
 
       buttonToggleDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
       buttonToggleNativeElement = buttonToggleDebugElement.nativeElement;

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -748,7 +748,6 @@ describe('MatCheckbox', () => {
     let checkboxNativeElement: HTMLElement;
     let testComponent: CheckboxWithTabIndex;
     let inputElement: HTMLInputElement;
-    let labelElement: HTMLLabelElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(CheckboxWithTabIndex);
@@ -758,7 +757,6 @@ describe('MatCheckbox', () => {
       checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
-      labelElement = <HTMLLabelElement>checkboxNativeElement.querySelector('label');
     });
 
     it('should preserve any given tabIndex', () => {
@@ -940,7 +938,6 @@ describe('MatCheckbox', () => {
 
   describe('without label', () => {
     let testComponent: CheckboxWithoutLabel;
-    let checkboxElement: HTMLElement;
     let checkboxInnerContainer: HTMLElement;
 
     beforeEach(() => {
@@ -949,7 +946,6 @@ describe('MatCheckbox', () => {
       const checkboxDebugEl = fixture.debugElement.query(By.directive(MatCheckbox));
 
       testComponent = fixture.componentInstance;
-      checkboxElement = checkboxDebugEl.nativeElement;
       checkboxInnerContainer = checkboxDebugEl
         .query(By.css('.mat-checkbox-inner-container')).nativeElement;
     });

--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -455,7 +455,6 @@ describe('MatChipList', () => {
   });
 
   describe('forms integration', () => {
-    let formField: HTMLElement;
     let nativeChips: HTMLElement[];
 
     describe('single selection', () => {
@@ -463,7 +462,6 @@ describe('MatChipList', () => {
         fixture = TestBed.createComponent(BasicChipList);
         fixture.detectChanges();
 
-        formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
         nativeChips = fixture.debugElement.queryAll(By.css('mat-chip'))
           .map((chip) => chip.nativeElement);
         chips = fixture.componentInstance.chips;
@@ -627,7 +625,6 @@ describe('MatChipList', () => {
         fixture = TestBed.createComponent(MultiSelectionChipList);
         fixture.detectChanges();
 
-        formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
         nativeChips = fixture.debugElement.queryAll(By.css('mat-chip'))
           .map((chip) => chip.nativeElement);
         chips = fixture.componentInstance.chips;
@@ -705,14 +702,12 @@ describe('MatChipList', () => {
   });
 
   describe('chip list with chip input', () => {
-    let formField: HTMLElement;
     let nativeChips: HTMLElement[];
 
     beforeEach(() => {
       fixture = TestBed.createComponent(InputChipList);
       fixture.detectChanges();
 
-      formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
       nativeChips = fixture.debugElement.queryAll(By.css('mat-chip'))
         .map((chip) => chip.nativeElement);
     });

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -389,6 +389,11 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     if (this._changeSubscription) {
       this._changeSubscription.unsubscribe();
     }
+
+    if (this._chipRemoveSubscription) {
+      this._chipRemoveSubscription.unsubscribe();
+    }
+
     this._dropSubscriptions();
     this.stateChanges.complete();
   }

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -4,13 +4,12 @@ import {createKeyboardEvent} from '@angular/cdk/testing';
 import {Component, DebugElement} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {MatChip, MatChipEvent, MatChipList, MatChipSelectionChange, MatChipsModule} from './index';
+import {MatChip, MatChipEvent, MatChipSelectionChange, MatChipsModule} from './index';
 
 
 describe('Chips', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
-  let chipListNativeElement: HTMLElement;
   let chipNativeElement: HTMLElement;
   let chipInstance: MatChip;
 
@@ -59,7 +58,6 @@ describe('Chips', () => {
       fixture.detectChanges();
 
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
-      chipListNativeElement = fixture.debugElement.query(By.directive(MatChipList)).nativeElement;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get(MatChip);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -543,14 +543,12 @@ describe('MatRipple', () => {
 
   describe('configuring behavior', () => {
     let controller: RippleContainerWithInputBindings;
-    let rippleComponent: MatRipple;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(RippleContainerWithInputBindings);
       fixture.detectChanges();
 
       controller = fixture.debugElement.componentInstance;
-      rippleComponent = controller.ripple;
       rippleTarget = fixture.debugElement.nativeElement.querySelector('[mat-ripple]');
     });
 

--- a/src/lib/datepicker/month-view.spec.ts
+++ b/src/lib/datepicker/month-view.spec.ts
@@ -262,7 +262,6 @@ describe('MatMonthView', () => {
 
   describe('month view with date filter', () => {
     let fixture: ComponentFixture<MonthViewWithDateFilter>;
-    let testComponent: MonthViewWithDateFilter;
     let monthViewNativeElement: Element;
 
     beforeEach(() => {
@@ -271,7 +270,6 @@ describe('MatMonthView', () => {
 
       let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView));
       monthViewNativeElement = monthViewDebugElement.nativeElement;
-      testComponent = fixture.componentInstance;
     });
 
     it('should disable filtered dates', () => {

--- a/src/lib/datepicker/multi-year-view.spec.ts
+++ b/src/lib/datepicker/multi-year-view.spec.ts
@@ -225,7 +225,6 @@ describe('MatMultiYearView', () => {
 
   describe('multi year view with date filter', () => {
     let fixture: ComponentFixture<MultiYearViewWithDateFilter>;
-    let testComponent: MultiYearViewWithDateFilter;
     let multiYearViewNativeElement: Element;
 
     beforeEach(() => {
@@ -234,7 +233,6 @@ describe('MatMultiYearView', () => {
 
       const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
-      testComponent = fixture.componentInstance;
     });
 
     it('should disablex years with no enabled days', () => {

--- a/src/lib/datepicker/year-view.spec.ts
+++ b/src/lib/datepicker/year-view.spec.ts
@@ -293,7 +293,6 @@ describe('MatYearView', () => {
 
   describe('year view with date filter', () => {
     let fixture: ComponentFixture<YearViewWithDateFilter>;
-    let testComponent: YearViewWithDateFilter;
     let yearViewNativeElement: Element;
 
     beforeEach(() => {
@@ -302,7 +301,6 @@ describe('MatYearView', () => {
 
       const yearViewDebugElement = fixture.debugElement.query(By.directive(MatYearView));
       yearViewNativeElement = yearViewDebugElement.nativeElement;
-      testComponent = fixture.componentInstance;
     });
 
     it('should disable months with no enabled days', () => {

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -109,7 +109,6 @@ export class MatListSubheaderCssMatStyler {}
 })
 export class MatListItem extends _MatListItemMixinBase implements AfterContentInit,
     CanDisableRipple {
-  private _lineSetter: MatLineSetter;
   private _isNavList: boolean = false;
 
   @ContentChildren(MatLine) _lines: QueryList<MatLine>;
@@ -130,7 +129,9 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
   }
 
   ngAfterContentInit() {
-    this._lineSetter = new MatLineSetter(this._lines, this._element);
+    // TODO: consider turning the setter into a function, it doesn't do anything as a class.
+    // tslint:disable-next-line:no-unused-expression
+    new MatLineSetter(this._lines, this._element);
   }
 
   /** Whether this list item should show a ripple effect when clicked. */

--- a/src/lib/list/selection-list.spec.ts
+++ b/src/lib/list/selection-list.spec.ts
@@ -1,5 +1,4 @@
 import {DOWN_ARROW, SPACE, ENTER, UP_ARROW, HOME, END} from '@angular/cdk/keycodes';
-import {Platform} from '@angular/cdk/platform';
 import {
   createKeyboardEvent,
   dispatchFakeEvent,
@@ -7,7 +6,7 @@ import {
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing';
 import {Component, DebugElement} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
   MatListModule,
@@ -22,7 +21,6 @@ describe('MatSelectionList without forms', () => {
   describe('with list option', () => {
     let fixture: ComponentFixture<SelectionListWithListOptions>;
     let listOptions: DebugElement[];
-    let listItemEl: DebugElement;
     let selectionList: DebugElement;
 
     beforeEach(async(() => {
@@ -45,7 +43,6 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
-      listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
     }));
 
@@ -436,8 +433,6 @@ describe('MatSelectionList without forms', () => {
     let fixture: ComponentFixture<SelectionListWithOnlyOneOption>;
     let listOption: DebugElement;
     let listItemEl: DebugElement;
-    let selectionList: DebugElement;
-    let platform: Platform;
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -457,12 +452,7 @@ describe('MatSelectionList without forms', () => {
       fixture = TestBed.createComponent(SelectionListWithOnlyOneOption);
       listOption = fixture.debugElement.query(By.directive(MatListOption));
       listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
       fixture.detectChanges();
-    }));
-
-    beforeEach(inject([Platform], (p: Platform) => {
-      platform = p;
     }));
 
     it('should be focused when focus on nativeElements', () => {
@@ -527,7 +517,6 @@ describe('MatSelectionList without forms', () => {
   describe('with list disabled', () => {
     let fixture: ComponentFixture<SelectionListWithListDisabled>;
     let listOption: DebugElement[];
-    let listItemEl: DebugElement;
     let selectionList: DebugElement;
 
     beforeEach(async(() => {
@@ -547,7 +536,6 @@ describe('MatSelectionList without forms', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SelectionListWithListDisabled);
       listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
-      listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
       fixture.detectChanges();
     }));
@@ -568,9 +556,6 @@ describe('MatSelectionList without forms', () => {
 
   describe('with checkbox position after', () => {
     let fixture: ComponentFixture<SelectionListWithCheckboxPositionAfter>;
-    let listOption: DebugElement[];
-    let listItemEl: DebugElement;
-    let selectionList: DebugElement;
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -588,9 +573,6 @@ describe('MatSelectionList without forms', () => {
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SelectionListWithCheckboxPositionAfter);
-      listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
-      listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
       fixture.detectChanges();
     }));
 
@@ -620,7 +602,6 @@ describe('MatSelectionList with forms', () => {
   describe('and ngModel', () => {
     let fixture: ComponentFixture<SelectionListWithModel>;
     let selectionListDebug: DebugElement;
-    let selectionList: MatSelectionList;
     let listOptions: MatListOption[];
     let ngModel: NgModel;
 
@@ -629,7 +610,6 @@ describe('MatSelectionList with forms', () => {
       fixture.detectChanges();
 
       selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList));
-      selectionList = selectionListDebug.componentInstance;
       ngModel = selectionListDebug.injector.get<NgModel>(NgModel);
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
         .map(optionDebugEl => optionDebugEl.componentInstance);
@@ -730,7 +710,7 @@ describe('MatSelectionList with forms', () => {
     it('should update the model if an option got selected via the model', fakeAsync(() => {
       expect(fixture.componentInstance.selectedOptions).toEqual([]);
 
-      selectionList.selectedOptions.select(listOptions[0]);
+      selectionListDebug.componentInstance.selectedOptions.select(listOptions[0]);
       fixture.detectChanges();
       tick();
 
@@ -741,16 +721,12 @@ describe('MatSelectionList with forms', () => {
 
   describe('and formControl', () => {
     let fixture: ComponentFixture<SelectionListWithFormControl>;
-    let selectionListDebug: DebugElement;
-    let selectionList: MatSelectionList;
     let listOptions: MatListOption[];
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SelectionListWithFormControl);
       fixture.detectChanges();
 
-      selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList));
-      selectionList = selectionListDebug.componentInstance;
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
         .map(optionDebugEl => optionDebugEl.componentInstance);
     });
@@ -786,8 +762,6 @@ describe('MatSelectionList with forms', () => {
     it('should mark options as selected when the value is set before they are initialized', () => {
       fixture.destroy();
       fixture = TestBed.createComponent(SelectionListWithFormControl);
-      selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList));
-      selectionList = selectionListDebug.componentInstance;
 
       fixture.componentInstance.formControl.setValue(['opt2', 'opt3']);
       fixture.detectChanges();

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -111,7 +111,6 @@ export class MatSelectionListChange {
 export class MatListOption extends _MatListOptionMixinBase
     implements AfterContentInit, OnDestroy, OnInit, FocusableOption, CanDisableRipple {
 
-  private _lineSetter: MatLineSetter;
   private _selected = false;
   private _disabled = false;
 
@@ -180,7 +179,9 @@ export class MatListOption extends _MatListOptionMixinBase
   }
 
   ngAfterContentInit() {
-    this._lineSetter = new MatLineSetter(this._lines, this._element);
+    // TODO: consider turning the setter into a function, it doesn't do anything as a class.
+    // tslint:disable-next-line:no-unused-expression
+    new MatLineSetter(this._lines, this._element);
   }
 
   ngOnDestroy(): void {

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -28,7 +28,6 @@ describe('MatRadio', () => {
   describe('inside of a group', () => {
     let fixture: ComponentFixture<RadiosInsideRadioGroup>;
     let groupDebugElement: DebugElement;
-    let groupNativeElement: HTMLElement;
     let radioDebugElements: DebugElement[];
     let radioNativeElements: HTMLElement[];
     let radioLabelElements: HTMLLabelElement[];
@@ -44,7 +43,6 @@ describe('MatRadio', () => {
       testComponent = fixture.debugElement.componentInstance;
 
       groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
-      groupNativeElement = groupDebugElement.nativeElement;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
 
       radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
@@ -379,7 +377,6 @@ describe('MatRadio', () => {
   describe('group with ngModel', () => {
     let fixture: ComponentFixture<RadioGroupWithNgModel>;
     let groupDebugElement: DebugElement;
-    let groupNativeElement: HTMLElement;
     let radioDebugElements: DebugElement[];
     let innerRadios: DebugElement[];
     let radioLabelElements: HTMLLabelElement[];
@@ -395,7 +392,6 @@ describe('MatRadio', () => {
       testComponent = fixture.debugElement.componentInstance;
 
       groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
-      groupNativeElement = groupDebugElement.nativeElement;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
       groupNgModel = groupDebugElement.injector.get<NgModel>(NgModel);
 

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2711,15 +2711,11 @@ describe('MatSelect', () => {
 
     let fixture: ComponentFixture<SelectWithoutOptionCentering>;
     let trigger: HTMLElement;
-    let select: HTMLElement;
-    let formField: HTMLElement;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(SelectWithoutOptionCentering);
       fixture.detectChanges();
       trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-      select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
-      formField = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
     }));
 
     it('should not align the active option with the trigger if centering is disabled',
@@ -2752,14 +2748,12 @@ describe('MatSelect', () => {
 
     let fixture: ComponentFixture<BasicSelect>;
     let trigger: HTMLElement;
-    let select: HTMLElement;
     let formField: HTMLElement;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(BasicSelect);
       fixture.detectChanges();
       trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-      select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
       formField = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
     }));
 
@@ -2898,7 +2892,6 @@ describe('MatSelect', () => {
         let groupFixture = TestBed.createComponent(SelectWithGroups);
         groupFixture.detectChanges();
         trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-        select = groupFixture.debugElement.query(By.css('mat-select')).nativeElement;
         formField = groupFixture.debugElement.query(By.css('mat-form-field')).nativeElement;
 
         formField.style.position = 'fixed';
@@ -3411,7 +3404,6 @@ describe('MatSelect', () => {
         multiFixture.detectChanges();
         formField = multiFixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
         trigger = multiFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-        select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
 
         formField.style.position = 'fixed';
         formField.style.left = '60px';
@@ -3457,7 +3449,6 @@ describe('MatSelect', () => {
         groupFixture.detectChanges();
         formField = groupFixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
         trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-        select = groupFixture.debugElement.query(By.css('mat-select')).nativeElement;
 
         formField.style.position = 'fixed';
         formField.style.left = '60px';

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -60,7 +60,6 @@ describe('MatSlider without forms', () => {
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
     let trackFillElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(StandardSlider);
@@ -71,7 +70,6 @@ describe('MatSlider without forms', () => {
       sliderInstance = sliderDebugElement.componentInstance;
 
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should set the default values', () => {
@@ -214,7 +212,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<StandardSlider>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let sliderInstance: MatSlider;
     let trackFillElement: HTMLElement;
 
@@ -224,7 +221,6 @@ describe('MatSlider without forms', () => {
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       sliderInstance = sliderDebugElement.componentInstance;
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
@@ -290,7 +286,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let trackFillElement: HTMLElement;
     let ticksContainerElement: HTMLElement;
     let ticksElement: HTMLElement;
@@ -304,7 +299,6 @@ describe('MatSlider without forms', () => {
       testComponent = fixture.debugElement.componentInstance;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
       ticksContainerElement =
           <HTMLElement>sliderNativeElement.querySelector('.mat-slider-ticks-container');
@@ -390,7 +384,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SliderWithValue);
@@ -399,7 +392,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should set the default value from the attribute', () => {
@@ -428,7 +420,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
@@ -438,7 +429,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
 
@@ -575,7 +565,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let thumbLabelTextElement: Element;
 
     beforeEach(() => {
@@ -585,7 +574,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       thumbLabelTextElement = sliderNativeElement.querySelector('.mat-slider-thumb-label-text')!;
     });
 
@@ -619,7 +607,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithOneWayBinding;
     let trackFillElement: HTMLElement;
 
@@ -632,7 +619,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
 
@@ -655,7 +641,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
@@ -665,7 +650,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
 
@@ -685,7 +669,6 @@ describe('MatSlider without forms', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
@@ -695,7 +678,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
 
@@ -714,7 +696,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<SliderWithChangeHandler>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithChangeHandler;
 
     beforeEach(() => {
@@ -727,7 +708,6 @@ describe('MatSlider without forms', () => {
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should emit change on click', () => {
@@ -787,7 +767,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<SliderWithChangeHandler>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithChangeHandler;
 
     beforeEach(() => {
@@ -800,7 +779,6 @@ describe('MatSlider without forms', () => {
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should emit an input event while sliding', () => {
@@ -836,7 +814,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<SliderWithChangeHandler>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithChangeHandler;
     let sliderInstance: MatSlider;
 
@@ -850,7 +827,6 @@ describe('MatSlider without forms', () => {
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
     });
 
@@ -977,7 +953,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<SliderWithDirAndInvert>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let sliderInstance: MatSlider;
     let testComponent: SliderWithDirAndInvert;
 
@@ -989,7 +964,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('works in inverted mode', () => {
@@ -1119,7 +1093,6 @@ describe('MatSlider without forms', () => {
     let fixture: ComponentFixture<VerticalSlider>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderWrapperElement: HTMLElement;
     let trackFillElement: HTMLElement;
     let sliderInstance: MatSlider;
     let testComponent: VerticalSlider;
@@ -1132,7 +1105,6 @@ describe('MatSlider without forms', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
     });
 
@@ -1232,8 +1204,6 @@ describe('MatSlider with forms module', () => {
     let fixture: ComponentFixture<SliderWithNgModel>;
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
-    let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithNgModel;
 
     beforeEach(() => {
@@ -1244,8 +1214,6 @@ describe('MatSlider with forms module', () => {
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
-      sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should update the model on click', () => {
@@ -1298,7 +1266,6 @@ describe('MatSlider with forms module', () => {
     let sliderDebugElement: DebugElement;
     let sliderNativeElement: HTMLElement;
     let sliderInstance: MatSlider;
-    let sliderWrapperElement: HTMLElement;
     let testComponent: SliderWithFormControl;
 
     beforeEach(() => {
@@ -1310,7 +1277,6 @@ describe('MatSlider with forms module', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
-      sliderWrapperElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-wrapper');
     });
 
     it('should not update the control when the value is updated', () => {

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -511,7 +511,6 @@ describe('MatSnackBar Positioning', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerEl: HTMLElement;
 
-  let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
 
   let simpleMessage = 'Burritos are here!';
@@ -539,7 +538,6 @@ describe('MatSnackBar Positioning', () => {
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
     viewContainerFixture.detectChanges();
-    testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   });
 
   it('should default to bottom center', fakeAsync(() => {

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -631,14 +631,12 @@ describe('MatTooltip', () => {
   describe('scrollable usage', () => {
     let fixture: ComponentFixture<ScrollableTooltipDemo>;
     let buttonDebugElement: DebugElement;
-    let buttonElement: HTMLButtonElement;
     let tooltipDirective: MatTooltip;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(ScrollableTooltipDemo);
       fixture.detectChanges();
       buttonDebugElement = fixture.debugElement.query(By.css('button'));
-      buttonElement = <HTMLButtonElement> buttonDebugElement.nativeElement;
       tooltipDirective = buttonDebugElement.injector.get<MatTooltip>(MatTooltip);
     });
 

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -24,7 +24,6 @@ describe('MatTree', () => {
   const _ = {};
 
   let treeElement: HTMLElement;
-  let tree: MatTree<TestData>;
   let underlyingDataSource: FakeDataSource;
 
   function configureMatTreeTestingModule(declarations) {
@@ -35,8 +34,6 @@ describe('MatTree', () => {
   }
 
   describe('flat tree', () => {
-    let dataSource: MatTreeFlatDataSource<TestData, TestData>;
-
     describe('should initialize', () => {
       let fixture: ComponentFixture<SimpleMatTreeApp>;
       let component: SimpleMatTreeApp;
@@ -48,8 +45,6 @@ describe('MatTree', () => {
 
         component = fixture.componentInstance;
         underlyingDataSource = component.underlyingDataSource;
-        tree = component.tree;
-        dataSource = component.dataSource;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
         fixture.detectChanges();
@@ -99,7 +94,6 @@ describe('MatTree', () => {
         fixture = TestBed.createComponent(MatTreeAppWithToggle);
 
         component = fixture.componentInstance;
-        tree = component.tree;
         underlyingDataSource = component.underlyingDataSource;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
@@ -208,7 +202,6 @@ describe('MatTree', () => {
 
         component = fixture.componentInstance;
         underlyingDataSource = component.underlyingDataSource;
-        tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
         fixture.detectChanges();
@@ -235,7 +228,6 @@ describe('MatTree', () => {
 
         component = fixture.componentInstance;
         underlyingDataSource = component.underlyingDataSource;
-        tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
         fixture.detectChanges();
@@ -318,7 +310,6 @@ describe('MatTree', () => {
 
         component = fixture.componentInstance;
         underlyingDataSource = component.underlyingDataSource;
-        tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
         fixture.detectChanges();
@@ -343,7 +334,6 @@ describe('MatTree', () => {
 
         component = fixture.componentInstance;
         underlyingDataSource = component.underlyingDataSource;
-        tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('mat-tree');
 
         fixture.detectChanges();

--- a/tools/package-tools/build-package.ts
+++ b/tools/package-tools/build-package.ts
@@ -33,12 +33,6 @@ export class BuildPackage {
   /** Path to the entry file of the package in the output directory. */
   readonly entryFilePath: string;
 
-  /** Path to the tsconfig file, which will be used to build the package. */
-  private readonly tsconfigBuild: string;
-
-  /** Path to the tsconfig file, which will be used to build the tests. */
-  private readonly tsconfigTests: string;
-
   /** Package bundler instance. */
   private bundler = new PackageBundler(this);
 
@@ -60,10 +54,6 @@ export class BuildPackage {
     this.sourceDir = join(packagesDir, name);
     this.outputDir = join(outputDir, 'packages', name);
     this.esm5OutputDir = join(outputDir, 'packages', name, 'esm5');
-
-    this.tsconfigBuild = join(this.sourceDir, buildTsconfigName);
-    this.tsconfigTests = join(this.sourceDir, testsTsconfigName);
-
     this.entryFilePath = join(this.outputDir, 'index.js');
   }
 


### PR DESCRIPTION
Clears out private properties and local variables that are declared and assigned values, but aren't actually being read at any point. This will start being caught by tslint once we update to TS 2.6.