### PR TITLE
build: overlay container not being cleaned up in global overlay tests

### DIFF
--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -2,7 +2,7 @@ import {NgModule, NgZone, Component} from '@angular/core';
 import {TestBed, inject} from '@angular/core/testing';
 import {MockNgZone} from '@angular/cdk/testing';
 import {PortalModule, ComponentPortal} from '@angular/cdk/portal';
-import {OverlayModule, Overlay, OverlayConfig, OverlayRef} from '../index';
+import {OverlayModule, Overlay, OverlayConfig, OverlayRef, OverlayContainer} from '../index';
 
 
 describe('GlobalPositonStrategy', () => {
@@ -21,12 +21,14 @@ describe('GlobalPositonStrategy', () => {
     })();
   });
 
-  afterEach(() => {
+  afterEach(inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
     if (overlayRef) {
       overlayRef.dispose();
       overlayRef = null!;
     }
-  });
+
+    overlayContainer.ngOnDestroy();
+  }));
 
   function attachOverlay(config: OverlayConfig): OverlayRef {
     const portal = new ComponentPortal(BlankPortal);

--- a/src/material-examples/bottom-sheet-overview/bottom-sheet-overview-example.ts
+++ b/src/material-examples/bottom-sheet-overview/bottom-sheet-overview-example.ts
@@ -24,7 +24,7 @@ export class BottomSheetOverviewExample {
 export class BottomSheetOverviewExampleSheet {
   constructor(private bottomSheetRef: MatBottomSheetRef<BottomSheetOverviewExampleSheet>) {}
 
-  onNoClick(event: MouseEvent): void {
+  openLink(event: MouseEvent): void {
     this.bottomSheetRef.dismiss();
     event.preventDefault();
   }


### PR DESCRIPTION
* Fixes the `GlobalPositionStrategy` tests leaking `.cdk-overlay-container` instances which can cause flakes in other tests.
* Fixes a wrong method name in the bottom sheet overview.