### PR TITLE
feat(portal): allow custom ComponentFactoryResolver to be passed to CdkPortalOutlet

### DIFF
--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -131,9 +131,15 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
    * Attach the given ComponentPortal to this PortalOutlet using the ComponentFactoryResolver.
    *
    * @param portal Portal to be attached to the portal outlet.
+   * @param componentFactoryResolver Alternate `ComponentFactoryResolver` to use when attaching the
+   *    portal. Defaults to the resolver associated with the portal outlet instance.
    * @returns Reference to the created component.
    */
-  attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
+  attachComponentPortal<T>(
+    portal: ComponentPortal<T>,
+    componentFactoryResolver: ComponentFactoryResolver = this._componentFactoryResolver):
+    ComponentRef<T> {
+
     portal.setAttachedHost(this);
 
     // If the portal specifies an origin, use that as the logical location of the component
@@ -142,8 +148,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
         portal.viewContainerRef :
         this._viewContainerRef;
 
-    const componentFactory =
-        this._componentFactoryResolver.resolveComponentFactory(portal.component);
+    const componentFactory = componentFactoryResolver.resolveComponentFactory(portal.component);
     const ref = viewContainerRef.createComponent(
         componentFactory, viewContainerRef.length,
         portal.injector || viewContainerRef.parentInjector);

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -311,6 +311,21 @@ describe('Portals', () => {
       expect(instance.portalOutlet.hasAttached()).toBe(true);
     });
 
+    it('should be able to use a custom component factory resolver',
+      inject([ComponentFactoryResolver], (resolver: ComponentFactoryResolver) => {
+        const testAppComponent = fixture.componentInstance;
+        const spy = jasmine.createSpy('resolveComponentFactorySpy');
+
+        testAppComponent.portalOutlet.attachComponentPortal(new ComponentPortal(PizzaMsg), {
+          resolveComponentFactory: (...args: any[]) => {
+            spy();
+            return resolver.resolveComponentFactory.apply(resolver, args);
+          }
+        });
+
+        expect(spy).toHaveBeenCalled();
+      }));
+
   });
 
   describe('DomPortalOutlet', () => {


### PR DESCRIPTION
Adds the ability for consumers to pass in a different `ComponentFactoryResolver` when attaching to a `CdkPortalOutlet` programmatically.

Fixes #9712.