### PR TITLE
 fix(select):change calculateOverlayOffsetY to address offset for small lists

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -1114,38 +1114,45 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    */
   private _calculateOverlayOffsetY(selectedIndex: number, scrollBuffer: number,
                                   maxScroll: number): number {
-    const itemHeight = this._getItemHeight();
-    const optionHeightAdjustment = (itemHeight - this._triggerRect.height) / 2;
-    const maxOptionsDisplayed = Math.floor(SELECT_PANEL_MAX_HEIGHT / itemHeight);
-    let optionOffsetFromPanelTop: number;
+    // Only enable offset for larger lists
+	if (this._getItemCount() > 10) { 	  
+	  const itemHeight = this._getItemHeight();
+      const optionHeightAdjustment = (itemHeight - this._triggerRect.height) / 2;
+      const maxOptionsDisplayed = Math.floor(SELECT_PANEL_MAX_HEIGHT / itemHeight);
+      let optionOffsetFromPanelTop: number;
 
-    if (this._scrollTop === 0) {
-      optionOffsetFromPanelTop = selectedIndex * itemHeight;
-    } else if (this._scrollTop === maxScroll) {
-      const firstDisplayedIndex = this._getItemCount() - maxOptionsDisplayed;
-      const selectedDisplayIndex = selectedIndex - firstDisplayedIndex;
+      if (this._scrollTop === 0) {
+        optionOffsetFromPanelTop = selectedIndex * itemHeight;
+      } else if (this._scrollTop === maxScroll) {
+        const firstDisplayedIndex = this._getItemCount() - maxOptionsDisplayed;
+        const selectedDisplayIndex = selectedIndex - firstDisplayedIndex;
 
-      // The first item is partially out of the viewport. Therefore we need to calculate what
-      // portion of it is shown in the viewport and account for it in our offset.
-      let partialItemHeight =
-          itemHeight - (this._getItemCount() * itemHeight - SELECT_PANEL_MAX_HEIGHT) % itemHeight;
+        // The first item is partially out of the viewport. Therefore we need to calculate what
+        // portion of it is shown in the viewport and account for it in our offset.
+        let partialItemHeight =
+            itemHeight - (this._getItemCount() * itemHeight - SELECT_PANEL_MAX_HEIGHT) % itemHeight;
 
-      // Because the panel height is longer than the height of the options alone,
-      // there is always extra padding at the top or bottom of the panel. When
-      // scrolled to the very bottom, this padding is at the top of the panel and
-      // must be added to the offset.
-      optionOffsetFromPanelTop = selectedDisplayIndex * itemHeight + partialItemHeight;
-    } else {
-      // If the option was scrolled to the middle of the panel using a scroll buffer,
-      // its offset will be the scroll buffer minus the half height that was added to
-      // center it.
-      optionOffsetFromPanelTop = scrollBuffer - itemHeight / 2;
-    }
+        // Because the panel height is longer than the height of the options alone,
+        // there is always extra padding at the top or bottom of the panel. When
+        // scrolled to the very bottom, this padding is at the top of the panel and
+        // must be added to the offset.
+        optionOffsetFromPanelTop = selectedDisplayIndex * itemHeight + partialItemHeight;
+      } else {
+        // If the option was scrolled to the middle of the panel using a scroll buffer,
+        // its offset will be the scroll buffer minus the half height that was added to
+        // center it.
+        optionOffsetFromPanelTop = scrollBuffer - itemHeight / 2;
+      }
 
-    // The final offset is the option's offset from the top, adjusted for the height
-    // difference, multiplied by -1 to ensure that the overlay moves in the correct
-    // direction up the page.
-    return optionOffsetFromPanelTop * -1 - optionHeightAdjustment;
+      // The final offset is the option's offset from the top, adjusted for the height
+      // difference, multiplied by -1 to ensure that the overlay moves in the correct
+      // direction up the page.
+	
+	  return optionOffsetFromPanelTop * -1 - optionHeightAdjustment;
+	} else {  
+	  // disable offset for smaller lists
+	  return 0;
+	}
   }
 
   /**

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -1114,45 +1114,43 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    */
   private _calculateOverlayOffsetY(selectedIndex: number, scrollBuffer: number,
                                   maxScroll: number): number {
-    // Only enable offset for larger lists
-	if (this._getItemCount() > 10) { 	  
-	  const itemHeight = this._getItemHeight();
-      const optionHeightAdjustment = (itemHeight - this._triggerRect.height) / 2;
-      const maxOptionsDisplayed = Math.floor(SELECT_PANEL_MAX_HEIGHT / itemHeight);
-      let optionOffsetFromPanelTop: number;
+    const itemHeight = this._getItemHeight();
+    const optionHeightAdjustment = (itemHeight - this._triggerRect.height) / 2;
+    const maxOptionsDisplayed = Math.floor(SELECT_PANEL_MAX_HEIGHT / itemHeight);
+    let optionOffsetFromPanelTop: number;
 
-      if (this._scrollTop === 0) {
-        optionOffsetFromPanelTop = selectedIndex * itemHeight;
-      } else if (this._scrollTop === maxScroll) {
-        const firstDisplayedIndex = this._getItemCount() - maxOptionsDisplayed;
-        const selectedDisplayIndex = selectedIndex - firstDisplayedIndex;
+    // Disable offset for smaller lists by returning 0 as value to offset
+    if (this._getItemCount() <= maxOptionsDisplayed) {
+      return 0;
+    }
 
-        // The first item is partially out of the viewport. Therefore we need to calculate what
-        // portion of it is shown in the viewport and account for it in our offset.
-        let partialItemHeight =
-            itemHeight - (this._getItemCount() * itemHeight - SELECT_PANEL_MAX_HEIGHT) % itemHeight;
+    if (this._scrollTop === 0) {
+      optionOffsetFromPanelTop = selectedIndex * itemHeight;
+    } else if (this._scrollTop === maxScroll) {
+      const firstDisplayedIndex = this._getItemCount() - maxOptionsDisplayed;
+      const selectedDisplayIndex = selectedIndex - firstDisplayedIndex;
 
-        // Because the panel height is longer than the height of the options alone,
-        // there is always extra padding at the top or bottom of the panel. When
-        // scrolled to the very bottom, this padding is at the top of the panel and
-        // must be added to the offset.
-        optionOffsetFromPanelTop = selectedDisplayIndex * itemHeight + partialItemHeight;
-      } else {
-        // If the option was scrolled to the middle of the panel using a scroll buffer,
-        // its offset will be the scroll buffer minus the half height that was added to
-        // center it.
-        optionOffsetFromPanelTop = scrollBuffer - itemHeight / 2;
-      }
+      // The first item is partially out of the viewport. Therefore we need to calculate what
+      // portion of it is shown in the viewport and account for it in our offset.
+      let partialItemHeight =
+          itemHeight - (this._getItemCount() * itemHeight - SELECT_PANEL_MAX_HEIGHT) % itemHeight;
 
-      // The final offset is the option's offset from the top, adjusted for the height
-      // difference, multiplied by -1 to ensure that the overlay moves in the correct
-      // direction up the page.
-	
-	  return optionOffsetFromPanelTop * -1 - optionHeightAdjustment;
-	} else {  
-	  // disable offset for smaller lists
-	  return 0;
-	}
+      // Because the panel height is longer than the height of the options alone,
+      // there is always extra padding at the top or bottom of the panel. When
+      // scrolled to the very bottom, this padding is at the top of the panel and
+      // must be added to the offset.
+      optionOffsetFromPanelTop = selectedDisplayIndex * itemHeight + partialItemHeight;
+    } else {
+      // If the option was scrolled to the middle of the panel using a scroll buffer,
+      // its offset will be the scroll buffer minus the half height that was added to
+      // center it.
+      optionOffsetFromPanelTop = scrollBuffer - itemHeight / 2;
+    }
+
+    // The final offset is the option's offset from the top, adjusted for the height
+    // difference, multiplied by -1 to ensure that the overlay moves in the correct
+    // direction up the page.
+    return optionOffsetFromPanelTop * -1 - optionHeightAdjustment;
   }
 
   /**


### PR DESCRIPTION

Fixes #9751 

Adds to the `_calculateOverlayOffsetY` function of `select.ts` to disable the offset for smaller lists when an option is already selected.
Current implementation determines a list is small if the number of items it contains is less than its maximum number of items it can display. Criteria can be changed if needed.

"Large" list with offset:
![select list large list offset](https://user-images.githubusercontent.com/16708173/36071207-9fb2c576-0ed8-11e8-8d77-99d48275d8d3.JPG)

"Small" list without offset:
![select list small list no offset](https://user-images.githubusercontent.com/16708173/36071209-b21548b0-0ed8-11e8-8ec5-b39675e7a528.JPG)