### PR TITLE
build: fix runtime errors not being logged out on karma initialization

### DIFF
--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -117,9 +117,15 @@ System.config({
 });
 
 // Configure the Angular test bed and run all specs once configured.
- configureTestBed()
+configureTestBed()
   .then(runMaterialSpecs)
-  .then(__karma__.start, __karma__.error);
+  .then(__karma__.start, function(error) {
+    // Passing in the error object directly to Karma won't log out the stack trace and
+    // passing the `originalErr` doesn't work correctly either. We have to log out the
+    // stack trace so we can actually debug errors before the tests have started.
+    console.error(error.originalErr.stack);
+    __karma__.error(error);
+  });
 
 
 /** Runs the Angular Material specs in Karma. */


### PR DESCRIPTION
Currently if something throws an error right after Karma has initialized, the log will look something like the following:

```
HeadlessChrome 0.0.0 (Windows 10 0.0.0) ERROR
  {
    "originalErr": {},
    "__zone_symbol__currentTask": {
      "type": "microTask",
      "state": "notScheduled",
      "source": "Promise.then",
      "zone": "<root>",
      "cancelFn": null,
      "runCount": 0
    }
  }
```

These changes log out the stack trace explicitly so we have some more info to work with if it happens.