### PR TITLE
chore: typo in dgeni processor

### DIFF
--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -1,13 +1,13 @@
-/**
- * We want to avoid emitting selectors that are deprecated but don't have a way to mark
- * them as such in the source code. Thus, we maintain a separate blacklist of selectors
- * that should not be emitted in the documentation.
- */
 import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
 import {MemberDoc} from 'dgeni-packages/typescript/api-doc-types/MemberDoc';
 import {CategorizedClassDoc, DeprecationDoc, HasDecoratorsDoc} from './dgeni-definitions';
 
+/**
+ * We want to avoid emitting selectors that are deprecated but don't have a way to mark
+ * them as such in the source code. Thus, we maintain a separate blacklist of selectors
+ * that should not be emitted in the documentation.
+ */
 const SELECTOR_BLACKLIST = new Set([
   '[portal]',
   '[portalHost]',

--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -13,10 +13,10 @@ export class MergeInheritedProperties implements Processor {
   $process(docs: DocCollection) {
     return docs
       .filter(doc => doc.docType === 'class')
-      .forEach(doc => this.addInhertiedProperties(doc));
+      .forEach(doc => this.addInheritedProperties(doc));
   }
 
-  private addInhertiedProperties(doc: ClassExportDoc) {
+  private addInheritedProperties(doc: ClassExportDoc) {
     doc.implementsClauses.filter(clause => clause.doc).forEach(clause => {
       clause.doc!.members.forEach(member => this.addMemberDocIfNotPresent(doc, member));
     });


### PR DESCRIPTION
* Fixes a minor typo in the `MergeInheritedProperties` processor.
* Fixes an incorrectly placed comment inside of `decorators.ts`.
* Cleans up the `dgeni/index.ts` file