### PR TITLE
fix: list options require a parent selection list

### DIFF
--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -24,7 +24,6 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   QueryList,
   ViewChild,
@@ -164,8 +163,8 @@ export class MatListOption extends _MatListOptionMixinBase
 
   constructor(private _element: ElementRef,
               private _changeDetector: ChangeDetectorRef,
-              /** @docs-private */ @Optional() @Inject(forwardRef(() => MatSelectionList))
-              public selectionList: MatSelectionList) {
+              /** @docs-private */
+              @Inject(forwardRef(() => MatSelectionList)) public selectionList: MatSelectionList) {
     super();
   }
 


### PR DESCRIPTION
* Since the `MatListOption` component requires a parent `MatSelectionList`, the DI of the selection list shouldn't be optional. Otherwise there will be runtime exceptions due to an undefined selection list property.

@jelbourn @crisbeto  Technically this is a breaking change, because before you could theoretically place a `<mat-list-option>` element without a list. This shouldn't be the case though, because there would be too many runtime exceptions. Also instead of Angular's default `No provider` message, we could have a custom one, to make it more clear what's going on.