### PR TITLE
refactor(overlay): avoid circular type references

### DIFF
--- a/src/cdk/overlay/overlay-reference.ts
+++ b/src/cdk/overlay/overlay-reference.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Portal} from '@angular/cdk/portal';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+
+/**
+ * Basic interface for an overlay. Used to avoid circular type references between
+ * `OverlayRef`, `PositionStrategy` and `ScrollStrategy`, and `OverlayConfig`.
+ * @docs-private
+ */
+export interface OverlayReference {
+  attach: (portal: Portal<any>) => any;
+  detach: () => any;
+  dispose: () => void;
+  overlayElement: HTMLElement;
+  hostElement: HTMLElement;
+  getConfig: () => any;
+  hasAttached: () => boolean;
+  updateSize: (config: any) => void;
+  updatePosition: () => void;
+  getDirection: () => Direction;
+  setDirection: (dir: Direction | Directionality) => void;
+}

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -10,7 +10,6 @@ import {Direction} from '@angular/cdk/bidi';
 import {CdkScrollable, ViewportRuler} from '@angular/cdk/scrolling';
 import {ElementRef} from '@angular/core';
 import {Observable} from 'rxjs';
-import {OverlayRef} from '../overlay-ref';
 import {
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
@@ -20,7 +19,7 @@ import {
 import {FlexibleConnectedPositionStrategy} from './flexible-connected-position-strategy';
 import {PositionStrategy} from './position-strategy';
 import {Platform} from '@angular/cdk/platform';
-
+import {OverlayReference} from '../overlay-reference';
 
 /**
  * A strategy for positioning overlays. Using this strategy, an overlay is given an
@@ -39,7 +38,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   _positionStrategy: FlexibleConnectedPositionStrategy;
 
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayReference;
 
   private _direction: Direction | null;
 
@@ -84,7 +83,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   }
 
   /** Attach this position strategy to an overlay. */
-  attach(overlayRef: OverlayRef): void {
+  attach(overlayRef: OverlayReference): void {
     this._overlayRef = overlayRef;
     this._positionStrategy.attach(overlayRef);
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -17,7 +17,7 @@ import {
   validateVerticalPosition,
 } from './connected-position';
 import {Observable, Subscription, Subject} from 'rxjs';
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';
 import {coerceCssPixelValue} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
@@ -34,7 +34,7 @@ import {Platform} from '@angular/cdk/platform';
  */
 export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayReference;
 
   /** Whether we're performing the very first positioning of the overlay. */
   private _isInitialRender = true;
@@ -137,7 +137,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   }
 
   /** Attaches this position strategy to an overlay. */
-  attach(overlayRef: OverlayRef): void {
+  attach(overlayRef: OverlayReference): void {
     if (this._overlayRef && overlayRef !== this._overlayRef) {
       throw Error('This position strategy is already attached to an overlay');
     }

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -7,7 +7,7 @@
  */
 
 import {PositionStrategy} from './position-strategy';
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 
 
 /**
@@ -18,7 +18,7 @@ import {OverlayRef} from '../overlay-ref';
  */
 export class GlobalPositionStrategy implements PositionStrategy {
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayReference;
   private _cssPosition: string = 'static';
   private _topOffset: string = '';
   private _bottomOffset: string = '';
@@ -29,7 +29,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
   private _width: string = '';
   private _height: string = '';
 
-  attach(overlayRef: OverlayRef): void {
+  attach(overlayRef: OverlayReference): void {
     const config = overlayRef.getConfig();
 
     this._overlayRef = overlayRef;

--- a/src/cdk/overlay/position/position-strategy.ts
+++ b/src/cdk/overlay/position/position-strategy.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {OverlayRef} from '../overlay-ref';
-
+import {OverlayReference} from '../overlay-reference';
 
 /** Strategy for setting the position on an overlay. */
 export interface PositionStrategy {
   /** Attaches this position strategy to an overlay. */
-  attach(overlayRef: OverlayRef): void;
+  attach(overlayRef: OverlayReference): void;
 
   /** Updates the position of the overlay element. */
   apply(): void;

--- a/src/cdk/overlay/scroll/close-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.ts
@@ -7,7 +7,7 @@
  */
 import {NgZone} from '@angular/core';
 import {ScrollStrategy, getMatScrollStrategyAlreadyAttachedError} from './scroll-strategy';
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 import {Subscription} from 'rxjs';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
 
@@ -24,7 +24,7 @@ export interface CloseScrollStrategyConfig {
  */
 export class CloseScrollStrategy implements ScrollStrategy {
   private _scrollSubscription: Subscription|null = null;
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayReference;
   private _initialScrollPosition: number;
 
   constructor(
@@ -34,7 +34,7 @@ export class CloseScrollStrategy implements ScrollStrategy {
     private _config?: CloseScrollStrategyConfig) {}
 
   /** Attaches this scroll strategy to an overlay. */
-  attach(overlayRef: OverlayRef) {
+  attach(overlayRef: OverlayReference) {
     if (this._overlayRef) {
       throw getMatScrollStrategyAlreadyAttachedError();
     }

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
@@ -9,7 +9,7 @@
 import {NgZone} from '@angular/core';
 import {Subscription} from 'rxjs';
 import {ScrollStrategy, getMatScrollStrategyAlreadyAttachedError} from './scroll-strategy';
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
 import {isElementScrolledOutsideView} from '../position/scroll-clip';
 
@@ -29,7 +29,7 @@ export interface RepositionScrollStrategyConfig {
  */
 export class RepositionScrollStrategy implements ScrollStrategy {
   private _scrollSubscription: Subscription|null = null;
-  private _overlayRef: OverlayRef;
+  private _overlayRef: OverlayReference;
 
   constructor(
     private _scrollDispatcher: ScrollDispatcher,
@@ -38,7 +38,7 @@ export class RepositionScrollStrategy implements ScrollStrategy {
     private _config?: RepositionScrollStrategyConfig) { }
 
   /** Attaches this scroll strategy to an overlay. */
-  attach(overlayRef: OverlayRef) {
+  attach(overlayRef: OverlayReference) {
     if (this._overlayRef) {
       throw getMatScrollStrategyAlreadyAttachedError();
     }

--- a/src/cdk/overlay/scroll/scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 
 /**
  * Describes a strategy that will be used by an overlay to handle scroll events while it is open.
@@ -19,7 +19,7 @@ export interface ScrollStrategy {
   disable: () => void;
 
   /** Attaches this `ScrollStrategy` to an overlay. */
-  attach: (overlayRef: OverlayRef) => void;
+  attach: (overlayRef: OverlayReference) => void;
 }
 
 /**


### PR DESCRIPTION
Currently there is a circular type reference between `OverlayRef`, `PositionStrategy`/`ScrollStrategy` and `OverlayConfig` which can cause issues with some build tools. These changes introduce the `OverlayRefBase` type to avoid the circular reference.

Fixes #9491.