### PR TITLE
chore: fix e2e axe failure

### DIFF
--- a/src/e2e-app/e2e-app/e2e-app.html
+++ b/src/e2e-app/e2e-app/e2e-app.html
@@ -25,5 +25,5 @@
 </mat-nav-list>
 
 <main>
-  <router-outlet role="main"></router-outlet>
+  <router-outlet></router-outlet>
 </main>


### PR DESCRIPTION
Fixes the e2e setup failing due to an error being thrown by the Axe plugin that was caused by us having two main landmarks.