### PR TITLE
build: enforce that deprecated APIs have a deletion target

### DIFF
--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -16,7 +16,10 @@ export type RippleConfig = {
   persistent?: boolean;
   animation?: RippleAnimationConfig;
   terminateOnPointerUp?: boolean;
-  /** @deprecated Use the animation property instead. */
+  /**
+   * @deprecated Use the `animation` property instead.
+   * @deletion-target 7.0.0
+   */
   speedFactor?: number;
 };
 


### PR DESCRIPTION
Follow-up from #9881. Ensures that anything marked with `@deprecated` also has a `@deletion-target`.