### PR TITLE
fix(button): inconsistent overflow value between browsers

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -53,6 +53,10 @@ $mat-mini-fab-padding: 8px !default;
   padding: $mat-button-padding;
   border-radius: $mat-button-border-radius;
 
+  // Explicitly set the default overflow to `visible`. It is already set
+  // on most browsers except on IE11 where it defaults to `hidden`.
+  overflow: visible;
+
   &[disabled] {
     cursor: default;
   }


### PR DESCRIPTION
By default most browsers will set the button overflow to `visible`, however it's `hidden` on IE. This is particularly visible on buttons with badges. These changes add a default value so the buttons are consistent between browsers.