### PR TITLE
docs(select): Change select's openedChange output comment

### DIFF
--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -420,7 +420,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       .pipe(take(1), switchMap(() => this.optionSelectionChanges));
   });
 
-   /** Event emitted when the select has been opened (true) or closed (false). */
+   /** Event emitted when the select panel has been toggled. */
    @Output() readonly openedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
    /** Event emitted when the select has been opened. */

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -420,7 +420,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       .pipe(take(1), switchMap(() => this.optionSelectionChanges));
   });
 
-   /** Event emitted when the select has been opened. */
+   /** Event emitted when the select has been opened (true) or closed (false). */
    @Output() readonly openedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
    /** Event emitted when the select has been opened. */


### PR DESCRIPTION
Currently, the docs says the `openedChange` emits when the panel has been opened. It also emits when it has been closed though.

Related to #9928, specifically https://github.com/angular/material2/issues/9928#issuecomment-365395601.