### PR TITLE
build: conditional travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,21 @@ jobs:
     - env: "MODE=aot"
     - env: "MODE=payload"
     - env: "MODE=prerender"
-    # Closure Compiler CI check is temporarily disabled until a new version of
-    # the tool is released with https://github.com/google/closure-compiler/pull/2600
-    # - env: "MODE=closure-compiler"
     - env: "MODE=e2e"
     - env: "MODE=saucelabs_required"
     - env: "MODE=browserstack_required"
     - env: "MODE=travis_required"
     - env: "DEPLOY_MODE=build-artifacts"
+      if: type = push
     - env: "DEPLOY_MODE=docs-content"
+      if: type = push
     - env: "DEPLOY_MODE=screenshot-tool"
+      if: type = cron
     - env: "DEPLOY_MODE=dashboard"
+      if: type = cron
+    # Closure Compiler CI check is temporarily disabled until a new version of
+    # the tool is released with https://github.com/google/closure-compiler/pull/2600
+    # - env: "MODE=closure-compiler"
 env:
   global:
   - LOGS_DIR=/tmp/angular-material2-build/logs

--- a/scripts/ci/travis-deploy.sh
+++ b/scripts/ci/travis-deploy.sh
@@ -12,14 +12,6 @@ cd $(dirname $0)/../..
 # Load the retry-call utility function.
 source scripts/retry-call.sh
 
-# If the current Travis job is triggered by a pull request skip the deployment.
-# This check is necessary because Travis still tries to run the deploy build-stage for
-# pull requests.
-if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-  echo "Build artifacts and docs content will only be deployed in Travis push builds."
-  exit 0;
-fi
-
 # Variable the specifies how often the deploy script should be invoked if it fails.
 DEPLOY_RETRIES=1
 
@@ -27,26 +19,12 @@ echo ""
 echo "Starting the deployment script. Running mode: ${DEPLOY_MODE}"
 echo ""
 
-# Deployment of the screenshot tool or dashboard should happen inside of a Cronjob.
-# For example, always deploying the screenshot functions on a per-commit base might cause problems
-# with the screenshot tests, because the functions can be non-responsive for a few seconds.
-if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
-  if [[ "${DEPLOY_MODE}" == "screenshot-tool" ]]; then
-    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-screenshot-tool.sh
-  elif [[ "${DEPLOY_MODE}" == "dashboard" ]]; then
-    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-dashboard.sh
-  else
-    echo "Docs content and build artifacts won't be published in Travis cronjobs."
-  fi
-
-# Deployment of the build artifacts and docs-content should only happen on a per-commit base.
-# The target is to provide build artifacts in the GitHub repository for every commit.
-else
-  if [[ "${DEPLOY_MODE}" == "build-artifacts" ]]; then
-    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-build-artifacts.sh
-  elif [[ "${DEPLOY_MODE}" == "docs-content" ]]; then
-    retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-docs-content.sh
-  else
-    echo "The dashboard and screenshot-tool will only be deployed in Travis cronjobs."
-  fi
+if [[ "${DEPLOY_MODE}" == "screenshot-tool" ]]; then
+  retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-screenshot-tool.sh
+elif [[ "${DEPLOY_MODE}" == "dashboard" ]]; then
+  retryCall ${DEPLOY_RETRIES} ./scripts/deploy/deploy-dashboard.sh
+elif [[ "${DEPLOY_MODE}" == "build-artifacts" ]]; then
+  retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-build-artifacts.sh
+elif [[ "${DEPLOY_MODE}" == "docs-content" ]]; then
+  retryCall ${DEPLOY_RETRIES} ./scripts/deploy/publish-docs-content.sh
 fi

--- a/scripts/ci/travis-env.sh
+++ b/scripts/ci/travis-env.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-if [[ -z "${TRAVIS}" ]]; then
-  echo "This script can only setup the environment inside of Travis builds"
-  exit 0
-fi
-
-# If FIREBASE_ACCESS_TOKEN not set yet, export the FIREBASE_ACCESS_TOKEN using the JWT token that Travis generated and exported for SAUCE_ACCESS_KEY.
+# If FIREBASE_ACCESS_TOKEN not set yet, export the FIREBASE_ACCESS_TOKEN using the JWT token that
+# Travis generated and exported for SAUCE_ACCESS_KEY.
 # This is a workaround for travis-ci/travis-ci#7223
 # WARNING: FIREBASE_ACCESS_TOKEN should NOT be printed
 export FIREBASE_ACCESS_TOKEN=${FIREBASE_ACCESS_TOKEN:-$SAUCE_ACCESS_KEY}
 
-# - we overwrite the value set by Travis JWT addon here to work around travis-ci/travis-ci#7223 for FIREBASE_ACCESS_TOKEN
+# - we overwrite the value set by Travis JWT addon here to work around travis-ci/travis-ci#7223
+# for FIREBASE_ACCESS_TOKEN
 export SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987

--- a/scripts/ci/travis-script.sh
+++ b/scripts/ci/travis-script.sh
@@ -9,11 +9,6 @@ set -e
 # Go to project directory
 cd $(dirname $0)/../..
 
-if [[ -z "$TRAVIS" ]]; then
-  echo "This script can only run inside of Travis build jobs."
-  exit 1
-fi
-
 if [[ "${MODE}" ]]; then
   ./scripts/ci/travis-testing.sh
 elif [[ "${DEPLOY_MODE}" ]]; then


### PR DESCRIPTION
* No longer runs the build artifacts, docs-content, dashboard, screenshot deployment tasks on Pull Requests. This means that there aren't any noop jobs running anymore

* Also removes some unnecessary `$TRAVIS` checks. Those files only run inside of Travis, so the checks are superfluous. 