### PR TITLE
chore(menu): fix incorrect docs example

### DIFF
--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -117,8 +117,8 @@ the `matMenuTriggerData` input. This allows for a single menu instance to be ren
 with a different set of data, depending on the trigger that opened it:
 
 ```html
-<mat-menu #appMenu="matMenu" let-user="user">
-  <ng-template matMenuContent>
+<mat-menu #appMenu="matMenu">
+  <ng-template matMenuContent let-user="user">
     <button mat-menu-item>Settings</button>
     <button mat-menu-item>Log off {{name}}</button>
   </ng-template>

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1572,7 +1572,7 @@ class SimpleLazyMenu {
       [matMenuTriggerData]="{label: 'two'}"
       #triggerTwo="matMenuTrigger">Two</button>
 
-    <mat-menu matMenuContent #menu="matMenu">
+    <mat-menu #menu="matMenu">
       <ng-template let-label="label" matMenuContent>
         <button mat-menu-item>{{label}}</button>
       </ng-template>


### PR DESCRIPTION
Fixes an incorrect example in the menu docs and the `matMenuContent` being used incorrectly in a unit test.

Fixes #9944.