### PR TITLE
fix(aria-describer): better handling of non-string values

### DIFF
--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -40,6 +40,15 @@ describe('AriaDescriber', () => {
     expect(getMessageElements()).toBe(null);
   });
 
+  it('should not register non-string values', () => {
+    expect(() => ariaDescriber.describe(component.element1, null!)).not.toThrow();
+    expect(getMessageElements()).toBe(null);
+  });
+
+  it('should not throw when trying to remove non-string value', () => {
+    expect(() => ariaDescriber.removeDescription(component.element1, null!)).not.toThrow();
+  });
+
   it('should de-dupe a message registered multiple times', () => {
     ariaDescriber.describe(component.element1, 'My Message');
     ariaDescriber.describe(component.element2, 'My Message');

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -60,7 +60,7 @@ export class AriaDescriber {
    * message element.
    */
   describe(hostElement: Element, message: string) {
-    if (hostElement.nodeType !== this._document.ELEMENT_NODE || !message.trim()) {
+    if (!this._canBeDescribed(hostElement, message)) {
       return;
     }
 
@@ -75,7 +75,7 @@ export class AriaDescriber {
 
   /** Removes the host element's aria-describedby reference to the message element. */
   removeDescription(hostElement: Element, message: string) {
-    if (hostElement.nodeType !== this._document.ELEMENT_NODE || !message.trim()) {
+    if (!this._canBeDescribed(hostElement, message)) {
       return;
     }
 
@@ -194,6 +194,12 @@ export class AriaDescriber {
     const messageId = registeredMessage && registeredMessage.messageElement.id;
 
     return !!messageId && referenceIds.indexOf(messageId) != -1;
+  }
+
+  /** Determines whether a message can be described on a particular element. */
+  private _canBeDescribed(element: Element, message: string): boolean {
+    return element.nodeType === this._document.ELEMENT_NODE && message != null &&
+        !!`${message}`.trim();
   }
 
 }


### PR DESCRIPTION
Currently the `AriaDescriber` assumes that any values being described are going to be strings, however that may not be the case if a value is being passed it directly from the view. These changes add an extra check in order to avoid having to do null checks on consumption (see #9957).