### PR TITLE
fix(selection-list): incorrect cursor if disabled

### DIFF
--- a/src/demo-app/list/list-demo.html
+++ b/src/demo-app/list/list-demo.html
@@ -109,7 +109,8 @@
 
     <mat-selection-list #groceries [ngModel]="selectedOptions"
                         (ngModelChange)="onSelectedOptionsChange($event)"
-                        (change)="changeEventCount = changeEventCount + 1">
+                        (change)="changeEventCount = changeEventCount + 1"
+                        [disabled]="selectionListDisabled">
       <h3 mat-subheader>Groceries</h3>
 
       <mat-list-option value="bananas" checkboxPosition="before">Bananas</mat-list-option>
@@ -121,6 +122,7 @@
     <p>Selected: {{selectedOptions | json}}</p>
     <p>Change Event Count {{changeEventCount}}</p>
     <p>Model Change Event Count {{modelChangeEventCount}}</p>
+    <mat-checkbox [(ngModel)]="selectionListDisabled">Disable Selection List</mat-checkbox>
 
     <p>
       <button mat-raised-button (click)="groceries.selectAll()">Select all</button>

--- a/src/demo-app/list/list-demo.ts
+++ b/src/demo-app/list/list-demo.ts
@@ -59,6 +59,7 @@ export class ListDemo {
 
   thirdLine: boolean = false;
   infoClicked: boolean = false;
+  selectionListDisabled: boolean = false;
 
   selectedOptions: string[] = ['apples'];
   changeEventCount: number = 0;

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -254,7 +254,7 @@ $mat-list-item-inset-divider-offset: 72px;
 }
 
 .mat-list-option {
-  &:not([disabled]) {
+  &:not(.mat-list-item-disabled) {
     cursor: pointer;
   }
 }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -283,7 +283,8 @@ export class MatListOption extends _MatListOptionMixinBase
     '(focus)': 'focus()',
     '(blur)': '_onTouched()',
     '(keydown)': '_keydown($event)',
-    '[attr.aria-disabled]': 'disabled.toString()'},
+    '[attr.aria-disabled]': 'disabled.toString()',
+  },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None,
@@ -390,6 +391,10 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
 
   /** Passes relevant key presses to our key manager. */
   _keydown(event: KeyboardEvent) {
+    if (this.disabled) {
+      return;
+    }
+
     switch (event.keyCode) {
       case SPACE:
       case ENTER:


### PR DESCRIPTION
* Currently if a list option is disabled through the `[disabled]` binding, the disabled option still has the `pointer` cursor.
* Fixes that list options are still focusable if disabled.
* Fixes that the selection list is still focusable if disabled.

Fixes #9952