### PR TITLE
fix(menu): not picking up indirect descendant items

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -129,7 +129,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel, OnDestroy {
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
 
   /** List of the items inside of a menu. */
-  @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
+  @ContentChildren(MatMenuItem, {descendants: true}) items: QueryList<MatMenuItem>;
 
   /**
    * Menu content that will be rendered lazily.


### PR DESCRIPTION
Fixes the menu directive not picking up menu items that aren't direct descendants of the panel.

Fixes #9969.