### PR TITLE
fix(select): icons inside option not centered

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -48,6 +48,7 @@ $mat-menu-icon-margin: 16px !default;
 
   .mat-icon {
     margin-right: $mat-menu-icon-margin;
+    vertical-align: middle;
 
     [dir='rtl'] & {
       margin-left: $mat-menu-icon-margin;

--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -37,10 +37,6 @@ $mat-menu-submenu-indicator-size: 10px !default;
   @include mat-button-reset();
   @include mat-menu-item-base();
   position: relative;
-
-  .mat-icon {
-    vertical-align: middle;
-  }
 }
 
 .mat-menu-item-submenu-trigger {


### PR DESCRIPTION
Fixes `mat-icon` instances inside a `mat-option` not being centered vertically.

Fixes #9978.