### PR TITLE
refactor: deprecate tabindex mixin

### DIFF
--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -9,9 +9,11 @@
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {Platform} from '@angular/cdk/platform';
 import {
+  Attribute,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  Input,
   OnDestroy,
   ViewChild,
   ViewEncapsulation,
@@ -146,7 +148,7 @@ export class MatButton extends _MatButtonMixinBase
              a[mat-mini-fab], a[mat-stroked-button], a[mat-flat-button]`,
   exportAs: 'matButton, matAnchor',
   host: {
-    '[attr.tabindex]': 'disabled ? -1 : 0',
+    '[attr.tabindex]': 'disabled ? -1 : tabIndex',
     '[attr.disabled]': 'disabled || null',
     '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_haltDisabledEvents($event)',
@@ -159,11 +161,17 @@ export class MatButton extends _MatButtonMixinBase
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatAnchor extends MatButton {
-  constructor(
-      platform: Platform,
-      focusMonitor: FocusMonitor,
-      elementRef: ElementRef) {
+
+  /** Tabindex of the button anchor. */
+  @Input() tabIndex: number = 0;
+
+  constructor(platform: Platform,
+              focusMonitor: FocusMonitor,
+              elementRef: ElementRef,
+              @Attribute('tabindex') tabIndex: string) {
     super(elementRef, platform, focusMonitor);
+
+    this.tabIndex = parseInt(tabIndex) || 0;
   }
 
   _haltDisabledEvents(event: Event) {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -30,12 +30,10 @@ import {
   CanColor,
   CanDisable,
   CanDisableRipple,
-  HasTabIndex,
   MatRipple,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple,
-  mixinTabIndex,
   RippleRef,
 } from '@angular/material/core';
 import {MAT_CHECKBOX_CLICK_ACTION, MatCheckboxClickAction} from './checkbox-config';
@@ -84,7 +82,7 @@ export class MatCheckboxBase {
   constructor(public _elementRef: ElementRef) {}
 }
 export const _MatCheckboxMixinBase =
-  mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(MatCheckboxBase)), 'accent'));
+  mixinColor(mixinDisableRipple(mixinDisabled(MatCheckboxBase)), 'accent');
 
 
 /**
@@ -110,13 +108,15 @@ export const _MatCheckboxMixinBase =
     '[class.mat-checkbox-label-before]': 'labelPosition == "before"',
   },
   providers: [MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR],
-  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple', 'color'],
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAccessor,
-    AfterViewInit, OnDestroy, CanColor, CanDisable, HasTabIndex, CanDisableRipple {
+    AfterViewInit, OnDestroy, CanColor, CanDisable, CanDisableRipple {
+
+  private _uniqueId: string = `mat-checkbox-${++nextUniqueId}`;
 
   /**
    * Attached to the aria-label attribute of the host element. In most cases, arial-labelledby will
@@ -129,10 +129,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    */
   @Input('aria-labelledby') ariaLabelledby: string | null = null;
 
-  private _uniqueId: string = `mat-checkbox-${++nextUniqueId}`;
-
   /** A unique id for the checkbox input. If none is supplied, it will be auto-generated. */
   @Input() id: string = this._uniqueId;
+
+  /** Tabindex for the underlying checkbox input. */
+  @Input() tabIndex: number = 0;
 
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }

--- a/src/lib/core/common-behaviors/tabindex.ts
+++ b/src/lib/core/common-behaviors/tabindex.ts
@@ -9,13 +9,20 @@
 import {Constructor} from './constructor';
 import {CanDisable} from './disabled';
 
-/** @docs-private */
+/**
+ * @deprecated
+ * @deletion-target 7.0.0
+ */
 export interface HasTabIndex {
   /** Tabindex of the component. */
   tabIndex: number;
 }
 
-/** Mixin to augment a directive with a `tabIndex` property. */
+/**
+ * Mixin to augment a directive with a `tabIndex` property.
+ * @deprecated
+ * @deletion-target 7.0.0
+ */
 export function mixinTabIndex<T extends Constructor<CanDisable>>(base: T, defaultTabIndex = 0)
     : Constructor<HasTabIndex> & T {
   return class extends base {

--- a/src/lib/list/selection-list.spec.ts
+++ b/src/lib/list/selection-list.spec.ts
@@ -427,8 +427,8 @@ describe('MatSelectionList without forms', () => {
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      expect(selectionList.componentInstance.tabIndex)
-        .toBe(-1, 'Expected the tabIndex to be set to "-1" if selection list is disabled.');
+      expect(selectionList.nativeElement.hasAttribute('tabindex'))
+        .toBe(false, 'Expected the list element to no longer have a tabindex if disabled.');
     });
   });
 

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -32,12 +32,10 @@ import {
 import {
   CanDisable,
   CanDisableRipple,
-  HasTabIndex,
   MatLine,
   MatLineSetter,
   mixinDisabled,
   mixinDisableRipple,
-  mixinTabIndex,
 } from '@angular/material/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Subscription} from 'rxjs/Subscription';
@@ -45,8 +43,7 @@ import {Subscription} from 'rxjs/Subscription';
 
 /** @docs-private */
 export class MatSelectionListBase {}
-export const _MatSelectionListMixinBase =
-  mixinTabIndex(mixinDisableRipple(mixinDisabled(MatSelectionListBase)));
+export const _MatSelectionListMixinBase = mixinDisableRipple(mixinDisabled(MatSelectionListBase));
 
 /** @docs-private */
 export class MatListOptionBase {}
@@ -97,6 +94,7 @@ export class MatSelectionListChange {
     '(focus)': '_handleFocus()',
     '(blur)': '_handleBlur()',
     '(click)': '_handleClick()',
+    // TODO(paul): revisit with https://github.com/angular/material2/issues/9995
     'tabindex': '-1',
     '[class.mat-list-item-disabled]': 'disabled',
     '[class.mat-list-item-focus]': '_hasFocus',
@@ -275,15 +273,16 @@ export class MatListOption extends _MatListOptionMixinBase
   moduleId: module.id,
   selector: 'mat-selection-list',
   exportAs: 'matSelectionList',
-  inputs: ['disabled', 'disableRipple', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple'],
   host: {
     'role': 'listbox',
-    '[tabIndex]': 'tabIndex',
     'class': 'mat-selection-list',
     '(focus)': 'focus()',
     '(blur)': '_onTouched()',
     '(keydown)': '_keydown($event)',
     '[attr.aria-disabled]': 'disabled.toString()',
+    // TODO(paul): revisit with https://github.com/angular/material2/issues/9995
+    '[attr.tabindex]': 'disabled ? null : tabIndex',
   },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
@@ -293,7 +292,7 @@ export class MatListOption extends _MatListOptionMixinBase
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MatSelectionList extends _MatSelectionListMixinBase implements FocusableOption,
-    CanDisable, CanDisableRipple, HasTabIndex, AfterContentInit, ControlValueAccessor, OnDestroy {
+    CanDisable, CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy {
 
   /** The FocusKeyManager which handles focus. */
   _keyManager: FocusKeyManager<MatListOption>;
@@ -304,6 +303,9 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
   /** Emits a change event whenever the selected state of an option changes. */
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
       new EventEmitter<MatSelectionListChange>();
+
+  /** Tabindex of the selection list. */
+  @Input() tabIndex: number = 0;
 
   /** The currently selected options. */
   selectedOptions: SelectionModel<MatListOption> = new SelectionModel<MatListOption>(true);

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -12,6 +12,7 @@ import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {
   AfterContentInit,
   AfterViewInit,
+  Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -34,12 +35,10 @@ import {
   CanColor,
   CanDisable,
   CanDisableRipple,
-  HasTabIndex,
   MatRipple,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple,
-  mixinTabIndex,
   RippleRef,
 } from '@angular/material/core';
 
@@ -323,7 +322,7 @@ export class MatRadioButtonBase {
 // As per Material design specifications the selection control radio should use the accent color
 // palette by default. https://material.io/guidelines/components/selection-controls.html
 export const _MatRadioButtonMixinBase =
-    mixinColor(mixinDisableRipple(mixinTabIndex(MatRadioButtonBase)), 'accent');
+    mixinColor(mixinDisableRipple(MatRadioButtonBase), 'accent');
 
 /**
  * A Material design radio-button. Typically placed inside of `<mat-radio-group>` elements.
@@ -333,7 +332,7 @@ export const _MatRadioButtonMixinBase =
   selector: 'mat-radio-button',
   templateUrl: 'radio.html',
   styleUrls: ['radio.css'],
-  inputs: ['color', 'disableRipple', 'tabIndex'],
+  inputs: ['color', 'disableRipple'],
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
   exportAs: 'matRadioButton',
@@ -350,7 +349,7 @@ export const _MatRadioButtonMixinBase =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatRadioButton extends _MatRadioButtonMixinBase
-    implements OnInit, AfterViewInit, OnDestroy, CanColor, CanDisableRipple, HasTabIndex {
+    implements OnInit, AfterViewInit, OnDestroy, CanColor, CanDisableRipple {
 
   private _uniqueId: string = `mat-radio-${++nextUniqueId}`;
 
@@ -359,6 +358,9 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   /** Analog to HTML 'name' attribute used to group radios for unique selection. */
   @Input() name: string;
+
+  /** Tabindex of the underlying radio input element. */
+  @Input() tabIndex: number = 0;
 
   /** Used to set the 'aria-label' attribute on the underlying input element. */
   @Input('aria-label') ariaLabel: string;
@@ -497,8 +499,11 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
               elementRef: ElementRef,
               private _changeDetector: ChangeDetectorRef,
               private _focusMonitor: FocusMonitor,
-              private _radioDispatcher: UniqueSelectionDispatcher) {
+              private _radioDispatcher: UniqueSelectionDispatcher,
+              @Attribute('tabindex') tabIndex: string) {
     super(elementRef);
+
+    this.tabIndex = parseInt(tabIndex) || 0;
 
     // Assertions. Ideally these should be stripped out by the compiler.
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -220,10 +220,10 @@ describe('MatSelect', () => {
           expect(select.getAttribute('aria-disabled')).toEqual('true');
         }));
 
-        it('should set the tabindex of the select to -1 if disabled', fakeAsync(() => {
+        it('should remove the tabindex attribute if disabled', fakeAsync(() => {
           fixture.componentInstance.control.disable();
           fixture.detectChanges();
-          expect(select.getAttribute('tabindex')).toEqual('-1');
+          expect(select.hasAttribute('tabindex')).toBe(false);
 
           fixture.componentInstance.control.enable();
           fixture.detectChanges();
@@ -3806,7 +3806,7 @@ class BasicSelect {
   isRequired: boolean;
   heightAbove = 0;
   heightBelow = 0;
-  tabIndexOverride: number;
+  tabIndexOverride = 0;
   ariaLabel: string;
   ariaLabelledby: string;
   panelClass = ['custom-one', 'custom-two'];

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -71,12 +71,10 @@ import {
   ErrorStateMatcher,
   CanUpdateErrorState,
   mixinErrorState,
-  HasTabIndex,
   MatOptgroup,
   MatOption,
   MatOptionSelectionChange,
   mixinDisabled,
-  mixinTabIndex,
   MAT_OPTION_PARENT_COMPONENT,
   mixinDisableRipple,
   CanDisableRipple,
@@ -167,8 +165,8 @@ export class MatSelectBase {
               public _parentFormGroup: FormGroupDirective,
               public ngControl: NgControl) {}
 }
-export const _MatSelectMixinBase = mixinDisableRipple(
-    mixinTabIndex(mixinDisabled(mixinErrorState(MatSelectBase))));
+export const _MatSelectMixinBase =
+  mixinDisableRipple(mixinDisabled(mixinErrorState(MatSelectBase)));
 
 
 /**
@@ -186,14 +184,14 @@ export class MatSelectTrigger {}
   exportAs: 'matSelect',
   templateUrl: 'select.html',
   styleUrls: ['select.css'],
-  inputs: ['disabled', 'disableRipple', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple'],
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'role': 'listbox',
     '[attr.id]': 'id',
-    '[attr.tabindex]': 'tabIndex',
+    '[attr.tabindex]': 'disabled ? null : tabIndex',
     '[attr.aria-label]': '_ariaLabel',
     '[attr.aria-labelledby]': 'ariaLabelledby',
     '[attr.aria-required]': 'required.toString()',
@@ -221,8 +219,9 @@ export class MatSelectTrigger {}
   ],
 })
 export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges,
-    OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable, HasTabIndex,
+    OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable,
     MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
+
   /** Whether or not the overlay panel is open. */
   private _panelOpen = false;
 
@@ -334,6 +333,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Classes to be passed to the select panel. Supports the same syntax as `ngClass`. */
   @Input() panelClass: string|string[]|Set<string>|{[key: string]: any};
+
+  /** Tabindex of the select element. */
+  @Input() tabIndex: number = 0;
 
   /** User-supplied override of the trigger element. */
   @ContentChild(MatSelectTrigger) customTrigger: MatSelectTrigger;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -30,12 +30,10 @@ import {
   CanDisable,
   CanDisableRipple,
   HammerInput,
-  HasTabIndex,
   MatRipple,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple,
-  mixinTabIndex,
   RippleRef,
 } from '@angular/material/core';
 
@@ -63,7 +61,7 @@ export class MatSlideToggleBase {
   constructor(public _elementRef: ElementRef) {}
 }
 export const _MatSlideToggleMixinBase =
-  mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(MatSlideToggleBase)), 'accent'));
+  mixinColor(mixinDisableRipple(mixinDisabled(MatSlideToggleBase)), 'accent');
 
 /** Represents a slidable "switch" toggle that can be moved between on and off. */
 @Component({
@@ -80,13 +78,13 @@ export const _MatSlideToggleMixinBase =
   templateUrl: 'slide-toggle.html',
   styleUrls: ['slide-toggle.css'],
   providers: [MAT_SLIDE_TOGGLE_VALUE_ACCESSOR],
-  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple', 'color'],
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit,
-    ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
+    ControlValueAccessor, CanDisable, CanColor, CanDisableRipple {
 
   private onChange = (_: any) => {};
   private onTouched = () => {};
@@ -107,6 +105,9 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
 
   /** Whether the label should appear after or before the slide-toggle. Defaults to 'after' */
   @Input() labelPosition: 'before' | 'after' = 'after';
+
+  /** Tabindex of the underlying slide-toggle input element. */
+  @Input() tabIndex: number = 0;
 
   /** Whether the slide-toggle element is checked or not */
 

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -281,7 +281,8 @@ describe('MatSlider without forms', () => {
     });
 
     it('should disable tabbing to the slider', () => {
-      expect(sliderNativeElement.tabIndex).toBe(-1);
+      expect(sliderNativeElement.hasAttribute('tabindex'))
+        .toBe(false, 'Slider element should not have a tabindex set if disabled.');
     });
   });
 
@@ -1181,18 +1182,17 @@ describe('MatSlider without forms', () => {
 
   describe('tabindex', () => {
 
-    it('should allow setting the tabIndex through binding', () => {
+    it('should set the tabIndex binding on the native element', () => {
       const fixture = TestBed.createComponent(SliderWithTabIndexBinding);
+      const sliderEl = fixture.debugElement.query(By.directive(MatSlider)).nativeElement;
       fixture.detectChanges();
 
-      const slider = fixture.debugElement.query(By.directive(MatSlider)).componentInstance;
-
-      expect(slider.tabIndex).toBe(0, 'Expected the tabIndex to be set to 0 by default.');
+      expect(sliderEl.tabIndex).toBe(0, 'Expected the tabIndex to be set to 0 by default.');
 
       fixture.componentInstance.tabIndex = 3;
       fixture.detectChanges();
 
-      expect(slider.tabIndex).toBe(3, 'Expected the tabIndex to have been changed.');
+      expect(sliderEl.tabIndex).toBe(3, 'Expected the tabIndex to have been changed.');
     });
 
     it('should detect the native tabindex attribute', () => {
@@ -1530,16 +1530,14 @@ class VerticalSlider {
   styles: [styles],
 })
 class SliderWithTabIndexBinding {
-  tabIndex: number;
+  tabIndex = 0;
 }
 
 @Component({
   template: `<mat-slider tabindex="5"></mat-slider>`,
   styles: [styles],
 })
-class SliderWithNativeTabindexAttr {
-  tabIndex: number;
-}
+class SliderWithNativeTabindexAttr {}
 
 /**
  * Dispatches a click event sequence (consisting of moueseenter, click) from an element.

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -40,10 +40,8 @@ import {
   CanColor,
   CanDisable,
   HammerInput,
-  HasTabIndex,
   mixinColor,
   mixinDisabled,
-  mixinTabIndex,
 } from '@angular/material/core';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -87,8 +85,7 @@ export class MatSliderChange {
 export class MatSliderBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatSliderMixinBase =
-  mixinTabIndex(mixinColor(mixinDisabled(MatSliderBase), 'accent'));
+export const _MatSliderMixinBase = mixinColor(mixinDisabled(MatSliderBase), 'accent');
 
 /**
  * Allows users to select from a range of values by moving the slider thumb. It is similar in
@@ -111,7 +108,7 @@ export const _MatSliderMixinBase =
     '(slidestart)': '_onSlideStart($event)',
     'class': 'mat-slider',
     'role': 'slider',
-    '[tabIndex]': 'tabIndex',
+    '[attr.tabindex]': 'disabled ? null : tabIndex',
     '[attr.aria-disabled]': 'disabled',
     '[attr.aria-valuemax]': 'max',
     '[attr.aria-valuemin]': 'min',
@@ -129,13 +126,13 @@ export const _MatSliderMixinBase =
   },
   templateUrl: 'slider.html',
   styleUrls: ['slider.css'],
-  inputs: ['disabled', 'color', 'tabIndex'],
+  inputs: ['disabled', 'color'],
   encapsulation: ViewEncapsulation.None,
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatSlider extends _MatSliderMixinBase
-    implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit, HasTabIndex {
+    implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit {
   /** Whether the slider is inverted. */
   @Input()
   get invert(): boolean { return this._invert; }
@@ -254,6 +251,9 @@ export class MatSlider extends _MatSliderMixinBase
     this._vertical = coerceBooleanProperty(value);
   }
   private _vertical = false;
+
+  /** Tabindex of the slider element. */
+  @Input() tabIndex: number = 0;
 
   /** Event emitted when the slider value has changed. */
   @Output() readonly change: EventEmitter<MatSliderChange> = new EventEmitter<MatSliderChange>();

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -116,13 +116,13 @@ describe('MatTabNavBar', () => {
         .map(tabLinkDebugEl => tabLinkDebugEl.nativeElement);
 
       expect(tabLinkElements.every(tabLink => tabLink.tabIndex === 0))
-        .toBe(true, 'Expected element to be keyboard focusable by default');
+        .toBe(true, 'Expected all links to be tabbable by default');
 
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      expect(tabLinkElements.every(tabLink => tabLink.tabIndex === -1))
-        .toBe(true, 'Expected element to no longer be keyboard focusable if disabled.');
+      expect(tabLinkElements.every(tabLink => tabLink.hasAttribute('tabindex') === false))
+        .toBe(true, 'Expected all links to no longer be focusable if disabled.');
     });
 
     it('should prevent default action for clicks if links are disabled', () => {

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -32,12 +32,11 @@ import {
   CanColor,
   CanDisable,
   CanDisableRipple,
-  HasTabIndex,
   MAT_RIPPLE_GLOBAL_OPTIONS,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple,
-  mixinTabIndex, RippleConfig,
+  RippleConfig,
   RippleGlobalOptions,
   RippleRenderer,
   RippleTarget,
@@ -173,8 +172,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
 
 // Boilerplate for applying mixins to MatTabLink.
 export class MatTabLinkBase {}
-export const _MatTabLinkMixinBase =
-  mixinTabIndex(mixinDisableRipple(mixinDisabled(MatTabLinkBase)));
+export const _MatTabLinkMixinBase = mixinDisableRipple(mixinDisabled(MatTabLinkBase));
 
 /**
  * Link inside of a `mat-tab-nav-bar`.
@@ -182,18 +180,18 @@ export const _MatTabLinkMixinBase =
 @Directive({
   selector: '[mat-tab-link], [matTabLink]',
   exportAs: 'matTabLink',
-  inputs: ['disabled', 'disableRipple', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple'],
   host: {
     'class': 'mat-tab-link',
     '[attr.aria-disabled]': 'disabled.toString()',
-    '[attr.tabIndex]': 'tabIndex',
+    '[attr.tabindex]': 'disabled ? null : tabIndex',
     '[class.mat-tab-disabled]': 'disabled',
     '[class.mat-tab-label-active]': 'active',
     '(click)': '_handleClick($event)'
   }
 })
 export class MatTabLink extends _MatTabLinkMixinBase
-    implements OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget {
+    implements OnDestroy, CanDisable, CanDisableRipple, RippleTarget {
 
   /** Whether the tab link is active or not. */
   private _isActive: boolean = false;
@@ -210,6 +208,9 @@ export class MatTabLink extends _MatTabLinkMixinBase
       this._tabNavBar.updateActiveLink(this._elementRef);
     }
   }
+
+  /** Tabindex of the tab link. */
+  @Input() tabIndex: number = 0;
 
   /**
    * Ripple configuration for ripples that are launched on pointer down.


### PR DESCRIPTION
Deprecates the `mixinTabIndex`, because it's not very flexible and also always assumes that the given component should fallback to a `tabIndex` of `-1` if disabled. This is a wrong assumption, because
there can be also components that rather would like to remove the `tabIndex` completely using `[attr.tabIndex]`, instead of setting the tabIndex just to `-1`.

For custom elements, removing the `tabIndex` attribute completely means, that those elements are not even programmatically focusable.
For some native elements, like anchors (`<a>`), removing the attribute is wrong, because it would mean that the anchor falls back to a `tabindex` of `0` (_meaning that it's still tabbable_). In that case, we would like to use `-1` instead of removing it.

TL;DR

* Fixes that the `tabindex` attribute is not supported on radio buttons.
* Fixes that some components are still programmatically focusable if disabled (selection-list, select, slider, tab-nav-bar)

**Note**: I decided to not use a host mixin (_as discussed on Slack_) here, because I think it's better to be explicit. It should be clear to what the tabIndex falls back if the component is disabled. Also it's just for a few components, because most of them have an underlying input and therefore don't need a fallback tabindex. 