### PR TITLE
fix(dialog): don't provide directionality if user injector has one already

### DIFF
--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -262,13 +262,17 @@ export class Dialog {
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
     const injectionTokens = new WeakMap();
 
-    injectionTokens.set(this.injector.get(DIALOG_REF), dialogRef);
-    injectionTokens.set(this.injector.get(DIALOG_CONTAINER), dialogContainer);
-    injectionTokens.set(DIALOG_DATA, config.data);
-    injectionTokens.set(Directionality, {
-      value: config.direction,
-      change: observableOf()
-    });
+    injectionTokens
+      .set(this.injector.get(DIALOG_REF), dialogRef)
+      .set(this.injector.get(DIALOG_CONTAINER), dialogContainer)
+      .set(DIALOG_DATA, config.data);
+
+    if (!userInjector || !userInjector.get(Directionality, null)) {
+      injectionTokens.set(Directionality, {
+        value: config.direction,
+        change: observableOf()
+      });
+    }
 
     return new PortalInjector(userInjector || this.injector, injectionTokens);
   }

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -279,7 +279,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
    */
   @Input()
   get selectable(): boolean { return this._selectable; }
-  set selectable(value: boolean) { 
+  set selectable(value: boolean) {
     this._selectable = coerceBooleanProperty(value);
     if (this.chips) {
       this.chips.forEach(chip => chip.chipListSelectable = this._selectable);

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -269,17 +269,21 @@ export class MatDialog {
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
     const injectionTokens = new WeakMap();
 
-    injectionTokens.set(MatDialogRef, dialogRef);
     // The MatDialogContainer is injected in the portal as the MatDialogContainer and the dialog's
     // content are created out of the same ViewContainerRef and as such, are siblings for injector
-    // purposes.  To allow the hierarchy that is expected, the MatDialogContainer is explicitly
+    // purposes. To allow the hierarchy that is expected, the MatDialogContainer is explicitly
     // added to the injection tokens.
-    injectionTokens.set(MatDialogContainer, dialogContainer);
-    injectionTokens.set(MAT_DIALOG_DATA, config.data);
-    injectionTokens.set(Directionality, {
-      value: config.direction,
-      change: observableOf()
-    });
+    injectionTokens
+      .set(MatDialogContainer, dialogContainer)
+      .set(MAT_DIALOG_DATA, config.data)
+      .set(MatDialogRef, dialogRef);
+
+    if (!userInjector || !userInjector.get(Directionality, null)) {
+      injectionTokens.set(Directionality, {
+        value: config.direction,
+        change: observableOf()
+      });
+    }
 
     return new PortalInjector(userInjector || this._injector, injectionTokens);
   }


### PR DESCRIPTION
Switches the dialog injector to provide the `Directionality` only when the user-provided injector doesn't have one already.

Relates to #9996.