### PR TITLE
fix(menu): detach lazily-rendered content when the menu is closed

### DIFF
--- a/src/lib/menu/menu-content.ts
+++ b/src/lib/menu/menu-content.ts
@@ -44,9 +44,9 @@ export class MatMenuContent implements OnDestroy {
   attach(context: any = {}) {
     if (!this._portal) {
       this._portal = new TemplatePortal(this._template, this._viewContainerRef);
-    } else if (this._portal.isAttached) {
-      this._portal.detach();
     }
+
+    this.detach();
 
     if (!this._outlet) {
       this._outlet = new DomPortalOutlet(this._document.createElement('div'),
@@ -60,6 +60,16 @@ export class MatMenuContent implements OnDestroy {
     // risk it staying attached to a pane that's no longer in the DOM.
     element.parentNode!.insertBefore(this._outlet.outletElement, element);
     this._portal.attach(this._outlet, context);
+  }
+
+  /**
+   * Detaches the content.
+   * @docs-private
+   */
+  detach() {
+    if (this._portal.isAttached) {
+      this._portal.detach();
+    }
   }
 
   ngOnDestroy() {

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -33,6 +33,7 @@ import {
   OnInit,
 } from '@angular/core';
 import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
 import {merge} from 'rxjs/observable/merge';
 import {Subscription} from 'rxjs/Subscription';
 import {matMenuAnimations} from './menu-animations';
@@ -102,6 +103,9 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
 
   /** Current state of the panel animation. */
   _panelAnimationState: 'void' | 'enter' = 'void';
+
+  /** Emits whenever an animation on the menu completes. */
+  _animationDone = new Subject<void>();
 
   /** Parent menu of the current menu panel. */
   parentMenu: MatMenuPanel | undefined;
@@ -324,7 +328,7 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
   }
 
   /** Callback that is invoked when the panel animation completes. */
-  _onAnimationDone(_event: AnimationEvent) {
-    // @deletion-target 6.0.0 Not being used anymore. To be removed.
+  _onAnimationDone() {
+    this._animationDone.next();
   }
 }

--- a/src/lib/menu/menu.html
+++ b/src/lib/menu/menu.html
@@ -5,6 +5,7 @@
     (keydown)="_handleKeydown($event)"
     (click)="closed.emit('click')"
     [@transformMenu]="_panelAnimationState"
+    (@transformMenu.done)="_onAnimationDone()"
     tabindex="-1"
     role="menu">
     <div class="mat-menu-content">

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -353,8 +353,8 @@ describe('MatMenu', () => {
   describe('lazy rendering', () => {
     it('should be able to render the menu content lazily', fakeAsync(() => {
       const fixture = TestBed.createComponent(SimpleLazyMenu);
-      fixture.detectChanges();
 
+      fixture.detectChanges();
       fixture.componentInstance.triggerEl.nativeElement.click();
       fixture.detectChanges();
       tick(500);
@@ -364,6 +364,24 @@ describe('MatMenu', () => {
       expect(panel).toBeTruthy('Expected panel to be defined');
       expect(panel.textContent).toContain('Another item', 'Expected panel to have correct content');
       expect(fixture.componentInstance.trigger.menuOpen).toBe(true, 'Expected menu to be open');
+    }));
+
+    it('should detach the lazy content when the menu is closed', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SimpleLazyMenu);
+
+      fixture.detectChanges();
+      fixture.componentInstance.trigger.openMenu();
+      fixture.detectChanges();
+      tick(500);
+
+      expect(fixture.componentInstance.items.length).toBeGreaterThan(0);
+
+      fixture.componentInstance.trigger.closeMenu();
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.items.length).toBe(0);
     }));
 
     it('should focus the first menu item when opening a lazy menu via keyboard', fakeAsync(() => {
@@ -398,8 +416,8 @@ describe('MatMenu', () => {
 
     it('should be able to open the same menu with a different context', fakeAsync(() => {
       const fixture = TestBed.createComponent(LazyMenuWithContext);
-      fixture.detectChanges();
 
+      fixture.detectChanges();
       fixture.componentInstance.triggerOne.openMenu();
       fixture.detectChanges();
       tick(500);
@@ -1589,6 +1607,7 @@ class FakeIcon {}
 class SimpleLazyMenu {
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
   @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 }
 
 


### PR DESCRIPTION
Currently the lazily-rendered content is maintained in the background while a menu is open. These changes switch to detaching it once the user closes the menu.

Fixes #9915.