### PR TITLE
fix(dialog): actions not being pulled down when trapping focus

### DIFF
--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -49,12 +49,8 @@ $mat-dialog-button-margin: 8px !default;
   display: flex;
   flex-wrap: wrap;
 
-  &:last-child {
-    // If the actions are the last element in a dialog, we need to pull them down
-    // over the dialog padding, in order to avoid the action's padding stacking
-    // with the dialog's.
-    margin-bottom: -$mat-dialog-padding;
-  }
+  // Pull the actions down to avoid their padding stacking with the dialog's padding.
+  margin-bottom: -$mat-dialog-padding;
 
   &[align='end'] {
     justify-content: flex-end;


### PR DESCRIPTION
Fixes the dialog action buttons not being pulled down to the correct spacing when there is a focus trap around the actions container. These changes remove the `:last-child` selector, because it is easy to break and the actions are intended to always be placed at the bottom of a dialog anyway.

Fixes #9722.