### PR TITLE
docs(datepicker): improve and fix month picker example

### DIFF
--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -279,7 +279,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
    */
   @Input()
   get selectable(): boolean { return this._selectable; }
-  set selectable(value: boolean) { 
+  set selectable(value: boolean) {
     this._selectable = coerceBooleanProperty(value);
     if (this.chips) {
       this.chips.forEach(chip => chip.chipListSelectable = this._selectable);
@@ -747,4 +747,3 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     });
   }
 }
-

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.css
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.css
@@ -1,7 +1,7 @@
 .example-month-picker .mat-calendar-period-button {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 .example-month-picker .mat-calendar-arrow {
-    display: none;
+  display: none;
 }

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.css
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.css
@@ -1,1 +1,7 @@
-/** No CSS for this example */
+.example-month-picker .mat-calendar-period-button {
+    pointer-events: none;
+}
+
+.example-month-picker .mat-calendar-arrow {
+    display: none;
+}

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.html
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.html
@@ -1,6 +1,10 @@
-<mat-form-field class="example-month-picker">
+<mat-form-field>
   <input matInput [matDatepicker]="dp" placeholder="Month and Year" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
-  <mat-datepicker #dp (yearSelected)="chosenYearHandler($event)"
-                  (monthSelected)="chosenMonthHandler($event, dp)"></mat-datepicker>
+  <mat-datepicker #dp
+                  startView="multi-year"
+                  (yearSelected)="chosenYearHandler($event)"
+                  (monthSelected)="chosenMonthHandler($event, dp)"
+                  panelClass="example-month-picker">
+  </mat-datepicker>
 </mat-form-field>

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.html
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field class="example-month-picker">
   <input matInput [matDatepicker]="dp" placeholder="Month and Year" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp (yearSelected)="chosenYearHandler($event)"

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MatDatepicker} from '@angular/material/datepicker';
 import {MomentDateAdapter} from '@angular/material-moment-adapter';
@@ -31,6 +31,7 @@ export const MY_FORMATS = {
   selector: 'datepicker-views-selection-example',
   templateUrl: 'datepicker-views-selection-example.html',
   styleUrls: ['datepicker-views-selection-example.css'],
+  encapsulation: ViewEncapsulation.None,
   providers: [
     // `MomentDateAdapter` can be automatically provided by importing `MomentDateModule` in your
     // application's root module. We provide it at the component level here, due to limitations of


### PR DESCRIPTION
Disable the period change button (top left corner of the calendar).

It improves the example because it prevents the end user from accidentally switch views and fix some missing things, like `startView="multi-year"`

![image](https://media.giphy.com/media/3Wv8zz4s0pgh3srDix/giphy.gif)

Thanks for the suggestion, @willshowell.

cc: @mmalerba 

edit: I've removed a trailing white space that was causing a lint error in chips list. Didn't change anything else.