### PR TITLE
build: publish docs-content based on branch

### DIFF
--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -19,20 +19,26 @@ if [[ ! ${*} == *--no-build* ]]; then
   $(npm bin)/gulp docs
 fi
 
-# Path to the directory that contains the generated docs output.
-docsDistPath="./dist/docs"
+# Path to the project directory.
+projectPath="$(pwd)"
 
-# Path to the release output of the @angular/material-examples package.
-examplesPackagePath="./dist/releases/material-examples"
+# Path to the directory that contains the generated docs output.
+docsDistPath="${projectPath}/dist/docs"
 
 # Path to the cloned docs-content repository.
-docsContentPath=./tmp/material2-docs-content
+docsContentPath="${projectPath}/tmp/material2-docs-content"
+
+# Path to the release output of the @angular/material-examples package.
+examplesPackagePath="${projectPath}/dist/releases/material-examples"
 
 # Git clone URL for the material2-docs-content repository.
 docsContentRepoUrl="https://github.com/angular/material2-docs-content"
 
 # Current version of Angular Material from the package.json file
 buildVersion=$(node -pe "require('./package.json').version")
+
+# Name of the branch that is currently being deployed.
+branchName=${TRAVIS_BRANCH:-'master'}
 
 # Additional information about the last commit for docs-content commits.
 commitSha=$(git rev-parse --short HEAD)
@@ -41,14 +47,38 @@ commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 commitTag="${buildVersion}-${commitSha}"
 
+buildVersionName="${buildVersion}-${commitSha}"
+buildTagName="${branchName}-${commitSha}"
+buildCommitMessage="${branchName} - ${commitMessage}"
+
+echo "Starting deployment of the docs-content for ${buildVersionName} in ${branchName}"
+
 # Remove the docs-content repository if the directory exists
 rm -Rf ${docsContentPath}
 
 # Clone the docs-content repository.
 git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1
 
+echo "Successfully cloned docs-content repository."
+
+# Go into the repository directory.
+cd ${docsContentPath}
+
+echo "Switched into the repository directory."
+
+if [[ $(git ls-remote --heads origin ${branchName}) ]]; then
+  git checkout ${branchName}
+  echo "Switched to ${branchName} branch."
+else
+  echo "Branch ${branchName} does not exist on the docs-content repo yet. Creating ${branchName}.."
+  git checkout -b ${branchName}
+  echo "Branch created and checked out."
+fi
+
 # Remove everything inside of the docs-content repository.
 rm -Rf ${docsContentPath}/*
+
+echo "Removed everything from the docs-content repository. Copying all files into repository.."
 
 # Create all folders that need to exist in the docs-content repository.
 mkdir ${docsContentPath}/{overview,guides,api,examples,stackblitz,examples-package}
@@ -62,7 +92,7 @@ cp -r ${docsDistPath}/stackblitz/* ${docsContentPath}/stackblitz
 cp -r ${examplesPackagePath}/* ${docsContentPath}/examples-package
 
 # Copy the license file to the docs-content repository.
-cp ./LICENSE ${docsContentPath}
+cp ${projectPath}/LICENSE ${docsContentPath}
 
 # Copy all immediate children of the markdown output the guides/ directory.
 for guidePath in $(find ${docsDistPath}/markdown/ -maxdepth 1 -type f); do
@@ -74,8 +104,12 @@ for overviewPath in $(find ${docsDistPath}/markdown/ -mindepth 2 -type f); do
   cp ${overviewPath} ${docsContentPath}/overview
 done
 
-# Go into the repository directory.
-cd ${docsContentPath}
+echo "Successfully copied all content into the docs-content repository."
+
+if [[ $(git ls-remote origin "refs/tags/${buildTagName}") ]]; then
+  echo "Skipping publish of docs-content because tag is already published. Exiting.."
+  exit 0
+fi
 
 # Setup the Git configuration
 git config user.name "$commitAuthorName"
@@ -84,7 +118,11 @@ git config credential.helper "store --file=.git/credentials"
 
 echo "https://${MATERIAL2_DOCS_CONTENT_TOKEN}:@github.com" > .git/credentials
 
+echo "Credentials for docs-content repository are now set up. Publishing.."
+
 git add -A
-git commit --allow-empty -m "${commitMessage}"
-git tag "${commitTag}"
+git commit --allow-empty -m "${buildCommitMessage}"
+git tag "${buildTagName}"
 git push origin master --tags
+
+echo "Published docs-content for ${buildVersionName} into ${branchName} successfully"


### PR DESCRIPTION
Docs content will be published differently for different branches. For example, commits in `master` will be published on the `master` branch on the docs-content repository. `5.2.x` commits will be published on the `5.2.x` branch on the docs-content repository.

 Tags on the docs-content repository will be explicit to indicate from what branch they come.