### PR TITLE
refactor(stepper): use common keyboard focus handling

### DIFF
--- a/src/cdk/stepper/BUILD.bazel
+++ b/src/cdk/stepper/BUILD.bazel
@@ -6,6 +6,7 @@ ng_module(
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/cdk/stepper",
   deps = [
+    "//src/cdk/a11y",
     "//src/cdk/bidi",
     "//src/cdk/coercion",
     "//src/cdk/keycodes",

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -100,4 +100,8 @@ export class MatStepHeader implements OnDestroy {
   _getHostElement() {
     return this._element.nativeElement;
   }
+
+  focus() {
+    this._getHostElement().focus();
+  }
 }

--- a/src/lib/stepper/stepper-horizontal.html
+++ b/src/lib/stepper/stepper-horizontal.html
@@ -3,7 +3,7 @@
     <mat-step-header  class="mat-horizontal-stepper-header"
                      (click)="step.select()"
                      (keydown)="_onKeydown($event)"
-                     [tabIndex]="_focusIndex === i ? 0 : -1"
+                     [tabIndex]="_getFocusIndex() === i ? 0 : -1"
                      [id]="_getStepLabelId(i)"
                      [attr.aria-controls]="_getStepContentId(i)"
                      [attr.aria-selected]="selectedIndex == i"

--- a/src/lib/stepper/stepper-vertical.html
+++ b/src/lib/stepper/stepper-vertical.html
@@ -2,7 +2,7 @@
   <mat-step-header  class="mat-vertical-stepper-header"
                    (click)="step.select()"
                    (keydown)="_onKeydown($event)"
-                   [tabIndex]="_focusIndex == i ? 0 : -1"
+                   [tabIndex]="_getFocusIndex() == i ? 0 : -1"
                    [id]="_getStepLabelId(i)"
                    [attr.aria-controls]="_getStepContentId(i)"
                    [attr.aria-selected]="selectedIndex === i"

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -477,14 +477,12 @@ describe('MatStepper', () => {
       expect(stepperComponent.selectedIndex).toBe(2);
     });
 
-    it('should not focus step header upon click if it is not able to be selected', () => {
+    it('should be able to focus step header upon click if it is unable to be selected', () => {
       let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
 
-      spyOn(stepHeaderEl, 'blur');
-      stepHeaderEl.click();
       fixture.detectChanges();
 
-      expect(stepHeaderEl.blur).toHaveBeenCalled();
+      expect(stepHeaderEl.getAttribute('tabindex')).toBe('-1');
     });
 
     it('should be able to move to next step even when invalid if current step is optional', () => {
@@ -705,14 +703,14 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
   let nextKey = orientation === 'vertical' ? DOWN_ARROW : RIGHT_ARROW;
   let prevKey = orientation === 'vertical' ? UP_ARROW : LEFT_ARROW;
 
-  expect(stepperComponent._focusIndex).toBe(0);
+  expect(stepperComponent._getFocusIndex()).toBe(0);
   expect(stepperComponent.selectedIndex).toBe(0);
 
   let stepHeaderEl = stepHeaders[0].nativeElement;
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', nextKey);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(1, 'Expected index of focused step to increase by 1 after pressing the next key.');
   expect(stepperComponent.selectedIndex)
       .toBe(0, 'Expected index of selected step to remain unchanged after pressing the next key.');
@@ -721,7 +719,7 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', ENTER);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(1, 'Expected index of focused step to remain unchanged after ENTER event.');
   expect(stepperComponent.selectedIndex)
       .toBe(1,
@@ -731,19 +729,19 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', prevKey);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(0, 'Expected index of focused step to decrease by 1 after pressing the previous key.');
   expect(stepperComponent.selectedIndex).toBe(1,
       'Expected index of selected step to remain unchanged after pressing the previous key.');
 
   // When the focus is on the last step and right arrow key is pressed, the focus should cycle
   // through to the first step.
-  stepperComponent._focusIndex = 2;
+  stepperComponent._keyManager.updateActiveItemIndex(2);
   stepHeaderEl = stepHeaders[2].nativeElement;
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', nextKey);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex).toBe(0,
+  expect(stepperComponent._getFocusIndex()).toBe(0,
       'Expected index of focused step to cycle through to index 0 after pressing the next key.');
   expect(stepperComponent.selectedIndex)
       .toBe(1, 'Expected index of selected step to remain unchanged after pressing the next key.');
@@ -752,19 +750,19 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', SPACE);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(0, 'Expected index of focused to remain unchanged after SPACE event.');
   expect(stepperComponent.selectedIndex)
       .toBe(0,
           'Expected index of selected step to change to index of focused step after SPACE event.');
 
   const endEvent = dispatchKeyboardEvent(stepHeaderEl, 'keydown', END);
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(stepHeaders.length - 1, 'Expected last step to be focused when pressing END.');
   expect(endEvent.defaultPrevented).toBe(true, 'Expected default END action to be prevented.');
 
   const homeEvent = dispatchKeyboardEvent(stepHeaderEl, 'keydown', HOME);
-  expect(stepperComponent._focusIndex)
+  expect(stepperComponent._getFocusIndex())
       .toBe(0, 'Expected first step to be focused when pressing HOME.');
   expect(homeEvent.defaultPrevented).toBe(true, 'Expected default HOME action to be prevented.');
 }
@@ -774,19 +772,19 @@ function assertArrowKeyInteractionInRtl(fixture: ComponentFixture<any>,
                                         stepHeaders: DebugElement[]) {
   let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
 
-  expect(stepperComponent._focusIndex).toBe(0);
+  expect(stepperComponent._getFocusIndex()).toBe(0);
 
   let stepHeaderEl = stepHeaders[0].nativeElement;
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', LEFT_ARROW);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex).toBe(1);
+  expect(stepperComponent._getFocusIndex()).toBe(1);
 
   stepHeaderEl = stepHeaders[1].nativeElement;
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', RIGHT_ARROW);
   fixture.detectChanges();
 
-  expect(stepperComponent._focusIndex).toBe(0);
+  expect(stepperComponent._getFocusIndex()).toBe(0);
 }
 
 function asyncValidator(minLength: number, validationTrigger: Observable<any>): AsyncValidatorFn {

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -14,7 +14,6 @@ import {
   ContentChild,
   ContentChildren,
   Directive,
-  ElementRef,
   forwardRef,
   Inject,
   QueryList,
@@ -76,7 +75,7 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
 })
 export class MatStepper extends CdkStepper implements AfterContentInit {
   /** The list of step headers of the steps in the stepper. */
-  @ViewChildren(MatStepHeader, {read: ElementRef}) _stepHeader: QueryList<ElementRef>;
+  @ViewChildren(MatStepHeader) _stepHeader: QueryList<MatStepHeader>;
 
   /** Steps that the stepper holds. */
   @ContentChildren(MatStep) _steps: QueryList<MatStep>;


### PR DESCRIPTION
Switches the stepper to use the `FocusKeyManager`, instead of re-implementing all of the logic itself.