### PR TITLE
fix(list-key-manager): not ignoring vertical key events in horizontal-only mode

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -138,6 +138,28 @@ describe('Key managers', () => {
         expect(fakeKeyEvents.unsupported.defaultPrevented).toBe(false);
       });
 
+      it('should ignore the horizontal keys when only in vertical mode', () => {
+        keyManager.withVerticalOrientation().withHorizontalOrientation(null);
+
+        expect(keyManager.activeItemIndex).toBe(0);
+
+        keyManager.onKeydown(fakeKeyEvents.rightArrow);
+
+        expect(keyManager.activeItemIndex).toBe(0);
+        expect(fakeKeyEvents.rightArrow.defaultPrevented).toBe(false);
+      });
+
+      it('should ignore the horizontal keys when only in horizontal mode', () => {
+        keyManager.withVerticalOrientation(false).withHorizontalOrientation('ltr');
+
+        expect(keyManager.activeItemIndex).toBe(0);
+
+        keyManager.onKeydown(fakeKeyEvents.downArrow);
+
+        expect(keyManager.activeItemIndex).toBe(0);
+        expect(fakeKeyEvents.downArrow.defaultPrevented).toBe(false);
+      });
+
       describe('with `vertical` direction', () => {
         beforeEach(() => {
           keyManager.withVerticalOrientation();

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -171,12 +171,16 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
         if (this._vertical) {
           this.setNextItemActive();
           break;
+        } else {
+          return;
         }
 
       case UP_ARROW:
         if (this._vertical) {
           this.setPreviousItemActive();
           break;
+        } else {
+          return;
         }
 
       case RIGHT_ARROW:
@@ -186,6 +190,8 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
         } else if (this._horizontal === 'rtl') {
           this.setPreviousItemActive();
           break;
+        } else {
+          return;
         }
 
       case LEFT_ARROW:
@@ -195,6 +201,8 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
         } else if (this._horizontal === 'rtl') {
           this.setNextItemActive();
           break;
+        } else {
+          return;
         }
 
       default:


### PR DESCRIPTION
Fixes the a `ListKeyManager` that is in `horizontal`-only mode not ignoring the vertical key events due it falling into the switch statement.