### PR TITLE
chore(menu): fix incorrect docs example

### DIFF
--- a/src/lib/menu/menu.md
+++ b/src/lib/menu/menu.md
@@ -118,7 +118,7 @@ with a different set of data, depending on the trigger that opened it:
 
 ```html
 <mat-menu #appMenu="matMenu">
-  <ng-template matMenuContent let-user="user">
+  <ng-template matMenuContent let-name="name">
     <button mat-menu-item>Settings</button>
     <button mat-menu-item>Log off {{name}}</button>
   </ng-template>


### PR DESCRIPTION
Corrects the variable name used on an `ng-template` in the "Passing in data to a menu" example.