### PR TITLE
chore: revert #9971

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -129,7 +129,7 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
 
   /** List of the items inside of a menu. */
-  @ContentChildren(MatMenuItem, {descendants: true}) items: QueryList<MatMenuItem>;
+  @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 
   /**
    * Menu content that will be rendered lazily.


### PR DESCRIPTION
Reverts the changes from #9971, because they break the case where a mat-menu is placed inside another mat-menu, causing the keyboard controls to be thrown off and nested menus not to work. Having a solution that supports both cases will require moving some more code around.

Fixes #10081.