### PR TITLE
 fix(drawer): drawer running inside the zone keydown event.

### DIFF
--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -57,7 +57,6 @@ export class MatSidenavContent extends MatDrawerContent {
     '[@transform]': '_animationState',
     '(@transform.start)': '_onAnimationStart($event)',
     '(@transform.done)': '_onAnimationEnd($event)',
-    '(keydown)': 'handleKeydown($event)',
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',
     '[class.mat-drawer-end]': 'position === "end"',


### PR DESCRIPTION
Currently, the drawer is listening to the event 'keydown' inside the zone. This makes the change detector be fired every time while we are pressing 'any' key, even it's is not the ESCAPE key.
With this code, we can escape it, and run only inside the zone when there is an escape event.

Do we really need this?
I'm sure most apps would not need that, but for example, in our app, we have a drawer that inside has a bunch of controls that are controlled by keyboard events... so this has an impact to our performance since change detector is fired while pressing. So I think it would be a good change, although it's is not much elegant, but it is functional.