### PR TITLE
build: fix TS 2.6 compilation error in tree

### DIFF
--- a/src/cdk/tree/tsconfig-build.json
+++ b/src/cdk/tree/tsconfig-build.json
@@ -6,7 +6,7 @@
   ],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
-    "strictMetadataEmit": true,
+    "strictMetadataEmit": false, // Workaround for Angular #22210
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk/tree",
     "skipTemplateCodegen": true

--- a/src/lib/tree/tsconfig-build.json
+++ b/src/lib/tree/tsconfig-build.json
@@ -6,7 +6,7 @@
   ],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
-    "strictMetadataEmit": true,
+    "strictMetadataEmit": false, // Workaround for Angular #22210
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/material/tree",
     "skipTemplateCodegen": true,


### PR DESCRIPTION
Fixes a compilation error in the tree after the update to Angular 6 and TS 2.6.