### PR TITLE
build: handle prerelease versions in deletion target rule

### DIFF
--- a/tools/tslint-rules/deletionTargetRule.ts
+++ b/tools/tslint-rules/deletionTargetRule.ts
@@ -9,7 +9,8 @@ import * as path from 'path';
  */
 export class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    const packageVersion = require(path.join(process.cwd(), 'package.json')).version;
+    // Split it on the dash to ignore `-beta.x` suffixes.
+    const packageVersion = require(path.join(process.cwd(), 'package.json')).version.split('-')[0];
 
     return this.applyWithFunction(sourceFile, (ctx: Lint.WalkContext<any>) => {
       utils.forEachComment(ctx.sourceFile, (file, {pos, end}) => {


### PR DESCRIPTION
Currently the deletion target rule doesn't handle comparing something like `6.0.0-beta.2` and `6.0.0`. With these changes both versions will be considered the same.

**Note:** lint failures are to be expected, because the rule not compares the beta version correctly. We may have to delay merging this in until we've done all the breaking changes.