### PR TITLE
virtual-scroll: simplify scroll listener logic

### DIFF
--- a/src/demo-app/demo-app/demo-module.ts
+++ b/src/demo-app/demo-app/demo-module.ts
@@ -63,12 +63,11 @@ import {
 } from '../tabs/tabs-demo';
 import {ToolbarDemo} from '../toolbar/toolbar-demo';
 import {TooltipDemo} from '../tooltip/tooltip-demo';
+import {TreeDemoModule} from '../tree/tree-demo-module';
 import {TypographyDemo} from '../typography/typography-demo';
 import {VirtualScrollDemo} from '../virtual-scroll/virtual-scroll-demo';
 import {DemoApp, Home} from './demo-app';
 import {DEMO_APP_ROUTES} from './routes';
-import {TableDemoModule} from '../table/table-demo-module';
-import {TreeDemoModule} from '../tree/tree-demo-module';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
This was way more complicated than it needed to be because I was listening to scroll events outside the `NgZone`. Instead I'm now subscribing to a version of the scroll events stream that's throttled to `requestAnimationFrame` to begin with, so no need to leave the `NgZone`.