### PR TITLE
build: e2e test timeout due to missing systemjs map

### DIFF
--- a/src/e2e-app/system-config.ts
+++ b/src/e2e-app/system-config.ts
@@ -47,6 +47,7 @@ System.config({
     '@angular/cdk/scrolling': 'dist/bundles/cdk-scrolling.umd.js',
     '@angular/cdk/stepper': 'dist/bundles/cdk-stepper.umd.js',
     '@angular/cdk/table': 'dist/bundles/cdk-table.umd.js',
+    '@angular/cdk/tree': 'dist/bundles/cdk-tree.umd.js',
     '@angular/cdk/testing': 'dist/bundles/cdk-testing.umd.js',
     '@angular/material-examples': 'dist/bundles/material-examples.umd.js',
 
@@ -83,6 +84,7 @@ System.config({
     '@angular/material/tabs': 'dist/bundles/material-tabs.umd.js',
     '@angular/material/toolbar': 'dist/bundles/material-toolbar.umd.js',
     '@angular/material/tooltip': 'dist/bundles/material-tooltip.umd.js',
+    '@angular/material/tree': 'dist/bundles/material-tree.umd.js',
   },
   packages: {
     // Thirdparty barrels.


### PR DESCRIPTION
Fixes the e2e tests currently timing out, because the e2e app throws a runtime error due to a missing mapping for the `tree` in the SystemJS config.