### PR TITLE
fix(bottom-sheet): error when attempting to open multiple instances quickly

### DIFF
--- a/src/lib/bottom-sheet/bottom-sheet-container.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-container.ts
@@ -83,6 +83,9 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   /** Server-side rendering-compatible reference to the global document object. */
   private _document: Document;
 
+  /** Whether the component has been destroyed. */
+  private _destroyed: boolean;
+
   constructor(
     private _elementRef: ElementRef,
     private _changeDetectorRef: ChangeDetectorRef,
@@ -122,18 +125,23 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
 
   /** Begin animation of bottom sheet entrance into view. */
   enter(): void {
-    this._animationState = 'visible';
-    this._changeDetectorRef.detectChanges();
+    if (!this._destroyed) {
+      this._animationState = 'visible';
+      this._changeDetectorRef.detectChanges();
+    }
   }
 
   /** Begin animation of the bottom sheet exiting from view. */
   exit(): void {
-    this._animationState = 'hidden';
-    this._changeDetectorRef.markForCheck();
+    if (!this._destroyed) {
+      this._animationState = 'hidden';
+      this._changeDetectorRef.markForCheck();
+    }
   }
 
   ngOnDestroy() {
     this._breakpointSubscription.unsubscribe();
+    this._destroyed = true;
   }
 
   _onAnimationDone(event: AnimationEvent) {

--- a/src/lib/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.spec.ts
@@ -290,6 +290,17 @@ describe('MatBottomSheet', () => {
     expect(overlayContainerElement.textContent).toContain('Taco');
   }));
 
+  it('should not throw when opening multiple bottom sheet in quick succession', fakeAsync(() => {
+    expect(() => {
+      for (let i = 0; i < 3; i++) {
+        bottomSheet.open(PizzaMsg);
+        viewContainerFixture.detectChanges();
+      }
+
+      flush();
+    }).not.toThrow();
+  }));
+
   it('should remove bottom sheet if another is shown while its still animating open',
     fakeAsync(() => {
       bottomSheet.open(PizzaMsg);


### PR DESCRIPTION
Fixes an error that is thrown when attempting to open more than three bottom sheets in quick succession.