### PR TITLE
virtual-scroll: allow user to pass `Observable<T[]>`

### DIFF
--- a/src/cdk-experimental/scrolling/virtual-for-of.ts
+++ b/src/cdk-experimental/scrolling/virtual-for-of.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CollectionViewer, DataSource, Range, StaticArrayDataSource} from '@angular/cdk/collections';
+import {ArrayDataSource, CollectionViewer, DataSource, Range} from '@angular/cdk/collections';
 import {
   Directive,
   DoCheck,
@@ -35,7 +35,7 @@ import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 /** The context for an item rendered by `CdkVirtualForOf` */
 export type CdkVirtualForOfContext<T> = {
   $implicit: T;
-  cdkVirtualForOf: NgIterable<T> | DataSource<T>;
+  cdkVirtualForOf: DataSource<T> | Observable<T[]> | NgIterable<T>;
   index: number;
   count: number;
   first: boolean;
@@ -61,15 +61,18 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
 
   /** The DataSource to display. */
   @Input()
-  get cdkVirtualForOf(): NgIterable<T> | DataSource<T> { return this._cdkVirtualForOf; }
-  set cdkVirtualForOf(value: NgIterable<T> | DataSource<T>) {
+  get cdkVirtualForOf(): DataSource<T> | Observable<T[]> | NgIterable<T> {
+    return this._cdkVirtualForOf;
+  }
+  set cdkVirtualForOf(value: DataSource<T> | Observable<T[]> | NgIterable<T>) {
     this._cdkVirtualForOf = value;
     const ds = value instanceof DataSource ? value :
-        // Slice the value since NgIterable may be array-like rather than an array.
-        new StaticArrayDataSource<T>(Array.prototype.slice.call(value));
+        // Slice the value if its an NgIterable to ensure we're working with an array.
+        new ArrayDataSource<T>(
+            value instanceof Observable ? value : Array.prototype.slice.call(value));
     this._dataSourceChanges.next(ds);
   }
-  _cdkVirtualForOf: NgIterable<T> | DataSource<T>;
+  _cdkVirtualForOf: DataSource<T> | Observable<T[]> | NgIterable<T>;
 
   /**
    * The `TrackByFunction` to use for tracking changes. The `TrackByFunction` takes the index and

--- a/src/cdk/collections/array-data-source.ts
+++ b/src/cdk/collections/array-data-source.ts
@@ -12,11 +12,11 @@ import {DataSource} from './data-source';
 
 
 /** DataSource wrapper for a native array. */
-export class StaticArrayDataSource<T> implements DataSource<T> {
-  constructor(private _data: T[]) {}
+export class ArrayDataSource<T> implements DataSource<T> {
+  constructor(private _data: T[] | Observable<T[]>) {}
 
   connect(): Observable<T[]> {
-    return observableOf(this._data);
+    return this._data instanceof Observable ? this._data : observableOf(this._data);
   }
 
   disconnect() {}

--- a/src/cdk/collections/public-api.ts
+++ b/src/cdk/collections/public-api.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './array-data-source';
 export * from './collection-viewer';
 export * from './data-source';
 export * from './selection';
-export * from './static-array-data-source';
 export {
   UniqueSelectionDispatcher,
   UniqueSelectionDispatcherListener,


### PR DESCRIPTION
For convenience, the user is allowed to pass `DataSource<T>`, `NgIterable<T>`, or `Observable<NgIterable<T>>` to the virtual scroller. It will be automatically converted into a `DataSource` so that the same logic can be used no matter what the user passes.

Fixes #10120 

@andrewseguin @tinayuangao do you guys do something like this for tree and table? We probably should do it for all three for consistency.