### PR TITLE
refactor(select): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -10,7 +10,7 @@
       <mat-select
         [value]="pageSize"
         [aria-label]="_intl.itemsPerPageLabel"
-        (change)="_changePageSize($event.value)">
+        (selectionChange)="_changePageSize($event.value)">
         <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
           {{pageSizeOption}}
         </mat-option>

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2686,7 +2686,7 @@ describe('MatSelect', () => {
       const spy = jasmine.createSpy('change spy');
 
       fixture.detectChanges();
-      instance.select.change.subscribe(() => spy(instance.selectedFood));
+      instance.select.selectionChange.subscribe(() => spy(instance.selectedFood));
 
       expect(instance.selectedFood).toBeFalsy();
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -433,42 +433,17 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    /** Event emitted when the select panel has been toggled. */
    @Output() readonly openedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-   /** Event emitted when the select has been opened. */
-   @Output('opened')
-   get _openedStream(): Observable<void> {
-    return this.openedChange.pipe(filter(o => o), map(() => {}));
-  }
+  /** Event emitted when the select has been opened. */
+  @Output('opened') readonly _openedStream: Observable<void> =
+      this.openedChange.pipe(filter(o => o), map(() => {}));
 
   /** Event emitted when the select has been closed. */
-  @Output('closed')
-  get _closedStream(): Observable<void> {
-    return this.openedChange.pipe(filter(o => !o), map(() => {}));
-  }
-
-  /**
-   * Event emitted when the select has been opened.
-   * @deprecated Use `openedChange` instead.
-   * @deletion-target 6.0.0
-   */
-  @Output() readonly onOpen: Observable<void> = this._openedStream;
-
-  /**
-   * Event emitted when the select has been closed.
-   * @deprecated Use `openedChange` instead.
-   * @deletion-target 6.0.0
-   */
-  @Output() readonly onClose: Observable<void> = this._closedStream;
+  @Output('closed') readonly _closedStream: Observable<void> =
+      this.openedChange.pipe(filter(o => !o), map(() => {}));
 
    /** Event emitted when the selected value has been changed by the user. */
   @Output() readonly selectionChange: EventEmitter<MatSelectChange> =
       new EventEmitter<MatSelectChange>();
-
-  /**
-   * Event emitted when the selected value has been changed by the user.
-   * @deprecated Use `selectionChange` instead.
-   * @deletion-target 6.0.0
-   */
-  @Output() readonly change: EventEmitter<MatSelectChange> = this.selectionChange;
 
   /**
    * Event that emits whenever the raw value of the select changes. This is here primarily


### PR DESCRIPTION
Removes the targets marked for 6.0.0 deletion from the `material/select` entry point.

BREAKING CHANGES:
* `onOpen`, which was deprecated in 5.0.0, has been removed.
* `onClose`, which was deprecated in 5.0.0, has been removed.
* `change`, which was deprecated in 5.0.0, has been removed.