### PR TITLE
refactor(form-field): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/form-field/form-field.html
+++ b/src/lib/form-field/form-field.html
@@ -1,3 +1,4 @@
+<!-- @deletion-target 7.0.0 Remove all of the `mat-input-*` classes -->
 <div class="mat-input-wrapper mat-form-field-wrapper">
   <div class="mat-input-flex mat-form-field-flex" #connectionContainer
        (click)="_control.onContainerClick && _control.onContainerClick($event)">
@@ -8,21 +9,10 @@
     <div class="mat-input-infix mat-form-field-infix" #inputContainer>
       <ng-content></ng-content>
 
-      <!--
-        TODO: remove `mat-input-placeholder-wrapper` and `mat-form-field-placeholder-wrapper`
-        next time we do breaking changes.
-        @deletion-target 6.0.0
-      -->
-      <span class="mat-form-field-label-wrapper mat-input-placeholder-wrapper mat-form-field-placeholder-wrapper">
+      <span class="mat-form-field-label-wrapper">
         <!-- We add aria-owns as a workaround for an issue in JAWS & NVDA where the label isn't
              read if it comes before the control in the DOM. -->
-
-        <!--
-          TODO: remove `mat-input-placeholder` and `mat-form-field-placeholder`
-          next time we do breaking changes.
-          @deletion-target 6.0.0
-        -->
-        <label class="mat-form-field-label mat-input-placeholder mat-form-field-placeholder"
+        <label class="mat-form-field-label"
                [attr.for]="_control.id"
                [attr.aria-owns]="_control.id"
                [class.mat-empty]="_control.empty && !_shouldAlwaysFloat"

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -139,14 +139,6 @@ export class MatFormField extends _MatFormFieldMixinBase
   }
   _appearance: MatFormFieldAppearance;
 
-  /**
-   * @deprecated Use `color` instead.
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get dividerColor(): ThemePalette { return this.color; }
-  set dividerColor(value: ThemePalette) { this.color = value; }
-
   /** Whether the required marker should be hidden. */
   @Input()
   get hideRequiredMarker(): boolean { return this._hideRequiredMarker; }
@@ -180,15 +172,6 @@ export class MatFormField extends _MatFormFieldMixinBase
 
   // Unique id for the hint label.
   _hintLabelId: string = `mat-hint-${nextUniqueId++}`;
-
-  /**
-   * Whether the placeholder should always float, never float or float as the user types.
-   * @deprecated Use floatLabel instead.
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get floatPlaceholder(): FloatLabelType { return this.floatLabel; }
-  set floatPlaceholder(value: FloatLabelType) { this.floatLabel = value; }
 
   /**
    * Whether the label should always float, never float or float as the user types.


### PR DESCRIPTION
Removes the targets marked for 6.0.0 deletion from the `material/form-field`.

BREAKING CHANGES:
* `dividerColor` which was deprecated in 5.0.0 has been removed. Use `color` instead.
* `floatPlaceholder` which was deprecated in 5.0.0 has been removed. Use `floatLabel` instead.
* `MatFormFieldControl.shouldPlaceholderFloat` which was deprecated in 5.0.0 has been removed. Use `shouldLabelFloat` instead.
* `FloatPlaceholderType`  which was deprecated in 5.0.0 has been removed. Use `FloatLabelType` instead.
* `PlaceholderOptions` which was deprecated in 5.0.0 has been removed. Use `LabelOptions` instead.
* `MAT_PLACEHOLDER_GLOBAL_OPTIONS`  which was deprecated in 5.0.0 has been removed. Use `MAT_LABEL_GLOBAL_OPTIONS` instead.
* The `mat-input-placeholder-wrapper` and `mat-form-field-placeholder-wrapper` CSS classes which were deprecated in 5.0.0 have bee removed. The same element can be targeted using the `mat-form-field-label-wrapper` class.
* The `mat-input-placeholder` and `mat-form-field-placeholder` CSS classes which were deprecated in 5.0.0 have bee removed. The same element can be targeted using the `mat-form-field-label` class.