### PR TITLE
fix(icon): namespace error when registering an icon on the server

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -459,9 +459,6 @@ export class MatIconRegistry {
    * Sets the default attributes for an SVG element to be used as an icon.
    */
   private _setSvgAttributes(svg: SVGElement): SVGElement {
-    if (!svg.getAttribute('xmlns')) {
-      svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-    }
     svg.setAttribute('fit', '');
     svg.setAttribute('height', '100%');
     svg.setAttribute('width', '100%');

--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -15,7 +15,10 @@ const result = renderModuleFactory(KitchenSinkServerModuleNgFactory, {
 
 result
   .then(content => {
-    writeFileSync(join(__dirname, 'index-prerendered.html'), content, 'utf-8');
+    const filename = join(__dirname, 'index-prerendered.html');
+
+    console.log(`Outputting result to ${filename}`);
+    writeFileSync(filename, content, 'utf-8');
     log('Prerender done.');
   })
   // If rendering the module factory fails, exit the process with an error code because otherwise


### PR DESCRIPTION
Fixes the `MatIconRegistry` throwing a namespace error on the server due to the `xmlns` attribute. These changes remove the attribute, because it's optional under HTML5.

Fixes #10170.