### PR TITLE
virtual-scroll: switch `throttleTime` to `sampleTime`

### DIFF
--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
@@ -177,6 +177,8 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
 
       this._ngZone.runOutsideAngular(() => {
         fromEvent(this.elementRef.nativeElement, 'scroll')
+            // Sample the scroll stream at every animation frame. This way if there are multiple
+            // scroll events in the same frame we only need to recheck our layout once
             .pipe(sampleTime(0, animationFrame))
             .subscribe(() => this._scrollStrategy.onContentScrolled());
       });

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
@@ -22,8 +22,8 @@ import {
 } from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {fromEvent} from 'rxjs/observable/fromEvent';
+import {sampleTime} from 'rxjs/operators/sampleTime';
 import {takeUntil} from 'rxjs/operators/takeUntil';
-import {throttleTime} from 'rxjs/operators/throttleTime';
 import {animationFrame} from 'rxjs/scheduler/animationFrame';
 import {Subject} from 'rxjs/Subject';
 import {CdkVirtualForOf} from './virtual-for-of';
@@ -177,7 +177,7 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
 
       this._ngZone.runOutsideAngular(() => {
         fromEvent(this.elementRef.nativeElement, 'scroll')
-            .pipe(throttleTime(0, animationFrame))
+            .pipe(sampleTime(0, animationFrame))
             .subscribe(() => this._scrollStrategy.onContentScrolled());
       });
     });

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -71,6 +71,8 @@ export const rollupGlobals = {
   'rxjs/observable/of': 'Rx.Observable',
   'rxjs/observable/throw': 'Rx.Observable',
 
+  'rxjs/scheduler/animationFrame': 'Rx.Scheduler',
+
   'rxjs/operators/auditTime': 'Rx.operators',
   'rxjs/operators/catchError': 'Rx.operators',
   'rxjs/operators/combineLatest': 'Rx.operators',
@@ -81,6 +83,7 @@ export const rollupGlobals = {
   'rxjs/operators/first': 'Rx.operators',
   'rxjs/operators/map': 'Rx.operators',
   'rxjs/operators/pairwise': 'Rx.operators',
+  'rxjs/operators/sampleTime': 'Rx.operators',
   'rxjs/operators/share': 'Rx.operators',
   'rxjs/operators/shareReplay': 'Rx.operators',
   'rxjs/operators/startWith': 'Rx.operators',


### PR DESCRIPTION
`sampleTime` is actually what I want here since `throttleTime` could theoretically fail to emit the last scroll event:

[`throttleTime`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-throttleTime):
> Emits a value from the source Observable, then ignores subsequent source values for duration milliseconds, then repeats this process.

[`sampleTime`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-sampleTime):
> periodically looks at the source Observable and emits whichever value it has most recently emitted since the previous sampling, unless the source has not emitted anything since the previous sampling. 