### PR TITLE
refactor(menu): remove 6.0.0 deletion targets

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -73,7 +73,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
    * Stream that emits any time the TAB key is pressed, so components can react
    * when focus is shifted off of the list.
    */
-  tabOut: Subject<void> = new Subject<void>();
+  tabOut: Subject<KeyboardEvent> = new Subject<KeyboardEvent>();
 
   /** Stream that emits whenever the active item of the list manager changes. */
   change = new Subject<number>();
@@ -189,7 +189,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
 
     switch (keyCode) {
       case TAB:
-        this.tabOut.next();
+        this.tabOut.next(event);
         return;
 
       case DOWN_ARROW:

--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -140,7 +140,7 @@
     <p>overlapTrigger: false</p>
 
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="menuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="menuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -156,7 +156,7 @@
       Position x: before, overlapTrigger: false
     </p>
     <mat-toolbar class="end-icon">
-      <button mat-icon-button [mat-menu-trigger-for]="posXMenuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="posXMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -173,7 +173,7 @@
       Position y: above, overlapTrigger: false
     </p>
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="posYMenuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="posYMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -189,7 +189,7 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
       new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
 
   /**
-   * @deprecated Use `close` instead.
+   * @deprecated Use `closed` instead.
    * @deletion-target 7.0.0
    */
   readonly close: EventEmitter<void | 'click' | 'keydown' | 'tab'> = this.closed;

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -192,7 +192,7 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
    * @deprecated Use `close` instead.
    * @deletion-target 7.0.0
    */
-  @Output() readonly close: EventEmitter<void | 'click' | 'keydown' | 'tab'> = this.closed;
+  readonly close: EventEmitter<void | 'click' | 'keydown' | 'tab'> = this.closed;
 
   constructor(
     private _elementRef: ElementRef,

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -184,27 +184,15 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
     }
   }
 
-  /**
-   * This method takes classes set on the host mat-menu element and applies them on the
-   * menu template that displays in the overlay container.  Otherwise, it's difficult
-   * to style the containing menu from outside the component.
-   * @deprecated Use `panelClass` instead.
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get classList(): string { return this.panelClass; }
-  set classList(classes: string) { this.panelClass = classes; }
-
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void | 'click' | 'keydown' | 'tab'> =
       new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
 
   /**
-   * Event emitted when the menu is closed.
-   * @deprecated Switch to `closed` instead
-   * @deletion-target 6.0.0
+   * @deprecated Use `close` instead.
+   * @deletion-target 7.0.0
    */
-  @Output() close = this.closed;
+  @Output() readonly close: EventEmitter<void | 'click' | 'keydown' | 'tab'> = this.closed;
 
   constructor(
     private _elementRef: ElementRef,
@@ -217,7 +205,7 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
 
   ngAfterContentInit() {
     this._keyManager = new FocusKeyManager<MatMenuItem>(this.items).withWrap().withTypeAhead();
-    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.close.emit('tab'));
+    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
   }
 
   ngOnDestroy() {
@@ -314,16 +302,12 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
     }
   }
 
-  /** Starts the enter animation. */
-  _startAnimation() {
-    // @deletion-target 6.0.0 Combine with _resetAnimation.
-    this._panelAnimationState = 'enter';
-  }
-
-  /** Resets the panel animation to its initial state. */
-  _resetAnimation() {
-    // @deletion-target 6.0.0 Combine with _startAnimation.
-    this._panelAnimationState = 'void';
+  /**
+   * Starts an animation of the menu.
+   * @param toState State to which to animate the menu.
+   */
+  _startAnimation(toState: 'void' | 'enter') {
+    this._panelAnimationState = toState;
   }
 
   /** Callback that is invoked when the panel animation completes. */

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -69,36 +69,26 @@ export class MatMenuItem extends _MatMenuItemMixinBase
 
   constructor(
     private _elementRef: ElementRef,
-    @Inject(DOCUMENT) document?: any,
-    private _focusMonitor?: FocusMonitor) {
+    @Inject(DOCUMENT) document: any,
+    private _focusMonitor: FocusMonitor) {
 
-    // @deletion-target 6.0.0 make `_focusMonitor` and `document` required params.
     super();
 
-    if (_focusMonitor) {
-      // Start monitoring the element so it gets the appropriate focused classes. We want
-      // to show the focus style for menu items only when the focus was not caused by a
-      // mouse or touch interaction.
-      _focusMonitor.monitor(this._getHostElement(), false);
-    }
+    // Start monitoring the element so it gets the appropriate focused classes. We want
+    // to show the focus style for menu items only when the focus was not caused by a
+    // mouse or touch interaction.
+    _focusMonitor.monitor(this._getHostElement(), false);
 
     this._document = document;
   }
 
   /** Focuses the menu item. */
   focus(origin: FocusOrigin = 'program'): void {
-    if (this._focusMonitor) {
-      this._focusMonitor.focusVia(this._getHostElement(), origin);
-    } else {
-      this._getHostElement().focus();
-    }
+    this._focusMonitor.focusVia(this._getHostElement(), origin);
   }
 
   ngOnDestroy() {
-    if (this._focusMonitor) {
-      this._focusMonitor.stopMonitoring(this._getHostElement());
-    }
-
+    this._focusMonitor.stopMonitoring(this._getHostElement());
     this._hovered.complete();
   }
 
@@ -130,7 +120,6 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   /** Gets the label to be used when determining whether the option should be focused. */
   getLabel(): string {
     const element: HTMLElement = this._elementRef.nativeElement;
-    const textNodeType = this._document ? this._document.TEXT_NODE : 3;
     let output = '';
 
     if (element.childNodes) {
@@ -140,7 +129,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
       // We skip anything that's not a text node to prevent the text from
       // being thrown off by something like an icon.
       for (let i = 0; i < length; i++) {
-        if (element.childNodes[i].nodeType === textNodeType) {
+        if (element.childNodes[i].nodeType === this._document.TEXT_NODE) {
           output += element.childNodes[i].textContent;
         }
       }

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -21,7 +21,17 @@ export interface MatMenuPanel {
   yPosition: MenuPositionY;
   overlapTrigger: boolean;
   templateRef: TemplateRef<any>;
-  close: EventEmitter<void | 'click' | 'keydown' | 'tab'>;
+  /**
+   * @deprecated Use `closed` instead.
+   * @deletion-target 7.0.0
+   */
+  close?: EventEmitter<void | 'click' | 'keydown' | 'tab'>;
+
+  /**
+   * @deprecated Signature to be changed to `Event | void` and to become required.
+   * @deletion-target 7.0.0
+   */
+  closed?: EventEmitter<void | 'click' | 'keydown' | 'tab'>;
   parentMenu?: MatMenuPanel | undefined;
   direction?: Direction;
   focusFirstItem: (origin?: FocusOrigin) => void;

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1477,7 +1477,7 @@ class CustomMenuPanel implements MatMenuPanel {
   parentMenu: MatMenuPanel;
 
   @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
-  @Output() close = new EventEmitter<void | 'click' | 'keydown'>();
+  @Output() closed = new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
   focusFirstItem = () => {};
   resetActiveItem = () => {};
   setPositionClasses = () => {};


### PR DESCRIPTION
Removes the menu APIs that were marked for deletion in 6.0.0.

BREAKING CHANGES:
* `mat-menu-trigger-for` which was deprecated in 5.0.0 has been removed. Use `matMenuTriggerFor` instead.
* `onMenuOpen` which was deprecated in 5.0.0 has been removed. Use `menuOpened` instead.
* `onMenuClose` which was deprecated in 5.0.0 has been removed. Use `menuClosed` instead.
* `_focusMonitor` parameter in the `MatMenuTrigger` constructor is now required.
* `close` which was deprecated in 5.0.0 has been removed. Use `closed` instead. Also applies to custom menus that implement the `MatMenuPanel` interface.
* `classList` which was deprecated in 5.0.0 has been removed. Use the `panelClass` property or pass in the classes via the `class attribute.
* `_startAnimation` which was deprecated in 5.0.0 has been combined with `_resetAnimation`.
* `_focusMonitor` and `document` parameters in the `MatMenuItem` constructor are now required.