### PR TITLE
Revert "fix(button): hide overflow of buttons"

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -34,7 +34,6 @@ $mat-mini-fab-padding: 8px !default;
 // Applies base styles to all button types.
 @mixin mat-button-base {
   box-sizing: border-box;
-  overflow: hidden;
   position: relative;
 
   // Reset browser <button> styles.


### PR DESCRIPTION
Reverts angular/material2#9424

This broke lint rule, and the change has no effect since there's another `overflow` rule after it.