### PR TITLE
refactor(radio): remove 6.0.0 deletion targets

### DIFF
--- a/src/demo-app/radio/radio-demo.html
+++ b/src/demo-app/radio/radio-demo.html
@@ -34,7 +34,7 @@
     name="my_options"
     [disabled]="isDisabled"
     [required]="isRequired"
-    [align]="isAlignEnd ? 'end' : 'start'">
+    [labelPosition]="isAlignEnd ? 'end' : 'start'">
     <mat-radio-button value="option_1">Option 1</mat-radio-button>
     <mat-radio-button value="option_2">Option 2</mat-radio-button>
     <mat-radio-button value="option_3">Option 3</mat-radio-button>

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -141,29 +141,13 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
     this._updateRadioButtonNames();
   }
 
-  /**
-   * Alignment of the radio-buttons relative to their labels. Can be 'before' or 'after'.
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get align(): 'start' | 'end' {
-    // align refers to the checkbox relative to the label, while labelPosition refers to the
-    // label relative to the checkbox. As such, they are inverted.
-    return this.labelPosition == 'after' ? 'start' : 'end';
-  }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
-  }
-
-
   /** Whether the labels should appear after or before the radio-buttons. Defaults to 'after' */
   @Input()
   get labelPosition(): 'before' | 'after' {
     return this._labelPosition;
   }
   set labelPosition(v) {
-    this._labelPosition = (v == 'before') ? 'before' : 'after';
+    this._labelPosition = v === 'before' ? 'before' : 'after';
     this._markRadiosForCheck();
   }
 
@@ -412,23 +396,6 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
     }
   }
 
-  /**
-   * Whether or not the radio-button should appear before or after the label.
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get align(): 'start' | 'end' {
-    // align refers to the checkbox relative to the label, while labelPosition refers to the
-    // label relative to the checkbox. As such, they are inverted.
-    return this.labelPosition == 'after' ? 'start' : 'end';
-  }
-  set align(v) {
-    this.labelPosition = (v == 'start') ? 'after' : 'before';
-  }
-
-  private _labelPosition: 'before' | 'after';
-
   /** Whether the label should appear after or before the radio button. Defaults to 'after' */
   @Input()
   get labelPosition(): 'before' | 'after' {
@@ -437,6 +404,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   set labelPosition(value) {
     this._labelPosition = value;
   }
+  private _labelPosition: 'before' | 'after';
 
   /** Whether the radio button is disabled. */
   @Input()


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 in the `material/radio` entry point.

BREAKING CHANGES:
* `align` input in `MatRadioGroup` which was deprecated in 5.0.0 has been removed. Use `labelPosition` instead.
* `align` input in `MatRadioButton` which was deprecated in 5.0.0 has been removed. Use `labelPosition` instead.