### PR TITLE
virtual-scroll: add autosize scroll strategy

### DIFF
--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, forwardRef, Input, OnChanges} from '@angular/core';
+import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
+import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+
+
+/** Virtual scrolling strategy for lists with items of unknown or dynamic size. */
+export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
+  /** The attached viewport. */
+  private _viewport: CdkVirtualScrollViewport | null = null;
+
+  /** The size of the items in the virtually scrolling list. */
+  private _minBufferPx: number;
+
+  /** The number of buffer items to render beyond the edge of the viewport. */
+  private _addBufferPx: number;
+
+  /**
+   * @param minBufferPx The minimum amount of buffer rendered beyond the viewport (in pixels).
+   *     If the amount of buffer dips below this number, more items will be rendered.
+   * @param addBufferPx The number of pixels worth of buffer to shoot for when rendering new items.
+   *     If the actual amount turns out to be less it will not necessarily trigger an additional
+   *     rendering cycle (as long as the amount of buffer is still greater than `minBufferPx`).
+   */
+  constructor(minBufferPx: number, addBufferPx: number) {
+    this._minBufferPx = minBufferPx;
+    this._addBufferPx = addBufferPx;
+  }
+
+  /**
+   * Attaches this scroll strategy to a viewport.
+   * @param viewport The viewport to attach this strategy to.
+   */
+  attach(viewport: CdkVirtualScrollViewport) {
+    this._viewport = viewport;
+    // TODO: kick off rendering (start with totally made up size estimate).
+  }
+
+  /** Detaches this scroll strategy from the currently attached viewport. */
+  detach() {
+    this._viewport = null;
+  }
+
+  /** Called when the viewport is scrolled (debounced using requestAnimationFrame). */
+  onContentScrolled() {
+    // TODO: do stuff.
+  }
+
+  /** Called when the length of the data changes. */
+  onDataLengthChanged() {
+    // TODO: do stuff.
+  }
+
+  updateBufferSize(minBufferPx, addBufferPx) {
+    this._minBufferPx = minBufferPx;
+    this._addBufferPx = addBufferPx;
+  }
+}
+
+/**
+ * Provider factory for `AutoSizeVirtualScrollStrategy` that simply extracts the already created
+ * `AutoSizeVirtualScrollStrategy` from the given directive.
+ * @param autoSizeDir The instance of `CdkAutoSizeVirtualScroll` to extract the
+ *     `AutoSizeVirtualScrollStrategy` from.
+ */
+export function _autoSizeVirtualScrollStrategyFactory(autoSizeDir: CdkAutoSizeVirtualScroll) {
+  return autoSizeDir._scrollStrategy;
+}
+
+
+/** A virtual scroll strategy that supports unknown or dynamic size items. */
+@Directive({
+  selector: 'cdk-virtual-scroll-viewport[autosize]',
+  providers: [{
+    provide: VIRTUAL_SCROLL_STRATEGY,
+    useFactory: _autoSizeVirtualScrollStrategyFactory,
+    deps: [forwardRef(() => CdkAutoSizeVirtualScroll)],
+  }],
+})
+export class CdkAutoSizeVirtualScroll implements OnChanges {
+  /**
+   * The minimum amount of buffer rendered beyond the viewport (in pixels).
+   * If the amount of buffer dips below this number, more items will be rendered.
+   */
+  @Input() minBufferPx = 20;
+
+  /**
+   * The number of pixels worth of buffer to shoot for when rendering new items.
+   * If the actual amount turns out to be less it will not necessarily trigger an additional
+   * rendering cycle (as long as the amount of buffer is still greater than `minBufferPx`).
+   */
+  @Input() addBufferPx = 5;
+
+  /** The scroll strategy used by this directive. */
+  _scrollStrategy = new AutoSizeVirtualScrollStrategy(this.minBufferPx, this.addBufferPx);
+
+  ngOnChanges() {
+    this._scrollStrategy.updateBufferSize(this.minBufferPx, this.addBufferPx);
+  }
+}

--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -6,9 +6,51 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Range} from '@angular/cdk/collections';
 import {Directive, forwardRef, Input, OnChanges} from '@angular/core';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+
+
+/**
+ * A class that tracks the size of items that have been seen and uses it to estimate the average
+ * item size.
+ */
+export class ItemSizeEstimator {
+  /** The total amount of weight behind the current average. */
+  private _totalWeight = 0;
+
+  /** The current average item size. */
+  private _averageItemSize: number;
+
+  /** @param defaultItemSize The default size to use for items when no data is available. */
+  constructor(defaultItemSize = 50) {
+    this._averageItemSize = defaultItemSize;
+  }
+
+  /** Returns the average item size. */
+  getAverageItemSize(): number {
+    return this._averageItemSize;
+  }
+
+  /**
+   * Adds a measurement sample for the estimator to consider.
+   * @param range The measured range.
+   * @param size The measured size of the given range in pixels.
+   */
+  addSample(range: Range, size: number) {
+    const weight = range.end - range.start;
+    const newTotalWeight = this._totalWeight + weight;
+    if (newTotalWeight) {
+      const newAverageItemSize =
+          (size * weight + this._averageItemSize * this._totalWeight) / newTotalWeight;
+      if (newAverageItemSize) {
+        this._averageItemSize = newAverageItemSize;
+        this._totalWeight = newTotalWeight;
+      }
+    }
+  }
+}
 
 
 /** Virtual scrolling strategy for lists with items of unknown or dynamic size. */
@@ -16,11 +58,14 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   /** The attached viewport. */
   private _viewport: CdkVirtualScrollViewport | null = null;
 
-  /** The size of the items in the virtually scrolling list. */
+  /** The minimum amount of buffer rendered beyond the viewport (in pixels). */
   private _minBufferPx: number;
 
-  /** The number of buffer items to render beyond the edge of the viewport. */
+  /** The number of buffer items to render beyond the edge of the viewport (in pixels). */
   private _addBufferPx: number;
+
+  /** The estimator used to estimate the size of unseen items. */
+  private _estimator: ItemSizeEstimator;
 
   /**
    * @param minBufferPx The minimum amount of buffer rendered beyond the viewport (in pixels).
@@ -28,10 +73,12 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
    * @param addBufferPx The number of pixels worth of buffer to shoot for when rendering new items.
    *     If the actual amount turns out to be less it will not necessarily trigger an additional
    *     rendering cycle (as long as the amount of buffer is still greater than `minBufferPx`).
+   * @param estimator The estimator used to estimate the size of unseen items.
    */
-  constructor(minBufferPx: number, addBufferPx: number) {
+  constructor(minBufferPx: number, addBufferPx: number, estimator = new ItemSizeEstimator()) {
     this._minBufferPx = minBufferPx;
     this._addBufferPx = addBufferPx;
+    this._estimator = estimator;
   }
 
   /**
@@ -48,7 +95,7 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     this._viewport = null;
   }
 
-  /** Called when the viewport is scrolled (debounced using requestAnimationFrame). */
+  /** Called when the viewport is scrolled. */
   onContentScrolled() {
     // TODO: do stuff.
   }
@@ -58,6 +105,12 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     // TODO: do stuff.
   }
 
+  /**
+   * Update the buffer parameters.
+   * @param minBufferPx The minimum amount of buffer rendered beyond the viewport (in pixels).
+   * @param addBufferPx The number of buffer items to render beyond the edge of the viewport (in
+   *     pixels).
+   */
   updateBufferSize(minBufferPx, addBufferPx) {
     this._minBufferPx = minBufferPx;
     this._addBufferPx = addBufferPx;

--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Range} from '@angular/cdk/collections';
+import {ListRange} from '@angular/cdk/collections';
 import {Directive, forwardRef, Input, OnChanges} from '@angular/core';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
@@ -38,7 +38,7 @@ export class ItemSizeAverager {
    * @param range The measured range.
    * @param size The measured size of the given range in pixels.
    */
-  addSample(range: Range, size: number) {
+  addSample(range: ListRange, size: number) {
     const weight = range.end - range.start;
     const newTotalWeight = this._totalWeight + weight;
     if (newTotalWeight) {
@@ -117,7 +117,7 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
    * @param addBufferPx The number of buffer items to render beyond the edge of the viewport (in
    *     pixels).
    */
-  updateBufferSize(minBufferPx, addBufferPx) {
+  updateBufferSize(minBufferPx: number, addBufferPx: number) {
     this._minBufferPx = minBufferPx;
     this._addBufferPx = addBufferPx;
   }
@@ -148,9 +148,9 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
    * @param startIndex The index to start the range at
    * @return a range estimated to be large enough to fill the viewport when rendered.
    */
-  private _getVisibleRangeForIndex(startIndex: number): Range {
+  private _getVisibleRangeForIndex(startIndex: number): ListRange {
     const viewport = this._viewport!;
-    let range = {
+    const range: ListRange = {
       start: startIndex,
       end: startIndex +
           Math.ceil(viewport.getViewportSize() / this._averager.getAverageItemSize())
@@ -171,7 +171,7 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
    * @param expandEnd The number of items to expand the end of the range by.
    * @return The expanded range.
    */
-  private _expandRange(range: Range, expandStart: number, expandEnd: number): Range {
+  private _expandRange(range: ListRange, expandStart: number, expandEnd: number): ListRange {
     const viewport = this._viewport!;
     const start = Math.max(0, range.start - expandStart);
     const end = Math.min(viewport.getDataLength(), range.end + expandEnd);
@@ -210,14 +210,14 @@ export class CdkAutoSizeVirtualScroll implements OnChanges {
    * The minimum amount of buffer rendered beyond the viewport (in pixels).
    * If the amount of buffer dips below this number, more items will be rendered.
    */
-  @Input() minBufferPx = 100;
+  @Input() minBufferPx: number = 100;
 
   /**
    * The number of pixels worth of buffer to shoot for when rendering new items.
    * If the actual amount turns out to be less it will not necessarily trigger an additional
    * rendering cycle (as long as the amount of buffer is still greater than `minBufferPx`).
    */
-  @Input() addBufferPx = 200;
+  @Input() addBufferPx: number = 200;
 
   /** The scroll strategy used by this directive. */
   _scrollStrategy = new AutoSizeVirtualScrollStrategy(this.minBufferPx, this.addBufferPx);

--- a/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
@@ -13,7 +13,7 @@ import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 
 
 /** Virtual scrolling strategy for lists with items of known fixed size. */
-export class VirtualScrollFixedSizeStrategy implements VirtualScrollStrategy {
+export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   /** The attached viewport. */
   private _viewport: CdkVirtualScrollViewport | null = null;
 
@@ -120,7 +120,7 @@ export class VirtualScrollFixedSizeStrategy implements VirtualScrollStrategy {
  * @param fixedSizeDir The instance of `CdkVirtualScrollFixedSize` to extract the
  *     `VirtualScrollFixedSizeStrategy` from.
  */
-export function _virtualScrollFixedSizeStrategyFactory(fixedSizeDir: CdkVirtualScrollFixedSize) {
+export function _virtualScrollFixedSizeStrategyFactory(fixedSizeDir: CdkFixedSizeVirtualScroll) {
   return fixedSizeDir._scrollStrategy;
 }
 
@@ -131,10 +131,10 @@ export function _virtualScrollFixedSizeStrategyFactory(fixedSizeDir: CdkVirtualS
   providers: [{
     provide: VIRTUAL_SCROLL_STRATEGY,
     useFactory: _virtualScrollFixedSizeStrategyFactory,
-    deps: [forwardRef(() => CdkVirtualScrollFixedSize)],
+    deps: [forwardRef(() => CdkFixedSizeVirtualScroll)],
   }],
 })
-export class CdkVirtualScrollFixedSize implements OnChanges {
+export class CdkFixedSizeVirtualScroll implements OnChanges {
   /** The size of the items in the list (in pixels). */
   @Input() itemSize = 20;
 
@@ -142,7 +142,7 @@ export class CdkVirtualScrollFixedSize implements OnChanges {
   @Input() bufferSize = 5;
 
   /** The scroll strategy used by this directive. */
-  _scrollStrategy = new VirtualScrollFixedSizeStrategy(this.itemSize, this.bufferSize);
+  _scrollStrategy = new FixedSizeVirtualScrollStrategy(this.itemSize, this.bufferSize);
 
   ngOnChanges() {
     this._scrollStrategy.updateItemAndBufferSize(this.itemSize, this.bufferSize);

--- a/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
@@ -59,7 +59,7 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     this._updateRenderedRange();
   }
 
-  /** Called when the viewport is scrolled (debounced using requestAnimationFrame). */
+  /** Called when the viewport is scrolled. */
   onContentScrolled() {
     this._updateRenderedRange();
   }

--- a/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/fixed-size-virtual-scroll.ts
@@ -25,7 +25,7 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
 
   /**
    * @param itemSize The size of the items in the virtually scrolling list.
-   * @param bufferSize he number of buffer items to render beyond the edge of the viewport.
+   * @param bufferSize The number of buffer items to render beyond the edge of the viewport.
    */
   constructor(itemSize: number, bufferSize: number) {
     this._itemSize = itemSize;
@@ -115,12 +115,12 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
 
 
 /**
- * Provider factory for `VirtualScrollFixedSizeStrategy` that simply extracts the already created
- * `VirtualScrollFixedSizeStrategy` from the given directive.
- * @param fixedSizeDir The instance of `CdkVirtualScrollFixedSize` to extract the
- *     `VirtualScrollFixedSizeStrategy` from.
+ * Provider factory for `FixedSizeVirtualScrollStrategy` that simply extracts the already created
+ * `FixedSizeVirtualScrollStrategy` from the given directive.
+ * @param fixedSizeDir The instance of `CdkFixedSizeVirtualScroll` to extract the
+ *     `FixedSizeVirtualScrollStrategy` from.
  */
-export function _virtualScrollFixedSizeStrategyFactory(fixedSizeDir: CdkFixedSizeVirtualScroll) {
+export function _fixedSizeVirtualScrollStrategyFactory(fixedSizeDir: CdkFixedSizeVirtualScroll) {
   return fixedSizeDir._scrollStrategy;
 }
 
@@ -130,7 +130,7 @@ export function _virtualScrollFixedSizeStrategyFactory(fixedSizeDir: CdkFixedSiz
   selector: 'cdk-virtual-scroll-viewport[itemSize]',
   providers: [{
     provide: VIRTUAL_SCROLL_STRATEGY,
-    useFactory: _virtualScrollFixedSizeStrategyFactory,
+    useFactory: _fixedSizeVirtualScrollStrategyFactory,
     deps: [forwardRef(() => CdkFixedSizeVirtualScroll)],
   }],
 })

--- a/src/cdk-experimental/scrolling/public-api.ts
+++ b/src/cdk-experimental/scrolling/public-api.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './auto-size-virtual-scroll';
+export * from './fixed-size-virtual-scroll';
 export * from './scrolling-module';
 export * from './virtual-for-of';
-export * from './fixed-size-virtual-scroll';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';

--- a/src/cdk-experimental/scrolling/public-api.ts
+++ b/src/cdk-experimental/scrolling/public-api.ts
@@ -8,6 +8,6 @@
 
 export * from './scrolling-module';
 export * from './virtual-for-of';
-export * from './virtual-scroll-fixed-size';
+export * from './fixed-size-virtual-scroll';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';

--- a/src/cdk-experimental/scrolling/scrolling-module.ts
+++ b/src/cdk-experimental/scrolling/scrolling-module.ts
@@ -8,19 +8,19 @@
 
 import {NgModule} from '@angular/core';
 import {CdkVirtualForOf} from './virtual-for-of';
-import {CdkVirtualScrollFixedSize} from './virtual-scroll-fixed-size';
+import {CdkFixedSizeVirtualScroll} from './fixed-size-virtual-scroll';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 
 
 @NgModule({
   exports: [
     CdkVirtualForOf,
-    CdkVirtualScrollFixedSize,
+    CdkFixedSizeVirtualScroll,
     CdkVirtualScrollViewport,
   ],
   declarations: [
     CdkVirtualForOf,
-    CdkVirtualScrollFixedSize,
+    CdkFixedSizeVirtualScroll,
     CdkVirtualScrollViewport,
   ],
 })

--- a/src/cdk-experimental/scrolling/scrolling-module.ts
+++ b/src/cdk-experimental/scrolling/scrolling-module.ts
@@ -7,20 +7,23 @@
  */
 
 import {NgModule} from '@angular/core';
-import {CdkVirtualForOf} from './virtual-for-of';
+import {CdkAutoSizeVirtualScroll} from './auto-size-virtual-scroll';
 import {CdkFixedSizeVirtualScroll} from './fixed-size-virtual-scroll';
+import {CdkVirtualForOf} from './virtual-for-of';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 
 
 @NgModule({
   exports: [
-    CdkVirtualForOf,
+    CdkAutoSizeVirtualScroll,
     CdkFixedSizeVirtualScroll,
+    CdkVirtualForOf,
     CdkVirtualScrollViewport,
   ],
   declarations: [
-    CdkVirtualForOf,
+    CdkAutoSizeVirtualScroll,
     CdkFixedSizeVirtualScroll,
+    CdkVirtualForOf,
     CdkVirtualScrollViewport,
   ],
 })

--- a/src/demo-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/demo-app/virtual-scroll/virtual-scroll-demo.html
@@ -1,19 +1,32 @@
-<cdk-virtual-scroll-viewport class="demo-viewport" [itemSize]="20">
-  <div *cdkVirtualFor="let size of data; let i = index" class="demo-item" [style.height.px]="size">
-    Item #{{i}} - ({{size}}px)
-  </div>
-</cdk-virtual-scroll-viewport>
-
-<cdk-virtual-scroll-viewport class="demo-viewport demo-horizontal" [itemSize]="20"
-                             orientation="horizontal">
-  <div *cdkVirtualFor="let size of data; let i = index" class="demo-item" [style.width.px]="size">
-    Item #{{i}} - ({{size}}px)
-  </div>
-</cdk-virtual-scroll-viewport>
-
+<h2>Autosize</h2>
 
 <cdk-virtual-scroll-viewport class="demo-viewport" autosize>
-  <div *cdkVirtualFor="let size of data; let i = index" class="demo-item" [style.height.px]="size">
+  <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
+       [style.height.px]="size">
+    Item #{{i}} - ({{size}}px)
+  </div>
+</cdk-virtual-scroll-viewport>
+
+<cdk-virtual-scroll-viewport class="demo-viewport" autosize>
+  <div *cdkVirtualFor="let size of randomData; let i = index" class="demo-item"
+       [style.height.px]="size">
+    Item #{{i}} - ({{size}}px)
+  </div>
+</cdk-virtual-scroll-viewport>
+
+<h2>Fixed size</h2>
+
+<cdk-virtual-scroll-viewport class="demo-viewport" [itemSize]="50">
+  <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
+       [style.height.px]="size">
+    Item #{{i}} - ({{size}}px)
+  </div>
+</cdk-virtual-scroll-viewport>
+
+<cdk-virtual-scroll-viewport class="demo-viewport demo-horizontal" [itemSize]="50"
+                             orientation="horizontal">
+  <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
+       [style.width.px]="size">
     Item #{{i}} - ({{size}}px)
   </div>
 </cdk-virtual-scroll-viewport>

--- a/src/demo-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/demo-app/virtual-scroll/virtual-scroll-demo.html
@@ -10,3 +10,10 @@
     Item #{{i}} - ({{size}}px)
   </div>
 </cdk-virtual-scroll-viewport>
+
+
+<cdk-virtual-scroll-viewport class="demo-viewport" autosize>
+  <div *cdkVirtualFor="let size of data; let i = index" class="demo-item" [style.height.px]="size">
+    Item #{{i}} - ({{size}}px)
+  </div>
+</cdk-virtual-scroll-viewport>

--- a/src/demo-app/virtual-scroll/virtual-scroll-demo.ts
+++ b/src/demo-app/virtual-scroll/virtual-scroll-demo.ts
@@ -16,5 +16,6 @@ import {Component, ViewEncapsulation} from '@angular/core';
   encapsulation: ViewEncapsulation.None,
 })
 export class VirtualScrollDemo {
-  data = Array(10000).fill(20);
+  fixedSizeData = Array(10000).fill(50);
+  randomData = Array(10000).fill(0).map(() => Math.round(Math.random() * 100));
 }

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -91,5 +91,4 @@ export const rollupGlobals = {
   'rxjs/operators/take': 'Rx.operators',
   'rxjs/operators/takeUntil': 'Rx.operators',
   'rxjs/operators/tap': 'Rx.operators',
-  'rxjs/operators/throttleTime': 'Rx.operators',
 };

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -91,4 +91,5 @@ export const rollupGlobals = {
   'rxjs/operators/take': 'Rx.operators',
   'rxjs/operators/takeUntil': 'Rx.operators',
   'rxjs/operators/tap': 'Rx.operators',
+  'rxjs/operators/throttleTime': 'Rx.operators',
 };


### PR DESCRIPTION
Note: the strategy in its current state is pretty useless and amounts to doing the same thing as the fixed size strategy. In future PRs I will add logic to measure the rendered range and update the item size estimate, and to use different logic when the scroll delta is small to avoid scroll jank.

Part of #10113