### PR TITLE
virtual-scroll: rename `Range` to `ListRange` to avoid confusion with native `Range`

### DIFF
--- a/src/cdk-experimental/scrolling/virtual-for-of.ts
+++ b/src/cdk-experimental/scrolling/virtual-for-of.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ArrayDataSource, CollectionViewer, DataSource, Range} from '@angular/cdk/collections';
+import {ArrayDataSource, CollectionViewer, DataSource, ListRange} from '@angular/cdk/collections';
 import {
   Directive,
   DoCheck,
@@ -54,7 +54,7 @@ export type CdkVirtualForOfContext<T> = {
 })
 export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy {
   /** Emits when the rendered view of the data changes. */
-  viewChange = new Subject<Range>();
+  viewChange = new Subject<ListRange>();
 
   /** Subject that emits when a new DataSource instance is given. */
   private _dataSourceChanges = new Subject<DataSource<T>>();
@@ -124,7 +124,7 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   private _renderedItems: T[];
 
   /** The currently rendered range of indices. */
-  private _renderedRange: Range;
+  private _renderedRange: ListRange;
 
   /**
    * The template cache used to hold on ot template instancess that have been stamped out, but don't
@@ -221,7 +221,7 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   }
 
   /** React to scroll state changes in the viewport. */
-  private _onRenderedRangeChange(renderedRange: Range) {
+  private _onRenderedRangeChange(renderedRange: ListRange) {
     this._renderedRange = renderedRange;
     this.viewChange.next(this._renderedRange);
     this._renderedItems = this._data.slice(this._renderedRange.start, this._renderedRange.end);

--- a/src/cdk-experimental/scrolling/virtual-scroll-fixed-size.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-fixed-size.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Range} from '@angular/cdk/collections';
+import {ListRange} from '@angular/cdk/collections';
 import {Directive, forwardRef, Input, OnChanges} from '@angular/core';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
@@ -102,7 +102,7 @@ export class VirtualScrollFixedSizeStrategy implements VirtualScrollStrategy {
    * @param expandEnd The number of items to expand the end of the range by.
    * @return The expanded range.
    */
-  private _expandRange(range: Range, expandStart: number, expandEnd: number): Range {
+  private _expandRange(range: ListRange, expandStart: number, expandEnd: number): ListRange {
     if (!this._viewport) {
       return {...range};
     }

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Range} from '@angular/cdk/collections';
+import {ListRange} from '@angular/cdk/collections';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -31,7 +31,7 @@ import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-s
 
 
 /** Checks if the given ranges are equal. */
-function rangesEqual(r1: Range, r2: Range): boolean {
+function rangesEqual(r1: ListRange, r2: ListRange): boolean {
   return r1.start == r2.start && r1.end == r2.end;
 }
 
@@ -54,7 +54,7 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
   private _detachedSubject = new Subject<void>();
 
   /** Emits when the rendered range changes. */
-  private _renderedRangeSubject = new Subject<Range>();
+  private _renderedRangeSubject = new Subject<ListRange>();
 
   /** The direction the viewport scrolls. */
   @Input() orientation: 'horizontal' | 'vertical' = 'vertical';
@@ -63,7 +63,7 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
   @ViewChild('contentWrapper') _contentWrapper: ElementRef;
 
   /** A stream that emits whenever the rendered range changes. */
-  renderedRangeStream: Observable<Range> = this._renderedRangeSubject.asObservable();
+  renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();
 
   /**
    * The total size of all content (in pixels), including content that is not currently rendered.
@@ -74,7 +74,7 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
   _renderedContentTransform: string;
 
   /** The currently rendered range of indices. */
-  private _renderedRange: Range = {start: 0, end: 0};
+  private _renderedRange: ListRange = {start: 0, end: 0};
 
   /** The length of the data bound to this viewport (in number of items). */
   private _dataLength = 0;
@@ -116,7 +116,7 @@ export class CdkVirtualScrollViewport implements OnInit, OnDestroy {
   }
 
   /** Sets the currently rendered range of indices. */
-  setRenderedRange(range: Range) {
+  setRenderedRange(range: ListRange) {
     if (!rangesEqual(this._renderedRange, range)) {
       // Re-enter the Angular zone so we can mark for change detection.
       this._ngZone.run(() => {

--- a/src/cdk/collections/collection-viewer.ts
+++ b/src/cdk/collections/collection-viewer.ts
@@ -10,7 +10,7 @@ import {Observable} from 'rxjs/Observable';
 
 
 /** Represents a range of numbers with a specified start and end. */
-export type Range = {start: number, end: number};
+export type ListRange = {start: number, end: number};
 
 
 /**
@@ -22,5 +22,5 @@ export interface CollectionViewer {
    * A stream that emits whenever the `CollectionViewer` starts looking at a new portion of the
    * data. The `start` index is inclusive, while the `end` is exclusive.
    */
-  viewChange: Observable<Range>;
+  viewChange: Observable<ListRange>;
 }


### PR DESCRIPTION
Open to calling it something else if anyone has a better idea