### PR TITLE
refactor(selection-list): rename `list-disabled` class to `option-disabled`

### DIFF
--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  .mat-list-item-disabled {
+  .mat-list-option-disabled {
     background-color: mat-color($background, disabled-list-option);
   }
 

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -252,7 +252,7 @@ $mat-list-item-inset-divider-offset: 72px;
   }
 }
 
-.mat-list-option:not(.mat-list-item-disabled) {
+.mat-list-option:not(.mat-list-option-disabled) {
   cursor: pointer;
   outline: none;
 }

--- a/src/lib/list/selection-list.spec.ts
+++ b/src/lib/list/selection-list.spec.ts
@@ -499,13 +499,13 @@ describe('MatSelectionList without forms', () => {
         .toBe(true, 'Expected ripples to be disabled if option is disabled');
     });
 
-    it('should apply the "mat-list-item-disabled" class properly', () => {
-      expect(listOptionEl.classList).not.toContain('mat-list-item-disabled');
+    it('should apply the "mat-list-option-disabled" class properly', () => {
+      expect(listOptionEl.classList).not.toContain('mat-list-option-disabled');
 
       fixture.componentInstance.disableItem = true;
       fixture.detectChanges();
 
-      expect(listOptionEl.classList).toContain('mat-list-item-disabled');
+      expect(listOptionEl.classList).toContain('mat-list-option-disabled');
     });
   });
 

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -95,7 +95,7 @@ export class MatSelectionListChange {
     '(blur)': '_handleBlur()',
     '(click)': '_handleClick()',
     'tabindex': '-1',
-    '[class.mat-list-item-disabled]': 'disabled',
+    '[class.mat-list-option-disabled]': 'disabled',
     '[class.mat-list-item-focus]': '_hasFocus',
     '[attr.aria-selected]': 'selected.toString()',
     '[attr.aria-disabled]': 'disabled.toString()',


### PR DESCRIPTION
* Renames the `mat-list-item-disabled` class to `mat-list-option-disabled`, because only list options can be disabled. Normal list items can't be disabled, and the `list-item-disabled` class is only being used by the selection list.