### PR TITLE
fix(drawer): show backdrop in "side" mode if hasBackdrop is explicitly set to true

### DIFF
--- a/src/demo-app/sidenav/sidenav-demo.html
+++ b/src/demo-app/sidenav/sidenav-demo.html
@@ -4,7 +4,7 @@
 
 <div class="demo-sidenav-area" *ngIf="isLaunched">
   <mat-toolbar *ngIf="showHeader && !coverHeader">Header</mat-toolbar>
-  <mat-sidenav-container>
+  <mat-sidenav-container [hasBackdrop]="hasBackdrop">
     <mat-sidenav #start (open)="myinput.focus()" [mode]="mode"
                  [fixedInViewport]="fixed" [fixedTopGap]="fixedTop" [fixedBottomGap]="fixedBottom">
       Start Side Sidenav
@@ -41,6 +41,7 @@
           <h3>Sidenav</h3>
           <button mat-button (click)="start.toggle(undefined, 'mouse')">Toggle Start Side Sidenav</button>
           <button mat-button (click)="end.toggle(undefined, 'mouse')">Toggle End Side Sidenav</button>
+          <mat-checkbox [(ngModel)]="hasBackdrop">Has backdrop</mat-checkbox>
           <mat-checkbox [(ngModel)]="fixed">Fixed mode</mat-checkbox>
           <mat-checkbox [(ngModel)]="coverHeader">Sidenav covers header/footer</mat-checkbox>
         </div>

--- a/src/demo-app/sidenav/sidenav-demo.ts
+++ b/src/demo-app/sidenav/sidenav-demo.ts
@@ -25,6 +25,7 @@ export class SidenavDemo {
   showHeader = false;
   showFooter = false;
   modeIndex = 0;
+  hasBackdrop: boolean;
   get mode() { return ['side', 'over', 'push'][this.modeIndex]; }
   get fixedTop() { return this.fixed && this.showHeader && !this.coverHeader ? 64 : 0; }
   get fixedBottom() { return this.fixed && this.showFooter && !this.coverHeader ? 64 : 0; }

--- a/src/lib/sidenav/drawer.scss
+++ b/src/lib/sidenav/drawer.scss
@@ -45,6 +45,12 @@ $mat-drawer-over-drawer-z-index: 4;
       overflow: hidden;
     }
   }
+
+  // When the consumer explicitly enabled the backdrop,
+  // we have to pull the side drawers above it.
+  &.mat-drawer-container-explicit-backdrop .mat-drawer-side {
+    z-index: $mat-drawer-backdrop-z-index;
+  }
 }
 
 .mat-drawer-backdrop {

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -643,6 +643,35 @@ describe('MatDrawerContainer', () => {
       expect(fixture.nativeElement.querySelector('.mat-drawer-backdrop')).toBeFalsy();
     }));
 
+    it('should be able to explicitly enable the backdrop in `side` mode', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicTestApp);
+      const root = fixture.nativeElement;
+
+      fixture.componentInstance.drawer.mode = 'side';
+      fixture.detectChanges();
+      fixture.componentInstance.drawer.open();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      let backdrop = root.querySelector('.mat-drawer-backdrop.mat-drawer-shown');
+
+      expect(backdrop).toBeFalsy();
+
+      fixture.componentInstance.hasBackdrop = true;
+      fixture.detectChanges();
+      backdrop = root.querySelector('.mat-drawer-backdrop.mat-drawer-shown');
+
+      expect(backdrop).toBeTruthy();
+      expect(fixture.componentInstance.drawer.opened).toBe(true);
+
+      backdrop.click();
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.drawer.opened).toBe(false);
+    }));
+
 });
 
 
@@ -666,7 +695,7 @@ class DrawerContainerTwoDrawerTestApp {
 @Component({
   template: `
     <mat-drawer-container (backdropClick)="backdropClicked()" [hasBackdrop]="hasBackdrop">
-      <mat-drawer #drawer position="start"
+      <mat-drawer #drawer="matDrawer" position="start"
                  (opened)="open()"
                  (openedStart)="openStart()"
                  (closed)="close()"
@@ -683,8 +712,9 @@ class BasicTestApp {
   closeCount = 0;
   closeStartCount = 0;
   backdropClickedCount = 0;
-  hasBackdrop = true;
+  hasBackdrop: boolean | null = null;
 
+  @ViewChild('drawer') drawer: MatDrawer;
   @ViewChild('drawerButton') drawerButton: ElementRef;
   @ViewChild('openButton') openButton: ElementRef;
   @ViewChild('closeButton') closeButton: ElementRef;

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -106,6 +106,7 @@ export class MatSidenav extends MatDrawer {
   styleUrls: ['drawer.css'],
   host: {
     'class': 'mat-drawer-container mat-sidenav-container',
+    '[class.mat-drawer-container-explicit-backdrop]': '_backdropOverride',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Currently we only use `hasBackdrop` to hide the backdrop, however setting it to `true` explicitly also expresses an intent that the consumer might want the backdrop to always be shown. These changes make it so backdrop will also be shown for `side` drawers if `hasBackdrop` is set to `true`.