### PR TITLE
refactor(observers): remove 6.0.0 deletion targets

### DIFF
--- a/src/cdk/observers/public-api.ts
+++ b/src/cdk/observers/public-api.ts
@@ -7,9 +7,3 @@
  */
 
 export * from './observe-content';
-
-/**
- * @deprecated Use CdkObserveContent
- * @deletion-target 6.0.0
- */
-export {CdkObserveContent as ObserveContent} from './observe-content';


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 in the `cdk/observers` entry point.

BREAKING CHANGES:
* `ObserveContent` which was deprecated in 5.0.0 has been removed. Use `CdkObserveContent` instead.