### PR TITLE
fix(input): setting blank placeholder by default

### DIFF
--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -71,6 +71,7 @@ describe('MatInput without forms', () => {
         MatInputOnPush,
         MatInputWithReadonlyInput,
         MatInputWithLabelAndPlaceholder,
+        MatInputWithoutPlaceholder,
       ],
     });
 
@@ -792,6 +793,14 @@ describe('MatInput without forms', () => {
     const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
 
     expect(container.classList).not.toContain('mat-form-field-hide-placeholder');
+  });
+
+  it('should not add the `placeholder` attribute if there is no placeholder', () => {
+    const fixture = TestBed.createComponent(MatInputWithoutPlaceholder);
+    fixture.detectChanges();
+    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(input.hasAttribute('placeholder')).toBe(false);
   });
 
   it('should not show the native placeholder when floatLabel is set to "never"', () => {
@@ -1567,4 +1576,14 @@ class MatInputWithLabelAndPlaceholder {
 class MatInputWithAppearance {
   @ViewChild(MatFormField) formField: MatFormField;
   appearance: MatFormFieldAppearance;
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput>
+    </mat-form-field>
+  `
+})
+class MatInputWithoutPlaceholder {
 }

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -68,7 +68,7 @@ export const _MatInputMixinBase = mixinErrorState(MatInputBase);
     // Native input properties that are overwritten by Angular inputs need to be synced with
     // the native input element. Otherwise property bindings for those don't work.
     '[attr.id]': 'id',
-    '[placeholder]': 'placeholder',
+    '[attr.placeholder]': 'placeholder',
     '[disabled]': 'disabled',
     '[required]': 'required',
     '[readonly]': 'readonly',
@@ -152,7 +152,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  @Input() placeholder: string = '';
+  @Input() placeholder: string;
 
   /**
    * Implemented as part of MatFormFieldControl.


### PR DESCRIPTION
Fixes the `matInput` directive setting the `placeholder` attribute to a blank string by default, causing it to be rendered in the DOM.