### PR TITLE
fix(checkbox): setting blank aria-label by default

### DIFF
--- a/src/lib/checkbox/checkbox.html
+++ b/src/lib/checkbox/checkbox.html
@@ -11,7 +11,7 @@
            [attr.name]="name"
            [tabIndex]="tabIndex"
            [indeterminate]="indeterminate"
-           [attr.aria-label]="ariaLabel"
+           [attr.aria-label]="ariaLabel || null"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-checked]="_getAriaChecked()"
            (change)="_onInteractionEvent($event)"

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -701,7 +701,7 @@ describe('MatCheckbox', () => {
     }));
   });
 
-  describe('with provided aria-label ', () => {
+  describe('aria-label ', () => {
     let checkboxDebugElement: DebugElement;
     let checkboxNativeElement: HTMLElement;
     let inputElement: HTMLInputElement;
@@ -714,6 +714,13 @@ describe('MatCheckbox', () => {
 
       fixture.detectChanges();
       expect(inputElement.getAttribute('aria-label')).toBe('Super effective');
+    });
+
+    it('should not set the aria-label attribute if no value is provided', () => {
+      fixture = TestBed.createComponent(SingleCheckbox);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('input').hasAttribute('aria-label')).toBe(false);
     });
   });
 


### PR DESCRIPTION
Fixes the checkbox adding a blank `aria-label` to the underlying input element by default.