### PR TITLE
docs(stepper): use mat-icon for custom icons example

### DIFF
--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -129,16 +129,18 @@ by placing a `matStepperIcon` for each of the icons that you want to override:
 ```html
 <mat-vertical-stepper>
   <ng-template matStepperIcon="edit">
-    <custom-icon>edit</custom-icon>
+    <mat-icon>insert_drive_file</mat-icon>
   </ng-template>
 
   <ng-template matStepperIcon="done">
-    <custom-icon>done</custom-icon>
+    <mat-icon>done_all</mat-icon>
   </ng-template>
 
   <!-- Stepper steps go here -->
 </mat-vertical-stepper>
 ```
+
+Note that you aren't limited to using the `mat-icon` component when providing custom icons.
 
 ### Keyboard interaction
 - <kbd>LEFT_ARROW</kbd>: Focuses the previous step header


### PR DESCRIPTION
Switches the custom icon example in the stepper to use `mat-icon` instead of the non-existing `custom-icon`. The idea with `custom-icon` was to show that consumers aren't limited to using `mat-icon`, however somebody that is copying from the examples would get a compilation error.

Fixes #10283.