### PR TITLE
refactor(form-field): remove deprecated placeholder options.

### DIFF
--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -18,23 +18,5 @@ export * from './label/label-options';
 export * from './ripple/index';
 export * from './selection/index';
 
-/**
- * @deprecated
- * @deletion-target 6.0.0
- */
-export {MAT_LABEL_GLOBAL_OPTIONS as MAT_PLACEHOLDER_GLOBAL_OPTIONS} from './label/label-options';
-
-/**
- * @deprecated
- * @deletion-target 6.0.0
- */
-export {FloatLabelType as FloatPlaceholderType} from './label/label-options';
-
-/**
- * @deprecated
- * @deletion-target 6.0.0
- */
-export {LabelOptions as PlaceholderOptions} from './label/label-options';
-
 // TODO: don't have this
 export * from './testing/month-constants';


### PR DESCRIPTION
small piece of #10164, split out for presubmit reasons

BREAKING CHANGES:
* `FloatPlaceholderType` which was deprecated in 5.0.0 has been removed. Use `FloatLabelType` instead.
* `PlaceholderOptions` which was deprecated in 5.0.0 has been removed. Use `LabelOptions` instead.
* `MAT_PLACEHOLDER_GLOBAL_OPTIONS` which was deprecated in 5.0.0 has been removed. Use `MAT_LABEL_GLOBAL_OPTIONS` instead.