### PR TITLE
refactor(form-field): remove `shouldPlaceholderFloat` on `MatFormFieldControl`

### DIFF
--- a/src/lib/form-field/form-field-control.ts
+++ b/src/lib/form-field/form-field-control.ts
@@ -37,14 +37,7 @@ export abstract class MatFormFieldControl<T> {
   readonly empty: boolean;
 
   /** Whether the `MatFormField` label should try to float. */
-  readonly shouldLabelFloat?: boolean;
-
-  /**
-   * Whether the `MatFormField` placeholder should try to float.
-   * @deprecated Use `shouldLabelFloat` instead.
-   * @deletion-target 6.0.0
-   */
-  readonly shouldPlaceholderFloat?: boolean;
+  readonly shouldLabelFloat: boolean;
 
   /** Whether the control is required. */
   readonly required: boolean;

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -299,8 +299,7 @@ export class MatFormField extends _MatFormFieldMixinBase
   }
 
   _shouldLabelFloat() {
-    return this._canLabelFloat && (this._control.shouldLabelFloat ||
-        this._control.shouldPlaceholderFloat || this._shouldAlwaysFloat);
+    return this._canLabelFloat && (this._control.shouldLabelFloat || this._shouldAlwaysFloat);
   }
 
   _hideControlPlaceholder() {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -1272,7 +1272,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  get shouldPlaceholderFloat(): boolean {
+  get shouldLabelFloat(): boolean {
     return this._panelOpen || !this.empty;
   }
 }


### PR DESCRIPTION
small piece of #10164, split out for presubmit reasons

BREAKING CHANGES:
* `MatFormFieldControl.shouldPlaceholderFloat` which was deprecated in 5.0.0 has been removed. `MatFormFieldControl.shouldLabelFloat` is no longer optional and should be used instead.