### PR TITLE
test(layout): remove async wrapper to prevent hiding test failure

### DIFF
--- a/src/cdk/layout/breakpoints-observer.spec.ts
+++ b/src/cdk/layout/breakpoints-observer.spec.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {LayoutModule, BreakpointObserver, BreakpointState} from './index';
+import {LayoutModule} from './layout-module';
+import {BreakpointObserver, BreakpointState} from './breakpoints-observer';
 import {MediaMatcher} from './media-matcher';
 import {async, TestBed, inject} from '@angular/core/testing';
 import {Injectable} from '@angular/core';
@@ -77,11 +78,9 @@ describe('BreakpointObserver', () => {
       queryMatchState = state.matches;
     });
 
-    async(() => {
-      expect(queryMatchState).toBeTruthy();
-      mediaMatcher.setMatchesQuery(query, false);
-      expect(queryMatchState).toBeFalsy();
-    });
+    expect(queryMatchState).toBeTruthy();
+    mediaMatcher.setMatchesQuery(query, false);
+    expect(queryMatchState).toBeFalsy();
   });
 
   it('emits a true matches state when the query is matched', () => {

--- a/src/cdk/layout/layout-module.ts
+++ b/src/cdk/layout/layout-module.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {NgModule} from '@angular/core';
+import {PlatformModule} from '@angular/cdk/platform';
+import {BreakpointObserver} from './breakpoints-observer';
+import {MediaMatcher} from './media-matcher';
+
+@NgModule({
+  providers: [BreakpointObserver, MediaMatcher],
+  imports: [PlatformModule],
+})
+export class LayoutModule {}

--- a/src/cdk/layout/public-api.ts
+++ b/src/cdk/layout/public-api.ts
@@ -5,17 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {NgModule} from '@angular/core';
-import {PlatformModule} from '@angular/cdk/platform';
-import {BreakpointObserver} from './breakpoints-observer';
-import {MediaMatcher} from './media-matcher';
 
-@NgModule({
-  providers: [BreakpointObserver, MediaMatcher],
-  imports: [PlatformModule],
-})
-export class LayoutModule {}
-
+export {LayoutModule} from './layout-module';
 export {BreakpointObserver, BreakpointState} from './breakpoints-observer';
 export {Breakpoints} from './breakpoints';
 export {MediaMatcher} from './media-matcher';


### PR DESCRIPTION
* With the async call around the checks in the layout test, the
  results of the subscribe are never actually checked