### PR TITLE
refactor(autocomplete): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/autocomplete/autocomplete-module.ts
+++ b/src/lib/autocomplete/autocomplete-module.ts
@@ -10,7 +10,7 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {MatOptionModule, MatCommonModule} from '@angular/material/core';
-import {MatAutocomplete} from './autocomplete';
+import {MatAutocomplete, MAT_AUTOCOMPLETE_DEFAULT_OPTIONS} from './autocomplete';
 import {
   MatAutocompleteTrigger,
   MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER,
@@ -20,6 +20,9 @@ import {
   imports: [MatOptionModule, OverlayModule, MatCommonModule, CommonModule],
   exports: [MatAutocomplete, MatOptionModule, MatAutocompleteTrigger, MatCommonModule],
   declarations: [MatAutocomplete, MatAutocompleteTrigger],
-  providers: [MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER],
+  providers: [
+    MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER,
+    {provide: MAT_AUTOCOMPLETE_DEFAULT_OPTIONS, useValue: false}
+  ],
 })
 export class MatAutocompleteModule {}

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -21,7 +21,6 @@ import {
   Output,
   InjectionToken,
   Inject,
-  Optional,
 } from '@angular/core';
 import {
   MatOption,
@@ -150,16 +149,10 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
     private _elementRef: ElementRef,
-
-    // @deletion-target Turn into required param in 6.0.0
-    @Optional() @Inject(MAT_AUTOCOMPLETE_DEFAULT_OPTIONS)
-        defaults?: MatAutocompleteDefaultOptions) {
+    @Inject(MAT_AUTOCOMPLETE_DEFAULT_OPTIONS) defaults: MatAutocompleteDefaultOptions) {
     super();
 
-    this._autoActiveFirstOption = defaults &&
-        typeof defaults.autoActiveFirstOption !== 'undefined' ?
-            defaults.autoActiveFirstOption :
-            false;
+    this._autoActiveFirstOption = !!defaults.autoActiveFirstOption;
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 in the `material/autocomplete` module.

BREAKING CHANGES:
* The `defaults` parameter in the `MatAutocomplete` constructor is now required.