### PR TITLE
docs(overlay): add 1 word in the comments for API

### DIFF
--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -29,7 +29,7 @@ import {OverlayRef} from '../overlay-ref';
 
 /**
  * A strategy for positioning overlays. Using this strategy, an overlay is given an
- * implicit position relative some origin element. The relative position is defined in terms of
+ * implicit position relative to some origin element. The relative position is defined in terms of
  * a point on the origin element that is connected to a point on the overlay element. For example,
  * a basic dropdown is connecting the bottom-left corner of the origin to the top-left corner
  * of the overlay.


### PR DESCRIPTION
Just like the API GlobalPositionStrategy, I believe this word was missing.