### PR TITLE
refactor(a11y): remove 6.0.0 deletion targets

### DIFF
--- a/src/cdk/a11y/a11y-module.ts
+++ b/src/cdk/a11y/a11y-module.ts
@@ -11,18 +11,14 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ARIA_DESCRIBER_PROVIDER, AriaDescriber} from './aria-describer/aria-describer';
 import {CdkMonitorFocus, FOCUS_MONITOR_PROVIDER} from './focus-monitor/focus-monitor';
-import {
-  CdkTrapFocus,
-  FocusTrapDeprecatedDirective,
-  FocusTrapFactory,
-} from './focus-trap/focus-trap';
+import {CdkTrapFocus, FocusTrapFactory} from './focus-trap/focus-trap';
 import {InteractivityChecker} from './interactivity-checker/interactivity-checker';
 import {LIVE_ANNOUNCER_PROVIDER} from './live-announcer/live-announcer';
 
 @NgModule({
   imports: [CommonModule, PlatformModule],
-  declarations: [CdkTrapFocus, FocusTrapDeprecatedDirective, CdkMonitorFocus],
-  exports: [CdkTrapFocus, FocusTrapDeprecatedDirective, CdkMonitorFocus],
+  declarations: [CdkTrapFocus, CdkMonitorFocus],
+  exports: [CdkTrapFocus, CdkMonitorFocus],
   providers: [
     InteractivityChecker,
     FocusTrapFactory,

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -15,7 +15,6 @@ import {
   OnDestroy,
   Optional,
   Output,
-  Renderer2,
   SkipSelf,
 } from '@angular/core';
 import {Observable} from 'rxjs/Observable';
@@ -75,30 +74,13 @@ export class FocusMonitor implements OnDestroy {
   constructor(private _ngZone: NgZone, private _platform: Platform) {}
 
   /**
-   * @docs-private
-   * @deprecated renderer param no longer needed.
-   * @deletion-target 6.0.0
-   */
-  monitor(element: HTMLElement, renderer: Renderer2, checkChildren: boolean):
-      Observable<FocusOrigin>;
-  /**
    * Monitors focus on an element and applies appropriate CSS classes.
    * @param element The element to monitor
    * @param checkChildren Whether to count the element as focused when its children are focused.
    * @returns An observable that emits when the focus state of the element changes.
    *     When the element is blurred, null will be emitted.
    */
-  monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin>;
-  monitor(
-      element: HTMLElement,
-      renderer?: Renderer2 | boolean,
-      checkChildren?: boolean): Observable<FocusOrigin> {
-    // TODO(mmalerba): clean up after deprecated signature is removed.
-    if (!(renderer instanceof Renderer2)) {
-      checkChildren = renderer;
-    }
-    checkChildren = !!checkChildren;
-
+  monitor(element: HTMLElement, checkChildren: boolean = false): Observable<FocusOrigin> {
     // Do nothing if we're not on the browser platform.
     if (!this._platform.isBrowser) {
       return observableOf(null);

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -303,40 +303,6 @@ export class FocusTrapFactory {
   }
 }
 
-
-/**
- * Directive for trapping focus within a region.
- * @docs-private
- * @deprecated
- * @deletion-target 6.0.0
- */
-@Directive({
-  selector: 'cdk-focus-trap',
-})
-export class FocusTrapDeprecatedDirective implements OnDestroy, AfterContentInit {
-  focusTrap: FocusTrap;
-
-  /** Whether the focus trap is active. */
-  @Input()
-  get disabled(): boolean { return !this.focusTrap.enabled; }
-  set disabled(val: boolean) {
-    this.focusTrap.enabled = !coerceBooleanProperty(val);
-  }
-
-  constructor(private _elementRef: ElementRef, private _focusTrapFactory: FocusTrapFactory) {
-    this.focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement, true);
-  }
-
-  ngOnDestroy() {
-    this.focusTrap.destroy();
-  }
-
-  ngAfterContentInit() {
-    this.focusTrap.attachAnchors();
-  }
-}
-
-
 /** Directive for trapping focus within a region. */
 @Directive({
   selector: '[cdkTrapFocus]',

--- a/src/cdk/a11y/public-api.ts
+++ b/src/cdk/a11y/public-api.ts
@@ -5,9 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CdkTrapFocus} from './focus-trap/focus-trap';
-
-
 export * from './aria-describer/aria-describer';
 export * from './key-manager/activedescendant-key-manager';
 export * from './key-manager/focus-key-manager';
@@ -18,9 +15,3 @@ export * from './live-announcer/live-announcer';
 export * from './focus-monitor/focus-monitor';
 export * from './fake-mousedown';
 export * from './a11y-module';
-
-/**
- * @deprecated Renamed to CdkTrapFocus.
- * @deletion-target 6.0.0
- */
-export {CdkTrapFocus as FocusTrapDirective};


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 from the `cdk/a11y` entry point.

BREAKING CHANGES:
* The `renderer` parameter in `FocusMonitor.monitor` has been removed.
* `cdk-focus-trap` which was deprecated in 5.0.0 has been removed. Use `cdkTrapFocus` instead.