### PR TITLE
fix(tree): invalid style declaration during server-side rendering

### DIFF
--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -70,7 +70,7 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
 
   _setPadding() {
     const padding = this._paddingIndent();
-    const paddingProp = this._dir && this._dir.value === 'rtl' ? 'padding-right' : 'padding-left';
+    const paddingProp = this._dir && this._dir.value === 'rtl' ? 'paddingRight' : 'paddingLeft';
 
     this._renderer.setStyle(this._element.nativeElement, paddingProp, padding);
   }


### PR DESCRIPTION
Switches to camel-cased properties when declaring the inline styles for the tree, in order to avoid invalid style declarations when they get passed through Domino.

Relates to #10131.