### PR TITLE
feat(table): add optional footer row

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -8,12 +8,17 @@
 
 import {ContentChild, Directive, ElementRef, Input, TemplateRef} from '@angular/core';
 
+/** Base class for a cell definition. Captures a column's cell template definition. */
+export interface BaseCellDef {
+  template: TemplateRef<any>;
+}
+
 /**
  * Cell definition for a CDK table.
  * Captures the template of a column's data row cell as well as cell-specific properties.
  */
 @Directive({selector: '[cdkCellDef]'})
-export class CdkCellDef {
+export class CdkCellDef implements BaseCellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) { }
 }
 
@@ -22,7 +27,16 @@ export class CdkCellDef {
  * Captures the template of a column's header cell and as well as cell-specific properties.
  */
 @Directive({selector: '[cdkHeaderCellDef]'})
-export class CdkHeaderCellDef {
+export class CdkHeaderCellDef implements BaseCellDef {
+  constructor(/** @docs-private */ public template: TemplateRef<any>) { }
+}
+
+/**
+ * Footer cell definition for a CDK table.
+ * Captures the template of a column's footer cell and as well as cell-specific properties.
+ */
+@Directive({selector: '[cdkFooterCellDef]'})
+export class CdkFooterCellDef implements BaseCellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) { }
 }
 
@@ -51,6 +65,9 @@ export class CdkColumnDef {
   /** @docs-private */
   @ContentChild(CdkHeaderCellDef) headerCell: CdkHeaderCellDef;
 
+  /** @docs-private */
+  @ContentChild(CdkFooterCellDef) footerCell: CdkFooterCellDef;
+
   /**
    * Transformed version of the column name that can be used as part of a CSS classname. Excludes
    * all non-alphanumeric characters and the special characters '-' and '_'. Any characters that
@@ -68,6 +85,20 @@ export class CdkColumnDef {
   },
 })
 export class CdkHeaderCell {
+  constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+    elementRef.nativeElement.classList.add(`cdk-column-${columnDef.cssClassFriendlyName}`);
+  }
+}
+
+/** Footer cell template container that adds the right classes and role. */
+@Directive({
+  selector: 'cdk-footer-cell',
+  host: {
+    'class': 'cdk-footer-cell',
+    'role': 'gridcell',
+  },
+})
+export class CdkFooterCell {
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
     elementRef.nativeElement.classList.add(`cdk-column-${columnDef.cssClassFriendlyName}`);
   }

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -18,7 +18,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {CdkCellDef} from './cell';
+import {CdkCellDef, CdkColumnDef} from './cell';
 
 /**
  * The row template that can be used by the mat-table. Should not be used outside of the
@@ -57,6 +57,9 @@ export abstract class BaseRowDef {
   getColumnsDiff(): IterableChanges<any> | null {
     return this._columnsDiffer.diff(this.columns);
   }
+
+  /** Gets this row def's relevant cell template from the provided column def. */
+  abstract extractCellTemplate(column: CdkColumnDef): TemplateRef<any>;
 }
 
 /**
@@ -70,6 +73,30 @@ export abstract class BaseRowDef {
 export class CdkHeaderRowDef extends BaseRowDef {
   constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
     super(template, _differs);
+  }
+
+  /** Gets this row def's relevant cell template from the provided column def. */
+  extractCellTemplate(column: CdkColumnDef): TemplateRef<any> {
+    return column.headerCell.template;
+  }
+}
+
+/**
+ * Footer row definition for the CDK table.
+ * Captures the footer row's template and other footer properties such as the columns to display.
+ */
+@Directive({
+  selector: '[cdkFooterRowDef]',
+  inputs: ['columns: cdkFooterRowDef'],
+})
+export class CdkFooterRowDef extends BaseRowDef {
+  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
+    super(template, _differs);
+  }
+
+  /** Gets this row def's relevant cell template from the provided column def. */
+  extractCellTemplate(column: CdkColumnDef): TemplateRef<any> {
+    return column.footerCell.template;
   }
 }
 
@@ -95,6 +122,11 @@ export class CdkRowDef<T> extends BaseRowDef {
   //   if this template should be used.
   constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
     super(template, _differs);
+  }
+
+  /** Gets this row def's relevant cell template from the provided column def. */
+  extractCellTemplate(column: CdkColumnDef): TemplateRef<any> {
+    return column.cell.template;
   }
 }
 
@@ -161,6 +193,21 @@ export class CdkCellOutlet {
   encapsulation: ViewEncapsulation.None,
 })
 export class CdkHeaderRow { }
+
+
+/** Footer template container that contains the cell outlet. Adds the right class and role. */
+@Component({
+  moduleId: module.id,
+  selector: 'cdk-footer-row',
+  template: CDK_ROW_TEMPLATE,
+  host: {
+    'class': 'cdk-footer-row',
+    'role': 'row',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class CdkFooterRow { }
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({

--- a/src/cdk/table/table-module.ts
+++ b/src/cdk/table/table-module.ts
@@ -8,9 +8,15 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {HeaderRowPlaceholder, RowPlaceholder, CdkTable} from './table';
-import {CdkCellOutlet, CdkHeaderRow, CdkHeaderRowDef, CdkRow, CdkRowDef} from './row';
-import {CdkColumnDef, CdkHeaderCellDef, CdkHeaderCell, CdkCell, CdkCellDef} from './cell';
+import {HeaderRowPlaceholder, RowPlaceholder, CdkTable, FooterRowPlaceholder} from './table';
+import {
+  CdkCellOutlet, CdkFooterRow, CdkFooterRowDef, CdkHeaderRow, CdkHeaderRowDef, CdkRow,
+  CdkRowDef
+} from './row';
+import {
+  CdkColumnDef, CdkHeaderCellDef, CdkHeaderCell, CdkCell, CdkCellDef,
+  CdkFooterCellDef, CdkFooterCell
+} from './cell';
 
 const EXPORTED_DECLARATIONS = [
   CdkTable,
@@ -18,14 +24,19 @@ const EXPORTED_DECLARATIONS = [
   CdkCellDef,
   CdkCellOutlet,
   CdkHeaderCellDef,
+  CdkFooterCellDef,
   CdkColumnDef,
   CdkCell,
   CdkRow,
   CdkHeaderCell,
+  CdkFooterCell,
   CdkHeaderRow,
   CdkHeaderRowDef,
+  CdkFooterRow,
+  CdkFooterRowDef,
   RowPlaceholder,
   HeaderRowPlaceholder,
+  FooterRowPlaceholder,
 ];
 
 @NgModule({

--- a/src/cdk/table/table.md
+++ b/src/cdk/table/table.md
@@ -18,13 +18,16 @@ top of the CDK data-table.
 
 The first step to writing the data-table template is to define the columns.
 A column definition is specified via an `<ng-container>` with the `cdkColumnDef` directive, giving
-the column a name. Each column definition then further defines both a header-cell template
-(`cdkHeaderCellDef`) and a data-cell template (`cdkCellDef`).
+the column a name. Each column definition then further defines a header-cell template
+(`cdkHeaderCellDef`), data-cell template (`cdkCellDef`), and footer-cell 
+template (`cdkFooterCellDef`). Note that each of these cell definitions need to be present if they
+are used by their respective row definition. 
 
 ```html
 <ng-container cdkColumnDef="username">
   <cdk-header-cell *cdkHeaderCellDef> User name </cdk-header-cell>
   <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+  <cdk-footer-cell *cdkFooterCellDef> User name </cdk-footer-cell>
 </ng-container>
 ```
 
@@ -35,11 +38,15 @@ Note that `cdkCellDef` exports the row context such that the row data can be ref
 template. The directive also exports the same properties as `ngFor` (index, even, odd, first,
 last).
 
-The next step is to define the table's header-row (`cdkHeaderRowDef`) and data-row (`cdkRowDef`).
+The next step is to define the table's header-row (`cdkHeaderRowDef`), data-row (`cdkRowDef`),
+and fitler-row (`cdkFooterRowDef`). Note that each of these are optional to include, depending on
+what type of rows you want rendered (e.g. if you do not need a footer row, simply do not add
+its definition).
 
 ```html
 <cdk-header-row *cdkHeaderRowDef="['username', 'age', 'title']"></cdk-header-row>
 <cdk-row *cdkRowDef="let row; columns: ['username', 'age', 'title']"></cdk-row>
+<cdk-footer-row *cdkFooterRowDef="['username', 'age', 'title']"></cdk-footer-row>
 ```
 
 These row templates accept the specific columns to be rendered via the name given to the

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1,5 +1,13 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ContentChild, ContentChildren, Input, QueryList, ViewChild} from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  ContentChildren,
+  Input,
+  QueryList,
+  Type,
+  ViewChild
+} from '@angular/core';
 import {CdkTable} from './table';
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
@@ -18,11 +26,8 @@ import {CdkHeaderRowDef, CdkRowDef} from './row';
 import {CdkColumnDef} from './cell';
 
 describe('CdkTable', () => {
-  let fixture: ComponentFixture<SimpleCdkTableApp>;
-
-  let component: SimpleCdkTableApp;
-  let dataSource: FakeDataSource;
-  let table: CdkTable<any>;
+  let fixture: ComponentFixture<any>;
+  let component: any;
   let tableElement: HTMLElement;
 
   beforeEach(async(() => {
@@ -42,84 +47,218 @@ describe('CdkTable', () => {
         WhenRowCdkTableApp,
         WhenRowWithoutDefaultCdkTableApp,
         WhenRowMultipleDefaultsCdkTableApp,
-        MissingRowDefsCdkTableApp,
+        MissingAllRowDefsCdkTableApp,
         BooleanRowCdkTableApp,
         WrapperCdkTableApp,
         OuterTableApp,
         CdkTableWithDifferentDataInputsApp,
+        MissingHeaderRowDefCdkTableApp,
+        MissingRowDefCdkTableApp,
+        MissingFooterRowDefCdkTableApp,
       ],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SimpleCdkTableApp);
-
+  function setupTableTestApp(componentType: Type<any>) {
+    fixture = TestBed.createComponent(componentType);
     component = fixture.componentInstance;
-    dataSource = component.dataSource as FakeDataSource;
-    table = component.table;
     tableElement = fixture.nativeElement.querySelector('cdk-table');
 
     fixture.detectChanges();
-  });
+  }
 
-  describe('should initialize', () => {
-    it('with a connected data source', () => {
-      expect(table.dataSource).toBe(dataSource);
+  describe('in a typical simple use case', () => {
+    let dataSource: FakeDataSource;
+    let table: CdkTable<TestData>;
+
+    beforeEach(() => {
+      setupTableTestApp(SimpleCdkTableApp);
+
+      component = fixture.componentInstance as SimpleCdkTableApp;
+      dataSource = component.dataSource;
+      table = component.table;
+
+      fixture.detectChanges();
+    });
+
+    describe('should initialize', () => {
+      it('with a connected data source', () => {
+        expect(table.dataSource).toBe(dataSource);
+        expect(dataSource.isConnected).toBe(true);
+      });
+
+      it('with a rendered header with the right number of header cells', () => {
+        const header = getHeaderRow(tableElement);
+
+        expect(header).toBeTruthy();
+        expect(header.classList).toContain('customHeaderRowClass');
+        expect(getHeaderCells(tableElement).length).toBe(component.columnsToRender.length);
+      });
+
+      it('with rendered rows with right number of row cells', () => {
+        const rows = getRows(tableElement);
+
+        expect(rows.length).toBe(dataSource.data.length);
+        rows.forEach(row => {
+          expect(row.classList).toContain('customRowClass');
+          expect(getCells(row).length).toBe(component.columnsToRender.length);
+        });
+      });
+
+      it('with column class names provided to header and data row cells', () => {
+        getHeaderCells(tableElement).forEach((headerCell, index) => {
+          expect(headerCell.classList).toContain(`cdk-column-${component.columnsToRender[index]}`);
+        });
+
+        getRows(tableElement).forEach(row => {
+          getCells(row).forEach((cell, index) => {
+            expect(cell.classList).toContain(`cdk-column-${component.columnsToRender[index]}`);
+          });
+        });
+      });
+
+      it('with the right accessibility roles', () => {
+        expect(tableElement.getAttribute('role')).toBe('grid');
+
+        expect(getHeaderRow(tableElement).getAttribute('role')).toBe('row');
+        getHeaderCells(tableElement).forEach(cell => {
+          expect(cell.getAttribute('role')).toBe('columnheader');
+        });
+
+        getRows(tableElement).forEach(row => {
+          expect(row.getAttribute('role')).toBe('row');
+          getCells(row).forEach(cell => {
+            expect(cell.getAttribute('role')).toBe('gridcell');
+          });
+        });
+      });
+    });
+
+    it('should disconnect the data source when table is destroyed', () => {
       expect(dataSource.isConnected).toBe(true);
+
+      fixture.destroy();
+      expect(dataSource.isConnected).toBe(false);
     });
 
-    it('with a rendered header with the right number of header cells', () => {
-      const header = getHeaderRow(tableElement);
+    it('should re-render the rows when the data changes', () => {
+      dataSource.addData();
+      fixture.detectChanges();
 
-      expect(header).toBeTruthy();
-      expect(header.classList).toContain('customHeaderRowClass');
-      expect(getHeaderCells(tableElement).length).toBe(component.columnsToRender.length);
-    });
+      expect(getRows(tableElement).length).toBe(dataSource.data.length);
 
-    it('with rendered rows with right number of row cells', () => {
-      const rows = getRows(tableElement);
-
-      expect(rows.length).toBe(dataSource.data.length);
-      rows.forEach(row => {
-        expect(row.classList).toContain('customRowClass');
+      // Check that the number of cells is correct
+      getRows(tableElement).forEach(row => {
         expect(getCells(row).length).toBe(component.columnsToRender.length);
       });
     });
 
-    it('with column class names provided to header and data row cells', () => {
-      getHeaderCells(tableElement).forEach((headerCell, index) => {
-        expect(headerCell.classList).toContain(`cdk-column-${component.columnsToRender[index]}`);
+    it('should use differ to add/remove/move rows', () => {
+      // Each row receives an attribute 'initialIndex' the element's original place
+      getRows(tableElement).forEach((row: Element, index: number) => {
+        row.setAttribute('initialIndex', index.toString());
       });
 
-      getRows(tableElement).forEach(row => {
-        getCells(row).forEach((cell, index) => {
-          expect(cell.classList).toContain(`cdk-column-${component.columnsToRender[index]}`);
-        });
-      });
+      // Prove that the attributes match their indicies
+      const initialRows = getRows(tableElement);
+      expect(initialRows[0].getAttribute('initialIndex')).toBe('0');
+      expect(initialRows[1].getAttribute('initialIndex')).toBe('1');
+      expect(initialRows[2].getAttribute('initialIndex')).toBe('2');
+
+      // Swap first and second data in data array
+      const copiedData = component.dataSource!.data.slice();
+      const temp = copiedData[0];
+      copiedData[0] = copiedData[1];
+      copiedData[1] = temp;
+
+      // Remove the third element
+      copiedData.splice(2, 1);
+
+      // Add new data
+      component.dataSource!.data = copiedData;
+      component.dataSource!.addData();
+
+      // Expect that the first and second rows were swapped and that the last row is new
+      const changedRows = getRows(tableElement);
+      expect(changedRows.length).toBe(3);
+      expect(changedRows[0].getAttribute('initialIndex')).toBe('1');
+      expect(changedRows[1].getAttribute('initialIndex')).toBe('0');
+      expect(changedRows[2].getAttribute('initialIndex')).toBe(null);
     });
 
-    it('with the right accessibility roles', () => {
-      expect(tableElement.getAttribute('role')).toBe('grid');
+    it('should clear the row view containers on destroy', () => {
+      const rowPlaceholder = fixture.componentInstance.table._rowPlaceholder.viewContainer;
+      const headerPlaceholder = fixture.componentInstance.table._headerRowPlaceholder.viewContainer;
 
-      expect(getHeaderRow(tableElement).getAttribute('role')).toBe('row');
-      getHeaderCells(tableElement).forEach(cell => {
-        expect(cell.getAttribute('role')).toBe('columnheader');
-      });
+      spyOn(rowPlaceholder, 'clear').and.callThrough();
+      spyOn(headerPlaceholder, 'clear').and.callThrough();
 
-      getRows(tableElement).forEach(row => {
-        expect(row.getAttribute('role')).toBe('row');
-        getCells(row).forEach(cell => {
-          expect(cell.getAttribute('role')).toBe('gridcell');
-        });
-      });
+      fixture.destroy();
+
+      expect(rowPlaceholder.clear).toHaveBeenCalled();
+      expect(headerPlaceholder.clear).toHaveBeenCalled();
+    });
+
+    it('should match the right table content with dynamic data', () => {
+      const initialDataLength = dataSource.data.length;
+      expect(dataSource.data.length).toBe(3);
+
+      let data = dataSource.data;
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        [data[0].a, data[0].b, data[0].c],
+        [data[1].a, data[1].b, data[1].c],
+        [data[2].a, data[2].b, data[2].c],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+
+      // Add data to the table and recreate what the rendered output should be.
+      dataSource.addData();
+      expect(dataSource.data.length).toBe(initialDataLength + 1); // Make sure data was added
+      fixture.detectChanges();
+
+      data = dataSource.data;
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        [data[0].a, data[0].b, data[0].c],
+        [data[1].a, data[1].b, data[1].c],
+        [data[2].a, data[2].b, data[2].c],
+        [data[3].a, data[3].b, data[3].c],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+    });
+
+    it('should be able to dynamically change the columns for header and rows', () => {
+      expect(dataSource.data.length).toBe(3);
+
+      let data = dataSource.data;
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        [data[0].a, data[0].b, data[0].c],
+        [data[1].a, data[1].b, data[1].c],
+        [data[2].a, data[2].b, data[2].c],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+
+      // Remove column_a and swap column_b/column_c.
+      component.columnsToRender = ['column_c', 'column_b'];
+      fixture.detectChanges();
+
+      let changedTableContent = [['Column C', 'Column B']];
+      dataSource.data.forEach(rowData => changedTableContent.push([rowData.c, rowData.b]));
+
+      data = dataSource.data;
+      expectTableToMatchContent(tableElement, [
+        ['Column C', 'Column B'],
+        [data[0].c, data[0].b],
+        [data[1].c, data[1].b],
+        [data[2].c, data[2].b],
+        ['Footer C', 'Footer B'],
+      ]);
     });
   });
 
   describe('with different data inputs other than data source', () => {
-    let dataInputFixture: ComponentFixture<CdkTableWithDifferentDataInputsApp>;
-    let dataInputComponent: CdkTableWithDifferentDataInputsApp;
-    let dataInputTableElement: HTMLElement;
-
     let baseData: TestData[] = [
       {a: 'a_1', b: 'b_1', c: 'c_1'},
       {a: 'a_2', b: 'b_2', c: 'c_2'},
@@ -127,17 +266,14 @@ describe('CdkTable', () => {
     ];
 
     beforeEach(() => {
-      dataInputFixture = TestBed.createComponent(CdkTableWithDifferentDataInputsApp);
-      dataInputComponent = dataInputFixture.componentInstance;
-      dataInputFixture.detectChanges();
-
-      dataInputTableElement = dataInputFixture.nativeElement.querySelector('cdk-table');
+      setupTableTestApp(CdkTableWithDifferentDataInputsApp);
+      component = fixture.componentInstance;
     });
 
     it('should render with data array input', () => {
       const data = baseData.slice();
-      dataInputComponent.dataSource = data;
-      dataInputFixture.detectChanges();
+      component.dataSource = data;
+      fixture.detectChanges();
 
       const expectedRender = [
         ['Column A', 'Column B', 'Column C'],
@@ -145,45 +281,45 @@ describe('CdkTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
       ];
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Push data to the array but neglect to tell the table, should be no change
       data.push({a: 'a_4', b: 'b_4', c: 'c_4'});
 
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Notify table of the change, expect another row
-      dataInputComponent.table.renderRows();
-      dataInputFixture.detectChanges();
+      component.table.renderRows();
+      fixture.detectChanges();
 
       expectedRender.push(['a_4', 'b_4', 'c_4']);
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Remove a row and expect the change in rows
       data.pop();
-      dataInputComponent.table.renderRows();
+      component.table.renderRows();
 
       expectedRender.pop();
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Remove the data input entirely and expect no rows - just header.
-      dataInputComponent.dataSource = null;
-      dataInputFixture.detectChanges();
+      component.dataSource = null;
+      fixture.detectChanges();
 
-      expectTableToMatchContent(dataInputTableElement, [expectedRender[0]]);
+      expectTableToMatchContent(tableElement, [expectedRender[0]]);
 
       // Add back the data to verify that it renders rows
-      dataInputComponent.dataSource = data;
-      dataInputFixture.detectChanges();
+      component.dataSource = data;
+      fixture.detectChanges();
 
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
     });
 
     it('should render with data stream input', () => {
       const data = baseData.slice();
       const stream = new BehaviorSubject<TestData[]>(data);
-      dataInputComponent.dataSource = stream;
-      dataInputFixture.detectChanges();
+      component.dataSource = stream;
+      fixture.detectChanges();
 
       const expectedRender = [
         ['Column A', 'Column B', 'Column C'],
@@ -191,69 +327,95 @@ describe('CdkTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
       ];
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Push data to the array and emit the data array on the stream
       data.push({a: 'a_4', b: 'b_4', c: 'c_4'});
       stream.next(data);
-      dataInputFixture.detectChanges();
+      fixture.detectChanges();
 
       expectedRender.push(['a_4', 'b_4', 'c_4']);
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Push data to the array but rather than emitting, call renderRows.
       data.push({a: 'a_5', b: 'b_5', c: 'c_5'});
-      dataInputComponent.table.renderRows();
-      dataInputFixture.detectChanges();
+      component.table.renderRows();
+      fixture.detectChanges();
 
       expectedRender.push(['a_5', 'b_5', 'c_5']);
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Remove a row and expect the change in rows
       data.pop();
       expectedRender.pop();
       stream.next(data);
 
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
 
       // Remove the data input entirely and expect no rows - just header.
-      dataInputComponent.dataSource = null;
-      dataInputFixture.detectChanges();
+      component.dataSource = null;
+      fixture.detectChanges();
 
-      expectTableToMatchContent(dataInputTableElement, [expectedRender[0]]);
+      expectTableToMatchContent(tableElement, [expectedRender[0]]);
 
       // Add back the data to verify that it renders rows
-      dataInputComponent.dataSource = stream;
-      dataInputFixture.detectChanges();
+      component.dataSource = stream;
+      fixture.detectChanges();
 
-      expectTableToMatchContent(dataInputTableElement, expectedRender);
+      expectTableToMatchContent(tableElement, expectedRender);
     });
 
     it('should throw an error if the data source is not valid', () => {
-      dataInputComponent.dataSource = {invalid: 'dataSource'};
+      component.dataSource = {invalid: 'dataSource'};
 
-      expect(() => dataInputFixture.detectChanges())
+      expect(() => fixture.detectChanges())
           .toThrowError(getTableUnknownDataSourceError().message);
     });
 
     it('should throw an error if the data source is not valid', () => {
-      dataInputComponent.dataSource = undefined;
-      dataInputFixture.detectChanges();
+      component.dataSource = undefined;
+      fixture.detectChanges();
 
       // Expect the table to render just the header, no rows
-      expectTableToMatchContent(dataInputTableElement, [
+      expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C']
       ]);
     });
   });
 
-  it('should render cells even if row data is falsy', () => {
-    const booleanRowCdkTableAppFixture = TestBed.createComponent(BooleanRowCdkTableApp);
-    const booleanRowCdkTableElement =
-        booleanRowCdkTableAppFixture.nativeElement.querySelector('cdk-table');
-    booleanRowCdkTableAppFixture.detectChanges();
+  describe('missing row defs', () => {
+    it('should be able to render without a header row def', () => {
+      setupTableTestApp(MissingHeaderRowDefCdkTableApp);
+      expectTableToMatchContent(tableElement, [
+        ['a_1'],  // Data rows
+        ['a_2'],
+        ['a_3'],
+        ['Footer A'],  // Footer row
+      ]);
+    });
 
-    expectTableToMatchContent(booleanRowCdkTableElement, [
+    it('should be able to render without a data row def', () => {
+      setupTableTestApp(MissingRowDefCdkTableApp);
+      expectTableToMatchContent(tableElement, [
+        ['Column A'],  // Header row
+        ['Footer A'],  // Footer row
+      ]);
+    });
+
+    it('should be able to render without a footer row def', () => {
+      setupTableTestApp(MissingFooterRowDefCdkTableApp);
+      expectTableToMatchContent(tableElement, [
+        ['Column A'],  // Header row
+        ['a_1'],  // Data rows
+        ['a_2'],
+        ['a_3'],
+      ]);
+    });
+  });
+
+  it('should render cells even if row data is falsy', () => {
+    setupTableTestApp(BooleanRowCdkTableApp);
+    expectTableToMatchContent(tableElement, [
       [''], // Header row
       ['false'], // Data rows
       ['true'],
@@ -263,28 +425,15 @@ describe('CdkTable', () => {
   });
 
   it('should be able to apply class-friendly css class names for the column cells', () => {
-    const crazyColumnNameAppFixture = TestBed.createComponent(CrazyColumnNameCdkTableApp);
-    const crazyColumnNameTableElement =
-        crazyColumnNameAppFixture.nativeElement.querySelector('cdk-table');
-    crazyColumnNameAppFixture.detectChanges();
-
+    setupTableTestApp(CrazyColumnNameCdkTableApp);
     // Column was named 'crazy-column-NAME-1!@#$%^-_&*()2'
-    expect(getHeaderCells(crazyColumnNameTableElement)[0].classList)
+    expect(getHeaderCells(tableElement)[0].classList)
         .toContain('cdk-column-crazy-column-NAME-1-------_----2');
   });
 
-  it('should disconnect the data source when table is destroyed', () => {
-    expect(dataSource.isConnected).toBe(true);
-
-    fixture.destroy();
-    expect(dataSource.isConnected).toBe(false);
-  });
-
   it('should not clobber an existing table role', () => {
-    fixture = TestBed.createComponent(CustomRoleCdkTableApp);
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector('cdk-table').getAttribute('role')).toBe('treegrid');
+    setupTableTestApp(CustomRoleCdkTableApp);
+    expect(tableElement.getAttribute('role')).toBe('treegrid');
   });
 
   it('should throw an error if two column definitions have the same name', () => {
@@ -298,17 +447,16 @@ describe('CdkTable', () => {
   });
 
   it('should throw an error if the row definitions are missing', () => {
-    expect(() => TestBed.createComponent(MissingRowDefsCdkTableApp).detectChanges())
+    expect(() => TestBed.createComponent(MissingAllRowDefsCdkTableApp).detectChanges())
         .toThrowError(getTableMissingRowDefsError().message);
   });
 
   it('should not throw an error if columns are undefined on initialization', () => {
-    const undefinedColumnsFixture = TestBed.createComponent(UndefinedColumnsCdkTableApp);
-    undefinedColumnsFixture.detectChanges();
+    setupTableTestApp(UndefinedColumnsCdkTableApp);
 
-    tableElement = undefinedColumnsFixture.nativeElement.querySelector('cdk-table');
-
-    expect(getHeaderRow(tableElement)).toBeNull('Should be no header without cells');
+    // Header should be empty since there are no columns to display.
+    const headerRow = getHeaderRow(tableElement);
+    expect(headerRow.textContent).toBe('');
 
     // Rows should be empty since there are no columns to display.
     const rows = getRows(tableElement);
@@ -318,17 +466,13 @@ describe('CdkTable', () => {
   });
 
   it('should be able to dynamically add/remove column definitions', () => {
-    const dynamicColumnDefFixture = TestBed.createComponent(DynamicColumnDefinitionsCdkTableApp);
-    dynamicColumnDefFixture.detectChanges();
-
-    const dynamicColumnDefTable = dynamicColumnDefFixture.nativeElement.querySelector('cdk-table');
-    const dynamicColumnDefComp = dynamicColumnDefFixture.componentInstance;
+    setupTableTestApp(DynamicColumnDefinitionsCdkTableApp);
 
     // Add a new column and expect it to show up in the table
     let columnA = 'columnA';
-    dynamicColumnDefComp.dynamicColumns.push(columnA);
-    dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTable, [
+    component.dynamicColumns.push(columnA);
+    fixture.detectChanges();
+    expectTableToMatchContent(tableElement, [
       [columnA], // Header row
       [columnA], // Data rows
       [columnA],
@@ -337,9 +481,9 @@ describe('CdkTable', () => {
 
     // Add another new column and expect it to show up in the table
     let columnB = 'columnB';
-    dynamicColumnDefComp.dynamicColumns.push(columnB);
-    dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTable, [
+    component.dynamicColumns.push(columnB);
+    fixture.detectChanges();
+    expectTableToMatchContent(tableElement, [
       [columnA, columnB], // Header row
       [columnA, columnB], // Data rows
       [columnA, columnB],
@@ -347,9 +491,9 @@ describe('CdkTable', () => {
     ]);
 
     // Remove column A expect only column B to be rendered
-    dynamicColumnDefComp.dynamicColumns.shift();
-    dynamicColumnDefFixture.detectChanges();
-    expectTableToMatchContent(dynamicColumnDefTable, [
+    component.dynamicColumns.shift();
+    fixture.detectChanges();
+    expectTableToMatchContent(tableElement, [
       [columnB], // Header row
       [columnB], // Data rows
       [columnB],
@@ -357,27 +501,14 @@ describe('CdkTable', () => {
     ]);
   });
 
-  it('should re-render the rows when the data changes', () => {
-    dataSource.addData();
-    fixture.detectChanges();
-
-    expect(getRows(tableElement).length).toBe(dataSource.data.length);
-
-    // Check that the number of cells is correct
-    getRows(tableElement).forEach(row => {
-      expect(getCells(row).length).toBe(component.columnsToRender.length);
-    });
-  });
-
   it('should be able to register column, row, and header row definitions outside content', () => {
-    const outerTableAppFixture = TestBed.createComponent(OuterTableApp);
-    outerTableAppFixture.detectChanges();
+    setupTableTestApp(DynamicColumnDefinitionsCdkTableApp);
 
     // The first two columns were defined in the wrapped table component as content children,
     // while the injected columns were provided to the wrapped table from the outer component.
     // A special row was provided with a when predicate that shows the single column with text.
     // The header row was defined by the outer component.
-    expectTableToMatchContent(outerTableAppFixture.nativeElement.querySelector('cdk-table'), [
+    expectTableToMatchContent(tableElement, [
       ['Content Column A', 'Content Column B', 'Injected Column A', 'Injected Column B'],
       ['injected row with when predicate'],
       ['a_2', 'b_2', 'a_2', 'b_2'],
@@ -387,11 +518,9 @@ describe('CdkTable', () => {
 
   describe('using when predicate', () => {
     it('should be able to display different row templates based on the row data', () => {
-      let whenFixture = TestBed.createComponent(WhenRowCdkTableApp);
-      whenFixture.detectChanges();
-
-      let data = whenFixture.componentInstance.dataSource.data;
-      expectTableToMatchContent(whenFixture.nativeElement.querySelector('cdk-table'), [
+      setupTableTestApp(WhenRowCdkTableApp);
+      let data = component.dataSource.data;
+      expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         [data[0].a, data[0].b, data[0].c],
         ['index_1_special_row'],
@@ -401,79 +530,25 @@ describe('CdkTable', () => {
     });
 
     it('should error if there is row data that does not have a matching row template', () => {
-      let whenFixture = TestBed.createComponent(WhenRowWithoutDefaultCdkTableApp);
-      expect(() => whenFixture.detectChanges())
+      expect(() => TestBed.createComponent(WhenRowWithoutDefaultCdkTableApp).detectChanges())
           .toThrowError(getTableMissingMatchingRowDefError().message);
     });
 
     it('should error if there are multiple rows that do not have a when function', () => {
-      let whenFixture = TestBed.createComponent(WhenRowMultipleDefaultsCdkTableApp);
-      expect(() => whenFixture.detectChanges())
+      expect(() => TestBed.createComponent(WhenRowMultipleDefaultsCdkTableApp).detectChanges())
           .toThrowError(getTableMultipleDefaultRowDefsError().message);
     });
   });
 
-  it('should use differ to add/remove/move rows', () => {
-    // Each row receives an attribute 'initialIndex' the element's original place
-    getRows(tableElement).forEach((row: Element, index: number) => {
-      row.setAttribute('initialIndex', index.toString());
-    });
-
-    // Prove that the attributes match their indicies
-    const initialRows = getRows(tableElement);
-    expect(initialRows[0].getAttribute('initialIndex')).toBe('0');
-    expect(initialRows[1].getAttribute('initialIndex')).toBe('1');
-    expect(initialRows[2].getAttribute('initialIndex')).toBe('2');
-
-    // Swap first and second data in data array
-    const copiedData = component.dataSource!.data.slice();
-    const temp = copiedData[0];
-    copiedData[0] = copiedData[1];
-    copiedData[1] = temp;
-
-    // Remove the third element
-    copiedData.splice(2, 1);
-
-    // Add new data
-    component.dataSource!.data = copiedData;
-    component.dataSource!.addData();
-
-    // Expect that the first and second rows were swapped and that the last row is new
-    const changedRows = getRows(tableElement);
-    expect(changedRows.length).toBe(3);
-    expect(changedRows[0].getAttribute('initialIndex')).toBe('1');
-    expect(changedRows[1].getAttribute('initialIndex')).toBe('0');
-    expect(changedRows[2].getAttribute('initialIndex')).toBe(null);
-  });
-
-  it('should clear the row view containers on destroy', () => {
-    const rowPlaceholder = fixture.componentInstance.table._rowPlaceholder.viewContainer;
-    const headerPlaceholder = fixture.componentInstance.table._headerRowPlaceholder.viewContainer;
-
-    spyOn(rowPlaceholder, 'clear').and.callThrough();
-    spyOn(headerPlaceholder, 'clear').and.callThrough();
-
-    fixture.destroy();
-
-    expect(rowPlaceholder.clear).toHaveBeenCalled();
-    expect(headerPlaceholder.clear).toHaveBeenCalled();
-  });
-
   describe('with trackBy', () => {
-
-    let trackByComponent: TrackByCdkTableApp;
-    let trackByFixture: ComponentFixture<TrackByCdkTableApp>;
-
     function createTestComponentWithTrackyByTable(trackByStrategy) {
-      trackByFixture = TestBed.createComponent(TrackByCdkTableApp);
+      fixture = TestBed.createComponent(TrackByCdkTableApp);
 
-      trackByComponent = trackByFixture.componentInstance;
-      trackByComponent.trackByStrategy = trackByStrategy;
+      component = fixture.componentInstance;
+      component.trackByStrategy = trackByStrategy;
 
-      dataSource = trackByComponent.dataSource as FakeDataSource;
-      table = trackByComponent.table;
-      tableElement = trackByFixture.nativeElement.querySelector('cdk-table');
-      trackByFixture.detectChanges();
+      tableElement = fixture.nativeElement.querySelector('cdk-table');
+      fixture.detectChanges();
 
       // Each row receives an attribute 'initialIndex' the element's original place
       getRows(tableElement).forEach((row: Element, index: number) => {
@@ -490,7 +565,7 @@ describe('CdkTable', () => {
     // Swap first two elements, remove the third, add new data
     function mutateData() {
       // Swap first and second data in data array
-      const copiedData = trackByComponent.dataSource.data.slice();
+      const copiedData = component.dataSource.data.slice();
       const temp = copiedData[0];
       copiedData[0] = copiedData[1];
       copiedData[1] = temp;
@@ -499,8 +574,8 @@ describe('CdkTable', () => {
       copiedData.splice(2, 1);
 
       // Add new data
-      trackByComponent.dataSource.data = copiedData;
-      trackByComponent.dataSource.addData();
+      component.dataSource.data = copiedData;
+      component.dataSource.addData();
     }
 
     it('should add/remove/move rows with reference-based trackBy', () => {
@@ -520,7 +595,7 @@ describe('CdkTable', () => {
       mutateData();
 
       // Change each item reference to show that the trackby is not checking the item properties.
-      trackByComponent.dataSource.data = trackByComponent.dataSource.data
+      component.dataSource.data = component.dataSource.data
           .map(item => { return {a: item.a, b: item.b, c: item.c}; });
 
       // Expect that all the rows are considered new since their references are all different
@@ -537,7 +612,7 @@ describe('CdkTable', () => {
 
       // Change each item reference to show that the trackby is checking the item properties.
       // Otherwise this would cause them all to be removed/added.
-      trackByComponent.dataSource.data = trackByComponent.dataSource.data
+      component.dataSource.data = component.dataSource.data
           .map(item => { return {a: item.a, b: item.b, c: item.c}; });
 
       // Expect that the first and second rows were swapped and that the last row is new
@@ -554,7 +629,7 @@ describe('CdkTable', () => {
 
       // Change each item reference to show that the trackby is checking the index.
       // Otherwise this would cause them all to be removed/added.
-      trackByComponent.dataSource.data = trackByComponent.dataSource.data
+      component.dataSource.data = component.dataSource.data
           .map(item => { return {a: item.a, b: item.b, c: item.c}; });
 
       // Expect first two to be the same since they were swapped but indicies are consistent.
@@ -576,48 +651,18 @@ describe('CdkTable', () => {
 
       // Change each item reference to show that the trackby is checking the index.
       // Otherwise this would cause them all to be removed/added.
-      trackByComponent.dataSource.data = trackByComponent.dataSource.data
+      component.dataSource.data = component.dataSource.data
           .map(item => ({a: item.a, b: item.b, c: item.c}));
 
       // Expect the rows were given the right implicit data even though the rows were not moved.
-      trackByFixture.detectChanges();
+      fixture.detectChanges();
       expect(firstRow.textContent!.trim()).toBe('a_2 b_2');
       expect(firstRow.getAttribute('initialIndex')).toBe('0');
     });
   });
 
-  it('should match the right table content with dynamic data', () => {
-    const initialDataLength = dataSource.data.length;
-    expect(dataSource.data.length).toBe(3);
-
-    let data = dataSource.data;
-    expectTableToMatchContent(tableElement, [
-      ['Column A', 'Column B', 'Column C'],
-      [data[0].a, data[0].b, data[0].c],
-      [data[1].a, data[1].b, data[1].c],
-      [data[2].a, data[2].b, data[2].c],
-    ]);
-
-    // Add data to the table and recreate what the rendered output should be.
-    dataSource.addData();
-    expect(dataSource.data.length).toBe(initialDataLength + 1); // Make sure data was added
-    fixture.detectChanges();
-
-    data = dataSource.data;
-    expectTableToMatchContent(tableElement, [
-      ['Column A', 'Column B', 'Column C'],
-      [data[0].a, data[0].b, data[0].c],
-      [data[1].a, data[1].b, data[1].c],
-      [data[2].a, data[2].b, data[2].c],
-      [data[3].a, data[3].b, data[3].c],
-    ]);
-  });
-
   it('should match the right table content with dynamic data source', () => {
-    const dynamicDataSourceFixture = TestBed.createComponent(DynamicDataSourceCdkTableApp);
-    component = dynamicDataSourceFixture.componentInstance;
-    tableElement = dynamicDataSourceFixture.nativeElement.querySelector('cdk-table');
-    dynamicDataSourceFixture.detectChanges();
+    setupTableTestApp(DynamicDataSourceCdkTableApp);
 
     // Expect that the component has no data source and the table element reflects empty data.
     expect(component.dataSource).toBeUndefined();
@@ -628,7 +673,7 @@ describe('CdkTable', () => {
     // Add a data source that has initialized data. Expect that the table shows this data.
     const dynamicDataSource = new FakeDataSource();
     component.dataSource = dynamicDataSource;
-    dynamicDataSourceFixture.detectChanges();
+    fixture.detectChanges();
     expect(dynamicDataSource.isConnected).toBe(true);
 
     const data = component.dataSource.data;
@@ -641,7 +686,7 @@ describe('CdkTable', () => {
 
     // Remove the data source and check to make sure the table is empty again.
     component.dataSource = undefined;
-    dynamicDataSourceFixture.detectChanges();
+    fixture.detectChanges();
 
     // Expect that the old data source has been disconnected.
     expect(dynamicDataSource.isConnected).toBe(false);
@@ -652,7 +697,7 @@ describe('CdkTable', () => {
     // Reconnect a data source and check that the table is populated
     const newDynamicDataSource = new FakeDataSource();
     component.dataSource = newDynamicDataSource;
-    dynamicDataSourceFixture.detectChanges();
+    fixture.detectChanges();
     expect(newDynamicDataSource.isConnected).toBe(true);
 
     const newData = component.dataSource.data;
@@ -665,12 +710,9 @@ describe('CdkTable', () => {
   });
 
   it('should be able to apply classes to rows based on their context', () => {
-    const contextFixture = TestBed.createComponent(RowContextCdkTableApp);
-    const contextComponent = contextFixture.componentInstance;
-    tableElement = contextFixture.nativeElement.querySelector('cdk-table');
-    contextFixture.detectChanges();
+    setupTableTestApp(RowContextCdkTableApp);
 
-    let rowElements = contextFixture.nativeElement.querySelectorAll('cdk-row');
+    let rowElements = tableElement.querySelectorAll('cdk-row');
 
     // Rows should not have any context classes
     for (let i = 0; i < rowElements.length; i++) {
@@ -681,8 +723,8 @@ describe('CdkTable', () => {
     }
 
     // Enable all the context classes
-    contextComponent.enableRowContextClasses = true;
-    contextFixture.detectChanges();
+    component.enableRowContextClasses = true;
+    fixture.detectChanges();
 
     expect(rowElements[0].classList.contains('custom-row-class-first')).toBe(true);
     expect(rowElements[0].classList.contains('custom-row-class-last')).toBe(false);
@@ -701,12 +743,9 @@ describe('CdkTable', () => {
   });
 
   it('should be able to apply classes to cells based on their row context', () => {
-    const contextFixture = TestBed.createComponent(RowContextCdkTableApp);
-    const contextComponent = contextFixture.componentInstance;
-    tableElement = contextFixture.nativeElement.querySelector('cdk-table');
-    contextFixture.detectChanges();
+    setupTableTestApp(RowContextCdkTableApp);
 
-    const rowElements = contextFixture.nativeElement.querySelectorAll('cdk-row');
+    const rowElements = fixture.nativeElement.querySelectorAll('cdk-row');
 
     for (let i = 0; i < rowElements.length; i++) {
       // Cells should not have any context classes
@@ -720,8 +759,8 @@ describe('CdkTable', () => {
     }
 
     // Enable the context classes
-    contextComponent.enableCellContextClasses = true;
-    contextFixture.detectChanges();
+    component.enableCellContextClasses = true;
+    fixture.detectChanges();
 
     let cellElement = rowElements[0].querySelectorAll('cdk-cell')[0];
     expect(cellElement.classList.contains('custom-cell-class-first')).toBe(true);
@@ -740,33 +779,6 @@ describe('CdkTable', () => {
     expect(cellElement.classList.contains('custom-cell-class-last')).toBe(true);
     expect(cellElement.classList.contains('custom-cell-class-even')).toBe(true);
     expect(cellElement.classList.contains('custom-cell-class-odd')).toBe(false);
-  });
-
-  it('should be able to dynamically change the columns for header and rows', () => {
-    expect(dataSource.data.length).toBe(3);
-
-    let data = dataSource.data;
-    expectTableToMatchContent(tableElement, [
-      ['Column A', 'Column B', 'Column C'],
-      [data[0].a, data[0].b, data[0].c],
-      [data[1].a, data[1].b, data[1].c],
-      [data[2].a, data[2].b, data[2].c],
-    ]);
-
-    // Remove column_a and swap column_b/column_c.
-    component.columnsToRender = ['column_c', 'column_b'];
-    fixture.detectChanges();
-
-    let changedTableContent = [['Column C', 'Column B']];
-    dataSource.data.forEach(rowData => changedTableContent.push([rowData.c, rowData.b]));
-
-    data = dataSource.data;
-    expectTableToMatchContent(tableElement, [
-      ['Column C', 'Column B'],
-      [data[0].c, data[0].b],
-      [data[1].c, data[1].b],
-      [data[2].c, data[2].b],
-    ]);
   });
 });
 
@@ -826,24 +838,29 @@ class BooleanDataSource extends DataSource<boolean> {
   template: `
     <cdk-table [dataSource]="dataSource">
       <ng-container cdkColumnDef="column_a">
-        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+        <cdk-header-cell *cdkHeaderCellDef> Column A </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer A </cdk-footer-cell>
       </ng-container>
 
       <ng-container cdkColumnDef="column_b">
-        <cdk-header-cell *cdkHeaderCellDef> Column B</cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row"> {{row.b}}</cdk-cell>
+        <cdk-header-cell *cdkHeaderCellDef> Column B </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.b}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer B </cdk-footer-cell>
       </ng-container>
 
       <ng-container cdkColumnDef="column_c">
-        <cdk-header-cell *cdkHeaderCellDef> Column C</cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row"> {{row.c}}</cdk-cell>
+        <cdk-header-cell *cdkHeaderCellDef> Column C </cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.c}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer C </cdk-footer-cell>
       </ng-container>
 
       <cdk-header-row class="customHeaderRowClass"
                       *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
       <cdk-row class="customRowClass"
                *cdkRowDef="let row; columns: columnsToRender"></cdk-row>
+      <cdk-footer-row class="customFooterRowClass"
+                      *cdkFooterRowDef="columnsToRender"></cdk-footer-row>
     </cdk-table>
   `
 })
@@ -1047,7 +1064,7 @@ class WhenRowMultipleDefaultsCdkTableApp {
   `
 })
 class DynamicDataSourceCdkTableApp {
-  dataSource: FakeDataSource;
+  dataSource: FakeDataSource | undefined;
   columnsToRender = ['column_a'];
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
@@ -1197,7 +1214,61 @@ class MissingColumnDefCdkTableApp {
     </cdk-table>
   `
 })
-class MissingRowDefsCdkTableApp {
+class MissingAllRowDefsCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer A </cdk-footer-cell>
+      </ng-container>
+
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+      <cdk-footer-row *cdkFooterRowDef="['column_a']"></cdk-footer-row>
+    </cdk-table>
+  `
+})
+class MissingHeaderRowDefCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer A </cdk-footer-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-footer-row *cdkFooterRowDef="['column_a']"></cdk-footer-row>
+    </cdk-table>
+  `
+})
+class MissingRowDefCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}} </cdk-cell>
+        <cdk-footer-cell *cdkFooterCellDef> Footer A </cdk-footer-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+    </cdk-table>
+  `
+})
+class MissingFooterRowDefCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
 }
 
@@ -1329,6 +1400,10 @@ function getHeaderRow(tableElement: Element): Element {
   return tableElement.querySelector('.cdk-header-row')!;
 }
 
+function getFooterRow(tableElement: Element): Element {
+  return tableElement.querySelector('.cdk-footer-row')!;
+}
+
 function getRows(tableElement: Element): Element[] {
   return getElements(tableElement, '.cdk-row');
 }
@@ -1340,41 +1415,46 @@ function getHeaderCells(tableElement: Element): Element[] {
   return getElements(getHeaderRow(tableElement), '.cdk-header-cell');
 }
 
-function expectTableToMatchContent(tableElement: Element, expectedTableContent: any[]) {
+function getFooterCells(tableElement: Element): Element[] {
+  return getElements(getFooterRow(tableElement), '.cdk-footer-cell');
+}
+
+function getActualTableContent(tableElement: Element): string[][] {
+  let actualTableContent: Element[][] = [];
+  if (getHeaderRow(tableElement)) {
+    actualTableContent.push(getHeaderCells(tableElement));
+  }
+
+  // Check data row cells
+  const rows = getRows(tableElement).map(row => getCells(row));
+  actualTableContent = actualTableContent.concat(rows);
+
+  if (getFooterRow(tableElement)) {
+    actualTableContent.push(getFooterCells(tableElement));
+  }
+
+  // Convert the nodes into their text content;
+  return actualTableContent.map(row => row.map(cell => cell.textContent!.trim()));
+}
+
+function expectTableToMatchContent(tableElement: Element, expected: any[]) {
   const missedExpectations: string[] = [];
-  function checkCellContent(cell: Element, expectedTextContent: string) {
-    const actualTextContent = cell.textContent!.trim();
-    if (actualTextContent !== expectedTextContent) {
-      missedExpectations.push(
-          `Expected cell contents to be ${expectedTextContent} but was ${actualTextContent}`);
+  function checkCellContent(actualCell: string, expectedCell: string) {
+    if (actualCell !== expectedCell) {
+      missedExpectations.push(`Expected cell contents to be ${actualCell} but was ${expectedCell}`);
     }
   }
 
-  // Copy the expected data array to avoid mutating the test's array
-  expectedTableContent = expectedTableContent.slice();
+  const actual = getActualTableContent(tableElement);
 
-  // Check header cells
-  const expectedHeaderContent = expectedTableContent.shift();
-  getHeaderCells(tableElement).forEach((cell, index) => {
-    const expected = expectedHeaderContent ?
-        expectedHeaderContent[index] :
-        null;
-    checkCellContent(cell, expected);
-  });
-
-  // Check data row cells
-  const rows = getRows(tableElement);
-  if (rows.length !== expectedTableContent.length) {
-    missedExpectations.push(
-        `Expected ${expectedTableContent.length} rows but found ${rows.length}`);
+  if (actual.length !== expected.length) {
+    missedExpectations.push(`Expected ${expected.length} total rows but got ${actual.length}`);
     fail(missedExpectations.join('\n'));
   }
-  rows.forEach((row, rowIndex) => {
-    getCells(row).forEach((cell, cellIndex) => {
-      const expected = expectedTableContent.length ?
-          expectedTableContent[rowIndex][cellIndex] :
-          null;
-      checkCellContent(cell, expected);
+  actual.forEach((row, rowIndex) => {
+    row.forEach((actualCell, cellIndex) => {
+      const expectedCell = expected[rowIndex] ? expected[rowIndex][cellIndex] : null;
+      checkCellContent(actualCell, expectedCell);
     });
   });
 

--- a/src/demo-app/table/footer/footer-table.html
+++ b/src/demo-app/table/footer/footer-table.html
@@ -1,0 +1,21 @@
+<h3>Table with Footer</h3>
+
+<mat-card class="demo-table-card">
+  <mat-table [dataSource]="data" cdk-scrollable>
+    <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+      <mat-header-cell *matHeaderCellDef> {{column}} </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{element[column]}} </mat-cell>
+      <mat-footer-cell *matFooterCellDef> {{column}} Footer </mat-footer-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="columnsToDisplay"
+                    [class.demo-sticky-row]="!isScrollPositionTop">
+    </mat-header-row>
+
+    <mat-row *matRowDef="let row; columns: columnsToDisplay;"></mat-row>
+
+    <mat-footer-row *matFooterRowDef="columnsToDisplay"
+                    [class.demo-sticky-row]="!isScrollPositionBottom">
+    </mat-footer-row>
+  </mat-table>
+</mat-card>

--- a/src/demo-app/table/footer/footer-table.scss
+++ b/src/demo-app/table/footer/footer-table.scss
@@ -1,0 +1,32 @@
+mat-card {
+  margin: 8px 0;
+  padding: 0;
+}
+
+mat-table {
+  height: 500px;
+  overflow: auto;
+}
+
+.mat-header-row, .mat-footer-row {
+  position: -webkit-sticky;
+  background: white;
+  transition: box-shadow 200ms ease-in-out;
+}
+
+.mat-header-row {
+  top: 0;
+}
+
+.mat-footer-row {
+  bottom: 0;
+  border-top-width: 1px;
+}
+
+.mat-row:last-of-type {
+  border-bottom-width: 0;
+}
+
+.demo-sticky-row {
+  box-shadow: 0 0 8px 1px #ccc;
+}

--- a/src/demo-app/table/footer/footer-table.ts
+++ b/src/demo-app/table/footer/footer-table.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectorRef, Component, ViewChild} from '@angular/core';
+import {ELEMENT_DATA} from '../element-data';
+import {CdkScrollable} from '@angular/cdk/scrolling';
+
+@Component({
+  moduleId: module.id,
+  templateUrl: 'footer-table.html',
+  styleUrls: ['footer-table.css'],
+})
+export class FooterTableDemo {
+  columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
+  data = ELEMENT_DATA.slice();
+
+  isScrollPositionTop = true;
+  isScrollPositionBottom = false;
+
+  @ViewChild(CdkScrollable) scrollable: CdkScrollable;
+
+  constructor(private changeDetectorRef: ChangeDetectorRef) { }
+
+  ngAfterViewInit() {
+    this.scrollable.elementScrolled().subscribe(() => this.updateStickyStyles());
+  }
+
+  updateStickyStyles() {
+    const tableEl = this.scrollable.getElementRef().nativeElement;
+    let changed = false;
+
+    const isScrollPositionTop = !tableEl.scrollTop;
+    if (this.isScrollPositionTop != isScrollPositionTop) {
+      this.isScrollPositionTop = isScrollPositionTop;
+      changed = true;
+    }
+
+    const height = tableEl.getBoundingClientRect().height;
+    const isScrollPositionBottom = !(tableEl.scrollHeight - tableEl.scrollTop - height);
+
+    if (this.isScrollPositionBottom != isScrollPositionBottom) {
+      this.isScrollPositionBottom = isScrollPositionBottom;
+      changed = true;
+    }
+
+    if (changed) {
+      this.changeDetectorRef.detectChanges();
+    }
+  }
+}

--- a/src/demo-app/table/routes.ts
+++ b/src/demo-app/table/routes.ts
@@ -10,10 +10,12 @@ import {Routes} from '@angular/router';
 import {TableDemo} from './table-demo';
 import {CustomTableDemo} from './custom-table/custom-table';
 import {DataInputTableDemo} from './data-input-table/data-input-table';
+import {FooterTableDemo} from './footer/footer-table';
 
 export const TABLE_DEMO_ROUTES: Routes = [
   {path: '', redirectTo: 'main-demo', pathMatch: 'full'},
   {path: 'main-demo', component: TableDemo},
   {path: 'custom-table', component: CustomTableDemo},
   {path: 'data-input-table', component: DataInputTableDemo},
+  {path: 'footer-table', component: FooterTableDemo},
 ];

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -17,11 +17,13 @@ import {
   MatCardModule,
   MatCheckboxModule,
   MatIconModule,
-  MatInputModule, MatMenuModule,
+  MatInputModule,
+  MatMenuModule,
   MatPaginatorModule,
   MatRadioModule,
   MatSortModule,
-  MatTableModule, MatTabsModule
+  MatTableModule,
+  MatTabsModule
 } from '@angular/material';
 import {FormsModule} from '@angular/forms';
 import {CdkTableModule} from '@angular/cdk/table';
@@ -30,9 +32,12 @@ import {RouterModule} from '@angular/router';
 import {WrapperTable} from './custom-table/wrapper-table';
 import {SimpleColumn} from './custom-table/simple-column';
 import {DataInputTableDemo} from './data-input-table/data-input-table';
+import {FooterTableDemo} from './footer/footer-table';
+import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 
 @NgModule({
   imports: [
+    ScrollDispatchModule,
     CdkTableModule,
     CommonModule,
     FormsModule,
@@ -57,6 +62,7 @@ import {DataInputTableDemo} from './data-input-table/data-input-table';
     TableHeaderDemo,
     WrapperTable,
     SimpleColumn,
+    FooterTableDemo,
   ],
   providers: [
     PeopleDatabase

--- a/src/demo-app/table/table-demo-page.ts
+++ b/src/demo-app/table/table-demo-page.ts
@@ -17,5 +17,6 @@ export class TableDemoPage {
     {name: 'Main Page', link: 'main-demo'},
     {name: 'Custom Table', link: 'custom-table'},
     {name: 'Direct Data', link: 'data-input-table'},
+    {name: 'Footer Table', link: 'footer-table'},
   ];
 }

--- a/src/lib/table/_table-theme.scss
+++ b/src/lib/table/_table-theme.scss
@@ -10,15 +10,15 @@
     background: mat-color($background, 'card');
   }
 
-  .mat-row, .mat-header-row {
-    border-bottom-color: mat-color($foreground, divider);
+  .mat-row, .mat-header-row, .mat-footer-row {
+    border-color: mat-color($foreground, divider);
   }
 
   .mat-header-cell {
     color: mat-color($foreground, secondary-text);
   }
 
-  .mat-cell {
+  .mat-cell, .mat-footer-cell {
     color: mat-color($foreground, text);
   }
 }
@@ -33,7 +33,7 @@
     font-weight: mat-font-weight($config, body-2);
   }
 
-  .mat-cell {
+  .mat-cell, .mat-footer-cell {
     font-size: mat-font-size($config, body-1);
   }
 }

--- a/src/lib/table/cell.ts
+++ b/src/lib/table/cell.ts
@@ -10,7 +10,7 @@ import {Directive, ElementRef, Input} from '@angular/core';
 import {
   CdkCell,
   CdkCellDef,
-  CdkColumnDef,
+  CdkColumnDef, CdkFooterCell, CdkFooterCellDef,
   CdkHeaderCell,
   CdkHeaderCellDef,
 } from '@angular/cdk/table';
@@ -36,6 +36,16 @@ export class MatCellDef extends CdkCellDef { }
 export class MatHeaderCellDef extends CdkHeaderCellDef { }
 
 /**
+ * Footer cell definition for the mat-table.
+ * Captures the template of a column's footer cell and as well as cell-specific properties.
+ */
+@Directive({
+  selector: '[matFooterCellDef]',
+  providers: [{provide: CdkFooterCellDef, useExisting: MatFooterCellDef}]
+})
+export class MatFooterCellDef extends CdkFooterCellDef { }
+
+/**
  * Column definition for the mat-table.
  * Defines a set of cells available for a table column.
  */
@@ -57,6 +67,22 @@ export class MatColumnDef extends CdkColumnDef {
   },
 })
 export class MatHeaderCell extends CdkHeaderCell {
+  constructor(columnDef: CdkColumnDef,
+              elementRef: ElementRef) {
+    super(columnDef, elementRef);
+    elementRef.nativeElement.classList.add(`mat-column-${columnDef.cssClassFriendlyName}`);
+  }
+}
+
+/** Footer cell template container that adds the right classes and role. */
+@Directive({
+  selector: 'mat-footer-cell',
+  host: {
+    'class': 'mat-footer-cell',
+    'role': 'gridcell',
+  },
+})
+export class MatFooterCell extends CdkFooterCell {
   constructor(columnDef: CdkColumnDef,
               elementRef: ElementRef) {
     super(columnDef, elementRef);

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -8,7 +8,7 @@
 
 import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '@angular/core';
 import {
-  CDK_ROW_TEMPLATE,
+  CDK_ROW_TEMPLATE, CdkFooterRow, CdkFooterRowDef,
   CdkHeaderRow,
   CdkHeaderRowDef,
   CdkRow,
@@ -27,8 +27,19 @@ import {
 export class MatHeaderRowDef extends CdkHeaderRowDef { }
 
 /**
+ * Footer row definition for the mat-table.
+ * Captures the footer row's template and other footer properties such as the columns to display.
+ */
+@Directive({
+  selector: '[matFooterRowDef]',
+  providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
+  inputs: ['columns: matFooterRowDef'],
+})
+export class MatFooterRowDef extends CdkFooterRowDef { }
+
+/**
  * Data row definition for the mat-table.
- * Captures the header row's template and other row properties such as the columns to display and
+ * Captures the footer row's template and other footer properties such as the columns to display and
  * a when predicate that describes when this row should be used.
  */
 @Directive({
@@ -39,7 +50,7 @@ export class MatHeaderRowDef extends CdkHeaderRowDef { }
 export class MatRowDef<T> extends CdkRowDef<T> {
 }
 
-/** Header template container that contains the cell outlet. Adds the right class and role. */
+/** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   moduleId: module.id,
   selector: 'mat-header-row',
@@ -53,6 +64,21 @@ export class MatRowDef<T> extends CdkRowDef<T> {
   exportAs: 'matHeaderRow',
 })
 export class MatHeaderRow extends CdkHeaderRow { }
+
+/** Footer template container that contains the cell outlet. Adds the right class and role. */
+@Component({
+  moduleId: module.id,
+  selector: 'mat-footer-row',
+  template: CDK_ROW_TEMPLATE,
+  host: {
+    'class': 'mat-footer-row',
+    'role': 'row',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'matFooterRow',
+})
+export class MatFooterRow extends CdkFooterRow { }
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({

--- a/src/lib/table/table-module.ts
+++ b/src/lib/table/table-module.ts
@@ -9,18 +9,24 @@
 import {NgModule} from '@angular/core';
 import {MatTable} from './table';
 import {CdkTableModule} from '@angular/cdk/table';
-import {MatCell, MatCellDef, MatColumnDef, MatHeaderCell, MatHeaderCellDef} from './cell';
-import {MatHeaderRow, MatHeaderRowDef, MatRow, MatRowDef} from './row';
+import {
+  MatCell, MatCellDef, MatColumnDef, MatFooterCell, MatFooterCellDef, MatHeaderCell,
+  MatHeaderCellDef
+} from './cell';
+import {
+  MatFooterRow, MatFooterRowDef, MatHeaderRow, MatHeaderRowDef, MatRow,
+  MatRowDef
+} from './row';
 import {CommonModule} from '@angular/common';
 import {MatCommonModule} from '@angular/material/core';
 
 @NgModule({
   imports: [CdkTableModule, CommonModule, MatCommonModule],
-  exports: [MatTable, MatCellDef, MatHeaderCellDef, MatColumnDef,
-    MatHeaderCell, MatCell, MatHeaderRow, MatRow,
-    MatHeaderRowDef, MatRowDef],
-  declarations: [MatTable, MatCellDef, MatHeaderCellDef, MatColumnDef,
-    MatHeaderCell, MatCell, MatHeaderRow, MatRow,
-    MatHeaderRowDef, MatRowDef],
+  exports: [MatTable, MatCellDef, MatHeaderCellDef, MatFooterCellDef, MatColumnDef,
+    MatHeaderCell, MatFooterCell, MatCell, MatHeaderRow, MatFooterRow, MatRow,
+    MatHeaderRowDef, MatFooterRowDef, MatRowDef],
+  declarations: [MatTable, MatCellDef, MatHeaderCellDef, MatFooterCellDef, MatColumnDef,
+    MatHeaderCell, MatFooterCell, MatCell, MatHeaderRow, MatFooterRow, MatRow,
+    MatHeaderRowDef, MatFooterRowDef, MatRowDef],
 })
 export class MatTableModule {}

--- a/src/lib/table/table.md
+++ b/src/lib/table/table.md
@@ -257,6 +257,28 @@ masterToggle() {
 }
 ```
 
+#### Footer row
+
+A footer row can be added to the table by adding a footer row definition to the table and adding
+footer cell templates to column definitions. The footer row will be rendered after the rendered
+data rows.
+
+```html
+<ng-container matColumnDef="cost">
+  <mat-header-cell *matHeaderCellDef> Cost </mat-header-cell>
+  <mat-cell *matCellDef="let data"> {{data.cost}} </mat-cell>
+    <mat-header-cell *matHeaderCellDef> {{totalCost}} </mat-header-cell>
+</ng-container>
+
+...
+
+<mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+<mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></mat-row>
+<mat-footer-row *matFooterRowDef="columnsToDisplay"></mat-footer-row>
+```
+
+<!--- example(table-footer-row) -->
+
 ##### 4. Include overflow styling 
 
 Finally, adjust the styling for the select column so that its overflow is not hidden. This allows 

--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -10,14 +10,17 @@ $mat-row-horizontal-padding: 24px;
   min-height: $mat-header-row-height;
 }
 
-.mat-row {
+.mat-row, .mat-footer-row {
   min-height: $mat-row-height;
 }
 
-.mat-row, .mat-header-row {
+.mat-row, .mat-header-row, .mat-footer-row {
   display: flex;
+  // Define a border style, but then widths default to 3px. Reset them to 0px except the bottom
+  // which should be 1px;
+  border-width: 0;
   border-bottom-width: 1px;
-  border-bottom-style: solid;
+  border-style: solid;
   align-items: center;
   padding: 0 $mat-row-horizontal-padding;
   box-sizing: border-box;
@@ -32,7 +35,7 @@ $mat-row-horizontal-padding: 24px;
   }
 }
 
-.mat-cell, .mat-header-cell {
+.mat-cell, .mat-header-cell, .mat-footer-cell {
   flex: 1;
   overflow: hidden;
   word-wrap: break-word;

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -30,7 +30,8 @@ describe('MatTable', () => {
         [data[0].a, data[0].b, data[0].c],
         [data[1].a, data[1].b, data[1].c],
         [data[2].a, data[2].b, data[2].c],
-        ['fourth_row']
+        ['fourth_row'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -44,7 +45,8 @@ describe('MatTable', () => {
         ['a_1'],
         ['a_2'],
         ['a_3'],
-        ['fourth_row']
+        ['fourth_row'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
   });
@@ -70,6 +72,7 @@ describe('MatTable', () => {
         ['a_1', 'b_1', 'c_1'],
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -83,6 +86,7 @@ describe('MatTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
         ['a_4', 'b_4', 'c_4'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Remove data
@@ -95,6 +99,7 @@ describe('MatTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
         ['a_4', 'b_4', 'c_4'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -107,6 +112,7 @@ describe('MatTable', () => {
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_1', 'b_1', 'c_1'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       flushMicrotasks();  // Resolve promise that updates paginator's length
@@ -120,6 +126,7 @@ describe('MatTable', () => {
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_2', 'b_2', 'c_2'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Change filter to empty string, should match all rows
@@ -134,6 +141,7 @@ describe('MatTable', () => {
         ['a_1', 'b_1', 'c_1'],
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Change filter function and filter, should match to rows with zebra.
@@ -153,6 +161,7 @@ describe('MatTable', () => {
       expectTableToMatchContent(tableElement, [
         ['Column A', 'Column B', 'Column C'],
         ['a_2', 'b_2', 'c_2'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     }));
 
@@ -165,6 +174,7 @@ describe('MatTable', () => {
         ['a_1', 'b_1', 'c_1'],
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Activate column A sort again (reverse direction)
@@ -175,6 +185,7 @@ describe('MatTable', () => {
         ['a_3', 'b_3', 'c_3'],
         ['a_2', 'b_2', 'c_2'],
         ['a_1', 'b_1', 'c_1'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Change sort function to customize how it sorts - first column 1, then 3, then 2
@@ -193,6 +204,7 @@ describe('MatTable', () => {
         ['a_1', 'b_1', 'c_1'],
         ['a_3', 'b_3', 'c_3'],
         ['a_2', 'b_2', 'c_2'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -208,6 +220,7 @@ describe('MatTable', () => {
         ['', 'b_1', 'c_1'],
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Expect that empty string row comes before the other values
@@ -218,6 +231,7 @@ describe('MatTable', () => {
         ['a_3', 'b_3', 'c_3'],
         ['a_2', 'b_2', 'c_2'],
         ['', 'b_1', 'c_1'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -233,6 +247,7 @@ describe('MatTable', () => {
         ['', 'b_1', 'c_1'],
         ['a_2', 'b_2', 'c_2'],
         ['a_3', 'b_3', 'c_3'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
 
@@ -244,6 +259,7 @@ describe('MatTable', () => {
         ['a_3', 'b_3', 'c_3'],
         ['a_2', 'b_2', 'c_2'],
         ['', 'b_1', 'c_1'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
 
@@ -261,6 +277,7 @@ describe('MatTable', () => {
         ['a_3', 'b_3', 'c_3'],
         ['a_4', 'b_4', 'c_4'],
         ['a_5', 'b_5', 'c_5'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
 
       // Navigate to the next page
@@ -273,6 +290,7 @@ describe('MatTable', () => {
         ['a_8', 'b_8', 'c_8'],
         ['a_9', 'b_9', 'c_9'],
         ['a_10', 'b_10', 'c_10'],
+        ['Footer A', 'Footer B', 'Footer C'],
       ]);
     }));
   });
@@ -320,16 +338,19 @@ class FakeDataSource extends DataSource<TestData> {
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer A</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="column_b">
         <mat-header-cell *matHeaderCellDef> Column B</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.b}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer B</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="column_c">
         <mat-header-cell *matHeaderCellDef> Column C</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.c}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer C</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="special_column">
@@ -339,6 +360,7 @@ class FakeDataSource extends DataSource<TestData> {
       <mat-header-row *matHeaderRowDef="columnsToRender"></mat-header-row>
       <mat-row *matRowDef="let row; columns: columnsToRender"></mat-row>
       <mat-row *matRowDef="let row; columns: ['special_column']; when: isFourthRow"></mat-row>
+      <mat-footer-row *matFooterRowDef="columnsToRender"></mat-footer-row>
     </mat-table>
   `
 })
@@ -357,6 +379,7 @@ class MatTableApp {
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer A</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="special_column">
@@ -366,6 +389,7 @@ class MatTableApp {
       <mat-header-row *matHeaderRowDef="['column_a']"></mat-header-row>
       <mat-row *matRowDef="let row; columns: ['column_a']"></mat-row>
       <mat-row *matRowDef="let row; columns: ['special_column']; when: isFourthRow"></mat-row>
+      <mat-footer-row *matFooterRowDef="['column_a']"></mat-footer-row>
     </mat-table>
   `
 })
@@ -383,20 +407,24 @@ class MatTableWithWhenRowApp {
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef mat-sort-header="a"> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer A</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="column_b">
         <mat-header-cell *matHeaderCellDef> Column B</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.b}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer B</mat-footer-cell>
       </ng-container>
 
       <ng-container matColumnDef="column_c">
         <mat-header-cell *matHeaderCellDef> Column C</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.c}}</mat-cell>
+        <mat-footer-cell *matFooterCellDef> Footer C</mat-footer-cell>
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="columnsToRender"></mat-header-row>
       <mat-row *matRowDef="let row; columns: columnsToRender"></mat-row>
+      <mat-footer-row *matFooterRowDef="columnsToRender"></mat-footer-row>
     </mat-table>
 
     <mat-paginator [pageSize]="5"></mat-paginator>
@@ -433,13 +461,16 @@ class ArrayDataSourceMatTableApp {
   }
 }
 
-// Utilities copied from CDKTable's spec
 function getElements(element: Element, query: string): Element[] {
   return [].slice.call(element.querySelectorAll(query));
 }
 
 function getHeaderRow(tableElement: Element): Element {
   return tableElement.querySelector('.mat-header-row')!;
+}
+
+function getFooterRow(tableElement: Element): Element {
+  return tableElement.querySelector('.mat-footer-row')!;
 }
 
 function getRows(tableElement: Element): Element[] {
@@ -453,35 +484,46 @@ function getHeaderCells(tableElement: Element): Element[] {
   return getElements(getHeaderRow(tableElement), '.mat-header-cell');
 }
 
-function expectTableToMatchContent(tableElement: Element, expectedTableContent: any[]) {
+function getFooterCells(tableElement: Element): Element[] {
+  return getElements(getFooterRow(tableElement), '.mat-footer-cell');
+}
+
+function getActualTableContent(tableElement: Element): string[][] {
+  let actualTableContent: Element[][] = [];
+  if (getHeaderRow(tableElement)) {
+    actualTableContent.push(getHeaderCells(tableElement));
+  }
+
+  // Check data row cells
+  const rows = getRows(tableElement).map(row => getCells(row));
+  actualTableContent = actualTableContent.concat(rows);
+
+  if (getFooterRow(tableElement)) {
+    actualTableContent.push(getFooterCells(tableElement));
+  }
+
+  // Convert the nodes into their text content;
+  return actualTableContent.map(row => row.map(cell => cell.textContent!.trim()));
+}
+
+function expectTableToMatchContent(tableElement: Element, expected: any[]) {
   const missedExpectations: string[] = [];
-  function checkCellContent(cell: Element, expectedTextContent: string) {
-    const actualTextContent = cell.textContent!.trim();
-    if (actualTextContent !== expectedTextContent) {
-      missedExpectations.push(
-          `Expected cell contents to be ${expectedTextContent} but was ${actualTextContent}`);
+  function checkCellContent(actualCell: string, expectedCell: string) {
+    if (actualCell !== expectedCell) {
+      missedExpectations.push(`Expected cell contents to be ${actualCell} but was ${expectedCell}`);
     }
   }
 
-  // Check header cells
-  const expectedHeaderContent = expectedTableContent.shift();
-  getHeaderCells(tableElement).forEach((cell, index) => {
-    const expected = expectedHeaderContent ?
-        expectedHeaderContent[index] :
-        null;
-    checkCellContent(cell, expected);
-  });
+  const actual = getActualTableContent(tableElement);
 
-  // Check data row cells
-  const rows = getRows(tableElement);
-  expect(rows.length).toBe(expectedTableContent.length,
-      `Found ${rows.length} rows but expected ${expectedTableContent.length}`);
-  rows.forEach((row, rowIndex) => {
-    getCells(row).forEach((cell, cellIndex) => {
-      const expected = expectedTableContent.length ?
-          expectedTableContent[rowIndex][cellIndex] :
-          null;
-      checkCellContent(cell, expected);
+  if (actual.length !== expected.length) {
+    missedExpectations.push(`Expected ${expected.length} total rows but got ${actual.length}`);
+    fail(missedExpectations.join('\n'));
+  }
+  actual.forEach((row, rowIndex) => {
+    row.forEach((actualCell, cellIndex) => {
+      const expectedCell = expected[rowIndex] ? expected[rowIndex][cellIndex] : null;
+      checkCellContent(actualCell, expectedCell);
     });
   });
 

--- a/src/material-examples/table-footer-row/table-footer-row-example.css
+++ b/src/material-examples/table-footer-row/table-footer-row-example.css
@@ -1,0 +1,11 @@
+.example-container {
+  display: flex;
+  flex-direction: column;
+  max-height: 500px;
+  min-width: 300px;
+}
+
+.mat-table {
+  overflow: auto;
+  max-height: 500px;
+}

--- a/src/material-examples/table-footer-row/table-footer-row-example.html
+++ b/src/material-examples/table-footer-row/table-footer-row-example.html
@@ -1,0 +1,22 @@
+<div class="example-container mat-elevation-z8">
+  <mat-table [dataSource]="transactions">
+
+    <!-- Item Column -->
+    <ng-container matColumnDef="item">
+      <mat-header-cell *matHeaderCellDef> Item </mat-header-cell>
+      <mat-cell *matCellDef="let transaction"> {{transaction.item}} </mat-cell>
+      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
+    </ng-container>
+
+    <!-- Cost Column -->
+    <ng-container matColumnDef="cost">
+      <mat-header-cell *matHeaderCellDef> Cost </mat-header-cell>
+      <mat-cell *matCellDef="let transaction"> {{transaction.cost | currency}} </mat-cell>
+      <mat-footer-cell *matFooterCellDef> getTotalCost() </mat-footer-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-footer-row *matFooterRowDef="displayedColumns"></mat-footer-row>
+  </mat-table>
+</div>

--- a/src/material-examples/table-footer-row/table-footer-row-example.ts
+++ b/src/material-examples/table-footer-row/table-footer-row-example.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+
+export interface Transaction {
+  item: string;
+  cost: number;
+}
+
+/**
+ * @title Footer row table
+ */
+@Component({
+  selector: 'table-footer-row-example',
+  styleUrls: ['table-footer-row-example.css'],
+  templateUrl: 'table-footer-row-example.html',
+})
+export class TableFooterRowExample {
+  displayedColumns = ['item', 'cost'];
+  transactions: Transaction[] = [
+    {item: 'Beach ball', cost: 4},
+    {item: 'Towel', cost: 5},
+    {item: 'Frisbee', cost: 2},
+    {item: 'Sunscreen', cost: 4},
+    {item: 'Cooler', cost: 25},
+    {item: 'Swim suit', cost: 15},
+  ];
+
+  /** Gets the total cost of all transactions. */
+  getTotalCost() {
+    return this.transactions.map(t => t.cost).reduce((acc, value) => acc + value, 0);
+  }
+}


### PR DESCRIPTION
Adds an optional footer row to the table. Since header row has similar logic, a refactoring of the table code was necessary to avoid duplicating work.

Note that the `table.spec.ts` was reworked as well to remove a lot of boilerplate (most tests begin by setting up a fixture, component, table element, etc.). Added a utility function at the top of the file to handle this.

Closes #7548