### PR TITLE
docs(datepicker): typos

### DIFF
--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -55,8 +55,8 @@ year containing the `startAt` date.
 
 When a year or a month is selected in `multi-year` and `year` views respectively, the `yearSelected`
 and `monthSelected` outputs emit a normalized date representing the chosen year or month. By
-"normalized" we mean that the dates representing a year will have their month set to January and
-their day set to the 1st. Dates representing a month will have their day set to the 1st of that
+"normalized" we mean that the dates representing years will have their month set to January and
+their day set to the 1st. Dates representing months will have their day set to the 1st of the
 month. For example, if `<mat-datepicker>` is configured to work with javascript native Date
 objects, the `yearSelected` will emit `new Date(2017, 0, 1)` if the user selects 2017 in
 `multi-year` view. Similarly, `monthSelected` will emit `new Date(2017, 1, 1)` if the user

--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -53,15 +53,16 @@ year containing the `startAt` date.
 
 #### Watching the views for changes on selected years and months
 
-When a year or a month is selected in `multi-year` and `year` views respecively, the `yearSelected`
+When a year or a month is selected in `multi-year` and `year` views respectively, the `yearSelected`
 and `monthSelected` outputs emit a normalized date representing the chosen year or month. By
 "normalized" we mean that the dates representing a year will have their month set to January and
-their day set to the 1st. Dates representing months will have their day set to the 1st of the
+their day set to the 1st. Dates representing a month will have their day set to the 1st of that
 month. For example, if `<mat-datepicker>` is configured to work with javascript native Date
 objects, the `yearSelected` will emit `new Date(2017, 0, 1)` if the user selects 2017 in
-`multi-year` view. Similarly, `monthSelected` will emit `new Date(2017, 1, 0)` if the user
+`multi-year` view. Similarly, `monthSelected` will emit `new Date(2017, 1, 1)` if the user
 selects **February** in `year` view and the current date value of the connected `<input>` was
-something like `new Date(2017, MM, dd)` (the month and day are irrelevant in this case).
+set to something like `new Date(2017, MM, dd)` when the calendar was opened (the month and day are
+irrelevant in this case).
 
 Notice that the emitted value does not affect the current value in the connected `<input>`, which
 is only bound to the selection made in the `month` view. So if the end user closes the calendar 


### PR DESCRIPTION
Fixes some typos in datepicker docs.