### PR TITLE
fix(stepper): header icon collapsing with very long labels

### DIFF
--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -28,6 +28,7 @@ $mat-step-header-icon-size: 16px !default;
   align-items: center;
   justify-content: center;
   display: flex;
+  flex-shrink: 0;
 }
 
 .mat-step-icon .mat-icon {


### PR DESCRIPTION
Fixes the width of the icon inside the stepper header collapsing with really long labels.

Fixes #10332.