### PR TITLE
refactor(checkbox): remove 6.0.0 deletion targets

### DIFF
--- a/src/demo-app/checkbox/checkbox-demo.html
+++ b/src/demo-app/checkbox/checkbox-demo.html
@@ -7,7 +7,7 @@
              (change)="isIndeterminate = false"
              [indeterminate]="isIndeterminate"
              [disabled]="isDisabled"
-             [align]="alignment">
+             [labelPosition]="labelPosition">
   Do you want to <em>foobar</em> the <em>bazquux</em>?
 
 </mat-checkbox> - <strong>{{printResult()}}</strong>
@@ -24,23 +24,23 @@
 <label for="color-toggle">Toggle Color</label>
 </div>
 <div>
-  <p>Alignment:</p>
+  <p>Label position:</p>
   <div>
-    <input #start type="radio"
-                  value="start"
-                  id="align-start"
-                  name="alignment"
-                  (click)="alignment = start.value"
+    <input #after type="radio"
+                  value="after"
+                  id="align-after"
+                  name="labelPosition"
+                  (click)="labelPosition = after.value"
                   checked>
-    <label for="align-start">Start</label>
+    <label for="align-after">After</label>
   </div>
   <div>
-    <input #end type="radio"
-                  value="end"
-                  id="align-end"
-                  name="alignment"
-                  (click)="alignment = end.value">
-    <label for="align-end">End</label>
+    <input #before type="radio"
+                  value="before"
+                  id="align-before"
+                  name="labelPosition"
+                  (click)="labelPosition = before.value">
+    <label for="align-before">Before</label>
   </div>
 </div>
 

--- a/src/demo-app/checkbox/checkbox-demo.ts
+++ b/src/demo-app/checkbox/checkbox-demo.ts
@@ -79,7 +79,7 @@ export class CheckboxDemo {
   isIndeterminate: boolean = false;
   isChecked: boolean = false;
   isDisabled: boolean = false;
-  alignment: string = 'start';
+  labelPosition: string = 'after';
   useAlternativeColor: boolean = false;
 
   printResult() {

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -142,21 +142,6 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   set required(value: boolean) { this._required = coerceBooleanProperty(value); }
   private _required: boolean;
 
-  /**
-   * Whether or not the checkbox should appear before or after the label.
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input()
-  get align(): 'start' | 'end' {
-    // align refers to the checkbox relative to the label, while labelPosition refers to the
-    // label relative to the checkbox. As such, they are inverted.
-    return this.labelPosition == 'after' ? 'start' : 'end';
-  }
-  set align(value: 'start' | 'end') {
-    this.labelPosition = (value == 'start') ? 'after' : 'before';
-  }
-
   /** Whether the label should appear after or before the checkbox. Defaults to 'after' */
   @Input() labelPosition: 'before' | 'after' = 'after';
 

--- a/src/material-examples/checkbox-configurable/checkbox-configurable-example.html
+++ b/src/material-examples/checkbox-configurable/checkbox-configurable-example.html
@@ -9,9 +9,9 @@
 
     <section class="example-section">
       <label class="example-margin">Align:</label>
-      <mat-radio-group [(ngModel)]="align">
-        <mat-radio-button class="example-margin" value="start">Start</mat-radio-button>
-        <mat-radio-button class="example-margin" value="end">End</mat-radio-button>
+      <mat-radio-group [(ngModel)]="labelPosition">
+        <mat-radio-button class="example-margin" value="after">After</mat-radio-button>
+        <mat-radio-button class="example-margin" value="before">Before</mat-radio-button>
       </mat-radio-group>
     </section>
 
@@ -30,7 +30,7 @@
           class="example-margin"
           [(ngModel)]="checked"
           [(indeterminate)]="indeterminate"
-          [align]="align"
+          [labelPosition]="labelPosition"
           [disabled]="disabled">
         I'm a checkbox
       </mat-checkbox>

--- a/src/material-examples/checkbox-configurable/checkbox-configurable-example.ts
+++ b/src/material-examples/checkbox-configurable/checkbox-configurable-example.ts
@@ -11,6 +11,6 @@ import {Component} from '@angular/core';
 export class CheckboxConfigurableExample {
   checked = false;
   indeterminate = false;
-  align = 'start';
+  labelPosition = 'after';
   disabled = false;
 }


### PR DESCRIPTION
Removes the 6.0.0 deletion targets from the `material/checkbox` entry point.

BREAKING CHANGES:
* `align` which was deprecated in 5.0.0 has been removed. Use `labelPosition` instead. Note that the values are different.