### PR TITLE
refactor(tabs): provide method for re-aligning the ink bar

### DIFF
--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -84,6 +84,8 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
 
   @ViewChild('tabBodyWrapper') _tabBodyWrapper: ElementRef;
 
+  @ViewChild('tabHeader') _tabHeader: MatTabHeader;
+
   /** The tab index that should be selected after the content has been checked. */
   private _indexToSelect: number | null = 0;
 
@@ -207,6 +209,13 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   ngOnDestroy() {
     this._tabsSubscription.unsubscribe();
     this._tabLabelSubscription.unsubscribe();
+  }
+
+  /** Re-aligns the ink bar to the selected tab element. */
+  realignInkBar() {
+    if (this._tabHeader) {
+      this._tabHeader._alignInkBarToSelectedTab();
+    }
   }
 
   _focusChanged(index: number) {

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -450,7 +450,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
   }
 
   /** Tells the ink-bar to align itself to the current label wrapper */
-  private _alignInkBarToSelectedTab(): void {
+  _alignInkBarToSelectedTab(): void {
     const selectedLabelWrapper = this._labelWrappers && this._labelWrappers.length ?
         this._labelWrappers.toArray()[this.selectedIndex].elementRef.nativeElement :
         null;


### PR DESCRIPTION
Adds the `realignInkBar` method to the `MatTabGroup` which allows consumers to re-align the ink bar programmatically. This is useful for the cases where Material can't figure out that it needs to be re-aligned or doing so would be very inefficient.

Fixes #10340.