### PR TITLE
fix(button): icons not centered inside stroked buttons

### DIFF
--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -79,7 +79,7 @@
 }
 
 // The text and icon should be vertical aligned inside a button
-.mat-button, .mat-raised-button, .mat-icon-button, .mat-fab, .mat-mini-fab {
+.mat-button, .mat-raised-button, .mat-icon-button, .mat-fab, .mat-mini-fab, .mat-stroked-button {
   color: currentColor;
   .mat-button-wrapper > * {
     vertical-align: middle;


### PR DESCRIPTION
Fixes icons placed inside of a stroked button not being centered vertically.

Fixes #10353.