### PR TITLE
fix(datepicker): high contrast accessibility improvements

### DIFF
--- a/src/lib/datepicker/calendar-body.scss
+++ b/src/lib/datepicker/calendar-body.scss
@@ -1,3 +1,5 @@
+@import '../../cdk/a11y/a11y';
+
 $mat-calendar-body-label-padding-start: 5% !default;
 // We don't want the label to jump around when we switch between month and year views, so we use
 // the same amount of padding regardless of the number of columns. We align the header label with
@@ -58,6 +60,22 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
 
   // Choosing a value clearly larger than the height ensures we get the correct capsule shape.
   border-radius: 999px;
+
+  @include cdk-high-contrast {
+    border: none;
+  }
+}
+
+
+@include cdk-high-contrast {
+  .mat-datepicker-popup,
+  .mat-calendar-body-selected {
+    outline: solid 1px;
+  }
+
+  .mat-calendar-body-today {
+    outline: dotted 1px;
+  }
 }
 
 [dir='rtl'] {


### PR DESCRIPTION
Adds a few improvements to the datepicker calendar in high contrast mode:

* Adds an outline around the calendar in popup, in order to make it stand out against the background.
* Fixes all of the dates appearing as selected due to their border.
* Adds an outline only around the selected date and a dotted outline against the current date.