### PR TITLE
fix(tab): add flex-basis hack for IE11

### DIFF
--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -49,6 +49,9 @@
   display: block;
   overflow: hidden;
 
+  // Fix for auto content wrapping in IE11
+  flex-basis: 100%;
+
   &.mat-tab-body-active {
     position: relative;
     overflow-x: hidden;


### PR DESCRIPTION
Fixes an issue where the content of a tab does not wrap in IE11. That happens because, for some reason, IE11 requires an explicit declaration that the tab content should occupy the full width of the tab while using flex.

Fixes #10237