### PR TITLE
fix(datepicker): overly broad selector in theme

### DIFF
--- a/src/lib/datepicker/_datepicker-theme.scss
+++ b/src/lib/datepicker/_datepicker-theme.scss
@@ -62,7 +62,7 @@ $mat-calendar-weekday-table-font-size: 11px !default;
     }
   }
 
-  :not(.mat-calendar-body-disabled):hover,
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover,
   .cdk-keyboard-focused .mat-calendar-body-active,
   .cdk-program-focused .mat-calendar-body-active {
     & > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {


### PR DESCRIPTION
Currently we've got the `:not(.mat-calendar-body-disabled):hover` selector in the datepicker theme which will match (almost) every single element on the page. This is unnecessary and can end up hurting performance down the road. These changes scope the selector only to datepicker cells.