### PR TITLE
refactor(slider): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -194,14 +194,6 @@ export class MatSlider extends _MatSliderMixinBase
   private _thumbLabel: boolean = false;
 
   /**
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input('thumb-label')
-  get _thumbLabelDeprecated(): boolean { return this._thumbLabel; }
-  set _thumbLabelDeprecated(value) { this._thumbLabel = value; }
-
-  /**
    * How often to show ticks. Relative to the step so that a tick always appears on a step.
    * Ex: Tick interval of 4 with a step of 3 will draw a tick every 4 steps (every 12 values).
    */
@@ -217,14 +209,6 @@ export class MatSlider extends _MatSliderMixinBase
     }
   }
   private _tickInterval: 'auto' | number = 0;
-
-  /**
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input('tick-interval')
-  get _tickIntervalDeprecated() { return this.tickInterval; }
-  set _tickIntervalDeprecated(v) { this.tickInterval = v; }
 
   /** Value of the slider. */
   @Input()


### PR DESCRIPTION
Removes the 6.0.0 deletion targets from the `material/slider` entry point.

BREAKING CHANGES:
* `thumb-label` which was deprecated in 5.0.0 has been removed. Use `thumbLabel` instead.
* `tick-interval` which was deprecated in 5.0.0 has been removed. Use `tickInterval` instead.