### PR TITLE
fix(text-field): autosize textarea not scrolling to end of input on firefox

### DIFF
--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -193,10 +193,21 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     textarea.style.overflow = 'hidden';
     textarea.placeholder = '';
 
+    const height = textarea.scrollHeight;
+
     // Use the scrollHeight to know how large the textarea *would* be if fit its entire value.
-    textarea.style.height = `${textarea.scrollHeight}px`;
+    textarea.style.height = `${height}px`;
     textarea.style.overflow = '';
     textarea.placeholder = placeholderText;
+
+    // On Firefox resizing the textarea will prevent it from scrolling to the caret position.
+    // We need to re-set the selection in order for it to scroll to the proper position.
+    if (typeof requestAnimationFrame !== 'undefined') {
+      this._ngZone.runOutsideAngular(() => requestAnimationFrame(() => {
+        const {selectionStart, selectionEnd} = textarea;
+        textarea.setSelectionRange(selectionStart, selectionEnd);
+      }));
+    }
 
     this._previousValue = value;
   }


### PR DESCRIPTION
Fixes the textarea not being scrolled to the text cursor when the textarea is resized on Firefox.

Fixes #10400.