### PR TITLE
fix(table): change required for RxJS v6.0

### DIFF
--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -8,8 +8,9 @@
 
 import {DataSource} from '@angular/cdk/table';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {MatPaginator} from '@angular/material/paginator';
-import {MatSort} from '@angular/material/sort';
+import {MatPaginator, PageEvent} from '@angular/material/paginator';
+import {MatSort, Sort} from '@angular/material/sort';
+import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import {combineLatest} from 'rxjs/operators/combineLatest';
 import {map} from 'rxjs/operators/map';
@@ -178,8 +179,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
   _updateChangeSubscription() {
     // Sorting and/or pagination should be watched if MatSort and/or MatPaginator are provided.
     // Otherwise, use an empty observable stream to take their place.
-    const sortChange = this._sort ? this._sort.sortChange : empty();
-    const pageChange = this._paginator ? this._paginator.page : empty();
+    const sortChange: Observable<Sort> = this._sort ? this._sort.sortChange : empty();
+    const pageChange: Observable<PageEvent> = this._paginator ? this._paginator.page : empty();
 
     if (this._renderChangesSubscription) {
       this._renderChangesSubscription.unsubscribe();


### PR DESCRIPTION
`this._sort.sortChange` and `this._paginator.page` are of type `EventEmitter<Sort>` and `EventEmitter<PageEvent>`.

In RxJS 6.0 the `empty` observable returns `Observable<never>` instead of the currently `Observable<Sort>` and `Observable<PageEvent>`. Therefore with RxJS v6.0 `sortChange` is of type `EventEmitter<Sort>|Observable<never>` and `pageChange` is of type `EventEmitter<PageEvent>|Observable<never>`. The union Observable types throw `TS2554: Expected 0 arguments, but got 1.` error. Details in https://github.com/ReactiveX/rxjs/issues/3388