### PR TITLE
refactor(datepicker): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -254,14 +254,13 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   ngAfterContentInit() {
     if (this._datepicker) {
-      this._datepickerSubscription =
-          this._datepicker.selectedChanged.subscribe((selected: D) => {
-            this.value = selected;
-            this._cvaOnChange(selected);
-            this._onTouched();
-            this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-            this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-          });
+      this._datepickerSubscription = this._datepicker._selectedChanged.subscribe((selected: D) => {
+        this.value = selected;
+        this._cvaOnChange(selected);
+        this._onTouched();
+        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+      });
     }
   }
 

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -232,7 +232,7 @@ describe('MatDatepicker', () => {
       it('clicking the currently selected date should close the calendar ' +
          'without firing selectedChanged', fakeAsync(() => {
         const selectedChangedSpy =
-            spyOn(testComponent.datepicker.selectedChanged, 'emit').and.callThrough();
+            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
 
         for (let changeCount = 1; changeCount < 3; changeCount++) {
           const currentDay = changeCount;
@@ -256,7 +256,7 @@ describe('MatDatepicker', () => {
       it('pressing enter on the currently selected date should close the calendar without ' +
          'firing selectedChanged', () => {
         const selectedChangedSpy =
-            spyOn(testComponent.datepicker.selectedChanged, 'emit').and.callThrough();
+            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
 
         testComponent.datepicker.open();
         fixture.detectChanges();

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -237,13 +237,6 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   private _disabled: boolean;
 
   /**
-   * Emits new selected date when selected date changes.
-   * @deprecated Switch to the `dateChange` and `dateInput` binding on the input element.
-   * @deletion-target 6.0.0
-   */
-  @Output() readonly selectedChanged: EventEmitter<D> = new EventEmitter<D>();
-
-  /**
    * Emits selected year in multiyear view.
    * This doesn't imply a change on the selected date.
    */
@@ -317,6 +310,9 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   /** Emits when the datepicker is disabled. */
   readonly _disabledChange = new Subject<boolean>();
 
+  /** Emits new selected date when selected date changes. */
+  readonly _selectedChanged = new Subject<D>();
+
   constructor(private _dialog: MatDialog,
               private _overlay: Overlay,
               private _ngZone: NgZone,
@@ -346,7 +342,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
     let oldValue = this._selected;
     this._selected = date;
     if (!this._dateAdapter.sameDate(oldValue, this._selected)) {
-      this.selectedChanged.emit(date);
+      this._selectedChanged.next(date);
     }
   }
 


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 from `material/datepicker`.

BREAKING CHANGES:
* `selectedChanged` has been removed. Use `dateChange` or `dateInput` from `MatDatepickerInput`.