### PR TITLE
refactor(button-toggle): remove 6.0.0 deletion targets

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -154,26 +154,10 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase impleme
    */
   @Output() readonly valueChange = new EventEmitter<any>();
 
-  /**
-   * Selected button toggles in the group.
-   * @deprecated
-   * @deletion-target 6.0.0
-   */
-  @Input()
+  /** Selected button toggles in the group. */
   get selected() {
     const selected = this._selectionModel.selected;
     return this.multiple ? selected : (selected[0] || null);
-  }
-  set selected(selected: MatButtonToggle | MatButtonToggle[] | null) {
-    if (this._buttonToggles) {
-      this._clearSelection();
-
-      if (Array.isArray(selected)) {
-        selected.forEach(toggle => toggle.checked = true);
-      } else if (selected) {
-        selected.checked = true;
-      }
-    }
   }
 
   /** Whether multiple button toggles can be selected. */


### PR DESCRIPTION
Removes the deletion targets for 6.0.0 from the `material/button-toggle` entry point.

BREAKING CHANGES:
* `selected` is no longer an input and is now readonly.