### PR TITLE
refactor(typography): remove deprecated variable

### DIFF
--- a/src/lib/core/style/_variables.scss
+++ b/src/lib/core/style/_variables.scss
@@ -3,9 +3,6 @@
 $mat-xsmall: 'max-width: 599px';
 $mat-small: 'max-width: 959px';
 
-// TODO(crisbeto): this isn't being used anywhere within Material. keeping for backwards compat.
-$mat-font-family: Roboto, 'Helvetica Neue', sans-serif !default;
-
 // TODO: Revisit all z-indices before beta
 // z-index master list
 


### PR DESCRIPTION
Removes a typography variable that's been deprecated for a while.

BREAKING CHANGES:
* The `$mat-font-family` variable has been removed. Use the Material typography or redeclare in your project `$mat-font-family: Roboto, 'Helvetica Neue', sans-serif;`.