### PR TITLE
Changed directive name from `MdAccordion` to `MatAccordion`

### DIFF
--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -45,7 +45,7 @@ let uniqueId = 0;
  * `<mat-expansion-panel>`
  *
  * This component can be used as a single element to show expandable content, or as one of
- * multiple children of an element with the MdAccordion directive attached.
+ * multiple children of an element with the MatAccordion directive attached.
  */
 @Component({
   moduleId: module.id,


### PR DESCRIPTION
`MdAccordion` has been appearing in the comment, ideally it should be `MatAccordion`. I guess somehow we missed to change the text here in comment while migrating from `md` to `mat` prefix. 