### PR TITLE
chore(select): disable position locking

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -19,7 +19,6 @@
 <ng-template
   cdk-connected-overlay
   cdkConnectedOverlayHasBackdrop
-  cdkConnectedOverlayLockPosition
   cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
   [cdkConnectedOverlayScrollStrategy]="_scrollStrategy"
   [cdkConnectedOverlayOrigin]="origin"


### PR DESCRIPTION
Something that was done initially in #9153, but ended up being re-added after a large rebase.