### PR TITLE
fix(datepicker): incorrect icon color

### DIFF
--- a/src/lib/datepicker/_datepicker-theme.scss
+++ b/src/lib/datepicker/_datepicker-theme.scss
@@ -33,8 +33,11 @@ $mat-calendar-weekday-table-font-size: 11px !default;
     border-top-color: mat-color($foreground, icon);
   }
 
-  .mat-calendar-next-button,
-  .mat-calendar-previous-button {
+  // The prev/next buttons need a bit more specificity to
+  // avoid being overwritten by the .mat-icon-button.
+  .mat-datepicker-toggle,
+  .mat-datepicker-popup .mat-calendar-next-button,
+  .mat-datepicker-popup .mat-calendar-previous-button {
     color: mat-color($foreground, icon);
   }
 


### PR DESCRIPTION
* Fixes the datepicker previous and next icons having the wrong color, because they were being overwritten by the `.mat-icon-button` which sets it explicitly to `currentColor`.
* Sets the inactive datepicker toggle to use the `icon` color.