### PR TITLE
fix(input): inaccurate textarea check during server-side render

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -328,15 +328,9 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     return validity && validity.badInput;
   }
 
-  /** Determines if the component host is a textarea. If not recognizable it returns false. */
+  /** Determines if the component host is a textarea. */
   protected _isTextarea() {
-    let nativeElement = this._elementRef.nativeElement;
-
-    // In Universal, we don't have access to `nodeName`, but the same can be achieved with `name`.
-    // Note that this shouldn't be necessary once Angular switches to an API that resembles the
-    // DOM closer.
-    let nodeName = this._platform.isBrowser ? nativeElement.nodeName : nativeElement.name;
-    return nodeName ? nodeName.toLowerCase() === 'textarea' : false;
+    return this._elementRef.nativeElement.nodeName.toLowerCase() === 'textarea';
   }
 
   /**

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -112,7 +112,11 @@
 <h2>Input</h2>
 
 <mat-form-field floatLabel="never">
-  <input matInput placeholder="name">
+  <input matInput placeholder="name" type="text">
+</mat-form-field>
+
+<mat-form-field>
+  <textarea matInput placeholder="description"></textarea>
 </mat-form-field>
 
 <mat-form-field>


### PR DESCRIPTION
A while ago we added a check to the `_isTextarea` method that accounted for the old renderer's non-standard API. These changes remove that check, because it isn't accurate anymore with the new renderer.