### PR TITLE
chore(table): support for typescript 2.7.x

### DIFF
--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -8,8 +8,8 @@
 
 import {DataSource} from '@angular/cdk/table';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import {MatPaginator} from '@angular/material/paginator';
-import {MatSort} from '@angular/material/sort';
+import {MatPaginator, PageEvent} from '@angular/material/paginator';
+import {MatSort, Sort} from '@angular/material/sort';
 import {Subscription} from 'rxjs/Subscription';
 import {combineLatest} from 'rxjs/operators/combineLatest';
 import {map} from 'rxjs/operators/map';
@@ -178,8 +178,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
   _updateChangeSubscription() {
     // Sorting and/or pagination should be watched if MatSort and/or MatPaginator are provided.
     // Otherwise, use an empty observable stream to take their place.
-    const sortChange = this._sort ? this._sort.sortChange : empty();
-    const pageChange = this._paginator ? this._paginator.page : empty();
+    const sortChange = this._sort ? this._sort.sortChange : empty<Sort>();
+    const pageChange = this._paginator ? this._paginator.page : empty<PageEvent>();
 
     if (this._renderChangesSubscription) {
       this._renderChangesSubscription.unsubscribe();


### PR DESCRIPTION
I'm honestly opening this PR because I don't understand this particular error and it's occurring in my codebase as well. Looks like ternary statements are being type checked now and the way the types resolve appears to be an issue. I've tried a similar reproduction of the types and it seems that the way a ternary resolves for a generic is `T<A> | T<B>` (assuming the same base class with generic) instead of `T<A | B>`. Maybe this is a typescript or ~~rxjs issue~~ (or both)?

**EDIT**: This issue is present with rxjs 5.5.x+ and typescript 2.7.x

This is my simple reproduction:
![image](https://user-images.githubusercontent.com/4655972/37602691-45db5a84-2b63-11e8-9792-4bbe85561db8.png)


**Before**:
![image](https://user-images.githubusercontent.com/4655972/37602499-d69389e4-2b62-11e8-8a0d-d45d72d04cba.png)

**After**:
![image](https://user-images.githubusercontent.com/4655972/37602515-ddcd5e4c-2b62-11e8-9ff1-d2ed6746c07a.png)

Seems that because of the type ambiguity, the resolution for the `pipe` method is the `pipe` with no arguments.