### PR TITLE
fix(table): move padding from rows to cells

### DIFF
--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -19,7 +19,6 @@ $mat-row-horizontal-padding: 24px;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   align-items: center;
-  padding: 0 $mat-row-horizontal-padding;
   box-sizing: border-box;
 
   // Workaround for https://goo.gl/pFmjJD in IE 11. Adds a pseudo
@@ -32,8 +31,19 @@ $mat-row-horizontal-padding: 24px;
   }
 }
 
+.mat-cell:first-child, .mat-header-cell:first-child {
+  padding-left: $mat-row-horizontal-padding;
+}
+
+.mat-cell:last-child, .mat-header-cell:last-child {
+  padding-right: $mat-row-horizontal-padding;
+}
+
 .mat-cell, .mat-header-cell {
   flex: 1;
+  display: flex;
+  align-items: center;
   overflow: hidden;
   word-wrap: break-word;
+  min-height: inherit;
 }


### PR DESCRIPTION
Moves the material table's row padding to the first and last cells. This matches native tables which do not support row padding.

BREAKING CHANGES:
* The mat-table has moved its row padding to be on the first and last cells. This matches native tables which do not support row padding.