### PR TITLE
feat(material): use scoped injectables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,7 +5163,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -14708,7 +14708,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/cdk/layout/breakpoints-observer.ts
+++ b/src/cdk/layout/breakpoints-observer.ts
@@ -28,7 +28,7 @@ interface Query {
 }
 
 /** Utility for checking the matching state of @media queries. */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class BreakpointObserver implements OnDestroy {
   /**  A map of all media queries currently being listened for. */
   private _queries: Map<string, Query> = new Map();

--- a/src/cdk/layout/layout-module.ts
+++ b/src/cdk/layout/layout-module.ts
@@ -6,12 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {NgModule} from '@angular/core';
-import {PlatformModule} from '@angular/cdk/platform';
-import {BreakpointObserver} from './breakpoints-observer';
-import {MediaMatcher} from './media-matcher';
 
-@NgModule({
-  providers: [BreakpointObserver, MediaMatcher],
-  imports: [PlatformModule],
-})
+
+@NgModule()
 export class LayoutModule {}

--- a/src/cdk/layout/media-matcher.ts
+++ b/src/cdk/layout/media-matcher.ts
@@ -14,7 +14,7 @@ import {Platform} from '@angular/cdk/platform';
 const styleElementForWebkitCompatibility: Map<string, HTMLStyleElement> = new Map();
 
 /** A utility for calling matchMedia queries. */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MediaMatcher {
   /** The internal matchMedia method to return back a MediaQueryList like object. */
   private _matchMedia: (query: string) => MediaQueryList;

--- a/src/lib/autocomplete/autocomplete-module.ts
+++ b/src/lib/autocomplete/autocomplete-module.ts
@@ -10,19 +10,14 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {MatOptionModule, MatCommonModule} from '@angular/material/core';
-import {MatAutocomplete, MAT_AUTOCOMPLETE_DEFAULT_OPTIONS} from './autocomplete';
+import {MatAutocomplete} from './autocomplete';
 import {
   MatAutocompleteTrigger,
-  MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER,
 } from './autocomplete-trigger';
 
 @NgModule({
   imports: [MatOptionModule, OverlayModule, MatCommonModule, CommonModule],
   exports: [MatAutocomplete, MatOptionModule, MatAutocompleteTrigger, MatCommonModule],
   declarations: [MatAutocomplete, MatAutocompleteTrigger],
-  providers: [
-    MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER,
-    {provide: MAT_AUTOCOMPLETE_DEFAULT_OPTIONS, useValue: false}
-  ],
 })
 export class MatAutocompleteModule {}

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -6,21 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Directionality} from '@angular/cdk/bidi';
-import {DOWN_ARROW, ENTER, ESCAPE, UP_ARROW, TAB} from '@angular/cdk/keycodes';
+import {DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
 import {
   FlexibleConnectedPositionStrategy,
   Overlay,
-  OverlayRef,
   OverlayConfig,
+  OverlayRef,
   PositionStrategy,
   ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {filter} from 'rxjs/operators/filter';
-import {take} from 'rxjs/operators/take';
-import {switchMap} from 'rxjs/operators/switchMap';
-import {tap} from 'rxjs/operators/tap';
-import {delay} from 'rxjs/operators/delay';
+import {DOCUMENT} from '@angular/common';
 import {
   ChangeDetectorRef,
   Directive,
@@ -28,6 +24,7 @@ import {
   forwardRef,
   Host,
   Inject,
+  inject,
   InjectionToken,
   Input,
   NgZone,
@@ -37,19 +34,23 @@ import {
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
+  _countGroupLabelsBeforeOption,
+  _getOptionScrollPosition,
   MatOption,
   MatOptionSelectionChange,
-  _getOptionScrollPosition,
-  _countGroupLabelsBeforeOption,
 } from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
-import {DOCUMENT} from '@angular/common';
 import {Observable} from 'rxjs/Observable';
-import {Subject} from 'rxjs/Subject';
 import {defer} from 'rxjs/observable/defer';
 import {fromEvent} from 'rxjs/observable/fromEvent';
 import {merge} from 'rxjs/observable/merge';
 import {of as observableOf} from 'rxjs/observable/of';
+import {delay} from 'rxjs/operators/delay';
+import {filter} from 'rxjs/operators/filter';
+import {switchMap} from 'rxjs/operators/switchMap';
+import {take} from 'rxjs/operators/take';
+import {tap} from 'rxjs/operators/tap';
+import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {MatAutocomplete} from './autocomplete';
 
@@ -68,20 +69,13 @@ export const AUTOCOMPLETE_PANEL_HEIGHT = 256;
 
 /** Injection token that determines the scroll handling while the autocomplete panel is open. */
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY =
-    new InjectionToken<() => ScrollStrategy>('mat-autocomplete-scroll-strategy');
-
-/** @docs-private */
-export function MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => ScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-/** @docs-private */
-export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER = {
-  provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: MAT_AUTOCOMPLETE_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
+    new InjectionToken<() => ScrollStrategy>('mat-autocomplete-scroll-strategy', {
+      providedIn: 'root',
+      factory: () => {
+        const overlay = inject(Overlay);
+        return () => overlay.scrollStrategies.reposition();
+      }
+    });
 
 /**
  * Provider that allows the autocomplete to register as a ControlValueAccessor.

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -61,7 +61,10 @@ export interface MatAutocompleteDefaultOptions {
 
 /** Injection token to be used to override the default options for `mat-autocomplete`. */
 export const MAT_AUTOCOMPLETE_DEFAULT_OPTIONS =
-    new InjectionToken<MatAutocompleteDefaultOptions>('mat-autocomplete-default-options');
+    new InjectionToken<MatAutocompleteDefaultOptions>('mat-autocomplete-default-options', {
+      providedIn: 'root',
+      factory: () => ({autoActiveFirstOption: false}),
+    });
 
 
 @Component({

--- a/src/lib/badge/badge-module.ts
+++ b/src/lib/badge/badge-module.ts
@@ -8,20 +8,12 @@
 
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
-import {A11yModule} from '@angular/cdk/a11y';
 import {MatBadge} from './badge';
 
 
 @NgModule({
-  imports: [
-    MatCommonModule,
-    A11yModule,
-  ],
-  exports: [
-    MatBadge,
-  ],
-  declarations: [
-    MatBadge,
-  ],
+  imports: [MatCommonModule],
+  exports: [MatBadge],
+  declarations: [MatBadge],
 })
 export class MatBadgeModule {}

--- a/src/lib/bottom-sheet/bottom-sheet-module.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-module.ts
@@ -6,25 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {MatCommonModule} from '@angular/material/core';
-import {A11yModule} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {PortalModule} from '@angular/cdk/portal';
-import {LayoutModule} from '@angular/cdk/layout';
-import {MatBottomSheetContainer} from './bottom-sheet-container';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatCommonModule} from '@angular/material/core';
 import {MatBottomSheet} from './bottom-sheet';
+import {MatBottomSheetContainer} from './bottom-sheet-container';
 
 
 @NgModule({
   imports: [
-    A11yModule,
     CommonModule,
     OverlayModule,
     MatCommonModule,
     PortalModule,
-    LayoutModule,
   ],
   exports: [MatBottomSheetContainer, MatCommonModule],
   declarations: [MatBottomSheetContainer],

--- a/src/lib/button-toggle/button-toggle-module.ts
+++ b/src/lib/button-toggle/button-toggle-module.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatButtonToggle, MatButtonToggleGroup} from './button-toggle';
 
 
 @NgModule({
-  imports: [MatCommonModule, MatRippleModule, A11yModule],
+  imports: [MatCommonModule, MatRippleModule],
   exports: [MatCommonModule, MatButtonToggleGroup, MatButtonToggle],
   declarations: [MatButtonToggleGroup, MatButtonToggle],
 })

--- a/src/lib/button/button-module.ts
+++ b/src/lib/button/button-module.ts
@@ -6,14 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
-import {A11yModule} from '@angular/cdk/a11y';
-import {
-  MatAnchor,
-  MatButton,
-} from './button';
+import {MatAnchor, MatButton} from './button';
 
 
 @NgModule({
@@ -21,7 +17,6 @@ import {
     CommonModule,
     MatRippleModule,
     MatCommonModule,
-    A11yModule,
   ],
   exports: [
     MatButton,

--- a/src/lib/card/card-module.ts
+++ b/src/lib/card/card-module.ts
@@ -10,19 +10,19 @@ import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
 import {
   MatCard,
-  MatCardHeader,
-  MatCardTitleGroup,
-  MatCardContent,
-  MatCardTitle,
-  MatCardSubtitle,
   MatCardActions,
-  MatCardFooter,
-  MatCardSmImage,
-  MatCardMdImage,
-  MatCardLgImage,
-  MatCardImage,
-  MatCardXlImage,
   MatCardAvatar,
+  MatCardContent,
+  MatCardFooter,
+  MatCardHeader,
+  MatCardImage,
+  MatCardLgImage,
+  MatCardMdImage,
+  MatCardSmImage,
+  MatCardSubtitle,
+  MatCardTitle,
+  MatCardTitleGroup,
+  MatCardXlImage,
 } from './card';
 
 

--- a/src/lib/checkbox/checkbox-module.ts
+++ b/src/lib/checkbox/checkbox-module.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {ObserversModule} from '@angular/cdk/observers';
-import {MatRippleModule, MatCommonModule} from '@angular/material/core';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatCheckbox} from './checkbox';
 import {MatCheckboxRequiredValidator} from './checkbox-required-validator';
-import {A11yModule} from '@angular/cdk/a11y';
+
 
 @NgModule({
-  imports: [CommonModule, MatRippleModule, MatCommonModule, ObserversModule, A11yModule],
+  imports: [CommonModule, MatRippleModule, MatCommonModule, ObserversModule],
   exports: [MatCheckbox, MatCheckboxRequiredValidator, MatCommonModule],
   declarations: [MatCheckbox, MatCheckboxRequiredValidator],
 })

--- a/src/lib/chips/chips-module.ts
+++ b/src/lib/chips/chips-module.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformModule} from '@angular/cdk/platform';
+import {ENTER} from '@angular/cdk/keycodes';
 import {NgModule} from '@angular/core';
 import {ErrorStateMatcher} from '@angular/material/core';
 import {MatChip, MatChipAvatar, MatChipRemove, MatChipTrailingIcon} from './chip';
+import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
 import {MatChipInput} from './chip-input';
 import {MatChipList} from './chip-list';
-import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
-import {ENTER} from '@angular/cdk/keycodes';
 
 const CHIP_DECLARATIONS = [
   MatChipList,
@@ -25,7 +24,6 @@ const CHIP_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: [PlatformModule],
   exports: CHIP_DECLARATIONS,
   declarations: CHIP_DECLARATIONS,
   providers: [

--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -11,7 +11,10 @@ import {BidiModule} from '@angular/cdk/bidi';
 
 
 /** Injection token that configures whether the Material sanity checks are enabled. */
-export const MATERIAL_SANITY_CHECKS = new InjectionToken<boolean>('mat-sanity-checks');
+export const MATERIAL_SANITY_CHECKS = new InjectionToken<boolean>('mat-sanity-checks', {
+  providedIn: 'root',
+  factory: () => true,
+});
 
 
 /**
@@ -23,9 +26,6 @@ export const MATERIAL_SANITY_CHECKS = new InjectionToken<boolean>('mat-sanity-ch
 @NgModule({
   imports: [BidiModule],
   exports: [BidiModule],
-  providers: [{
-    provide: MATERIAL_SANITY_CHECKS, useValue: true,
-  }],
 })
 export class MatCommonModule {
   /** Whether we've done the global sanity checks (e.g. a theme is loaded, there is a doctype). */

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken, LOCALE_ID} from '@angular/core';
+import {inject, InjectionToken, LOCALE_ID} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
 
 /** InjectionToken for datepicker that can be used to override default locale code. */
-export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE');
-
-/** Provider for MAT_DATE_LOCALE injection token. */
-export const MAT_DATE_LOCALE_PROVIDER = {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID};
+export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE', {
+  providedIn: 'root',
+  factory: () => inject(LOCALE_ID)
+});
 
 /** Adapts type `D` to be usable as a date by cdk-based components that work with dates. */
 export abstract class DateAdapter<D> {

--- a/src/lib/core/datetime/index.ts
+++ b/src/lib/core/datetime/index.ts
@@ -8,7 +8,7 @@
 
 import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
-import {DateAdapter, MAT_DATE_LOCALE_PROVIDER} from './date-adapter';
+import {DateAdapter} from './date-adapter';
 import {MAT_DATE_FORMATS} from './date-formats';
 import {NativeDateAdapter} from './native-date-adapter';
 import {MAT_NATIVE_DATE_FORMATS} from './native-date-formats';
@@ -23,7 +23,6 @@ export * from './native-date-formats';
   imports: [PlatformModule],
   providers: [
     {provide: DateAdapter, useClass: NativeDateAdapter},
-    MAT_DATE_LOCALE_PROVIDER
   ],
 })
 export class NativeDateModule {}

--- a/src/lib/core/error/error-options.ts
+++ b/src/lib/core/error/error-options.ts
@@ -18,7 +18,7 @@ export class ShowOnDirtyErrorStateMatcher implements ErrorStateMatcher {
 }
 
 /** Provider that defines how form controls behave with regards to displaying error messages. */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class ErrorStateMatcher {
   isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.invalid && (control.touched || (form && form.submitted)));

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -11,7 +11,7 @@ import {Subject} from 'rxjs/Subject';
 
 
 /** Datepicker data that requires internationalization. */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MatDatepickerIntl {
   /**
    * Stream that emits whenever the labels here are changed. Use this to notify

--- a/src/lib/datepicker/datepicker-module.ts
+++ b/src/lib/datepicker/datepicker-module.ts
@@ -25,11 +25,11 @@ import {MatYearView} from './year-view';
 
 @NgModule({
   imports: [
+    A11yModule,
     CommonModule,
     MatButtonModule,
     MatDialogModule,
     OverlayModule,
-    A11yModule,
   ],
   exports: [
     MatCalendar,

--- a/src/lib/datepicker/datepicker-module.ts
+++ b/src/lib/datepicker/datepicker-module.ts
@@ -14,11 +14,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatCalendar} from './calendar';
 import {MatCalendarBody} from './calendar-body';
-import {
-  MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER,
-  MatDatepicker,
-  MatDatepickerContent,
-} from './datepicker';
+import {MatDatepicker, MatDatepickerContent} from './datepicker';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatDatepickerIntl} from './datepicker-intl';
 import {MatDatepickerToggle, MatDatepickerToggleIcon} from './datepicker-toggle';
@@ -61,7 +57,6 @@ import {MatYearView} from './year-view';
   ],
   providers: [
     MatDatepickerIntl,
-    MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER,
   ],
   entryComponents: [
     MatDatepickerContent,

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1,8 +1,8 @@
 import {ENTER, ESCAPE, RIGHT_ARROW} from '@angular/cdk/keycodes';
-import {OverlayContainer, Overlay, ScrollDispatcher} from '@angular/cdk/overlay';
+import {Overlay, OverlayContainer, ScrollDispatcher} from '@angular/cdk/overlay';
 import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing';
 import {Component, ViewChild} from '@angular/core';
-import {fakeAsync, flush, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {
   DEC,
@@ -14,15 +14,15 @@ import {
   NativeDateModule,
   SEP,
 } from '@angular/material/core';
-import {MatFormFieldModule, MatFormField} from '@angular/material/form-field';
+import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Subject} from 'rxjs/Subject';
 import {MatInputModule} from '../input/index';
 import {MatDatepicker} from './datepicker';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatDatepickerToggle} from './datepicker-toggle';
-import {MatDatepickerIntl, MatDatepickerModule, MAT_DATEPICKER_SCROLL_STRATEGY} from './index';
-import {Subject} from 'rxjs/Subject';
+import {MAT_DATEPICKER_SCROLL_STRATEGY, MatDatepickerIntl, MatDatepickerModule} from './index';
 
 describe('MatDatepicker', () => {
   const SUPPORTS_INTL = typeof Intl != 'undefined';

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -10,67 +10,60 @@ import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {
+  FlexibleConnectedPositionStrategy,
   Overlay,
   OverlayConfig,
   OverlayRef,
   PositionStrategy,
-  RepositionScrollStrategy,
   ScrollStrategy,
-  FlexibleConnectedPositionStrategy,
 } from '@angular/cdk/overlay';
 import {ComponentPortal} from '@angular/cdk/portal';
-import {take} from 'rxjs/operators/take';
-import {filter} from 'rxjs/operators/filter';
+import {DOCUMENT} from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ComponentRef,
   ElementRef,
   EventEmitter,
   Inject,
+  inject,
   InjectionToken,
   Input,
   NgZone,
   OnDestroy,
+  OnInit,
   Optional,
   Output,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-  ChangeDetectorRef,
-  OnInit,
 } from '@angular/core';
 import {CanColor, DateAdapter, mixinColor, ThemePalette} from '@angular/material/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
-import {DOCUMENT} from '@angular/common';
+import {merge} from 'rxjs/observable/merge';
+import {filter} from 'rxjs/operators/filter';
+import {take} from 'rxjs/operators/take';
 import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
-import {merge} from 'rxjs/observable/merge';
-import {createMissingDateImplError} from './datepicker-errors';
-import {MatDatepickerInput} from './datepicker-input';
 import {MatCalendar} from './calendar';
 import {matDatepickerAnimations} from './datepicker-animations';
+import {createMissingDateImplError} from './datepicker-errors';
+import {MatDatepickerInput} from './datepicker-input';
 
 /** Used to generate a unique ID for each datepicker instance. */
 let datepickerUid = 0;
 
 /** Injection token that determines the scroll handling while the calendar is open. */
 export const MAT_DATEPICKER_SCROLL_STRATEGY =
-    new InjectionToken<() => ScrollStrategy>('mat-datepicker-scroll-strategy');
-
-/** @docs-private */
-export function MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => RepositionScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-/** @docs-private */
-export const MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER = {
-  provide: MAT_DATEPICKER_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: MAT_DATEPICKER_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
+    new InjectionToken<() => ScrollStrategy>('mat-datepicker-scroll-strategy', {
+      providedIn: 'root',
+      factory: () => {
+        const overlay = inject(Overlay);
+        return () => overlay.scrollStrategies.reposition();
+      }
+    });
 
 // Boilerplate for applying mixins to MatDatepickerContent.
 /** @docs-private */

--- a/src/lib/dialog/dialog-module.ts
+++ b/src/lib/dialog/dialog-module.ts
@@ -6,22 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {PortalModule} from '@angular/cdk/portal';
-import {A11yModule} from '@angular/cdk/a11y';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
-import {
-  MatDialog,
-  MAT_DIALOG_SCROLL_STRATEGY_PROVIDER
-} from './dialog';
+import {MAT_DIALOG_SCROLL_STRATEGY_PROVIDER, MatDialog} from './dialog';
 import {MatDialogContainer} from './dialog-container';
 import {
+  MatDialogActions,
   MatDialogClose,
   MatDialogContent,
   MatDialogTitle,
-  MatDialogActions
 } from './dialog-content-directives';
 
 
@@ -30,7 +26,6 @@ import {
     CommonModule,
     OverlayModule,
     PortalModule,
-    A11yModule,
     MatCommonModule,
   ],
   exports: [

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -10,15 +10,16 @@ import {Directionality} from '@angular/cdk/bidi';
 import {
   Overlay,
   OverlayConfig,
+  OverlayContainer,
   OverlayRef,
   ScrollStrategy,
-  OverlayContainer,
 } from '@angular/cdk/overlay';
 import {ComponentPortal, ComponentType, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
 import {Location} from '@angular/common';
 import {
   ComponentRef,
   Inject,
+  inject,
   Injectable,
   InjectionToken,
   Injector,
@@ -44,7 +45,13 @@ export const MAT_DIALOG_DEFAULT_OPTIONS =
 
 /** Injection token that determines the scroll handling while the dialog is open. */
 export const MAT_DIALOG_SCROLL_STRATEGY =
-    new InjectionToken<() => ScrollStrategy>('mat-dialog-scroll-strategy');
+    new InjectionToken<() => ScrollStrategy>('mat-dialog-scroll-strategy', {
+      providedIn: 'root',
+      factory: () => {
+        const overlay = inject(Overlay);
+        return () => overlay.scrollStrategies.block();
+      }
+    });
 
 /** @docs-private */
 export function MAT_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):

--- a/src/lib/divider/divider-module.ts
+++ b/src/lib/divider/divider-module.ts
@@ -6,20 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
 import {MatDivider} from './divider';
 
 
 @NgModule({
   imports: [MatCommonModule, CommonModule],
-  exports: [
-    MatDivider,
-    MatCommonModule,
-  ],
-  declarations: [
-    MatDivider,
-  ],
+  exports: [MatDivider, MatCommonModule],
+  declarations: [MatDivider],
 })
 export class MatDividerModule {}

--- a/src/lib/expansion/expansion-module.ts
+++ b/src/lib/expansion/expansion-module.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
 import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
@@ -22,7 +21,7 @@ import {
 
 
 @NgModule({
-  imports: [CommonModule, A11yModule, CdkAccordionModule, PortalModule],
+  imports: [CommonModule, CdkAccordionModule, PortalModule],
   exports: [
     MatAccordion,
     MatExpansionPanel,

--- a/src/lib/form-field/form-field-module.ts
+++ b/src/lib/form-field/form-field-module.ts
@@ -8,38 +8,34 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {PlatformModule} from '@angular/cdk/platform';
 import {MatError} from './error';
 import {MatFormField} from './form-field';
 import {MatHint} from './hint';
+import {MatLabel} from './label';
 import {MatPlaceholder} from './placeholder';
 import {MatPrefix} from './prefix';
 import {MatSuffix} from './suffix';
-import {MatLabel} from './label';
 
 
 @NgModule({
   declarations: [
     MatError,
-    MatHint,
     MatFormField,
+    MatHint,
+    MatLabel,
     MatPlaceholder,
     MatPrefix,
     MatSuffix,
-    MatLabel,
   ],
-  imports: [
-    CommonModule,
-    PlatformModule,
-  ],
+  imports: [CommonModule],
   exports: [
     MatError,
-    MatHint,
     MatFormField,
+    MatHint,
+    MatLabel,
     MatPlaceholder,
     MatPrefix,
     MatSuffix,
-    MatLabel,
   ],
 })
 export class MatFormFieldModule {}

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -76,7 +76,7 @@ class SvgIconConfig {
  * - Registers aliases for CSS classes, for use with icon fonts.
  * - Loads icons from URLs and extracts individual icons from icon sets.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MatIconRegistry {
   private _document: Document;
 

--- a/src/lib/input/input-module.ts
+++ b/src/lib/input/input-module.ts
@@ -7,7 +7,6 @@
  */
 
 import {TextFieldModule} from '@angular/cdk/text-field';
-import {PlatformModule} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ErrorStateMatcher} from '@angular/material/core';
@@ -22,7 +21,6 @@ import {MatInput} from './input';
     CommonModule,
     TextFieldModule,
     MatFormFieldModule,
-    PlatformModule,
   ],
   exports: [
     TextFieldModule,

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -61,12 +61,20 @@ export interface MatMenuDefaultOptions {
   backdropClass: string;
 
   /** Whether the menu has a backdrop. */
-  hasBackdrop: boolean;
+  hasBackdrop?: boolean;
 }
 
 /** Injection token to be used to override the default options for `mat-menu`. */
 export const MAT_MENU_DEFAULT_OPTIONS =
-    new InjectionToken<MatMenuDefaultOptions>('mat-menu-default-options');
+    new InjectionToken<MatMenuDefaultOptions>('mat-menu-default-options', {
+      providedIn: 'root',
+      factory: () => ({
+        overlapTrigger: true,
+        xPosition: 'after',
+        yPosition: 'below',
+        backdropClass: 'cdk-overlay-transparent-backdrop',
+      })
+    });
 
 /**
  * Start elevation for the menu panel.
@@ -159,11 +167,11 @@ export class MatMenu implements OnInit, AfterContentInit, MatMenuPanel, OnDestro
 
   /** Whether the menu has a backdrop. */
   @Input()
-  get hasBackdrop(): boolean { return this._hasBackdrop; }
-  set hasBackdrop(value: boolean) {
+  get hasBackdrop(): boolean | undefined { return this._hasBackdrop; }
+  set hasBackdrop(value: boolean | undefined) {
     this._hasBackdrop = coerceBooleanProperty(value);
   }
-  private _hasBackdrop: boolean = this._defaultOptions.hasBackdrop;
+  private _hasBackdrop: boolean | undefined = this._defaultOptions.hasBackdrop;
 
   /**
    * This method takes classes set on the host mat-menu element and applies them on the

--- a/src/lib/menu/menu-module.ts
+++ b/src/lib/menu/menu-module.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
-import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
@@ -20,12 +18,10 @@ import {MatMenuTrigger} from './menu-trigger';
 
 @NgModule({
   imports: [
-    A11yModule,
     CommonModule,
     MatCommonModule,
     MatRippleModule,
     OverlayModule,
-    PortalModule,
   ],
   exports: [MatMenu, MatMenuItem, MatMenuTrigger, MatMenuContent, MatCommonModule],
   declarations: [MatMenu, MatMenuItem, MatMenuTrigger, MatMenuContent],

--- a/src/lib/menu/menu-module.ts
+++ b/src/lib/menu/menu-module.ts
@@ -8,14 +8,14 @@
 
 import {A11yModule} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
+import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
-import {PortalModule} from '@angular/cdk/portal';
-import {MAT_MENU_DEFAULT_OPTIONS, MatMenu} from './menu-directive';
-import {MatMenuItem} from './menu-item';
-import {MAT_MENU_SCROLL_STRATEGY_PROVIDER, MatMenuTrigger} from './menu-trigger';
 import {MatMenuContent} from './menu-content';
+import {MatMenu} from './menu-directive';
+import {MatMenuItem} from './menu-item';
+import {MatMenuTrigger} from './menu-trigger';
 
 
 @NgModule({
@@ -29,17 +29,5 @@ import {MatMenuContent} from './menu-content';
   ],
   exports: [MatMenu, MatMenuItem, MatMenuTrigger, MatMenuContent, MatCommonModule],
   declarations: [MatMenu, MatMenuItem, MatMenuTrigger, MatMenuContent],
-  providers: [
-    MAT_MENU_SCROLL_STRATEGY_PROVIDER,
-    {
-      provide: MAT_MENU_DEFAULT_OPTIONS,
-      useValue: {
-        overlapTrigger: true,
-        xPosition: 'after',
-        yPosition: 'below',
-        backdropClass: 'cdk-overlay-transparent-backdrop'
-      },
-    }
-  ],
 })
 export class MatMenuModule {}

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -6,28 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isFakeMousedownFromScreenReader} from '@angular/cdk/a11y';
+import {FocusMonitor, FocusOrigin, isFakeMousedownFromScreenReader} from '@angular/cdk/a11y';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {
   FlexibleConnectedPositionStrategy,
   HorizontalConnectionPos,
   Overlay,
-  OverlayRef,
   OverlayConfig,
-  RepositionScrollStrategy,
+  OverlayRef,
   ScrollStrategy,
   VerticalConnectionPos,
 } from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {filter} from 'rxjs/operators/filter';
-import {take} from 'rxjs/operators/take';
 import {
   AfterContentInit,
   Directive,
   ElementRef,
   EventEmitter,
   Inject,
+  inject,
   InjectionToken,
   Input,
   OnDestroy,
@@ -38,31 +36,24 @@ import {
 } from '@angular/core';
 import {merge} from 'rxjs/observable/merge';
 import {of as observableOf} from 'rxjs/observable/of';
+import {filter} from 'rxjs/operators/filter';
+import {take} from 'rxjs/operators/take';
 import {Subscription} from 'rxjs/Subscription';
 import {MatMenu} from './menu-directive';
 import {throwMatMenuMissingError} from './menu-errors';
 import {MatMenuItem} from './menu-item';
 import {MatMenuPanel} from './menu-panel';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
-import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 
 /** Injection token that determines the scroll handling while the menu is open. */
 export const MAT_MENU_SCROLL_STRATEGY =
-    new InjectionToken<() => ScrollStrategy>('mat-menu-scroll-strategy');
-
-/** @docs-private */
-export function MAT_MENU_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => RepositionScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-/** @docs-private */
-export const MAT_MENU_SCROLL_STRATEGY_PROVIDER = {
-  provide: MAT_MENU_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: MAT_MENU_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
-
+    new InjectionToken<() => ScrollStrategy>('mat-menu-scroll-strategy', {
+      providedIn: 'root',
+      factory: () => {
+        const overlay = inject(Overlay);
+        return () => overlay.scrollStrategies.reposition();
+      }
+    });
 
 // TODO(andrewseguin): Remove the kebab versions in favor of camelCased attribute selectors
 

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -13,7 +13,7 @@ import {Subject} from 'rxjs/Subject';
  * To modify the labels and text displayed, create a new instance of MatPaginatorIntl and
  * include it in a custom provider
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MatPaginatorIntl {
   /**
    * Stream that emits whenever the labels here are changed. Use this to notify

--- a/src/lib/progress-spinner/progress-spinner-module.ts
+++ b/src/lib/progress-spinner/progress-spinner-module.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {NgModule} from '@angular/core';
-import {PlatformModule} from '@angular/cdk/platform';
 import {MatCommonModule} from '@angular/material/core';
 import {MatProgressSpinner, MatSpinner} from './progress-spinner';
 
+
 @NgModule({
-  imports: [MatCommonModule, PlatformModule],
+  imports: [MatCommonModule],
   exports: [
     MatProgressSpinner,
     MatSpinner,

--- a/src/lib/radio/radio-module.ts
+++ b/src/lib/radio/radio-module.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
@@ -14,7 +13,7 @@ import {MatRadioButton, MatRadioGroup} from './radio';
 
 
 @NgModule({
-  imports: [CommonModule, MatRippleModule, MatCommonModule, A11yModule],
+  imports: [CommonModule, MatRippleModule, MatCommonModule],
   exports: [MatRadioGroup, MatRadioButton, MatCommonModule],
   declarations: [MatRadioGroup, MatRadioButton],
 })

--- a/src/lib/select/select-module.ts
+++ b/src/lib/select/select-module.ts
@@ -7,11 +7,10 @@
  */
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {MatSelect, MatSelectTrigger, MAT_SELECT_SCROLL_STRATEGY_PROVIDER} from './select';
+import {MatSelect, MatSelectTrigger} from './select';
 import {MatCommonModule, MatOptionModule} from '@angular/material/core';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {MatFormFieldModule} from '@angular/material/form-field';
-import {ErrorStateMatcher} from '@angular/material/core';
 
 
 @NgModule({
@@ -23,6 +22,5 @@ import {ErrorStateMatcher} from '@angular/material/core';
   ],
   exports: [MatFormFieldModule, MatSelect, MatSelectTrigger, MatOptionModule, MatCommonModule],
   declarations: [MatSelect, MatSelectTrigger],
-  providers: [MAT_SELECT_SCROLL_STRATEGY_PROVIDER, ErrorStateMatcher]
 })
 export class MatSelectModule {}

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
 import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
@@ -14,24 +15,12 @@ import {
   END,
   ENTER,
   HOME,
-  SPACE,
-  UP_ARROW,
   LEFT_ARROW,
   RIGHT_ARROW,
+  SPACE,
+  UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {
-  CdkConnectedOverlay,
-  Overlay,
-  RepositionScrollStrategy,
-  ScrollStrategy,
-  ViewportRuler,
-} from '@angular/cdk/overlay';
-import {filter} from 'rxjs/operators/filter';
-import {take} from 'rxjs/operators/take';
-import {map} from 'rxjs/operators/map';
-import {switchMap} from 'rxjs/operators/switchMap';
-import {startWith} from 'rxjs/operators/startWith';
-import {takeUntil} from 'rxjs/operators/takeUntil';
+import {CdkConnectedOverlay, Overlay, ScrollStrategy, ViewportRuler} from '@angular/cdk/overlay';
 import {
   AfterContentInit,
   Attribute,
@@ -45,6 +34,7 @@ import {
   ElementRef,
   EventEmitter,
   Inject,
+  inject,
   InjectionToken,
   Input,
   isDevMode,
@@ -60,34 +50,35 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
+import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {
-  ControlValueAccessor,
-  FormGroupDirective,
-  NgControl,
-  NgForm
-} from '@angular/forms';
-import {
+  _countGroupLabelsBeforeOption,
+  _getOptionScrollPosition,
   CanDisable,
-  ErrorStateMatcher,
+  CanDisableRipple,
   CanUpdateErrorState,
-  mixinErrorState,
+  ErrorStateMatcher,
   HasTabIndex,
+  MAT_OPTION_PARENT_COMPONENT,
   MatOptgroup,
   MatOption,
   MatOptionSelectionChange,
   mixinDisabled,
-  mixinTabIndex,
-  MAT_OPTION_PARENT_COMPONENT,
   mixinDisableRipple,
-  CanDisableRipple,
-  _countGroupLabelsBeforeOption,
-  _getOptionScrollPosition,
+  mixinErrorState,
+  mixinTabIndex,
 } from '@angular/material/core';
 import {MatFormField, MatFormFieldControl} from '@angular/material/form-field';
 import {Observable} from 'rxjs/Observable';
-import {merge} from 'rxjs/observable/merge';
-import {Subject} from 'rxjs/Subject';
 import {defer} from 'rxjs/observable/defer';
+import {merge} from 'rxjs/observable/merge';
+import {filter} from 'rxjs/operators/filter';
+import {map} from 'rxjs/operators/map';
+import {startWith} from 'rxjs/operators/startWith';
+import {switchMap} from 'rxjs/operators/switchMap';
+import {take} from 'rxjs/operators/take';
+import {takeUntil} from 'rxjs/operators/takeUntil';
+import {Subject} from 'rxjs/Subject';
 import {matSelectAnimations} from './select-animations';
 import {
   getMatSelectDynamicMultipleError,
@@ -134,20 +125,13 @@ export const SELECT_PANEL_VIEWPORT_PADDING = 8;
 
 /** Injection token that determines the scroll handling while a select is open. */
 export const MAT_SELECT_SCROLL_STRATEGY =
-    new InjectionToken<() => ScrollStrategy>('mat-select-scroll-strategy');
-
-/** @docs-private */
-export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => RepositionScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-/** @docs-private */
-export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER = {
-  provide: MAT_SELECT_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
+    new InjectionToken<() => ScrollStrategy>('mat-select-scroll-strategy', {
+      providedIn: 'root',
+      factory: () => {
+        const overlay = inject(Overlay);
+        return () => overlay.scrollStrategies.reposition();
+      }
+    });
 
 /** Change event object that is emitted when the select value has changed. */
 export class MatSelectChange {

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationEvent} from '@angular/animations';
-import {FocusTrap, FocusTrapFactory, FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
+import {FocusMonitor, FocusOrigin, FocusTrap, FocusTrapFactory} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
+import {CdkScrollable} from '@angular/cdk/scrolling';
+import {DOCUMENT} from '@angular/common';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -23,29 +25,27 @@ import {
   EventEmitter,
   forwardRef,
   Inject,
+  InjectionToken,
   Input,
   NgZone,
   OnDestroy,
   Optional,
   Output,
   QueryList,
-  ViewEncapsulation,
-  InjectionToken,
   ViewChild,
+  ViewEncapsulation,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
-import {merge} from 'rxjs/observable/merge';
-import {filter} from 'rxjs/operators/filter';
-import {take} from 'rxjs/operators/take';
-import {startWith} from 'rxjs/operators/startWith';
-import {takeUntil} from 'rxjs/operators/takeUntil';
-import {debounceTime} from 'rxjs/operators/debounceTime';
-import {map} from 'rxjs/operators/map';
-import {fromEvent} from 'rxjs/observable/fromEvent';
-import {Subject} from 'rxjs/Subject';
 import {Observable} from 'rxjs/Observable';
+import {fromEvent} from 'rxjs/observable/fromEvent';
+import {merge} from 'rxjs/observable/merge';
+import {debounceTime} from 'rxjs/operators/debounceTime';
+import {filter} from 'rxjs/operators/filter';
+import {map} from 'rxjs/operators/map';
+import {startWith} from 'rxjs/operators/startWith';
+import {take} from 'rxjs/operators/take';
+import {takeUntil} from 'rxjs/operators/takeUntil';
+import {Subject} from 'rxjs/Subject';
 import {matDrawerAnimations} from './drawer-animations';
-import {CdkScrollable} from '@angular/cdk/scrolling';
 
 
 /** Throws an exception when two MatDrawer are matching the same position. */
@@ -59,7 +59,10 @@ export type MatDrawerToggleResult = 'open' | 'close';
 
 /** Configures whether drawers should use auto sizing by default. */
 export const MAT_DRAWER_DEFAULT_AUTOSIZE =
-    new InjectionToken<boolean>('MAT_DRAWER_DEFAULT_AUTOSIZE');
+    new InjectionToken<boolean>('MAT_DRAWER_DEFAULT_AUTOSIZE', {
+      providedIn: 'root',
+      factory: () => false,
+    });
 
 @Component({
   moduleId: module.id,

--- a/src/lib/sidenav/sidenav-module.ts
+++ b/src/lib/sidenav/sidenav-module.ts
@@ -5,21 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
 import {A11yModule} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
+import {PlatformModule} from '@angular/cdk/platform';
+import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
-import {ScrollDispatchModule} from '@angular/cdk/scrolling';
-import {PlatformModule} from '@angular/cdk/platform';
+import {MatDrawer, MatDrawerContainer, MatDrawerContent} from './drawer';
 import {MatSidenav, MatSidenavContainer, MatSidenavContent} from './sidenav';
-import {
-  MatDrawer,
-  MatDrawerContainer,
-  MatDrawerContent,
-  MAT_DRAWER_DEFAULT_AUTOSIZE,
-} from './drawer';
 
 
 @NgModule({
@@ -48,8 +42,5 @@ import {
     MatSidenavContainer,
     MatSidenavContent,
   ],
-  providers: [
-    {provide: MAT_DRAWER_DEFAULT_AUTOSIZE, useValue: false}
-  ]
 })
 export class MatSidenavModule {}

--- a/src/lib/sidenav/sidenav-module.ts
+++ b/src/lib/sidenav/sidenav-module.ts
@@ -5,8 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {A11yModule} from '@angular/cdk/a11y';
-import {OverlayModule} from '@angular/cdk/overlay';
 import {PlatformModule} from '@angular/cdk/platform';
 import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
@@ -20,8 +18,6 @@ import {MatSidenav, MatSidenavContainer, MatSidenavContent} from './sidenav';
   imports: [
     CommonModule,
     MatCommonModule,
-    A11yModule,
-    OverlayModule,
     ScrollDispatchModule,
     PlatformModule,
   ],

--- a/src/lib/slide-toggle/slide-toggle-module.ts
+++ b/src/lib/slide-toggle/slide-toggle-module.ts
@@ -7,20 +7,14 @@
  */
 
 import {ObserversModule} from '@angular/cdk/observers';
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
-import {
-  GestureConfig,
-  MatCommonModule,
-  MatRippleModule,
-} from '@angular/material/core';
+import {GestureConfig, MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
-import {A11yModule} from '@angular/cdk/a11y';
 import {MatSlideToggle} from './slide-toggle';
 
 
 @NgModule({
-  imports: [MatRippleModule, MatCommonModule, PlatformModule, ObserversModule, A11yModule],
+  imports: [MatRippleModule, MatCommonModule, ObserversModule],
   exports: [MatSlideToggle, MatCommonModule],
   declarations: [MatSlideToggle],
   providers: [

--- a/src/lib/slider/slider-module.ts
+++ b/src/lib/slider/slider-module.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
-import {BidiModule} from '@angular/cdk/bidi';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {GestureConfig, MatCommonModule} from '@angular/material/core';
@@ -16,7 +14,7 @@ import {MatSlider} from './slider';
 
 
 @NgModule({
-  imports: [CommonModule, MatCommonModule, BidiModule, A11yModule],
+  imports: [CommonModule, MatCommonModule],
   exports: [MatSlider, MatCommonModule],
   declarations: [MatSlider],
   providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]

--- a/src/lib/snack-bar/snack-bar-module.ts
+++ b/src/lib/snack-bar/snack-bar-module.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LayoutModule} from '@angular/cdk/layout';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
@@ -23,7 +22,6 @@ import {MatSnackBarContainer} from './snack-bar-container';
     PortalModule,
     CommonModule,
     MatCommonModule,
-    LayoutModule,
   ],
   exports: [MatSnackBarContainer, MatCommonModule],
   declarations: [MatSnackBarContainer, SimpleSnackBar],

--- a/src/lib/snack-bar/snack-bar-module.ts
+++ b/src/lib/snack-bar/snack-bar-module.ts
@@ -13,15 +13,9 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
 import {SimpleSnackBar} from './simple-snack-bar';
-import {MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBar} from './snack-bar';
-import {MatSnackBarConfig} from './snack-bar-config';
+import {MatSnackBar} from './snack-bar';
 import {MatSnackBarContainer} from './snack-bar-container';
 
-
-/** @docs-private */
-export function MAT_SNACK_BAR_DEFAULT_OPTIONS_PROVIDER_FACTORY() {
-  return new MatSnackBarConfig();
-}
 
 @NgModule({
   imports: [
@@ -34,12 +28,6 @@ export function MAT_SNACK_BAR_DEFAULT_OPTIONS_PROVIDER_FACTORY() {
   exports: [MatSnackBarContainer, MatCommonModule],
   declarations: [MatSnackBarContainer, SimpleSnackBar],
   entryComponents: [MatSnackBarContainer, SimpleSnackBar],
-  providers: [
-    MatSnackBar,
-    {
-      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
-      useFactory: MAT_SNACK_BAR_DEFAULT_OPTIONS_PROVIDER_FACTORY
-    },
-  ]
+  providers: [MatSnackBar]
 })
 export class MatSnackBarModule {}

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -31,7 +31,10 @@ import {MatSnackBarRef} from './snack-bar-ref';
 
 /** Injection token that can be used to specify default snack bar. */
 export const MAT_SNACK_BAR_DEFAULT_OPTIONS =
-    new InjectionToken<MatSnackBarConfig>('mat-snack-bar-default-options');
+    new InjectionToken<MatSnackBarConfig>('mat-snack-bar-default-options', {
+      providedIn: 'root',
+      factory: () => new MatSnackBarConfig(),
+    });
 
 /**
  * Service to dispatch Material Design snack bar messages.

--- a/src/lib/sort/sort-header-intl.ts
+++ b/src/lib/sort/sort-header-intl.ts
@@ -14,7 +14,7 @@ import {SortDirection} from './sort-direction';
  * To modify the labels and text displayed, create a new instance of MatSortHeaderIntl and
  * include it in a custom provider.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MatSortHeaderIntl {
   /**
    * Stream that emits whenever the labels here are changed. Use this to notify

--- a/src/lib/stepper/stepper-intl.ts
+++ b/src/lib/stepper/stepper-intl.ts
@@ -11,7 +11,7 @@ import {Subject} from 'rxjs/Subject';
 
 
 /** Stepper data that is required for internationalization. */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class MatStepperIntl {
   /**
    * Stream that emits whenever the labels here are changed. Use this to notify

--- a/src/lib/stepper/stepper-module.ts
+++ b/src/lib/stepper/stepper-module.ts
@@ -6,20 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
 import {PortalModule} from '@angular/cdk/portal';
 import {CdkStepperModule} from '@angular/cdk/stepper';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
-import {MatCommonModule, MatRippleModule, ErrorStateMatcher} from '@angular/material/core';
+import {ErrorStateMatcher, MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatStepHeader} from './step-header';
 import {MatStepLabel} from './step-label';
-import {MatStepperNext, MatStepperPrevious} from './stepper-button';
-import {MatStepperIntl} from './stepper-intl';
-import {MatStepperIcon} from './stepper-icon';
 import {MatHorizontalStepper, MatStep, MatStepper, MatVerticalStepper} from './stepper';
+import {MatStepperNext, MatStepperPrevious} from './stepper-button';
+import {MatStepperIcon} from './stepper-icon';
+import {MatStepperIntl} from './stepper-intl';
 
 
 @NgModule({
@@ -30,7 +29,6 @@ import {MatHorizontalStepper, MatStep, MatStepper, MatVerticalStepper} from './s
     MatButtonModule,
     CdkStepperModule,
     MatIconModule,
-    A11yModule,
     MatRippleModule,
   ],
   exports: [

--- a/src/lib/table/table-module.ts
+++ b/src/lib/table/table-module.ts
@@ -16,11 +16,29 @@ import {MatCommonModule} from '@angular/material/core';
 
 @NgModule({
   imports: [CdkTableModule, CommonModule, MatCommonModule],
-  exports: [MatTable, MatCellDef, MatHeaderCellDef, MatColumnDef,
-    MatHeaderCell, MatCell, MatHeaderRow, MatRow,
-    MatHeaderRowDef, MatRowDef],
-  declarations: [MatTable, MatCellDef, MatHeaderCellDef, MatColumnDef,
-    MatHeaderCell, MatCell, MatHeaderRow, MatRow,
-    MatHeaderRowDef, MatRowDef],
+  exports: [
+    MatCell,
+    MatCellDef,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatTable,
+  ],
+  declarations: [
+    MatCell,
+    MatCellDef,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatTable,
+  ],
 })
 export class MatTableModule {}

--- a/src/lib/tabs/tabs-module.ts
+++ b/src/lib/tabs/tabs-module.ts
@@ -8,7 +8,6 @@
 
 import {ObserversModule} from '@angular/cdk/observers';
 import {PortalModule} from '@angular/cdk/portal';
-import {ScrollDispatchModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
@@ -30,7 +29,6 @@ import {MatTabLink, MatTabNav} from './tab-nav-bar/tab-nav-bar';
     PortalModule,
     MatRippleModule,
     ObserversModule,
-    ScrollDispatchModule,
   ],
   // Don't export all components because some are only to be used internally.
   exports: [

--- a/src/lib/toolbar/toolbar-module.ts
+++ b/src/lib/toolbar/toolbar-module.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
 import {MatToolbar, MatToolbarRow} from './toolbar';
 
 
 @NgModule({
-  imports: [MatCommonModule, PlatformModule],
+  imports: [MatCommonModule],
   exports: [MatToolbar, MatToolbarRow, MatCommonModule],
   declarations: [MatToolbar, MatToolbarRow],
 })

--- a/src/lib/tooltip/tooltip-module.ts
+++ b/src/lib/tooltip/tooltip-module.ts
@@ -13,12 +13,7 @@ import {PlatformModule} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
-import {
-  MAT_TOOLTIP_DEFAULT_OPTIONS,
-  MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER,
-  MatTooltip,
-  TooltipComponent,
-} from './tooltip';
+import {MatTooltip, TooltipComponent} from './tooltip';
 
 
 @NgModule({
@@ -33,16 +28,5 @@ import {
   exports: [MatTooltip, TooltipComponent, MatCommonModule],
   declarations: [MatTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
-  providers: [
-    MAT_TOOLTIP_SCROLL_STRATEGY_PROVIDER,
-    {
-      provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-      useValue: {
-        showDelay: 0,
-        hideDelay: 0,
-        touchendHideDelay: 1500
-      }
-    }
-  ],
 })
 export class MatTooltipModule {}

--- a/src/lib/tooltip/tooltip-module.ts
+++ b/src/lib/tooltip/tooltip-module.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {A11yModule} from '@angular/cdk/a11y';
-import {LayoutModule} from '@angular/cdk/layout';
 import {OverlayModule} from '@angular/cdk/overlay';
-import {PlatformModule} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
@@ -21,9 +18,6 @@ import {MatTooltip, TooltipComponent} from './tooltip';
     CommonModule,
     OverlayModule,
     MatCommonModule,
-    PlatformModule,
-    A11yModule,
-    LayoutModule,
   ],
   exports: [MatTooltip, TooltipComponent, MatCommonModule],
   declarations: [MatTooltip, TooltipComponent],

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -10,7 +10,6 @@ import {NgModule} from '@angular/core';
 import {
   DateAdapter,
   MAT_DATE_LOCALE,
-  MAT_DATE_LOCALE_PROVIDER,
   MAT_DATE_FORMATS
 } from '@angular/material';
 import {MomentDateAdapter} from './moment-date-adapter';
@@ -22,7 +21,6 @@ export * from './moment-date-formats';
 
 @NgModule({
   providers: [
-    MAT_DATE_LOCALE_PROVIDER,
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]}
   ],
 })


### PR DESCRIPTION
Also catches cdk/layout which was missed earlier.

The overlay and the family of components based on it (dialog, snackbar, etc.) can't use the new semantics because they need the most appropriate `ComponentFactoryResolver` instead of the one that's always at the root.