### PR TITLE
build: log out full stack trace in unit tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = (config) => {
     },
 
     specReporter: {
-      maxLogLines: 1,
+      maxLogLines: Infinity, // Log out the entire stack trace on errors and failures.
       suppressSkipped: true,
       showSpecTiming: true,
     },


### PR DESCRIPTION
Removes the one-line limit for the stack traces inside unit tests.