### PR TITLE
feat(slider):initial implementation of warn color slider

### DIFF
--- a/src/lib/slider/slider.html
+++ b/src/lib/slider/slider.html
@@ -8,8 +8,8 @@
   </div>
   <div class="mat-slider-thumb-container" [ngStyle]="_thumbContainerStyles">
     <div class="mat-slider-focus-ring"></div>
-    <div class="mat-slider-thumb"></div>
-    <div class="mat-slider-thumb-label">
+    <div class="mat-slider-thumb" [ngStyle]="_thumbFillStyles"></div>
+    <div class="mat-slider-thumb-label" [ngStyle]="_thumbFillStyles">
       <span class="mat-slider-thumb-label-text">{{displayValue}}</span>
     </div>
   </div>

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -43,6 +43,7 @@ describe('MatSlider without forms', () => {
         SliderWithNativeTabindexAttr,
         VerticalSlider,
         SliderWithCustomThumbLabelFormatting,
+        SliderWithThreshold
       ],
       providers: [
         {provide: HAMMER_GESTURE_CONFIG, useFactory: () => {
@@ -1210,6 +1211,53 @@ describe('MatSlider without forms', () => {
         .toBe(5, 'Expected the tabIndex to be set to the value of the native attribute.');
     });
   });
+
+  describe('slider with threshold', () => {
+    let fixture: ComponentFixture<SliderWithThreshold>;
+    let sliderDebugElement: DebugElement;
+    let sliderInstance: MatSlider;
+    let trackFillNativeElement: HTMLElement;
+    let originalColor: string;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SliderWithThreshold);
+      fixture.detectChanges();
+
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
+      trackFillNativeElement = fixture.nativeElement.querySelector('.mat-slider-track-fill');
+      originalColor = getComputedStyle(trackFillNativeElement, '')
+        .getPropertyValue('background-color');
+    });
+
+    it('should check that the originalColor is set correctly', () => {
+      expect(originalColor).toBe('rgb(63, 81, 181)');
+    });
+
+    it('should set the default value from the attribute and have no overridden color', () => {
+      expect(sliderInstance.value).toBe(50);
+      expect(trackFillNativeElement.style.backgroundColor).toBe('');
+    });
+
+    it('should increase the value to breach the threshold and change to warn color', () => {
+      sliderInstance.value = 51;
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(51);
+      expect(trackFillNativeElement.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    });
+
+    it('should breach threshold, then reduce back and have no color override', () => {
+      sliderInstance.value = 51;
+      fixture.detectChanges();
+
+      sliderInstance.value = 49;
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(49);
+      expect(trackFillNativeElement.style.backgroundColor).toBe('');
+    });
+  });
 });
 
 describe('MatSlider with forms module', () => {
@@ -1558,6 +1606,14 @@ class SliderWithTabIndexBinding {
 })
 class SliderWithNativeTabindexAttr {
   tabIndex: number;
+}
+
+@Component({
+  template: `<mat-slider value="50" color="primary"
+    warnColor="#FF0000" threshold="50"></mat-slider>`,
+  styles: [styles],
+})
+class SliderWithThreshold {
 }
 
 /**

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -129,7 +129,7 @@ export const _MatSliderMixinBase =
   },
   templateUrl: 'slider.html',
   styleUrls: ['slider.css'],
-  inputs: ['disabled', 'color', 'tabIndex'],
+  inputs: ['disabled', 'color', 'tabIndex', 'warnColor', 'threshold'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -171,6 +171,27 @@ export class MatSlider extends _MatSliderMixinBase
     this._changeDetectorRef.markForCheck();
   }
   private _min: number = 0;
+
+  /** The maximum value that the slider can have before adding warn color. */
+  @Input()
+  get threshold(): number { return this._threshold; }
+  set threshold(v: number) {
+    this._threshold = coerceNumberProperty(v, this._threshold);
+    if (this._threshold > this._max) {
+      this._threshold = this._max;
+    } else if (this._threshold < this._min) {
+      this._threshold = this._min;
+    }
+  }
+  private _threshold: number = this._max;
+
+  /** The input for warn color. */
+  @Input()
+  get warnColor(): string { return this._warnColor; }
+  set warnColor(v: string) {
+    this._warnColor = v;
+  }
+  private _warnColor: string = '#FF0000';
 
   /** The values at which the thumb will snap. */
   @Input()
@@ -339,8 +360,10 @@ export class MatSlider extends _MatSliderMixinBase
   get _trackFillStyles(): { [key: string]: string } {
     let axis = this.vertical ? 'Y' : 'X';
     let sign = this._invertMouseCoords ? '' : '-';
+    let color = this.displayValue > this._threshold ? this._warnColor : '';
     return {
-      'transform': `translate${axis}(${sign}${this._thumbGap}px) scale${axis}(${this.percent})`
+      'transform': `translate${axis}(${sign}${this._thumbGap}px) scale${axis}(${this.percent})`,
+      'background-color': `${color}`
     };
   }
 
@@ -391,6 +414,14 @@ export class MatSlider extends _MatSliderMixinBase
     let offset = (invertOffset ? this.percent : 1 - this.percent) * 100;
     return {
       'transform': `translate${axis}(-${offset}%)`
+    };
+  }
+
+  /** CSS styles for the thumb fill element. */
+  get _thumbFillStyles(): { [key: string]: string } {
+    let color = this.displayValue > this._threshold ? this._warnColor : '';
+    return {
+      'background-color': `${color}`
     };
   }
 


### PR DESCRIPTION
Fixes #9478 

Adds the ability to set a threshold value (via `threshold` attribute) and color (via `warnColor` attribute) to change the slider when the value becomes greater than the threshold. This is currenty done via the ngStyle binding to override the css `background-color` of the element.

Usage:
``` html
<mat-slider color="primary" warnColor="#FF0000" threshold="50" value="50" thumbLabel aria-label="Primary color slider"></mat-slider>
```

Demo (threshold of 50 for first slider, 75 for second slider):
![slider-themed-threshold](https://user-images.githubusercontent.com/16708173/37750732-f78da4f0-2d64-11e8-8450-5addc1e65542.gif)

Note: the demo doesn't fully reflect the current implementation (which also changes the color of the thumb and thumb label). The reason is I get the following errors when trying to start the devapp after my most recent update and rebase (have I done something that a more recent commit makes invalid?):
![image](https://user-images.githubusercontent.com/16708173/37750922-ce901546-2d65-11e8-8cbf-e3c30a41207f.png)
![image](https://user-images.githubusercontent.com/16708173/37750939-e9f44488-2d65-11e8-9592-aa94ef7c219f.png)