### PR TITLE
feat(overlay): add the ability to set the default offsets on FlexibleConnectedPositionStrategy

### DIFF
--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -174,12 +174,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * @param offset New offset in the X axis.
    */
   withOffsetX(offset: number): this {
-    this._preferredPositions.forEach(position => {
-      if (position.offsetX == null) {
-        position.offsetX = offset;
-      }
-    });
-
+    this._positionStrategy.withDefaultOffsetX(offset);
     return this;
   }
 
@@ -188,12 +183,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * @param  offset New offset in the Y axis.
    */
   withOffsetY(offset: number): this {
-    this._preferredPositions.forEach(position => {
-      if (position.offsetY == null) {
-        position.offsetY = offset;
-      }
-    });
-
+    this._positionStrategy.withDefaultOffsetY(offset);
     return this;
   }
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -385,10 +385,80 @@ describe('FlexibleConnectedPositionStrategy', () => {
         expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left + 10));
       });
 
+      it('should be able to set the default x offset', () => {
+        const originRect = originElement.getBoundingClientRect();
+
+        positionStrategy.withDefaultOffsetX(20).withPositions([{
+          originX: 'start',
+          originY: 'top',
+          overlayX: 'start',
+          overlayY: 'top',
+        }]);
+
+        attachOverlay({positionStrategy});
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left + 20));
+      });
+
+      it('should have the position offset x take precedence over the default offset x', () => {
+        const originRect = originElement.getBoundingClientRect();
+
+        positionStrategy.withDefaultOffsetX(20).withPositions([{
+          originX: 'start',
+          originY: 'top',
+          overlayX: 'start',
+          overlayY: 'top',
+          offsetX: 10
+        }]);
+
+        attachOverlay({positionStrategy});
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left + 10));
+      });
+
       it('should position a panel with the y offset provided', () => {
         const originRect = originElement.getBoundingClientRect();
 
         positionStrategy.withPositions([{
+          originX: 'start',
+          originY: 'top',
+          overlayX: 'start',
+          overlayY: 'top',
+          offsetY: 50
+        }]);
+
+        attachOverlay({positionStrategy});
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top + 50));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
+      });
+
+      it('should be able to set the default y offset', () => {
+        const originRect = originElement.getBoundingClientRect();
+
+        positionStrategy.withDefaultOffsetY(60).withPositions([{
+          originX: 'start',
+          originY: 'top',
+          overlayX: 'start',
+          overlayY: 'top',
+        }]);
+
+        attachOverlay({positionStrategy});
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top + 60));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
+      });
+
+      it('should have the position offset y take precedence over the default offset y', () => {
+        const originRect = originElement.getBoundingClientRect();
+
+        positionStrategy.withDefaultOffsetY(60).withPositions([{
           originX: 'start',
           originY: 'top',
           overlayX: 'start',


### PR DESCRIPTION
Ports over the functionality that we used to have on the `ConnectedPositionStrategy` where consumers can set a default offset on the position strategy itself, to which it'll fall back if a `ConnectedPosition` doesn't have an offset. This helps avoid repetition in the cases where the consumer wants to have the same offset on all positions.