### PR TITLE
chore(button-toggle): use more accurate example in docs

### DIFF
--- a/src/material-examples/button-toggle-overview/button-toggle-overview-example.html
+++ b/src/material-examples/button-toggle-overview/button-toggle-overview-example.html
@@ -1,1 +1,5 @@
-<mat-button-toggle>Toggle me!</mat-button-toggle>
+<mat-button-toggle-group name="fontStyle">
+  <mat-button-toggle value="bold">Bold</mat-button-toggle>
+  <mat-button-toggle value="italic">Italic</mat-button-toggle>
+  <mat-button-toggle value="underline">Underline</mat-button-toggle>
+</mat-button-toggle-group>


### PR DESCRIPTION
Uses a button toggle group with multiple toggles, rather than a single toggle, for the basic example in the docs. This is a better representation of the average use case of a button toggle.

Fixes #10559.