### PR TITLE
fix(button-toggle): focus monitoring not being cleaned up on destroy

### DIFF
--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -19,6 +19,7 @@ import {
   EventEmitter,
   forwardRef,
   Input,
+  OnDestroy,
   OnInit,
   Optional,
   Output,
@@ -331,7 +332,8 @@ export const _MatButtonToggleMixinBase = mixinDisableRipple(MatButtonToggleBase)
     '[attr.id]': 'id',
   }
 })
-export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, CanDisableRipple {
+export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit,
+  CanDisableRipple, OnDestroy {
 
   private _isSingleSelector = false;
   private _checked = false;
@@ -350,7 +352,7 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
   /** Type of the button toggle. Either 'radio' or 'checkbox'. */
   _type: ToggleType;
 
-  @ViewChild('input') _inputElement: ElementRef;
+  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
   /** The parent button toggle group (exclusive selection). Optional. */
   buttonToggleGroup: MatButtonToggleGroup;
@@ -400,7 +402,7 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
 
   constructor(@Optional() toggleGroup: MatButtonToggleGroup,
               private _changeDetectorRef: ChangeDetectorRef,
-              private _elementRef: ElementRef,
+              private _elementRef: ElementRef<HTMLElement>,
               private _focusMonitor: FocusMonitor) {
     super();
 
@@ -421,6 +423,10 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
     }
 
     this._focusMonitor.monitor(this._elementRef.nativeElement, true);
+  }
+
+  ngOnDestroy() {
+    this._focusMonitor.stopMonitoring(this._elementRef.nativeElement);
   }
 
   /** Focuses the button. */


### PR DESCRIPTION
Fixes the focus monitoring for the individual buttons toggles not being cleaned up when they're destroyed, causing the reference to stay inside the `FocusMonitor`.