### PR TITLE
fix(tree): fix the MatTreeNodeOutlet not exported issue

### DIFF
--- a/src/lib/tree/public-api.ts
+++ b/src/lib/tree/public-api.ts
@@ -12,5 +12,6 @@ export * from './padding';
 export * from './tree';
 export * from './tree-module';
 export * from './toggle';
+export * from './outlet';
 export * from './data-source/flat-data-source';
 export * from './data-source/nested-data-source';


### PR DESCRIPTION
Fixes #10437 