### PR TITLE
fix(datepicker): add back MAT_DATE_LOCALE_PROVIDER

### DIFF
--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -9,12 +9,19 @@
 import {inject, InjectionToken, LOCALE_ID} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 
-
 /** InjectionToken for datepicker that can be used to override default locale code. */
 export const MAT_DATE_LOCALE = new InjectionToken<string>('MAT_DATE_LOCALE', {
   providedIn: 'root',
   factory: () => inject(LOCALE_ID)
 });
+
+/**
+ * No longer needed since MAT_DATE_LOCALE has been changed to a scoped injectable.
+ * If you are importing and providing this in your code you can simply remove it.
+ * @deprecated
+ * @deletion-target 7.0.0
+ */
+export const MAT_DATE_LOCALE_PROVIDER = {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID};
 
 /** Adapts type `D` to be usable as a date by cdk-based components that work with dates. */
 export abstract class DateAdapter<D> {


### PR DESCRIPTION
Some people who are using custom date adapters were importing this to provide in their `NgModule`