### PR TITLE
fix(button-toggle): setting blank aria-label attribute by default

### DIFF
--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -621,16 +621,22 @@ describe('MatButtonToggle without forms', () => {
 
   });
 
-  describe('with provided aria-label ', () => {
-    let checkboxDebugElement: DebugElement;
-    let checkboxNativeElement: HTMLElement;
-    let inputElement: HTMLInputElement;
+  describe('aria-label handling ', () => {
+    it('should not set the aria-label attribute if none is provided', () => {
+      let fixture = TestBed.createComponent(StandaloneButtonToggle);
+      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      let checkboxNativeElement = checkboxDebugElement.nativeElement;
+      let inputElement = checkboxNativeElement.querySelector('input') as HTMLInputElement;
+
+      fixture.detectChanges();
+      expect(inputElement.hasAttribute('aria-label')).toBe(false);
+    });
 
     it('should use the provided aria-label', () => {
       let fixture = TestBed.createComponent(ButtonToggleWithAriaLabel);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
-      checkboxNativeElement = checkboxDebugElement.nativeElement;
-      inputElement = checkboxNativeElement.querySelector('input') as HTMLInputElement;
+      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      let checkboxNativeElement = checkboxDebugElement.nativeElement;
+      let inputElement = checkboxNativeElement.querySelector('input') as HTMLInputElement;
 
       fixture.detectChanges();
       expect(inputElement.getAttribute('aria-label')).toBe('Super effective');

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -333,7 +333,7 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
    * Attached to the aria-label attribute of the host element. In most cases, arial-labelledby will
    * take precedence so this may be omitted.
    */
-  @Input('aria-label') ariaLabel: string = '';
+  @Input('aria-label') ariaLabel: string;
 
   /**
    * Users can specify the `aria-labelledby` attribute which will be forwarded to the input element


### PR DESCRIPTION
Fixes the button toggle setting the `aria-label` of its underlying input to a blank value by default.