### PR TITLE
fix(focus-monitor): hitting ngzone when using focusVia

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -240,8 +240,10 @@ export class FocusMonitor implements OnDestroy {
    * @param origin The origin to set.
    */
   private _setOriginForCurrentEventQueue(origin: FocusOrigin): void {
-    this._origin = origin;
-    this._originTimeoutId = setTimeout(() => this._origin = null, 0);
+    this._ngZone.runOutsideAngular(() => {
+      this._origin = origin;
+      this._originTimeoutId = setTimeout(() => this._origin = null, 0);
+    });
   }
 
   /**


### PR DESCRIPTION
Currently most of the timeouts inside the `FocusMonitor` are run outside the `NgZone`, because they're called from event listeners that are bound on the outside, however the one from `_setOriginForCurrentEventQueue` can still end up inside when it's called by `focusVia`.