### PR TITLE
fix(table,sort,paginator): incorrect spacing in rtl

### DIFF
--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -45,6 +45,11 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
   display: flex;
   align-items: baseline;
   margin-right: $mat-paginator-page-size-margin-right;
+
+  [dir='rtl'] & {
+    margin-right: 0;
+    margin-left: $mat-paginator-page-size-margin-right;
+  }
 }
 
 .mat-paginator-page-size-label {

--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -34,11 +34,16 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
   height: $mat-sort-header-arrow-container-size;
   width: $mat-sort-header-arrow-container-size;
   min-width: $mat-sort-header-arrow-container-size;
-  margin: 0 0 0 $mat-sort-header-arrow-margin;
   position: relative;
   display: flex;
 
-  .mat-sort-header-position-before & {
+  &,
+  [dir='rtl'] .mat-sort-header-position-before & {
+    margin: 0 0 0 $mat-sort-header-arrow-margin;
+  }
+
+  .mat-sort-header-position-before &,
+  [dir='rtl'] & {
     margin: 0 $mat-sort-header-arrow-margin 0 0;
   }
 }

--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -36,10 +36,20 @@ mat-row, mat-header-row {
 
 mat-cell:first-child, mat-header-cell:first-child {
   padding-left: $mat-row-horizontal-padding;
+
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: $mat-row-horizontal-padding;
+  }
 }
 
 mat-cell:last-child, mat-header-cell:last-child {
   padding-right: $mat-row-horizontal-padding;
+
+  [dir='rtl'] & {
+    padding-right: 0;
+    padding-left: $mat-row-horizontal-padding;
+  }
 }
 
 mat-cell, mat-header-cell {


### PR DESCRIPTION
Fixes a few instances in the `table` and `sort` modules where the spacings weren't being inverted in RTL layouts.