### PR TITLE
fix(sort): arrow not centered vertically inside multiline headers

### DIFF
--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -8,6 +8,7 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
 .mat-sort-header-container {
   display: flex;
   cursor: pointer;
+  align-items: center;
 
   .mat-sort-header-disabled & {
     cursor: default;


### PR DESCRIPTION
Fixes the arrow icon from the sort header not being centered inside its cell when there is multiline text.

Fixes #10604.