### PR TITLE
chore(docs): update autocomplete.md to match new example

### DIFF
--- a/src/lib/autocomplete/autocomplete.md
+++ b/src/lib/autocomplete/autocomplete.md
@@ -61,7 +61,7 @@ option's first letter. We already have access to the built-in `valueChanges` Obs
 them through this filter. The resulting Observable, `filteredOptions`, can be added to the
 template in place of the `options` property using the `async` pipe.
 
-Below we are also priming our value change stream with `null` so that the options are filtered by
+Below we are also priming our value change stream with an empty string so that the options are filtered by
 that value on init (before there are any value changes).
 
 \*For optimal accessibility, you may want to consider adding text guidance on the page to explain


### PR DESCRIPTION
An example of autocomplete filter was updated in PR #8167 but docs still refer to the old implementation. This PR makes them in sync.