### PR TITLE
fix(stepper): horizontal stepper cutting off bottom part of content

### DIFF
--- a/src/lib/stepper/stepper.scss
+++ b/src/lib/stepper/stepper.scss
@@ -63,12 +63,9 @@ $mat-stepper-line-gap: 8px !default;
   }
 }
 
-.mat-horizontal-stepper-content {
+.mat-horizontal-stepper-content[aria-expanded='false'] {
+  height: 0;
   overflow: hidden;
-
-  &[aria-expanded='false'] {
-    height: 0;
-  }
 }
 
 .mat-horizontal-content-container {


### PR DESCRIPTION
Fixes the horizontal stepper cutting off the bottom part of its content due to it having `overflow: hidden`. These changes scope the `overflow` only to when the stepper is collapsed.

Fixes #10634.