### PR TITLE
build: lock down typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material2-srcs",
-  "version": "6.0.0-beta.5",
+  "version": "6.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "tsconfig-paths": "^2.3.0",
     "tslint": "^5.9.1",
     "tsutils": "^2.6.0",
-    "typescript": "^2.7.2",
+    "typescript": "2.7.x",
     "uglify-js": "^2.8.14",
     "web-animations-js": "^2.2.5"
   }


### PR DESCRIPTION
Locks down the version of `typescript` to the same one as core.

Fixes #10648.