### PR TITLE
chore: enforce consistency in class names of demo-app

### DIFF
--- a/src/demo-app/a11y/a11y-module.ts
+++ b/src/demo-app/a11y/a11y-module.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {ACCESSIBILITY_DEMO_ROUTES} from './routes';
 import {DemoMaterialModule} from '../demo-material-module';
 import {AccessibilityDemo, AccessibilityHome} from './a11y';
 import {AutocompleteAccessibilityDemo} from './autocomplete/autocomplete-a11y';
-import {ButtonAccessibilityDemo} from './button/button-a11y';
 import {ButtonToggleAccessibilityDemo} from './button-toggle/button-toggle-a11y';
+import {ButtonAccessibilityDemo} from './button/button-a11y';
 import {CardAccessibilityDemo} from './card/card-a11y';
 import {CheckboxAccessibilityDemo} from './checkbox/checkbox-a11y';
 import {ChipsAccessibilityDemo} from './chips/chips-a11y';
+import {DatepickerAccessibilityDemo} from './datepicker/datepicker-a11y';
 import {
   DialogAccessibilityDemo,
   DialogAddressFormDialog,
@@ -29,31 +29,32 @@ import {
 } from './dialog/dialog-a11y';
 import {ExpansionPanelAccessibilityDemo} from './expansion/expansion-a11y';
 import {GridListAccessibilityDemo} from './grid-list/grid-list-a11y';
-import {ListAccessibilityDemo} from './list/list-a11y';
-import {RadioAccessibilityDemo} from './radio/radio-a11y';
-import {ToolbarAccessibilityDemo} from './toolbar/toolbar-a11y';
-import {DatepickerAccessibilityDemo} from './datepicker/datepicker-a11y';
 import {IconAccessibilityDemo} from './icon/icon-a11y';
 import {InputAccessibilityDemo} from './input/input-a11y';
+import {ListAccessibilityDemo} from './list/list-a11y';
 import {MenuAccessibilityDemo} from './menu/menu-a11y';
 import {ProgressBarAccessibilityDemo} from './progress-bar/progress-bar-a11y';
 import {ProgressSpinnerAccessibilityDemo} from './progress-spinner/progress-spinner-a11y';
-import {SliderAccessibilityDemo} from './slider/slider-a11y';
-import {SlideToggleAccessibilityDemo} from './slide-toggle/slide-toggle-a11y';
-import {SnackBarAccessibilityDemo} from './snack-bar/snack-bar-a11y';
+import {RadioAccessibilityDemo} from './radio/radio-a11y';
+import {ACCESSIBILITY_DEMO_ROUTES} from './routes';
 import {SelectAccessibilityDemo} from './select/select-a11y';
-import {TableAccessibilityDemo} from './table/table-a11y';
-import {
-  TabsAccessibilityDemo,
-  SunnyTabContent,
-  RainyTabContent,
-  FoggyTabContent,
-} from './tabs/tabs-a11y';
-import {TooltipAccessibilityDemo} from './tooltip/tooltip-a11y';
-import {SidenavAccessibilityDemo} from './sidenav/sidenav-a11y';
 import {SidenavBasicAccessibilityDemo} from './sidenav/basic-sidenav-a11y';
 import {SidenavDualAccessibilityDemo} from './sidenav/dual-sidenav-a11y';
 import {SidenavMobileAccessibilityDemo} from './sidenav/mobile-sidenav-a11y';
+import {SidenavAccessibilityDemo} from './sidenav/sidenav-a11y';
+import {SlideToggleAccessibilityDemo} from './slide-toggle/slide-toggle-a11y';
+import {SliderAccessibilityDemo} from './slider/slider-a11y';
+import {SnackBarAccessibilityDemo} from './snack-bar/snack-bar-a11y';
+import {TableAccessibilityDemo} from './table/table-a11y';
+import {
+  FoggyTabContent,
+  RainyTabContent,
+  SunnyTabContent,
+  TabsAccessibilityDemo,
+} from './tabs/tabs-a11y';
+import {ToolbarAccessibilityDemo} from './toolbar/toolbar-a11y';
+import {TooltipAccessibilityDemo} from './tooltip/tooltip-a11y';
+
 
 @NgModule({
   imports: [
@@ -105,11 +106,11 @@ export class AccessibilityRoutingModule {}
     SidenavBasicAccessibilityDemo,
     SidenavDualAccessibilityDemo,
     SidenavMobileAccessibilityDemo,
-    SliderAccessibilityDemo,
     SlideToggleAccessibilityDemo,
+    SliderAccessibilityDemo,
     SnackBarAccessibilityDemo,
-    TableAccessibilityDemo,
     SunnyTabContent,
+    TableAccessibilityDemo,
     TabsAccessibilityDemo,
     ToolbarAccessibilityDemo,
     TooltipAccessibilityDemo,

--- a/src/demo-app/a11y/a11y.ts
+++ b/src/demo-app/a11y/a11y.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, OnDestroy, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, ElementRef, OnDestroy, ViewChild} from '@angular/core';
 import {NavigationEnd, Router} from '@angular/router';
 import {Subscription} from 'rxjs';
+
 
 @Component({
   moduleId: module.id,
@@ -22,10 +23,9 @@ export class AccessibilityHome {}
   selector: 'accessibility-demo',
   templateUrl: 'a11y.html',
   styleUrls: ['a11y.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class AccessibilityDemo implements OnDestroy {
-  currentComponent: string = '';
+  currentComponent = '';
 
   fullscreen = false;
 
@@ -67,8 +67,8 @@ export class AccessibilityDemo implements OnDestroy {
   constructor(router: Router) {
     this._routerSubscription = router.events.subscribe((e) => {
       if (e instanceof NavigationEnd) {
-        let fragments = e.url.split('/');
-        let nav = this.navItems.find(navItem => {
+        const fragments = e.url.split('/');
+        const nav = this.navItems.find(navItem => {
           return fragments[fragments.length - 1] === navItem.route;
         });
         this.currentComponent = nav ? nav.name : '';

--- a/src/demo-app/a11y/button/button-a11y.ts
+++ b/src/demo-app/a11y/button/button-a11y.ts
@@ -9,6 +9,7 @@
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 
+
 @Component({
   moduleId: module.id,
   selector: 'button-a11y',

--- a/src/demo-app/a11y/card/card-a11y.html
+++ b/src/demo-app/a11y/card/card-a11y.html
@@ -1,7 +1,7 @@
 <section>
   <h2>Dogs group</h2>
   <p>Showing a card with a group of content.</p>
-  <mat-card class="example-card" role="group">
+  <mat-card class="demo-card" role="group">
     <mat-card-content>
       <p>Herding Group</p>
       <p>Hound Group</p>
@@ -19,7 +19,7 @@
 <section>
   <h2>Husky</h2>
   <p>Showing a card with title only.</p>
-  <mat-card class="example-card">
+  <mat-card class="demo-card">
     Siberian Husky
   </mat-card>
 </section>
@@ -27,7 +27,7 @@
 <section>
   <h2>Malamute</h2>
   <p>Showing a Card with title and subtitle.</p>
-  <mat-card class="example-card">
+  <mat-card class="demo-card">
     <mat-card-title>Alaskan Malamute</mat-card-title>
     <mat-card-subtitle>Dog breed</mat-card-subtitle>
   </mat-card>
@@ -37,7 +37,7 @@
 <section>
   <h2>German Shepherd</h2>
   <p>Showing a card with title, subtitle, and a footer.</p>
-  <mat-card class="example-card">
+  <mat-card class="demo-card">
     <mat-card-subtitle>Dog breed</mat-card-subtitle>
     <mat-card-title>German Shepherd</mat-card-title>
     <mat-card-content>
@@ -54,7 +54,7 @@
 <section>
   <h2>Dachshund</h2>
   <p>Showing a card with title, subtitle, and avatar as header and a card image.</p>
-  <mat-card class="example-card">
+  <mat-card class="demo-card">
     <mat-card-header>
       <img mat-card-avatar src="a11y/card/assets/dachshund-avatar.jpg" aria-label="Dachshund avatar">
       <mat-card-title>Dachshund</mat-card-title>
@@ -71,7 +71,7 @@
 <section>
   <h2>Shiba Inu</h2>
   <p>Showing a card with header, content, image, and two action buttons: "share" and "like".</p>
-  <mat-card class="example-card">
+  <mat-card class="demo-card">
     <mat-card-header>
       <img mat-card-avatar src="a11y/card/assets/shiba-inu-avatar.jpg" aria-label="Shiba Inu avatar">
       <mat-card-title>Shiba Inu</mat-card-title>

--- a/src/demo-app/a11y/card/card-a11y.scss
+++ b/src/demo-app/a11y/card/card-a11y.scss
@@ -1,7 +1,7 @@
-.example-card button {
+.demo-card button {
   text-transform: uppercase;
 }
 
-.example-card {
+.demo-card {
   max-width: 450px;
 }

--- a/src/demo-app/a11y/card/card-a11y.ts
+++ b/src/demo-app/a11y/card/card-a11y.ts
@@ -9,6 +9,7 @@
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 
+
 @Component({
   moduleId: module.id,
   selector: 'card-a11y',

--- a/src/demo-app/a11y/checkbox/checkbox-a11y.html
+++ b/src/demo-app/a11y/checkbox/checkbox-a11y.html
@@ -24,7 +24,7 @@
                    (change)="setAllCompleted(task.subtasks, $event.checked)">
         {{task.name}}
       </mat-checkbox>
-      <div class="sub-list">
+      <div class="demo-sub-list">
         <div *ngFor="let subtask of task.subtasks">
           <mat-checkbox [(ngModel)]="subtask.completed">
             {{subtask.name}}

--- a/src/demo-app/a11y/checkbox/checkbox-a11y.scss
+++ b/src/demo-app/a11y/checkbox/checkbox-a11y.scss
@@ -1,3 +1,3 @@
-.sub-list {
+.demo-sub-list {
   margin-left: 20px;
 }

--- a/src/demo-app/a11y/checkbox/checkbox-a11y.ts
+++ b/src/demo-app/a11y/checkbox/checkbox-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 export interface Task {
   name: string;
   completed: boolean;
@@ -27,30 +28,26 @@ export class CheckboxAccessibilityDemo {
       name: 'Reminders',
       completed: false,
       subtasks: [
-        { name: 'Cook Dinner', completed: false },
-        { name: 'Read the Material Design Spec', completed: false },
-        { name: 'Upgrade Application to Angular', completed: false }
+        {name: 'Cook Dinner', completed: false},
+        {name: 'Read the Material Design Spec', completed: false},
+        {name: 'Upgrade Application to Angular', completed: false}
       ]
     },
     {
       name: 'Groceries',
       completed: false,
       subtasks: [
-        { name: 'Organic Eggs', completed: false },
-        { name: 'Protein Powder', completed: false },
-        { name: 'Almond Meal Flour', completed: false }
+        {name: 'Organic Eggs', completed: false},
+        {name: 'Protein Powder', completed: false},
+        {name: 'Almond Meal Flour', completed: false}
       ]
     }
   ];
 
   allComplete(task: Task): boolean {
-    let subtasks = task.subtasks;
+    const subtasks = task.subtasks;
 
-    if (!subtasks) {
-      return false;
-    }
-
-    return subtasks.every(t => t.completed);
+    return task.completed || (subtasks != null && subtasks.every(t => t.completed));
   }
 
   someComplete(tasks: Task[]): boolean {

--- a/src/demo-app/a11y/chips/chips-a11y.ts
+++ b/src/demo-app/a11y/chips/chips-a11y.ts
@@ -29,19 +29,19 @@ export class ChipsAccessibilityDemo {
   message: string = '';
 
   people: Person[] = [
-    { name: 'Kara' },
-    { name: 'Jeremy' },
-    { name: 'Topher' },
-    { name: 'Elad' },
-    { name: 'Kristiyan' },
-    { name: 'Paul' }
+    {name: 'Kara'},
+    {name: 'Jeremy'},
+    {name: 'Topher'},
+    {name: 'Elad'},
+    {name: 'Kristiyan'},
+    {name: 'Paul'}
   ];
 
   availableColors = [
-    { name: 'none', color: '' },
-    { name: 'Primary', color: 'primary' },
-    { name: 'Accent', color: 'accent' },
-    { name: 'Warn', color: 'warn' }
+    {name: 'none', color: ''},
+    {name: 'Primary', color: 'primary'},
+    {name: 'Accent', color: 'accent'},
+    {name: 'Warn', color: 'warn'}
   ];
 
   constructor(public snackBar: MatSnackBar) {}
@@ -51,8 +51,8 @@ export class ChipsAccessibilityDemo {
   }
 
   add(event: MatChipInputEvent): void {
-    let input = event.input;
-    let value = event.value;
+    const input = event.input;
+    const value = event.value;
 
     // Add our person
     if ((value || '').trim()) {
@@ -69,7 +69,7 @@ export class ChipsAccessibilityDemo {
   }
 
   remove(person: Person): void {
-    let index = this.people.indexOf(person);
+    const index = this.people.indexOf(person);
 
     if (index >= 0) {
       this.people.splice(index, 1);
@@ -80,6 +80,4 @@ export class ChipsAccessibilityDemo {
   toggleVisible(): void {
     this.visible = false;
   }
-
-
 }

--- a/src/demo-app/a11y/datepicker/datepicker-a11y.ts
+++ b/src/demo-app/a11y/datepicker/datepicker-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'datepicker-a11y',

--- a/src/demo-app/a11y/dialog/dialog-a11y.ts
+++ b/src/demo-app/a11y/dialog/dialog-a11y.ts
@@ -17,12 +17,12 @@ import {MatDialog} from '@angular/material';
   styleUrls: ['dialog-a11y.css'],
 })
 export class DialogAccessibilityDemo {
-  fruitSelectedOption: string = '';
+  fruitSelectedOption = '';
 
   constructor(public dialog: MatDialog) {}
 
   openFruitDialog() {
-    let dialogRef = this.dialog.open(DialogFruitExampleDialog);
+    const dialogRef = this.dialog.open(DialogFruitExampleDialog);
     dialogRef.afterClosed().subscribe(result => {
       this.fruitSelectedOption = result;
     });
@@ -44,21 +44,21 @@ export class DialogAccessibilityDemo {
 @Component({
   moduleId: module.id,
   selector: 'dialog-fruit-a11y',
-  templateUrl: 'dialog-fruit-a11y.html'
+  templateUrl: 'dialog-fruit-a11y.html',
 })
 export class DialogFruitExampleDialog {}
 
 @Component({
   moduleId: module.id,
   selector: 'dialog-welcome-a11y',
-  templateUrl: 'dialog-welcome-a11y.html'
+  templateUrl: 'dialog-welcome-a11y.html',
 })
 export class DialogWelcomeExampleDialog {}
 
 @Component({
   moduleId: module.id,
   selector: 'dialog-neptune-a11y-dialog',
-  templateUrl: './dialog-neptune-a11y.html'
+  templateUrl: './dialog-neptune-a11y.html',
 })
 export class DialogNeptuneExampleDialog {
   constructor(public dialog: MatDialog) { }
@@ -71,18 +71,23 @@ export class DialogNeptuneExampleDialog {
 @Component({
   moduleId: module.id,
   selector: 'dialog-neptune-iframe-dialog',
-  styles: [
-    `iframe {
+  styles: [`
+    iframe {
       width: 800px;
-    }`
-  ],
-  templateUrl: './dialog-neptune-iframe-a11y.html'
+    }
+  `],
+  templateUrl: './dialog-neptune-iframe-a11y.html',
 })
 export class DialogNeptuneIFrameDialog {}
 
 @Component({
   moduleId: module.id,
   selector: 'dialog-address-form-a11y',
-  templateUrl: 'dialog-address-form-a11y.html'
+  styles: [`
+    .demo-full-width {
+      width: 100%;
+    }
+  `],
+  templateUrl: 'dialog-address-form-a11y.html',
 })
 export class DialogAddressFormDialog {}

--- a/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
+++ b/src/demo-app/a11y/dialog/dialog-address-form-a11y.html
@@ -1,44 +1,44 @@
 <h2 mat-dialog-title>Company</h2>
 
 <mat-dialog-content>
-  <form class="example-form">
-    <mat-form-field class="example-full-width">
+  <form>
+    <mat-form-field class="demo-full-width">
       <mat-label>Company (disabled)</mat-label>
       <input matInput disabled value="Google">
     </mat-form-field>
 
-    <table class="example-full-width" cellspacing="0"><tr>
-      <td><mat-form-field class="example-full-width">
+    <table class="demo-full-width" cellspacing="0"><tr>
+      <td><mat-form-field class="demo-full-width">
         <mat-label>First name</mat-label>
         <input matInput>
       </mat-form-field></td>
-      <td><mat-form-field class="example-full-width">
+      <td><mat-form-field class="demo-full-width">
         <mat-label>Long last name that will be truncated</mat-label>
         <input matInput>
       </mat-form-field></td>
     </tr></table>
 
     <p>
-      <mat-form-field class="example-full-width">
+      <mat-form-field class="demo-full-width">
         <mat-label>Address</mat-label>
         <textarea matInput>1600 Amphitheatre Pkwy</textarea>
       </mat-form-field>
-      <mat-form-field class="example-full-width">
+      <mat-form-field class="demo-full-width">
         <mat-label>Address 2</mat-label>
         <textarea matInput></textarea>
       </mat-form-field>
     </p>
 
-    <table class="example-full-width" cellspacing="0"><tr>
-      <td><mat-form-field class="example-full-width">
+    <table class="demo-full-width" cellspacing="0"><tr>
+      <td><mat-form-field class="demo-full-width">
         <mat-label>City</mat-label>
         <input matInput>
       </mat-form-field></td>
-      <td><mat-form-field class="example-full-width">
+      <td><mat-form-field class="demo-full-width">
         <mat-label>State</mat-label>
         <input matInput>
       </mat-form-field></td>
-      <td><mat-form-field class="example-full-width">
+      <td><mat-form-field class="demo-full-width">
         <mat-label>Postal code</mat-label>
         <input matInput #postalCode maxlength="5" value="94043">
         <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>

--- a/src/demo-app/a11y/expansion/expansion-a11y.html
+++ b/src/demo-app/a11y/expansion/expansion-a11y.html
@@ -1,7 +1,7 @@
 <section class="demo-expansion">
   <h2>Siberian Husky</h2>
   <p>Single expansion panel</p>
-  <mat-expansion-panel class="mat-expansion-demo-width" #myPanel>
+  <mat-expansion-panel #myPanel>
     <mat-expansion-panel-header>
       <mat-panel-description>
         Dog breed
@@ -20,7 +20,7 @@
 <section class="demo-expansion">
   <h2>Dog breeds</h2>
   <p>Multiple expansion panel</p>
-  <mat-accordion class="mat-expansion-demo-width">
+  <mat-accordion>
     <mat-expansion-panel #panel1 >
       <mat-expansion-panel-header>Golden Retriever</mat-expansion-panel-header>
       <p>

--- a/src/demo-app/a11y/expansion/expansion-a11y.ts
+++ b/src/demo-app/a11y/expansion/expansion-a11y.ts
@@ -8,11 +8,11 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'expansion-a11y',
   templateUrl: 'expansion-a11y.html',
   styleUrls: ['expansion-a11y.css']
 })
-export class ExpansionPanelAccessibilityDemo {
-}
+export class ExpansionPanelAccessibilityDemo {}

--- a/src/demo-app/a11y/grid-list/grid-list-a11y.ts
+++ b/src/demo-app/a11y/grid-list/grid-list-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 export interface Dog {
   name: string;
   human: string;
@@ -21,12 +22,12 @@ export interface Dog {
 })
 export class GridListAccessibilityDemo {
   dogs: Dog[] = [
-    { name: 'Porter', human: 'Kara' },
-    { name: 'Mal', human: 'Jeremy' },
-    { name: 'Koby', human: 'Igor' },
-    { name: 'Razzle', human: 'Ward' },
-    { name: 'Molly', human: 'Rob' },
-    { name: 'Husi', human: 'Matias' },
+    {name: 'Porter', human: 'Kara'},
+    {name: 'Mal', human: 'Jeremy'},
+    {name: 'Koby', human: 'Igor'},
+    {name: 'Razzle', human: 'Ward'},
+    {name: 'Molly', human: 'Rob'},
+    {name: 'Husi', human: 'Matias'},
   ];
 
   tiles = [

--- a/src/demo-app/a11y/icon/icon-a11y.ts
+++ b/src/demo-app/a11y/icon/icon-a11y.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
+
 
 @Component({
   moduleId: module.id,
   selector: 'icon-a11y',
   templateUrl: 'icon-a11y.html',
-  encapsulation: ViewEncapsulation.None,
 })
 export class IconAccessibilityDemo {
   constructor(private snackBar: MatSnackBar) {}

--- a/src/demo-app/a11y/input/input-a11y.ts
+++ b/src/demo-app/a11y/input/input-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 const USD_TO_JPY = 110.29;
 
 @Component({

--- a/src/demo-app/a11y/list/list-a11y.ts
+++ b/src/demo-app/a11y/list/list-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'list-a11y',

--- a/src/demo-app/a11y/menu/menu-a11y.scss
+++ b/src/demo-app/a11y/menu/menu-a11y.scss
@@ -9,4 +9,3 @@
     padding: 5px 15px;
   }
 }
-

--- a/src/demo-app/a11y/menu/menu-a11y.ts
+++ b/src/demo-app/a11y/menu/menu-a11y.ts
@@ -8,11 +8,11 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'menu-a11y',
   templateUrl: 'menu-a11y.html',
   styleUrls: ['menu-a11y.css'],
 })
-export class MenuAccessibilityDemo {
-}
+export class MenuAccessibilityDemo {}

--- a/src/demo-app/a11y/progress-spinner/progress-spinner-a11y.ts
+++ b/src/demo-app/a11y/progress-spinner/progress-spinner-a11y.ts
@@ -8,11 +8,12 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'progress-spinner-a11y',
-  templateUrl: 'progress-spinner-a11y.html'
+  templateUrl: 'progress-spinner-a11y.html',
 })
 export class ProgressSpinnerAccessibilityDemo {
-  portionValue: number = 60;
+  portionValue = 60;
 }

--- a/src/demo-app/a11y/select/select-a11y.html
+++ b/src/demo-app/a11y/select/select-a11y.html
@@ -45,7 +45,7 @@
 <section>
   <h2>Colors</h2>
 
-  <div class="select-a11y-spacer">
+  <div class="demo-select-a11y-spacer">
     <mat-form-field  color="primary">
       <mat-label>ZIP code</mat-label>
       <mat-select>
@@ -71,7 +71,7 @@
     </mat-form-field>
   </div>
 
-  <div class="select-a11y-spacer">
+  <div class="demo-select-a11y-spacer">
     <mat-form-field color="primary">
       <mat-label>Digimon</mat-label>
       <mat-select multiple>

--- a/src/demo-app/a11y/select/select-a11y.scss
+++ b/src/demo-app/a11y/select/select-a11y.scss
@@ -1,3 +1,3 @@
-.select-a11y-spacer {
+.demo-select-a11y-spacer {
   margin-bottom: 10px;
 }

--- a/src/demo-app/a11y/sidenav/basic-sidenav-a11y.html
+++ b/src/demo-app/a11y/sidenav/basic-sidenav-a11y.html
@@ -2,10 +2,10 @@
   <button mat-icon-button aria-label="Navigation menu" (click)="snav.toggle()">
     <mat-icon aria-hidden="true">menu</mat-icon>
   </button>
-  <h1 class="a11y-demo-sidenav-app-name">Basic Sidenav App</h1>
+  <h1 class="demo-a11y-sidenav-app-name">Basic Sidenav App</h1>
 </mat-toolbar>
 
-<mat-sidenav-container class="a11y-demo-sidenav-container">
+<mat-sidenav-container class="demo-a11y-sidenav-container">
   <mat-sidenav #snav mode="side" role="navigation">
     <mat-nav-list>
       <a mat-list-item routerLink="..">Home</a>
@@ -17,7 +17,7 @@
 
   <mat-sidenav-content role="region">
     <button mat-raised-button aria-label="Close basic sidenav example" color="primary"
-            class="a11y-demo-sidenav-close" routerLink="..">
+            class="demo-a11y-sidenav-close" routerLink="..">
       Close example
     </button>
   </mat-sidenav-content>

--- a/src/demo-app/a11y/sidenav/basic-sidenav-a11y.ts
+++ b/src/demo-app/a11y/sidenav/basic-sidenav-a11y.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 
 
 @Component({
@@ -14,7 +14,6 @@ import {Component, ViewEncapsulation} from '@angular/core';
   selector: 'basic-sidenav-a11y',
   templateUrl: 'basic-sidenav-a11y.html',
   styleUrls: ['shared.css'],
-  host: {'class': 'a11y-demo-sidenav-app'},
-  encapsulation: ViewEncapsulation.None,
+  host: {'class': 'demo-a11y-sidenav-app'},
 })
 export class SidenavBasicAccessibilityDemo {}

--- a/src/demo-app/a11y/sidenav/dual-sidenav-a11y.html
+++ b/src/demo-app/a11y/sidenav/dual-sidenav-a11y.html
@@ -2,14 +2,14 @@
   <button mat-icon-button aria-label="Navigation menu" (click)="startSnav.toggle()">
     <mat-icon aria-hidden="true">menu</mat-icon>
   </button>
-  <h1 class="a11y-demo-sidenav-app-name">Dual Sidenav App</h1>
-  <span class="a11y-demo-sidenav-spacer" aria-hidden="true"></span>
+  <h1 class="demo-a11y-sidenav-app-name">Dual Sidenav App</h1>
+  <span class="demo-a11y-sidenav-spacer" aria-hidden="true"></span>
   <button mat-icon-button aria-label="Playlist menu" (click)="endSnav.toggle()">
     <mat-icon aria-hidden="true">playlist_play</mat-icon>
   </button>
 </mat-toolbar>
 
-<mat-sidenav-container class="a11y-demo-sidenav-container">
+<mat-sidenav-container class="demo-a11y-sidenav-container">
   <mat-sidenav #startSnav mode="side" role="navigation">
     <mat-nav-list>
       <a mat-list-item routerLink="..">Home</a>
@@ -21,14 +21,14 @@
 
   <mat-sidenav-content role="region">
     <button mat-raised-button aria-label="Close dual sidenav example" color="primary"
-            class="a11y-demo-sidenav-close" routerLink="..">
+            class="demo-a11y-sidenav-close" routerLink="..">
       Close example
     </button>
   </mat-sidenav-content>
 
-  <mat-sidenav #endSnav mode="side" position="end" class="a11y-demo-sidenav-playlist" role="region"
+  <mat-sidenav #endSnav mode="side" position="end" class="demo-a11y-sidenav-playlist" role="region"
                (open)="playlist1.focus()">
-    <h2 class="a11y-demo-sidenav-playlist-header">Playlists</h2>
+    <h2 class="demo-a11y-sidenav-playlist-header">Playlists</h2>
     <button #playlist1 mat-button aria-label="Thumbs up playlist" (click)="play('Thumbs up')">
       Thumbs up
     </button>

--- a/src/demo-app/a11y/sidenav/dual-sidenav-a11y.scss
+++ b/src/demo-app/a11y/sidenav/dual-sidenav-a11y.scss
@@ -1,13 +1,13 @@
-.a11y-demo-sidenav-spacer {
+.demo-a11y-sidenav-spacer {
   flex: 1;
 }
 
-mat-sidenav.a11y-demo-sidenav-playlist {
+mat-sidenav.demo-a11y-sidenav-playlist {
   display: flex;
   flex-direction: column;
   width: 200px;
 }
 
-.a11y-demo-sidenav-playlist-header {
+.demo-a11y-sidenav-playlist-header {
   text-align: center;
 }

--- a/src/demo-app/a11y/sidenav/dual-sidenav-a11y.ts
+++ b/src/demo-app/a11y/sidenav/dual-sidenav-a11y.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material/snack-bar';
 
 
@@ -15,8 +15,7 @@ import {MatSnackBar} from '@angular/material/snack-bar';
   selector: 'dual-sidenav-a11y',
   templateUrl: 'dual-sidenav-a11y.html',
   styleUrls: ['shared.css', 'dual-sidenav-a11y.css'],
-  host: {'class': 'a11y-demo-sidenav-app'},
-  encapsulation: ViewEncapsulation.None,
+  host: {'class': 'demo-a11y-sidenav-app'},
 })
 export class SidenavDualAccessibilityDemo {
   constructor(private _snackbar: MatSnackBar) {}

--- a/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.html
+++ b/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.html
@@ -1,14 +1,14 @@
 <mat-toolbar color="primary" role="header" aria-label="Responsive sidenav app"
-            [class.a11y-demo-sidenav-header-fixed]="mobileQuery.matches">
+            [class.demo-a11y-sidenav-header-fixed]="mobileQuery.matches">
   <button mat-icon-button aria-label="Navigation menu" (click)="snav.toggle()">
     <mat-icon aria-hidden="true">menu</mat-icon>
   </button>
-  <h1 class="a11y-demo-sidenav-app-name">Responsive Sidenav App</h1>
+  <h1 class="demo-a11y-sidenav-app-name">Responsive Sidenav App</h1>
 </mat-toolbar>
 
 <mat-sidenav-container
-    class="a11y-demo-sidenav-container"
-    [class.a11y-demo-sidenav-container-fixed]="mobileQuery.matches"
+    class="demo-a11y-sidenav-container"
+    [class.demo-a11y-sidenav-container-fixed]="mobileQuery.matches"
     [style.marginTop.px]="mobileQuery.matches ? 56 : 0">
   <mat-sidenav
       #snav
@@ -21,14 +21,14 @@
       <a mat-list-item routerLink="../mobile">Responsive sidenav example</a>
       <a mat-list-item routerLink="../dual">Dual sidenavs example</a>
     </mat-nav-list>
-    <p class="a11y-demo-sidenav-filler" *ngFor="let f of filler">Filler content</p>
+    <p class="demo-a11y-sidenav-filler" *ngFor="let f of filler">Filler content</p>
   </mat-sidenav>
 
   <mat-sidenav-content role="region">
     <button mat-raised-button aria-label="Close responsive sidenav example" color="primary"
-            class="a11y-demo-sidenav-close" routerLink="..">
+            class="demo-a11y-sidenav-close" routerLink="..">
       Close example
     </button>
-    <p class="a11y-demo-sidenav-filler" *ngFor="let f of filler">Filler content</p>
+    <p class="demo-a11y-sidenav-filler" *ngFor="let f of filler">Filler content</p>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.scss
+++ b/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.scss
@@ -1,4 +1,4 @@
-.a11y-demo-sidenav-header-fixed {
+.demo-a11y-sidenav-header-fixed {
   position: fixed;
   z-index: 2;
 }

--- a/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.ts
+++ b/src/demo-app/a11y/sidenav/mobile-sidenav-a11y.ts
@@ -7,7 +7,7 @@
  */
 
 import {MediaMatcher} from '@angular/cdk/layout';
-import {ChangeDetectorRef, Component, OnDestroy, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectorRef, Component, OnDestroy} from '@angular/core';
 
 
 @Component({
@@ -15,8 +15,7 @@ import {ChangeDetectorRef, Component, OnDestroy, ViewEncapsulation} from '@angul
   selector: 'mobile-sidenav-a11y',
   templateUrl: 'mobile-sidenav-a11y.html',
   styleUrls: ['shared.css', 'mobile-sidenav-a11y.css'],
-  host: {'class': 'a11y-demo-sidenav-app'},
-  encapsulation: ViewEncapsulation.None,
+  host: {'class': 'demo-a11y-sidenav-app'},
 })
 export class SidenavMobileAccessibilityDemo implements OnDestroy {
   mobileQuery: MediaQueryList;

--- a/src/demo-app/a11y/sidenav/shared.scss
+++ b/src/demo-app/a11y/sidenav/shared.scss
@@ -1,4 +1,4 @@
-.a11y-demo-sidenav-app {
+.demo-a11y-sidenav-app {
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -8,22 +8,22 @@
   right: 0;
 }
 
-.a11y-demo-sidenav-container {
+.demo-a11y-sidenav-container {
   flex: 1;
 }
 
-.a11y-demo-sidenav-container-fixed {
+.demo-a11y-sidenav-container-fixed {
   flex: none;
 }
 
-h1.a11y-demo-sidenav-app-name {
+h1.demo-a11y-sidenav-app-name {
   margin-left: 8px;
 }
 
-button.a11y-demo-sidenav-close {
+button.demo-a11y-sidenav-close {
   margin: 20px;
 }
 
-.a11y-demo-sidenav-filler {
+.demo-a11y-sidenav-filler {
   margin: 100px 20px;
 }

--- a/src/demo-app/a11y/slide-toggle/slide-toggle-a11y.ts
+++ b/src/demo-app/a11y/slide-toggle/slide-toggle-a11y.ts
@@ -13,12 +13,12 @@ import {MatSnackBar} from '@angular/material';
 @Component({
   moduleId: module.id,
   selector: 'slide-toggle-a11y',
-  templateUrl: 'slide-toggle-a11y.html'
+  templateUrl: 'slide-toggle-a11y.html',
 })
 export class SlideToggleAccessibilityDemo {
-  emailToggle: boolean = true;
-  termsToggle: boolean = false;
-  musicToggle: boolean = false;
+  emailToggle = true;
+  termsToggle = false;
+  musicToggle = false;
 
   constructor(private snackBar: MatSnackBar) {}
 

--- a/src/demo-app/a11y/slider/slider-a11y.ts
+++ b/src/demo-app/a11y/slider/slider-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'slider-a11y',

--- a/src/demo-app/a11y/snack-bar/snack-bar-a11y.ts
+++ b/src/demo-app/a11y/snack-bar/snack-bar-a11y.ts
@@ -9,6 +9,7 @@
 import {Component} from '@angular/core';
 import {MatSnackBar} from '@angular/material';
 
+
 @Component({
   moduleId: module.id,
   selector: 'snack-bar-a11y',

--- a/src/demo-app/a11y/table/table-a11y.ts
+++ b/src/demo-app/a11y/table/table-a11y.ts
@@ -12,6 +12,7 @@ import {merge, Observable, BehaviorSubject} from 'rxjs';
 import {MatSort, MatPaginator} from '@angular/material';
 import {map} from 'rxjs/operators';
 
+
 export interface UserData {
   name: string;
   color: string;
@@ -85,12 +86,12 @@ export class SortDataSource extends DataSource<UserData> {
 
   getSortedData(): UserData[] {
     const data = [...exampleData];
-    if (!this._sort.active || this._sort.direction == '') {
+    if (!this._sort.active || this._sort.direction === '') {
       return data;
     }
 
     return data.sort((a: UserData, b: UserData) => {
-      return (a.age < b.age ? -1 : 1) * (this._sort.direction == 'asc' ? 1 : -1);
+      return (a.age < b.age ? -1 : 1) * (this._sort.direction === 'asc' ? 1 : -1);
     });
   }
 }

--- a/src/demo-app/a11y/tabs/tabs-a11y.html
+++ b/src/demo-app/a11y/tabs/tabs-a11y.html
@@ -18,10 +18,10 @@
   <h2>Dog breeds</h2>
   <p>Dynamic height tabs</p>
 
-  <mat-tab-group class="demo-tab-group" dynamicHeight>
+  <mat-tab-group dynamicHeight>
     <mat-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
       <ng-template mat-tab-label>{{tab.label}}</ng-template>
-      <div class="tab-content">
+      <div>
         {{tab.content}}
         <br>
         <br>
@@ -30,28 +30,28 @@
           one of the most popular breeds of dog in the United Kingdom and the United States.
           <br>
           <br>
-          A favourite disability assistance breed in many countries, Labradors are frequently 
+          A favourite disability assistance breed in many countries, Labradors are frequently
           trained to aid the blind, those who have autism, to act as a therapy dog and perform
           screening and detection work for law enforcement and other official agencies. They are
           prized as sporting and hunting dogs.
           <br>
           <br>
-          A few kennels breeding their ancestors, the St. John's water dog, were in England. 
+          A few kennels breeding their ancestors, the St. John's water dog, were in England.
           At the same time, a combination of the sheep protection policy in Newfoundland and rabies
-          quarantine in the United Kingdom, led to the gradual demise of the St. John's water dog 
+          quarantine in the United Kingdom, led to the gradual demise of the St. John's water dog
           in Canada.
           <br>
           <br>
-          In the 1830s, the 10th Earl of Home and his nephews the 5th Duke of Buccleuch and Lord 
-          John Scott, had imported progenitors of the breed from Newfoundland to Europe for 
-          use as gundogs. Another early advocate of these Newfoundland dogs, or Labrador Retrievers 
-          as they later became known, was the 2nd Earl of Malmesbury who bred them for their 
+          In the 1830s, the 10th Earl of Home and his nephews the 5th Duke of Buccleuch and Lord
+          John Scott, had imported progenitors of the breed from Newfoundland to Europe for
+          use as gundogs. Another early advocate of these Newfoundland dogs, or Labrador Retrievers
+          as they later became known, was the 2nd Earl of Malmesbury who bred them for their
           expertise in waterfowling.
 
-          During the 1880s, the 3rd Earl of Malmesbury, the 6th Duke of Buccleuch and the 12th Earl 
-          of Home collaborated to develop and establish the modern Labrador breed. The dogs 
-          Buccleuch Avon and Buccleuch Ned, given by Malmesbury to Buccleuch, were mated with 
-          bitches carrying blood from those originally imported by the 5th Duke and the 10th Earl 
+          During the 1880s, the 3rd Earl of Malmesbury, the 6th Duke of Buccleuch and the 12th Earl
+          of Home collaborated to develop and establish the modern Labrador breed. The dogs
+          Buccleuch Avon and Buccleuch Ned, given by Malmesbury to Buccleuch, were mated with
+          bitches carrying blood from those originally imported by the 5th Duke and the 10th Earl
           of Home. The offspring are considered to be the ancestors of modern Labradors.
           <br>
           <br>

--- a/src/demo-app/a11y/toolbar/toolbar-a11y.html
+++ b/src/demo-app/a11y/toolbar/toolbar-a11y.html
@@ -22,7 +22,7 @@
     <h2>Toolbar with favorite icon</h2>
     <mat-toolbar>
       <h1>My App</h1>
-      <span class="example-spacer"></span>
+      <span class="demo-spacer"></span>
       <button mat-button>
         <mat-icon aria-label="favorite">favorite</mat-icon>
       </button>

--- a/src/demo-app/a11y/toolbar/toolbar-a11y.scss
+++ b/src/demo-app/a11y/toolbar/toolbar-a11y.scss
@@ -15,6 +15,6 @@
   }
 }
 
-.example-spacer {
+.demo-spacer {
   flex: 1 1 auto;
 }

--- a/src/demo-app/a11y/tooltip/tooltip-a11y.ts
+++ b/src/demo-app/a11y/tooltip/tooltip-a11y.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'tooltip-a11y',

--- a/src/demo-app/autocomplete/autocomplete-demo.html
+++ b/src/demo-app/autocomplete/autocomplete-demo.html
@@ -1,8 +1,8 @@
 Space above cards: <input type="number" [formControl]="topHeightCtrl">
 <div [style.height.px]="topHeightCtrl.value"></div>
 <div class="demo-autocomplete">
-  <mat-card>
-    Reactive length: {{ reactiveStates.length }}
+  <mat-card *ngIf="(reactiveStates | async) as tempStates">
+    Reactive length: {{ tempStates.length }}
     <div>Reactive value: {{ stateCtrl.value | json }}</div>
     <div>Reactive dirty: {{ stateCtrl.dirty }}</div>
 
@@ -10,9 +10,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <mat-label>State</mat-label>
       <input matInput [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
       <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn">
-        <mat-option *ngFor="let state of reactiveStates | async" [value]="state">
+        <mat-option *ngFor="let state of tempStates" [value]="state">
           <span>{{ state.name }}</span>
-          <span class="demo-secondary-text"> ({{state.code}}) </span>
+          <span class="demo-secondary-text"> ({{ state.code }}) </span>
         </mat-option>
       </mat-autocomplete>
     </mat-form-field>

--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {FormControl, NgModel} from '@angular/forms';
+import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
 
 
@@ -26,7 +27,6 @@ export interface StateGroup {
   selector: 'autocomplete-demo',
   templateUrl: 'autocomplete-demo.html',
   styleUrls: ['autocomplete-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class AutocompleteDemo {
   stateCtrl: FormControl;
@@ -34,8 +34,8 @@ export class AutocompleteDemo {
   currentGroupedState = '';
   topHeightCtrl = new FormControl(0);
 
-  reactiveStates: any;
-  tdStates: any[];
+  reactiveStates: Observable<State[]>;
+  tdStates: State[];
 
   tdDisabled = false;
 
@@ -106,18 +106,19 @@ export class AutocompleteDemo {
         map(name => this.filterStates(name))
       );
 
-    this.filteredGroupedStates = this.groupedStates = this.states.reduce((groups, state) => {
-      let group = groups.find(g => g.letter === state.name[0]);
+    this.filteredGroupedStates = this.groupedStates =
+        this.states.reduce<StateGroup[]>((groups, state) => {
+          let group = groups.find(g => g.letter === state.name[0]);
 
-      if (!group) {
-        group = { letter: state.name[0], states: [] };
-        groups.push(group);
-      }
+          if (!group) {
+            group = { letter: state.name[0], states: [] };
+            groups.push(group);
+          }
 
-      group.states.push({ code: state.code, name: state.name });
+          group.states.push({ code: state.code, name: state.name });
 
-      return groups;
-    }, [] as StateGroup[]);
+          return groups;
+        }, []);
   }
 
   displayFn(value: any): string {

--- a/src/demo-app/badge/badge-demo.html
+++ b/src/demo-app/badge/badge-demo.html
@@ -1,6 +1,6 @@
-<div class="badge-demo">
+<div>
 
-  <div class="badge-examples">
+  <div class="demo-badge">
     <h3>Text</h3>
     <span [matBadge]="badgeContent" matBadgeOverlap="false" *ngIf="visible">
       Hello
@@ -34,7 +34,7 @@
     <button (click)="visible = !visible">Toggle</button>
   </div>
 
-  <div class="badge-examples">
+  <div class="demo-badge">
     <h3>Buttons</h3>
     <button mat-raised-button [matBadge]="badgeContent">
       <mat-icon color="primary">home</mat-icon>
@@ -57,7 +57,7 @@
     </button>
   </div>
 
-  <div class="badge-examples">
+  <div class="demo-badge">
     <h3>Icons</h3>
     <mat-icon [matBadge]="badgeContent">
       home
@@ -76,7 +76,7 @@
     </mat-icon>
   </div>
 
-   <div class="badge-examples">
+   <div class="demo-badge">
     <h3>Size</h3>
     <mat-icon [matBadge]="badgeContent" matBadgeSize="small">
       home

--- a/src/demo-app/badge/badge-demo.scss
+++ b/src/demo-app/badge/badge-demo.scss
@@ -1,3 +1,3 @@
-.badge-examples {
+.demo-badge {
   margin-bottom: 25px;
 }

--- a/src/demo-app/baseline/baseline-demo.scss
+++ b/src/demo-app/baseline/baseline-demo.scss
@@ -1,10 +1,11 @@
-
 .demo-basic {
   padding: 0;
 }
+
 .demo-basic .mat-card-content {
   padding: 16px;
 }
+
 .demo-full-width {
   width: 100%;
 }

--- a/src/demo-app/bottom-sheet/bottom-sheet-demo.ts
+++ b/src/demo-app/bottom-sheet/bottom-sheet-demo.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation, TemplateRef, ViewChild} from '@angular/core';
+import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {
   MatBottomSheet,
-  MatBottomSheetRef,
   MatBottomSheetConfig,
+  MatBottomSheetRef,
 } from '@angular/material/bottom-sheet';
+
 
 const defaultConfig = new MatBottomSheetConfig();
 
@@ -20,7 +21,6 @@ const defaultConfig = new MatBottomSheetConfig();
   selector: 'bottom-sheet-demo',
   styleUrls: ['bottom-sheet-demo.css'],
   templateUrl: 'bottom-sheet-demo.html',
-  encapsulation: ViewEncapsulation.None,
 })
 export class BottomSheetDemo {
   config: MatBottomSheetConfig = {

--- a/src/demo-app/button-toggle/button-toggle-demo.html
+++ b/src/demo-app/button-toggle/button-toggle-demo.html
@@ -8,7 +8,7 @@
 
 <h1>Exclusive Selection</h1>
 
-<section class="demo-section">
+<section>
   <mat-button-toggle-group name="alignment" [vertical]="isVertical">
     <mat-button-toggle value="left"[disabled]="isDisabled">
       <mat-icon>format_align_left</mat-icon>
@@ -27,7 +27,7 @@
 
 <h1>Disabled Group</h1>
 
-<section class="demo-section">
+<section>
   <mat-button-toggle-group name="checkbox" [vertical]="isVertical" [disabled]="isDisabled">
     <mat-button-toggle value="bold">
       <mat-icon>format_bold</mat-icon>
@@ -42,7 +42,7 @@
 </section>
 
 <h1>Multiple Selection</h1>
-<section class="demo-section">
+<section>
   <mat-button-toggle-group multiple [vertical]="isVertical">
     <mat-button-toggle>Flour</mat-button-toggle>
     <mat-button-toggle>Eggs</mat-button-toggle>
@@ -55,7 +55,7 @@
 <mat-button-toggle>Yes</mat-button-toggle>
 
 <h1>Dynamic Exclusive Selection</h1>
-<section class="demo-section">
+<section>
   <mat-button-toggle-group name="pies" [(ngModel)]="favoritePie" [vertical]="isVertical">
     <mat-button-toggle *ngFor="let pie of pieOptions" [value]="pie">
       {{pie}}

--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -8,10 +8,11 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'button-toggle-demo',
-  templateUrl: 'button-toggle-demo.html'
+  templateUrl: 'button-toggle-demo.html',
 })
 export class ButtonToggleDemo {
   isVertical = false;

--- a/src/demo-app/button/button-demo.html
+++ b/src/demo-app/button/button-demo.html
@@ -1,5 +1,5 @@
 <div class="demo-button">
-  <h4 class="section-header">Buttons</h4>
+  <h4 class="demo-section-header">Buttons</h4>
   <section>
     <button mat-button>normal</button>
     <button mat-raised-button>raised</button>
@@ -9,7 +9,7 @@
     <button mat-mini-fab><mat-icon>check</mat-icon></button>
   </section>
 
-  <h4 class="section-header">Anchors</h4>
+  <h4 class="demo-section-header">Anchors</h4>
   <section>
     <a href="//www.google.com" mat-button color="primary">SEARCH</a>
     <a href="//www.google.com" mat-raised-button>SEARCH</a>
@@ -19,7 +19,7 @@
     <a href="//www.google.com" mat-mini-fab><mat-icon>check</mat-icon></a>
   </section>
 
-  <h4 class="section-header">Text Buttons [mat-button]</h4>
+  <h4 class="demo-section-header">Text Buttons [mat-button]</h4>
   <section>
     <button mat-button color="primary">primary</button>
     <button mat-button color="accent">accent</button>
@@ -27,7 +27,7 @@
     <button mat-button disabled>disabled</button>
   </section>
 
-  <h4 class="section-header">Raised Buttons [mat-raised-button]</h4>
+  <h4 class="demo-section-header">Raised Buttons [mat-raised-button]</h4>
   <section>
     <button mat-raised-button color="primary">primary</button>
     <button mat-raised-button color="accent">accent</button>
@@ -35,7 +35,7 @@
     <button mat-raised-button disabled>disabled</button>
   </section>
 
-  <h4 class="section-header">Stroked Buttons [mat-stroked-button]</h4>
+  <h4 class="demo-section-header">Stroked Buttons [mat-stroked-button]</h4>
   <section>
     <button mat-stroked-button color="primary">primary</button>
     <button mat-stroked-button color="accent">accent</button>
@@ -43,7 +43,7 @@
     <button mat-stroked-button disabled>disabled</button>
   </section>
 
-  <h4 class="section-header">Flat Buttons [mat-flat-button]</h4>
+  <h4 class="demo-section-header">Flat Buttons [mat-flat-button]</h4>
   <section>
     <button mat-flat-button color="primary">primary</button>
     <button mat-flat-button color="accent">accent</button>
@@ -51,7 +51,7 @@
     <button mat-flat-button disabled>disabled</button>
   </section>
 
-  <h4 class="section-header"> Icon Buttons [mat-icon-button]</h4>
+  <h4 class="demo-section-header"> Icon Buttons [mat-icon-button]</h4>
   <section>
     <button mat-icon-button color="primary"><mat-icon>cached</mat-icon></button>
     <button mat-icon-button color="accent"><mat-icon>backup</mat-icon></button>
@@ -59,7 +59,7 @@
     <button mat-icon-button disabled><mat-icon>visibility</mat-icon></button>
   </section>
 
-  <h4 class="section-header">Fab Buttons [mat-fab]</h4>
+  <h4 class="demo-section-header">Fab Buttons [mat-fab]</h4>
   <section>
     <button mat-fab color="primary"><mat-icon>delete</mat-icon></button>
     <button mat-fab color="accent"><mat-icon>bookmark</mat-icon></button>
@@ -67,7 +67,7 @@
     <button mat-fab disabled><mat-icon>favorite</mat-icon></button>
   </section>
 
-  <h4 class="section-header"> Mini Fab Buttons [mat-mini-fab]</h4>
+  <h4 class="demo-section-header"> Mini Fab Buttons [mat-mini-fab]</h4>
   <section>
     <button mat-mini-fab color="primary"><mat-icon>menu</mat-icon></button>
     <button mat-mini-fab color="accent"><mat-icon>plus_one</mat-icon></button>
@@ -75,8 +75,8 @@
     <button mat-mini-fab disabled><mat-icon>home</mat-icon></button>
   </section>
 
-  <h4 class="section-header">Interaction/State</h4>
-  <section class="no-flex">
+  <h4 class="demo-section-header">Interaction/State</h4>
+  <section class="demo-no-flex">
     <div>
       <p>isDisabled: {{isDisabled}}</p>
       <p>Button 1 as been clicked {{clickCounter}} times</p>

--- a/src/demo-app/button/button-demo.scss
+++ b/src/demo-app/button/button-demo.scss
@@ -1,4 +1,3 @@
-
 .demo-button {
   button, a {
     margin: 8px;
@@ -15,12 +14,12 @@
     padding: 5px 15px;
   }
 
-  .section-header {
+  .demo-section-header {
     font-weight: 500;
     margin: 0;
   }
 
-  .no-flex {
+  .demo-no-flex {
     display: block;
   }
 }

--- a/src/demo-app/checkbox/checkbox-demo.html
+++ b/src/demo-app/checkbox/checkbox-demo.html
@@ -12,7 +12,7 @@
 
 </mat-checkbox> - <strong>{{printResult()}}</strong>
 </form>
-<div class="demo-checkboxes">
+<div class="demo-checkbox">
 <input id="indeterminate-toggle"
        type="checkbox"
        [(ngModel)]="isIndeterminate"

--- a/src/demo-app/checkbox/checkbox-demo.scss
+++ b/src/demo-app/checkbox/checkbox-demo.scss
@@ -1,3 +1,3 @@
-.demo-checkboxes {
+.demo-checkbox {
   margin: 8px 0;
 }

--- a/src/demo-app/checkbox/checkbox-demo.ts
+++ b/src/demo-app/checkbox/checkbox-demo.ts
@@ -31,32 +31,26 @@ export class MatCheckboxDemoNestedChecklist {
       name: 'Reminders',
       completed: false,
       subtasks: [
-        { name: 'Cook Dinner', completed: false },
-        { name: 'Read the Material Design Spec', completed: false },
-        { name: 'Upgrade Application to Angular', completed: false }
+        {name: 'Cook Dinner', completed: false},
+        {name: 'Read the Material Design Spec', completed: false},
+        {name: 'Upgrade Application to Angular', completed: false}
       ]
     },
     {
       name: 'Groceries',
       completed: false,
       subtasks: [
-        { name: 'Organic Eggs', completed: false },
-        { name: 'Protein Powder', completed: false },
-        { name: 'Almond Meal Flour', completed: false }
+        {name: 'Organic Eggs', completed: false},
+        {name: 'Protein Powder', completed: false},
+        {name: 'Almond Meal Flour', completed: false}
       ]
     }
   ];
 
   allComplete(task: Task): boolean {
-    let subtasks = task.subtasks;
+    const subtasks = task.subtasks;
 
-    if (!subtasks) {
-      return false;
-    }
-
-    return subtasks.every(t => t.completed) ? true
-        : subtasks.every(t => !t.completed) ? false
-        : task.completed;
+    return task.completed || (subtasks != null && subtasks.every(t => t.completed));
   }
 
   someComplete(tasks: Task[]): boolean {

--- a/src/demo-app/chips/chips-demo.html
+++ b/src/demo-app/chips/chips-demo.html
@@ -1,4 +1,4 @@
-<div class="chips-demo">
+<div class="demo-chips">
   <mat-card>
     <mat-toolbar color="primary">Static Chips</mat-toolbar>
 
@@ -98,7 +98,7 @@
       <button mat-button (click)="tabIndex = (tabIndex === 0 ? -1 : 0)">
         Set tabIndex to {{tabIndex === 0 ? -1 : 0}}
       </button>
-      <mat-form-field class="has-chip-list">
+      <mat-form-field class="demo-has-chip-list">
         <mat-chip-list [tabIndex]="tabIndex" #chipList1 [(ngModel)]="selectedPeople" required>
           <mat-chip  *ngFor="let person of people" [color]="color" [selectable]="selectable"
                    [removable]="removable" (removed)="remove(person)">
@@ -140,7 +140,7 @@
       </p>
 
 
-      <mat-form-field class="has-chip-list">
+      <mat-form-field class="demo-has-chip-list">
         <mat-chip-list #chipList3>
           <mat-chip *ngFor="let person of people" [color]="color" [selectable]="selectable"
                    [removable]="removable" (removed)="remove(person)">
@@ -172,25 +172,25 @@
 
       <mat-chip-list class="mat-chip-list-stacked" aria-orientation="vertical" [tabIndex]="-1">
         <mat-chip *ngFor="let aColor of availableColors"
-                 (focus)="color = aColor.color" color="{{aColor.color}}" selected="true">
+                 (focus)="color = aColor.color" [color]="aColor.color" selected="true">
           {{aColor.name}}
         </mat-chip>
       </mat-chip-list>
 
       <h4>NgModel with chip list</h4>
       <mat-chip-list [multiple]="true" [(ngModel)]="selectedColors">
-        <mat-chip *ngFor="let aColor of availableColors" color="{{aColor.color}}"
+        <mat-chip *ngFor="let aColor of availableColors" [color]="aColor.color"
                  [value]="aColor.name" (removed)="removeColor(aColor)">
           {{aColor.name}}
           <mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
 
-      The selected colors are <span *ngFor="let color of selectedColors"> {{color}}</span>.
+      The selected colors are <span *ngFor="let color of selectedColors">{{color}}</span>.
 
       <h4>NgModel with single selection chip list</h4>
       <mat-chip-list [(ngModel)]="selectedColor">
-        <mat-chip *ngFor="let aColor of availableColors" color="{{aColor.color}}"
+        <mat-chip *ngFor="let aColor of availableColors" [color]="aColor.color"
                  [value]="aColor.name" (removed)="removeColor(aColor)">
           {{aColor.name}}
           <mat-icon matChipRemove>cancel</mat-icon>

--- a/src/demo-app/chips/chips-demo.scss
+++ b/src/demo-app/chips/chips-demo.scss
@@ -1,4 +1,4 @@
-.chips-demo {
+.demo-chips {
   .mat-chip-list-stacked {
     display: block;
     max-width: 200px;
@@ -26,6 +26,6 @@
   }
 }
 
-.has-chip-list {
+.demo-has-chip-list {
   width: 100%;
 }

--- a/src/demo-app/chips/chips-demo.ts
+++ b/src/demo-app/chips/chips-demo.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ENTER, COMMA} from '@angular/cdk/keycodes';
+import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {Component} from '@angular/core';
-import {MatChipInputEvent} from '@angular/material';
+import {MatChipInputEvent, ThemePalette} from '@angular/material';
+
 
 export interface Person {
   name: string;
@@ -16,7 +17,7 @@ export interface Person {
 
 export interface DemoColor {
   name: string;
-  color: string;
+  color: ThemePalette;
 }
 
 @Component({
@@ -26,13 +27,13 @@ export interface DemoColor {
   styleUrls: ['chips-demo.css']
 })
 export class ChipsDemo {
-  tabIndex: number = 0;
-  visible: boolean = true;
-  color: string = '';
-  selectable: boolean = true;
-  removable: boolean = true;
-  addOnBlur: boolean = true;
-  message: string = '';
+  tabIndex = 0;
+  visible = true;
+  color = '';
+  selectable = true;
+  removable = true;
+  addOnBlur = true;
+  message = '';
 
   // Enter, comma, semi-colon
   separatorKeysCodes = [ENTER, COMMA, 186];
@@ -40,19 +41,19 @@ export class ChipsDemo {
   selectedPeople = null;
 
   people: Person[] = [
-    { name: 'Kara' },
-    { name: 'Jeremy' },
-    { name: 'Topher' },
-    { name: 'Elad' },
-    { name: 'Kristiyan' },
-    { name: 'Paul' }
+    {name: 'Kara'},
+    {name: 'Jeremy'},
+    {name: 'Topher'},
+    {name: 'Elad'},
+    {name: 'Kristiyan'},
+    {name: 'Paul'}
   ];
 
   availableColors: DemoColor[] = [
-    { name: 'none', color: '' },
-    { name: 'Primary', color: 'primary' },
-    { name: 'Accent', color: 'accent' },
-    { name: 'Warn', color: 'warn' }
+    {name: 'none', color: undefined},
+    {name: 'Primary', color: 'primary'},
+    {name: 'Accent', color: 'accent'},
+    {name: 'Warn', color: 'warn'}
   ];
 
   displayMessage(message: string): void {
@@ -60,8 +61,7 @@ export class ChipsDemo {
   }
 
   add(event: MatChipInputEvent): void {
-    let input = event.input;
-    let value = event.value;
+    const {input, value} = event;
 
     // Add our person
     if ((value || '').trim()) {
@@ -75,7 +75,7 @@ export class ChipsDemo {
   }
 
   remove(person: Person): void {
-    let index = this.people.indexOf(person);
+    const index = this.people.indexOf(person);
 
     if (index >= 0) {
       this.people.splice(index, 1);
@@ -99,6 +99,6 @@ export class ChipsDemo {
   toggleVisible(): void {
     this.visible = false;
   }
-  selectedColors: any[] = ['Primary', 'Warn'];
+  selectedColors: string[] = ['Primary', 'Warn'];
   selectedColor = 'Accent';
 }

--- a/src/demo-app/connected-overlay/connected-overlay-demo.html
+++ b/src/demo-app/connected-overlay/connected-overlay-demo.html
@@ -93,7 +93,6 @@
   </div>
 </div>
 
-
 <div class="demo-trigger">
   <button mat-raised-button
       cdkOverlayOrigin

--- a/src/demo-app/connected-overlay/connected-overlay-demo.ts
+++ b/src/demo-app/connected-overlay/connected-overlay-demo.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild, ViewContainerRef, ViewEncapsulation} from '@angular/core';
-import {ComponentPortal} from '@angular/cdk/portal';
 import {Directionality} from '@angular/cdk/bidi';
 import {
+  CdkOverlayOrigin,
   HorizontalConnectionPos,
   Overlay,
-  CdkOverlayOrigin,
   OverlayRef,
   VerticalConnectionPos
 } from '@angular/cdk/overlay';
+import {ComponentPortal} from '@angular/cdk/portal';
+import {Component, ViewChild, ViewContainerRef} from '@angular/core';
 
 
 @Component({
@@ -23,7 +23,6 @@ import {
   selector: 'overlay-demo',
   templateUrl: 'connected-overlay-demo.html',
   styleUrls: ['connected-overlay-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class ConnectedOverlayDemo {
   @ViewChild(CdkOverlayOrigin) _overlayOrigin: CdkOverlayOrigin;
@@ -115,7 +114,7 @@ export class ConnectedOverlayDemo {
     <div style="overflow: auto;">
       <ul><li *ngFor="let item of items; index as i">{{text}} {{i}}</li></ul>
     </div>`,
-  encapsulation: ViewEncapsulation.None,
+
 })
 export class DemoOverlay {
   items: number[];

--- a/src/demo-app/datepicker/datepicker-demo.ts
+++ b/src/demo-app/datepicker/datepicker-demo.ts
@@ -21,6 +21,7 @@ import {MatDatepickerInputEvent} from '@angular/material/datepicker';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
+
 @Component({
   moduleId: module.id,
   selector: 'datepicker-demo',
@@ -86,13 +87,13 @@ export class CustomHeader<D> implements OnDestroy {
   }
 
   previousClicked(mode: 'month' | 'year') {
-    this._calendar.activeDate = mode == 'month' ?
+    this._calendar.activeDate = mode === 'month' ?
         this._dateAdapter.addCalendarMonths(this._calendar.activeDate, -1) :
         this._dateAdapter.addCalendarYears(this._calendar.activeDate, -1);
   }
 
   nextClicked(mode: 'month' | 'year') {
-    this._calendar.activeDate = mode == 'month' ?
+    this._calendar.activeDate = mode === 'month' ?
         this._dateAdapter.addCalendarMonths(this._calendar.activeDate, 1) :
         this._dateAdapter.addCalendarYears(this._calendar.activeDate, 1);
   }

--- a/src/demo-app/demo-app-types.d.ts
+++ b/src/demo-app/demo-app-types.d.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-declare var module: { id: string };
+declare var module: {id: string};

--- a/src/demo-app/demo-app/demo-app.html
+++ b/src/demo-app/demo-app/demo-app.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="demo-root" fullscreen>
+<mat-sidenav-container fullscreen>
   <mat-sidenav #start>
     <mat-nav-list>
       <a *ngFor="let navItem of navItems"
@@ -34,7 +34,7 @@
             <mat-icon>fullscreen</mat-icon>
           </button>
           <button mat-button (click)="toggleTheme()">{{dark ? 'Light' : 'Dark'}} theme</button>
-          <button mat-button (click)="root.dir = (root.dir == 'rtl' ? 'ltr' : 'rtl')" title="Toggle between RTL and LTR">
+          <button mat-button (click)="root.dir = (root.dir === 'rtl' ? 'ltr' : 'rtl')" title="Toggle between RTL and LTR">
             {{root.dir.toUpperCase()}}
           </button>
         </div>

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -9,6 +9,7 @@
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {Component, ElementRef, ViewEncapsulation} from '@angular/core';
 
+
 /**
  * The entry app for demo site. Routes under `accessibility` will use AccessibilityDemo component,
  * while other demos will use `DemoApp` component. Since DemoApp and AccessibilityDemo use
@@ -19,7 +20,6 @@ import {Component, ElementRef, ViewEncapsulation} from '@angular/core';
   moduleId: module.id,
   selector: 'entry-app',
   template: '<router-outlet></router-outlet>',
-  encapsulation: ViewEncapsulation.None,
 })
 export class EntryApp {}
 
@@ -31,7 +31,7 @@ export class EntryApp {}
   template: `
     <p>Welcome to the development demos for Angular Material!</p>
     <p>Open the sidenav to select a demo.</p>
-  `
+  `,
 })
 export class Home {}
 
@@ -97,7 +97,7 @@ export class DemoApp {
     private _overlayContainer: OverlayContainer) {}
 
   toggleFullscreen() {
-    let elem = this._element.nativeElement.querySelector('.demo-content');
+    const elem = this._element.nativeElement.querySelector('.demo-content');
     if (elem.requestFullscreen) {
       elem.requestFullscreen();
     } else if (elem.webkitRequestFullScreen) {

--- a/src/demo-app/demo-app/demo-module.ts
+++ b/src/demo-app/demo-app/demo-module.ts
@@ -6,19 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {LayoutModule} from '@angular/cdk/layout';
 import {FullscreenOverlayContainer, OverlayContainer} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {AutocompleteDemo} from '../autocomplete/autocomplete-demo';
-import {BottomSheetDemo, ExampleBottomSheet} from '../bottom-sheet/bottom-sheet-demo';
+import {BadgeDemo} from '../badge/badge-demo';
 import {BaselineDemo} from '../baseline/baseline-demo';
+import {BottomSheetDemo, ExampleBottomSheet} from '../bottom-sheet/bottom-sheet-demo';
 import {ButtonToggleDemo} from '../button-toggle/button-toggle-demo';
 import {ButtonDemo} from '../button/button-demo';
 import {CardDemo} from '../card/card-demo';
 import {CheckboxDemo, MatCheckboxDemoNestedChecklist} from '../checkbox/checkbox-demo';
 import {ChipsDemo} from '../chips/chips-demo';
+import {ConnectedOverlayDemo, DemoOverlay} from '../connected-overlay/connected-overlay-demo';
 import {CustomHeader, DatepickerDemo} from '../datepicker/datepicker-demo';
 import {DemoMaterialModule} from '../demo-material-module';
 import {ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog} from '../dialog/dialog-demo';
@@ -36,7 +39,7 @@ import {
   KeyboardTrackingPanel,
   OverlayDemo,
   RotiniPanel,
-  SpagettiPanel
+  SpaghettiPanel
 } from '../overlay/overlay-demo';
 import {PlatformDemo} from '../platform/platform-demo';
 import {PortalDemo, ScienceJoke} from '../portal/portal-demo';
@@ -44,26 +47,24 @@ import {ProgressBarDemo} from '../progress-bar/progress-bar-demo';
 import {ProgressSpinnerDemo} from '../progress-spinner/progress-spinner-demo';
 import {RadioDemo} from '../radio/radio-demo';
 import {RippleDemo} from '../ripple/ripple-demo';
+import {ScreenTypeDemo} from '../screen-type/screen-type-demo';
 import {SelectDemo} from '../select/select-demo';
 import {SidenavDemo} from '../sidenav/sidenav-demo';
 import {SlideToggleDemo} from '../slide-toggle/slide-toggle-demo';
 import {SliderDemo} from '../slider/slider-demo';
 import {SnackBarDemo} from '../snack-bar/snack-bar-demo';
 import {StepperDemo} from '../stepper/stepper-demo';
-import {ScreenTypeDemo} from '../screen-type/screen-type-demo';
-import {LayoutModule} from '@angular/cdk/layout';
+import {TableDemoModule} from '../table/table-demo-module';
 import {
-  FoggyTabContent, RainyTabContent, SunnyTabContent, TabsDemo, Counter
+  Counter, FoggyTabContent, RainyTabContent, SunnyTabContent, TabsDemo
 } from '../tabs/tabs-demo';
 import {ToolbarDemo} from '../toolbar/toolbar-demo';
 import {TooltipDemo} from '../tooltip/tooltip-demo';
+import {TreeDemoModule} from '../tree/tree-demo-module';
 import {TypographyDemo} from '../typography/typography-demo';
 import {DemoApp, Home} from './demo-app';
 import {DEMO_APP_ROUTES} from './routes';
-import {TableDemoModule} from '../table/table-demo-module';
-import {BadgeDemo} from '../badge/badge-demo';
-import {TreeDemoModule} from '../tree/tree-demo-module';
-import {ConnectedOverlayDemo, DemoOverlay} from '../connected-overlay/connected-overlay-demo';
+
 
 @NgModule({
   imports: [
@@ -78,29 +79,33 @@ import {ConnectedOverlayDemo, DemoOverlay} from '../connected-overlay/connected-
   ],
   declarations: [
     AutocompleteDemo,
-    BottomSheetDemo,
+    BadgeDemo,
     BaselineDemo,
+    BottomSheetDemo,
     ButtonDemo,
     ButtonToggleDemo,
-    BadgeDemo,
     CardDemo,
     CheckboxDemo,
     ChipsDemo,
+    ConnectedOverlayDemo,
     ContentElementDialog,
-    DatepickerDemo,
+    Counter,
     CustomHeader,
+    DatepickerDemo,
     DemoApp,
+    DemoOverlay,
     DialogDemo,
     DrawerDemo,
+    ExampleBottomSheet,
+    ExpansionDemo,
     ExpansionDemo,
     FocusOriginDemo,
     FoggyTabContent,
-    Counter,
     GesturesDemo,
     GridListDemo,
     Home,
-    IconDemo,
     IFrameDialog,
+    IconDemo,
     InputDemo,
     JazzDialog,
     KeyboardTrackingPanel,
@@ -121,36 +126,32 @@ import {ConnectedOverlayDemo, DemoOverlay} from '../connected-overlay/connected-
     ScreenTypeDemo,
     SelectDemo,
     SidenavDemo,
-    SliderDemo,
     SlideToggleDemo,
+    SliderDemo,
     SnackBarDemo,
-    SpagettiPanel,
+    SpaghettiPanel,
     StepperDemo,
     SunnyTabContent,
     TabsDemo,
     ToolbarDemo,
     TooltipDemo,
     TypographyDemo,
-    ExampleBottomSheet,
-    ExpansionDemo,
-    ConnectedOverlayDemo,
-    DemoOverlay,
   ],
   providers: [
     {provide: OverlayContainer, useClass: FullscreenOverlayContainer},
   ],
   entryComponents: [
     ContentElementDialog,
+    CustomHeader,
     DemoApp,
+    DemoOverlay,
+    ExampleBottomSheet,
     IFrameDialog,
     JazzDialog,
     KeyboardTrackingPanel,
     RotiniPanel,
     ScienceJoke,
-    SpagettiPanel,
-    ExampleBottomSheet,
-    CustomHeader,
-    DemoOverlay,
+    SpaghettiPanel,
   ],
 })
 export class DemoModule {}

--- a/src/demo-app/demo-app/routes.ts
+++ b/src/demo-app/demo-app/routes.ts
@@ -55,6 +55,7 @@ import {TABLE_DEMO_ROUTES} from '../table/routes';
 import {BadgeDemo} from '../badge/badge-demo';
 import {ConnectedOverlayDemo} from '../connected-overlay/connected-overlay-demo';
 
+
 export const DEMO_APP_ROUTES: Routes = [
   {path: '', component: DemoApp, children: [
     {path: '', component: Home},

--- a/src/demo-app/demo-material-module.ts
+++ b/src/demo-app/demo-material-module.ts
@@ -56,6 +56,7 @@ import {
   MatTreeModule
 } from '@angular/material';
 
+
 /**
  * NgModule that includes all Material modules that are required to serve the demo-app.
  */

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Inject, ViewChild, TemplateRef} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {MatDialog, MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
+import {Component, Inject, TemplateRef, ViewChild} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogConfig, MatDialogRef} from '@angular/material';
+
 
 const defaultDialogConfig = new MatDialogConfig();
 
@@ -75,7 +76,7 @@ export class DialogDemo {
   }
 
   openContentElement() {
-    let dialogRef = this.dialog.open(ContentElementDialog, this.config);
+    const dialogRef = this.dialog.open(ContentElementDialog, this.config);
     dialogRef.componentInstance.actionsAlignment = this.actionsAlignment;
   }
 
@@ -125,11 +126,11 @@ export class JazzDialog {
 
 @Component({
   selector: 'demo-content-element-dialog',
-  styles: [
-    `img {
+  styles: [`
+    img {
       max-width: 100%;
-    }`
-  ],
+    }
+  `],
   template: `
     <h2 mat-dialog-title>Neptune</h2>
 
@@ -179,11 +180,11 @@ export class ContentElementDialog {
 
 @Component({
   selector: 'demo-iframe-dialog',
-  styles: [
-    `iframe {
+  styles: [`
+    iframe {
       width: 800px;
-    }`
-  ],
+    }
+  `],
   template: `
     <h2 mat-dialog-title>Neptune</h2>
 
@@ -199,5 +200,4 @@ export class ContentElementDialog {
     </mat-dialog-actions>
   `
 })
-export class IFrameDialog {
-}
+export class IFrameDialog {}

--- a/src/demo-app/drawer/drawer-demo.html
+++ b/src/demo-app/drawer/drawer-demo.html
@@ -9,7 +9,7 @@
     <button mat-button (click)="end.open()">Open End Side</button>
     <br>
     <button mat-button
-            (click)="start.mode = (start.mode == 'push' ? 'over' : (start.mode == 'over' ? 'side' : 'push'))">Toggle Mode</button>
+            (click)="start.mode = (start.mode === 'push' ? 'over' : (start.mode === 'over' ? 'side' : 'push'))">Toggle Mode</button>
     <div>Mode: {{start.mode}}</div>
     <br>
     <input #myinput>

--- a/src/demo-app/drawer/drawer-demo.ts
+++ b/src/demo-app/drawer/drawer-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 
 
 @Component({
@@ -14,7 +14,6 @@ import {Component, ViewEncapsulation} from '@angular/core';
   selector: 'drawer-demo',
   templateUrl: 'drawer-demo.html',
   styleUrls: ['drawer-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class DrawerDemo {
   invert = false;

--- a/src/demo-app/expansion/expansion-demo.html
+++ b/src/demo-app/expansion/expansion-demo.html
@@ -1,6 +1,6 @@
 <h1>Single Expansion Panel</h1>
 
-<mat-expansion-panel class="mat-expansion-demo-width" #myPanel>
+<mat-expansion-panel class="demo-expansion-width" #myPanel>
   <mat-expansion-panel-header [expandedHeight]="expandedHeight" [collapsedHeight]="collapsedHeight">
     <mat-panel-description>This is a panel description.</mat-panel-description>
     <mat-panel-title>Panel Title</mat-panel-title>
@@ -56,7 +56,7 @@
 </div>
 <br>
 <mat-accordion [displayMode]="displayMode" [multi]="multi"
-              class="mat-expansion-demo-width">
+              class="demo-expansion-width">
   <mat-expansion-panel #panel1  [hideToggle]="hideToggle">
     <mat-expansion-panel-header>Section 1</mat-expansion-panel-header>
     <p>This is the content text that makes sense here.</p>
@@ -82,7 +82,7 @@
     <mat-slide-toggle [(ngModel)]="accordion1.multi">Allow Multi Expansion</mat-slide-toggle>
   </div>
 </div>
-<cdk-accordion class="mat-expansion-demo-width" #accordion1="cdkAccordion">
+<cdk-accordion class="demo-expansion-width" #accordion1="cdkAccordion">
   <cdk-accordion-item #item1="cdkAccordionItem">
     <p>
       Item 1:

--- a/src/demo-app/expansion/expansion-demo.scss
+++ b/src/demo-app/expansion/expansion-demo.scss
@@ -1,4 +1,4 @@
-.mat-expansion-demo-width {
+.demo-expansion-width {
   width: 600px;
   display: block;
 }

--- a/src/demo-app/expansion/expansion-demo.ts
+++ b/src/demo-app/expansion/expansion-demo.ts
@@ -6,20 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {MatAccordion} from '@angular/material';
+
 
 @Component({
   moduleId: module.id,
   selector: 'expansion-demo',
   styleUrls: ['expansion-demo.css'],
   templateUrl: 'expansion-demo.html',
-  encapsulation: ViewEncapsulation.None,
 })
 export class ExpansionDemo {
   @ViewChild(MatAccordion) accordion: MatAccordion;
 
-  displayMode: string = 'default';
+  displayMode = 'default';
   multi = false;
   hideToggle = false;
   disabled = false;

--- a/src/demo-app/gestures/gestures-demo.ts
+++ b/src/demo-app/gestures/gestures-demo.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'gestures-demo',

--- a/src/demo-app/grid-list/grid-list-demo.html
+++ b/src/demo-app/grid-list/grid-list-demo.html
@@ -30,7 +30,7 @@
 
   <mat-card>
     <mat-card-title>Ratio-height grid list</mat-card-title>
-    <mat-card-content class="demo-ratio-list">
+    <mat-card-content>
       <mat-grid-list cols="2" [rowHeight]="ratio" gutterSize="4px">
         <mat-grid-tile *ngFor="let tile of tiles" [style.background]="'lightblue'">
           {{tile.text}}
@@ -44,7 +44,7 @@
 
   <mat-card>
     <mat-card-title>Fit-height grid list</mat-card-title>
-    <mat-card-content class="demo-fit-list">
+    <mat-card-content>
       <mat-grid-list cols="2" rowHeight="fit" [gutterSize]="ratioGutter"
                     [style.height]="fitListHeight">
         <mat-grid-tile *ngFor="let tile of tiles" [style.background]="'#F1EBBA'">

--- a/src/demo-app/grid-list/grid-list-demo.ts
+++ b/src/demo-app/grid-list/grid-list-demo.ts
@@ -16,20 +16,20 @@ import {Component} from '@angular/core';
   styleUrls: ['grid-list-demo.css']
 })
 export class GridListDemo {
-  tiles: any[] = [
+  tiles: {text: string, cols: number, rows: number, color: string}[] = [
     {text: 'One', cols: 3, rows: 1, color: 'lightblue'},
     {text: 'Two', cols: 1, rows: 2, color: 'lightgreen'},
     {text: 'Three', cols: 1, rows: 1, color: 'lightpink'},
     {text: 'Four', cols: 2, rows: 1, color: '#DDBDF1'},
   ];
 
-  dogs: Object[] = [
-    { name: 'Porter', human: 'Kara' },
-    { name: 'Mal', human: 'Jeremy' },
-    { name: 'Koby', human: 'Igor' },
-    { name: 'Razzle', human: 'Ward' },
-    { name: 'Molly', human: 'Rob' },
-    { name: 'Husi', human: 'Matias' },
+  dogs: {name: string, human: string}[] = [
+    {name: 'Porter', human: 'Kara'},
+    {name: 'Mal', human: 'Jeremy'},
+    {name: 'Koby', human: 'Igor'},
+    {name: 'Razzle', human: 'Ward'},
+    {name: 'Molly', human: 'Rob'},
+    {name: 'Husi', human: 'Matias'},
   ];
 
   basicRowHeight = 80;

--- a/src/demo-app/icon/icon-demo.html
+++ b/src/demo-app/icon/icon-demo.html
@@ -5,7 +5,7 @@
 
   <p>
     By name registered with MatIconProvider:
-    <mat-icon svgIcon="thumb-up" class="green"></mat-icon>
+    <mat-icon svgIcon="thumb-up" class="demo-icon-green"></mat-icon>
     <mat-icon svgIcon="thumb-up"></mat-icon>
   </p>
 

--- a/src/demo-app/icon/icon-demo.scss
+++ b/src/demo-app/icon/icon-demo.scss
@@ -1,3 +1,3 @@
-.demo-icon .mat-icon.green {
+.demo-icon .mat-icon.demo-icon-green {
   color: green;
 }

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
-import {DomSanitizer} from '@angular/platform-browser';
+import {Component} from '@angular/core';
 import {MatIconRegistry} from '@angular/material';
+import {DomSanitizer} from '@angular/platform-browser';
+
 
 @Component({
   moduleId: module.id,
   selector: 'mat-icon-demo',
   templateUrl: 'icon-demo.html',
   styleUrls: ['icon-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class IconDemo {
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {

--- a/src/demo-app/input/input-demo.scss
+++ b/src/demo-app/input/input-demo.scss
@@ -3,9 +3,11 @@
 .demo-basic {
   padding: 0;
 }
+
 .demo-basic .mat-card-content {
   padding: 16px;
 }
+
 .demo-full-width {
   width: 100%;
 }

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -23,7 +23,7 @@ const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA
   styleUrls: ['input-demo.css'],
 })
 export class InputDemo {
-  floatingLabel: string = 'auto';
+  floatingLabel = 'auto';
   color: boolean;
   requiredField: boolean;
   hideRequiredMarker: boolean;
@@ -39,12 +39,12 @@ export class InputDemo {
   dividerColorExample1: string;
   dividerColorExample2: string;
   dividerColorExample3: string;
-  items: any[] = [
-    { value: 10 },
-    { value: 20 },
-    { value: 30 },
-    { value: 40 },
-    { value: 50 },
+  items: {value: number}[] = [
+    {value: 10},
+    {value: 20},
+    {value: 30},
+    {value: 40},
+    {value: 50},
   ];
   rows = 8;
   formControl = new FormControl('hello', Validators.required);

--- a/src/demo-app/list/list-demo.html
+++ b/src/demo-app/list/list-demo.html
@@ -1,9 +1,9 @@
 
 <h1>mat-list demo</h1>
 
-<button mat-raised-button (click)="thirdLine=!thirdLine" class="demo-button">Show third line</button>
+<button mat-raised-button (click)="thirdLine=!thirdLine">Show third line</button>
 
-<div class="demo">
+<div class="demo-list">
   <div>
     <h2>Normal lists</h2>
 

--- a/src/demo-app/list/list-demo.scss
+++ b/src/demo-app/list/list-demo.scss
@@ -1,5 +1,4 @@
-
-.demo {
+.demo-list {
   display: flex;
   flex-flow: row wrap;
 

--- a/src/demo-app/list/list-demo.ts
+++ b/src/demo-app/list/list-demo.ts
@@ -22,13 +22,13 @@ export class ListDemo {
     'Paprika'
   ];
 
-  contacts: any[] = [
+  contacts: {name: string, headline: string}[] = [
     {name: 'Nancy', headline: 'Software engineer'},
     {name: 'Mary', headline: 'TPM'},
     {name: 'Bobby', headline: 'UX designer'}
   ];
 
-  messages: any[] = [
+  messages: {from: string, subject: string, message: string, image: string}[] = [
     {
       from: 'Nancy',
       subject: 'Brunch?',
@@ -49,7 +49,7 @@ export class ListDemo {
     }
   ];
 
-  links: any[] = [
+  links: {name: string}[] = [
     {name: 'Inbox'},
     {name: 'Outbox'},
     {name: 'Spam'},
@@ -57,13 +57,13 @@ export class ListDemo {
 
   ];
 
-  thirdLine: boolean = false;
-  infoClicked: boolean = false;
-  selectionListDisabled: boolean = false;
+  thirdLine = false;
+  infoClicked = false;
+  selectionListDisabled = false;
 
   selectedOptions: string[] = ['apples'];
-  changeEventCount: number = 0;
-  modelChangeEventCount: number = 0;
+  changeEventCount = 0;
+  modelChangeEventCount = 0;
 
   onSelectedOptionsChange(values: string[]) {
     this.selectedOptions = values;

--- a/src/demo-app/live-announcer/live-announcer-demo.html
+++ b/src/demo-app/live-announcer/live-announcer-demo.html
@@ -1,5 +1,3 @@
-<div class="demo-live-announcer">
-
+<div>
   <button mat-button (click)="announceText('Hey Google')">Announce Text</button>
-
 </div>

--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -1,5 +1,5 @@
 <div class="demo-menu">
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>You clicked on: {{ selected }}</p>
 
     <mat-toolbar>
@@ -14,7 +14,7 @@
       </button>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>Menu with divider</p>
 
     <mat-toolbar>
@@ -32,7 +32,7 @@
       </ng-container>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>Nested menu</p>
 
     <mat-toolbar>
@@ -86,7 +86,7 @@
       <button mat-menu-item>Blue Spiny Lizard</button>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>Clicking these will navigate:</p>
     <mat-toolbar>
       <button mat-icon-button [matMenuTriggerFor]="anchorMenu" aria-label="Open anchor menu">
@@ -100,24 +100,24 @@
       </a>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>
       Position x: before
     </p>
-    <mat-toolbar class="end-icon">
+    <mat-toolbar class="demo-end-icon">
       <button mat-icon-button [matMenuTriggerFor]="posXMenu" aria-label="Open x-positioned menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
 
-    <mat-menu xPosition="before" #posXMenu="matMenu" class="before">
+    <mat-menu xPosition="before" #posXMenu="matMenu">
       <button mat-menu-item *ngFor="let item of iconItems" [disabled]="item.disabled">
         <mat-icon>{{ item.icon }}</mat-icon>
         {{ item.text }}
       </button>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>
       Position y: above
     </p>
@@ -136,7 +136,7 @@
 </div>
 
 <div class="demo-menu">
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>overlapTrigger: false</p>
 
     <mat-toolbar>
@@ -151,24 +151,24 @@
       </button>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>
       Position x: before, overlapTrigger: false
     </p>
-    <mat-toolbar class="end-icon">
+    <mat-toolbar class="demo-end-icon">
       <button mat-icon-button [mat-menu-trigger-for]="posXMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
 
-    <mat-menu xPosition="before" [overlapTrigger]="false" #posXMenuOverlay="matMenu" class="before">
+    <mat-menu xPosition="before" [overlapTrigger]="false" #posXMenuOverlay="matMenu">
       <button mat-menu-item *ngFor="let item of iconItems" [disabled]="item.disabled">
         <mat-icon>{{ item.icon }}</mat-icon>
         {{ item.text }}
       </button>
     </mat-menu>
   </div>
-  <div class="menu-section">
+  <div class="demo-menu-section">
     <p>
       Position y: above, overlapTrigger: false
     </p>

--- a/src/demo-app/menu/menu-demo.scss
+++ b/src/demo-app/menu/menu-demo.scss
@@ -2,12 +2,12 @@
   display: flex;
   flex-flow: row wrap;
 
-  .menu-section {
+  .demo-menu-section {
     width: 300px;
     margin: 20px;
   }
 
-  .end-icon {
+  .demo-end-icon {
     justify-content: flex-end;
   }
 }

--- a/src/demo-app/overlay/overlay-demo.scss
+++ b/src/demo-app/overlay/overlay-demo.scss
@@ -10,7 +10,7 @@
   background-color: lightgoldenrodyellow;
 }
 
-.demo-spagetti {
+.demo-spaghetti {
   margin: 0;
   padding: 10px;
   border: 1px solid black;

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -13,8 +13,7 @@ import {
   QueryList,
   ViewChild,
   ViewChildren,
-  ViewContainerRef,
-  ViewEncapsulation,
+  ViewContainerRef
 } from '@angular/core';
 import {filter, tap} from 'rxjs/operators';
 
@@ -24,7 +23,6 @@ import {filter, tap} from 'rxjs/operators';
   selector: 'overlay-demo',
   templateUrl: 'overlay-demo.html',
   styleUrls: ['overlay-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class OverlayDemo {
   nextPosition: number = 0;
@@ -39,7 +37,7 @@ export class OverlayDemo {
   constructor(public overlay: Overlay, public viewContainerRef: ViewContainerRef) { }
 
   openRotiniPanel() {
-    let config = new OverlayConfig();
+    const config = new OverlayConfig();
 
     config.positionStrategy = this.overlay.position()
         .global()
@@ -48,12 +46,12 @@ export class OverlayDemo {
 
     this.nextPosition += 30;
 
-    let overlayRef = this.overlay.create(config);
+    const overlayRef = this.overlay.create(config);
     overlayRef.attach(new ComponentPortal(RotiniPanel, this.viewContainerRef));
   }
 
   openFusilliPanel() {
-    let config = new OverlayConfig();
+    const config = new OverlayConfig();
 
     config.positionStrategy = this.overlay.position()
         .global()
@@ -62,51 +60,51 @@ export class OverlayDemo {
 
     this.nextPosition += 30;
 
-    let overlayRef = this.overlay.create(config);
+    const overlayRef = this.overlay.create(config);
     overlayRef.attach(this.templatePortals.first);
   }
 
   openSpaghettiPanel() {
     // TODO(jelbourn): separate overlay demo for connected positioning.
-    let strategy = this.overlay.position()
+    const strategy = this.overlay.position()
         .connectedTo(
             this._overlayOrigin.elementRef,
             {originX: 'start', originY: 'bottom'},
             {overlayX: 'start', overlayY: 'top'} );
 
-    let config = new OverlayConfig({positionStrategy: strategy});
-    let overlayRef = this.overlay.create(config);
+    const config = new OverlayConfig({positionStrategy: strategy});
+    const overlayRef = this.overlay.create(config);
 
-    overlayRef.attach(new ComponentPortal(SpagettiPanel, this.viewContainerRef));
+    overlayRef.attach(new ComponentPortal(SpaghettiPanel, this.viewContainerRef));
   }
 
   openTortelliniPanel() {
-    let strategy = this.overlay.position()
+    const strategy = this.overlay.position()
         .connectedTo(
             this.tortelliniOrigin.elementRef,
             {originX: 'start', originY: 'bottom'},
             {overlayX: 'end', overlayY: 'top'} );
 
-    let config = new OverlayConfig({positionStrategy: strategy});
-    let overlayRef = this.overlay.create(config);
+    const config = new OverlayConfig({positionStrategy: strategy});
+    const overlayRef = this.overlay.create(config);
 
     overlayRef.attach(this.tortelliniTemplate);
   }
 
   openPanelWithBackdrop() {
-    let config = new OverlayConfig({
+    const config = new OverlayConfig({
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-transparent-backdrop',
       positionStrategy: this.overlay.position().global().centerHorizontally()
     });
 
-    let overlayRef = this.overlay.create(config);
+    const overlayRef = this.overlay.create(config);
     overlayRef.attach(this.templatePortals.first);
     overlayRef.backdropClick().subscribe(() => overlayRef.detach());
   }
 
   openKeyboardTracking() {
-    let config = new OverlayConfig();
+    const config = new OverlayConfig();
 
     config.positionStrategy = this.overlay.position()
       .global()
@@ -115,7 +113,7 @@ export class OverlayDemo {
 
     this.nextPosition += 30;
 
-    let overlayRef = this.overlay.create(config);
+    const overlayRef = this.overlay.create(config);
     const componentRef = overlayRef
         .attach(new ComponentPortal(KeyboardTrackingPanel, this.viewContainerRef));
 
@@ -125,14 +123,13 @@ export class OverlayDemo {
         filter(e => e.key === 'Escape')
       ).subscribe(() => overlayRef.detach());
   }
-
 }
 
 /** Simple component to load into an overlay */
 @Component({
   moduleId: module.id,
   selector: 'rotini-panel',
-  template: '<p class="demo-rotini">Rotini {{value}}</p>'
+  template: '<p class="demo-rotini">Rotini {{value}}</p>',
 })
 export class RotiniPanel {
   value: number = 9000;
@@ -140,17 +137,17 @@ export class RotiniPanel {
 
 /** Simple component to load into an overlay */
 @Component({
-  selector: 'spagetti-panel',
-  template: '<div class="demo-spagetti">Spagetti {{value}}</div>'
+  selector: 'spaghetti-panel',
+  template: '<div class="demo-spaghetti">Spagetti {{value}}</div>',
 })
-export class SpagettiPanel {
+export class SpaghettiPanel {
   value: string = 'Omega';
 }
 
 /** Simple component to load into an overlay */
 @Component({
   selector: 'keyboard-panel',
-  template: '<div class="demo-keyboard">Last Keydown: {{ lastKeydown }}</div>'
+  template: '<div class="demo-keyboard">Last Keydown: {{ lastKeydown }}</div>',
 })
 export class KeyboardTrackingPanel {
   lastKeydown = '';

--- a/src/demo-app/screen-type/screen-type-demo.ts
+++ b/src/demo-app/screen-type/screen-type-demo.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
-import {BreakpointObserver, BreakpointState, Breakpoints} from '@angular/cdk/layout';
+import {BreakpointObserver, Breakpoints, BreakpointState} from '@angular/cdk/layout';
+import {Component} from '@angular/core';
 import {Observable} from 'rxjs';
+
 
 @Component({
   moduleId: module.id,
   selector: 'screen-type',
   templateUrl: 'screen-type-demo.html',
   styleUrls: ['screen-type-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class ScreenTypeDemo {
   isHandset: Observable<BreakpointState>;
@@ -24,12 +24,13 @@ export class ScreenTypeDemo {
   isPortrait: Observable<BreakpointState>;
   isLandscape: Observable<BreakpointState>;
 
-  constructor(private mqm: BreakpointObserver) {
-    this.isHandset = this.mqm.observe([Breakpoints.HandsetLandscape,
+  constructor(private breakpointObserver: BreakpointObserver) {
+    this.isHandset = this.breakpointObserver.observe([Breakpoints.HandsetLandscape,
                                        Breakpoints.HandsetPortrait]);
-    this.isTablet = this.mqm.observe(Breakpoints.Tablet);
-    this.isWeb = this.mqm.observe([Breakpoints.WebLandscape, Breakpoints.WebPortrait]);
-    this.isPortrait = this.mqm.observe('(orientation: portrait)');
-    this.isLandscape = this.mqm.observe('(orientation: landscape)');
+    this.isTablet = this.breakpointObserver.observe(Breakpoints.Tablet);
+    this.isWeb = this.breakpointObserver.observe([Breakpoints.WebLandscape,
+                                  Breakpoints.WebPortrait]);
+    this.isPortrait = this.breakpointObserver.observe('(orientation: portrait)');
+    this.isLandscape = this.breakpointObserver.observe('(orientation: landscape)');
   }
 }

--- a/src/demo-app/select/select-demo.html
+++ b/src/demo-app/select/select-demo.html
@@ -152,7 +152,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         <mat-form-field>
           <mat-label>Food I would like to eat</mat-label>
           <mat-select [formControl]="foodControl">
-            <mat-option *ngFor="let food of foods" [value]="food.value"> {{ food.viewValue }}</mat-option>
+            <mat-option *ngFor="let food of foods" [value]="food.value">{{ food.viewValue }}</mat-option>
           </mat-select>
         </mat-form-field>
         <p> Value: {{ foodControl.value }} </p>

--- a/src/demo-app/select/select-demo.ts
+++ b/src/demo-app/select/select-demo.ts
@@ -10,6 +10,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MatSelectChange} from '@angular/material';
 
+
 @Component({
     moduleId: module.id,
     selector: 'select-demo',
@@ -29,7 +30,7 @@ export class SelectDemo {
   currentPokemonFromGroup: string;
   currentDigimon: string;
   latestChangeEvent: MatSelectChange;
-  floatLabel: string = 'auto';
+  floatLabel = 'auto';
   foodControl = new FormControl('pizza-1');
   topHeightCtrl = new FormControl(0);
   drinksTheme = 'primary';
@@ -75,44 +76,44 @@ export class SelectDemo {
     {
       name: 'Grass',
       pokemon: [
-        { value: 'bulbasaur-0', viewValue: 'Bulbasaur' },
-        { value: 'oddish-1', viewValue: 'Oddish' },
-        { value: 'bellsprout-2', viewValue: 'Bellsprout' }
+        {value: 'bulbasaur-0', viewValue: 'Bulbasaur'},
+        {value: 'oddish-1', viewValue: 'Oddish'},
+        {value: 'bellsprout-2', viewValue: 'Bellsprout'}
       ]
     },
     {
       name: 'Water',
       pokemon: [
-        { value: 'squirtle-3', viewValue: 'Squirtle' },
-        { value: 'psyduck-4', viewValue: 'Psyduck' },
-        { value: 'horsea-5', viewValue: 'Horsea' }
+        {value: 'squirtle-3', viewValue: 'Squirtle'},
+        {value: 'psyduck-4', viewValue: 'Psyduck'},
+        {value: 'horsea-5', viewValue: 'Horsea'}
       ]
     },
     {
       name: 'Fire',
       disabled: true,
       pokemon: [
-        { value: 'charmander-6', viewValue: 'Charmander' },
-        { value: 'vulpix-7', viewValue: 'Vulpix' },
-        { value: 'flareon-8', viewValue: 'Flareon' }
+        {value: 'charmander-6', viewValue: 'Charmander'},
+        {value: 'vulpix-7', viewValue: 'Vulpix'},
+        {value: 'flareon-8', viewValue: 'Flareon'}
       ]
     },
     {
       name: 'Psychic',
       pokemon: [
-        { value: 'mew-9', viewValue: 'Mew' },
-        { value: 'mewtwo-10', viewValue: 'Mewtwo' },
+        {value: 'mew-9', viewValue: 'Mew'},
+        {value: 'mewtwo-10', viewValue: 'Mewtwo'},
       ]
     }
   ];
 
   digimon = [
-    { value: 'mihiramon-0', viewValue: 'Mihiramon' },
-    { value: 'sandiramon-1', viewValue: 'Sandiramon' },
-    { value: 'sinduramon-2', viewValue: 'Sinduramon' },
-    { value: 'pajiramon-3', viewValue: 'Pajiramon' },
-    { value: 'vajiramon-4', viewValue: 'Vajiramon' },
-    { value: 'indramon-5', viewValue: 'Indramon' }
+    {value: 'mihiramon-0', viewValue: 'Mihiramon'},
+    {value: 'sandiramon-1', viewValue: 'Sandiramon'},
+    {value: 'sinduramon-2', viewValue: 'Sinduramon'},
+    {value: 'pajiramon-3', viewValue: 'Pajiramon'},
+    {value: 'vajiramon-4', viewValue: 'Vajiramon'},
+    {value: 'indramon-5', viewValue: 'Indramon'}
   ];
 
   toggleDisabled() {

--- a/src/demo-app/sidenav/sidenav-demo.ts
+++ b/src/demo-app/sidenav/sidenav-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 
 
 @Component({
@@ -14,7 +14,7 @@ import {Component, ViewEncapsulation} from '@angular/core';
   selector: 'sidenav-demo',
   templateUrl: 'sidenav-demo.html',
   styleUrls: ['sidenav-demo.css'],
-  encapsulation: ViewEncapsulation.None,
+
 })
 export class SidenavDemo {
   isLaunched = false;

--- a/src/demo-app/slide-toggle/slide-toggle-demo.html
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.html
@@ -1,4 +1,4 @@
-<div class="slide-toggle-example">
+<div class="demo-slide-toggle">
 
   <mat-slide-toggle color="primary" [(ngModel)]="firstToggle">
     Default Slide Toggle

--- a/src/demo-app/slide-toggle/slide-toggle-demo.scss
+++ b/src/demo-app/slide-toggle/slide-toggle-demo.scss
@@ -1,4 +1,4 @@
-.slide-toggle-example {
+.demo-slide-toggle {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/demo-app/snack-bar/snack-bar-demo.html
+++ b/src/demo-app/snack-bar/snack-bar-demo.html
@@ -28,7 +28,6 @@
         <mat-label>Snack bar action label</mat-label>
         <input matInput
                type="text"
-               class="demo-button-label-input"
                [(ngModel)]="actionButtonLabel">
       </mat-form-field>
     </mat-checkbox>
@@ -40,7 +39,6 @@
         <mat-label>Auto hide duration in ms</mat-label>
         <input matInput
                type="number"
-               class="demo-button-label-input"
                [(ngModel)]="autoHide">
       </mat-form-field>
     </mat-checkbox>

--- a/src/demo-app/snack-bar/snack-bar-demo.scss
+++ b/src/demo-app/snack-bar/snack-bar-demo.scss
@@ -1,8 +1,8 @@
-.party {
-  animation: party 5000ms infinite;
+.demo-party {
+  animation: demo-party 5000ms infinite;
 }
 
-@keyframes party {
+@keyframes demo-party {
   0% { background: #00f; }
   10% { background: #8e44ad; }
   20% { background: #1abc9c; }

--- a/src/demo-app/snack-bar/snack-bar-demo.ts
+++ b/src/demo-app/snack-bar/snack-bar-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Dir} from '@angular/cdk/bidi';
-import {Component, ViewEncapsulation, ViewChild, TemplateRef} from '@angular/core';
+import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {
   MatSnackBar,
   MatSnackBarConfig,
@@ -21,16 +21,15 @@ import {
   selector: 'snack-bar-demo',
   styleUrls: ['snack-bar-demo.css'],
   templateUrl: 'snack-bar-demo.html',
-  encapsulation: ViewEncapsulation.None,
 })
 export class SnackBarDemo {
   @ViewChild('template') template: TemplateRef<any>;
-  message: string = 'Snack Bar opened.';
-  actionButtonLabel: string = 'Retry';
-  action: boolean = false;
-  setAutoHide: boolean = true;
-  autoHide: number = 10000;
-  addExtraClass: boolean = false;
+  message = 'Snack Bar opened.';
+  actionButtonLabel = 'Retry';
+  action = false;
+  setAutoHide = true;
+  autoHide = 10000;
+  addExtraClass = false;
   horizontalPosition: MatSnackBarHorizontalPosition = 'center';
   verticalPosition: MatSnackBarVerticalPosition = 'bottom';
 
@@ -52,7 +51,7 @@ export class SnackBarDemo {
     config.verticalPosition = this.verticalPosition;
     config.horizontalPosition = this.horizontalPosition;
     config.duration = this.setAutoHide ? this.autoHide : 0;
-    config.panelClass = this.addExtraClass ? ['party'] : undefined;
+    config.panelClass = this.addExtraClass ? ['demo-party'] : undefined;
     config.direction = this.dir.value;
     return config;
   }

--- a/src/demo-app/stepper/stepper-demo.ts
+++ b/src/demo-app/stepper/stepper-demo.ts
@@ -9,10 +9,11 @@
 import {Component} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, Validators} from '@angular/forms';
 
+
 @Component({
   moduleId: module.id,
   selector: 'stepper-demo',
-  templateUrl: 'stepper-demo.html'
+  templateUrl: 'stepper-demo.html',
 })
 export class StepperDemo {
   formGroup: FormGroup;

--- a/src/demo-app/table/custom-table/custom-table.html
+++ b/src/demo-app/table/custom-table/custom-table.html
@@ -1,4 +1,4 @@
-<mat-card class="demo-table-card">
+<mat-card>
   <h3> MatTable with Simple Columns </h3>
 
   <mat-table [dataSource]="simpleTableDataSource"
@@ -20,7 +20,7 @@
 
 
 
-<mat-card class="demo-table-card">
+<mat-card>
   <h3> Wrapper Table </h3>
 
   <wrapper-table [dataSource]="wrapperTableDataSource" [columns]="columnsToDisplay"

--- a/src/demo-app/table/custom-table/custom-table.ts
+++ b/src/demo-app/table/custom-table/custom-table.ts
@@ -10,6 +10,7 @@ import {Component, ViewChild} from '@angular/core';
 import {MatSort, MatTableDataSource} from '@angular/material';
 import {Element, ELEMENT_DATA} from '../element-data';
 
+
 @Component({
   moduleId: module.id,
   templateUrl: 'custom-table.html',

--- a/src/demo-app/table/custom-table/simple-column.ts
+++ b/src/demo-app/table/custom-table/simple-column.ts
@@ -11,6 +11,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {MatSortHeader} from '@angular/material/sort';
 import {MatColumnDef, MatTable} from '@angular/material';
 
+
 /**
  * Column that shows simply shows text content for the header and row
  * cells. By default, the name of this column will be assumed to be both the header
@@ -93,6 +94,6 @@ export class SimpleColumn<T> {
   }
 
   getData(data: T): any {
-    return this.dataAccessor ? this.dataAccessor(data, this.name) : (<any>data)[this.name];
+    return this.dataAccessor ? this.dataAccessor(data, this.name) : (data as any)[this.name];
   }
 }

--- a/src/demo-app/table/custom-table/wrapper-table.ts
+++ b/src/demo-app/table/custom-table/wrapper-table.ts
@@ -11,6 +11,7 @@ import {DataSource} from '@angular/cdk/collections';
 import {MatColumnDef, MatHeaderRowDef, MatRowDef, MatTable} from '@angular/material';
 import {SimpleColumn} from './simple-column';
 
+
 @Component({
   moduleId: module.id,
   selector: 'wrapper-table',

--- a/src/demo-app/table/data-input-table/data-input-table.html
+++ b/src/demo-app/table/data-input-table/data-input-table.html
@@ -20,12 +20,12 @@
   <button mat-raised-button (click)="this.removeDataSource()">Remove Data Source</button>
 </div>
 
-<mat-card class="demo-table-card">
-  <h3> CdkTable  </h3>
+<mat-card>
+  <h3> CdkTable </h3>
 
   <cdk-table #cdkTable [dataSource]="dataSourceInput">
     <!-- Name (normal column) -->
-    <ng-container cdkColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+    <ng-container [cdkColumnDef]="column" *ngFor="let column of columnsToDisplay">
       <cdk-header-cell *cdkHeaderCellDef> {{column}} </cdk-header-cell>
       <cdk-cell *cdkCellDef="let element"> {{element[column]}} </cdk-cell>
     </ng-container>
@@ -35,12 +35,12 @@
   </cdk-table>
 </mat-card>
 
-<mat-card class="demo-table-card">
+<mat-card>
   <h3> MatTable </h3>
 
   <mat-table #matTable [dataSource]="dataSourceInput">
     <!-- Name (normal column) -->
-    <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+    <ng-container [matColumnDef]="column" *ngFor="let column of columnsToDisplay">
       <mat-header-cell *matHeaderCellDef> {{column}} </mat-header-cell>
       <mat-cell *matCellDef="let element"> {{element[column]}} </mat-cell>
     </ng-container>

--- a/src/demo-app/table/native-table/native-table.html
+++ b/src/demo-app/table/native-table/native-table.html
@@ -4,7 +4,7 @@
   <input matInput #filter>
 </mat-form-field>
 
-<div class="demo-table-container demo-mat-table-example mat-elevation-z4 demo-selectable">
+<div class="mat-elevation-z4 demo-selectable">
 
   <table-header-demo (shiftColumns)="displayedColumns.push(displayedColumns.shift())"
                      (toggleColorColumn)="toggleColorColumn()" *ngIf="selection.isEmpty()">
@@ -15,10 +15,10 @@
     </button>
   </table-header-demo>
 
-  <div class="example-header demo-selection-header"
+  <div class="demo-selection-header"
        *ngIf="!selection.isEmpty()">
     {{selection.selected.length}}
-    {{selection.selected.length == 1 ? 'user' : 'users'}}
+    {{selection.selected.length === 1 ? 'user' : 'users'}}
     selected
   </div>
 
@@ -90,11 +90,11 @@
   </mat-paginator>
 </div>
 
-<h3 class="demo-card-title"> CdkTable </h3>
+<h3> CdkTable </h3>
 <mat-card class="demo-table-card">
 
   <table cdk-table [dataSource]="data" class="demo-table">
-    <ng-container cdkColumnDef="{{column}}" *ngFor="let column of definedColumns">
+    <ng-container [cdkColumnDef]="column" *ngFor="let column of definedColumns">
       <th cdk-header-cell *cdkHeaderCellDef> {{column}} </th>
       <td cdk-cell *cdkCellDef="let element"> {{element[column]}} </td>
     </ng-container>
@@ -104,11 +104,11 @@
   </table>
 </mat-card>
 
-<h3 class="demo-card-title"> MatTable </h3>
+<h3> MatTable </h3>
 <mat-card class="demo-table-card">
 
   <table mat-table [dataSource]="data" class="demo-table">
-    <ng-container matColumnDef="{{column}}" *ngFor="let column of definedColumns">
+    <ng-container [matColumnDef]="column" *ngFor="let column of definedColumns">
       <th mat-header-cell *matHeaderCellDef> {{column}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column]}} </td>
     </ng-container>
@@ -118,7 +118,7 @@
   </table>
 </mat-card>
 
-<h3 class="demo-card-title"> Native table with classes </h3>
+<h3> Native table with classes </h3>
 <mat-card class="demo-table-card">
   <table class="mat-table demo-table">
     <thead>

--- a/src/demo-app/table/native-table/native-table.ts
+++ b/src/demo-app/table/native-table/native-table.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, ViewChild} from '@angular/core';
-import {ELEMENT_DATA, Element} from '../element-data';
-import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
-import {PeopleDatabase, UserData} from '../people-database';
 import {SelectionModel} from '@angular/cdk/collections';
-import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
+import {Component, ElementRef, ViewChild} from '@angular/core';
+import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
 import {fromEvent} from 'rxjs';
+import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
+import {Element, ELEMENT_DATA} from '../element-data';
+import {PeopleDatabase, UserData} from '../people-database';
+
 
 @Component({
   moduleId: module.id,
@@ -106,7 +107,7 @@ export class NativeTableDemo {
   }
 
   getOpacity(progress: number) {
-    let distanceFromMiddle = Math.abs(50 - progress);
+    const distanceFromMiddle = Math.abs(50 - progress);
     return distanceFromMiddle / 50 + .3;
   }
 }

--- a/src/demo-app/table/people-database.ts
+++ b/src/demo-app/table/people-database.ts
@@ -7,9 +7,10 @@
  */
 
 import {Injectable} from '@angular/core';
-import {NAMES} from '../dataset/names';
-import {COLORS} from '../dataset/colors';
 import {BehaviorSubject} from 'rxjs';
+import {COLORS} from '../dataset/colors';
+import {NAMES} from '../dataset/names';
+
 
 export let LATEST_ID: number = 0;
 
@@ -39,7 +40,7 @@ export class PeopleDatabase {
   shuffle(changeReferences: boolean) {
     let copiedData = this.data.slice();
     for (let i = copiedData.length; i; i--) {
-      let j = Math.floor(Math.random() * i);
+      const j = Math.floor(Math.random() * i);
       [copiedData[i - 1], copiedData[j]] = [copiedData[j], copiedData[i - 1]];
     }
 

--- a/src/demo-app/table/person-data-source.ts
+++ b/src/demo-app/table/person-data-source.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MatPaginator, MatSort} from '@angular/material';
 import {DataSource} from '@angular/cdk/collections';
+import {MatPaginator, MatSort} from '@angular/material';
 import {merge, Observable} from 'rxjs';
-import {PeopleDatabase, UserData} from './people-database';
 import {map} from 'rxjs/operators';
+import {PeopleDatabase, UserData} from './people-database';
+
 
 export class PersonDataSource extends DataSource<any> {
   constructor(private _peopleDatabase: PeopleDatabase,
@@ -41,7 +42,7 @@ export class PersonDataSource extends DataSource<any> {
   /** Returns a sorted copy of the database data. */
   getSortedData(): UserData[] {
     const data = this._peopleDatabase.data.slice();
-    if (!this._sort.active || this._sort.direction == '') { return data; }
+    if (!this._sort.active || this._sort.direction === '') { return data; }
 
     return data.sort((a, b) => {
       let propertyA: number|string = '';
@@ -54,10 +55,10 @@ export class PersonDataSource extends DataSource<any> {
         case 'color': [propertyA, propertyB] = [a.color, b.color]; break;
       }
 
-      let valueA = isNaN(+propertyA) ? propertyA : +propertyA;
-      let valueB = isNaN(+propertyB) ? propertyB : +propertyB;
+      const valueA = isNaN(+propertyA) ? propertyA : +propertyA;
+      const valueB = isNaN(+propertyB) ? propertyB : +propertyB;
 
-      return (valueA < valueB ? -1 : 1) * (this._sort.direction == 'asc' ? 1 : -1);
+      return (valueA < valueB ? -1 : 1) * (this._sort.direction === 'asc' ? 1 : -1);
     });
   }
 }

--- a/src/demo-app/table/person-detail-data-source.ts
+++ b/src/demo-app/table/person-detail-data-source.ts
@@ -12,6 +12,7 @@ import {UserData} from './people-database';
 import {map} from 'rxjs/operators';
 import {PersonDataSource} from './person-data-source';
 
+
 export interface DetailRow {
   detailRow: boolean;
   data: UserData;

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -32,6 +32,7 @@ import {SimpleColumn} from './custom-table/simple-column';
 import {DataInputTableDemo} from './data-input-table/data-input-table';
 import {NativeTableDemo} from './native-table/native-table';
 
+
 @NgModule({
   imports: [
     CdkTableModule,

--- a/src/demo-app/table/table-demo-page.ts
+++ b/src/demo-app/table/table-demo-page.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   templateUrl: 'table-demo-page.html',

--- a/src/demo-app/table/table-demo.html
+++ b/src/demo-app/table/table-demo.html
@@ -30,7 +30,7 @@
       </button>
       <button mat-raised-button
               (click)="removeDynamicColumnDef()"
-              [disabled]="dynamicColumnIds.length == 0">
+              [disabled]="dynamicColumnIds.length === 0">
         Remove Column Def
       </button>
     </div>
@@ -120,7 +120,7 @@
 
 <h3>MatTable Example</h3>
 
-<div class="demo-table-container demo-mat-table-example mat-elevation-z4">
+<div class="demo-table-container demo-table-header mat-elevation-z4">
 
   <table-header-demo (shiftColumns)="displayedColumns.push(displayedColumns.shift())"
                      (toggleColorColumn)="toggleColorColumn()">
@@ -174,12 +174,12 @@
 
 <h3>MatTable with First/Last Buttons Example</h3>
 
-<div class="demo-table-container demo-mat-table-example mat-elevation-z4">
+<div class="demo-table-container demo-table-header mat-elevation-z4">
 
   <table-header-demo>
   </table-header-demo>
 
-  <h4 class="paginator-output">{{paginatorOutput | json}}</h4>
+  <h4 class="demo-paginator-output">{{paginatorOutput | json}}</h4>
 
   <mat-paginator #paginator
                 [length]="_peopleDatabase.data.length"
@@ -219,11 +219,11 @@
     <mat-header-row *matHeaderRowDef="['userId', 'userName']"></mat-header-row>
     <mat-row *matRowDef="let row; columns: ['userId', 'userName'];"
              matRipple
-             class="user-row"
-             [style.borderBottomColor]="expandedPerson == row ? 'transparent' : ''"
+             class="demo-user-row"
+             [style.borderBottomColor]="expandedPerson === row ? 'transparent' : ''"
              (click)="expandedPerson = row; wasExpanded.add(row)"></mat-row>
     <mat-row *matRowDef="let row; columns: ['details']; when: isDetailRow"
-             [@detailExpand]="row.data == expandedPerson ? 'expanded' : 'collapsed'"
+             [@detailExpand]="row.data === expandedPerson ? 'expanded' : 'collapsed'"
              style="overflow: hidden">
     </mat-row>
   </mat-table>
@@ -236,7 +236,7 @@
   <input matInput #filter>
 </mat-form-field>
 
-<div class="demo-table-container demo-mat-table-example mat-elevation-z4 mat-table-selectable">
+<div class="demo-table-container demo-table-header mat-elevation-z4 mat-table-selectable">
 
   <table-header-demo (shiftColumns)="displayedColumns.push(displayedColumns.shift())"
                      (toggleColorColumn)="toggleColorColumn()" *ngIf="selection.isEmpty()">
@@ -247,10 +247,10 @@
     </button>
   </table-header-demo>
 
-  <div class="example-header example-selection-header"
+  <div class="demo-header demo-selection-header"
        *ngIf="!selection.isEmpty()">
     {{selection.selected.length}}
-    {{selection.selected.length == 1 ? 'user' : 'users'}}
+    {{selection.selected.length === 1 ? 'user' : 'users'}}
     selected
   </div>
 

--- a/src/demo-app/table/table-demo.scss
+++ b/src/demo-app/table/table-demo.scss
@@ -34,7 +34,7 @@
   }
 }
 
-.user-row {
+.demo-user-row {
   cursor: pointer;
   position: relative; // For matRipple
 
@@ -67,7 +67,7 @@
   }
 }
 
-.demo-mat-table-example {
+.demo-table-header {
   table-header-demo {
     background: white;
   }
@@ -126,7 +126,7 @@
   }
 }
 
-.example-selection-header {
+.demo-selection-header {
   height: 64px;
   background: white;
   display: flex;
@@ -143,6 +143,6 @@
   }
 }
 
-.paginator-output {
+.demo-paginator-output {
   margin-left: 20px;
 }

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -52,7 +52,7 @@ export class TableDemo {
 
   @ViewChild('filter') filter: ElementRef;
 
-  dynamicColumnDefs: any[] = [];
+  dynamicColumnDefs: {id: string, property: string, headerText: string}[] = [];
   dynamicColumnIds: string[] = [];
 
   expandedPerson: UserData;
@@ -161,7 +161,7 @@ export class TableDemo {
   }
 
   getOpacity(progress: number) {
-    let distanceFromMiddle = Math.abs(50 - progress);
+    const distanceFromMiddle = Math.abs(50 - progress);
     return distanceFromMiddle / 50 + .3;
   }
 
@@ -174,8 +174,8 @@ export class TableDemo {
   }
 
   toggleColorColumn() {
-    let colorColumnIndex = this.displayedColumns.indexOf('color');
-    if (colorColumnIndex == -1) {
+    const colorColumnIndex = this.displayedColumns.indexOf('color');
+    if (colorColumnIndex === -1) {
       this.displayedColumns.push('color');
     } else {
       this.displayedColumns.splice(colorColumnIndex, 1);

--- a/src/demo-app/table/table-header-demo.html
+++ b/src/demo-app/table/table-header-demo.html
@@ -1,8 +1,8 @@
-<div class="title">
+<div class="demo-title">
   Users
 </div>
 
-<div class="actions">
+<div class="demo-actions">
   <button mat-icon-button [matMenuTriggerFor]="menu">
     <mat-icon>more_vert</mat-icon>
   </button>

--- a/src/demo-app/table/table-header-demo.scss
+++ b/src/demo-app/table/table-header-demo.scss
@@ -6,10 +6,10 @@
   padding: 0 24px;
 }
 
-.title {
+.demo-title {
   font-size: 20px;
 }
 
-.actions {
+.demo-actions {
   color: rgba(0, 0, 0, 0.54);
 }

--- a/src/demo-app/table/table-header-demo.ts
+++ b/src/demo-app/table/table-header-demo.ts
@@ -8,6 +8,7 @@
 
 import {Component, EventEmitter, Output} from '@angular/core';
 
+
 @Component({
   moduleId: module.id,
   selector: 'table-header-demo',

--- a/src/demo-app/tabs/tabs-demo.html
+++ b/src/demo-app/tabs/tabs-demo.html
@@ -55,7 +55,7 @@
   <mat-tab-group class="demo-tab-group" dynamicHeight [(selectedIndex)]="activeTabIndex">
     <mat-tab *ngFor="let tab of dynamicTabs" [disabled]="tab.disabled">
       <ng-template mat-tab-label>{{tab.label}}</ng-template>
-      <div class="tab-content">
+      <div class="demo-tab-content">
         {{tab.content}}
         <br>
         <br>
@@ -94,7 +94,7 @@
         </mat-form-field>
         <br><br>
         <button mat-raised-button
-                [disabled]="dynamicTabs.length == 1"
+                [disabled]="dynamicTabs.length === 1"
                 (click)="deleteTab(tab)">
           Delete Tab
         </button>
@@ -108,7 +108,7 @@
 <mat-tab-group class="demo-tab-group" dynamicHeight>
   <mat-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
     <ng-template mat-tab-label>{{tab.label}}</ng-template>
-    <div class="tab-content">
+    <div class="demo-tab-content">
       {{tab.content}}
       <br>
       <br>
@@ -155,7 +155,7 @@
 <mat-tab-group class="demo-tab-group" style="height: 220px">
   <mat-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
     <ng-template mat-tab-label>{{tab.label}}</ng-template>
-    <div class="tab-content">
+    <div class="demo-tab-content">
       {{tab.content}}
       <br>
       <br>
@@ -201,7 +201,7 @@
 <mat-tab-group class="demo-tab-group" style="height: 200px" mat-stretch-tabs>
   <mat-tab *ngFor="let tab of tabs" [disabled]="tab.disabled">
     <ng-template mat-tab-label>{{tab.label}}</ng-template>
-    <div class="tab-content">
+    <div class="demo-tab-content">
       {{tab.content}}
     </div>
   </mat-tab>
@@ -211,10 +211,10 @@
 <h1>Async Tabs</h1>
 
 <mat-tab-group class="demo-tab-group">
-  <mat-tab *ngFor="let tab of asyncTabs | async; let i = index" [disabled]="i == 1">
+  <mat-tab *ngFor="let tab of asyncTabs | async; let i = index" [disabled]="i === 1">
     <ng-template mat-tab-label>{{tab.label}}</ng-template>
 
-    <div class="tab-content">
+    <div class="demo-tab-content">
       {{tab.content}}
       <br>
       <br>
@@ -231,7 +231,7 @@
 <h1>Tabs with simplified api</h1>
 <mat-tab-group class="demo-tab-group">
   <mat-tab label="Earth">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about the Earth!
     </div>
   </mat-tab>
@@ -243,12 +243,12 @@
 <h1>Inverted tabs</h1>
 <mat-tab-group class="demo-tab-group" headerPosition="below">
   <mat-tab label="Earth">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about the Earth!
     </div>
   </mat-tab>
   <mat-tab label="Fire">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about combustion!
     </div>
   </mat-tab>
@@ -257,12 +257,12 @@
 <h1>Accent tabs</h1>
 <mat-tab-group class="demo-tab-group" color="accent">
   <mat-tab label="Earth">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about the Earth!
     </div>
   </mat-tab>
   <mat-tab label="Fire">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about combustion!
     </div>
   </mat-tab>
@@ -271,12 +271,12 @@
 <h1>Tabs with background color</h1>
 <mat-tab-group class="demo-tab-group" backgroundColor="primary" color="accent">
   <mat-tab label="Earth">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about the Earth!
     </div>
   </mat-tab>
   <mat-tab label="Fire">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       This tab is about combustion!
     </div>
   </mat-tab>
@@ -285,7 +285,7 @@
 <h1>Tabs with autosize textarea</h1>
 <mat-tab-group class="demo-tab-group">
   <mat-tab label="Tab 1">
-    <div class="tab-content">
+    <div class="demo-tab-content">
       <mat-form-field>
         <mat-label>Autosize textarea</mat-label>
         <textarea matInput cdkTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
@@ -308,5 +308,5 @@
   </mat-tab>
   <mat-tab label="Third">
       <counter></counter>
-  </mat-tab>  
+  </mat-tab>
 </mat-tab-group>

--- a/src/demo-app/tabs/tabs-demo.scss
+++ b/src/demo-app/tabs/tabs-demo.scss
@@ -57,6 +57,6 @@ tabs-demo .mat-card {
   }
 }
 
-.tab-content {
+.demo-tab-content {
   padding: 16px;
 }

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -6,28 +6,35 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Component} from '@angular/core';
+import {Observable, Observer} from 'rxjs';
+
+
+export interface DemoTab {
+  content: string;
+  disabled?: boolean;
+  extraContent?: boolean;
+  label: string;
+}
 
 @Component({
   moduleId: module.id,
   selector: 'tabs-demo',
   templateUrl: 'tabs-demo.html',
   styleUrls: ['tabs-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class TabsDemo {
   // Nav bar demo
-  tabLinks = [
+  tabLinks: {label: string, link: string}[] = [
     {label: 'Sun', link: 'sunny-tab'},
     {label: 'Rain', link: 'rainy-tab'},
     {label: 'Fog', link: 'foggy-tab'},
   ];
 
-  tabNavBackground: any = undefined;
+  tabNavBackground: string | undefined = undefined;
 
   // Standard tabs demo
-  tabs = [
+  tabs: DemoTab[] = [
     {
       label: 'Tab 1',
       content: 'This is the body of the first tab'
@@ -50,7 +57,7 @@ export class TabsDemo {
   addTabPosition = 0;
   gotoNewTabAfterAdding = false;
   createWithLongContent = false;
-  dynamicTabs = [
+  dynamicTabs: DemoTab[] = [
     {
       label: 'Tab 1',
       content: 'This is the body of the first tab'
@@ -68,10 +75,10 @@ export class TabsDemo {
     },
   ];
 
-  asyncTabs: Observable<any>;
+  asyncTabs: Observable<DemoTab[]>;
 
   constructor() {
-    this.asyncTabs = Observable.create((observer: any) => {
+    this.asyncTabs = Observable.create((observer: Observer<DemoTab[]>) => {
       setTimeout(() => {
         observer.next(this.tabs);
       }, 1000);
@@ -90,7 +97,7 @@ export class TabsDemo {
     }
   }
 
-  deleteTab(tab: any) {
+  deleteTab(tab: DemoTab) {
     this.dynamicTabs.splice(this.dynamicTabs.indexOf(tab), 1);
   }
 
@@ -105,7 +112,7 @@ export class TabsDemo {
   }
 
   toggleBackground() {
-    this.tabNavBackground = this.tabNavBackground ? undefined : 'primary';
+    this.tabNavBackground = this.tabNavBackground || 'primary';
   }
 }
 
@@ -133,13 +140,14 @@ export class RainyTabContent {}
 })
 export class FoggyTabContent {}
 
+
 @Component({
   moduleId: module.id,
   selector: 'counter',
   template: `<span>Content</span>`
- })
- export class Counter {
+})
+export class Counter {
   ngOnInit() {
     console.log('Tab Loaded');
   }
- }
+}

--- a/src/demo-app/toolbar/toolbar-demo.ts
+++ b/src/demo-app/toolbar/toolbar-demo.ts
@@ -15,6 +15,4 @@ import {Component} from '@angular/core';
   templateUrl: 'toolbar-demo.html',
   styleUrls: ['toolbar-demo.css'],
 })
-export class ToolbarDemo {
-
-}
+export class ToolbarDemo {}

--- a/src/demo-app/tooltip/tooltip-demo.html
+++ b/src/demo-app/tooltip/tooltip-demo.html
@@ -1,11 +1,11 @@
 <button *ngFor="let tooltip of tooltips" matTooltip="Tooltip message">Tooltip Button</button>
 <button (click)="tooltips.push('')">Add tooltip</button>
-<button (click)="tooltips.shift()" [disabled]="tooltips.length == 0">Remove tooltip</button>
+<button (click)="tooltips.shift()" [disabled]="tooltips.length === 0">Remove tooltip</button>
 
 <div class="demo-tooltip">
   <h1>Tooltip Demo</h1>
 
-  <div class="centered" cdk-scrollable>
+  <div class="demo-tooltip-centered" cdk-scrollable>
     <button #tooltip="matTooltip"
             mat-raised-button
             color="primary"
@@ -14,7 +14,7 @@
             [matTooltipDisabled]="disabled"
             [matTooltipShowDelay]="showDelay"
             [matTooltipHideDelay]="hideDelay"
-            [matTooltipClass]="{'red-tooltip': showExtraClass}">
+            [matTooltipClass]="{'demo-red-tooltip': showExtraClass}">
       Mouse over to see the tooltip
     </button>
     <div>Scroll down while tooltip is open to see it hide automatically</div>

--- a/src/demo-app/tooltip/tooltip-demo.scss
+++ b/src/demo-app/tooltip/tooltip-demo.scss
@@ -1,5 +1,5 @@
 .demo-tooltip {
-  .centered {
+  .demo-tooltip-centered {
     text-align: center;
     height: 200px;
     overflow: auto;
@@ -8,12 +8,13 @@
       margin: 75px 16px 16px;
     }
   }
+
   .mat-radio-button {
     display: block;
   }
 }
 
-.red-tooltip {
+.demo-red-tooltip {
   background-color: rgb(255, 128, 128);
   color: black;
 }

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component} from '@angular/core';
 import {TooltipPosition} from '@angular/material';
 
 
@@ -15,11 +15,10 @@ import {TooltipPosition} from '@angular/material';
   selector: 'tooltip-demo',
   templateUrl: 'tooltip-demo.html',
   styleUrls: ['tooltip-demo.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class TooltipDemo {
   position: TooltipPosition = 'after';
-  message: string = 'Here is the tooltip';
+  message = 'Here is the tooltip';
   tooltips: string[] = [];
   disabled = false;
   showDelay = 0;

--- a/src/demo-app/tree/checklist-tree-demo/checklist-database.ts
+++ b/src/demo-app/tree/checklist-tree-demo/checklist-database.ts
@@ -8,6 +8,7 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
+
 /**
  * Node for to-do item
  */
@@ -58,17 +59,17 @@ export class ChecklistDatabase {
   /** Add an item to to-do list */
   insertItem(parent: TodoItemNode, name: string) {
     const child = new TodoItemNode(name, [], parent);
-    let children = parent.children.value;
+    const children = parent.children.value;
     children.push(child);
     parent.children.next(children);
     this.dataChange.next(this.data);
   }
 
   updateItem(node: TodoItemNode, name: string) {
-    let newNode = new TodoItemNode(name, node.children.value, node.parent);
+    const newNode = new TodoItemNode(name, node.children.value, node.parent);
     if (node.parent) {
-      let children = node.parent.children.value;
-      let index = children.indexOf(node);
+      const children = node.parent.children.value;
+      const index = children.indexOf(node);
       children.splice(index, 1, newNode);
       node.parent.children.next(children);
       this.dataChange.next(this.data);

--- a/src/demo-app/tree/checklist-tree-demo/checklist-nested-tree-demo.scss
+++ b/src/demo-app/tree/checklist-tree-demo/checklist-nested-tree-demo.scss
@@ -1,6 +1,7 @@
 .demo-tree-node-invisible {
   display: none;
 }
+
 .demo-tree-node-nested {
   padding-left: 40px;
 }

--- a/src/demo-app/tree/checklist-tree-demo/checklist-nested-tree-demo.ts
+++ b/src/demo-app/tree/checklist-tree-demo/checklist-nested-tree-demo.ts
@@ -11,6 +11,7 @@ import {NestedTreeControl} from '@angular/cdk/tree';
 import {Observable} from 'rxjs';
 import {ChecklistDatabase, TodoItemNode} from './checklist-database';
 
+
 /**
  * Checklist demo with nested tree
  */

--- a/src/demo-app/tree/checklist-tree-demo/checklist-tree-demo.scss
+++ b/src/demo-app/tree/checklist-tree-demo/checklist-tree-demo.scss
@@ -1,6 +1,7 @@
 .demo-tree-node-invisible {
   display: none;
 }
+
 .demo-tree-node-nested {
   padding-left: 40px;
 }

--- a/src/demo-app/tree/checklist-tree-demo/checklist-tree-demo.ts
+++ b/src/demo-app/tree/checklist-tree-demo/checklist-tree-demo.ts
@@ -12,6 +12,7 @@ import {MatTreeFlattener, MatTreeFlatDataSource} from '@angular/material/tree';
 import {TodoItemNode, ChecklistDatabase} from './checklist-database';
 import {BehaviorSubject} from 'rxjs';
 
+
 /**
  * Checklist demo with flat tree
  */

--- a/src/demo-app/tree/dynamic-tree-demo/dynamic-database.ts
+++ b/src/demo-app/tree/dynamic-tree-demo/dynamic-database.ts
@@ -70,11 +70,10 @@ export class DynamicDataSource {
 
   connect(collectionViewer: CollectionViewer): Observable<DynamicFlatNode[]> {
     this.treeControl.expansionModel.onChange!.subscribe(change => {
-        if ((change as SelectionChange<DynamicFlatNode>).added ||
-          (change as SelectionChange<DynamicFlatNode>).removed) {
-          this.handleTreeControl(change as SelectionChange<DynamicFlatNode>);
-        }
-      });
+      if (change.added || change.removed) {
+        this.handleTreeControl(change);
+      }
+    });
 
     return merge(collectionViewer.viewChange, this.dataChange).pipe(map(() => this.data));
   }

--- a/src/demo-app/tree/dynamic-tree-demo/dynamic-tree-demo.ts
+++ b/src/demo-app/tree/dynamic-tree-demo/dynamic-tree-demo.ts
@@ -10,6 +10,7 @@ import {Component} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {DynamicDataSource, DynamicFlatNode, DynamicDatabase} from './dynamic-database';
 
+
 @Component({
   moduleId: module.id,
   selector: 'dynamic-tree-demo',

--- a/src/demo-app/tree/file-database.ts
+++ b/src/demo-app/tree/file-database.ts
@@ -8,6 +8,7 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
+
 /**
  * File node data with nested structure.
  * Each node has a filename, and a type or a list of children.
@@ -100,10 +101,10 @@ export class FileDatabase {
    * The return value is the list of `FileNode`.
    */
   buildFileTree(value: any, level: number) {
-    let data: any[] = [];
+    const data: FileNode[] = [];
     for (let k in value) {
-      let v = value[k];
-      let node = new FileNode();
+      const v = value[k];
+      const node = new FileNode();
       node.filename = `${k}`;
       if (v === null || v === undefined) {
         // no action

--- a/src/demo-app/tree/loadmore-tree-demo/loadmore-database.ts
+++ b/src/demo-app/tree/loadmore-tree-demo/loadmore-database.ts
@@ -8,6 +8,7 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
+
 const LOAD_MORE = 'LOAD_MORE';
 
 /** Nested node */
@@ -66,7 +67,7 @@ export class LoadmoreDatabase {
       return;
     }
     const newChildrenNumber = parent.children!.length + this.batchNumber;
-    let nodes = children.slice(0, newChildrenNumber)
+    const nodes = children.slice(0, newChildrenNumber)
         .map(name => this._generateNode(name));
     if (newChildrenNumber < children.length) {
       // Need a new load more node

--- a/src/demo-app/tree/loadmore-tree-demo/loadmore-tree-demo.ts
+++ b/src/demo-app/tree/loadmore-tree-demo/loadmore-tree-demo.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
+import {Component} from '@angular/core';
 import {MatTreeFlatDataSource, MatTreeFlattener} from '@angular/material/tree';
 import {Observable} from 'rxjs';
-import {LoadmoreNode, LoadmoreFlatNode, LoadmoreDatabase} from './loadmore-database';
+import {LoadmoreDatabase, LoadmoreFlatNode, LoadmoreNode} from './loadmore-database';
+
 
 const LOAD_MORE = 'LOAD_MORE';
 
@@ -57,7 +58,8 @@ export class LoadmoreTreeDemo {
     if (this.nodeMap.has(node.item)) {
       return this.nodeMap.get(node.item)!;
     }
-    let newNode = new LoadmoreFlatNode(node.item, level, node.hasChildren, node.loadMoreParentItem);
+    const newNode =
+        new LoadmoreFlatNode(node.item, level, node.hasChildren, node.loadMoreParentItem);
     this.nodeMap.set(node.item, newNode);
     return newNode;
   }

--- a/src/demo-app/tree/tree-demo-module.ts
+++ b/src/demo-app/tree/tree-demo-module.ts
@@ -25,6 +25,7 @@ import {ChecklistNestedTreeDemo} from './checklist-tree-demo/checklist-nested-tr
 import {DynamicTreeDemo} from './dynamic-tree-demo/dynamic-tree-demo';
 import {LoadmoreTreeDemo} from './loadmore-tree-demo/loadmore-tree-demo';
 
+
 @NgModule({
   imports: [
     CdkTreeModule,

--- a/src/demo-app/tree/tree-demo.html
+++ b/src/demo-app/tree/tree-demo.html
@@ -1,5 +1,3 @@
-
-
 <mat-accordion class="demo-tree-container">
 
   <mat-expansion-panel>
@@ -41,7 +39,7 @@
             </button>
             {{node.filename}}
           </div>
-          <ul [class.tree-demo-invisible]="!nestedTreeControl.isExpanded(node)">
+          <ul [class.demo-tree-invisible]="!nestedTreeControl.isExpanded(node)">
             <ng-container matTreeNodeOutlet></ng-container>
           </ul>
         </li>
@@ -59,7 +57,7 @@
       <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
                      class="demo-tree-node">
         <button mat-icon-button [attr.aria-label]="'toggle ' + node.filename"
-                cdkTreeNodeToggle class="demo-tree-toggle">
+                cdkTreeNodeToggle>
           <mat-icon>
             {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
           </mat-icon>
@@ -78,13 +76,13 @@
       </cdk-nested-tree-node>
       <cdk-nested-tree-node *cdkTreeNodeDef="let node; when: hasNestedChild" class="demo-tree-node">
         <button mat-icon-button [attr.aria-label]="'toggle ' + node.filename"
-                cdkTreeNodeToggle class="demo-tree-toggle">
+                cdkTreeNodeToggle>
           <mat-icon>
             {{nestedTreeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
           </mat-icon>
         </button>
         {{node.filename}}:  {{node.type}}
-        <div [class.tree-demo-invisible]="!nestedTreeControl.isExpanded(node)"
+        <div [class.demo-tree-invisible]="!nestedTreeControl.isExpanded(node)"
              class="demo-tree-nested-node">
           <ng-container cdkTreeNodeOutlet></ng-container>
         </div>

--- a/src/demo-app/tree/tree-demo.scss
+++ b/src/demo-app/tree/tree-demo.scss
@@ -7,7 +7,7 @@
     padding-left: 20px;
   }
 
-  .tree-demo-invisible {
+  .demo-tree-invisible {
     display: none;
   }
 

--- a/src/demo-app/tree/tree-demo.ts
+++ b/src/demo-app/tree/tree-demo.ts
@@ -57,7 +57,7 @@ export class TreeDemo {
   }
 
   transformer = (node: FileNode, level: number) => {
-    let flatNode = new FileFlatNode();
+    const flatNode = new FileFlatNode();
     flatNode.filename = node.filename;
     flatNode.type = node.type;
     flatNode.level = level;


### PR DESCRIPTION
This:
- Ensure that all css classes are prefixed by `.demo-`;
- Removes some unused css classes;
- Enables `ViewEncapsulation` for all components, except `demo-app` since it applies CSS to the whole content;
- Organizes imports, removing some duplicates;