### PR TITLE
fix(platform): change isBrowser check to use Angular PLATFORM_ID

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -1,5 +1,5 @@
 import {Platform} from '@angular/cdk/platform';
-import {Component, ViewChild} from '@angular/core';
+import {Component, PLATFORM_ID, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {A11yModule, FocusTrap, CdkTrapFocus} from '../index';
 
@@ -47,8 +47,9 @@ describe('FocusTrap', () => {
       // focus event handler directly.
       const result = focusTrapInstance.focusLastTabbableElement();
 
+      const platformId = TestBed.get(PLATFORM_ID);
       // In iOS button elements are never tabbable, so the last element will be the input.
-      const lastElement = new Platform().IOS ? 'input' : 'button';
+      const lastElement = new Platform(platformId).IOS ? 'input' : 'button';
 
       expect(document.activeElement.nodeName.toLowerCase())
           .toBe(lastElement, `Expected ${lastElement} element to be focused`);

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -5,6 +5,9 @@ import {InteractivityChecker} from './interactivity-checker';
 describe('InteractivityChecker', () => {
   let testContainerElement: HTMLElement;
   let checker: InteractivityChecker;
+  // TODO: refactor this to be injected with the platformId
+  // Needs to be done carefully due to the runIf checks below executing
+  // before injection
   let platform: Platform = new Platform();
 
   beforeEach(() => {

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -7,7 +7,7 @@ import {Overlay, OverlayContainer, OverlayModule, OverlayRef, OverlayConfig} fro
 
 
 describe('BlockScrollStrategy', () => {
-  let platform = new Platform();
+  let platform: Platform;
   let viewport: ViewportRuler;
   let overlayRef: OverlayRef;
   let componentPortal: ComponentPortal<FocacciaMsg>;
@@ -22,7 +22,8 @@ describe('BlockScrollStrategy', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([Overlay, ViewportRuler], (overlay: Overlay, viewportRuler: ViewportRuler) => {
+  beforeEach(inject([Overlay, ViewportRuler, Platform],
+    (overlay: Overlay, viewportRuler: ViewportRuler, _platform: Platform) => {
     let overlayConfig = new OverlayConfig({scrollStrategy: overlay.scrollStrategies.block()});
 
     overlayRef = overlay.create(overlayConfig);
@@ -34,6 +35,7 @@ describe('BlockScrollStrategy', () => {
     forceScrollElement.style.width = '100px';
     forceScrollElement.style.height = '3000px';
     forceScrollElement.style.background = 'rebeccapurple';
+    platform = _platform;
   }));
 
   afterEach(inject([OverlayContainer], (container: OverlayContainer) => {

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Inject, Injectable, Optional, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
 
 
 // Whether the current platform supports the V8 Break Iterator. The V8 check
@@ -19,8 +20,14 @@ const hasV8BreakIterator = (typeof Intl !== 'undefined' && (Intl as any).v8Break
  */
 @Injectable({providedIn: 'root'})
 export class Platform {
-  /** Whether the Angular application is being rendered in the browser. */
-  isBrowser: boolean = typeof document === 'object' && !!document;
+  /**
+   * Whether the Angular application is being rendered in the browser.
+   * We want to use the Angular platform check because if the Document is shimmed
+   * without the navigator, the following checks will fail. This is preferred because
+   * sometimes the Document may be shimmed without the user's knowledge or intention
+   */
+  isBrowser: boolean = this._platformId ?
+      isPlatformBrowser(this._platformId) : typeof document === 'object' && !!document;
 
   /** Whether the current browser is Microsoft Edge. */
   EDGE: boolean = this.isBrowser && /(edge)/i.test(navigator.userAgent);
@@ -31,7 +38,7 @@ export class Platform {
   /** Whether the current rendering engine is Blink. */
   // EdgeHTML and Trident mock Blink specific things and need to be excluded from this check.
   BLINK: boolean = this.isBrowser && (!!((window as any).chrome || hasV8BreakIterator) &&
-    typeof CSS !== 'undefined' && !this.EDGE && !this.TRIDENT);
+      typeof CSS !== 'undefined' && !this.EDGE && !this.TRIDENT);
 
   /** Whether the current rendering engine is WebKit. */
   // Webkit is part of the userAgent in EdgeHTML, Blink and Trident. Therefore we need to
@@ -59,4 +66,11 @@ export class Platform {
   // this and just place the Safari keyword in the userAgent. To be more safe about Safari every
   // Safari browser should also use Webkit as its layout engine.
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
+
+  /**
+   * @deletion-target v7.0.0 remove optional decorator
+   */
+  constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {
+  }
 }
+

--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -8,7 +8,7 @@ const SUPPORTS_INTL = typeof Intl != 'undefined';
 
 
 describe('NativeDateAdapter', () => {
-  const platform = new Platform();
+  let platform: Platform;
   let adapter: NativeDateAdapter;
   let assertValidDate: (d: Date | null, valid: boolean) => void;
 
@@ -18,8 +18,10 @@ describe('NativeDateAdapter', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([DateAdapter], (dateAdapter: NativeDateAdapter) => {
+  beforeEach(inject([DateAdapter, Platform],
+    (dateAdapter: NativeDateAdapter, _platform: Platform) => {
     adapter = dateAdapter;
+    platform = _platform;
 
     assertValidDate = (d: Date | null, valid: boolean) => {
       expect(adapter.isDateInstance(d)).not.toBeNull(`Expected ${d} to be a date instance`);


### PR DESCRIPTION
* Use the Angular PLATFORM_ID token as a more reliable check for
  whether the current platform is browser. This is because the
  previous check for a global document could be a false positive
  if another application pollutes the global namespace

BREAKING CHANGE:

* Platform now takes the PLATFORM_ID as an optional parameter in
  its constructor. This will become a required parameter in v7