### PR TITLE
fix: remove duplicate imports

### DIFF
--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -1,18 +1,17 @@
-import {ElementRef, Component, NgModule, NgZone} from '@angular/core';
-import {TestBed, inject} from '@angular/core/testing';
-import {CdkScrollable} from '@angular/cdk/scrolling';
-import {Subscription} from 'rxjs';
-import {ScrollDispatchModule} from '@angular/cdk/scrolling';
-import {MockNgZone} from '@angular/cdk/testing';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
+import {CdkScrollable, ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {MockNgZone} from '@angular/cdk/testing';
+import {Component, ElementRef, NgModule, NgZone} from '@angular/core';
+import {inject, TestBed} from '@angular/core/testing';
+import {Subscription} from 'rxjs';
 import {
-  OverlayModule,
-  Overlay,
-  OverlayRef,
-  OverlayContainer,
-  ConnectedPositionStrategy,
   ConnectedOverlayPositionChange,
+  ConnectedPositionStrategy,
   ConnectionPositionPair,
+  Overlay,
+  OverlayContainer,
+  OverlayModule,
+  OverlayRef,
 } from '../index';
 
 

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -6,23 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PositionStrategy} from './position-strategy';
-import {ElementRef} from '@angular/core';
-import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Direction} from '@angular/cdk/bidi';
+import {CdkScrollable, ViewportRuler} from '@angular/cdk/scrolling';
+import {ElementRef} from '@angular/core';
+import {Observable} from 'rxjs';
+import {OverlayRef} from '../overlay-ref';
 import {
+  ConnectedOverlayPositionChange,
   ConnectionPositionPair,
   OriginConnectionPosition,
   OverlayConnectionPosition,
-  ConnectedOverlayPositionChange,
   validateHorizontalPosition,
   validateVerticalPosition,
 } from './connected-position';
-import {Observable} from 'rxjs';
-import {CdkScrollable} from '@angular/cdk/scrolling';
-import {OverlayRef} from '../overlay-ref';
 import {FlexibleConnectedPositionStrategy} from './flexible-connected-position-strategy';
-
+import {PositionStrategy} from './position-strategy';
 
 
 /**

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1,21 +1,21 @@
-import {ElementRef, NgModule, Component, NgZone} from '@angular/core';
-import {TestBed, inject} from '@angular/core/testing';
-import {CdkScrollable} from '@angular/cdk/scrolling';
-import {PortalModule, ComponentPortal} from '@angular/cdk/portal';
+import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
+import {CdkScrollable, ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {MockNgZone} from '@angular/cdk/testing';
+import {Component, ElementRef, NgModule, NgZone} from '@angular/core';
+import {inject, TestBed} from '@angular/core/testing';
 import {Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {ScrollDispatchModule} from '@angular/cdk/scrolling';
-import {MockNgZone} from '@angular/cdk/testing';
 import {
-  OverlayModule,
+  ConnectedOverlayPositionChange,
+  FlexibleConnectedPositionStrategy,
   Overlay,
   OverlayConfig,
-  OverlayRef,
   OverlayContainer,
-  FlexibleConnectedPositionStrategy,
-  ConnectedOverlayPositionChange,
+  OverlayModule,
+  OverlayRef,
   ViewportRuler,
 } from '../index';
+
 
 // Default width and height of the overlay and origin panels throughout these tests.
 const DEFAULT_HEIGHT = 30;

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -17,8 +17,7 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import {Observable, Subject} from 'rxjs';
-import {empty as observableEmpty} from 'rxjs';
+import {empty, Observable, Subject} from 'rxjs';
 
 
 /** An event that is emitted when the autofill state of an input changes. */
@@ -59,7 +58,7 @@ export class AutofillMonitor implements OnDestroy {
    */
   monitor(element: Element): Observable<AutofillEvent> {
     if (!this._platform.isBrowser) {
-      return observableEmpty();
+      return empty();
     }
 
     const info = this._monitoredElements.get(element);

--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -8,8 +8,8 @@
 
 import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
 import {FormControl, NgModel} from '@angular/forms';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
+
 
 export interface State {
   code: string;

--- a/src/demo-app/datepicker/datepicker-demo.ts
+++ b/src/demo-app/datepicker/datepicker-demo.ts
@@ -8,10 +8,9 @@
 
 import {ChangeDetectionStrategy, Component, Host} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {MatDatepickerInputEvent} from '@angular/material/datepicker';
-import {DateAdapter} from '@angular/material/core';
-import {MatCalendar} from '@angular/material';
-import {ThemePalette} from '@angular/material/core';
+import {DateAdapter, ThemePalette} from '@angular/material/core';
+import {MatCalendar, MatDatepickerInputEvent} from '@angular/material/datepicker';
+
 
 @Component({
   moduleId: module.id,

--- a/src/demo-app/overlay/overlay-demo.ts
+++ b/src/demo-app/overlay/overlay-demo.ts
@@ -16,8 +16,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {filter} from 'rxjs/operators';
-import {tap} from 'rxjs/operators';
+import {filter, tap} from 'rxjs/operators';
 
 
 @Component({

--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, ViewChild} from '@angular/core';
-import {PeopleDatabase, UserData} from './people-database';
-import {PersonDataSource} from './person-data-source';
-import {MatPaginator, MatSort, MatTableDataSource, PageEvent} from '@angular/material';
-import {DetailRow, PersonDetailDataSource} from './person-detail-data-source';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 import {SelectionModel} from '@angular/cdk/collections';
-import {distinctUntilChanged} from 'rxjs/operators';
-import {debounceTime} from 'rxjs/operators';
+import {Component, ElementRef, ViewChild} from '@angular/core';
+import {MatPaginator, MatSort, MatTableDataSource, PageEvent} from '@angular/material';
 import {fromEvent} from 'rxjs';
+import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
+import {PeopleDatabase, UserData} from './people-database';
+import {PersonDataSource} from './person-data-source';
+import {DetailRow, PersonDetailDataSource} from './person-detail-data-source';
+
 
 export type UserProperties = 'userId' | 'userName' | 'progress' | 'color' | undefined;
 

--- a/src/demo-app/tree/dynamic-tree-demo/dynamic-database.ts
+++ b/src/demo-app/tree/dynamic-tree-demo/dynamic-database.ts
@@ -8,10 +8,9 @@
 import {Injectable} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {CollectionViewer, SelectionChange} from '@angular/cdk/collections';
-import {BehaviorSubject} from 'rxjs';
-import {Observable} from 'rxjs';
-import {merge} from 'rxjs';
+import {BehaviorSubject, merge, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+
 
 /** Flat node with expandable and level information */
 export class DynamicFlatNode {

--- a/src/demo-app/tree/tree-demo.ts
+++ b/src/demo-app/tree/tree-demo.ts
@@ -6,17 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {FlatTreeControl, NestedTreeControl} from '@angular/cdk/tree';
+import {Component} from '@angular/core';
 import {
-  MatTreeFlattener,
   MatTreeFlatDataSource,
+  MatTreeFlattener,
   MatTreeNestedDataSource
 } from '@angular/material/tree';
-import {of as ofObservable} from 'rxjs';
-import {Observable} from 'rxjs';
+import {Observable, of as ofObservable} from 'rxjs';
+import {FileDatabase, FileFlatNode, FileNode} from './file-database';
 
-import {FileNode, FileFlatNode, FileDatabase} from './file-database';
 
 @Component({
   moduleId: module.id,

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1,53 +1,50 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {DOWN_ARROW, ENTER, ESCAPE, SPACE, UP_ARROW, TAB} from '@angular/cdk/keycodes';
-import {OverlayContainer, Overlay} from '@angular/cdk/overlay';
-import {map} from 'rxjs/operators';
-import {startWith} from 'rxjs/operators';
+import {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
+import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
-  dispatchKeyboardEvent,
   dispatchFakeEvent,
-  typeInElement,
+  dispatchKeyboardEvent,
   MockNgZone,
+  typeInElement,
 } from '@angular/cdk/testing';
 import {
   ChangeDetectionStrategy,
   Component,
+  NgZone,
   OnDestroy,
   OnInit,
+  Provider,
   QueryList,
   ViewChild,
   ViewChildren,
-  NgZone,
-  Provider,
 } from '@angular/core';
 import {
   async,
   ComponentFixture,
   fakeAsync,
+  flush,
   inject,
   TestBed,
   tick,
-  flush,
 } from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatOption, MatOptionSelectionChange} from '@angular/material/core';
 import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Observable} from 'rxjs';
-import {Subject} from 'rxjs';
-import {Subscription} from 'rxjs';
+import {Observable, Subject, Subscription} from 'rxjs';
+import {map, startWith} from 'rxjs/operators';
 import {MatInputModule} from '../input/index';
 import {
   getMatAutocompleteMissingPanelError,
+  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
   MatAutocomplete,
   MatAutocompleteModule,
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
-  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
-  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
 } from './index';
 
 

--- a/src/lib/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-ref.ts
@@ -6,14 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {OverlayRef} from '@angular/cdk/overlay';
 import {ESCAPE} from '@angular/cdk/keycodes';
-import {Observable} from 'rxjs';
-import {Subject} from 'rxjs';
-import {merge} from 'rxjs';
-import {filter} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
+import {OverlayRef} from '@angular/cdk/overlay';
+import {merge, Observable, Subject} from 'rxjs';
+import {filter, take} from 'rxjs/operators';
 import {MatBottomSheetContainer} from './bottom-sheet-container';
+
 
 /**
  * Reference to a bottom sheet dispatched from the bottom sheet service.

--- a/src/lib/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.spec.ts
@@ -1,32 +1,31 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {A, ESCAPE} from '@angular/cdk/keycodes';
+import {OverlayContainer, ViewportRuler} from '@angular/cdk/overlay';
+import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {
-  Directive,
   Component,
-  NgModule,
-  ViewContainerRef,
-  ViewChild,
+  Directive,
   Inject,
   Injector,
+  NgModule,
   TemplateRef,
+  ViewChild,
+  ViewContainerRef,
 } from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
+  flush,
   flushMicrotasks,
   inject,
   TestBed,
   tick,
-  flush,
 } from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Directionality} from '@angular/cdk/bidi';
-import {MatBottomSheetModule} from './bottom-sheet-module';
 import {MatBottomSheet} from './bottom-sheet';
+import {MAT_BOTTOM_SHEET_DATA, MatBottomSheetConfig} from './bottom-sheet-config';
+import {MatBottomSheetModule} from './bottom-sheet-module';
 import {MatBottomSheetRef} from './bottom-sheet-ref';
-import {MAT_BOTTOM_SHEET_DATA} from './bottom-sheet-config';
-import {MatBottomSheetConfig} from './bottom-sheet-config';
-import {OverlayContainer, ViewportRuler} from '@angular/cdk/overlay';
-import {A, ESCAPE} from '@angular/cdk/keycodes';
-import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 
 
 describe('MatBottomSheet', () => {

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -32,12 +32,11 @@ import {
 import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {CanUpdateErrorState, ErrorStateMatcher, mixinErrorState} from '@angular/material/core';
 import {MatFormFieldControl} from '@angular/material/form-field';
-import {Observable} from 'rxjs';
-import {merge} from 'rxjs';
+import {merge, Observable, Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
-import {Subscription} from 'rxjs';
 import {MatChip, MatChipEvent, MatChipSelectionChange} from './chip';
 import {MatChipInput} from './chip-input';
+
 
 // Boilerplate for applying mixins to MatChipList.
 /** @docs-private */

--- a/src/lib/core/common-behaviors/initialized.ts
+++ b/src/lib/core/common-behaviors/initialized.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Observable, Subscriber} from 'rxjs';
 import {Constructor} from './constructor';
-import {Observable} from 'rxjs';
-import {Subscriber} from 'rxjs';
+
 
 /**
  * Mixin that adds an initialized property to a directive which, when subscribed to, will emit a

--- a/src/lib/datepicker/datepicker-module.ts
+++ b/src/lib/datepicker/datepicker-module.ts
@@ -8,12 +8,12 @@
 
 import {A11yModule} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
+import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDialogModule} from '@angular/material/dialog';
-import {MatCalendar} from './calendar';
-import {MatCalendarHeader} from './calendar';
+import {MatCalendar, MatCalendarHeader} from './calendar';
 import {MatCalendarBody} from './calendar-body';
 import {MatDatepicker, MatDatepickerContent} from './datepicker';
 import {MatDatepickerInput} from './datepicker-input';
@@ -22,7 +22,6 @@ import {MatDatepickerToggle, MatDatepickerToggleIcon} from './datepicker-toggle'
 import {MatMonthView} from './month-view';
 import {MatMultiYearView} from './multi-year-view';
 import {MatYearView} from './year-view';
-import {PortalModule} from '@angular/cdk/portal';
 
 
 @NgModule({

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -12,17 +12,15 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
+  Directive,
   Input,
   OnChanges,
   OnDestroy,
   SimpleChanges,
   ViewEncapsulation,
-  Directive,
-  ContentChild,
 } from '@angular/core';
-import {merge} from 'rxjs';
-import {of as observableOf} from 'rxjs';
-import {Subscription} from 'rxjs';
+import {merge, of as observableOf, Subscription} from 'rxjs';
 import {MatDatepicker} from './datepicker';
 import {MatDatepickerIntl} from './datepicker-intl';
 

--- a/src/lib/datepicker/month-view.spec.ts
+++ b/src/lib/datepicker/month-view.spec.ts
@@ -1,3 +1,4 @@
+import {Direction, Directionality} from '@angular/cdk/bidi';
 import {
   DOWN_ARROW,
   END,
@@ -9,15 +10,14 @@ import {
   RIGHT_ARROW,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {By} from '@angular/platform-browser';
+import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {Component} from '@angular/core';
-import {Direction, Directionality} from '@angular/cdk/bidi';
-import {JAN, MAR, NOV, FEB} from '@angular/material/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {DEC, FEB, JAN, MAR, MatNativeDateModule, NOV} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
 import {MatCalendarBody} from './calendar-body';
 import {MatMonthView} from './month-view';
-import {MatNativeDateModule, DEC} from '@angular/material/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {dispatchKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
+
 
 describe('MatMonthView', () => {
   let dir: {value: Direction};

--- a/src/lib/datepicker/year-view.spec.ts
+++ b/src/lib/datepicker/year-view.spec.ts
@@ -1,3 +1,4 @@
+import {Direction, Directionality} from '@angular/cdk/bidi';
 import {
   DOWN_ARROW,
   END,
@@ -8,15 +9,27 @@ import {
   RIGHT_ARROW,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {By} from '@angular/platform-browser';
+import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {Component, ViewChild} from '@angular/core';
-import {Direction, Directionality} from '@angular/cdk/bidi';
-import {FEB, JAN, JUL, JUN, MAR, DEC, NOV, AUG, MAY, OCT, SEP} from '@angular/material/core';
-import {MatCalendarBody} from './calendar-body';
-import {MatNativeDateModule} from '@angular/material/core';
-import {MatYearView} from './year-view';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {dispatchKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
+import {
+  AUG,
+  DEC,
+  FEB,
+  JAN,
+  JUL,
+  JUN,
+  MAR,
+  MatNativeDateModule,
+  MAY,
+  NOV,
+  OCT,
+  SEP
+} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {MatCalendarBody} from './calendar-body';
+import {MatYearView} from './year-view';
+
 
 describe('MatYearView', () => {
   let dir: {value: Direction};

--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -6,15 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {OverlayRef, GlobalPositionStrategy} from '@angular/cdk/overlay';
 import {ESCAPE} from '@angular/cdk/keycodes';
+import {GlobalPositionStrategy, OverlayRef} from '@angular/cdk/overlay';
 import {Location} from '@angular/common';
-import {filter} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
+import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
+import {filter, take} from 'rxjs/operators';
 import {DialogPosition} from './dialog-config';
-import {Observable, SubscriptionLike} from 'rxjs';
-import {Subject} from 'rxjs';
-import {Subscription} from 'rxjs';
 import {MatDialogContainer} from './dialog-container';
 
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -27,14 +27,12 @@ import {
   SkipSelf,
   TemplateRef,
 } from '@angular/core';
-import {Observable} from 'rxjs';
-import {defer} from 'rxjs';
-import {of as observableOf} from 'rxjs';
+import {defer, Observable, of as observableOf, Subject} from 'rxjs';
 import {startWith} from 'rxjs/operators';
-import {Subject} from 'rxjs';
 import {MatDialogConfig} from './dialog-config';
 import {MatDialogContainer} from './dialog-container';
 import {MatDialogRef} from './dialog-ref';
+
 
 /** Injection token that can be used to access the data that was passed in to a dialog. */
 export const MAT_DIALOG_DATA = new InjectionToken<any>('MatDialogData');

--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -8,7 +8,6 @@
 
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
-import {filter} from 'rxjs/operators';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -20,10 +19,10 @@ import {
   OnDestroy,
   ViewEncapsulation,
 } from '@angular/core';
-import {merge} from 'rxjs';
-import {Subscription} from 'rxjs';
-import {MatExpansionPanel} from './expansion-panel';
+import {merge, Subscription} from 'rxjs';
+import {filter} from 'rxjs/operators';
 import {matExpansionAnimations} from './expansion-animations';
+import {MatExpansionPanel} from './expansion-panel';
 
 
 /**

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -7,10 +7,16 @@
  */
 
 import {AnimationEvent} from '@angular/animations';
+import {CdkAccordionItem} from '@angular/cdk/accordion';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
+import {TemplatePortal} from '@angular/cdk/portal';
 import {
+  AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   Directive,
   Host,
   Input,
@@ -18,22 +24,15 @@ import {
   OnDestroy,
   Optional,
   SimpleChanges,
-  ViewEncapsulation,
   ViewContainerRef,
-  AfterContentInit,
-  ContentChild,
+  ViewEncapsulation,
 } from '@angular/core';
-import {CdkAccordionItem} from '@angular/cdk/accordion';
-import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
-import {TemplatePortal} from '@angular/cdk/portal';
 import {Subject} from 'rxjs';
-import {take} from 'rxjs/operators';
-import {filter} from 'rxjs/operators';
-import {startWith} from 'rxjs/operators';
+import {filter, startWith, take} from 'rxjs/operators';
 import {MatAccordion} from './accordion';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {MatExpansionPanelContent} from './expansion-panel-content';
 import {matExpansionAnimations} from './expansion-animations';
+import {MatExpansionPanelContent} from './expansion-panel-content';
+
 
 /** MatExpansionPanel's states. */
 export type MatExpansionPanelState = 'expanded' | 'collapsed';

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -34,8 +34,7 @@ import {
   mixinColor,
 } from '@angular/material/core';
 import {fromEvent} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
+import {startWith, take} from 'rxjs/operators';
 import {MatError} from './error';
 import {matFormFieldAnimations} from './form-field-animations';
 import {MatFormFieldControl} from './form-field-control';

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -6,26 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {catchError} from 'rxjs/operators';
-import {tap} from 'rxjs/operators';
-import {finalize} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
-import {share} from 'rxjs/operators';
+import {DOCUMENT} from '@angular/common';
+import {HttpClient} from '@angular/common/http';
 import {
-  Injectable,
   Inject,
+  Injectable,
   InjectionToken,
   Optional,
   SecurityContext,
   SkipSelf,
 } from '@angular/core';
-import {HttpClient} from '@angular/common/http';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
-import {Observable} from 'rxjs';
-import {forkJoin} from 'rxjs';
-import {of as observableOf} from 'rxjs';
-import {throwError as observableThrow} from 'rxjs';
-import {DOCUMENT} from '@angular/common';
+import {forkJoin, Observable, of as observableOf, throwError as observableThrow} from 'rxjs';
+import {catchError, finalize, map, share, tap} from 'rxjs/operators';
 
 
 /**

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -6,12 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusKeyManager} from '@angular/cdk/a11y';
+import {FocusKeyManager, FocusOrigin} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
-import {startWith} from 'rxjs/operators';
-import {switchMap} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -23,27 +21,23 @@ import {
   Inject,
   InjectionToken,
   Input,
+  NgZone,
   OnDestroy,
+  OnInit,
   Output,
   QueryList,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
-  NgZone,
-  OnInit,
 } from '@angular/core';
-import {Observable} from 'rxjs';
-import {Subject} from 'rxjs';
-import {merge} from 'rxjs';
-import {Subscription} from 'rxjs';
+import {merge, Observable, Subject, Subscription} from 'rxjs';
+import {startWith, switchMap, take} from 'rxjs/operators';
 import {matMenuAnimations} from './menu-animations';
+import {MatMenuContent} from './menu-content';
 import {throwMatMenuInvalidPositionX, throwMatMenuInvalidPositionY} from './menu-errors';
 import {MatMenuItem} from './menu-item';
 import {MatMenuPanel} from './menu-panel';
-import {MatMenuContent} from './menu-content';
 import {MenuPositionX, MenuPositionY} from './menu-positions';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {FocusOrigin} from '@angular/cdk/a11y';
 
 
 /** Default `mat-menu` options that can be overridden. */

--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, SkipSelf, Optional } from '@angular/core';
+import {Injectable, Optional, SkipSelf} from '@angular/core';
 import {Subject} from 'rxjs';
+
 
 /**
  * To modify the labels and text displayed, create a new instance of MatPaginatorIntl and

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -4,11 +4,11 @@ import {
   END,
   ENTER,
   HOME,
+  LEFT_ARROW,
+  RIGHT_ARROW,
   SPACE,
   TAB,
   UP_ARROW,
-  LEFT_ARROW,
-  RIGHT_ARROW,
 } from '@angular/cdk/keycodes';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {Platform} from '@angular/cdk/platform';
@@ -58,9 +58,8 @@ import {
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Subject, Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {Subject} from 'rxjs';
-import {Subscription} from 'rxjs';
 import {MatSelectModule} from './index';
 import {MatSelect} from './select';
 import {
@@ -68,6 +67,7 @@ import {
   getMatSelectNonArrayValueError,
   getMatSelectNonFunctionValueError,
 } from './select-errors';
+
 
 /** The debounce interval when typing letters to select an option. */
 const LETTER_KEY_DEBOUNCE_INTERVAL = 200;

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -6,30 +6,30 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  Component,
-  ComponentRef,
-  EmbeddedViewRef,
-  ViewChild,
-  NgZone,
-  OnDestroy,
-  ElementRef,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  ChangeDetectorRef,
-} from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {
   BasePortalOutlet,
-  ComponentPortal,
   CdkPortalOutlet,
+  ComponentPortal,
   TemplatePortal,
 } from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ComponentRef,
+  ElementRef,
+  EmbeddedViewRef,
+  NgZone,
+  OnDestroy,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+import {Observable, Subject} from 'rxjs';
 import {take} from 'rxjs/operators';
-import {Observable} from 'rxjs';
-import {Subject} from 'rxjs';
-import {MatSnackBarConfig} from './snack-bar-config';
 import {matSnackBarAnimations} from './snack-bar-animations';
+import {MatSnackBarConfig} from './snack-bar-config';
+
 
 /**
  * Internal component that wraps user-provided snack bar content.

--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -7,9 +7,9 @@
  */
 
 import {OverlayRef} from '@angular/cdk/overlay';
-import {Observable} from 'rxjs';
-import {Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 import {MatSnackBarContainer} from './snack-bar-container';
+
 
 /** Event that is emitted when a snack bar is dismissed. */
 export interface MatSnackBarDismiss {

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -9,20 +9,19 @@
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 import {Overlay, OverlayConfig, OverlayRef} from '@angular/cdk/overlay';
-import {ComponentPortal, TemplatePortal, ComponentType, PortalInjector} from '@angular/cdk/portal';
+import {ComponentPortal, ComponentType, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
 import {
   ComponentRef,
   EmbeddedViewRef,
   Inject,
   Injectable,
-  Injector,
   InjectionToken,
+  Injector,
   Optional,
   SkipSelf,
   TemplateRef,
 } from '@angular/core';
-import {take} from 'rxjs/operators';
-import {takeUntil} from 'rxjs/operators';
+import {take, takeUntil} from 'rxjs/operators';
 import {SimpleSnackBar} from './simple-snack-bar';
 import {MAT_SNACK_BAR_DATA, MatSnackBarConfig} from './snack-bar-config';
 import {MatSnackBarContainer} from './snack-bar-container';

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {CdkColumnDef} from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -14,16 +16,14 @@ import {
   Optional,
   ViewEncapsulation
 } from '@angular/core';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {CdkColumnDef} from '@angular/cdk/table';
-import {Subscription} from 'rxjs';
-import {merge} from 'rxjs';
-import {MatSort, MatSortable} from './sort';
-import {SortDirection} from './sort-direction';
-import {MatSortHeaderIntl} from './sort-header-intl';
-import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
 import {CanDisable, mixinDisabled} from '@angular/material/core';
+import {merge, Subscription} from 'rxjs';
+import {MatSort, MatSortable} from './sort';
 import {matSortAnimations} from './sort-animations';
+import {SortDirection} from './sort-direction';
+import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
+import {MatSortHeaderIntl} from './sort-header-intl';
+
 
 // Boilerplate for applying mixins to the sort header.
 /** @docs-private */

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -24,14 +24,13 @@ import {
 } from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
-import {Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
+import {map, take} from 'rxjs/operators';
 import {MatStepperModule} from './index';
 import {MatHorizontalStepper, MatStep, MatStepper, MatVerticalStepper} from './stepper';
 import {MatStepperNext, MatStepperPrevious} from './stepper-button';
 import {MatStepperIntl} from './stepper-intl';
+
 
 const VALID_REGEX = /valid/;
 

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -6,15 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {_isNumberValue} from '@angular/cdk/coercion';
 import {DataSource} from '@angular/cdk/table';
-import {BehaviorSubject, Observable} from 'rxjs';
 import {MatPaginator, PageEvent} from '@angular/material/paginator';
 import {MatSort, Sort} from '@angular/material/sort';
-import {Subscription, combineLatest} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {startWith} from 'rxjs/operators';
-import {empty} from 'rxjs';
-import {_isNumberValue} from '@angular/cdk/coercion';
+import {BehaviorSubject, combineLatest, empty, Observable, Subscription} from 'rxjs';
+import {map, startWith} from 'rxjs/operators';
+
 
 /**
  * Data source that accepts a client-side data array and includes native support of filtering,

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -1,14 +1,14 @@
-import {async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
-import {Component, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
-import {BehaviorSubject} from 'rxjs';
-import {Observable} from 'rxjs';
-import {MatTableModule} from './index';
-import {MatTable} from './table';
+import {Component, ViewChild} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {MatPaginator, MatPaginatorModule} from '../paginator/index';
 import {MatSort, MatSortHeader, MatSortModule} from '../sort/index';
+import {MatTableModule} from './index';
+import {MatTable} from './table';
 import {MatTableDataSource} from './table-data-source';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
 
 describe('MatTable', () => {
   beforeEach(async(() => {

--- a/src/lib/tabs/ink-bar.ts
+++ b/src/lib/tabs/ink-bar.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Directive, ElementRef, Inject, InjectionToken, NgZone } from '@angular/core';
+import {Directive, ElementRef, Inject, InjectionToken, NgZone} from '@angular/core';
+
 
 /**
  * Interface for a a MatInkBar positioner method, defining the positioning and width of the ink

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -22,11 +23,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
-import {Subscription} from 'rxjs';
-import {MatTab} from './tab';
-import {MatTabHeader} from './tab-header';
-import {merge} from 'rxjs';
 import {
   CanColor,
   CanDisableRipple,
@@ -34,6 +30,9 @@ import {
   mixinDisableRipple,
   ThemePalette
 } from '@angular/material/core';
+import {merge, Subscription} from 'rxjs';
+import {MatTab} from './tab';
+import {MatTabHeader} from './tab-header';
 
 
 /** Used to generate unique ID's for each tab component */

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -7,7 +7,9 @@
  */
 
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE, HOME, END} from '@angular/cdk/keycodes';
+import {coerceNumberProperty} from '@angular/cdk/coercion';
+import {END, ENTER, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE} from '@angular/cdk/keycodes';
+import {ViewportRuler} from '@angular/cdk/scrolling';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -26,13 +28,9 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {CanDisableRipple, mixinDisableRipple} from '@angular/material/core';
-import {merge} from 'rxjs';
-import {of as observableOf} from 'rxjs';
-import {Subscription} from 'rxjs';
-import {coerceNumberProperty} from '@angular/cdk/coercion';
+import {merge, of as observableOf, Subscription} from 'rxjs';
 import {MatInkBar} from './ink-bar';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
-import {ViewportRuler} from '@angular/cdk/scrolling';
 
 
 /**

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -43,10 +43,8 @@ import {
   RippleTarget,
   ThemePalette,
 } from '@angular/material/core';
-import {merge} from 'rxjs';
-import {of as observableOf} from 'rxjs';
+import {merge, of as observableOf, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
-import {Subject} from 'rxjs';
 import {MatInkBar} from '../ink-bar';
 
 

--- a/src/lib/tree/data-source/flat-data-source.ts
+++ b/src/lib/tree/data-source/flat-data-source.ts
@@ -8,11 +8,9 @@
 
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {FlatTreeControl, TreeControl} from '@angular/cdk/tree';
-import {Observable} from 'rxjs';
-import {merge} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {take} from 'rxjs/operators';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, merge, Observable} from 'rxjs';
+import {map, take} from 'rxjs/operators';
+
 
 /**
  * Tree flattener to convert a normal type of node to node with children & level information.

--- a/src/lib/tree/data-source/nested-data-source.ts
+++ b/src/lib/tree/data-source/nested-data-source.ts
@@ -7,10 +7,9 @@
  */
 
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
-import {Observable} from 'rxjs';
-import {merge} from 'rxjs';
+import {BehaviorSubject, merge, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {BehaviorSubject} from 'rxjs';
+
 
 /**
  * Data source for nested tree.

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -5,18 +5,17 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TreeControl, FlatTreeControl, NestedTreeControl} from '@angular/cdk/tree';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FlatTreeControl, NestedTreeControl, TreeControl} from '@angular/cdk/tree';
 import {Component, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {
   MatTree,
-  MatTreeModule,
-  MatTreeFlattener,
   MatTreeFlatDataSource,
+  MatTreeFlattener,
+  MatTreeModule,
   MatTreeNestedDataSource
 } from './index';
-import {BehaviorSubject} from 'rxjs';
-import {Observable} from 'rxjs';
 
 
 describe('MatTree', () => {

--- a/src/material-examples/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
+++ b/src/material-examples/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
@@ -1,8 +1,7 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 /**
  * @title Highlight the first autocomplete option

--- a/src/material-examples/autocomplete-display/autocomplete-display-example.ts
+++ b/src/material-examples/autocomplete-display/autocomplete-display-example.ts
@@ -1,8 +1,7 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 export class User {
   constructor(public name: string) { }

--- a/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
@@ -1,8 +1,7 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 /**
  * @title Filter autocomplete

--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -2,8 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
 import {Observable} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 export class State {
   constructor(public name: string, public population: string, public flag: string) { }

--- a/src/material-examples/cdk-table-basic/cdk-table-basic-example.ts
+++ b/src/material-examples/cdk-table-basic/cdk-table-basic-example.ts
@@ -1,7 +1,6 @@
-import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
-import {BehaviorSubject} from 'rxjs';
-import {Observable} from 'rxjs';
+import {Component} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
 
 /**
  * @title Basic CDK data-table

--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -1,10 +1,9 @@
-import {Component, ViewChild, ElementRef} from '@angular/core';
-import {MatChipInputEvent, MatAutocompleteSelectedEvent} from '@angular/material';
-import {ENTER, COMMA} from '@angular/cdk/keycodes';
+import {COMMA, ENTER} from '@angular/cdk/keycodes';
+import {Component, ElementRef, ViewChild} from '@angular/core';
 import {FormControl} from '@angular/forms';
+import {MatAutocompleteSelectedEvent, MatChipInputEvent} from '@angular/material';
 import {Observable} from 'rxjs';
-import {startWith} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 /**
  * @title Chips Autocomplete

--- a/src/material-examples/datepicker-formats/datepicker-formats-example.ts
+++ b/src/material-examples/datepicker-formats/datepicker-formats-example.ts
@@ -8,7 +8,9 @@ import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using
 // the `default as` syntax.
 import * as _moment from 'moment';
+// tslint:disable-next-line:no-duplicate-imports
 import {default as _rollupMoment} from 'moment';
+
 const moment = _rollupMoment || _moment;
 
 // See the Moment.js docs for the meaning of these formats:

--- a/src/material-examples/datepicker-moment/datepicker-moment-example.ts
+++ b/src/material-examples/datepicker-moment/datepicker-moment-example.ts
@@ -8,7 +8,9 @@ import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using
 // the `default as` syntax.
 import * as _moment from 'moment';
+// tslint:disable-next-line:no-duplicate-imports
 import {default as _rollupMoment} from 'moment';
+
 const moment = _rollupMoment || _moment;
 
 /** @title Datepicker that uses Moment.js dates */

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -1,15 +1,17 @@
 import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {MatDatepicker} from '@angular/material/datepicker';
 import {MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {MatDatepicker} from '@angular/material/datepicker';
 
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using
 // the `default as` syntax.
 import * as _moment from 'moment';
+// tslint:disable-next-line:no-duplicate-imports
 import {default as _rollupMoment, Moment} from 'moment';
+
 const moment = _rollupMoment || _moment;
 
 // See the Moment.js docs for the meaning of these formats:

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -1,13 +1,8 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
-import {Observable} from 'rxjs';
-import {merge} from 'rxjs';
-import {of as observableOf} from 'rxjs';
-import {catchError} from 'rxjs/operators';
-import {map} from 'rxjs/operators';
-import {startWith} from 'rxjs/operators';
-import {switchMap} from 'rxjs/operators';
+import {merge, Observable, of as observableOf} from 'rxjs';
+import {catchError, map, startWith, switchMap} from 'rxjs/operators';
 
 /**
  * @title Table retrieving data through HTTP

--- a/src/material-examples/tree-flat-overview/tree-flat-overview-example.ts
+++ b/src/material-examples/tree-flat-overview/tree-flat-overview-example.ts
@@ -1,9 +1,7 @@
-import {Component, Injectable} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
-import {MatTreeFlattener, MatTreeFlatDataSource} from '@angular/material/tree';
-import {of} from 'rxjs';
-import {Observable} from 'rxjs';
-import {BehaviorSubject} from 'rxjs';
+import {Component, Injectable} from '@angular/core';
+import {MatTreeFlatDataSource, MatTreeFlattener} from '@angular/material/tree';
+import {BehaviorSubject, Observable, of as observableOf} from 'rxjs';
 
 /**
  * File node data with nested structure.
@@ -156,7 +154,9 @@ export class TreeFlatOverviewExample {
 
   private _isExpandable = (node: FileFlatNode) => { return node.expandable; };
 
-  private _getChildren = (node: FileNode): Observable<FileNode[]> => { return of(node.children); };
+  private _getChildren = (node: FileNode): Observable<FileNode[]> => {
+    return observableOf(node.children);
+  }
 
   hasChild = (_: number, _nodeData: FileFlatNode) => { return _nodeData.expandable; };
 }

--- a/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
+++ b/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
@@ -1,8 +1,7 @@
-import {Component, Injectable} from '@angular/core';
 import {NestedTreeControl} from '@angular/cdk/tree';
+import {Component, Injectable} from '@angular/core';
 import {MatTreeNestedDataSource} from '@angular/material/tree';
-import {of} from 'rxjs';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, of as observableOf} from 'rxjs';
 
 /**
  * Json node data with nested structure. Each node has a filename and a value or a list of children
@@ -126,7 +125,7 @@ export class TreeNestedOverviewExample {
     database.dataChange.subscribe(data => this.nestedDataSource.data = data);
   }
 
-  private _getChildren = (node: FileNode) => { return of(node.children); };
+  private _getChildren = (node: FileNode) => { return observableOf(node.children); };
 
   hasNestedChild = (_: number, nodeData: FileNode) => {return !(nodeData.type); };
 }

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -14,6 +14,7 @@ import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material';
 // the `default as` syntax.
 // TODO(mmalerba): See if we can clean this up at some point.
 import * as _moment from 'moment';
+// tslint:disable-next-line:no-duplicate-imports
 import {default as _rollupMoment, Moment} from 'moment';
 
 const moment = _rollupMoment || _moment;

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -1,6 +1,9 @@
+import {ViewportRuler} from '@angular/cdk/scrolling';
+import {
+  CdkTableModule,
+  DataSource
+} from '@angular/cdk/table';
 import {Component, NgModule} from '@angular/core';
-import {ServerModule} from '@angular/platform-server';
-import {BrowserModule} from '@angular/platform-browser';
 import {
   MatAutocompleteModule,
   MatBadgeModule,
@@ -10,8 +13,9 @@ import {
   MatCheckboxModule,
   MatChipsModule,
   MatDatepickerModule,
-  MatDividerModule,
+  MatDialog,
   MatDialogModule,
+  MatDividerModule,
   MatExpansionModule,
   MatFormFieldModule,
   MatGridListModule,
@@ -29,23 +33,18 @@ import {
   MatSidenavModule,
   MatSliderModule,
   MatSlideToggleModule,
+  MatSnackBar,
   MatSnackBarModule,
   MatSortModule,
+  MatStepperModule,
   MatTableModule,
   MatTabsModule,
   MatToolbarModule,
   MatTooltipModule,
-  MatStepperModule,
-  MatSnackBar,
-  MatDialog,
 } from '@angular/material';
-import {
-  CdkTableModule,
-  DataSource
-} from '@angular/cdk/table';
-import {ViewportRuler} from '@angular/cdk/scrolling';
-import {of as observableOf} from 'rxjs';
-import {Observable} from 'rxjs';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServerModule} from '@angular/platform-server';
+import {Observable, of as observableOf} from 'rxjs';
 
 export class TableDataSource extends DataSource<any> {
   connect(): Observable<any> {

--- a/tools/package-tools/metadata-inlining.ts
+++ b/tools/package-tools/metadata-inlining.ts
@@ -1,7 +1,6 @@
 import {readFileSync, writeFileSync} from 'fs';
-import {basename} from 'path';
 import {sync as glob} from 'glob';
-import {join} from 'path';
+import {basename, join} from 'path';
 
 /**
  * Recurse through a parsed metadata.json file and inline all html and css.

--- a/tslint.json
+++ b/tslint.json
@@ -83,6 +83,7 @@
     // Namespaces are no allowed, because of Closure compiler.
     "no-namespace": true,
     "jsdoc-format": [true, "check-multiline-start"],
+    "no-duplicate-imports": true,
 
     // Custom Rules
     "ts-loader": true,


### PR DESCRIPTION
This removes all duplicate imports. Some of them were added in #10496.

I also added a `tslint` rule to keep it consistent.