### PR TITLE
fix(slider): css animation not rendering properly in chrome

### DIFF
--- a/src/lib/slider/slider.scss
+++ b/src/lib/slider/slider.scss
@@ -51,6 +51,7 @@ $mat-slider-focus-ring-size: 30px !default;
 .mat-slider-track-fill {
   position: absolute;
   transform-origin: 0 0;
+  -webkit-transition: none !important;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
               background-color $swift-ease-out-duration $swift-ease-out-timing-function;
 }
@@ -58,6 +59,7 @@ $mat-slider-focus-ring-size: 30px !default;
 .mat-slider-track-background {
   position: absolute;
   transform-origin: 100% 100%;
+  -webkit-transition: none !important;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
               background-color $swift-ease-out-duration $swift-ease-out-timing-function;
 }
@@ -80,6 +82,7 @@ $mat-slider-focus-ring-size: 30px !default;
 .mat-slider-thumb-container {
   position: absolute;
   z-index: 1;
+  -webkit-transition: none !important;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 }
 


### PR DESCRIPTION
fixes #8495

Adds Vendor specific CSS property for web-kit to fix the rendering issue of the animation described in the issues above. The style was added to the mat-slider-track-fill, mat-slider-track-background and mat-slider-thumb-container classes to prevent the issue of affecting only one class as mentioned [here](https://github.com/angular/material2/issues/8495#issuecomment-345751121).

Demo:
![slider-chrome-animation](https://user-images.githubusercontent.com/16708173/38346130-1ca0e7aa-3861-11e8-847d-c647ef04aa3a.gif)