### PR TITLE
refactor(tree): use destroy cleanup logic from base class

### DIFF
--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -79,13 +79,12 @@ export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContent
           this.updateChildrenNodes();
         });
     this.nodeOutlet.changes.pipe(takeUntil(this._destroyed))
-        .subscribe((_) => this.updateChildrenNodes());
+        .subscribe(() => this.updateChildrenNodes());
   }
 
   ngOnDestroy() {
     this._clear();
-    this._destroyed.next();
-    this._destroyed.complete();
+    super.ngOnDestroy();
   }
 
   /** Add children dataNodes to the NodeOutlet */


### PR DESCRIPTION
Uses the `ngOnDestroy` logic from the `CdkTreeNode` rather than re-implementing it in the `CdkNestedTreeNode`. This is less prone to errors in the future, if we decide to introduce more cleanup logic inside the base class.