### PR TITLE
chore: fix test failure due to changed label

### DIFF
--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -277,7 +277,7 @@ describe('MatTable', () => {
       component.sort.sort(component.sortHeader);
       fixture.detectChanges();
       expectTableToMatchContent(tableElement, [
-        ['Column A\xa0Sorted by a ascending', 'Column B', 'Column C'],
+        ['Column A', 'Column B', 'Column C'],
         ['-1', 'b_3', 'c_3'],
         ['0', 'b_2', 'c_2'],
         ['1', 'b_1', 'c_1'],
@@ -289,7 +289,7 @@ describe('MatTable', () => {
       component.sort.sort(component.sortHeader);
       fixture.detectChanges();
       expectTableToMatchContent(tableElement, [
-        ['Column A\xa0Sorted by a descending', 'Column B', 'Column C'],
+        ['Column A', 'Column B', 'Column C'],
         ['1', 'b_1', 'c_1'],
         ['0', 'b_2', 'c_2'],
         ['-1', 'b_3', 'c_3'],


### PR DESCRIPTION
Fixes a test failure that was introduced in bcb5697a4e0a7dd401f8c42945fecb1a2ddafd28, as a result of 63f713f846a1b2c5a69c4342f0816085a341457f being merged in first which ended up changing the text inside the sort header.