### PR TITLE
chore(calendar): remove explicit preserveWhitespaces setting

### DIFF
--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -40,7 +40,6 @@ import {MatYearView} from './year-view';
   selector: 'mat-calendar-header',
   templateUrl: 'calendar-header.html',
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatCalendarHeader<D> implements OnDestroy {

--- a/tslint.json
+++ b/tslint.json
@@ -95,11 +95,12 @@
     ],
     "validate-decorators": [true, {
       "Component": {
-        "encapsulation": "\\.None$",
-        "moduleId": "^module\\.id$",
-        "changeDetection": "\\.OnPush$",
+        "!host": "\\[class\\]",
+        "!preserveWhitespaces": ".*",
         "!styles": ".*",
-        "!host": "\\[class\\]"
+        "changeDetection": "\\.OnPush$",
+        "encapsulation": "\\.None$",
+        "moduleId": "^module\\.id$"
       },
       "Directive": {
         "!host": "\\[class\\]"


### PR DESCRIPTION
The explicit `preserveWhitespaces` setting were removed in #10216, but #9639 added it to a new component (`MatCalendarHeader`). To prevent future mistakes like that I've added `"!preserveWhitespaces": ".*"` to the `validate-decorators` rule in `tslint.json`.