### PR TITLE
chore: remove unnecessary information in code_reviews

### DIFF
--- a/CODE_REVIEWS.md
+++ b/CODE_REVIEWS.md
@@ -3,12 +3,11 @@
 * Before any coding begins on new, large, or breaking work, a design discussion should take place.
 * All code changes require a review and approval.
 * All behaviors should be covered by unit tests in the same PR.
-* Large changes should be accompanied by corresponding e2e tests in the same PR. 
+* Large changes should be accompanied by corresponding e2e tests in the same PR.
 * Authors should attempt to keep PRs to 200 - 300 line changes.
- 
+
 ## Workflow
 1. The code author sends a PR for review. This request should include:
-  * A mention of the intended reviewer(s) (e.g., `@jelbourn`)
   * A high-level description of the change being made.
   * Links to any relevant issues.
   * Screenshots (for visual changes or new additions)


### PR DESCRIPTION
Since the [CODEOWNERS](https://help.github.com/articles/about-codeowners/) are automatically requested for review when someone opens a PR, there's no need to mention this in docs.