### PR TITLE
refactor(tree): ensure input is applied to the getter and not the setter

### DIFF
--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -26,21 +26,21 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
 
   /** The level of depth of the tree node. The padding will be `level * indent` pixels. */
   @Input('cdkTreeNodePadding')
+  get level(): number { return this._level; }
   set level(value: number) {
     this._level = coerceNumberProperty(value);
     this._setPadding();
   }
-  get level(): number { return this._level; }
   _level: number;
 
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   // TODO(tinayuangao): Make indent working with a string with unit, e.g. 10em
   @Input('cdkTreeNodePaddingIndent')
+  get indent(): number { return this._indent; }
   set indent(value: number) {
     this._indent = coerceNumberProperty(value);
     this._setPadding();
   }
-  get indent(): number { return this._indent; }
   _indent: number = 40;
 
   constructor(private _treeNode: CdkTreeNode<T>,

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -648,8 +648,8 @@ class FakeDataSource extends DataSource<TestData> {
   isConnected = false;
 
   _dataChange = new BehaviorSubject<TestData[]>([]);
-  set data(data: TestData[]) { this._dataChange.next(data); }
   get data() { return this._dataChange.getValue(); }
+  set data(data: TestData[]) { this._dataChange.next(data); }
 
   constructor(public treeControl: TreeControl<TestData>) {
     super();

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -435,8 +435,8 @@ export class TestData {
 class FakeDataSource {
   dataIndex = 0;
   _dataChange = new BehaviorSubject<TestData[]>([]);
-  set data(data: TestData[]) { this._dataChange.next(data); }
   get data() { return this._dataChange.getValue(); }
+  set data(data: TestData[]) { this._dataChange.next(data); }
 
   connect(): Observable<TestData[]> {
     return this._dataChange;


### PR DESCRIPTION
According to [CODING_STANDARDS.md#getters-and-setters](https://github.com/angular/material2/blob/master/CODING_STANDARDS.md#getters-and-setters):

- Decorators such as @Input should be applied to the getter and not the setter.