### PR TITLE
chore: add missing lifecycles interfaces to declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "integrity": "sha512-v2OOSoYCHP6QrdQ8/df22+jzqWGAkaB5UxRMpbIyvhEc+UIQxDLugCIxYKTSEmiVmaOwcoH6lYd18RpMkkLgtQ==",
       "dev": true,
       "requires": {
-        "ajv": "~6.4.0",
-        "chokidar": "^2.0.3",
-        "rxjs": "^6.0.0",
-        "source-map": "^0.5.6"
+        "ajv": "6.4.0",
+        "chokidar": "2.0.3",
+        "rxjs": "6.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "ajv": {
@@ -22,10 +22,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "anymatch": {
@@ -34,8 +34,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -56,16 +56,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -74,7 +74,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -85,18 +85,18 @@
           "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.1.3",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.5"
           }
         },
         "debug": {
@@ -114,13 +114,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -129,7 +129,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -138,7 +138,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -147,7 +147,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -156,7 +156,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -167,7 +167,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -176,7 +176,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -187,9 +187,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -206,14 +206,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -222,7 +222,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -231,7 +231,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -242,10 +242,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -254,7 +254,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -265,8 +265,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -275,7 +275,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -286,7 +286,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -295,7 +295,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -304,9 +304,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -321,7 +321,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -330,7 +330,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -339,7 +339,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -362,19 +362,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "source-map": {
@@ -392,7 +392,7 @@
       "dev": true,
       "requires": {
         "@angular-devkit/core": "0.5.13",
-        "rxjs": "^6.0.0"
+        "rxjs": "6.0.0"
       }
     },
     "@angular/animations": {
@@ -400,7 +400,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-6.0.0.tgz",
       "integrity": "sha512-jl3WZmM/csNeyzdb1cEEc5cUX7jLn3NvPYEiP/ZkKmib0XBGIGBBv7xiuoivTJFJsE4/N5sCFEHRFLnuBBE+OA==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/bazel": {
@@ -409,7 +409,7 @@
       "integrity": "sha512-nf8FN92LxKw4br6YHOPYeaIjMV/d2Fz9YdtKpSem3reKtWviTv4gX9gcs443ANKwg5vRZQxTmVQXRVx24MUMpw==",
       "dev": true,
       "requires": {
-        "@bazel/typescript": "^0.11.1",
+        "@bazel/typescript": "0.11.1",
         "@types/node": "6.0.84",
         "@types/shelljs": "0.7.7",
         "protobufjs": "5.0.0",
@@ -429,7 +429,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.0.0.tgz",
       "integrity": "sha512-oo/KESihAZo0FsZPHthO9PYhanN4Q+Lo7Lb2HNbWnD+xRIPa1yFC12JOWiD+SPPfFGWMI6aW3wAlcoej1+QKSw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler": {
@@ -437,7 +437,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.0.0.tgz",
       "integrity": "sha512-UsYfsvHf4VVtkhzM7tyabh8co7gqWZTm3p79hbLDeyCEojl0AkrwbSgh0DQnKRxp4Tu3DEeeDkg1ahA7n19I8A==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/compiler-cli": {
@@ -446,10 +446,10 @@
       "integrity": "sha512-RV0xTSTPT3yOnbS5Gx6lMAETQeTUr72Ifu0+JZh9AV07xGVislZ+SdQGSeNgXoqxise6e65lJp3Nrb5KE4Lv6g==",
       "dev": true,
       "requires": {
-        "chokidar": "^1.4.2",
-        "minimist": "^1.2.0",
-        "reflect-metadata": "^0.1.2",
-        "tsickle": "^0.27.2"
+        "chokidar": "1.7.0",
+        "minimist": "1.2.0",
+        "reflect-metadata": "0.1.12",
+        "tsickle": "0.27.5"
       }
     },
     "@angular/core": {
@@ -457,7 +457,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.0.0.tgz",
       "integrity": "sha512-52X2ZKXOoaMRYaC/ycHePTkXuwku8qJFxoEXAFBItAkk9rebLU4CD8Fx1Z9vUd8aWu1uFfLTxqkgE0mUyBANZw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/elements": {
@@ -465,7 +465,7 @@
       "resolved": "https://registry.npmjs.org/@angular/elements/-/elements-6.0.0.tgz",
       "integrity": "sha512-Jp26Suu7XRrS25qS1CMDo0IFmIJQIl/ahvOE+vY7Xv9/OEGGaRvkF2aUaWyrhuFdXir+xMQGnhTCd6NeJM9VRg==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/forms": {
@@ -473,7 +473,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.0.0.tgz",
       "integrity": "sha512-4eVfCcSyPRhml7Xa6ia/DgDl3JhOnEdBdHo+jads1YL5AF6D08Tthngjf3KjuctGqZDACPyxNt6ciX4g8IbGCA==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/http": {
@@ -482,7 +482,7 @@
       "integrity": "sha512-nBZ4KmXx0KR+cIPOMBsJpPhcec5wSCbVtTYRH0zTxmzTmqM3g6+i0PECpqbVgcQEGiOxBLcmXNWfXZl5czpiqw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-browser": {
@@ -490,7 +490,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.0.0.tgz",
       "integrity": "sha512-ExI1o40BJIbJKFz1p1ivGSgLA1+T0uUo8rjheOZhcGDwCNx54/RapCFLdcHCNiW8NzAIzx+kt4DdXnCSKitnDA==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-browser-dynamic": {
@@ -499,7 +499,7 @@
       "integrity": "sha512-yk4wZYn2bosuvDaYaEq6UuEeI966/28uCljm5iBfo3l8Vuv2IChk5664M68O6C+KwWzCCWDHvIqm0q178YUYug==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/platform-server": {
@@ -508,9 +508,9 @@
       "integrity": "sha512-1dmaM3xpayBdZrkpmhPfpJ1CDNntxlizL1td2DMRUfFqMNyE7acbc7vRuV9BOgniPGsMKphYQXczERNfoVeuSw==",
       "dev": true,
       "requires": {
-        "domino": "^2.0.1",
-        "tslib": "^1.9.0",
-        "xhr2": "^0.1.4"
+        "domino": "2.0.2",
+        "tslib": "1.9.0",
+        "xhr2": "0.1.4"
       }
     },
     "@angular/router": {
@@ -519,7 +519,7 @@
       "integrity": "sha512-ONrfgfYmFGz0Ht2MvymMvBMxPI9w5037ZfJWpTu1/Xo1XmVOawzj2SvYfEzTqexznWcTAALggq/A23k8r9ArKA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@angular/upgrade": {
@@ -528,7 +528,7 @@
       "integrity": "sha512-YpRqxcYzJ14Z98jNaAFzLCIxid3yZdmQFQw6i/E+Jkd9nj77A1/5GqnCWkKCs2C5BbbIe8uqDvVsGWDII61XRQ==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@bazel/ibazel": {
@@ -551,7 +551,7 @@
       "requires": {
         "@firebase/app-types": "0.1.2",
         "@firebase/util": "0.1.10",
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@firebase/app-types": {
@@ -585,7 +585,7 @@
         "@firebase/logger": "0.1.0",
         "@firebase/util": "0.1.10",
         "faye-websocket": "0.11.1",
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@firebase/database-types": {
@@ -603,8 +603,8 @@
         "@firebase/firestore-types": "0.2.2",
         "@firebase/logger": "0.1.0",
         "@firebase/webchannel-wrapper": "0.2.7",
-        "grpc": "^1.9.1",
-        "tslib": "^1.9.0"
+        "grpc": "1.10.1",
+        "tslib": "1.9.0"
       }
     },
     "@firebase/firestore-types": {
@@ -620,8 +620,8 @@
       "dev": true,
       "requires": {
         "@firebase/functions-types": "0.1.0",
-        "@firebase/messaging-types": "^0.1.1",
-        "isomorphic-fetch": "^2.2.1"
+        "@firebase/messaging-types": "0.1.2",
+        "isomorphic-fetch": "2.2.1"
       }
     },
     "@firebase/functions-types": {
@@ -644,7 +644,7 @@
       "requires": {
         "@firebase/messaging-types": "0.1.2",
         "@firebase/util": "0.1.10",
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@firebase/messaging-types": {
@@ -659,9 +659,9 @@
       "integrity": "sha512-nE8LMXBhvWdHBlxtjkZkid8WzowBbxUC+mcYdsEbvx5A7hWswisFZO8XwoKnM1jYYSOpDrtxFmyqWBAc15DmRg==",
       "dev": true,
       "requires": {
-        "promise-polyfill": "^7.1.0",
-        "tslib": "^1.9.0",
-        "whatwg-fetch": "^2.0.3"
+        "promise-polyfill": "7.1.2",
+        "tslib": "1.9.0",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "@firebase/storage": {
@@ -671,7 +671,7 @@
       "dev": true,
       "requires": {
         "@firebase/storage-types": "0.1.2",
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@firebase/storage-types": {
@@ -686,7 +686,7 @@
       "integrity": "sha512-XEogRfUQBZ4T37TMq/3ZbuiTdRAKX8hF3TgJglUZNCJf/6QnQ+jlupCuMAXBqCGfw2Mw0m2matoCUBWpsyevOA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "@firebase/webchannel-wrapper": {
@@ -701,24 +701,24 @@
       "integrity": "sha512-GrkaFoj0/oO36pNs4yLmaYhTujuA3i21FdQik99Fd/APix1uhf01VlpJY4lAteTDFLRNkRx6ydEh7OVvmeUHng==",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.3",
-        "arrify": "^1.0.1",
-        "concat-stream": "^1.6.0",
-        "create-error-class": "^3.0.2",
-        "duplexify": "^3.5.0",
-        "ent": "^2.2.0",
-        "extend": "^3.0.1",
-        "google-auto-auth": "^0.9.0",
-        "is": "^3.2.0",
+        "array-uniq": "1.0.3",
+        "arrify": "1.0.1",
+        "concat-stream": "1.6.2",
+        "create-error-class": "3.0.2",
+        "duplexify": "3.5.4",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "google-auto-auth": "0.9.7",
+        "is": "3.2.1",
         "log-driver": "1.2.7",
-        "methmeth": "^1.1.0",
-        "modelo": "^4.2.0",
-        "request": "^2.79.0",
-        "retry-request": "^3.0.0",
-        "split-array-stream": "^1.0.0",
-        "stream-events": "^1.0.1",
-        "string-format-obj": "^1.1.0",
-        "through2": "^2.0.3"
+        "methmeth": "1.1.0",
+        "modelo": "4.2.3",
+        "request": "2.85.0",
+        "retry-request": "3.3.1",
+        "split-array-stream": "1.0.3",
+        "stream-events": "1.0.3",
+        "string-format-obj": "1.1.1",
+        "through2": "2.0.3"
       }
     },
     "@google-cloud/common-grpc": {
@@ -727,15 +727,15 @@
       "integrity": "sha512-pspOZVfmrCTP0svTNwFE8nYJsQp5rTUaeUpJwpgslDk5tDWFbYT3dZkANbiURcTSq0mo6hZmd+M5rPIzWMVUmA==",
       "dev": true,
       "requires": {
-        "@google-cloud/common": "^0.17.0",
-        "dot-prop": "^4.2.0",
-        "duplexify": "^3.5.1",
-        "extend": "^3.0.1",
-        "grpc": "^1.10.0",
-        "is": "^3.2.0",
-        "modelo": "^4.2.0",
-        "retry-request": "^3.3.1",
-        "through2": "^2.0.3"
+        "@google-cloud/common": "0.17.0",
+        "dot-prop": "4.2.0",
+        "duplexify": "3.5.4",
+        "extend": "3.0.1",
+        "grpc": "1.10.1",
+        "is": "3.2.1",
+        "modelo": "4.2.3",
+        "retry-request": "3.3.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "@google-cloud/common": {
@@ -744,24 +744,24 @@
           "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
           "dev": true,
           "requires": {
-            "array-uniq": "^1.0.3",
-            "arrify": "^1.0.1",
-            "concat-stream": "^1.6.0",
-            "create-error-class": "^3.0.2",
-            "duplexify": "^3.5.0",
-            "ent": "^2.2.0",
-            "extend": "^3.0.1",
-            "google-auto-auth": "^0.10.0",
-            "is": "^3.2.0",
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.2",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.5.4",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "google-auto-auth": "0.10.0",
+            "is": "3.2.1",
             "log-driver": "1.2.7",
-            "methmeth": "^1.1.0",
-            "modelo": "^4.2.0",
-            "request": "^2.79.0",
-            "retry-request": "^3.0.0",
-            "split-array-stream": "^1.0.0",
-            "stream-events": "^1.0.1",
-            "string-format-obj": "^1.1.0",
-            "through2": "^2.0.3"
+            "methmeth": "1.1.0",
+            "modelo": "4.2.3",
+            "request": "2.85.0",
+            "retry-request": "3.3.1",
+            "split-array-stream": "1.0.3",
+            "stream-events": "1.0.3",
+            "string-format-obj": "1.1.1",
+            "through2": "2.0.3"
           }
         },
         "google-auto-auth": {
@@ -770,10 +770,10 @@
           "integrity": "sha512-R6m473OqgZacPvlidJ0aownTlUWyLy654ugjKSXyi1ffIicXlXg3wMfse9T9zxqG6w01q6K1iG+b7dImMkVJ2Q==",
           "dev": true,
           "requires": {
-            "async": "^2.3.0",
-            "gcp-metadata": "^0.6.1",
-            "google-auth-library": "^1.3.1",
-            "request": "^2.79.0"
+            "async": "2.6.0",
+            "gcp-metadata": "0.6.3",
+            "google-auth-library": "1.4.0",
+            "request": "2.85.0"
           }
         }
       }
@@ -784,16 +784,16 @@
       "integrity": "sha512-70PPCDg++AGx4OGW/FhDoDtIh4Z2WuwPMkHkvFWNvEDGghCxGrYgRvpCsfcZBU0TLYpcbsndrweLp972cwItrQ==",
       "dev": true,
       "requires": {
-        "@google-cloud/common": "^0.17.0",
-        "@google-cloud/common-grpc": "^0.6.0",
-        "bun": "^0.0.12",
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^0.16.0",
-        "is": "^3.2.1",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.3"
+        "@google-cloud/common": "0.17.0",
+        "@google-cloud/common-grpc": "0.6.1",
+        "bun": "0.0.12",
+        "deep-equal": "1.0.1",
+        "extend": "3.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "google-gax": "0.16.1",
+        "is": "3.2.1",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "@google-cloud/common": {
@@ -802,24 +802,24 @@
           "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
           "dev": true,
           "requires": {
-            "array-uniq": "^1.0.3",
-            "arrify": "^1.0.1",
-            "concat-stream": "^1.6.0",
-            "create-error-class": "^3.0.2",
-            "duplexify": "^3.5.0",
-            "ent": "^2.2.0",
-            "extend": "^3.0.1",
-            "google-auto-auth": "^0.10.0",
-            "is": "^3.2.0",
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.2",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.5.4",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "google-auto-auth": "0.10.0",
+            "is": "3.2.1",
             "log-driver": "1.2.7",
-            "methmeth": "^1.1.0",
-            "modelo": "^4.2.0",
-            "request": "^2.79.0",
-            "retry-request": "^3.0.0",
-            "split-array-stream": "^1.0.0",
-            "stream-events": "^1.0.1",
-            "string-format-obj": "^1.1.0",
-            "through2": "^2.0.3"
+            "methmeth": "1.1.0",
+            "modelo": "4.2.3",
+            "request": "2.85.0",
+            "retry-request": "3.3.1",
+            "split-array-stream": "1.0.3",
+            "stream-events": "1.0.3",
+            "string-format-obj": "1.1.1",
+            "through2": "2.0.3"
           }
         },
         "google-auto-auth": {
@@ -828,10 +828,10 @@
           "integrity": "sha512-R6m473OqgZacPvlidJ0aownTlUWyLy654ugjKSXyi1ffIicXlXg3wMfse9T9zxqG6w01q6K1iG+b7dImMkVJ2Q==",
           "dev": true,
           "requires": {
-            "async": "^2.3.0",
-            "gcp-metadata": "^0.6.1",
-            "google-auth-library": "^1.3.1",
-            "request": "^2.79.0"
+            "async": "2.6.0",
+            "gcp-metadata": "0.6.3",
+            "google-auth-library": "1.4.0",
+            "request": "2.85.0"
           }
         }
       }
@@ -872,9 +872,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
@@ -897,9 +897,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "colors": {
@@ -916,12 +916,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.2.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -937,9 +937,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -948,8 +948,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -958,7 +958,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "tmp": {
@@ -968,7 +968,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         },
         "winston": {
@@ -978,12 +978,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "stack-trace": "0.0.10"
           },
           "dependencies": {
             "colors": {
@@ -1002,18 +1002,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         }
       }
@@ -1024,27 +1024,27 @@
       "integrity": "sha512-yQ63bJYoiwY220gn/KdTLPoHppAPwFHfG7VFLPwJ+1R5U1eqUN5XV2a7uPj1szGF8/gxlKm2UbE8DgoJJ76DFw==",
       "dev": true,
       "requires": {
-        "@google-cloud/common": "^0.16.1",
-        "arrify": "^1.0.0",
-        "async": "^2.0.1",
-        "compressible": "^2.0.12",
-        "concat-stream": "^1.5.0",
-        "create-error-class": "^3.0.2",
-        "duplexify": "^3.5.0",
-        "extend": "^3.0.0",
-        "gcs-resumable-upload": "^0.9.0",
-        "hash-stream-validation": "^0.2.1",
-        "is": "^3.0.1",
-        "mime": "^2.2.0",
-        "mime-types": "^2.0.8",
-        "once": "^1.3.1",
-        "pumpify": "^1.3.3",
-        "request": "^2.83.0",
-        "safe-buffer": "^5.1.1",
-        "snakeize": "^0.1.0",
-        "stream-events": "^1.0.1",
-        "string-format-obj": "^1.0.0",
-        "through2": "^2.0.0"
+        "@google-cloud/common": "0.16.2",
+        "arrify": "1.0.1",
+        "async": "2.6.0",
+        "compressible": "2.0.13",
+        "concat-stream": "1.6.2",
+        "create-error-class": "3.0.2",
+        "duplexify": "3.5.4",
+        "extend": "3.0.1",
+        "gcs-resumable-upload": "0.9.0",
+        "hash-stream-validation": "0.2.1",
+        "is": "3.2.1",
+        "mime": "2.2.2",
+        "mime-types": "2.1.18",
+        "once": "1.4.0",
+        "pumpify": "1.4.0",
+        "request": "2.85.0",
+        "safe-buffer": "5.1.1",
+        "snakeize": "0.1.0",
+        "stream-events": "1.0.3",
+        "string-format-obj": "1.1.1",
+        "through2": "2.0.3"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1053,8 +1053,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -1087,8 +1087,8 @@
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -1129,7 +1129,7 @@
       "requires": {
         "@angular-devkit/core": "0.5.13",
         "@angular-devkit/schematics": "0.5.13",
-        "typescript": ">=2.6.2 <2.8"
+        "typescript": "2.7.2"
       }
     },
     "@sindresorhus/is": {
@@ -1157,7 +1157,7 @@
       "integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.59"
       }
     },
     "@types/glob": {
@@ -1166,9 +1166,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "7.0.59"
       }
     },
     "@types/google-cloud__storage": {
@@ -1177,7 +1177,7 @@
       "integrity": "sha512-010Llp+5ze+XWWmZuLDxs0pZgFjOgtJQVt9icJ0Ed67ZFLq7PnXkYx8x/k9nwDojR5/X4XoLPNqB1F627TScdQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.59"
       }
     },
     "@types/gulp": {
@@ -1186,9 +1186,9 @@
       "integrity": "sha1-g8WcaBzCM9Hsf4LSaVVVZvoTMVY=",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/orchestrator": "*",
-        "@types/vinyl": "*"
+        "@types/node": "7.0.59",
+        "@types/orchestrator": "0.3.2",
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/hammerjs": {
@@ -1215,7 +1215,7 @@
       "integrity": "sha1-njnQT2/k82+nR3VmytH6+AsqZx8=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.59"
       }
     },
     "@types/minimatch": {
@@ -1242,8 +1242,8 @@
       "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/q": "*"
+        "@types/node": "7.0.59",
+        "@types/q": "1.5.0"
       }
     },
     "@types/q": {
@@ -1258,8 +1258,8 @@
       "integrity": "sha1-atD3ODE24TklMi5p/EHbd7MLIHU=",
       "dev": true,
       "requires": {
-        "@types/gulp": "*",
-        "@types/node": "*"
+        "@types/gulp": "3.8.32",
+        "@types/node": "7.0.59"
       }
     },
     "@types/selenium-webdriver": {
@@ -1274,8 +1274,8 @@
       "integrity": "sha512-37gn9J75TVAhhmzBqoX0vzQodsjzri1SxElMX+Wk092IobNZSGW/8X4ygLOQOrKjCQr5nxGN9Ik0UA3fSdL1Pw==",
       "dev": true,
       "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "@types/glob": "5.0.35",
+        "@types/node": "7.0.59"
       }
     },
     "@types/vinyl": {
@@ -1284,7 +1284,7 @@
       "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.59"
       }
     },
     "@webcomponents/custom-elements": {
@@ -1298,8 +1298,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "a-sync-waterfall": {
@@ -1326,7 +1326,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -1348,7 +1348,7 @@
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
       "requires": {
-        "acorn": "^2.1.0"
+        "acorn": "2.7.0"
       },
       "dependencies": {
         "acorn": {
@@ -1383,7 +1383,7 @@
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -1392,10 +1392,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -1410,9 +1410,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -1427,7 +1427,7 @@
       "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       }
     },
     "ansi-colors": {
@@ -1436,7 +1436,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-escapes": {
@@ -1484,14 +1484,20 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+      "dev": true
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
       "dev": true
     },
     "aproba": {
@@ -1506,14 +1512,14 @@
       "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "async": "^2.0.0",
-        "buffer-crc32": "^0.2.1",
-        "glob": "^7.0.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0",
-        "tar-stream": "^1.5.0",
-        "zip-stream": "^1.2.0"
+        "archiver-utils": "1.3.0",
+        "async": "2.6.0",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.6",
+        "tar-stream": "1.5.5",
+        "zip-stream": "1.2.0"
       }
     },
     "archiver-utils": {
@@ -1522,12 +1528,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "graceful-fs": "^4.1.0",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.5",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "archy": {
@@ -1542,8 +1548,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -1552,7 +1558,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1561,7 +1567,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -1648,7 +1654,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1693,8 +1699,8 @@
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "dev": true,
       "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
+        "colour": "0.7.1",
+        "optjs": "3.2.2"
       }
     },
     "asn1": {
@@ -1727,7 +1733,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.5"
       }
     },
     "async-each": {
@@ -1760,12 +1766,12 @@
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.7.6",
-        "caniuse-db": "^1.0.30000634",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.2.16",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000824",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "aws-sign2": {
@@ -1792,8 +1798,8 @@
       "integrity": "sha512-DGjz5DqQ+btGCj49cFSF+ZK9UWcYCwXiYqIlfBDBbPAen2u/plEUsHBiQODpkhTpbFdnUgCwxf6cwaP8Ku6hCw==",
       "dev": true,
       "requires": {
-        "axe-core": "^2.6.1",
-        "selenium-webdriver": ">= 2.53.1"
+        "axe-core": "2.6.1",
+        "selenium-webdriver": "3.6.0"
       }
     },
     "axios": {
@@ -1802,8 +1808,8 @@
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
       }
     },
     "babel-code-frame": {
@@ -1812,9 +1818,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-runtime": {
@@ -1823,8 +1829,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babylon": {
@@ -1857,13 +1863,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1872,7 +1878,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1881,7 +1887,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1890,7 +1896,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1899,9 +1905,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1964,7 +1970,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1988,8 +1994,8 @@
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true,
       "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
       }
     },
     "binary-extensions": {
@@ -2004,8 +2010,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "blob": {
@@ -2020,7 +2026,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "blocking-proxy": {
@@ -2029,7 +2035,7 @@
       "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "bluebird": {
@@ -2045,15 +2051,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -2079,7 +2085,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "boxen": {
@@ -2088,15 +2094,15 @@
       "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
       "dev": true,
       "requires": {
-        "ansi-align": "^1.1.0",
-        "camelcase": "^2.1.0",
-        "chalk": "^1.1.1",
-        "cli-boxes": "^1.0.0",
-        "filled-array": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "repeating": "^2.0.0",
-        "string-width": "^1.0.1",
-        "widest-line": "^1.0.0"
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
       }
     },
     "brace-expansion": {
@@ -2105,7 +2111,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2115,9 +2121,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "browserslist": {
@@ -2126,8 +2132,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "^1.0.30000639",
-        "electron-to-chromium": "^1.2.7"
+        "caniuse-db": "1.0.30000824",
+        "electron-to-chromium": "1.3.42"
       }
     },
     "browserstack": {
@@ -2145,8 +2151,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           }
         },
         "debug": {
@@ -2164,9 +2170,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "semver": {
@@ -2183,8 +2189,8 @@
       "integrity": "sha512-7w7HYA00qjBtuQH0c5rqW7RbWPHyRROqTZofwNp5G0sKc2fYChsTfbHz3ul8Yd+ffkQvR81m+iPjEB004P6kxQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "^1.0.0",
-        "unzip": "~0.1.9"
+        "https-proxy-agent": "1.0.0",
+        "unzip": "0.1.11"
       },
       "dependencies": {
         "agent-base": {
@@ -2193,8 +2199,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           }
         },
         "debug": {
@@ -2212,9 +2218,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "semver": {
@@ -2255,9 +2261,9 @@
       "integrity": "sha1-Ia2XNd+/ZXZ0W+DXSiPvJXvzxY0=",
       "dev": true,
       "requires": {
-        "cross-spawn-async": "^1.0.1",
-        "err-code": "^0.1.0",
-        "q": "^1.0.1"
+        "cross-spawn-async": "1.0.1",
+        "err-code": "0.1.2",
+        "q": "1.4.1"
       }
     },
     "buffers": {
@@ -2272,7 +2278,7 @@
       "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "builtin-modules": {
@@ -2287,7 +2293,7 @@
       "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.32"
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -2302,10 +2308,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2322,7 +2328,7 @@
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "dev": true,
       "requires": {
-        "long": "~3"
+        "long": "3.2.0"
       }
     },
     "bytes": {
@@ -2337,15 +2343,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2405,8 +2411,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -2421,8 +2427,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caniuse-db": {
@@ -2461,7 +2467,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "~0.3.0"
+        "underscore-contrib": "0.3.0"
       }
     },
     "ccount": {
@@ -2476,8 +2482,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chainsaw": {
@@ -2486,7 +2492,7 @@
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true,
       "requires": {
-        "traverse": ">=0.3.0 <0.4"
+        "traverse": "0.3.9"
       },
       "dependencies": {
         "traverse": {
@@ -2503,11 +2509,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -2524,24 +2530,24 @@
       "integrity": "sha1-bJyONfh5CHCoK2sHRb6MPL75sIE=",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.2.0",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "constant-case": "2.0.0",
+        "dot-case": "2.1.1",
+        "header-case": "1.0.1",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "no-case": "2.3.2",
+        "param-case": "2.1.1",
+        "pascal-case": "2.0.1",
+        "path-case": "2.1.1",
+        "sentence-case": "2.1.1",
+        "snake-case": "2.1.0",
+        "swap-case": "1.1.2",
+        "title-case": "2.1.1",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
       }
     },
     "char-spinner": {
@@ -2580,15 +2586,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -2609,7 +2615,7 @@
       "integrity": "sha1-qS2ceG5b+bkwgGMp7gXV0yYbSvo=",
       "dev": true,
       "requires": {
-        "json-parse-helpfulerror": "^1.0.3"
+        "json-parse-helpfulerror": "1.0.3"
       }
     },
     "class-utils": {
@@ -2618,10 +2624,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2630,7 +2636,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -2647,7 +2653,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -2670,7 +2676,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-spinners": {
@@ -2695,9 +2701,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "colors": "^1.1.2",
-        "lodash": "^3.10.1",
-        "string-width": "^1.0.1"
+        "colors": "1.2.1",
+        "lodash": "3.10.1",
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "colors": {
@@ -2728,9 +2734,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -2751,8 +2757,8 @@
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-response": {
@@ -2762,7 +2768,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "clone-stats": {
@@ -2777,9 +2783,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -2794,6 +2800,28 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codelyzer": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-4.3.0.tgz",
+      "integrity": "sha512-RLMrtLwrBS0dfo2/KTP+2NHofCpzcuh0bEp/A/naqvQonbUL4AW/qWQdbpn8dMNudtpmzEx9eS8KEpGdVPg1BA==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "css-selector-tokenizer": "0.7.0",
+        "cssauron": "1.4.0",
+        "semver-dsl": "1.0.1",
+        "source-map": "0.5.7",
+        "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "collapse-white-space": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
@@ -2806,8 +2834,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2816,7 +2844,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -2849,7 +2877,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.5"
       }
     },
     "combined-stream": {
@@ -2858,7 +2886,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -2879,8 +2907,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -2889,7 +2917,7 @@
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         }
       }
@@ -2900,7 +2928,7 @@
       "integrity": "sha1-fAp5onu4C2xplERfgpWCWdPQIVM=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.1"
+        "semver": "5.5.0"
       }
     },
     "component-bind": {
@@ -2927,10 +2955,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "^0.2.1",
-        "crc32-stream": "^2.0.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "compressible": {
@@ -2939,7 +2967,7 @@
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.33.0 < 2"
+        "mime-db": "1.33.0"
       }
     },
     "compression": {
@@ -2948,13 +2976,13 @@
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.13",
+        "compressible": "2.0.13",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -2980,10 +3008,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -2992,12 +3020,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.2.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect": {
@@ -3008,7 +3036,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -3035,7 +3063,7 @@
       "integrity": "sha1-3kT1dyCdokBNH8BGktGkEY5YIRk=",
       "dev": true,
       "requires": {
-        "qs": "~6.4.0"
+        "qs": "6.4.0"
       },
       "dependencies": {
         "qs": {
@@ -3058,8 +3086,8 @@
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "dev": true,
       "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
       }
     },
     "content-disposition": {
@@ -3087,17 +3115,17 @@
       "integrity": "sha512-yCPXU/OXJmxgbvTQfIKXKwKa4KQTvlO0a4T/371Raz3bdxcHIGhQtHtdrNee4Z8nGLNfe54njHDblVG2JNFyjg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-atom": "^0.2.8",
-        "conventional-changelog-codemirror": "^0.3.8",
-        "conventional-changelog-core": "^2.0.10",
-        "conventional-changelog-ember": "^0.3.11",
-        "conventional-changelog-eslint": "^1.0.9",
-        "conventional-changelog-express": "^0.3.6",
-        "conventional-changelog-jquery": "^0.1.0",
-        "conventional-changelog-jscs": "^0.1.0",
-        "conventional-changelog-jshint": "^0.3.8",
-        "conventional-changelog-preset-loader": "^1.1.8"
+        "conventional-changelog-angular": "1.6.6",
+        "conventional-changelog-atom": "0.2.8",
+        "conventional-changelog-codemirror": "0.3.8",
+        "conventional-changelog-core": "2.0.10",
+        "conventional-changelog-ember": "0.3.11",
+        "conventional-changelog-eslint": "1.0.9",
+        "conventional-changelog-express": "0.3.6",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.3.8",
+        "conventional-changelog-preset-loader": "1.1.8"
       }
     },
     "conventional-changelog-angular": {
@@ -3106,8 +3134,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3124,7 +3152,7 @@
       "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3141,7 +3169,7 @@
       "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3158,19 +3186,19 @@
       "integrity": "sha512-FP0NHXIbpvU+f5jk/qZdnodhFmlzKW8ENRHQIWT69oe7ffur9nFRVJZlnXnFBOzwHM9WIRbC15ZWh9HZN6t9Uw==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^3.0.9",
-        "conventional-commits-parser": "^2.1.7",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "^1.3.6",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^1.3.6",
-        "lodash": "^4.2.1",
-        "normalize-package-data": "^2.3.5",
-        "q": "^1.5.1",
-        "read-pkg": "^1.1.0",
-        "read-pkg-up": "^1.0.1",
-        "through2": "^2.0.0"
+        "conventional-changelog-writer": "3.0.9",
+        "conventional-commits-parser": "2.1.7",
+        "dateformat": "3.0.3",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.3.6",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.3.6",
+        "lodash": "4.17.5",
+        "normalize-package-data": "2.4.0",
+        "q": "1.5.1",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "dateformat": {
@@ -3193,7 +3221,7 @@
       "integrity": "sha512-ErjPPiDmTd/WPgj2bSp+CGsLtJiv7FbdPKjZXH2Cd5P7j44Rqf0V9SIAAYFTQNoPqmvcp+sIcr/vH52WzPJUbw==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3210,7 +3238,7 @@
       "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3227,7 +3255,7 @@
       "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3244,7 +3272,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -3253,7 +3281,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.4.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -3262,8 +3290,8 @@
       "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -3286,16 +3314,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^1.1.6",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "semver": "^5.5.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.1.6",
+        "dateformat": "3.0.3",
+        "handlebars": "4.0.11",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.5",
+        "meow": "4.0.0",
+        "semver": "5.5.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -3310,9 +3338,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "dateformat": {
@@ -3333,10 +3361,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -3351,15 +3379,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -3368,8 +3396,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "read-pkg": {
@@ -3378,9 +3406,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -3389,8 +3417,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -3399,8 +3427,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "split": {
@@ -3409,7 +3437,7 @@
           "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
           "dev": true,
           "requires": {
-            "through": "2"
+            "through": "2.3.8"
           }
         },
         "strip-bom": {
@@ -3438,8 +3466,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -3448,13 +3476,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.5",
+        "meow": "4.0.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -3469,9 +3497,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "indent-string": {
@@ -3486,10 +3514,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -3504,15 +3532,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -3521,8 +3549,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "read-pkg": {
@@ -3531,9 +3559,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -3542,8 +3570,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -3552,8 +3580,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -3601,8 +3629,8 @@
       "integrity": "sha1-8DJLvumXcRAeezraES8xPDk9uO0=",
       "dev": true,
       "requires": {
-        "each-props": "^1.2.1",
-        "is-plain-object": "^2.0.1"
+        "each-props": "1.3.1",
+        "is-plain-object": "2.0.4"
       }
     },
     "core-js": {
@@ -3622,10 +3650,10 @@
       "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
       "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^3.0.0",
-        "require-from-string": "^2.0.1"
+        "is-directory": "0.3.1",
+        "js-yaml": "3.11.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.2"
       },
       "dependencies": {
         "parse-json": {
@@ -3634,7 +3662,7 @@
           "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1"
+            "error-ex": "1.3.1"
           }
         }
       }
@@ -3651,8 +3679,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
-        "readable-stream": "^2.0.0"
+        "crc": "3.5.0",
+        "readable-stream": "2.3.6"
       }
     },
     "create-error-class": {
@@ -3661,7 +3689,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-env": {
@@ -3670,8 +3698,8 @@
       "integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.1.0",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3680,9 +3708,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         }
       }
@@ -3693,8 +3721,8 @@
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.2",
+        "which": "1.3.0"
       }
     },
     "cross-spawn-async": {
@@ -3703,8 +3731,8 @@
       "integrity": "sha1-u1JcHkINmUJVLgR5Gj6y2Yh6EF8=",
       "dev": true,
       "requires": {
-        "lru-cache": "^2.6.5",
-        "which": "^1.1.1"
+        "lru-cache": "2.7.3",
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -3721,7 +3749,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -3730,7 +3758,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -3739,6 +3767,32 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      }
+    },
+    "cssauron": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
+      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
     "cssom": {
@@ -3753,7 +3807,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.2"
       }
     },
     "csv-streamify": {
@@ -3777,12 +3831,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -3797,8 +3851,8 @@
           "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "readable-stream": "2.0.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -3809,7 +3863,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "custom-event": {
@@ -3830,7 +3884,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.42"
       }
     },
     "dargs": {
@@ -3839,7 +3893,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
@@ -3848,7 +3902,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
@@ -3878,8 +3932,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "decode-uri-component": {
@@ -3895,7 +3949,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "deep-equal": {
@@ -3928,7 +3982,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       },
       "dependencies": {
         "clone": {
@@ -3945,8 +3999,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -3955,8 +4009,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3965,7 +4019,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3974,7 +4028,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3983,9 +4037,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -4008,13 +4062,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "globby": {
@@ -4023,12 +4077,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -4069,10 +4123,10 @@
       "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
       "dev": true,
       "requires": {
-        "commander": "^2.6.0",
-        "debug": "^2.2.0",
-        "filing-cabinet": "^1.9.0",
-        "precinct": "^3.8.0"
+        "commander": "2.15.1",
+        "debug": "2.6.9",
+        "filing-cabinet": "1.14.0",
+        "precinct": "3.8.0"
       },
       "dependencies": {
         "debug": {
@@ -4110,10 +4164,10 @@
       "integrity": "sha1-XrDfTvXBipQDOwfa8TbbzV/HXNU=",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.3.1",
-        "escodegen": "^1.8.0",
-        "get-amd-module-type": "^2.0.4",
-        "node-source-walk": "^3.0.0"
+        "ast-module-types": "2.3.2",
+        "escodegen": "1.9.1",
+        "get-amd-module-type": "2.0.5",
+        "node-source-walk": "3.3.0"
       }
     },
     "detective-cjs": {
@@ -4122,8 +4176,8 @@
       "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.0.0"
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
       }
     },
     "detective-es6": {
@@ -4132,7 +4186,7 @@
       "integrity": "sha1-a5s71Uf9jyH4lQL2JuRe0qMnb9w=",
       "dev": true,
       "requires": {
-        "node-source-walk": "^3.3.0"
+        "node-source-walk": "3.3.0"
       }
     },
     "detective-less": {
@@ -4141,9 +4195,9 @@
       "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
+        "debug": "2.2.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
       },
       "dependencies": {
         "debug": {
@@ -4169,9 +4223,9 @@
       "integrity": "sha1-BWYKoblc/Yf1dGQ7+s4+iiaBEqE=",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
+        "debug": "3.1.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
       }
     },
     "detective-scss": {
@@ -4180,9 +4234,9 @@
       "integrity": "sha1-dDJGoN01jZ2R/0ElQX9qd/vPJw8=",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
+        "debug": "3.1.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
       }
     },
     "detective-stylus": {
@@ -4208,7 +4262,7 @@
           "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.0.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "node-source-walk": {
@@ -4217,7 +4271,7 @@
           "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
           "dev": true,
           "requires": {
-            "babylon": "~6.8.1"
+            "babylon": "6.8.4"
           }
         },
         "typescript": {
@@ -4234,15 +4288,15 @@
       "integrity": "sha1-nkJ3WxOGyl64JHU6ws0WnY9hztE=",
       "dev": true,
       "requires": {
-        "canonical-path": "~0.0.2",
-        "dependency-graph": "~0.4.1",
+        "canonical-path": "0.0.2",
+        "dependency-graph": "0.4.1",
         "di": "0.0.1",
-        "lodash": "^3.10.1",
-        "objectdiff": "^1.1.0",
-        "optimist": "~0.6.1",
-        "q": "~1.4.1",
-        "validate.js": "^0.9.0",
-        "winston": "^2.1.1"
+        "lodash": "3.10.1",
+        "objectdiff": "1.1.0",
+        "optimist": "0.6.1",
+        "q": "1.4.1",
+        "validate.js": "0.9.0",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -4260,27 +4314,27 @@
       "dev": true,
       "requires": {
         "canonical-path": "0.0.2",
-        "catharsis": "^0.8.1",
+        "catharsis": "0.8.9",
         "change-case": "3.0.0",
-        "dgeni": "^0.4.9",
-        "espree": "^2.2.3",
-        "estraverse": "^4.1.0",
-        "glob": "^7.0.5",
-        "htmlparser2": "^3.7.3",
-        "lodash": "^4.13.1",
-        "marked": "^0.3.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "mkdirp-promise": "^5.0.0",
+        "dgeni": "0.4.9",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "glob": "7.1.2",
+        "htmlparser2": "3.9.2",
+        "lodash": "4.17.5",
+        "marked": "0.3.19",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "mkdirp-promise": "5.0.1",
         "node-html-encoder": "0.0.2",
-        "nunjucks": "^3.0.1",
-        "semver": "^5.2.0",
-        "shelljs": "^0.7.0",
-        "source-map-support": "^0.4.15",
-        "spdx-license-list": "^2.1.0",
-        "stringmap": "^0.2.2",
-        "typescript": "~2.7.1",
-        "urlencode": "^1.1.0"
+        "nunjucks": "3.1.2",
+        "semver": "5.5.0",
+        "shelljs": "0.7.8",
+        "source-map-support": "0.4.18",
+        "spdx-license-list": "2.1.0",
+        "stringmap": "0.2.2",
+        "typescript": "2.7.2",
+        "urlencode": "1.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -4330,8 +4384,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "dom-serialize": {
@@ -4340,10 +4394,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
       }
     },
     "dom-serializer": {
@@ -4352,8 +4406,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -4382,7 +4436,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domino": {
@@ -4397,8 +4451,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-case": {
@@ -4407,7 +4461,7 @@
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "dot-prop": {
@@ -4416,7 +4470,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotenv": {
@@ -4437,7 +4491,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexer3": {
@@ -4453,10 +4507,10 @@
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "each-props": {
@@ -4465,8 +4519,8 @@
       "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
       "dev": true,
       "requires": {
-        "is-plain-object": "^2.0.1",
-        "object.defaults": "^1.1.0"
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "eastasianwidth": {
@@ -4482,7 +4536,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ecdsa-sig-formatter": {
@@ -4491,8 +4545,8 @@
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "dev": true,
       "requires": {
-        "base64url": "^2.0.0",
-        "safe-buffer": "^5.0.1"
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "ee-first": {
@@ -4513,8 +4567,8 @@
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "empower-core": "^0.6.2"
+        "core-js": "2.5.5",
+        "empower-core": "0.6.2"
       }
     },
     "empower-core": {
@@ -4524,7 +4578,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "^2.0.0"
+        "core-js": "2.5.5"
       }
     },
     "encodeurl": {
@@ -4539,7 +4593,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.21"
       }
     },
     "end-of-stream": {
@@ -4548,7 +4602,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -4571,7 +4625,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.11",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -4649,10 +4703,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "object-assign": "^4.0.1",
-        "tapable": "^0.2.7"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
       }
     },
     "ent": {
@@ -4679,7 +4733,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -4688,7 +4742,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -4697,9 +4751,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -4708,9 +4762,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-promise": {
@@ -4725,7 +4779,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       },
       "dependencies": {
         "es6-promise": {
@@ -4742,11 +4796,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -4755,8 +4809,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "escape-html": {
@@ -4777,11 +4831,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -4804,7 +4858,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0"
+        "core-js": "2.5.5"
       }
     },
     "estraverse": {
@@ -4831,23 +4885,23 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "eventemitter3": {
@@ -4862,13 +4916,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4877,9 +4931,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         }
       }
@@ -4890,7 +4944,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "1.0.1"
       }
     },
     "exit": {
@@ -4917,9 +4971,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
         "array-slice": {
@@ -4934,7 +4988,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
         },
         "expand-range": {
@@ -4943,8 +4997,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
           }
         },
         "is-number": {
@@ -4967,7 +5021,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -4976,7 +5030,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "expand-tilde": {
@@ -4985,7 +5039,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -4995,36 +5049,36 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.2",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.3.1",
-        "type-is": "~1.6.15",
+        "statuses": "1.3.1",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -5058,8 +5112,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5068,7 +5122,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -5079,7 +5133,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -5100,9 +5154,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -5117,11 +5171,11 @@
       "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.8"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -5142,16 +5196,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5160,7 +5214,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5180,13 +5234,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5195,7 +5249,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -5204,7 +5258,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -5213,7 +5267,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5222,7 +5276,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5233,7 +5287,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5242,7 +5296,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5253,9 +5307,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -5272,14 +5326,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5288,7 +5342,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -5297,7 +5351,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5308,10 +5362,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5320,7 +5374,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5331,8 +5385,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -5341,7 +5395,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -5352,7 +5406,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5361,7 +5415,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5370,9 +5424,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -5387,7 +5441,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -5396,7 +5450,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5405,7 +5459,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5428,19 +5482,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -5463,8 +5517,14 @@
       "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
       "dev": true,
       "requires": {
-        "punycode": "^1.3.2"
+        "punycode": "1.4.1"
       }
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
     },
     "faye-websocket": {
       "version": "0.11.1",
@@ -5472,7 +5532,7 @@
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "figures": {
@@ -5481,8 +5541,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -5491,8 +5551,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-exists": {
@@ -5519,18 +5579,18 @@
       "integrity": "sha512-+qFmqBu42dJC+BkzrYlTWzBRxtdrBPeLGCABXaBblhiYnBHiwvs6LB7YdoeIUDqFrYZ8ci3pWDOJ7mestU8BOg==",
       "dev": true,
       "requires": {
-        "app-module-path": "^2.2.0",
-        "commander": "^2.13.0",
-        "debug": "^3.1.0",
-        "enhanced-resolve": "^3.4.1",
-        "is-relative-path": "^1.0.2",
-        "module-definition": "^2.2.4",
-        "module-lookup-amd": "^5.0.1",
-        "resolve": "^1.5.0",
-        "resolve-dependency-path": "^1.0.2",
-        "sass-lookup": "^1.1.0",
-        "stylus-lookup": "^1.0.1",
-        "typescript": "^2.4.2"
+        "app-module-path": "2.2.0",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "enhanced-resolve": "3.4.1",
+        "is-relative-path": "1.0.2",
+        "module-definition": "2.2.4",
+        "module-lookup-amd": "5.0.1",
+        "resolve": "1.7.0",
+        "resolve-dependency-path": "1.0.2",
+        "sass-lookup": "1.1.0",
+        "stylus-lookup": "1.0.2",
+        "typescript": "2.7.2"
       }
     },
     "fill-range": {
@@ -5539,11 +5599,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "filled-array": {
@@ -5559,12 +5619,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5590,7 +5650,7 @@
       "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
       "dev": true,
       "requires": {
-        "traverse-chain": "~0.1.0"
+        "traverse-chain": "0.1.0"
       }
     },
     "find-index": {
@@ -5611,7 +5671,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "findup-sync": {
@@ -5620,10 +5680,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5644,16 +5704,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5662,7 +5722,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5682,13 +5742,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5697,7 +5757,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -5706,7 +5766,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -5715,7 +5775,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5724,7 +5784,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5735,7 +5795,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5744,7 +5804,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5755,9 +5815,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -5774,14 +5834,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5790,7 +5850,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -5799,7 +5859,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5810,10 +5870,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5822,7 +5882,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5833,7 +5893,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5842,7 +5902,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5851,9 +5911,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -5868,7 +5928,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -5877,7 +5937,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5886,7 +5946,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5909,19 +5969,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -5932,11 +5992,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "firebase": {
@@ -5953,8 +6013,8 @@
         "@firebase/messaging": "0.2.3",
         "@firebase/polyfill": "0.3.0",
         "@firebase/storage": "0.1.8",
-        "dom-storage": "^2.0.2",
-        "xmlhttprequest": "^1.8.0"
+        "dom-storage": "2.1.0",
+        "xmlhttprequest": "1.8.0"
       }
     },
     "firebase-admin": {
@@ -5963,12 +6023,12 @@
       "integrity": "sha1-MpGwRmtNFhy0E16DyX+YeOd2jKw=",
       "dev": true,
       "requires": {
-        "@firebase/app": "^0.1.10",
-        "@firebase/database": "^0.2.0",
-        "@google-cloud/firestore": "^0.13.1",
-        "@google-cloud/storage": "^1.6.0",
-        "@types/google-cloud__storage": "^1.1.7",
-        "@types/node": "^8.0.53",
+        "@firebase/app": "0.1.10",
+        "@firebase/database": "0.2.1",
+        "@google-cloud/firestore": "0.13.1",
+        "@google-cloud/storage": "1.6.0",
+        "@types/google-cloud__storage": "1.1.7",
+        "@types/node": "8.10.4",
         "faye-websocket": "0.9.3",
         "jsonwebtoken": "8.1.0",
         "node-forge": "0.7.4"
@@ -5986,7 +6046,7 @@
           "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
           "dev": true,
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         },
         "jsonwebtoken": {
@@ -5995,16 +6055,16 @@
           "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
           "dev": true,
           "requires": {
-            "jws": "^3.1.4",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.0.0",
-            "xtend": "^4.0.1"
+            "jws": "3.1.4",
+            "lodash.includes": "4.3.0",
+            "lodash.isboolean": "3.0.3",
+            "lodash.isinteger": "4.0.4",
+            "lodash.isnumber": "3.0.3",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.isstring": "4.0.1",
+            "lodash.once": "4.1.1",
+            "ms": "2.0.0",
+            "xtend": "4.0.1"
           }
         },
         "node-forge": {
@@ -6021,45 +6081,45 @@
       "integrity": "sha1-KHVH2hMZLekZJ4ierbrMHzniQKY=",
       "dev": true,
       "requires": {
-        "@google-cloud/functions-emulator": "^1.0.0-beta.4",
-        "JSONStream": "^1.2.1",
-        "archiver": "^2.1.1",
-        "chalk": "^1.1.0",
-        "cjson": "^0.3.1",
-        "cli-table": "^0.3.1",
-        "commander": "^2.8.1",
-        "configstore": "^1.2.0",
-        "cross-env": "^5.1.3",
-        "cross-spawn": "^4.0.0",
-        "csv-streamify": "^3.0.4",
-        "didyoumean": "^1.2.1",
-        "es6-set": "^0.1.4",
-        "exit-code": "^1.0.2",
-        "filesize": "^3.1.3",
-        "firebase": "2.x.x",
-        "fs-extra": "^0.23.1",
-        "glob": "^7.1.2",
-        "google-auto-auth": "^0.7.2",
-        "inquirer": "^0.12.0",
-        "is": "^3.2.1",
-        "jsonschema": "^1.0.2",
-        "jsonwebtoken": "^7.4.1",
-        "lodash": "^4.6.1",
-        "open": "^0.0.5",
+        "@google-cloud/functions-emulator": "1.0.0-beta.4",
+        "JSONStream": "1.3.2",
+        "archiver": "2.1.1",
+        "chalk": "1.1.3",
+        "cjson": "0.3.3",
+        "cli-table": "0.3.1",
+        "commander": "2.15.1",
+        "configstore": "1.4.0",
+        "cross-env": "5.1.4",
+        "cross-spawn": "4.0.2",
+        "csv-streamify": "3.0.4",
+        "didyoumean": "1.2.1",
+        "es6-set": "0.1.5",
+        "exit-code": "1.0.2",
+        "filesize": "3.6.1",
+        "firebase": "2.4.2",
+        "fs-extra": "0.23.1",
+        "glob": "7.1.2",
+        "google-auto-auth": "0.7.2",
+        "inquirer": "0.12.0",
+        "is": "3.2.1",
+        "jsonschema": "1.2.4",
+        "jsonwebtoken": "7.4.3",
+        "lodash": "4.17.5",
+        "open": "0.0.5",
         "ora": "0.2.3",
-        "portfinder": "^0.4.0",
-        "progress": "^2.0.0",
-        "request": "^2.58.0",
-        "rsvp": "^3.0.18",
-        "semver": "^5.0.3",
-        "superstatic": "^5.0.1",
-        "tar": "^4.3.0",
+        "portfinder": "0.4.0",
+        "progress": "2.0.0",
+        "request": "2.85.0",
+        "rsvp": "3.6.2",
+        "semver": "5.5.0",
+        "superstatic": "5.0.1",
+        "tar": "4.4.1",
         "tmp": "0.0.33",
-        "universal-analytics": "^0.3.9",
-        "update-notifier": "^0.5.0",
-        "user-home": "^2.0.0",
-        "uuid": "^3.0.0",
-        "winston": "^1.0.1"
+        "universal-analytics": "0.3.11",
+        "update-notifier": "0.5.0",
+        "user-home": "2.0.0",
+        "uuid": "3.2.1",
+        "winston": "1.1.2"
       },
       "dependencies": {
         "configstore": {
@@ -6068,14 +6128,14 @@
           "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.1",
-            "os-tmpdir": "^1.0.0",
-            "osenv": "^0.1.0",
-            "uuid": "^2.0.1",
-            "write-file-atomic": "^1.1.2",
-            "xdg-basedir": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "os-tmpdir": "1.0.2",
+            "osenv": "0.1.5",
+            "uuid": "2.0.3",
+            "write-file-atomic": "1.3.4",
+            "xdg-basedir": "2.0.0"
           },
           "dependencies": {
             "uuid": {
@@ -6092,7 +6152,7 @@
           "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
           "dev": true,
           "requires": {
-            "faye-websocket": ">=0.6.0"
+            "faye-websocket": "0.9.3"
           },
           "dependencies": {
             "faye-websocket": {
@@ -6101,7 +6161,7 @@
               "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
               "dev": true,
               "requires": {
-                "websocket-driver": ">=0.5.1"
+                "websocket-driver": "0.5.2"
               },
               "dependencies": {
                 "websocket-driver": {
@@ -6110,7 +6170,7 @@
                   "integrity": "sha1-jHyF2gcTtAYFVrTXHAF3XuEmnrk=",
                   "dev": true,
                   "requires": {
-                    "websocket-extensions": ">=0.1.1"
+                    "websocket-extensions": "0.1.1"
                   },
                   "dependencies": {
                     "websocket-extensions": {
@@ -6131,10 +6191,10 @@
           "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "gcp-metadata": {
@@ -6143,8 +6203,8 @@
           "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "retry-request": "^3.0.0"
+            "extend": "3.0.1",
+            "retry-request": "3.3.1"
           }
         },
         "google-auth-library": {
@@ -6153,10 +6213,10 @@
           "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
           "dev": true,
           "requires": {
-            "gtoken": "^1.2.1",
-            "jws": "^3.1.4",
-            "lodash.noop": "^3.0.1",
-            "request": "^2.74.0"
+            "gtoken": "1.2.3",
+            "jws": "3.1.4",
+            "lodash.noop": "3.0.1",
+            "request": "2.85.0"
           }
         },
         "google-auto-auth": {
@@ -6165,10 +6225,10 @@
           "integrity": "sha1-v5NS1cSgiXvzH9nEkQKLdl++px4=",
           "dev": true,
           "requires": {
-            "async": "^2.3.0",
-            "gcp-metadata": "^0.3.0",
-            "google-auth-library": "^0.10.0",
-            "request": "^2.79.0"
+            "async": "2.6.0",
+            "gcp-metadata": "0.3.1",
+            "google-auth-library": "0.10.0",
+            "request": "2.85.0"
           }
         },
         "google-p12-pem": {
@@ -6177,7 +6237,7 @@
           "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
           "dev": true,
           "requires": {
-            "node-forge": "^0.7.1"
+            "node-forge": "0.7.5"
           }
         },
         "gtoken": {
@@ -6186,10 +6246,10 @@
           "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
           "dev": true,
           "requires": {
-            "google-p12-pem": "^0.1.0",
-            "jws": "^3.0.0",
-            "mime": "^1.4.1",
-            "request": "^2.72.0"
+            "google-p12-pem": "0.1.2",
+            "jws": "3.1.4",
+            "mime": "1.6.0",
+            "request": "2.85.0"
           }
         },
         "mime": {
@@ -6210,7 +6270,7 @@
           "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         },
         "winston": {
@@ -6219,13 +6279,13 @@
           "integrity": "sha1-aO3Xaf951PlSjPDl2AAhqt5nSAw=",
           "dev": true,
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "pkginfo": "0.3.x",
-            "stack-trace": "0.0.x"
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "pkginfo": "0.3.1",
+            "stack-trace": "0.0.10"
           },
           "dependencies": {
             "async": {
@@ -6242,9 +6302,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "xdg-basedir": {
@@ -6253,7 +6313,7 @@
           "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         }
       }
@@ -6276,10 +6336,10 @@
       "integrity": "sha1-m6p4Ct8FAfKC1ybJxqA426ROp28=",
       "dev": true,
       "requires": {
-        "array-flatten": "^1.0.0",
-        "as-array": "^1.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isobject": "^3.0.0"
+        "array-flatten": "1.1.1",
+        "as-array": "1.0.0",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isobject": "3.0.2"
       },
       "dependencies": {
         "as-array": {
@@ -6288,9 +6348,9 @@
           "integrity": "sha1-KKbu6qVynx9OyiBH316d4avaDtE=",
           "dev": true,
           "requires": {
-            "lodash.isarguments": "2.4.x",
-            "lodash.isobject": "^2.4.1",
-            "lodash.values": "^2.4.1"
+            "lodash.isarguments": "2.4.1",
+            "lodash.isobject": "2.4.1",
+            "lodash.values": "2.4.1"
           },
           "dependencies": {
             "lodash.isarguments": {
@@ -6305,7 +6365,7 @@
               "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
               "dev": true,
               "requires": {
-                "lodash._objecttypes": "~2.4.1"
+                "lodash._objecttypes": "2.4.1"
               }
             }
           }
@@ -6324,10 +6384,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "follow-redirects": {
@@ -6336,7 +6396,7 @@
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -6351,7 +6411,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -6378,9 +6438,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
@@ -6396,7 +6456,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -6418,8 +6478,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-access": {
@@ -6428,7 +6488,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs-extra": {
@@ -6437,9 +6497,9 @@
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
       },
       "dependencies": {
         "jsonfile": {
@@ -6448,7 +6508,7 @@
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -6459,7 +6519,7 @@
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.2.4"
       }
     },
     "fs.realpath": {
@@ -6475,8 +6535,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.39"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -6491,8 +6551,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -6512,8 +6572,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
           }
         },
         "asn1": {
@@ -6557,7 +6617,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
@@ -6565,7 +6625,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
@@ -6573,7 +6633,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
@@ -6581,7 +6641,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
           }
         },
@@ -6612,7 +6672,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -6635,7 +6695,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "dashdash": {
@@ -6644,7 +6704,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6693,7 +6753,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
@@ -6734,10 +6794,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
         "fstream-ignore": {
@@ -6746,9 +6806,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
@@ -6757,14 +6817,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
@@ -6773,7 +6833,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6789,12 +6849,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -6829,10 +6889,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -6846,9 +6906,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
@@ -6856,8 +6916,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -6902,7 +6962,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "jsbn": {
@@ -6923,7 +6983,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -7004,17 +7064,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
           }
         },
         "nopt": {
@@ -7023,8 +7083,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -7033,10 +7093,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -7061,7 +7121,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -7120,10 +7180,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -7139,13 +7199,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -7154,28 +7214,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           }
         },
         "rimraf": {
@@ -7183,7 +7243,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -7214,7 +7274,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "sshpk": {
@@ -7223,15 +7283,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -7247,9 +7307,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -7257,7 +7317,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7271,7 +7331,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -7285,9 +7345,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
@@ -7296,14 +7356,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
@@ -7312,7 +7372,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
@@ -7321,7 +7381,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "tweetnacl": {
@@ -7362,7 +7422,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -7378,10 +7438,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "functional-red-black-tree": {
@@ -7396,14 +7456,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       }
     },
     "gaze": {
@@ -7412,7 +7472,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "gcp-metadata": {
@@ -7421,8 +7481,8 @@
       "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "dev": true,
       "requires": {
-        "axios": "^0.18.0",
-        "extend": "^3.0.1",
+        "axios": "0.18.0",
+        "extend": "3.0.1",
         "retry-axios": "0.3.2"
       }
     },
@@ -7432,13 +7492,13 @@
       "integrity": "sha512-+Zrmr0JKO2y/2mg953TW6JLu+NAMHqQsKzqCm7CIT24gMQakolPJCMzDleVpVjXAqB7ZCD276tcUq2ebOfqTug==",
       "dev": true,
       "requires": {
-        "buffer-equal": "^1.0.0",
-        "configstore": "^3.0.0",
-        "google-auto-auth": "^0.9.0",
-        "pumpify": "^1.3.3",
-        "request": "^2.81.0",
-        "stream-events": "^1.0.1",
-        "through2": "^2.0.0"
+        "buffer-equal": "1.0.0",
+        "configstore": "3.1.2",
+        "google-auto-auth": "0.9.7",
+        "pumpify": "1.4.0",
+        "request": "2.85.0",
+        "stream-events": "1.0.3",
+        "through2": "2.0.3"
       }
     },
     "generate-function": {
@@ -7453,7 +7513,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-amd-module-type": {
@@ -7462,8 +7522,8 @@
       "integrity": "sha1-5nHsWpatX79To6IqKJ6SOMdy3bA=",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.2.0"
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
       }
     },
     "get-caller-file": {
@@ -7484,11 +7544,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "parse-github-repo-url": "^1.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.6.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.3"
       }
     },
     "get-stdin": {
@@ -7515,7 +7575,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "git-raw-commits": {
@@ -7524,11 +7584,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "4.0.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -7543,9 +7603,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "indent-string": {
@@ -7560,10 +7620,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash.template": {
@@ -7572,8 +7632,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -7582,7 +7642,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "map-obj": {
@@ -7597,15 +7657,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -7614,8 +7674,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "read-pkg": {
@@ -7624,9 +7684,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -7635,8 +7695,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -7645,8 +7705,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -7675,8 +7735,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -7693,8 +7753,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -7709,9 +7769,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "indent-string": {
@@ -7726,10 +7786,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -7744,15 +7804,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -7761,8 +7821,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "read-pkg": {
@@ -7771,9 +7831,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -7782,8 +7842,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -7792,8 +7852,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -7822,7 +7882,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.2"
+        "ini": "1.3.5"
       }
     },
     "github": {
@@ -7831,12 +7891,12 @@
       "integrity": "sha512-HhWjhd/OATC4Hjj7xfGjGRtwWzo/fzTc55EkvsRatI9G6Vp47mVcdBIt1lQ56A9Qit/yVQRX1+M9jbWlcJvgug==",
       "dev": true,
       "requires": {
-        "dotenv": "^4.0.0",
+        "dotenv": "4.0.0",
         "follow-redirects": "1.2.6",
-        "https-proxy-agent": "^2.1.0",
-        "lodash": "^4.17.4",
-        "mime": "^2.0.3",
-        "netrc": "^0.1.4"
+        "https-proxy-agent": "2.2.1",
+        "lodash": "4.17.5",
+        "mime": "2.2.2",
+        "netrc": "0.1.4"
       },
       "dependencies": {
         "follow-redirects": {
@@ -7845,7 +7905,7 @@
           "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
           "dev": true,
           "requires": {
-            "debug": "^3.1.0"
+            "debug": "3.1.0"
           }
         }
       }
@@ -7856,12 +7916,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -7870,8 +7930,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -7880,7 +7940,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-slash": {
@@ -7895,9 +7955,9 @@
       "integrity": "sha1-dHoOW7IiZC7hDT4FRD4QlJPLD44=",
       "dev": true,
       "requires": {
-        "glob-slash": "^1.0.0",
-        "lodash.isobject": "^2.4.1",
-        "toxic": "^1.0.0"
+        "glob-slash": "1.0.0",
+        "lodash.isobject": "2.4.1",
+        "toxic": "1.0.0"
       }
     },
     "glob-stream": {
@@ -7906,12 +7966,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -7920,10 +7980,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -7938,7 +7998,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -7947,10 +8007,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -7965,8 +8025,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -7983,7 +8043,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -7992,7 +8052,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global-modules": {
@@ -8001,9 +8061,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -8012,11 +8072,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globby": {
@@ -8025,13 +8085,13 @@
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "fast-glob": "2.2.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "globjoin": {
@@ -8046,7 +8106,7 @@
       "integrity": "sha1-ZwA3ElKHy2VJqtlqRM+mhP18VQI=",
       "dev": true,
       "requires": {
-        "glob": "^7.1.1"
+        "glob": "7.1.2"
       }
     },
     "globule": {
@@ -8055,9 +8115,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -8066,9 +8126,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -8101,8 +8161,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -8113,7 +8173,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "gm": {
@@ -8122,9 +8182,9 @@
       "integrity": "sha1-ftXtBds20wwZQ/OcO8HIObjyNh0=",
       "dev": true,
       "requires": {
-        "array-parallel": "~0.1.3",
-        "array-series": "~0.1.5",
-        "debug": "~2.2.0"
+        "array-parallel": "0.1.3",
+        "array-series": "0.1.5",
+        "debug": "2.2.0"
       },
       "dependencies": {
         "debug": {
@@ -8150,7 +8210,7 @@
       "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.1.3"
       },
       "dependencies": {
         "minimist": {
@@ -8167,13 +8227,13 @@
       "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
       "dev": true,
       "requires": {
-        "axios": "^0.18.0",
-        "gcp-metadata": "^0.6.2",
-        "gtoken": "^2.2.0",
-        "jws": "^3.1.4",
-        "lodash.isstring": "^4.0.1",
-        "lru-cache": "^4.1.2",
-        "retry-axios": "^0.3.2"
+        "axios": "0.18.0",
+        "gcp-metadata": "0.6.3",
+        "gtoken": "2.3.0",
+        "jws": "3.1.4",
+        "lodash.isstring": "4.0.1",
+        "lru-cache": "4.1.2",
+        "retry-axios": "0.3.2"
       }
     },
     "google-auto-auth": {
@@ -8182,10 +8242,10 @@
       "integrity": "sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==",
       "dev": true,
       "requires": {
-        "async": "^2.3.0",
-        "gcp-metadata": "^0.6.1",
-        "google-auth-library": "^1.3.1",
-        "request": "^2.79.0"
+        "async": "2.6.0",
+        "gcp-metadata": "0.6.3",
+        "google-auth-library": "1.4.0",
+        "request": "2.85.0"
       }
     },
     "google-closure-compiler": {
@@ -8194,9 +8254,9 @@
       "integrity": "sha1-3Bvimp9+74YRNkUzsnG5+sdXyXA=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "vinyl": "^2.0.1",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "chalk": "1.1.3",
+        "vinyl": "2.1.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "google-gax": {
@@ -8205,16 +8265,16 @@
       "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.4",
-        "extend": "^3.0.0",
-        "globby": "^8.0.0",
-        "google-auto-auth": "^0.10.0",
-        "google-proto-files": "^0.15.0",
-        "grpc": "^1.10.0",
-        "is-stream-ended": "^0.1.0",
-        "lodash": "^4.17.2",
-        "protobufjs": "^6.8.0",
-        "through2": "^2.0.3"
+        "duplexify": "3.5.4",
+        "extend": "3.0.1",
+        "globby": "8.0.1",
+        "google-auto-auth": "0.10.0",
+        "google-proto-files": "0.15.1",
+        "grpc": "1.10.1",
+        "is-stream-ended": "0.1.4",
+        "lodash": "4.17.5",
+        "protobufjs": "6.8.6",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "@types/node": {
@@ -8229,10 +8289,10 @@
           "integrity": "sha512-R6m473OqgZacPvlidJ0aownTlUWyLy654ugjKSXyi1ffIicXlXg3wMfse9T9zxqG6w01q6K1iG+b7dImMkVJ2Q==",
           "dev": true,
           "requires": {
-            "async": "^2.3.0",
-            "gcp-metadata": "^0.6.1",
-            "google-auth-library": "^1.3.1",
-            "request": "^2.79.0"
+            "async": "2.6.0",
+            "gcp-metadata": "0.6.3",
+            "google-auth-library": "1.4.0",
+            "request": "2.85.0"
           }
         },
         "long": {
@@ -8247,19 +8307,19 @@
           "integrity": "sha512-eH2OTP9s55vojr3b7NBaF9i4WhWPkv/nq55nznWNp/FomKrLViprUcqnBjHph2tFQ+7KciGPTPsVWGz0SOhL0Q==",
           "dev": true,
           "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^3.0.32",
-            "@types/node": "^8.9.4",
-            "long": "^4.0.0"
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/base64": "1.1.2",
+            "@protobufjs/codegen": "2.0.4",
+            "@protobufjs/eventemitter": "1.1.0",
+            "@protobufjs/fetch": "1.1.0",
+            "@protobufjs/float": "1.0.2",
+            "@protobufjs/inquire": "1.1.0",
+            "@protobufjs/path": "1.1.2",
+            "@protobufjs/pool": "1.1.0",
+            "@protobufjs/utf8": "1.1.0",
+            "@types/long": "3.0.32",
+            "@types/node": "8.10.4",
+            "long": "4.0.0"
           }
         }
       }
@@ -8270,8 +8330,8 @@
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "dev": true,
       "requires": {
-        "node-forge": "^0.7.4",
-        "pify": "^3.0.0"
+        "node-forge": "0.7.5",
+        "pify": "3.0.0"
       }
     },
     "google-proto-files": {
@@ -8280,9 +8340,9 @@
       "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
       "dev": true,
       "requires": {
-        "globby": "^7.1.1",
-        "power-assert": "^1.4.4",
-        "protobufjs": "^6.8.0"
+        "globby": "7.1.1",
+        "power-assert": "1.5.0",
+        "protobufjs": "6.8.6"
       },
       "dependencies": {
         "@types/node": {
@@ -8297,12 +8357,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.7",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "long": {
@@ -8317,19 +8377,19 @@
           "integrity": "sha512-eH2OTP9s55vojr3b7NBaF9i4WhWPkv/nq55nznWNp/FomKrLViprUcqnBjHph2tFQ+7KciGPTPsVWGz0SOhL0Q==",
           "dev": true,
           "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^3.0.32",
-            "@types/node": "^8.9.4",
-            "long": "^4.0.0"
+            "@protobufjs/aspromise": "1.1.2",
+            "@protobufjs/base64": "1.1.2",
+            "@protobufjs/codegen": "2.0.4",
+            "@protobufjs/eventemitter": "1.1.0",
+            "@protobufjs/fetch": "1.1.0",
+            "@protobufjs/float": "1.0.2",
+            "@protobufjs/inquire": "1.1.0",
+            "@protobufjs/path": "1.1.2",
+            "@protobufjs/pool": "1.1.0",
+            "@protobufjs/utf8": "1.1.0",
+            "@types/long": "3.0.32",
+            "@types/node": "8.10.4",
+            "long": "4.0.0"
           }
         }
       }
@@ -8353,11 +8413,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "gtoken": "^1.2.3",
-            "jws": "^3.1.4",
-            "lodash.isstring": "^4.0.1",
-            "lodash.merge": "^4.6.0",
-            "request": "^2.81.0"
+            "gtoken": "1.2.3",
+            "jws": "3.1.4",
+            "lodash.isstring": "4.0.1",
+            "lodash.merge": "4.6.1",
+            "request": "2.85.0"
           }
         },
         "google-p12-pem": {
@@ -8367,7 +8427,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "node-forge": "^0.7.1"
+            "node-forge": "0.7.5"
           }
         },
         "gtoken": {
@@ -8377,10 +8437,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "google-p12-pem": "^0.1.0",
-            "jws": "^3.0.0",
-            "mime": "^1.4.1",
-            "request": "^2.72.0"
+            "google-p12-pem": "0.1.2",
+            "jws": "3.1.4",
+            "mime": "1.6.0",
+            "request": "2.85.0"
           }
         },
         "mime": {
@@ -8399,23 +8459,23 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -8436,7 +8496,7 @@
       "integrity": "sha1-5ZnkBzPvgOFlO/6JpfAx7PKqSqo=",
       "dev": true,
       "requires": {
-        "temp": "~0.4.0"
+        "temp": "0.4.0"
       }
     },
     "grpc": {
@@ -8445,10 +8505,10 @@
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.15.0",
-        "nan": "^2.10.0",
+        "lodash": "4.17.5",
+        "nan": "2.10.0",
         "node-pre-gyp": "0.7.0",
-        "protobufjs": "^5.0.0"
+        "protobufjs": "5.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -8463,37 +8523,37 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.5"
           }
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true
         },
@@ -8505,7 +8565,7 @@
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
@@ -8517,33 +8577,33 @@
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
           "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
@@ -8552,34 +8612,34 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
@@ -8589,24 +8649,24 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
@@ -8616,7 +8676,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.x.x"
+            "boom": "5.2.0"
           },
           "dependencies": {
             "boom": {
@@ -8625,18 +8685,18 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
               }
             }
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "debug": {
@@ -8650,19 +8710,19 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
           "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
@@ -8674,23 +8734,23 @@
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
@@ -8708,7 +8768,7 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
@@ -8718,63 +8778,63 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.18"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "glob": {
@@ -8783,17 +8843,17 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
@@ -8809,13 +8869,13 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
@@ -8825,10 +8885,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "hoek": {
@@ -8843,24 +8903,24 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
@@ -8872,41 +8932,41 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
@@ -8918,13 +8978,13 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
@@ -8946,16 +9006,16 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.33.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
@@ -8966,7 +9026,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -8983,7 +9043,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -8993,16 +9053,16 @@
           "integrity": "sha1-Va7/uu2TtQ0KRlfUaRmM2ArJ3zY=",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
             "request": "2.83.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.1"
           }
         },
         "nopt": {
@@ -9011,58 +9071,58 @@
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
@@ -9072,13 +9132,13 @@
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
@@ -9096,7 +9156,7 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
@@ -9112,10 +9172,10 @@
           "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "readable-stream": {
@@ -9124,13 +9184,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -9139,42 +9199,42 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
@@ -9186,13 +9246,13 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
@@ -9202,7 +9262,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "sshpk": {
@@ -9211,82 +9271,82 @@
           "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
           "dev": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
           "version": "3.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
           "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.9",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.3.5",
+            "rimraf": "2.6.2",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
@@ -9295,34 +9355,34 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
@@ -9334,27 +9394,27 @@
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           }
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
@@ -9366,11 +9426,11 @@
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "dev": true,
       "requires": {
-        "axios": "^0.18.0",
-        "google-p12-pem": "^1.0.0",
-        "jws": "^3.1.4",
-        "mime": "^2.2.0",
-        "pify": "^3.0.0"
+        "axios": "0.18.0",
+        "google-p12-pem": "1.0.2",
+        "jws": "3.1.4",
+        "mime": "2.2.2",
+        "pify": "3.0.0"
       }
     },
     "gulp": {
@@ -9379,19 +9439,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       },
       "dependencies": {
         "semver": {
@@ -9408,9 +9468,9 @@
       "integrity": "sha1-o0fUc6zqQBgvk1WHpFGUFnGSgQI=",
       "dev": true,
       "requires": {
-        "gulp-util": "^2.2.14",
-        "rimraf": "^2.2.8",
-        "through2": "^0.4.2"
+        "gulp-util": "2.2.20",
+        "rimraf": "2.6.2",
+        "through2": "0.4.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9431,11 +9491,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "clone-stats": {
@@ -9450,8 +9510,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -9460,14 +9520,14 @@
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           },
           "dependencies": {
             "through2": {
@@ -9476,8 +9536,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "~1.0.17",
-                "xtend": "~3.0.0"
+                "readable-stream": "1.0.34",
+                "xtend": "3.0.0"
               }
             }
           }
@@ -9488,7 +9548,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "isarray": {
@@ -9509,9 +9569,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.template": {
@@ -9520,13 +9580,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -9535,8 +9595,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
@@ -9557,10 +9617,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -9575,7 +9635,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -9590,8 +9650,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
           },
           "dependencies": {
             "xtend": {
@@ -9600,7 +9660,7 @@
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
               "dev": true,
               "requires": {
-                "object-keys": "~0.4.0"
+                "object-keys": "0.4.0"
               }
             }
           }
@@ -9611,7 +9671,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -9640,24 +9700,24 @@
       "integrity": "sha1-b1u+LNC9tISdEs+eEkalhh+LT4g=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.1.0",
-        "copy-props": "^1.4.1",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.3.0",
-        "lodash.isfunction": "^3.0.8",
-        "lodash.isplainobject": "^4.0.4",
-        "lodash.sortby": "^4.5.0",
-        "matchdep": "^1.0.0",
-        "mute-stdout": "^1.0.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver-greatest-satisfied-range": "^1.0.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.9",
-        "wreck": "^6.3.0",
-        "yargs": "^3.28.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "copy-props": "1.6.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "lodash.isfunction": "3.0.9",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.sortby": "4.7.0",
+        "matchdep": "1.0.1",
+        "mute-stdout": "1.0.0",
+        "pretty-hrtime": "1.0.3",
+        "semver-greatest-satisfied-range": "1.1.0",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "wreck": "6.3.0",
+        "yargs": "3.32.0"
       }
     },
     "gulp-connect": {
@@ -9666,15 +9726,15 @@
       "integrity": "sha512-oRBLjw/4EVaZb8g8OcxOVdGD8ZXYrRiWKcNxlrGjxb/6Cp0GDdqw7ieX7D8xJrQS7sbXT+G94u63pMJF3MMjQA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "connect": "^3.6.5",
-        "connect-livereload": "^0.5.4",
-        "event-stream": "^3.3.2",
-        "fancy-log": "^1.3.2",
-        "send": "^0.13.2",
-        "serve-index": "^1.9.1",
-        "serve-static": "^1.13.1",
-        "tiny-lr": "^0.2.1"
+        "ansi-colors": "1.1.0",
+        "connect": "3.6.6",
+        "connect-livereload": "0.5.4",
+        "event-stream": "3.3.4",
+        "fancy-log": "1.3.2",
+        "send": "0.13.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.1",
+        "tiny-lr": "0.2.1"
       },
       "dependencies": {
         "debug": {
@@ -9704,8 +9764,8 @@
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "statuses": "1"
+            "inherits": "2.0.3",
+            "statuses": "1.2.1"
           }
         },
         "mime": {
@@ -9732,18 +9792,18 @@
           "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "destroy": "~1.0.4",
-            "escape-html": "~1.0.3",
-            "etag": "~1.7.0",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "~1.3.1",
+            "http-errors": "1.3.1",
             "mime": "1.3.4",
             "ms": "0.7.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.0.3",
-            "statuses": "~1.2.1"
+            "on-finished": "2.3.0",
+            "range-parser": "1.0.3",
+            "statuses": "1.2.1"
           }
         },
         "statuses": {
@@ -9760,13 +9820,13 @@
       "integrity": "sha512-FbbYudKZvDIxhJ6Q9ZtxIQkeLzGucV43e/SfR1Ee/yK26q2FTySDe/CpdB1D2fj5Vsgfvqq/A74eb3CUOHDh3Q==",
       "dev": true,
       "requires": {
-        "add-stream": "^1.0.0",
-        "concat-stream": "^1.6.0",
-        "conventional-changelog": "^1.1.23",
-        "fancy-log": "^1.3.2",
-        "object-assign": "^4.0.1",
-        "plugin-error": "^1.0.1",
-        "through2": "^2.0.0"
+        "add-stream": "1.0.0",
+        "concat-stream": "1.6.2",
+        "conventional-changelog": "1.1.23",
+        "fancy-log": "1.3.2",
+        "object-assign": "4.1.1",
+        "plugin-error": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-dom": {
@@ -9798,8 +9858,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -9808,24 +9868,24 @@
           "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
           "dev": true,
           "requires": {
-            "array-differ": "^1.0.0",
-            "array-uniq": "^1.0.2",
-            "beeper": "^1.0.0",
-            "chalk": "^1.0.0",
-            "dateformat": "^1.0.11",
-            "fancy-log": "^1.1.0",
-            "gulplog": "^1.0.0",
-            "has-gulplog": "^0.1.0",
-            "lodash._reescape": "^3.0.0",
-            "lodash._reevaluate": "^3.0.0",
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.template": "^3.0.0",
-            "minimist": "^1.1.0",
-            "multipipe": "^0.1.2",
-            "object-assign": "^3.0.0",
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.1",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.3.2",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
             "replace-ext": "0.0.1",
-            "through2": "^2.0.0",
-            "vinyl": "^0.5.0"
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
           }
         },
         "object-assign": {
@@ -9846,12 +9906,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "replace-ext": {
@@ -9872,8 +9932,8 @@
           "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "readable-stream": "2.0.6",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -9882,8 +9942,8 @@
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -9895,8 +9955,8 @@
       "integrity": "sha1-Uef+wTozxARXjRjBWJ0bW8Rf4dY=",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.7",
-        "through2": "^2.0.0"
+        "gulp-util": "3.0.8",
+        "through2": "2.0.3"
       }
     },
     "gulp-highlight-files": {
@@ -9905,9 +9965,9 @@
       "integrity": "sha512-lGLApyg6ycB45MWsLx9WbsAv0iTPxGTUH+Lq8evAXUXCFBPITG2JmLxQ3OYWA1/AOItDeAX5yza1HdLlaIXIPA==",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.8",
-        "highlight.js": "^9.12.0",
-        "through2": "^2.0.3"
+        "gulp-util": "3.0.8",
+        "highlight.js": "9.12.0",
+        "through2": "2.0.3"
       }
     },
     "gulp-htmlmin": {
@@ -9916,12 +9976,12 @@
       "integrity": "sha1-GeqAAtEjHWsfGKEtIPKmand3D7M=",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.1.0",
-        "gulp-util": "^3.0.7",
-        "html-minifier": "^3.0.3",
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.2",
-        "tryit": "^1.0.1"
+        "bufferstreams": "1.1.3",
+        "gulp-util": "3.0.8",
+        "html-minifier": "3.5.14",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6",
+        "tryit": "1.0.3"
       }
     },
     "gulp-if": {
@@ -9930,9 +9990,9 @@
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
-        "gulp-match": "^1.0.3",
-        "ternary-stream": "^2.0.1",
-        "through2": "^2.0.1"
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-markdown": {
@@ -9941,9 +10001,9 @@
       "integrity": "sha1-N83GE3n7A5hB+myrSYSo55Eop3I=",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.0",
-        "marked": "^0.3.2",
-        "through2": "^2.0.0"
+        "gulp-util": "3.0.8",
+        "marked": "0.3.19",
+        "through2": "2.0.3"
       }
     },
     "gulp-match": {
@@ -9952,7 +10012,7 @@
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.3"
+        "minimatch": "3.0.4"
       }
     },
     "gulp-rename": {
@@ -9967,11 +10027,11 @@
       "integrity": "sha512-UATbRpSDsyXCnpYSPBUEvdvtSEzksJs7/oQ0CujIpzKqKrO6vlnYwhX2UTsGrf4rNLwqlSSaM271It0uHYvJ3Q==",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0",
-        "lodash.clonedeep": "^4.3.2",
-        "node-sass": "^4.8.3",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "gulp-util": "3.0.8",
+        "lodash.clonedeep": "4.5.0",
+        "node-sass": "4.8.3",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-transform": {
@@ -9980,8 +10040,8 @@
       "integrity": "sha1-esfj4+Bu1+vFKEe5tOKjaGsi5aI=",
       "dev": true,
       "requires": {
-        "gulp-util": "^3.0.8",
-        "lodash": "^4.17.4"
+        "gulp-util": "3.0.8",
+        "lodash": "4.17.5"
       }
     },
     "gulp-util": {
@@ -9990,24 +10050,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "clone": {
@@ -10040,8 +10100,8 @@
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -10053,7 +10113,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "hammerjs": {
@@ -10068,10 +10128,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -10086,7 +10146,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -10103,8 +10163,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -10113,7 +10173,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary": {
@@ -10151,7 +10211,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-symbol-support-x": {
@@ -10168,7 +10228,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -10183,9 +10243,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10202,8 +10262,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -10212,7 +10272,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10221,7 +10281,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -10232,7 +10292,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -10243,7 +10303,7 @@
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "hawk": {
@@ -10252,10 +10312,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -10270,8 +10330,8 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "highlight.js": {
@@ -10298,7 +10358,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -10313,7 +10373,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html-minifier": {
@@ -10322,13 +10382,13 @@
       "integrity": "sha512-sZjw6zhQgyUnIlIPU+W80XpRjWjdxHtNcxjfyOskOsCTDKytcfLY04wsQY/83Yqb4ndoiD2FtauiL7Yg6uUQFQ==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.1.x",
-        "commander": "2.15.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.3.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.15.1",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.3.20"
       },
       "dependencies": {
         "uglify-js": {
@@ -10337,8 +10397,8 @@
           "integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -10355,12 +10415,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "http-cache-semantics": {
@@ -10376,10 +10436,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-parser-js": {
@@ -10394,8 +10454,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-rewrite-middleware": {
@@ -10410,9 +10470,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "https-proxy-agent": {
@@ -10421,8 +10481,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
       }
     },
     "i": {
@@ -10438,7 +10498,7 @@
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "dev": true,
       "requires": {
-        "safer-buffer": "^2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -10453,11 +10513,11 @@
       "integrity": "sha1-gYoOZWrolIDoAufvFNtGCCb3MPw=",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
-        "buffered-spawn": "~1.1.1",
-        "commander": "~2.9.0",
-        "gm": "~1.21.1",
-        "mkdirp": "~0.3.5",
+        "async": "0.2.10",
+        "buffered-spawn": "1.1.2",
+        "commander": "2.9.0",
+        "gm": "1.21.1",
+        "mkdirp": "0.3.5",
         "tmp": "0.0.23"
       },
       "dependencies": {
@@ -10473,7 +10533,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         },
         "mkdirp": {
@@ -10514,7 +10574,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -10541,8 +10601,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -10563,19 +10623,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.5",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       }
     },
     "interpret": {
@@ -10591,8 +10651,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invert-kv": {
@@ -10620,8 +10680,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -10630,7 +10690,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-alphabetical": {
@@ -10651,8 +10711,8 @@
       "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
       "dev": true,
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
       }
     },
     "is-arrayish": {
@@ -10667,7 +10727,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -10682,7 +10742,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-data-descriptor": {
@@ -10691,7 +10751,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-decimal": {
@@ -10706,9 +10766,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -10737,7 +10797,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -10758,7 +10818,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -10767,7 +10827,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -10776,7 +10836,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hexadecimal": {
@@ -10791,7 +10851,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.0"
+        "lower-case": "1.1.4"
       }
     },
     "is-module": {
@@ -10812,11 +10872,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-npm": {
@@ -10831,7 +10891,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -10853,7 +10913,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -10876,7 +10936,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -10885,7 +10945,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -10900,7 +10960,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10947,7 +11007,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-relative-path": {
@@ -10992,7 +11052,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.7.0"
       }
     },
     "is-typedarray": {
@@ -11007,7 +11067,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-upper-case": {
@@ -11016,7 +11076,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.0"
+        "upper-case": "1.1.3"
       }
     },
     "is-url": {
@@ -11088,8 +11148,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -11104,20 +11164,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.11.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -11138,11 +11198,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
+            "esprima": "2.7.3",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.2.0"
           }
         },
         "esprima": {
@@ -11163,11 +11223,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "resolve": {
@@ -11183,7 +11243,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "wordwrap": {
@@ -11201,8 +11261,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jasmine": {
@@ -11211,9 +11271,9 @@
       "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "glob": "^7.0.6",
-        "jasmine-core": "~2.8.0"
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.8.0"
       }
     },
     "jasmine-core": {
@@ -11240,10 +11300,10 @@
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.22.0",
+        "topo": "1.1.0"
       },
       "dependencies": {
         "hoek": {
@@ -11260,9 +11320,9 @@
       "integrity": "sha1-EFNaEm0ky9Zff/zfFe8uYxB2tQU=",
       "dev": true,
       "requires": {
-        "as-array": "^2.0.0",
+        "as-array": "2.0.0",
         "url-join": "0.0.1",
-        "valid-url": "^1"
+        "valid-url": "1.0.9"
       }
     },
     "js-base64": {
@@ -11283,8 +11343,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -11308,26 +11368,26 @@
       "integrity": "sha1-/eKcEJwyoRMeC2xlkU5kGY+Xw3A=",
       "dev": true,
       "requires": {
-        "abab": "^1.0.0",
-        "acorn": "^2.4.0",
-        "acorn-globals": "^1.0.4",
-        "array-equal": "^1.0.0",
-        "content-type-parser": "^1.0.1",
-        "cssom": ">= 0.3.0 < 0.4.0",
-        "cssstyle": ">= 0.2.36 < 0.3.0",
-        "escodegen": "^1.6.1",
-        "html-encoding-sniffer": "^1.0.1",
-        "iconv-lite": "^0.4.13",
-        "nwmatcher": ">= 1.3.7 < 2.0.0",
-        "parse5": "^1.5.1",
-        "request": "^2.55.0",
-        "sax": "^1.1.4",
-        "symbol-tree": ">= 3.1.0 < 4.0.0",
-        "tough-cookie": "^2.3.1",
-        "webidl-conversions": "^3.0.1",
-        "whatwg-encoding": "^1.0.1",
-        "whatwg-url": "^3.0.0",
-        "xml-name-validator": ">= 2.0.1 < 3.0.0"
+        "abab": "1.0.4",
+        "acorn": "2.7.0",
+        "acorn-globals": "1.0.9",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.9.1",
+        "html-encoding-sniffer": "1.0.2",
+        "iconv-lite": "0.4.21",
+        "nwmatcher": "1.4.4",
+        "parse5": "1.5.1",
+        "request": "2.85.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.4",
+        "webidl-conversions": "3.0.1",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-url": "3.1.0",
+        "xml-name-validator": "2.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -11337,6 +11397,12 @@
           "dev": true
         }
       }
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -11357,7 +11423,7 @@
       "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
       "dev": true,
       "requires": {
-        "jju": "^1.1.0"
+        "jju": "1.3.0"
       }
     },
     "json-schema": {
@@ -11390,7 +11456,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonparse": {
@@ -11417,11 +11483,11 @@
       "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
       "dev": true,
       "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.4",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.0.0",
-        "xtend": "^4.0.1"
+        "joi": "6.10.1",
+        "jws": "3.1.4",
+        "lodash.once": "4.1.1",
+        "ms": "2.0.0",
+        "xtend": "4.0.1"
       }
     },
     "jsprim": {
@@ -11442,11 +11508,11 @@
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "core-js": {
@@ -11467,12 +11533,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11492,7 +11558,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "jws": {
@@ -11501,9 +11567,9 @@
       "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
       "dev": true,
       "requires": {
-        "base64url": "^2.0.0",
-        "jwa": "^1.1.4",
-        "safe-buffer": "^5.0.1"
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "karma": {
@@ -11512,33 +11578,33 @@
       "integrity": "sha512-k5pBjHDhmkdaUccnC7gE3mBzZjcxyxYsYVaqiL2G5AqlfLyBO5nw2VdNK+O16cveEPd/gIOWULH7gkiYYwVNHg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "chokidar": "^1.4.1",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^3.8.0",
-        "log4js": "^0.6.31",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.1",
+        "body-parser": "1.18.2",
+        "chokidar": "1.7.0",
+        "colors": "1.2.1",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.6",
+        "core-js": "2.5.5",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "3.10.1",
+        "log4js": "0.6.38",
+        "mime": "1.6.0",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.2.0",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
-        "source-map": "^0.5.3",
+        "source-map": "0.5.7",
         "tmp": "0.0.31",
-        "useragent": "^2.1.12"
+        "useragent": "2.3.0"
       },
       "dependencies": {
         "colors": {
@@ -11571,7 +11637,7 @@
           "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.1"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -11583,8 +11649,8 @@
       "dev": true,
       "requires": {
         "browserstack": "1.5.0",
-        "browserstacktunnel-wrapper": "~2.0.1",
-        "q": "~1.5.0"
+        "browserstacktunnel-wrapper": "2.0.2",
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -11601,8 +11667,8 @@
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "^1.0.0",
-        "which": "^1.2.1"
+        "fs-access": "1.0.1",
+        "which": "1.3.0"
       }
     },
     "karma-coverage": {
@@ -11611,11 +11677,11 @@
       "integrity": "sha1-Wv+LOc9plNwi3kyENix2ABtjfPY=",
       "dev": true,
       "requires": {
-        "dateformat": "^1.0.6",
-        "istanbul": "^0.4.0",
-        "lodash": "^3.8.0",
-        "minimatch": "^3.0.0",
-        "source-map": "^0.5.1"
+        "dateformat": "1.0.12",
+        "istanbul": "0.4.5",
+        "lodash": "3.10.1",
+        "minimatch": "3.0.4",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "dateformat": {
@@ -11624,8 +11690,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "lodash": {
@@ -11660,10 +11726,10 @@
       "integrity": "sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==",
       "dev": true,
       "requires": {
-        "q": "^1.5.0",
-        "sauce-connect-launcher": "^1.2.2",
-        "saucelabs": "^1.4.0",
-        "wd": "^1.4.0"
+        "q": "1.5.1",
+        "sauce-connect-launcher": "1.2.3",
+        "saucelabs": "1.4.0",
+        "wd": "1.6.1"
       },
       "dependencies": {
         "q": {
@@ -11680,8 +11746,8 @@
       "integrity": "sha512-iFpCfzNJmAJShNyoA9TSMUnVfVCaQzHVGw+CQfFuRHnKkfR6QcUtkMUhi38NUdW/S1qP50kT50fd1f8hXKOOgQ==",
       "dev": true,
       "requires": {
-        "karma-coverage": "^1.1.1",
-        "lodash": "^4.17.4"
+        "karma-coverage": "1.1.1",
+        "lodash": "4.17.5"
       }
     },
     "karma-sourcemap-loader": {
@@ -11690,7 +11756,7 @@
       "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2"
+        "graceful-fs": "4.1.11"
       }
     },
     "karma-spec-reporter": {
@@ -11699,7 +11765,7 @@
       "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2"
+        "colors": "1.2.1"
       },
       "dependencies": {
         "colors": {
@@ -11726,7 +11792,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -11735,7 +11801,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "known-css-properties": {
@@ -11750,7 +11816,7 @@
       "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
       "dev": true,
       "requires": {
-        "package-json": "^2.0.0"
+        "package-json": "2.4.0"
       }
     },
     "lazy-cache": {
@@ -11771,7 +11837,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcid": {
@@ -11780,7 +11846,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
@@ -11789,8 +11855,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lie": {
@@ -11799,7 +11865,7 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "liftoff": {
@@ -11808,14 +11874,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.7.0"
       }
     },
     "livereload-js": {
@@ -11830,11 +11896,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -11849,7 +11915,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -11860,8 +11926,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -11894,7 +11960,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -11957,8 +12023,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       }
     },
     "lodash._root": {
@@ -11973,7 +12039,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.assign": {
@@ -11994,8 +12060,8 @@
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
       }
     },
     "lodash.escape": {
@@ -12004,7 +12070,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.includes": {
@@ -12055,7 +12121,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.isplainobject": {
@@ -12076,9 +12142,9 @@
       "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash._shimkeys": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
+        "lodash._isnative": "2.4.1",
+        "lodash._shimkeys": "2.4.1",
+        "lodash.isobject": "2.4.1"
       }
     },
     "lodash.merge": {
@@ -12124,15 +12190,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -12141,9 +12207,9 @@
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "dev": true,
           "requires": {
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
           }
         }
       }
@@ -12154,8 +12220,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.tostring": {
@@ -12170,7 +12236,7 @@
       "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
       "dev": true,
       "requires": {
-        "lodash.tostring": "^4.0.0"
+        "lodash.tostring": "4.1.4"
       }
     },
     "lodash.values": {
@@ -12179,7 +12245,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       }
     },
     "log-driver": {
@@ -12194,7 +12260,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "log4js": {
@@ -12203,8 +12269,8 @@
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.2",
-        "semver": "~4.3.3"
+        "readable-stream": "1.0.34",
+        "semver": "4.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -12219,10 +12285,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "semver": {
@@ -12263,8 +12329,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -12279,7 +12345,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.2"
+        "lower-case": "1.1.4"
       }
     },
     "lowercase-keys": {
@@ -12294,8 +12360,8 @@
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "madge": {
@@ -12324,7 +12390,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^2.0.0"
+            "restore-cursor": "2.0.0"
           }
         },
         "cli-spinners": {
@@ -12339,7 +12405,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         },
         "debug": {
@@ -12363,7 +12429,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "ora": {
@@ -12372,10 +12438,10 @@
           "integrity": "sha1-Mvsxg1AO/oP16okQF4Xw7mBg/sk=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "cli-cursor": "^2.1.0",
-            "cli-spinners": "^1.0.0",
-            "log-symbols": "^1.0.2"
+            "chalk": "1.1.3",
+            "cli-cursor": "2.1.0",
+            "cli-spinners": "1.3.1",
+            "log-symbols": "1.0.2"
           }
         },
         "rc": {
@@ -12384,10 +12450,10 @@
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~1.0.4"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "1.0.4"
           }
         },
         "restore-cursor": {
@@ -12396,8 +12462,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
           }
         },
         "strip-json-comments": {
@@ -12414,7 +12480,7 @@
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "make-dir": {
@@ -12423,7 +12489,7 @@
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -12438,7 +12504,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -12473,7 +12539,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-escapes": {
@@ -12500,8 +12566,8 @@
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
       "dev": true,
       "requires": {
-        "buffers": "~0.1.1",
-        "readable-stream": "~1.0.0"
+        "buffers": "0.1.1",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -12516,10 +12582,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -12536,9 +12602,9 @@
       "integrity": "sha1-pXozgESR+64girqPaDgEN6vC3KU=",
       "dev": true,
       "requires": {
-        "findup-sync": "~0.3.0",
-        "micromatch": "^2.3.7",
-        "resolve": "~1.1.6",
+        "findup-sync": "0.3.0",
+        "micromatch": "2.3.11",
+        "resolve": "1.1.7",
         "stack-trace": "0.0.9"
       },
       "dependencies": {
@@ -12548,7 +12614,7 @@
           "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
           "dev": true,
           "requires": {
-            "glob": "~5.0.0"
+            "glob": "5.0.15"
           }
         },
         "glob": {
@@ -12557,11 +12623,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "resolve": {
@@ -12590,8 +12656,8 @@
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "dev": true,
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-modify-children": "1.1.1",
+        "unist-util-visit": "1.3.0"
       }
     },
     "media-typer": {
@@ -12606,7 +12672,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -12615,8 +12681,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -12625,16 +12691,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       }
     },
     "merge-descriptors": {
@@ -12650,7 +12716,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "merge2": {
@@ -12677,19 +12743,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -12710,7 +12776,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -12731,7 +12797,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -12745,8 +12811,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "minipass": {
@@ -12755,8 +12821,8 @@
       "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -12773,7 +12839,7 @@
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.2.4"
       }
     },
     "mixin-deep": {
@@ -12782,8 +12848,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -12792,7 +12858,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -12818,7 +12884,7 @@
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "dev": true,
       "requires": {
-        "mkdirp": "*"
+        "mkdirp": "0.5.1"
       }
     },
     "modelo": {
@@ -12839,8 +12905,8 @@
       "integrity": "sha1-wKN3HeWM9rzxKu0kdnBsWWrUsss=",
       "dev": true,
       "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.0.0"
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
       }
     },
     "module-lookup-amd": {
@@ -12849,12 +12915,12 @@
       "integrity": "sha512-rmljyiMrPqEfeOD1myMULVgnv1pRUqq1Dv/Xn0f9g36wCDWvqj07arG0fCEbKqU1sYFXptnaC1o+0oR7JpwOtg==",
       "dev": true,
       "requires": {
-        "commander": "^2.8.1",
-        "debug": "^3.1.0",
-        "file-exists": "^2.0.0",
-        "find": "^0.2.8",
-        "requirejs": "^2.3.5",
-        "requirejs-config-file": "^3.0.0"
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "file-exists": "2.0.0",
+        "find": "0.2.9",
+        "requirejs": "2.3.5",
+        "requirejs-config-file": "3.0.0"
       }
     },
     "moment": {
@@ -12869,11 +12935,11 @@
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "~2.0.0",
+        "basic-auth": "2.0.0",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -12908,7 +12974,7 @@
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.1.9"
+            "readable-stream": "1.1.14"
           }
         },
         "isarray": {
@@ -12923,10 +12989,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -12956,9 +13022,9 @@
       "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nan": {
@@ -12973,18 +13039,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -13013,10 +13079,10 @@
       "integrity": "sha1-y5ZHkc79N21Zz6zYAQknRhaqFdI=",
       "dev": true,
       "requires": {
-        "async": "^1.3.0",
-        "flat-arguments": "^1.0.0",
-        "lodash": "^3.10.0",
-        "minimist": "^1.1.0"
+        "async": "1.5.2",
+        "flat-arguments": "1.0.2",
+        "lodash": "3.10.1",
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "async": {
@@ -13058,7 +13124,7 @@
       "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "netrc": {
@@ -13079,7 +13145,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node-fetch": {
@@ -13088,8 +13154,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-forge": {
@@ -13104,19 +13170,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "2",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.5",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "semver": {
@@ -13131,9 +13197,9 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -13150,25 +13216,25 @@
       "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
       "dev": true,
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.3.1",
-        "npmlog": "^4.0.0",
-        "request": "~2.79.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.10.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
+        "request": "2.79.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
       },
       "dependencies": {
         "assert-plus": {
@@ -13189,7 +13255,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -13204,8 +13270,8 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.2",
+            "which": "1.3.0"
           }
         },
         "cryptiles": {
@@ -13214,7 +13280,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -13223,9 +13289,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "gaze": {
@@ -13234,7 +13300,7 @@
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "dev": true,
           "requires": {
-            "globule": "^1.0.0"
+            "globule": "1.2.0"
           }
         },
         "globule": {
@@ -13243,9 +13309,9 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "~7.1.1",
-            "lodash": "~4.17.4",
-            "minimatch": "~3.0.2"
+            "glob": "7.1.2",
+            "lodash": "4.17.5",
+            "minimatch": "3.0.4"
           }
         },
         "har-validator": {
@@ -13254,10 +13320,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
           }
         },
         "hawk": {
@@ -13266,10 +13332,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -13284,9 +13350,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "qs": {
@@ -13301,26 +13367,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -13329,7 +13395,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "tunnel-agent": {
@@ -13346,7 +13412,7 @@
       "integrity": "sha1-rRjjW/2z0Lb34OSv8eePhGo7iHM=",
       "dev": true,
       "requires": {
-        "babylon": "^6.17.0"
+        "babylon": "6.18.0"
       }
     },
     "node-status-codes": {
@@ -13361,7 +13427,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -13370,10 +13436,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -13382,7 +13448,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -13404,9 +13470,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.1",
+        "sort-keys": "2.0.0"
       }
     },
     "npm-run-path": {
@@ -13415,7 +13481,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -13424,10 +13490,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "null-check": {
@@ -13454,11 +13520,11 @@
       "integrity": "sha512-pJXncV07mmiuIDL9OqdNkcpvifuDMzMq9qBQT9SHasAS7AEwzNp/r/jHNl+9O0+zsldcdWG9ZtXo/nwu2cTqXA==",
       "dev": true,
       "requires": {
-        "a-sync-waterfall": "^1.0.0",
-        "asap": "^2.0.3",
-        "chokidar": "^1.6.0",
-        "postinstall-build": "^5.0.1",
-        "yargs": "^3.32.0"
+        "a-sync-waterfall": "1.0.0",
+        "asap": "2.0.6",
+        "chokidar": "1.7.0",
+        "postinstall-build": "5.0.1",
+        "yargs": "3.32.0"
       }
     },
     "nwmatcher": {
@@ -13491,9 +13557,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -13502,7 +13568,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -13519,7 +13585,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13536,10 +13602,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -13548,7 +13614,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -13565,8 +13631,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -13575,7 +13641,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -13586,8 +13652,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -13596,7 +13662,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13634,12 +13700,12 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13655,8 +13721,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -13673,12 +13739,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -13707,10 +13773,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "orchestrator": {
@@ -13719,9 +13785,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -13730,7 +13796,7 @@
           "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
           "dev": true,
           "requires": {
-            "once": "~1.3.0"
+            "once": "1.3.3"
           }
         },
         "once": {
@@ -13739,7 +13805,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -13762,7 +13828,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -13777,8 +13843,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "over": {
@@ -13813,7 +13879,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -13822,7 +13888,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-timeout": {
@@ -13832,7 +13898,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -13847,10 +13913,10 @@
       "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
       "dev": true,
       "requires": {
-        "got": "^5.0.0",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "5.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -13859,21 +13925,21 @@
           "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.1",
-            "duplexer2": "^0.1.4",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "node-status-codes": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "parse-json": "^2.1.0",
-            "pinkie-promise": "^2.0.0",
-            "read-all-stream": "^3.0.0",
-            "readable-stream": "^2.0.5",
-            "timed-out": "^3.0.0",
-            "unzip-response": "^1.0.2",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.6",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
           }
         },
         "prepend-http": {
@@ -13894,7 +13960,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         }
       }
@@ -13911,7 +13977,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-entities": {
@@ -13920,12 +13986,12 @@
       "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
       "dev": true,
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "parse-filepath": {
@@ -13934,9 +14000,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-github-repo-url": {
@@ -13951,10 +14017,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -13963,7 +14029,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-ms": {
@@ -13990,7 +14056,7 @@
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseqs": {
@@ -13999,7 +14065,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -14008,7 +14074,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -14023,8 +14089,8 @@
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "dev": true,
       "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "upper-case-first": "1.1.2"
       }
     },
     "pascalcase": {
@@ -14039,7 +14105,7 @@
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "path-dirname": {
@@ -14084,7 +14150,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -14105,7 +14171,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pause-stream": {
@@ -14114,7 +14180,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "performance-now": {
@@ -14141,7 +14207,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkginfo": {
@@ -14157,10 +14223,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -14190,7 +14256,7 @@
       "dev": true,
       "requires": {
         "async": "0.9.0",
-        "mkdirp": "0.5.x"
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "async": {
@@ -14213,10 +14279,10 @@
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
+        "chalk": "1.1.3",
+        "js-base64": "2.4.3",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "source-map": {
@@ -14233,9 +14299,9 @@
       "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.9.2",
-        "remark": "^8.0.0",
-        "unist-util-find-all-after": "^1.0.1"
+        "htmlparser2": "3.9.2",
+        "remark": "8.0.0",
+        "unist-util-find-all-after": "1.0.1"
       }
     },
     "postcss-less": {
@@ -14244,7 +14310,7 @@
       "integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
       "dev": true,
       "requires": {
-        "postcss": "^5.2.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-query-parser": {
@@ -14259,10 +14325,10 @@
       "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "postcss": "^6.0.8"
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14271,7 +14337,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14280,9 +14346,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14297,7 +14363,7 @@
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "2.3.2"
           }
         },
         "postcss": {
@@ -14306,9 +14372,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
@@ -14317,7 +14383,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14334,7 +14400,7 @@
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.6"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14343,7 +14409,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14352,9 +14418,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14369,9 +14435,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
@@ -14380,7 +14446,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14391,8 +14457,8 @@
       "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.0.3",
-        "postcss": "^6.0.6"
+        "gonzales-pe": "4.2.3",
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14401,7 +14467,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14410,9 +14476,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "gonzales-pe": {
@@ -14421,7 +14487,7 @@
           "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
           "dev": true,
           "requires": {
-            "minimist": "1.1.x"
+            "minimist": "1.1.3"
           }
         },
         "has-flag": {
@@ -14442,9 +14508,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
@@ -14453,7 +14519,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14464,7 +14530,7 @@
       "integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.21"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14473,7 +14539,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14482,9 +14548,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14499,9 +14565,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
@@ -14510,7 +14576,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14521,9 +14587,9 @@
       "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.1",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "dot-prop": "4.2.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-value-parser": {
@@ -14544,11 +14610,11 @@
       "integrity": "sha512-WaWSw+Ts283o6dzxW1BxIxoaHok7aSSGx4SaR6dW62Pk31ynv9DERDieuZpPYv5XaJ+H+zdcOaJQ+PvlasAOVw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "empower": "^1.2.3",
-        "power-assert-formatter": "^1.3.1",
-        "universal-deep-strict-equal": "^1.2.1",
-        "xtend": "^4.0.0"
+        "define-properties": "1.1.2",
+        "empower": "1.2.3",
+        "power-assert-formatter": "1.4.1",
+        "universal-deep-strict-equal": "1.2.2",
+        "xtend": "4.0.1"
       }
     },
     "power-assert-context-formatter": {
@@ -14557,8 +14623,8 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.1.1"
+        "core-js": "2.5.5",
+        "power-assert-context-traversal": "1.1.1"
       }
     },
     "power-assert-context-reducer-ast": {
@@ -14567,11 +14633,11 @@
       "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.0",
-        "acorn-es7-plugin": "^1.0.12",
-        "core-js": "^2.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.2.0"
+        "acorn": "4.0.13",
+        "acorn-es7-plugin": "1.1.7",
+        "core-js": "2.5.5",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
       }
     },
     "power-assert-context-traversal": {
@@ -14580,8 +14646,8 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "estraverse": "^4.1.0"
+        "core-js": "2.5.5",
+        "estraverse": "4.2.0"
       }
     },
     "power-assert-formatter": {
@@ -14590,13 +14656,13 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-context-formatter": "^1.0.7",
-        "power-assert-context-reducer-ast": "^1.0.7",
-        "power-assert-renderer-assertion": "^1.0.7",
-        "power-assert-renderer-comparison": "^1.0.7",
-        "power-assert-renderer-diagram": "^1.0.7",
-        "power-assert-renderer-file": "^1.0.7"
+        "core-js": "2.5.5",
+        "power-assert-context-formatter": "1.1.1",
+        "power-assert-context-reducer-ast": "1.1.2",
+        "power-assert-renderer-assertion": "1.1.1",
+        "power-assert-renderer-comparison": "1.1.1",
+        "power-assert-renderer-diagram": "1.1.2",
+        "power-assert-renderer-file": "1.1.1"
       }
     },
     "power-assert-renderer-assertion": {
@@ -14605,8 +14671,8 @@
       "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
       "dev": true,
       "requires": {
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1"
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.1.1"
       }
     },
     "power-assert-renderer-base": {
@@ -14621,11 +14687,11 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "diff-match-patch": "^1.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "stringifier": "^1.3.0",
-        "type-name": "^2.0.1"
+        "core-js": "2.5.5",
+        "diff-match-patch": "1.0.0",
+        "power-assert-renderer-base": "1.1.1",
+        "stringifier": "1.3.0",
+        "type-name": "2.0.2"
       }
     },
     "power-assert-renderer-diagram": {
@@ -14634,10 +14700,10 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1",
-        "stringifier": "^1.3.0"
+        "core-js": "2.5.5",
+        "power-assert-renderer-base": "1.1.1",
+        "power-assert-util-string-width": "1.1.1",
+        "stringifier": "1.3.0"
       }
     },
     "power-assert-renderer-file": {
@@ -14646,7 +14712,7 @@
       "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
       "dev": true,
       "requires": {
-        "power-assert-renderer-base": "^1.1.1"
+        "power-assert-renderer-base": "1.1.1"
       }
     },
     "power-assert-util-string-width": {
@@ -14655,7 +14721,7 @@
       "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
       "dev": true,
       "requires": {
-        "eastasianwidth": "^0.1.1"
+        "eastasianwidth": "0.1.1"
       }
     },
     "precinct": {
@@ -14664,18 +14730,18 @@
       "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
       "dev": true,
       "requires": {
-        "commander": "^2.11.0",
-        "debug": "^3.0.1",
-        "detective-amd": "^2.4.0",
-        "detective-cjs": "^2.0.0",
-        "detective-es6": "^1.2.0",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "detective-amd": "2.4.0",
+        "detective-cjs": "2.0.0",
+        "detective-es6": "1.2.0",
         "detective-less": "1.0.0",
-        "detective-sass": "^2.0.0",
-        "detective-scss": "^1.0.0",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^1.0.0",
-        "module-definition": "^2.2.4",
-        "node-source-walk": "^3.3.0"
+        "detective-sass": "2.0.1",
+        "detective-scss": "1.0.1",
+        "detective-stylus": "1.0.0",
+        "detective-typescript": "1.0.1",
+        "module-definition": "2.2.4",
+        "node-source-walk": "3.3.0"
       }
     },
     "prelude-ls": {
@@ -14714,9 +14780,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
       }
     },
     "process-nextick-args": {
@@ -14737,7 +14803,7 @@
       "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "dev": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-polyfill": {
@@ -14753,12 +14819,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "colors": "^1.1.2",
-        "pkginfo": "0.x.x",
-        "read": "1.0.x",
-        "revalidator": "0.1.x",
-        "utile": "0.3.x",
-        "winston": "2.1.x"
+        "colors": "1.2.1",
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.3.0",
+        "winston": "2.1.1"
       },
       "dependencies": {
         "async": {
@@ -14782,13 +14848,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "pkginfo": "0.3.x",
-            "stack-trace": "0.0.x"
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "pkginfo": "0.3.1",
+            "stack-trace": "0.0.10"
           },
           "dependencies": {
             "colors": {
@@ -14815,10 +14881,10 @@
       "integrity": "sha1-QiMGMjPqlqwGPKK1VANSBNtST6E=",
       "dev": true,
       "requires": {
-        "ascli": "~1",
-        "bytebuffer": "~5",
-        "glob": "^5.0.10",
-        "yargs": "^3.10.0"
+        "ascli": "1.0.1",
+        "bytebuffer": "5.0.1",
+        "glob": "5.0.15",
+        "yargs": "3.32.0"
       },
       "dependencies": {
         "glob": {
@@ -14827,11 +14893,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -14849,21 +14915,21 @@
       "integrity": "sha512-AW9qJ0prx2QEMy1gnhJ1Sl1WBQL2R3fx/VnG09FEmWprPIQPK14t0B83OB/pAGddpxiDCAAV0KiNNLf2c2Y/lQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^6.0.46",
-        "@types/q": "^0.0.32",
-        "@types/selenium-webdriver": "~2.53.39",
-        "blocking-proxy": "^1.0.0",
-        "chalk": "^1.1.3",
-        "glob": "^7.0.3",
+        "@types/node": "6.0.105",
+        "@types/q": "0.0.32",
+        "@types/selenium-webdriver": "2.53.43",
+        "blocking-proxy": "1.0.1",
+        "chalk": "1.1.3",
+        "glob": "7.1.2",
         "jasmine": "2.8.0",
-        "jasminewd2": "^2.1.0",
-        "optimist": "~0.6.0",
+        "jasminewd2": "2.2.0",
+        "optimist": "0.6.1",
         "q": "1.4.1",
-        "saucelabs": "~1.3.0",
+        "saucelabs": "1.3.0",
         "selenium-webdriver": "3.6.0",
-        "source-map-support": "~0.4.0",
-        "webdriver-js-extender": "^1.0.0",
-        "webdriver-manager": "^12.0.6"
+        "source-map-support": "0.4.18",
+        "webdriver-js-extender": "1.0.0",
+        "webdriver-manager": "12.0.6"
       },
       "dependencies": {
         "@types/node": {
@@ -14884,8 +14950,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           }
         },
         "debug": {
@@ -14903,9 +14969,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "saucelabs": {
@@ -14914,7 +14980,7 @@
           "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
           "dev": true,
           "requires": {
-            "https-proxy-agent": "^1.0.0"
+            "https-proxy-agent": "1.0.0"
           }
         },
         "semver": {
@@ -14935,7 +15001,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6"
+            "source-map": "0.5.7"
           }
         },
         "webdriver-manager": {
@@ -14944,17 +15010,17 @@
           "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
           "dev": true,
           "requires": {
-            "adm-zip": "^0.4.7",
-            "chalk": "^1.1.1",
-            "del": "^2.2.0",
-            "glob": "^7.0.3",
-            "ini": "^1.3.4",
-            "minimist": "^1.2.0",
-            "q": "^1.4.1",
-            "request": "^2.78.0",
-            "rimraf": "^2.5.2",
-            "semver": "^5.3.0",
-            "xml2js": "^0.4.17"
+            "adm-zip": "0.4.7",
+            "chalk": "1.1.3",
+            "del": "2.2.2",
+            "glob": "7.1.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "q": "1.4.1",
+            "request": "2.85.0",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "xml2js": "0.4.19"
           },
           "dependencies": {
             "semver": {
@@ -14974,7 +15040,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -14996,10 +15062,10 @@
       "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
       "dev": true,
       "requires": {
-        "over": ">= 0.0.5 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.2 < 2",
-        "slice-stream": ">= 1.0.0 < 2"
+        "over": "0.0.5",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5",
+        "slice-stream": "1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -15014,10 +15080,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15034,8 +15100,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -15044,9 +15110,9 @@
       "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.3",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.5.4",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -15080,9 +15146,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "quick-lru": {
@@ -15097,8 +15163,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -15107,7 +15173,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15116,7 +15182,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -15127,7 +15193,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -15165,7 +15231,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.5.0"
           }
         },
         "iconv-lite": {
@@ -15188,10 +15254,10 @@
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "read": {
@@ -15201,7 +15267,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-all-stream": {
@@ -15210,8 +15276,8 @@
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.6"
       }
     },
     "read-pkg": {
@@ -15220,9 +15286,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       },
       "dependencies": {
         "path-type": {
@@ -15231,9 +15297,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -15250,8 +15316,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -15260,8 +15326,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -15270,7 +15336,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -15281,13 +15347,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -15296,10 +15362,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "readline2": {
@@ -15308,8 +15374,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -15327,7 +15393,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.7.0"
       }
     },
     "redent": {
@@ -15336,14 +15402,20 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reflect-metadata": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
       "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -15358,7 +15430,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -15367,8 +15439,19 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -15377,8 +15460,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
@@ -15387,7 +15470,22 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.6"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
       }
     },
     "relateurl": {
@@ -15402,9 +15500,9 @@
       "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
       "dev": true,
       "requires": {
-        "remark-parse": "^4.0.0",
-        "remark-stringify": "^4.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "4.0.0",
+        "remark-stringify": "4.0.0",
+        "unified": "6.1.6"
       }
     },
     "remark-parse": {
@@ -15413,21 +15511,21 @@
       "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
       "dev": true,
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.3",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
+        "markdown-escapes": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2",
+        "xtend": "4.0.1"
       }
     },
     "remark-stringify": {
@@ -15436,20 +15534,20 @@
       "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
       "dev": true,
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.2",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.1",
+        "markdown-table": "1.1.1",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "stringify-entities": "1.3.1",
+        "unherit": "1.1.0",
+        "xtend": "4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -15476,7 +15574,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -15491,28 +15589,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "require-directory": {
@@ -15545,9 +15643,9 @@
       "integrity": "sha512-pssKfw0KhafnpOHA1+qWlDXcCEgf0p+qfTI8xOhqOhhdtz7m7VqhEorauKZOqv1GGA8ML3eKFU3sxGq5p4ZaEw==",
       "dev": true,
       "requires": {
-        "esprima": "^4.0.0",
-        "fs-extra": "^5.0.0",
-        "stringify-object": "^3.2.1"
+        "esprima": "4.0.0",
+        "fs-extra": "5.0.0",
+        "stringify-object": "3.2.2"
       },
       "dependencies": {
         "esprima": {
@@ -15562,9 +15660,9 @@
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "jsonfile": {
@@ -15573,7 +15671,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -15590,7 +15688,7 @@
       "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-bin": {
@@ -15599,7 +15697,7 @@
       "integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
       "dev": true,
       "requires": {
-        "find-parent-dir": "~0.3.0"
+        "find-parent-dir": "0.3.0"
       }
     },
     "resolve-dependency-path": {
@@ -15614,8 +15712,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -15637,7 +15735,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -15646,8 +15744,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "ret": {
@@ -15668,8 +15766,8 @@
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "dev": true,
       "requires": {
-        "request": "^2.81.0",
-        "through2": "^2.0.0"
+        "request": "2.85.0",
+        "through2": "2.0.3"
       }
     },
     "revalidator": {
@@ -15685,7 +15783,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -15694,7 +15792,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "rollup": {
@@ -15709,7 +15807,7 @@
       "integrity": "sha512-lB094zdi19FS+1bVarVp9kBN0Zk41PdTGoCk0z8xesKO7RGjOo18cp1hUzEqrOQ4bM9+KLD9nbnu/XUxQm9pbg==",
       "dev": true,
       "requires": {
-        "slash": "^1.0.0"
+        "slash": "1.0.0"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -15718,9 +15816,9 @@
       "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^2.0.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.1.6"
+        "builtin-modules": "2.0.0",
+        "is-module": "1.0.0",
+        "resolve": "1.7.0"
       },
       "dependencies": {
         "builtin-modules": {
@@ -15739,8 +15837,8 @@
       "requires": {
         "array-flatten": "2.1.1",
         "debug": "2.6.9",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
         "setprototypeof": "1.1.0",
         "utils-merge": "1.0.1"
@@ -15775,7 +15873,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "run-sequence": {
@@ -15784,8 +15882,8 @@
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
       "dev": true,
       "requires": {
-        "chalk": "*",
-        "gulp-util": "*"
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8"
       }
     },
     "rx-lite": {
@@ -15799,7 +15897,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0.tgz",
       "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.0"
       }
     },
     "safe-buffer": {
@@ -15814,7 +15912,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -15829,10 +15927,10 @@
       "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
       "dev": true,
       "requires": {
-        "es6-promise": "^3.1.2",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.2"
+        "es6-promise": "3.3.1",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "es6-promise": {
@@ -15849,10 +15947,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -15873,19 +15971,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -15894,7 +15992,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -15905,8 +16003,8 @@
       "integrity": "sha1-2kSiG+6llV8U7/24G97idRttFeI=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1",
-        "is-relative-path": "~1.0.0"
+        "commander": "2.8.1",
+        "is-relative-path": "1.0.2"
       },
       "dependencies": {
         "commander": {
@@ -15915,7 +16013,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -15926,11 +16024,11 @@
       "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
       "dev": true,
       "requires": {
-        "adm-zip": "~0.4.3",
-        "async": "^2.1.2",
-        "https-proxy-agent": "~1.0.0",
-        "lodash": "^4.16.6",
-        "rimraf": "^2.5.4"
+        "adm-zip": "0.4.7",
+        "async": "2.6.0",
+        "https-proxy-agent": "1.0.0",
+        "lodash": "4.17.5",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "agent-base": {
@@ -15939,8 +16037,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           }
         },
         "debug": {
@@ -15958,9 +16056,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "semver": {
@@ -15977,7 +16075,7 @@
       "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "^1.0.0"
+        "https-proxy-agent": "1.0.0"
       },
       "dependencies": {
         "agent-base": {
@@ -15986,8 +16084,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           }
         },
         "debug": {
@@ -16005,9 +16103,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "semver": {
@@ -16030,13 +16128,13 @@
       "integrity": "sha512-8gJxY6CmeSKNf/Kte/xAY/VhR+JF5RUCfHf6fu6pdAASqB9YN3Kuwp9mLbBIEKSl0LZvpK4aw0YfBH5TrA46Dg==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "fs-extra": "^5.0.0",
-        "globs": "^0.1.3",
-        "node-sass": "^4.7.2",
-        "pretty-bytes": "^4.0.2",
-        "promise": "^8.0.1",
-        "yargs": "^10.0.3"
+        "archy": "1.0.0",
+        "fs-extra": "5.0.0",
+        "globs": "0.1.3",
+        "node-sass": "4.8.3",
+        "pretty-bytes": "4.0.2",
+        "promise": "8.0.1",
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -16057,9 +16155,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "fs-extra": {
@@ -16068,9 +16166,9 @@
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -16085,7 +16183,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "os-locale": {
@@ -16094,9 +16192,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -16105,8 +16203,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -16115,7 +16213,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "yargs": {
@@ -16124,18 +16222,18 @@
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.1.0"
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
           }
         },
         "yargs-parser": {
@@ -16144,7 +16242,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -16155,8 +16253,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
+        "js-base64": "2.4.3",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -16165,7 +16263,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -16176,10 +16274,10 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "^3.1.3",
-        "rimraf": "^2.5.4",
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
         "tmp": "0.0.30",
-        "xml2js": "^0.4.17"
+        "xml2js": "0.4.19"
       }
     },
     "semver": {
@@ -16194,7 +16292,16 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
+      }
+    },
+    "semver-dsl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
+      "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
+      "dev": true,
+      "requires": {
+        "semver": "5.5.0"
       }
     },
     "semver-greatest-satisfied-range": {
@@ -16203,7 +16310,7 @@
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "^1.5.0"
+        "sver-compat": "1.5.0"
       }
     },
     "send": {
@@ -16213,18 +16320,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.3.1"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -16256,8 +16363,8 @@
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
+        "no-case": "2.3.2",
+        "upper-case-first": "1.1.2"
       }
     },
     "sequencify": {
@@ -16273,7 +16380,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "protochain": "^1.0.5"
+        "protochain": "1.0.5"
       }
     },
     "serve-index": {
@@ -16282,13 +16389,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -16308,9 +16415,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.1"
       }
     },
@@ -16332,10 +16439,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -16344,7 +16451,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -16367,7 +16474,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -16382,9 +16489,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "sigmund": {
@@ -16411,7 +16518,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -16428,7 +16535,7 @@
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.31"
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -16443,10 +16550,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -16469,7 +16576,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "snakeize": {
@@ -16484,14 +16591,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -16509,7 +16616,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -16518,7 +16625,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -16535,9 +16642,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -16546,7 +16653,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -16555,7 +16662,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -16564,7 +16671,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -16573,9 +16680,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -16598,7 +16705,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -16607,7 +16714,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "socket.io": {
@@ -16758,10 +16865,10 @@
       "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "^0.2.5",
-        "minimist": "^1.2.0",
-        "sander": "^0.5.0",
-        "sourcemap-codec": "^1.3.0"
+        "buffer-crc32": "0.2.13",
+        "minimist": "1.2.0",
+        "sander": "0.5.1",
+        "sourcemap-codec": "1.4.1"
       }
     },
     "sort-keys": {
@@ -16771,7 +16878,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -16785,11 +16892,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -16797,7 +16904,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
       "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
       "requires": {
-        "source-map": "^0.6.0"
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -16824,8 +16931,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -16840,8 +16947,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -16868,7 +16975,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-array-stream": {
@@ -16877,8 +16984,8 @@
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "dev": true,
       "requires": {
-        "async": "^2.4.0",
-        "is-stream-ended": "^0.1.0"
+        "async": "2.6.0",
+        "is-stream-ended": "0.1.4"
       }
     },
     "split-string": {
@@ -16887,7 +16994,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "split2": {
@@ -16896,7 +17003,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -16911,14 +17018,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -16939,8 +17046,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -16949,7 +17056,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -16966,7 +17073,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "stream-combiner": {
@@ -16975,7 +17082,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-consume": {
@@ -16990,7 +17097,7 @@
       "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
       "dev": true,
       "requires": {
-        "stubs": "^3.0.0"
+        "stubs": "3.0.0"
       }
     },
     "stream-shift": {
@@ -17018,7 +17125,7 @@
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "3.0.1"
       }
     },
     "string-template": {
@@ -17034,9 +17141,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -17045,7 +17152,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringifier": {
@@ -17054,9 +17161,9 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "traverse": "^0.6.6",
-        "type-name": "^2.0.1"
+        "core-js": "2.5.5",
+        "traverse": "0.6.6",
+        "type-name": "2.0.2"
       }
     },
     "stringify-entities": {
@@ -17065,10 +17172,10 @@
       "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
       "dev": true,
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "stringify-object": {
@@ -17077,9 +17184,9 @@
       "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "stringmap": {
@@ -17100,7 +17207,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -17109,8 +17216,8 @@
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -17125,7 +17232,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -17152,45 +17259,45 @@
       "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^7.1.2",
-        "balanced-match": "^1.0.0",
-        "chalk": "^2.0.1",
-        "cosmiconfig": "^3.1.0",
-        "debug": "^3.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^2.0.0",
-        "get-stdin": "^5.0.1",
-        "globby": "^7.0.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.5.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
-        "meow": "^4.0.0",
-        "micromatch": "^2.3.11",
-        "normalize-selector": "^0.2.0",
-        "pify": "^3.0.0",
-        "postcss": "^6.0.6",
-        "postcss-html": "^0.12.0",
-        "postcss-less": "^1.1.0",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^5.0.0",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^3.0.1",
-        "postcss-sass": "^0.2.0",
-        "postcss-scss": "^1.0.2",
-        "postcss-selector-parser": "^3.1.0",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
-        "specificity": "^0.3.1",
-        "string-width": "^2.1.0",
-        "style-search": "^0.1.0",
-        "sugarss": "^1.0.0",
-        "svg-tags": "^1.0.0",
-        "table": "^4.0.1"
+        "autoprefixer": "7.2.6",
+        "balanced-match": "1.0.0",
+        "chalk": "2.3.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "execall": "1.0.0",
+        "file-entry-cache": "2.0.0",
+        "get-stdin": "5.0.1",
+        "globby": "7.1.1",
+        "globjoin": "0.1.4",
+        "html-tags": "2.0.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "known-css-properties": "0.5.0",
+        "lodash": "4.17.5",
+        "log-symbols": "2.2.0",
+        "mathml-tag-names": "2.0.1",
+        "meow": "4.0.0",
+        "micromatch": "2.3.11",
+        "normalize-selector": "0.2.0",
+        "pify": "3.0.0",
+        "postcss": "6.0.21",
+        "postcss-html": "0.12.0",
+        "postcss-less": "1.1.5",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "5.0.0",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "3.0.1",
+        "postcss-sass": "0.2.0",
+        "postcss-scss": "1.0.5",
+        "postcss-selector-parser": "3.1.1",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "4.0.0",
+        "specificity": "0.3.2",
+        "string-width": "2.1.1",
+        "style-search": "0.1.0",
+        "sugarss": "1.0.1",
+        "svg-tags": "1.0.0",
+        "table": "4.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -17205,7 +17312,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "autoprefixer": {
@@ -17214,12 +17321,12 @@
           "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
           "dev": true,
           "requires": {
-            "browserslist": "^2.11.3",
-            "caniuse-lite": "^1.0.30000805",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "postcss": "^6.0.17",
-            "postcss-value-parser": "^3.2.3"
+            "browserslist": "2.11.3",
+            "caniuse-lite": "1.0.30000824",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "6.0.21",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "browserslist": {
@@ -17228,8 +17335,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000792",
-            "electron-to-chromium": "^1.3.30"
+            "caniuse-lite": "1.0.30000824",
+            "electron-to-chromium": "1.3.42"
           }
         },
         "camelcase": {
@@ -17244,9 +17351,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "chalk": {
@@ -17255,9 +17362,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "get-stdin": {
@@ -17272,12 +17379,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.7",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "has-flag": {
@@ -17304,10 +17411,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "log-symbols": {
@@ -17316,7 +17423,7 @@
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "2.3.2"
           }
         },
         "map-obj": {
@@ -17331,15 +17438,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -17348,8 +17455,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "postcss": {
@@ -17358,9 +17465,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "read-pkg": {
@@ -17369,9 +17476,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -17380,8 +17487,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -17390,8 +17497,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "string-width": {
@@ -17400,8 +17507,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -17410,7 +17517,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "strip-bom": {
@@ -17431,7 +17538,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "trim-newlines": {
@@ -17448,9 +17555,9 @@
       "integrity": "sha1-eVm+rAu1V+vROvO8Osvu/7J2YNQ=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1",
-        "debug": "^3.1.0",
-        "is-relative-path": "~1.0.0"
+        "commander": "2.8.1",
+        "debug": "3.1.0",
+        "is-relative-path": "1.0.2"
       },
       "dependencies": {
         "commander": {
@@ -17459,7 +17566,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -17470,7 +17577,7 @@
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.14"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17479,7 +17586,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -17488,9 +17595,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -17505,9 +17612,9 @@
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "supports-color": {
@@ -17516,7 +17623,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17527,36 +17634,36 @@
       "integrity": "sha1-8Kg5Qq2Ok8XFOpg0HEo94inf+U4=",
       "dev": true,
       "requires": {
-        "as-array": "^2.0.0",
-        "async": "^1.5.2",
-        "basic-auth-connect": "^1.0.0",
-        "chalk": "^1.1.3",
-        "char-spinner": "^1.0.1",
-        "compare-semver": "^1.0.0",
-        "compression": "^1.7.0",
-        "connect": "^3.6.2",
-        "connect-query": "^1.0.0",
-        "destroy": "^1.0.4",
-        "fast-url-parser": "^1.1.3",
-        "fs-extra": "^0.30.0",
-        "glob": "^7.1.2",
-        "glob-slasher": "^1.0.1",
-        "home-dir": "^1.0.0",
-        "is-url": "^1.2.2",
-        "join-path": "^1.1.1",
-        "lodash": "^4.17.4",
-        "mime-types": "^2.1.16",
-        "minimatch": "^3.0.4",
-        "morgan": "^1.8.2",
-        "nash": "^2.0.4",
-        "on-finished": "^2.2.0",
-        "on-headers": "^1.0.0",
-        "path-to-regexp": "^1.7.0",
-        "router": "^1.3.1",
-        "rsvp": "^3.6.2",
-        "string-length": "^1.0.0",
-        "try-require": "^1.0.0",
-        "update-notifier": "^1.0.3"
+        "as-array": "2.0.0",
+        "async": "1.5.2",
+        "basic-auth-connect": "1.0.0",
+        "chalk": "1.1.3",
+        "char-spinner": "1.0.1",
+        "compare-semver": "1.1.0",
+        "compression": "1.7.2",
+        "connect": "3.6.6",
+        "connect-query": "1.0.0",
+        "destroy": "1.0.4",
+        "fast-url-parser": "1.1.3",
+        "fs-extra": "0.30.0",
+        "glob": "7.1.2",
+        "glob-slasher": "1.0.1",
+        "home-dir": "1.0.0",
+        "is-url": "1.2.4",
+        "join-path": "1.1.1",
+        "lodash": "4.17.5",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "morgan": "1.9.0",
+        "nash": "2.0.4",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1",
+        "path-to-regexp": "1.7.0",
+        "router": "1.3.2",
+        "rsvp": "3.6.2",
+        "string-length": "1.0.1",
+        "try-require": "1.2.1",
+        "update-notifier": "1.0.3"
       },
       "dependencies": {
         "async": {
@@ -17571,15 +17678,15 @@
           "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
           "dev": true,
           "requires": {
-            "dot-prop": "^3.0.0",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.1",
-            "os-tmpdir": "^1.0.0",
-            "osenv": "^0.1.0",
-            "uuid": "^2.0.1",
-            "write-file-atomic": "^1.1.2",
-            "xdg-basedir": "^2.0.0"
+            "dot-prop": "3.0.0",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "os-tmpdir": "1.0.2",
+            "osenv": "0.1.5",
+            "uuid": "2.0.3",
+            "write-file-atomic": "1.3.4",
+            "xdg-basedir": "2.0.0"
           }
         },
         "dot-prop": {
@@ -17588,7 +17695,7 @@
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "fs-extra": {
@@ -17597,11 +17704,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "isarray": {
@@ -17625,14 +17732,14 @@
           "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
           "dev": true,
           "requires": {
-            "boxen": "^0.6.0",
-            "chalk": "^1.0.0",
-            "configstore": "^2.0.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^2.0.0",
-            "lazy-req": "^1.1.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^2.0.0"
+            "boxen": "0.6.0",
+            "chalk": "1.1.3",
+            "configstore": "2.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "2.0.0",
+            "lazy-req": "1.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "2.0.0"
           }
         },
         "uuid": {
@@ -17647,9 +17754,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "xdg-basedir": {
@@ -17658,7 +17765,7 @@
           "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         }
       }
@@ -17669,7 +17776,7 @@
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
-        "has-flag": "^1.0.0"
+        "has-flag": "1.0.0"
       }
     },
     "sver-compat": {
@@ -17678,8 +17785,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "svg-tags": {
@@ -17694,8 +17801,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
       }
     },
     "symbol-tree": {
@@ -17709,7 +17816,7 @@
       "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.43.tgz",
       "integrity": "sha1-mQLOW9qroDQTV1kCxrsYutLdq44=",
       "requires": {
-        "when": "^3.7.5"
+        "when": "3.7.8"
       }
     },
     "table": {
@@ -17718,12 +17825,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.4.0",
+        "ajv-keywords": "3.1.0",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -17732,10 +17839,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "ansi-regex": {
@@ -17750,7 +17857,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -17759,9 +17866,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -17782,8 +17889,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -17792,7 +17899,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -17801,7 +17908,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17818,13 +17925,13 @@
       "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
       "dev": true,
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.2.4",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.1",
-        "yallist": "^3.0.2"
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.2.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -17841,10 +17948,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "temp": {
@@ -17859,10 +17966,10 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.0",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^1.0.0",
-        "through2": "^2.0.1"
+        "duplexify": "3.5.4",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "text-extensions": {
@@ -17877,7 +17984,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "thenify-all": {
@@ -17886,7 +17993,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": ">= 3.1.0 < 4"
+        "thenify": "3.3.0"
       }
     },
     "through": {
@@ -17901,8 +18008,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "tildify": {
@@ -17911,7 +18018,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -17933,12 +18040,12 @@
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
-        "body-parser": "~1.14.0",
-        "debug": "~2.2.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.2.0",
-        "parseurl": "~1.3.0",
-        "qs": "~5.1.0"
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.3.0",
+        "parseurl": "1.3.2",
+        "qs": "5.1.0"
       },
       "dependencies": {
         "body-parser": {
@@ -17948,15 +18055,15 @@
           "dev": true,
           "requires": {
             "bytes": "2.2.0",
-            "content-type": "~1.0.1",
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "http-errors": "~1.3.1",
+            "content-type": "1.0.4",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "http-errors": "1.3.1",
             "iconv-lite": "0.4.13",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "5.2.0",
-            "raw-body": "~2.1.5",
-            "type-is": "~1.6.10"
+            "raw-body": "2.1.7",
+            "type-is": "1.6.16"
           },
           "dependencies": {
             "qs": {
@@ -17988,7 +18095,7 @@
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "dev": true,
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         },
         "http-errors": {
@@ -17997,8 +18104,8 @@
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "statuses": "1"
+            "inherits": "2.0.3",
+            "statuses": "1.5.0"
           }
         },
         "iconv-lite": {
@@ -18046,8 +18153,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -18056,7 +18163,7 @@
       "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
@@ -18071,7 +18178,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -18080,10 +18187,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -18092,8 +18199,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -18102,7 +18209,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -18113,7 +18220,7 @@
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       },
       "dependencies": {
         "hoek": {
@@ -18130,7 +18237,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "toxic": {
@@ -18139,7 +18246,7 @@
       "integrity": "sha1-8RVNi2rCGHWslDqfdAjfLf4WTqI=",
       "dev": true,
       "requires": {
-        "lodash": "^2.4.1"
+        "lodash": "2.4.2"
       },
       "dependencies": {
         "lodash": {
@@ -18204,7 +18311,7 @@
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dev": true,
       "requires": {
-        "glob": "^6.0.4"
+        "glob": "6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -18213,11 +18320,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -18240,16 +18347,16 @@
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "chalk": "^2.0.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.0",
-        "tsconfig": "^6.0.0",
-        "v8flags": "^3.0.0",
-        "yn": "^2.0.0"
+        "arrify": "1.0.1",
+        "chalk": "2.3.2",
+        "diff": "3.5.0",
+        "make-error": "1.3.4",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18",
+        "tsconfig": "6.0.0",
+        "v8flags": "3.0.2",
+        "yn": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18258,7 +18365,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -18267,9 +18374,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -18290,7 +18397,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6"
+            "source-map": "0.5.7"
           }
         },
         "supports-color": {
@@ -18299,7 +18406,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "v8flags": {
@@ -18308,7 +18415,7 @@
           "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -18319,8 +18426,8 @@
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "strip-bom": {
@@ -18337,9 +18444,9 @@
       "integrity": "sha512-PZWk7GDkXPGdnio/CzLJnaUdOBTIBdPuA77LK9u5XOpMk2RZnSk3k+wSefcbP7eSTJi4VZ0hXM+Vdf0YqR/qWg==",
       "dev": true,
       "requires": {
-        "deepmerge": "^2.0.1",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.1"
+        "deepmerge": "2.1.0",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "strip-bom": {
@@ -18355,10 +18462,10 @@
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.27.5.tgz",
       "integrity": "sha512-NP+CjM1EXza/M8mOXBLH3vkFEJiu1zfEAlC5WdJxHPn8l96QPz5eooP6uAgYtw1CcKfuSyIiheNUdKxtDWCNeg==",
       "requires": {
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.6.0",
-        "source-map-support": "^0.5.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.4"
       }
     },
     "tslib": {
@@ -18372,18 +18479,18 @@
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.2",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.7.0",
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.26.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18392,7 +18499,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -18401,9 +18508,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -18418,7 +18525,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18429,7 +18536,7 @@
       "integrity": "sha512-bnm9bcjOqOr1UljleL94wVCDlpa6KjfGaTkefeLch4GRafgDkROxPizbB/FxTEdI++5JqhxczRy/Qub0syNqZA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.0"
       }
     },
     "tunnel-agent": {
@@ -18438,7 +18545,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -18454,7 +18561,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -18464,7 +18571,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "type-name": {
@@ -18492,7 +18599,7 @@
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.0",
-        "object-assign": "^4.0.1"
+        "object-assign": "4.1.1"
       }
     },
     "uglify-js": {
@@ -18501,9 +18608,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -18518,8 +18625,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -18547,9 +18654,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -18595,8 +18702,8 @@
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "dev": true,
       "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "unherit": {
@@ -18605,8 +18712,8 @@
       "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -18615,13 +18722,13 @@
       "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
       "dev": true,
       "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4",
-        "x-is-string": "^0.1.0"
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.1",
+        "vfile": "2.3.0",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0"
       }
     },
     "union-value": {
@@ -18630,10 +18737,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -18642,7 +18749,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -18651,10 +18758,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -18677,7 +18784,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-util-find-all-after": {
@@ -18686,7 +18793,7 @@
       "integrity": "sha1-TlUSq/734GFnga7Pex7XUcAK+Qg=",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.1"
       }
     },
     "unist-util-is": {
@@ -18701,7 +18808,7 @@
       "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
       "dev": true,
       "requires": {
-        "array-iterate": "^1.0.0"
+        "array-iterate": "1.1.1"
       }
     },
     "unist-util-remove-position": {
@@ -18710,7 +18817,7 @@
       "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
       "dev": true,
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.3.0"
       }
     },
     "unist-util-stringify-position": {
@@ -18725,7 +18832,7 @@
       "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-is": "2.1.1"
       }
     },
     "universal-analytics": {
@@ -18734,10 +18841,10 @@
       "integrity": "sha1-USh5GToSpm3L2RhRITibq5E81LY=",
       "dev": true,
       "requires": {
-        "async": "0.2.x",
-        "node-uuid": "1.x",
-        "request": "2.x",
-        "underscore": "1.x"
+        "async": "0.2.10",
+        "node-uuid": "1.4.8",
+        "request": "2.85.0",
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "async": {
@@ -18760,9 +18867,9 @@
       "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
       "dev": true,
       "requires": {
-        "array-filter": "^1.0.0",
+        "array-filter": "1.0.0",
         "indexof": "0.0.1",
-        "object-keys": "^1.0.0"
+        "object-keys": "1.0.11"
       }
     },
     "universalify": {
@@ -18783,8 +18890,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -18793,9 +18900,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -18829,12 +18936,12 @@
       "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
       "dev": true,
       "requires": {
-        "binary": ">= 0.3.0 < 1",
-        "fstream": ">= 0.1.30 < 1",
-        "match-stream": ">= 0.0.2 < 1",
-        "pullstream": ">= 0.4.1 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.1 < 2"
+        "binary": "0.3.0",
+        "fstream": "0.1.31",
+        "match-stream": "0.0.2",
+        "pullstream": "0.4.1",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5"
       },
       "dependencies": {
         "fstream": {
@@ -18843,10 +18950,10 @@
           "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~3.0.2",
-            "inherits": "~2.0.0",
-            "mkdirp": "0.5",
-            "rimraf": "2"
+            "graceful-fs": "3.0.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
           }
         },
         "graceful-fs": {
@@ -18855,7 +18962,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.3"
           }
         },
         "isarray": {
@@ -18870,10 +18977,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -18902,13 +19009,13 @@
       "integrity": "sha1-B7XcIGazYnqztPUwEw9+3doHpMw=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "configstore": "^1.0.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^1.0.0",
-        "repeating": "^1.1.2",
-        "semver-diff": "^2.0.0",
-        "string-length": "^1.0.0"
+        "chalk": "1.1.3",
+        "configstore": "1.4.0",
+        "is-npm": "1.0.0",
+        "latest-version": "1.0.1",
+        "repeating": "1.1.3",
+        "semver-diff": "2.1.0",
+        "string-length": "1.0.1"
       },
       "dependencies": {
         "configstore": {
@@ -18917,14 +19024,14 @@
           "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.1",
-            "os-tmpdir": "^1.0.0",
-            "osenv": "^0.1.0",
-            "uuid": "^2.0.1",
-            "write-file-atomic": "^1.1.2",
-            "xdg-basedir": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "os-tmpdir": "1.0.2",
+            "osenv": "0.1.5",
+            "uuid": "2.0.3",
+            "write-file-atomic": "1.3.4",
+            "xdg-basedir": "2.0.0"
           }
         },
         "got": {
@@ -18933,16 +19040,16 @@
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "infinity-agent": "^2.0.0",
-            "is-redirect": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "nested-error-stacks": "^1.0.0",
-            "object-assign": "^3.0.0",
-            "prepend-http": "^1.0.0",
-            "read-all-stream": "^3.0.0",
-            "timed-out": "^2.0.0"
+            "duplexify": "3.5.4",
+            "infinity-agent": "2.0.3",
+            "is-redirect": "1.0.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "nested-error-stacks": "1.0.2",
+            "object-assign": "3.0.0",
+            "prepend-http": "1.0.4",
+            "read-all-stream": "3.1.0",
+            "timed-out": "2.0.0"
           },
           "dependencies": {
             "object-assign": {
@@ -18959,7 +19066,7 @@
           "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
           "dev": true,
           "requires": {
-            "package-json": "^1.0.0"
+            "package-json": "1.2.0"
           }
         },
         "package-json": {
@@ -18968,8 +19075,8 @@
           "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
           "dev": true,
           "requires": {
-            "got": "^3.2.0",
-            "registry-url": "^3.0.0"
+            "got": "3.3.1",
+            "registry-url": "3.1.0"
           }
         },
         "prepend-http": {
@@ -18984,7 +19091,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "timed-out": {
@@ -19005,9 +19112,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "xdg-basedir": {
@@ -19016,7 +19123,7 @@
           "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         }
       }
@@ -19033,7 +19140,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.1"
+        "upper-case": "1.1.3"
       }
     },
     "uri-js": {
@@ -19042,7 +19149,7 @@
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -19072,7 +19179,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prepend-http": "^2.0.0"
+        "prepend-http": "2.0.0"
       }
     },
     "url-to-options": {
@@ -19088,7 +19195,7 @@
       "integrity": "sha1-HyuibwE8hfATP3o61v8nMK33y7c=",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.11"
+        "iconv-lite": "0.4.21"
       }
     },
     "use": {
@@ -19097,7 +19204,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -19114,7 +19221,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "useragent": {
@@ -19123,8 +19230,8 @@
       "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
+        "lru-cache": "4.1.2",
+        "tmp": "0.0.30"
       }
     },
     "util-deprecate": {
@@ -19140,12 +19247,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~0.9.0",
-        "deep-equal": "~0.2.1",
-        "i": "0.3.x",
-        "mkdirp": "0.x.x",
-        "ncp": "1.0.x",
-        "rimraf": "2.x.x"
+        "async": "0.9.2",
+        "deep-equal": "0.2.2",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "1.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -19182,7 +19289,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       },
       "dependencies": {
         "user-home": {
@@ -19205,8 +19312,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validate.js": {
@@ -19233,9 +19340,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -19244,10 +19351,10 @@
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "1.1.6",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.1",
+        "vfile-message": "1.0.0"
       }
     },
     "vfile-location": {
@@ -19262,7 +19369,7 @@
       "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.1"
       }
     },
     "vinyl": {
@@ -19271,12 +19378,12 @@
       "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "dev": true,
       "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
+        "clone": "2.1.2",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.2",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-fs": {
@@ -19285,14 +19392,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -19313,7 +19420,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.3"
           }
         },
         "isarray": {
@@ -19328,10 +19435,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -19346,8 +19453,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -19356,8 +19463,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -19368,7 +19475,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -19406,7 +19513,7 @@
         "archiver": "1.3.0",
         "async": "2.0.1",
         "lodash": "4.16.2",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "0.5.1",
         "q": "1.4.1",
         "request": "2.79.0",
         "underscore.string": "3.3.4",
@@ -19419,15 +19526,15 @@
           "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
           "dev": true,
           "requires": {
-            "archiver-utils": "^1.3.0",
-            "async": "^2.0.0",
-            "buffer-crc32": "^0.2.1",
-            "glob": "^7.0.0",
-            "lodash": "^4.8.0",
-            "readable-stream": "^2.0.0",
-            "tar-stream": "^1.5.0",
-            "walkdir": "^0.0.11",
-            "zip-stream": "^1.1.0"
+            "archiver-utils": "1.3.0",
+            "async": "2.0.1",
+            "buffer-crc32": "0.2.13",
+            "glob": "7.1.2",
+            "lodash": "4.16.2",
+            "readable-stream": "2.3.6",
+            "tar-stream": "1.5.5",
+            "walkdir": "0.0.11",
+            "zip-stream": "1.2.0"
           }
         },
         "assert-plus": {
@@ -19442,7 +19549,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.16.2"
           }
         },
         "aws-sign2": {
@@ -19457,7 +19564,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -19472,7 +19579,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -19481,9 +19588,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -19492,10 +19599,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
           }
         },
         "hawk": {
@@ -19504,10 +19611,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -19522,9 +19629,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "lodash": {
@@ -19545,26 +19652,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -19573,7 +19680,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "tunnel-agent": {
@@ -19590,8 +19697,8 @@
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "^2.53.35",
-        "selenium-webdriver": "^2.53.2"
+        "@types/selenium-webdriver": "2.53.43",
+        "selenium-webdriver": "2.53.3"
       },
       "dependencies": {
         "adm-zip": {
@@ -19613,9 +19720,9 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "^2.2.8",
+            "rimraf": "2.6.2",
             "tmp": "0.0.24",
-            "ws": "^1.0.1",
+            "ws": "1.1.2",
             "xml2js": "0.4.4"
           }
         },
@@ -19631,8 +19738,8 @@
           "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
           "dev": true,
           "requires": {
-            "sax": "0.6.x",
-            "xmlbuilder": ">=1.0.0"
+            "sax": "0.6.1",
+            "xmlbuilder": "9.0.7"
           }
         }
       }
@@ -19649,8 +19756,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.11",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -19688,8 +19795,8 @@
       "integrity": "sha1-e9yuSQ+SGu9kUftnOexrvY6Qe/Y=",
       "dev": true,
       "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
       }
     },
     "when": {
@@ -19703,7 +19810,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -19718,7 +19825,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       }
     },
     "widest-line": {
@@ -19727,7 +19834,7 @@
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -19742,12 +19849,12 @@
       "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -19770,8 +19877,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -19786,8 +19893,8 @@
       "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
       "dev": true,
       "requires": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
+        "boom": "2.10.1",
+        "hoek": "2.16.3"
       },
       "dependencies": {
         "boom": {
@@ -19796,7 +19903,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "hoek": {
@@ -19813,7 +19920,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -19822,9 +19929,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -19833,8 +19940,8 @@
       "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
       "dev": true,
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "wtf-8": {
@@ -19879,8 +19986,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -19925,13 +20032,13 @@
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     },
     "yargs-parser": {
@@ -19941,7 +20048,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -19971,10 +20078,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0"
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.6"
       }
     },
     "zone.js": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "axe-core": "^2.3.1",
     "axe-webdriverjs": "^1.1.1",
     "chalk": "^1.1.3",
+    "codelyzer": "^4.3.0",
     "dgeni": "^0.4.9",
     "dgeni-packages": "^0.26.0",
     "firebase": "^4.0.0",

--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -6,30 +6,31 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  ElementRef,
-  HostBinding,
-  ViewChild,
-  ComponentRef,
-  EmbeddedViewRef,
-  ChangeDetectorRef,
-  Component,
-  Optional,
-  Inject,
-  ViewEncapsulation,
-  ChangeDetectionStrategy,
-} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
-import {trigger, state, style, transition, animate, AnimationEvent} from '@angular/animations';
+import {animate, AnimationEvent, state, style, transition, trigger} from '@angular/animations';
+import {FocusTrapFactory} from '@angular/cdk/a11y';
 import {
   BasePortalOutlet,
-  PortalHostDirective,
   ComponentPortal,
+  PortalHostDirective,
   TemplatePortal
 } from '@angular/cdk/portal';
-import {FocusTrapFactory} from '@angular/cdk/a11y';
-import {DialogConfig} from './dialog-config';
+import {DOCUMENT} from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ComponentRef,
+  ElementRef,
+  EmbeddedViewRef,
+  HostBinding,
+  Inject,
+  OnDestroy,
+  Optional,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
 import {Subject} from 'rxjs';
+import {DialogConfig} from './dialog-config';
 
 
 export function throwDialogContentAlreadyAttachedError() {
@@ -63,7 +64,7 @@ export function throwDialogContentAlreadyAttachedError() {
     '(@dialog.done)': '_onAnimationDone($event)',
   },
 })
-export class CdkDialogContainer extends BasePortalOutlet {
+export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
   /** State of the dialog animation. */
   _state: 'void' | 'enter' | 'exit' = 'enter';
 

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -11,6 +11,7 @@ import {
   Inject,
   Injectable,
   InjectionToken,
+  OnDestroy,
   Optional,
   SkipSelf,
 } from '@angular/core';
@@ -54,7 +55,7 @@ let messagesContainer: HTMLElement | null = null;
  * @docs-private
  */
 @Injectable({providedIn: 'root'})
-export class AriaDescriber {
+export class AriaDescriber implements OnDestroy {
   private _document: Document;
 
   constructor(@Inject(DOCUMENT) _document: any) {

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -7,19 +7,19 @@
  */
 
 import {
-  NgModule,
+  ComponentFactoryResolver,
   ComponentRef,
   Directive,
   EmbeddedViewRef,
-  TemplateRef,
-  ComponentFactoryResolver,
-  ViewContainerRef,
+  EventEmitter,
+  NgModule,
   OnDestroy,
   OnInit,
-  EventEmitter,
   Output,
+  TemplateRef,
+  ViewContainerRef,
 } from '@angular/core';
-import {Portal, TemplatePortal, ComponentPortal, BasePortalOutlet} from './portal';
+import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal} from './portal';
 
 
 /**
@@ -92,7 +92,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
     this._attachedPortal = portal;
   }
 
-  @Output('attached') attached: EventEmitter<CdkPortalOutletAttachedRef> =
+  @Output() attached: EventEmitter<CdkPortalOutletAttachedRef> =
       new EventEmitter<CdkPortalOutletAttachedRef>();
 
   /** Component or view reference that is attached to the portal. */

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -13,6 +13,7 @@ import {
   IterableChanges,
   IterableDiffer,
   IterableDiffers,
+  OnChanges,
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
@@ -30,7 +31,7 @@ export const CDK_ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
  * Base class for the CdkHeaderRowDef and CdkRowDef that handles checking their columns inputs
  * for changes and notifying the table.
  */
-export abstract class BaseRowDef {
+export abstract class BaseRowDef implements OnChanges {
   /** The columns to be displayed on this row. */
   columns: Iterable<string>;
 

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1,4 +1,6 @@
+import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {
+  AfterContentInit,
   Component,
   ContentChild,
   ContentChildren,
@@ -7,12 +9,13 @@ import {
   Type,
   ViewChild
 } from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
-import {CdkTable} from './table';
-import {CollectionViewer, DataSource} from '@angular/cdk/collections';
-import {combineLatest, BehaviorSubject, Observable, of as observableOf} from 'rxjs';
+import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {BehaviorSubject, combineLatest, Observable, of as observableOf} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {CdkColumnDef} from './cell';
 import {CdkTableModule} from './index';
+import {CdkHeaderRowDef, CdkRowDef} from './row';
+import {CdkTable} from './table';
 import {
   getTableDuplicateColumnNameError,
   getTableMissingMatchingRowDefError,
@@ -21,8 +24,6 @@ import {
   getTableUnknownColumnError,
   getTableUnknownDataSourceError
 } from './table-errors';
-import {CdkHeaderRowDef, CdkRowDef} from './row';
-import {CdkColumnDef} from './cell';
 
 describe('CdkTable', () => {
   let fixture: ComponentFixture<any>;
@@ -1502,7 +1503,7 @@ class RowContextCdkTableApp {
     </cdk-table>
   `
 })
-class WrapperCdkTableApp<T> {
+class WrapperCdkTableApp<T> implements AfterContentInit {
   @ContentChildren(CdkColumnDef) columnDefs: QueryList<CdkColumnDef>;
   @ContentChild(CdkHeaderRowDef) headerRowDef: CdkHeaderRowDef;
   @ContentChildren(CdkRowDef) rowDefs: QueryList<CdkRowDef<T>>;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {
   AfterContentChecked,
   Attribute,
@@ -22,6 +23,7 @@ import {
   IterableChangeRecord,
   IterableDiffer,
   IterableDiffers,
+  OnDestroy,
   OnInit,
   QueryList,
   TemplateRef,
@@ -30,7 +32,9 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {CollectionViewer, DataSource} from '@angular/cdk/collections';
+import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {CdkColumnDef} from './cell';
 import {
   BaseRowDef,
   CdkCellOutlet,
@@ -40,9 +44,6 @@ import {
   CdkHeaderRowDef,
   CdkRowDef
 } from './row';
-import {takeUntil} from 'rxjs/operators';
-import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
-import {CdkColumnDef} from './cell';
 import {
   getTableDuplicateColumnNameError,
   getTableMissingMatchingRowDefError,
@@ -144,7 +145,7 @@ export interface RenderRow<T> {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecked {
+export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
   /** Subject that emits when the component has been destroyed. */
   private _onDestroy = new Subject<void>();
 

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -8,6 +8,7 @@
 import {FocusableOption} from '@angular/cdk/a11y';
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {
+  AfterContentChecked,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -15,9 +16,9 @@ import {
   Directive,
   ElementRef,
   Input,
-  IterableDiffers,
-  IterableDiffer,
   IterableChangeRecord,
+  IterableDiffer,
+  IterableDiffers,
   OnDestroy,
   OnInit,
   QueryList,
@@ -25,16 +26,16 @@ import {
   ViewContainerRef,
   ViewEncapsulation
 } from '@angular/core';
-import {of, BehaviorSubject, Observable, Subject, Subscription} from 'rxjs';
+import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {TreeControl} from './control/tree-control';
 import {CdkTreeNodeDef, CdkTreeNodeOutletContext} from './node';
 import {CdkTreeNodeOutlet} from './outlet';
-import {TreeControl} from './control/tree-control';
 import {
+  getTreeControlFunctionsMissingError,
   getTreeControlMissingError,
   getTreeMissingMatchingNodeDefError,
   getTreeMultipleDefaultNodeDefsError,
-  getTreeControlFunctionsMissingError,
   getTreeNoValidDataSourceError
 } from './tree-errors';
 
@@ -130,7 +131,8 @@ export class CdkTreeNode<T>  implements FocusableOption, OnDestroy {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
+export class CdkTree<T>
+    implements AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
   /** Subject that emits when the component has been destroyed. */
   private _onDestroy = new Subject<void>();
 
@@ -257,7 +259,7 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
     } else if (this._dataSource instanceof Observable) {
       dataStream = this._dataSource;
     } else if (Array.isArray(this._dataSource)) {
-      dataStream = of(this._dataSource);
+      dataStream = observableOf(this._dataSource);
     }
 
     if (dataStream) {

--- a/src/demo-app/a11y/table/table-a11y.ts
+++ b/src/demo-app/a11y/table/table-a11y.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/table';
-import {merge, Observable, BehaviorSubject} from 'rxjs';
-import {MatSort, MatPaginator} from '@angular/material';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {MatPaginator, MatSort} from '@angular/material';
+import {BehaviorSubject, merge, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 
@@ -34,7 +34,7 @@ const exampleData = [
   templateUrl: 'table-a11y.html',
   styleUrls: ['table-a11y.css'],
 })
-export class TableAccessibilityDemo {
+export class TableAccessibilityDemo implements OnInit {
   @ViewChild(MatSort) sort: MatSort;
   @ViewChild(MatPaginator) pager: MatPaginator;
 

--- a/src/demo-app/example/example.ts
+++ b/src/demo-app/example/example.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, Input} from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Component, ElementRef, Input, OnInit} from '@angular/core';
 import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 @Component({
@@ -43,7 +43,7 @@ import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
     }
   `]
 })
-export class Example {
+export class Example implements OnInit {
   /** ID of the material example to display. */
   @Input() id: string;
 

--- a/src/demo-app/stepper/stepper-demo.ts
+++ b/src/demo-app/stepper/stepper-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 
@@ -15,7 +15,7 @@ import {AbstractControl, FormBuilder, FormGroup, Validators} from '@angular/form
   selector: 'stepper-demo',
   templateUrl: 'stepper-demo.html',
 })
-export class StepperDemo {
+export class StepperDemo implements OnInit {
   formGroup: FormGroup;
   isNonLinear = false;
   isNonEditable = false;

--- a/src/demo-app/table/custom-table/custom-table.ts
+++ b/src/demo-app/table/custom-table/custom-table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatSort, MatTableDataSource} from '@angular/material';
 import {Element, ELEMENT_DATA} from '../element-data';
 
@@ -15,9 +15,9 @@ import {Element, ELEMENT_DATA} from '../element-data';
   moduleId: module.id,
   selector: 'custom-table-demo',
   templateUrl: 'custom-table.html',
-  styleUrls: ['custom-table.css'],
+  styleUrls: ['custom-table.css']
 })
-export class CustomTableDemo {
+export class CustomTableDemo implements OnInit {
   columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
   simpleTableDataSource = new MatTableDataSource<Element>(ELEMENT_DATA);
   wrapperTableDataSource = new MatTableDataSource<Element>(ELEMENT_DATA);

--- a/src/demo-app/table/custom-table/simple-column.ts
+++ b/src/demo-app/table/custom-table/simple-column.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Input, Optional, ViewChild} from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Component, Input, OnDestroy, OnInit, Optional, ViewChild} from '@angular/core';
 import {MatSortHeader} from '@angular/material/sort';
-import {MatColumnDef, MatTable} from '@angular/material';
+import {MatColumnDef, MatTable} from '@angular/material/table';
 
 
 /**
@@ -36,7 +36,7 @@ import {MatColumnDef, MatTable} from '@angular/material';
     '[attr.ariaHidden]': 'true',
   }
 })
-export class SimpleColumn<T> {
+export class SimpleColumn<T> implements OnDestroy, OnInit {
   /** Column name that should be used to reference this column. */
   @Input()
   get name(): string { return this._name; }

--- a/src/demo-app/table/custom-table/wrapper-table.ts
+++ b/src/demo-app/table/custom-table/wrapper-table.ts
@@ -6,8 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ContentChild, ContentChildren, Input, QueryList, ViewChild} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
+import {
+  AfterContentInit,
+  Component,
+  ContentChild,
+  ContentChildren,
+  Input,
+  QueryList,
+  ViewChild
+} from '@angular/core';
 import {MatColumnDef, MatHeaderRowDef, MatRowDef, MatTable} from '@angular/material';
 import {SimpleColumn} from './simple-column';
 
@@ -27,7 +35,7 @@ import {SimpleColumn} from './simple-column';
     }
   `]
 })
-export class WrapperTable<T> {
+export class WrapperTable<T> implements AfterContentInit {
   /** Different ways the client can add column definitions */
   @ContentChildren(SimpleColumn) simpleColumns: QueryList<SimpleColumn<T>>;
   @ContentChildren(MatColumnDef) columnDefs: QueryList<MatColumnDef>;

--- a/src/demo-app/table/expandable-rows/expandable-rows.ts
+++ b/src/demo-app/table/expandable-rows/expandable-rows.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
-import {PeriodicElement, ELEMENT_DATA} from 'table/element-data';
 import {animate, state, style, transition, trigger} from '@angular/animations';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
+import {ELEMENT_DATA, PeriodicElement} from 'table/element-data';
 
 @Component({
   moduleId: module.id,
@@ -45,7 +45,7 @@ import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
     }
   `]
 })
-export class ExpandableRowsDemo {
+export class ExpandableRowsDemo implements OnInit {
   dataSource = new MatTableDataSource(ELEMENT_DATA.slice());
   columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
   expandedElement: PeriodicElement;

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 
 
@@ -146,7 +146,7 @@ export class FoggyTabContent {}
   selector: 'counter',
   template: `<span>Content</span>`
 })
-export class Counter {
+export class Counter implements OnInit {
   ngOnInit() {
     console.log('Tab Loaded');
   }

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -8,23 +8,23 @@
 
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
-import {Subject} from 'rxjs';
 import {
+  AfterViewChecked,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
+  Inject,
+  InjectionToken,
   Input,
+  OnDestroy,
   Optional,
   Output,
   QueryList,
   ViewEncapsulation,
-  InjectionToken,
-  Inject,
-  AfterViewChecked,
-  OnDestroy,
 } from '@angular/core';
+import {Subject} from 'rxjs';
 import {MatOptgroup} from './optgroup';
 
 /**
@@ -112,6 +112,7 @@ export class MatOption implements AfterViewChecked, OnDestroy {
   get disableRipple() { return this._parent && this._parent.disableRipple; }
 
   /** Event emitted when the option is selected or deselected. */
+  // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onSelectionChange = new EventEmitter<MatOptionSelectionChange>();
 
   /** Emits when the state of the option changes and any parents have to be notified. */

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -19,7 +19,6 @@ import {
   VerticalConnectionPos,
 } from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {filter, take, delay, takeUntil} from 'rxjs/operators';
 import {
   AfterContentInit,
   Directive,
@@ -35,7 +34,8 @@ import {
   Self,
   ViewContainerRef,
 } from '@angular/core';
-import {Subscription, merge, of as observableOf, asapScheduler} from 'rxjs';
+import {asapScheduler, merge, of as observableOf, Subscription} from 'rxjs';
+import {delay, filter, take, takeUntil} from 'rxjs/operators';
 import {MatMenu} from './menu-directive';
 import {throwMatMenuMissingError} from './menu-errors';
 import {MatMenuItem} from './menu-item';
@@ -112,6 +112,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * @deprecated Switch to `menuOpened` instead
    * @deletion-target 7.0.0
    */
+  // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onMenuOpen: EventEmitter<void> = this.menuOpened;
 
   /** Event emitted when the associated menu is closed. */
@@ -122,6 +123,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * @deprecated Switch to `menuClosed` instead
    * @deletion-target 7.0.0
    */
+  // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onMenuClose: EventEmitter<void> = this.menuClosed;
 
   constructor(private _overlay: Overlay,

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -12,6 +12,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
 import {CdkScrollable} from '@angular/cdk/scrolling';
+import {DOCUMENT} from '@angular/common';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -20,6 +21,7 @@ import {
   Component,
   ContentChild,
   ContentChildren,
+  DoCheck,
   ElementRef,
   EventEmitter,
   forwardRef,
@@ -34,9 +36,8 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
-import {filter, take, startWith, takeUntil, map, debounceTime} from 'rxjs/operators';
-import {merge, fromEvent, Observable, Subject} from 'rxjs';
+import {fromEvent, merge, Observable, Subject} from 'rxjs';
+import {debounceTime, filter, map, startWith, take, takeUntil} from 'rxjs/operators';
 import {matDrawerAnimations} from './drawer-animations';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
@@ -199,6 +200,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
   }
 
   /** Event emitted when the drawer's position changes. */
+  // tslint:disable-next-line:no-output-on-prefix
   @Output('positionChanged') onPositionChanged: EventEmitter<void> = new EventEmitter<void>();
 
   /**
@@ -396,7 +398,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatDrawerContainer implements AfterContentInit, OnDestroy {
+export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy {
   @ContentChildren(MatDrawer) _drawers: QueryList<MatDrawer>;
   @ContentChild(MatDrawerContent) _content: MatDrawerContent;
 

--- a/src/lib/sort/sort-header.ts
+++ b/src/lib/sort/sort-header.ts
@@ -13,6 +13,8 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  OnDestroy,
+  OnInit,
   Optional,
   ViewEncapsulation
 } from '@angular/core';
@@ -85,7 +87,8 @@ export interface ArrowViewStateTransition {
     matSortAnimations.allowChildren,
   ]
 })
-export class MatSortHeader extends _MatSortHeaderMixinBase implements MatSortable, CanDisable {
+export class MatSortHeader extends _MatSortHeaderMixinBase
+    implements CanDisable, MatSortable, OnDestroy, OnInit {
   private _rerenderSubscription: Subscription;
 
   /**

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -11,8 +11,8 @@ import {
 } from '@angular/cdk/keycodes';
 import {StepperOrientation} from '@angular/cdk/stepper';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
-import {Component, DebugElement, EventEmitter} from '@angular/core';
-import {async, ComponentFixture, inject, TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {Component, DebugElement, EventEmitter, OnInit} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {
   AbstractControl,
   AsyncValidatorFn,
@@ -922,7 +922,7 @@ function assertArrowKeyInteractionInRtl(fixture: ComponentFixture<any>,
   expect(stepperComponent._getFocusIndex()).toBe(0);
 }
 
-function asyncValidator(minLength: number, validationTrigger: Observable<any>): AsyncValidatorFn {
+function asyncValidator(minLength: number, validationTrigger: Subject<void>): AsyncValidatorFn {
   return (control: AbstractControl): Observable<ValidationErrors | null> => {
     return validationTrigger.pipe(
       map(() => control.value && control.value.length >= minLength ? null : {asyncValidation: {}}),
@@ -1036,12 +1036,12 @@ class SimpleMatVerticalStepperApp {
     </mat-vertical-stepper>
   `
 })
-class LinearMatVerticalStepperApp {
+class LinearMatVerticalStepperApp implements OnInit {
   oneGroup: FormGroup;
   twoGroup: FormGroup;
   threeGroup: FormGroup;
 
-  validationTrigger: Subject<any> = new Subject();
+  validationTrigger = new Subject<void>();
 
   ngOnInit() {
     this.oneGroup = new FormGroup({

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -1,5 +1,5 @@
 import {DataSource} from '@angular/cdk/collections';
-import {Component, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {BehaviorSubject, Observable} from 'rxjs';
@@ -559,7 +559,7 @@ class MatTableWithWhenRowApp {
     <mat-paginator [pageSize]="5"></mat-paginator>
   `
 })
-class ArrayDataSourceMatTableApp {
+class ArrayDataSourceMatTableApp implements OnInit {
   underlyingDataSource = new FakeDataSource();
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
@@ -612,7 +612,7 @@ class ArrayDataSourceMatTableApp {
     </mat-table>
   `
 })
-class MatTableWithSortApp {
+class MatTableWithSortApp implements OnInit {
   underlyingDataSource = new FakeDataSource();
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
@@ -663,7 +663,7 @@ class MatTableWithSortApp {
     <mat-paginator [pageSize]="5"></mat-paginator>
   `
 })
-class MatTableWithPaginatorApp {
+class MatTableWithPaginatorApp implements OnInit {
   underlyingDataSource = new FakeDataSource();
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -1,7 +1,7 @@
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {PortalModule, TemplatePortal} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
-import {Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {AfterContentInit, Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRippleModule} from '@angular/material/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -155,7 +155,7 @@ describe('MatTabBody', () => {
     <mat-tab-body [content]="content" [position]="position" [origin]="origin"></mat-tab-body>
   `
 })
-class SimpleTabBodyApp {
+class SimpleTabBodyApp implements AfterContentInit {
   content: TemplatePortal;
   position: number;
   origin: number;

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -1,8 +1,8 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {By} from '@angular/platform-browser';
 import {dispatchFakeEvent} from '@angular/cdk/testing';
+import {Component, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Observable} from 'rxjs';
 import {MatTab, MatTabGroup, MatTabHeaderPosition, MatTabsModule} from './index';
 
@@ -584,7 +584,7 @@ class DisabledTabsTestApp {
    </mat-tab-group>
   `
 })
-class AsyncTabsTestApp {
+class AsyncTabsTestApp implements OnInit {
   private _tabs = [
     { label: 'one', content: 'one' },
     { label: 'two', content: 'two' }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -9,6 +9,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {
+  AfterContentChecked,
   AfterContentInit,
   Attribute,
   ChangeDetectionStrategy,
@@ -69,8 +70,8 @@ export const _MatTabNavMixinBase = mixinDisableRipple(mixinColor(MatTabNavBase, 
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, CanColor,
-    CanDisableRipple, OnDestroy {
+export class MatTabNav extends _MatTabNavMixinBase
+    implements AfterContentChecked, AfterContentInit, CanColor, CanDisableRipple, OnDestroy {
 
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();

--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -7,22 +7,24 @@
  */
 
 import {
+  CdkNestedTreeNode,
+  CdkTree,
+  CdkTreeNode,
+  CdkTreeNodeDef,
+} from '@angular/cdk/tree';
+import {
+  AfterContentInit,
   Attribute,
   ContentChildren,
   Directive,
   ElementRef,
   Input,
   IterableDiffers,
+  OnDestroy,
   QueryList
 } from '@angular/core';
-import {
-  CdkNestedTreeNode,
-  CdkTree,
-  CdkTreeNodeDef,
-  CdkTreeNode,
-} from '@angular/cdk/tree';
+import {CanDisable, HasTabIndex, mixinDisabled, mixinTabIndex} from '@angular/material/core';
 import {MatTreeNodeOutlet} from './outlet';
-import {mixinTabIndex, mixinDisabled, CanDisable, HasTabIndex} from '@angular/material/core';
 
 
 export const _MatTreeNodeMixinBase = mixinTabIndex(mixinDisabled(CdkTreeNode));
@@ -43,7 +45,8 @@ export const _MatNestedTreeNodeMixinBase = mixinTabIndex(mixinDisabled(CdkNested
   },
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}]
 })
-export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T> implements HasTabIndex, CanDisable {
+export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T>
+    implements CanDisable, HasTabIndex {
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
   constructor(protected _elementRef: ElementRef,
@@ -87,7 +90,7 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   ]
 })
 export class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T>
-    implements HasTabIndex, CanDisable {
+    implements AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
 
   @Input('matNestedTreeNode') node: T;
 

--- a/src/material-examples/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
+++ b/src/material-examples/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -11,7 +11,7 @@ import {map, startWith} from 'rxjs/operators';
   templateUrl: 'autocomplete-auto-active-first-option-example.html',
   styleUrls: ['autocomplete-auto-active-first-option-example.css']
 })
-export class AutocompleteAutoActiveFirstOptionExample {
+export class AutocompleteAutoActiveFirstOptionExample implements OnInit {
   myControl: FormControl = new FormControl();
   options = ['One', 'Two', 'Three'];
   filteredOptions: Observable<string[]>;

--- a/src/material-examples/autocomplete-display/autocomplete-display-example.ts
+++ b/src/material-examples/autocomplete-display/autocomplete-display-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -15,7 +15,7 @@ export class User {
   templateUrl: 'autocomplete-display-example.html',
   styleUrls: ['autocomplete-display-example.css']
 })
-export class AutocompleteDisplayExample {
+export class AutocompleteDisplayExample implements OnInit {
 
   myControl = new FormControl();
 

--- a/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -11,7 +11,7 @@ import {map, startWith} from 'rxjs/operators';
   templateUrl: 'autocomplete-filter-example.html',
   styleUrls: ['autocomplete-filter-example.css']
 })
-export class AutocompleteFilterExample {
+export class AutocompleteFilterExample implements OnInit {
 
   myControl: FormControl = new FormControl();
 

--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -1,7 +1,7 @@
-import {Component, Injectable} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
-import {MatTreeFlattener, MatTreeFlatDataSource} from '@angular/material/tree';
-import {of, Observable, BehaviorSubject} from 'rxjs';
+import {Component, Injectable} from '@angular/core';
+import {MatTreeFlatDataSource, MatTreeFlattener} from '@angular/material/tree';
+import {BehaviorSubject, Observable, of as observableOf} from 'rxjs';
 
 /**
  * File node data with nested structure.
@@ -154,7 +154,9 @@ export class CdkTreeFlatExample {
 
   private _isExpandable = (node: FileFlatNode) => { return node.expandable; };
 
-  private _getChildren = (node: FileNode): Observable<FileNode[]> => { return of(node.children); };
+  private _getChildren = (node: FileNode): Observable<FileNode[]> => {
+    return observableOf(node.children);
+  }
 
   hasChild = (_: number, _nodeData: FileFlatNode) => { return _nodeData.expandable; };
 }

--- a/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
+++ b/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
@@ -1,7 +1,7 @@
-import {Component, Injectable} from '@angular/core';
 import {NestedTreeControl} from '@angular/cdk/tree';
+import {Component, Injectable} from '@angular/core';
 import {MatTreeNestedDataSource} from '@angular/material/tree';
-import {of, BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, of as observableOf} from 'rxjs';
 
 /**
  * Json node data with nested structure. Each node has a filename and a value or a list of children
@@ -125,7 +125,7 @@ export class CdkTreeNestedExample {
     database.dataChange.subscribe(data => this.nestedDataSource.data = data);
   }
 
-  private _getChildren = (node: FileNode) => { return of(node.children); };
+  private _getChildren = (node: FileNode) => { return observableOf(node.children); };
 
   hasNestedChild = (_: number, nodeData: FileNode) => {return !(nodeData.type); };
 }

--- a/src/material-examples/sidenav-responsive/sidenav-responsive-example.ts
+++ b/src/material-examples/sidenav-responsive/sidenav-responsive-example.ts
@@ -1,5 +1,5 @@
 import {MediaMatcher} from '@angular/cdk/layout';
-import {ChangeDetectorRef, Component} from '@angular/core';
+import {ChangeDetectorRef, Component, OnDestroy} from '@angular/core';
 
 /** @title Responsive sidenav */
 @Component({
@@ -7,7 +7,7 @@ import {ChangeDetectorRef, Component} from '@angular/core';
   templateUrl: 'sidenav-responsive-example.html',
   styleUrls: ['sidenav-responsive-example.css'],
 })
-export class SidenavResponsiveExample {
+export class SidenavResponsiveExample implements OnDestroy {
   mobileQuery: MediaQueryList;
 
   fillerNav = Array(50).fill(0).map((_, i) => `Nav Item ${i + 1}`);

--- a/src/material-examples/stepper-editable/stepper-editable-example.ts
+++ b/src/material-examples/stepper-editable/stepper-editable-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 /**
@@ -9,7 +9,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
   templateUrl: 'stepper-editable-example.html',
   styleUrls: ['stepper-editable-example.css']
 })
-export class StepperEditableExample {
+export class StepperEditableExample implements OnInit {
   firstFormGroup: FormGroup;
   secondFormGroup: FormGroup;
   isEditable: boolean = false;

--- a/src/material-examples/stepper-optional/stepper-optional-example.ts
+++ b/src/material-examples/stepper-optional/stepper-optional-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 /**
@@ -9,7 +9,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
   templateUrl: 'stepper-optional-example.html',
   styleUrls: ['stepper-optional-example.css']
 })
-export class StepperOptionalExample {
+export class StepperOptionalExample implements OnInit {
   firstFormGroup: FormGroup;
   secondFormGroup: FormGroup;
   isOptional: boolean = false;

--- a/src/material-examples/stepper-overview/stepper-overview-example.ts
+++ b/src/material-examples/stepper-overview/stepper-overview-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 /**
@@ -9,7 +9,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
   templateUrl: 'stepper-overview-example.html',
   styleUrls: ['stepper-overview-example.css']
 })
-export class StepperOverviewExample {
+export class StepperOverviewExample implements OnInit {
   isLinear = false;
   firstFormGroup: FormGroup;
   secondFormGroup: FormGroup;

--- a/src/material-examples/table-overview/table-overview-example.ts
+++ b/src/material-examples/table-overview/table-overview-example.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
 
 /**
@@ -9,7 +9,7 @@ import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
   styleUrls: ['table-overview-example.css'],
   templateUrl: 'table-overview-example.html',
 })
-export class TableOverviewExample {
+export class TableOverviewExample implements OnInit {
   displayedColumns = ['id', 'name', 'progress', 'color'];
   dataSource: MatTableDataSource<UserData>;
 

--- a/src/material-examples/table-pagination/table-pagination-example.ts
+++ b/src/material-examples/table-pagination/table-pagination-example.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {MatPaginator, MatTableDataSource} from '@angular/material';
 
 /**
@@ -9,7 +9,7 @@ import {MatPaginator, MatTableDataSource} from '@angular/material';
   styleUrls: ['table-pagination-example.css'],
   templateUrl: 'table-pagination-example.html',
 })
-export class TablePaginationExample {
+export class TablePaginationExample implements OnInit {
   displayedColumns = ['position', 'name', 'weight', 'symbol'];
   dataSource = new MatTableDataSource<PeriodicElement>(ELEMENT_DATA);
 

--- a/src/material-examples/table-sorting/table-sorting-example.ts
+++ b/src/material-examples/table-sorting/table-sorting-example.ts
@@ -1,5 +1,5 @@
-import {Component, ViewChild} from '@angular/core';
-import {MatTableDataSource, MatSort} from '@angular/material';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {MatSort, MatTableDataSource} from '@angular/material';
 
 /**
  * @title Table with sorting
@@ -9,7 +9,7 @@ import {MatTableDataSource, MatSort} from '@angular/material';
   styleUrls: ['table-sorting-example.css'],
   templateUrl: 'table-sorting-example.html',
 })
-export class TableSortingExample {
+export class TableSortingExample implements OnInit {
   displayedColumns = ['position', 'name', 'weight', 'symbol'];
   dataSource = new MatTableDataSource(ELEMENT_DATA);
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "rulesDirectory": [
-    "./tools/tslint-rules/"
+    "./tools/tslint-rules/",
+    "node_modules/codelyzer"
   ],
   "rules": {
     "max-line-length": [true, 100],
@@ -84,6 +85,14 @@
     "no-namespace": true,
     "jsdoc-format": [true, "check-multiline-start"],
     "no-duplicate-imports": true,
+
+    // Codelyzer
+    "banana-in-box": true,
+    "contextual-life-cycle": true,
+    "decorator-not-allowed": true,
+    "no-output-on-prefix": true,
+    "templates-no-negated-async": true,
+    "use-life-cycle-interface": true,
 
     // Custom Rules
     "ts-loader": true,


### PR DESCRIPTION
Some declarations weren't implementing the `LifeCycle`s hooks as `OnDestroy`, `OnInit`, etc. It's not necessary, much less a problem, but since in most declarations you usually use it, it's good to maintain the consistency.

Note that I added [codelyzer](https://github.com/mgechev/codelyzer/issues), which prevents these mistakes, let me know if you guys agree to add it or if I should remove it from this PR.