### PR TITLE
feat(checkbox): add orig event to output

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -77,7 +77,7 @@ export class MatCheckboxChange {
   /** The new `checked` value of the checkbox. */
   checked: boolean;
   /** The original event */
-  originalEvent: Event;
+  nativeEvent: Event;
 }
 
 // Boilerplate for applying mixins to MatCheckbox.
@@ -299,7 +299,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   private _emitChangeEvent(event: Event) {
     const changeEvent = new MatCheckboxChange();
     changeEvent.source = this;
-    changeEvent.originalEvent = event;
+    changeEvent.nativeEvent = event;
     changeEvent.checked = this.checked;
 
     this._controlValueAccessorChangeFn(this.checked);

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -77,7 +77,7 @@ export class MatCheckboxChange {
   /** The new `checked` value of the checkbox. */
   checked: boolean;
   /** The original event */
-  event: Event;
+  originalEvent: Event;
 }
 
 // Boilerplate for applying mixins to MatCheckbox.
@@ -299,7 +299,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   private _emitChangeEvent(event: Event) {
     const changeEvent = new MatCheckboxChange();
     changeEvent.source = this;
-    changeEvent.event = event;
+    changeEvent.originalEvent = event;
     changeEvent.checked = this.checked;
 
     this._controlValueAccessorChangeFn(this.checked);

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -76,6 +76,8 @@ export class MatCheckboxChange {
   source: MatCheckbox;
   /** The new `checked` value of the checkbox. */
   checked: boolean;
+  /** The original event */
+  event: Event;
 }
 
 // Boilerplate for applying mixins to MatCheckbox.
@@ -294,13 +296,14 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     }
   }
 
-  private _emitChangeEvent() {
-    let event = new MatCheckboxChange();
-    event.source = this;
-    event.checked = this.checked;
+  private _emitChangeEvent(event: Event) {
+    const changeEvent = new MatCheckboxChange();
+    changeEvent.source = this;
+    changeEvent.event = event;
+    changeEvent.checked = this.checked;
 
     this._controlValueAccessorChangeFn(this.checked);
-    this.change.emit(event);
+    this.change.emit(changeEvent);
   }
 
   /** Function is called whenever the focus changes for the input element. */
@@ -354,7 +357,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
       // Emit our custom change event if the native input emitted one.
       // It is important to only emit it, if the native input triggered one, because
       // we don't want to trigger a change event, when the `checked` variable changes for example.
-      this._emitChangeEvent();
+      this._emitChangeEvent(event);
     } else if (!this.disabled && this._clickAction === 'noop') {
       // Reset native input when clicked with noop. The native checkbox becomes checked after
       // click, reset it to be align with `checked` value of `mat-checkbox`.


### PR DESCRIPTION
This PR adds the original event to the output of the checkbox. This is required for gather information like was the shift button held down on click.