### PR TITLE
fix(overlay): handle OnDestroy in FullscreenOverlayContainer and use document injection token

### DIFF
--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -22,7 +22,7 @@ import {
 export class OverlayContainer implements OnDestroy {
   protected _containerElement: HTMLElement;
 
-  constructor(@Inject(DOCUMENT) private _document: any) {}
+  constructor(@Inject(DOCUMENT) protected _document: any) {}
 
   ngOnDestroy() {
     if (this._containerElement && this._containerElement.parentNode) {


### PR DESCRIPTION
* Fixes the `fullscreenchange` event handler not being cleared from the `FullscreenOverlayContainer` once it's destroyed.
* Uses the `DOCUMENT` token to avoid potential server-side rendering errors.