### PR TITLE
refactor: avoid casting document to any in constructor

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -109,7 +109,7 @@ export class CdkDialogContainer extends BasePortalOutlet {
     private _elementRef: ElementRef,
     private _focusTrapFactory: FocusTrapFactory,
     private _changeDetectorRef: ChangeDetectorRef,
-    @Optional() @Inject(DOCUMENT) private _document: any) {
+    @Optional() @Inject(DOCUMENT) private _document: Document) {
     super();
   }
 

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -55,11 +55,7 @@ let messagesContainer: HTMLElement | null = null;
  */
 @Injectable({providedIn: 'root'})
 export class AriaDescriber {
-  private _document: Document;
-
-  constructor(@Inject(DOCUMENT) _document: any) {
-    this._document = _document;
-  }
+  constructor(@Inject(DOCUMENT) private _document: Document) {}
 
   /**
    * Adds to the host element an aria-describedby reference to a hidden element that contains
@@ -213,7 +209,8 @@ export class AriaDescriber {
 
 
 /** @docs-private @deprecated @deletion-target 7.0.0 */
-export function ARIA_DESCRIBER_PROVIDER_FACTORY(parentDispatcher: AriaDescriber, _document: any) {
+export function ARIA_DESCRIBER_PROVIDER_FACTORY(parentDispatcher: AriaDescriber,
+  _document: Document) {
   return parentDispatcher || new AriaDescriber(_document);
 }
 
@@ -223,7 +220,7 @@ export const ARIA_DESCRIBER_PROVIDER = {
   provide: AriaDescriber,
   deps: [
     [new Optional(), new SkipSelf(), AriaDescriber],
-    DOCUMENT as InjectionToken<any>
+    DOCUMENT as InjectionToken<Document>
   ],
   useFactory: ARIA_DESCRIBER_PROVIDER_FACTORY
 };

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -285,15 +285,10 @@ export class FocusTrap {
 /** Factory that allows easy instantiation of focus traps. */
 @Injectable({providedIn: 'root'})
 export class FocusTrapFactory {
-  private _document: Document;
-
   constructor(
       private _checker: InteractivityChecker,
       private _ngZone: NgZone,
-      @Inject(DOCUMENT) _document: any) {
-
-    this._document = _document;
-  }
+      @Inject(DOCUMENT) private _document: Document) {}
 
   /**
    * Creates a focus-trapped region around the given element.
@@ -314,8 +309,6 @@ export class FocusTrapFactory {
   exportAs: 'cdkTrapFocus',
 })
 export class CdkTrapFocus implements OnDestroy, AfterContentInit {
-  private _document: Document;
-
   /** Underlying FocusTrap instance. */
   focusTrap: FocusTrap;
 
@@ -339,7 +332,7 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit {
   constructor(
       private _elementRef: ElementRef,
       private _focusTrapFactory: FocusTrapFactory,
-      @Inject(DOCUMENT) _document: any) {
+      @Inject(DOCUMENT) private _document: Document) {
 
     this._document = _document;
     this.focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement, true);

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -27,7 +27,7 @@ export class LiveAnnouncer implements OnDestroy {
 
   constructor(
       @Optional() @Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN) elementToken: any,
-      @Inject(DOCUMENT) private _document: any) {
+      @Inject(DOCUMENT) private _document: Document) {
 
     // We inject the live element as `any` because the constructor signature cannot reference
     // browser globals (HTMLElement) on non-browser environments, since having a class decorator
@@ -83,7 +83,7 @@ export class LiveAnnouncer implements OnDestroy {
 
 /** @docs-private @deprecated @deletion-target 7.0.0 */
 export function LIVE_ANNOUNCER_PROVIDER_FACTORY(
-    parentDispatcher: LiveAnnouncer, liveElement: any, _document: any) {
+    parentDispatcher: LiveAnnouncer, liveElement: any, _document: Document) {
   return parentDispatcher || new LiveAnnouncer(liveElement, _document);
 }
 

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
@@ -29,12 +29,9 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
   /** Currently attached overlays in the order they were attached. */
   _attachedOverlays: OverlayRef[] = [];
 
-  private _document: Document;
   private _isAttached: boolean;
 
-  constructor(@Inject(DOCUMENT) document: any) {
-    this._document = document;
-  }
+  constructor(@Inject(DOCUMENT) private _document: Document) {}
 
   ngOnDestroy() {
     this._detach();
@@ -97,7 +94,7 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
 
 /** @docs-private @deprecated @deletion-target 7.0.0 */
 export function OVERLAY_KEYBOARD_DISPATCHER_PROVIDER_FACTORY(
-    dispatcher: OverlayKeyboardDispatcher, _document: any) {
+    dispatcher: OverlayKeyboardDispatcher, _document: Document) {
   return dispatcher || new OverlayKeyboardDispatcher(_document);
 }
 
@@ -111,7 +108,7 @@ export const OVERLAY_KEYBOARD_DISPATCHER_PROVIDER = {
 
     // Coerce to `InjectionToken` so that the `deps` match the "shape"
     // of the type expected by Angular
-    DOCUMENT as InjectionToken<any>
+    DOCUMENT as InjectionToken<Document>
   ],
   useFactory: OVERLAY_KEYBOARD_DISPATCHER_PROVIDER_FACTORY
 };

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -22,7 +22,7 @@ import {
 export class OverlayContainer implements OnDestroy {
   protected _containerElement: HTMLElement;
 
-  constructor(@Inject(DOCUMENT) private _document: any) {}
+  constructor(@Inject(DOCUMENT) private _document: Document) {}
 
   ngOnDestroy() {
     if (this._containerElement && this._containerElement.parentNode) {
@@ -57,7 +57,7 @@ export class OverlayContainer implements OnDestroy {
 
 /** @docs-private @deprecated @deletion-target 7.0.0 */
 export function OVERLAY_CONTAINER_PROVIDER_FACTORY(parentContainer: OverlayContainer,
-  _document: any) {
+  _document: Document) {
   return parentContainer || new OverlayContainer(_document);
 }
 
@@ -67,7 +67,8 @@ export const OVERLAY_CONTAINER_PROVIDER = {
   provide: OverlayContainer,
   deps: [
     [new Optional(), new SkipSelf(), OverlayContainer],
-    DOCUMENT as InjectionToken<any> // We need to use the InjectionToken somewhere to keep TS happy
+    // We need to use the InjectionToken somewhere to keep TS happy
+    DOCUMENT as InjectionToken<Document>
   ],
   useFactory: OVERLAY_CONTAINER_PROVIDER_FACTORY
 };

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -51,7 +51,7 @@ export class Overlay {
               private _appRef: ApplicationRef,
               private _injector: Injector,
               private _ngZone: NgZone,
-              @Inject(DOCUMENT) private _document: any,
+              @Inject(DOCUMENT) private _document: Document,
               private _directionality: Directionality) { }
 
   /**

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -20,7 +20,7 @@ import {GlobalPositionStrategy} from './global-position-strategy';
 export class OverlayPositionBuilder {
   constructor(
     private _viewportRuler: ViewportRuler,
-    @Inject(DOCUMENT) private _document: any) { }
+    @Inject(DOCUMENT) private _document: Document) { }
 
   /**
    * Creates a global position strategy.

--- a/src/cdk/overlay/scroll/block-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.ts
@@ -17,11 +17,8 @@ export class BlockScrollStrategy implements ScrollStrategy {
   private _previousHTMLStyles = { top: '', left: '' };
   private _previousScrollPosition: { top: number, left: number };
   private _isEnabled = false;
-  private _document: Document;
 
-  constructor(private _viewportRuler: ViewportRuler, document: any) {
-    this._document = document;
-  }
+  constructor(private _viewportRuler: ViewportRuler, private _document: Document) {}
 
   /** Attaches this scroll strategy to an overlay. */
   attach() { }

--- a/src/cdk/overlay/scroll/scroll-strategy-options.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy-options.ts
@@ -26,15 +26,11 @@ import {
  */
 @Injectable({providedIn: 'root'})
 export class ScrollStrategyOptions {
-  private _document: Document;
-
   constructor(
     private _scrollDispatcher: ScrollDispatcher,
     private _viewportRuler: ViewportRuler,
     private _ngZone: NgZone,
-    @Inject(DOCUMENT) document: any) {
-      this._document = document;
-    }
+    @Inject(DOCUMENT) private _document: Document) {}
 
   /** Do nothing on scroll. */
   noop = () => new NoopScrollStrategy();

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -145,7 +145,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
               @Inject(MAT_AUTOCOMPLETE_SCROLL_STRATEGY) private _scrollStrategy,
               @Optional() private _dir: Directionality,
               @Optional() @Host() private _formField: MatFormField,
-              @Optional() @Inject(DOCUMENT) private _document: any,
+              @Optional() @Inject(DOCUMENT) private _document: Document,
               // @deletion-target 7.0.0 Make `_viewportRuler` required.
               private _viewportRuler?: ViewportRuler) {}
 

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -96,7 +96,7 @@ export class MatBadge implements OnDestroy {
   private _badgeElement: HTMLElement;
 
   constructor(
-      @Optional() @Inject(DOCUMENT) private _document: any,
+      @Optional() @Inject(DOCUMENT) private _document: Document,
       private _ngZone: NgZone,
       private _elementRef: ElementRef,
       private _ariaDescriber: AriaDescriber) {}

--- a/src/lib/bottom-sheet/bottom-sheet-container.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-container.ts
@@ -79,9 +79,6 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   /** Element that was focused before the bottom sheet was opened. */
   private _elementFocusedBeforeOpened: HTMLElement | null = null;
 
-  /** Server-side rendering-compatible reference to the global document object. */
-  private _document: Document;
-
   /** Whether the component has been destroyed. */
   private _destroyed: boolean;
 
@@ -90,10 +87,9 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
     private _changeDetectorRef: ChangeDetectorRef,
     private _focusTrapFactory: FocusTrapFactory,
     breakpointObserver: BreakpointObserver,
-    @Optional() @Inject(DOCUMENT) document: any) {
+    @Optional() @Inject(DOCUMENT) private _document: Document) {
     super();
 
-    this._document = document;
     this._breakpointSubscription = breakpointObserver
       .observe([Breakpoints.Medium, Breakpoints.Large, Breakpoints.XLarge])
       .subscribe(() => {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -313,7 +313,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
               @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) private _scrollStrategy,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,
-              @Optional() @Inject(DOCUMENT) private _document: any) {
+              @Optional() @Inject(DOCUMENT) private _document: Document) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }
@@ -371,7 +371,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
       throw Error('Attempted to open an MatDatepicker with no associated input.');
     }
     if (this._document) {
-      this._focusedElementBeforeOpen = this._document.activeElement;
+      this._focusedElementBeforeOpen = this._document.activeElement as HTMLElement;
     }
 
     this.touchUi ? this._openAsDialog() : this._openAsPopup();

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -98,7 +98,7 @@ export class MatDialogContainer extends BasePortalOutlet {
     private _elementRef: ElementRef,
     private _focusTrapFactory: FocusTrapFactory,
     private _changeDetectorRef: ChangeDetectorRef,
-    @Optional() @Inject(DOCUMENT) private _document: any) {
+    @Optional() @Inject(DOCUMENT) private _document: Document) {
 
     super();
   }

--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -71,8 +71,6 @@ class SvgIconConfig {
  */
 @Injectable({providedIn: 'root'})
 export class MatIconRegistry {
-  private _document: Document;
-
   /**
    * URLs and cached SVG elements for individual icons. Keys are of the format "[namespace]:[icon]".
    */
@@ -103,9 +101,7 @@ export class MatIconRegistry {
   constructor(
     @Optional() private _httpClient: HttpClient,
     private _sanitizer: DomSanitizer,
-    @Optional() @Inject(DOCUMENT) document: any) {
-      this._document = document;
-    }
+    @Optional() @Inject(DOCUMENT) private _document: Document) {}
 
   /**
    * Registers an icon by URL in the default namespace.

--- a/src/lib/menu/menu-content.ts
+++ b/src/lib/menu/menu-content.ts
@@ -35,7 +35,7 @@ export class MatMenuContent implements OnDestroy {
     private _appRef: ApplicationRef,
     private _injector: Injector,
     private _viewContainerRef: ViewContainerRef,
-    @Inject(DOCUMENT) private _document: any) {}
+    @Inject(DOCUMENT) private _document: Document) {}
 
   /**
    * Attaches the content with a particular context.

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -144,7 +144,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
 
   constructor(public _elementRef: ElementRef,
               platform: Platform,
-              @Optional() @Inject(DOCUMENT) private _document: any) {
+              @Optional() @Inject(DOCUMENT) private _document: Document) {
 
     super(_elementRef);
     this._fallbackAnimation = platform.EDGE || platform.TRIDENT;
@@ -244,7 +244,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
 })
 export class MatSpinner extends MatProgressSpinner {
   constructor(elementRef: ElementRef, platform: Platform,
-              @Optional() @Inject(DOCUMENT) document: any) {
+              @Optional() @Inject(DOCUMENT) document: Document) {
     super(elementRef, platform, document);
     this.mode = 'indeterminate';
   }


### PR DESCRIPTION
Removes all the places where we were casting the `Document` to `any` when passing it in to the constructor, in order to avoid AoT compilation issues. It seems like this is no longer necessary as of 6.0.