### PR TITLE
doc(autocomplete-filter): Update example to use Array.prototype.Inclu…

### DIFF
--- a/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/material-examples/autocomplete-filter/autocomplete-filter-example.ts
@@ -33,7 +33,7 @@ export class AutocompleteFilterExample {
 
   filter(val: string): string[] {
     return this.options.filter(option =>
-      option.toLowerCase().indexOf(val.toLowerCase()) === 0);
+      option.toLowerCase().includes(val.toLowerCase()));
   }
 
 }


### PR DESCRIPTION
…es()

Was researching the Auto-complete feature to add it to a project and this little enhancement is more straightforward when dealing with more complex strings.

Current example can't filter strings with spaces. By using includes() it can filter full sentences or more complex string values.