### PR TITLE
refactor(slider): improve unit test speed

### DIFF
--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -11,49 +11,30 @@ import {
   UP_ARROW,
 } from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing';
-import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {Component, DebugElement, ViewChild, Type} from '@angular/core';
+import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By, HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {MatSlider, MatSliderModule} from './index';
 import {TestGestureConfig} from './test-gesture-config';
 
-
-describe('MatSlider without forms', () => {
+describe('MatSlider', () => {
   let gestureConfig: TestGestureConfig;
 
-  beforeEach(async(() => {
+  function createComponent<T>(component: Type<T>): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatSliderModule, ReactiveFormsModule, FormsModule, BidiModule],
-      declarations: [
-        StandardSlider,
-        DisabledSlider,
-        SliderWithMinAndMax,
-        SliderWithValue,
-        SliderWithStep,
-        SliderWithAutoTickInterval,
-        SliderWithSetTickInterval,
-        SliderWithThumbLabel,
-        SliderWithOneWayBinding,
-        SliderWithValueSmallerThanMin,
-        SliderWithValueGreaterThanMax,
-        SliderWithChangeHandler,
-        SliderWithDirAndInvert,
-        SliderWithTabIndexBinding,
-        SliderWithNativeTabindexAttr,
-        VerticalSlider,
-        SliderWithCustomThumbLabelFormatting,
-      ],
+      declarations: [component],
       providers: [
         {provide: HAMMER_GESTURE_CONFIG, useFactory: () => {
           gestureConfig = new TestGestureConfig();
           return gestureConfig;
         }}
-      ],
-    });
+      ]
+    }).compileComponents();
 
-    TestBed.compileComponents();
-  }));
+    return TestBed.createComponent<T>(component);
+  }
 
   describe('standard slider', () => {
     let fixture: ComponentFixture<StandardSlider>;
@@ -63,7 +44,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(StandardSlider);
+      fixture = createComponent(StandardSlider);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -229,7 +210,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(DisabledSlider);
+      fixture = createComponent(DisabledSlider);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -305,7 +286,7 @@ describe('MatSlider without forms', () => {
     let testComponent: SliderWithMinAndMax;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithMinAndMax);
+      fixture = createComponent(SliderWithMinAndMax);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -399,7 +380,7 @@ describe('MatSlider without forms', () => {
     let sliderInstance: MatSlider;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithValue);
+      fixture = createComponent(SliderWithValue);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -436,7 +417,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithStep);
+      fixture = createComponent(SliderWithStep);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -509,7 +490,7 @@ describe('MatSlider without forms', () => {
     let ticksElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithAutoTickInterval);
+      fixture = createComponent(SliderWithAutoTickInterval);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -539,7 +520,7 @@ describe('MatSlider without forms', () => {
     let ticksElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithSetTickInterval);
+      fixture = createComponent(SliderWithSetTickInterval);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -581,7 +562,7 @@ describe('MatSlider without forms', () => {
     let thumbLabelTextElement: Element;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithThumbLabel);
+      fixture = createComponent(SliderWithThumbLabel);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -621,7 +602,7 @@ describe('MatSlider without forms', () => {
     let thumbLabelTextElement: Element;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithCustomThumbLabelFormatting);
+      fixture = createComponent(SliderWithCustomThumbLabelFormatting);
       fixture.detectChanges();
 
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -656,7 +637,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithOneWayBinding);
+      fixture = createComponent(SliderWithOneWayBinding);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -689,7 +670,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithValueSmallerThanMin);
+      fixture = createComponent(SliderWithValueSmallerThanMin);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -717,7 +698,7 @@ describe('MatSlider without forms', () => {
     let trackFillElement: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithValueGreaterThanMax);
+      fixture = createComponent(SliderWithValueGreaterThanMax);
       fixture.detectChanges();
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
@@ -744,7 +725,7 @@ describe('MatSlider without forms', () => {
     let testComponent: SliderWithChangeHandler;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithChangeHandler);
+      fixture = createComponent(SliderWithChangeHandler);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -815,7 +796,7 @@ describe('MatSlider without forms', () => {
     let testComponent: SliderWithChangeHandler;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithChangeHandler);
+      fixture = createComponent(SliderWithChangeHandler);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -863,7 +844,7 @@ describe('MatSlider without forms', () => {
     let sliderInstance: MatSlider;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithChangeHandler);
+      fixture = createComponent(SliderWithChangeHandler);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -1002,7 +983,7 @@ describe('MatSlider without forms', () => {
     let testComponent: SliderWithDirAndInvert;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithDirAndInvert);
+      fixture = createComponent(SliderWithDirAndInvert);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -1143,7 +1124,7 @@ describe('MatSlider without forms', () => {
     let testComponent: VerticalSlider;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(VerticalSlider);
+      fixture = createComponent(VerticalSlider);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -1199,7 +1180,7 @@ describe('MatSlider without forms', () => {
   describe('tabindex', () => {
 
     it('should allow setting the tabIndex through binding', () => {
-      const fixture = TestBed.createComponent(SliderWithTabIndexBinding);
+      const fixture = createComponent(SliderWithTabIndexBinding);
       fixture.detectChanges();
 
       const slider = fixture.debugElement.query(By.directive(MatSlider)).componentInstance;
@@ -1213,7 +1194,7 @@ describe('MatSlider without forms', () => {
     });
 
     it('should detect the native tabindex attribute', () => {
-      const fixture = TestBed.createComponent(SliderWithNativeTabindexAttr);
+      const fixture = createComponent(SliderWithNativeTabindexAttr);
       fixture.detectChanges();
 
       const slider = fixture.debugElement.query(By.directive(MatSlider)).componentInstance;
@@ -1222,28 +1203,6 @@ describe('MatSlider without forms', () => {
         .toBe(5, 'Expected the tabIndex to be set to the value of the native attribute.');
     });
   });
-});
-
-describe('MatSlider with forms module', () => {
-  let gestureConfig: TestGestureConfig;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSliderModule, ReactiveFormsModule, FormsModule, BidiModule],
-      declarations: [
-        SliderWithFormControl,
-        SliderWithNgModel,
-      ],
-      providers: [
-        {provide: HAMMER_GESTURE_CONFIG, useFactory: () => {
-          gestureConfig = new TestGestureConfig();
-          return gestureConfig;
-        }}
-      ],
-    });
-
-    TestBed.compileComponents();
-  }));
 
   describe('slider with ngModel', () => {
     let fixture: ComponentFixture<SliderWithNgModel>;
@@ -1252,7 +1211,7 @@ describe('MatSlider with forms module', () => {
     let testComponent: SliderWithNgModel;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithNgModel);
+      fixture = createComponent(SliderWithNgModel);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
@@ -1314,7 +1273,7 @@ describe('MatSlider with forms module', () => {
     let testComponent: SliderWithFormControl;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SliderWithFormControl);
+      fixture = createComponent(SliderWithFormControl);
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;


### PR DESCRIPTION
Reduces the slider test time to about half the initial time by not recompiling all the test cases for each test. Also removes the `async` usages and combines the two top-level `describe` blocks into one.