### PR TITLE
fix(scrolling): complete ScrollDispatcher.scrolled on destroy

### DIFF
--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -90,6 +90,17 @@ describe('Scroll Dispatcher', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
     });
+
+    it('should complete the `scrolled` stream on destroy', () => {
+      const completeSpy = jasmine.createSpy('complete spy');
+      const subscription = scroll.scrolled(0).subscribe(undefined, undefined, completeSpy);
+
+      scroll.ngOnDestroy();
+
+      expect(completeSpy).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
   });
 
   describe('Nested scrollables', () => {

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -109,6 +109,7 @@ export class ScrollDispatcher implements OnDestroy {
   ngOnDestroy() {
     this._removeGlobalListener();
     this.scrollContainers.forEach((_, container) => this.deregister(container));
+    this._scrolled.complete();
   }
 
   /**


### PR DESCRIPTION
Currently we stop emitting to `scrolled` once the provider is destroyed, however this can still leave some subscriptions hanging. These changes will also complete the `scrolled` subject.