### PR TITLE
build: fix sass compilation error

### DIFF
--- a/src/lib/core/_core.scss
+++ b/src/lib/core/_core.scss
@@ -37,10 +37,10 @@
   @include mat-optgroup-theme($theme);
   @include mat-pseudo-checkbox-theme($theme);
 
-  // Wrapper element that provides the theme background when the
-  // user's content isn't inside of a `mat-sidenav-container`.
-  .mat-app-background,
-  &.mat-app-background {
+  // Wrapper element that provides the theme background when the user's content isn't
+  // inside of a `mat-sidenav-container`. Note that we need to exclude the ampersand
+  // selector in case the mixin is included at the top level.
+  .mat-app-background#{if(&, ', &.mat-app-background', '')} {
     $background: map-get($theme, background);
     $foreground: map-get($theme, foreground);
 


### PR DESCRIPTION
Fixes the following SASS error due to a top-level ampersand selector:

```
Error in plugin 'sass'
Message:
    src\lib\core\_core.scss
Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
        on line 43 of src/lib/core/_core.scss, in mixin `mat-core-theme`
        from line 39 of src/lib/core/theming/_all-theme.scss, in mixin `angular-material-theme`
        from line 14 of src/lib/core/theming/prebuilt/deeppurple-amber.scss
>>   &.mat-app-background {

   --^
```