### PR TITLE
fix(overlay): use HTMLDocument instead of Document

### DIFF
--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -51,7 +51,7 @@ export class Overlay {
               private _appRef: ApplicationRef,
               private _injector: Injector,
               private _ngZone: NgZone,
-              @Inject(DOCUMENT) private _document: Document,
+              @Inject(DOCUMENT) private _document: HTMLDocument,
               private _directionality: Directionality) { }
 
   /**


### PR DESCRIPTION
In latest RC, constructing with the `Document` token creates a fatal error:

```bash
[1] ReferenceError: Document is not defined
[1]     at Overlay.ctorParameters (/Users/patrick/Code/fusing-angular/node_modules/@angular/src/cdk/overlay/overlay.ts:54:1)
[1]     at ReflectionCapabilities._ownParameters (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/core/npm_package.esm5/packages/core/src/reflection/reflection_capabilities.js:82:76)
[1]     at ReflectionCapabilities.parameters (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/core/npm_package.esm5/packages/core/src/reflection/reflection_capabilities.js:109:31)
[1]     at JitReflector.parameters (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/platform-browser-dynamic/npm_package.esm5/packages/platform-browser-dynamic/src/compiler_reflector.js:30:44)
[1]     at CompileMetadataResolver._getDependenciesMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:770:54)
[1]     at CompileMetadataResolver._getTypeMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:720:26)
[1]     at CompileMetadataResolver._getInjectableTypeMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:942:21)
[1]     at CompileMetadataResolver.getProviderMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:951:22)
[1]     at /execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:889:49
[1]     at Array.forEach (<anonymous>)
[1]     at CompileMetadataResolver._getProvidersMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:849:19)
[1]     at CompileMetadataResolver.getNgModuleMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:568:67)
[1]     at CompileMetadataResolver.getNgModuleSummary (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:398:35)
[1]     at /execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:485:55
[1]     at Array.forEach (<anonymous>)
[1]     at CompileMetadataResolver.getNgModuleMetadata (/execroot/angular/bazel-out/darwin-fastbuild/bin/packages/compiler/npm_package.esm5/packages/compiler/src/metadata_resolver.js:463:49)

```