### PR TITLE
build: mark material and cdk packages as sideEffect-free for webpack v4

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -28,5 +28,6 @@
   },
   "dependencies": {
     "tslib": "^1.7.1"
-  }
+  },
+  "sideEffects": false
 }

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -29,5 +29,6 @@
   "dependencies": {
     "tslib": "^1.7.1"
   },
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+  "sideEffects": false
 }

--- a/tools/package-tools/entry-point-package-json.ts
+++ b/tools/package-tools/entry-point-package-json.ts
@@ -10,6 +10,7 @@ export function createEntryPointPackageJson(destDir: string, packageName: string
     main: `../bundles/${packageName}-${entryPointName}.umd.js`,
     module: `../esm5/${entryPointName}.es5.js`,
     es2015: `../esm2015/${entryPointName}.js`,
+    sideEffects: false,
   };
 
   writeFileSync(join(destDir, 'package.json'), JSON.stringify(content, null, 2), 'utf-8');


### PR DESCRIPTION
This change enables material and cdk packages to take advantage of webpacks more advanced optimizations
documented at https://github.com/webpack/webpack/tree/master/examples/side-effects

Our code is already side-effect free because otherwise @angular-devkit/build-optimizer would break it, so it's safe
to turn this on.