### PR TITLE
refactor: use strongly-typed ElementRef

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -159,31 +159,31 @@ private _placeholder: string;
 
 #### `ngControl`
 
-This property allows the form field control to specify the `@angular/forms` control that is bound to this component. Since we haven't set up our component to act as a `ControlValueAccessor`, we'll just set this to `null` in our component. 
+This property allows the form field control to specify the `@angular/forms` control that is bound to this component. Since we haven't set up our component to act as a `ControlValueAccessor`, we'll just set this to `null` in our component.
 
 ```ts
 ngControl: NgControl = null;
 ```
 
-It is likely you will want to implement `ControlValueAccessor` so that your component can work with `formControl` and `ngModel`. If you do implement `ControlValueAccessor` you will need to get a reference to the `NgControl` associated with your control and make it publicly available. 
+It is likely you will want to implement `ControlValueAccessor` so that your component can work with `formControl` and `ngModel`. If you do implement `ControlValueAccessor` you will need to get a reference to the `NgControl` associated with your control and make it publicly available.
 
 The easy way is to add it as a public property to your constructor and let dependency injection handle it:
 
 ```ts
 constructor(
-  ..., 
+  ...,
   @Optional() @Self() public ngControl: NgControl,
   ...,
 ) { }
 ```
 
-Note that if your component implements `ControlValueAccessor`, it may already be set up to provide `NG_VALUE_ACCESSOR` (in the `providers` part of the component's decorator, or possibly in a module declaration). If so you may get a *cannot instantiate cyclic dependency* error. 
+Note that if your component implements `ControlValueAccessor`, it may already be set up to provide `NG_VALUE_ACCESSOR` (in the `providers` part of the component's decorator, or possibly in a module declaration). If so you may get a *cannot instantiate cyclic dependency* error.
 
 To resolve this, remove the `NG_VALUE_ACCESSOR` provider and instead set the value accessor directly:
 
 ```ts
 constructor(
-  ..., 
+  ...,
   @Optional() @Self() public ngControl: NgControl,
   ...,
 ) {
@@ -207,7 +207,7 @@ need to remember to emit on the `stateChanges` stream so change detection can ha
 ```ts
 focused = false;
 
-constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef) {
+constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef<HTMLElement>) {
   ...
   fm.monitor(elRef.nativeElement, true).subscribe(origin => {
     this.focused = !!origin;

--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -104,7 +104,7 @@ export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
   _afterExit: Subject<void> = new Subject();
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _focusTrapFactory: FocusTrapFactory,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(DOCUMENT) private _document: any,

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -181,16 +181,16 @@ function expectMessage(el: Element, message: string) {
   `,
 })
 class TestApp {
-  @ViewChild('element1') _element1: ElementRef;
+  @ViewChild('element1') _element1: ElementRef<HTMLElement>;
   get element1(): Element { return this._element1.nativeElement; }
 
-  @ViewChild('element2') _element2: ElementRef;
+  @ViewChild('element2') _element2: ElementRef<HTMLElement>;
   get element2(): Element { return this._element2.nativeElement; }
 
-  @ViewChild('element3') _element3: ElementRef;
+  @ViewChild('element3') _element3: ElementRef<HTMLElement>;
   get element3(): Element { return this._element3.nativeElement; }
 
-  @ViewChild('element4') _element4: ElementRef;
+  @ViewChild('element4') _element4: ElementRef<HTMLElement>;
   get element4(): Element { return this._element4.nativeElement; }
 
 

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -417,7 +417,7 @@ export class CdkMonitorFocus implements OnDestroy {
   private _monitorSubscription: Subscription;
   @Output() cdkFocusChange = new EventEmitter<FocusOrigin>();
 
-  constructor(private _elementRef: ElementRef, private _focusMonitor: FocusMonitor) {
+  constructor(private _elementRef: ElementRef<HTMLElement>, private _focusMonitor: FocusMonitor) {
     this._monitorSubscription = this._focusMonitor.monitor(
         this._elementRef,
         this._elementRef.nativeElement.hasAttribute('cdkMonitorSubtreeFocus'))

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -350,7 +350,7 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, DoCheck {
   private _autoCapture: boolean;
 
   constructor(
-      private _elementRef: ElementRef,
+      private _elementRef: ElementRef<HTMLElement>,
       private _focusTrapFactory: FocusTrapFactory,
       @Inject(DOCUMENT) _document: any) {
 

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -164,7 +164,8 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
 
   private _currentSubscription: Subscription | null = null;
 
-  constructor(private _contentObserver: ContentObserver, private _elementRef: ElementRef,
+  constructor(private _contentObserver: ContentObserver,
+              private _elementRef: ElementRef<HTMLElement>,
               private _ngZone: NgZone) {}
 
   ngAfterContentInit() {

--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -63,7 +63,7 @@ describe('ConnectedPositionStrategy', () => {
 
     let originElement: HTMLElement;
     let positionStrategy: ConnectedPositionStrategy;
-    let fakeElementRef: ElementRef;
+    let fakeElementRef: ElementRef<HTMLElement>;
 
     let originRect: ClientRect | null;
     let originCenterX: number | null;
@@ -73,7 +73,7 @@ describe('ConnectedPositionStrategy', () => {
       // The origin and overlay elements need to be in the document body in order to have geometry.
       originElement = createPositionedBlockElement();
       document.body.appendChild(originElement);
-      fakeElementRef = new ElementRef(originElement);
+      fakeElementRef = new ElementRef<HTMLElement>(originElement);
     });
 
     afterEach(() => {
@@ -583,7 +583,7 @@ describe('ConnectedPositionStrategy', () => {
     let positionChangeHandler: jasmine.Spy;
     let onPositionChangeSubscription: Subscription;
     let positionChange: ConnectedOverlayPositionChange;
-    let fakeElementRef: ElementRef;
+    let fakeElementRef: ElementRef<HTMLElement>;
     let positionStrategy: ConnectedPositionStrategy;
 
     beforeEach(() => {
@@ -597,14 +597,14 @@ describe('ConnectedPositionStrategy', () => {
       scrollable.appendChild(originElement);
 
       // Create a strategy with knowledge of the scrollable container
-      fakeElementRef = new ElementRef(originElement);
+      fakeElementRef = new ElementRef<HTMLElement>(originElement);
       positionStrategy = overlay.position().connectedTo(
           fakeElementRef,
           {originX: 'start', originY: 'bottom'},
           {overlayX: 'start', overlayY: 'top'});
 
       positionStrategy.withScrollableContainers([
-          new CdkScrollable(new ElementRef(scrollable), null!, null!)]);
+          new CdkScrollable(new ElementRef<HTMLElement>(scrollable), null!, null!)]);
       positionChangeHandler = jasmine.createSpy('positionChangeHandler');
       onPositionChangeSubscription =
           positionStrategy.onPositionChange.subscribe(positionChangeHandler);
@@ -673,13 +673,13 @@ describe('ConnectedPositionStrategy', () => {
   describe('positioning properties', () => {
     let originElement: HTMLElement;
     let positionStrategy: ConnectedPositionStrategy;
-    let fakeElementRef: ElementRef;
+    let fakeElementRef: ElementRef<HTMLElement>;
 
     beforeEach(() => {
       // The origin and overlay elements need to be in the document body in order to have geometry.
       originElement = createPositionedBlockElement();
       document.body.appendChild(originElement);
-      fakeElementRef = new ElementRef(originElement);
+      fakeElementRef = new ElementRef<HTMLElement>(originElement);
     });
 
     afterEach(() => {

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -58,7 +58,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   constructor(
       originPos: OriginConnectionPosition,
       overlayPos: OverlayConnectionPosition,
-      connectedTo: ElementRef,
+      connectedTo: ElementRef<HTMLElement>,
       viewportRuler: ViewportRuler,
       document: Document,
       // @breaking-change 7.0.0 `platform` parameter to be made required.

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1575,7 +1575,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
         }]);
 
       strategy.withScrollableContainers([
-        new CdkScrollable(new ElementRef(scrollable), null!, null!)
+        new CdkScrollable(new ElementRef<HTMLElement>(scrollable), null!, null!)
       ]);
 
       positionChangeHandler = jasmine.createSpy('positionChange handler');

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -117,7 +117,7 @@ describe('ScrollDispatcher', () => {
   describe('Nested scrollables', () => {
     let scroll: ScrollDispatcher;
     let fixture: ComponentFixture<NestedScrollingComponent>;
-    let element: ElementRef;
+    let element: ElementRef<HTMLElement>;
 
     beforeEach(inject([ScrollDispatcher], (s: ScrollDispatcher) => {
       scroll = s;
@@ -228,7 +228,7 @@ describe('ScrollDispatcher', () => {
 })
 class ScrollingComponent {
   @ViewChild(CdkScrollable) scrollable: CdkScrollable;
-  @ViewChild('scrollingElement') scrollingElement: ElementRef;
+  @ViewChild('scrollingElement') scrollingElement: ElementRef<HTMLElement>;
 }
 
 
@@ -245,7 +245,7 @@ class ScrollingComponent {
   `
 })
 class NestedScrollingComponent {
-  @ViewChild('interestingElement') interestingElement: ElementRef;
+  @ViewChild('interestingElement') interestingElement: ElementRef<HTMLElement>;
 }
 
 const TEST_COMPONENTS = [ScrollingComponent, NestedScrollingComponent];

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -141,14 +141,14 @@ export class ScrollDispatcher implements OnDestroy {
 
   /** Returns true if the element is contained within the provided Scrollable. */
   private _scrollableContainsElement(scrollable: CdkScrollable, elementRef: ElementRef): boolean {
-    let element = elementRef.nativeElement;
+    let element: HTMLElement | null = elementRef.nativeElement;
     let scrollableElement = scrollable.getElementRef().nativeElement;
 
     // Traverse through the element parents until we reach null, checking if any of the elements
     // are the scrollable's element.
     do {
       if (element == scrollableElement) { return true; }
-    } while (element = element.parentElement);
+    } while (element = element!.parentElement);
 
     return false;
   }

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -67,7 +67,8 @@ export interface RowOutlet {
  */
 @Directive({selector: '[rowOutlet]'})
 export class DataRowOutlet implements RowOutlet {
-  constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) { }
+  constructor(public viewContainer: ViewContainerRef,
+              public elementRef: ElementRef) { }
 }
 
 /**
@@ -76,7 +77,8 @@ export class DataRowOutlet implements RowOutlet {
  */
 @Directive({selector: '[headerRowOutlet]'})
 export class HeaderRowOutlet implements RowOutlet {
-  constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) { }
+  constructor(public viewContainer: ViewContainerRef,
+              public elementRef: ElementRef) { }
 }
 
 /**
@@ -85,7 +87,8 @@ export class HeaderRowOutlet implements RowOutlet {
  */
 @Directive({selector: '[footerRowOutlet]'})
 export class FooterRowOutlet implements RowOutlet {
-  constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) { }
+  constructor(public viewContainer: ViewContainerRef,
+              public elementRef: ElementRef) { }
 }
 
 /**

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -216,14 +216,16 @@ describe('cdkAutofill', () => {
   `
 })
 class Inputs {
-  @ViewChild('input1') input1: ElementRef;
-  @ViewChild('input2') input2: ElementRef;
-  @ViewChild('input3') input3: ElementRef;
+  // Cast to `any` so we can stub out some methods in the tests.
+  @ViewChild('input1') input1: ElementRef<any>;
+  @ViewChild('input2') input2: ElementRef<any>;
+  @ViewChild('input3') input3: ElementRef<any>;
 }
 
 @Component({
   template: `<input #input cdkAutofill>`
 })
 class InputWithCdkAutofilled {
-  @ViewChild('input') input: ElementRef;
+  // Cast to `any` so we can stub out some methods in the tests.
+  @ViewChild('input') input: ElementRef<any>;
 }

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -148,7 +148,8 @@ export class CdkAutofill implements OnDestroy, OnInit {
   /** Emits when the autofill state of the element changes. */
   @Output() cdkAutofill: EventEmitter<AutofillEvent> = new EventEmitter<AutofillEvent>();
 
-  constructor(private _elementRef: ElementRef, private _autofillMonitor: AutofillMonitor) {}
+  constructor(private _elementRef: ElementRef<HTMLElement>,
+              private _autofillMonitor: AutofillMonitor) {}
 
   ngOnInit() {
     this._autofillMonitor

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -78,7 +78,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   private _cachedLineHeight: number;
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _platform: Platform,
     private _ngZone: NgZone) {
     this._textareaElement = this._elementRef.nativeElement as HTMLTextAreaElement;

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -63,7 +63,7 @@ export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContent
   /** The children node placeholder. */
   @ContentChildren(CdkTreeNodeOutlet) nodeOutlet: QueryList<CdkTreeNodeOutlet>;
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,
               protected _differs: IterableDiffers) {
     super(_elementRef, _tree);

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -46,7 +46,7 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
   constructor(private _treeNode: CdkTreeNode<T>,
               private _tree: CdkTree<T>,
               private _renderer: Renderer2,
-              private _element: ElementRef,
+              private _element: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality) {
     this._setPadding();
     if (this._dir) {

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -322,7 +322,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
    */
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>) {
     CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T>;
   }

--- a/src/demo-app/a11y/a11y.ts
+++ b/src/demo-app/a11y/a11y.ts
@@ -31,8 +31,8 @@ export class AccessibilityDemo implements OnDestroy {
 
   private _routerSubscription = Subscription.EMPTY;
 
-  @ViewChild('maincontent') mainContent: ElementRef;
-  @ViewChild('header') sectionHeader: ElementRef;
+  @ViewChild('maincontent') mainContent: ElementRef<HTMLElement>;
+  @ViewChild('header') sectionHeader: ElementRef<HTMLElement>;
 
   navItems = [
     {name: 'Home', route: '.'},

--- a/src/demo-app/demo-app/demo-app.ts
+++ b/src/demo-app/demo-app/demo-app.ts
@@ -96,11 +96,12 @@ export class DemoApp {
   ];
 
   constructor(
-    private _element: ElementRef,
+    private _element: ElementRef<HTMLElement>,
     private _overlayContainer: OverlayContainer) {}
 
   toggleFullscreen() {
-    const elem = this._element.nativeElement.querySelector('.demo-content');
+    // Cast to `any`, because the typings don't include the browser-prefixed methods.
+    const elem = this._element.nativeElement.querySelector('.demo-content') as any;
     if (elem.requestFullscreen) {
       elem.requestFullscreen();
     } else if (elem.webkitRequestFullScreen) {

--- a/src/e2e-app/fullscreen/fullscreen-e2e.ts
+++ b/src/e2e-app/fullscreen/fullscreen-e2e.ts
@@ -10,7 +10,7 @@ export class FullscreenE2E {
 
   dialogRef: MatDialogRef<TestDialogFullScreen> | null;
 
-  constructor (private _element: ElementRef, private _dialog: MatDialog) { }
+  constructor (private _element: ElementRef<HTMLElement>, private _dialog: MatDialog) { }
 
   openDialog() {
     this.dialogRef = this._dialog.open(TestDialogFullScreen);
@@ -21,16 +21,16 @@ export class FullscreenE2E {
   }
 
   openFullscreen() {
-    let element = this._element.nativeElement.querySelector('#fullscreen-pane');
+    let element = this._element.nativeElement.querySelector('#fullscreen-pane') as any;
 
     if (element.requestFullscreen) {
       element.requestFullscreen();
     } else if (element.webkitRequestFullScreen) {
       element.webkitRequestFullScreen();
-    } else if ((element as any).mozRequestFullScreen) {
-      (element as any).mozRequestFullScreen();
-    } else if ((element as any).msRequestFullScreen) {
-      (element as any).msRequestFullScreen();
+    } else if (element.mozRequestFullScreen) {
+      element.mozRequestFullScreen();
+    } else if (element.msRequestFullScreen) {
+      element.msRequestFullScreen();
     }
   }
 

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -189,7 +189,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     this._autocompleteDisabled = coerceBooleanProperty(value);
   }
 
-  constructor(private _element: ElementRef, private _overlay: Overlay,
+  constructor(private _element: ElementRef<HTMLInputElement>, private _overlay: Overlay,
               private _viewContainerRef: ViewContainerRef,
               private _zone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef,
@@ -662,7 +662,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
 
   /** Determines whether the panel can be opened. */
   private _canOpen(): boolean {
-    const element: HTMLInputElement = this._element.nativeElement;
+    const element = this._element.nativeElement;
     return !element.readOnly && !element.disabled && !this._autocompleteDisabled;
   }
 }

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -160,7 +160,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
 
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     @Inject(MAT_AUTOCOMPLETE_DEFAULT_OPTIONS) defaults: MatAutocompleteDefaultOptions) {
     super();
 

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -101,7 +101,7 @@ export class MatBadge implements OnDestroy {
   constructor(
       @Optional() @Inject(DOCUMENT) private _document: any,
       private _ngZone: NgZone,
-      private _elementRef: ElementRef,
+      private _elementRef: ElementRef<HTMLElement>,
       private _ariaDescriber: AriaDescriber) {}
 
   /** Whether the badge is above the host or not */

--- a/src/lib/bottom-sheet/bottom-sheet-container.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-container.ts
@@ -84,7 +84,7 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   private _destroyed: boolean;
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
     private _focusTrapFactory: FocusTrapFactory,
     breakpointObserver: BreakpointObserver,

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -162,7 +162,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   @Input() value: string;
 
   /** The native `<input type="checkbox">` element */
-  @ViewChild('input') _inputElement: ElementRef;
+  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
   /** Reference to the ripple instance of the checkbox. */
   @ViewChild(MatRipple) ripple: MatRipple;
@@ -182,7 +182,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   /** Reference to the focused state ripple. */
   private _focusRipple: RippleRef | null;
 
-  constructor(elementRef: ElementRef,
+  constructor(elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,
               private _focusMonitor: FocusMonitor,
               private _ngZone: NgZone,

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -95,7 +95,7 @@ export class MatChipInput implements OnChanges {
   protected _inputElement: HTMLInputElement;
 
   constructor(
-    protected _elementRef: ElementRef,
+    protected _elementRef: ElementRef<HTMLInputElement>,
     @Inject(MAT_CHIPS_DEFAULT_OPTIONS) private _defaultOptions: MatChipsDefaultOptions) {
     this._inputElement = this._elementRef.nativeElement as HTMLInputElement;
   }

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -326,7 +326,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   /** The chip components contained within this chip list. */
   @ContentChildren(MatChip) chips: QueryList<MatChip>;
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,
               @Optional() private _dir: Directionality,
               @Optional() _parentForm: NgForm,
@@ -424,7 +424,6 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   // Implemented as part of ControlValueAccessor.
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
-    this._elementRef.nativeElement.disabled = isDisabled;
     this.stateChanges.next();
   }
 

--- a/src/lib/core/common-behaviors/color.spec.ts
+++ b/src/lib/core/common-behaviors/color.spec.ts
@@ -73,5 +73,5 @@ class TestClass {
   testElement: HTMLElement = document.createElement('div');
 
   /** Fake instance of an ElementRef. */
-  _elementRef = new ElementRef(this.testElement);
+  _elementRef = new ElementRef<HTMLElement>(this.testElement);
 }

--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -31,7 +31,7 @@ export class MatLine {}
  * @docs-private
  */
 export class MatLineSetter {
-  constructor(private _lines: QueryList<MatLine>, private _element: ElementRef) {
+  constructor(private _lines: QueryList<MatLine>, private _element: ElementRef<HTMLElement>) {
     this._setLineClass(this._lines.length);
 
     this._lines.changes.subscribe(() => {

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -118,7 +118,7 @@ export class MatOption implements AfterViewChecked, OnDestroy {
   readonly _stateChanges = new Subject<void>();
 
   constructor(
-    private _element: ElementRef,
+    private _element: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) private _parent: MatOptionParentComponent,
     @Optional() readonly group: MatOptgroup) {}

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -101,7 +101,7 @@ export class RippleRenderer {
 
   constructor(private _target: RippleTarget,
               private _ngZone: NgZone,
-              elementRef: ElementRef,
+              elementRef: ElementRef<HTMLElement>,
               platform: Platform) {
 
     // Only do anything if we're on the browser.

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -135,7 +135,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   /** Whether ripple directive is initialized and the input bindings are set. */
   private _isInitialized: boolean = false;
 
-  constructor(private _elementRef: ElementRef,
+  constructor(private _elementRef: ElementRef<HTMLElement>,
               ngZone: NgZone,
               platform: Platform,
               @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalOptions: RippleGlobalOptions,

--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -82,7 +82,7 @@ export class MatCalendarBody {
   /** Emits when a new value is selected. */
   @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
-  constructor(private _elementRef: ElementRef, private _ngZone: NgZone) { }
+  constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) { }
 
   _cellClicked(cell: MatCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {
@@ -112,7 +112,12 @@ export class MatCalendarBody {
   _focusActiveCell() {
     this._ngZone.runOutsideAngular(() => {
       this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
-        this._elementRef.nativeElement.querySelector('.mat-calendar-body-active').focus();
+        const activeCell: HTMLElement | null =
+            this._elementRef.nativeElement.querySelector('.mat-calendar-body-active');
+
+        if (activeCell) {
+          activeCell.focus();
+        }
       });
     });
   }

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -240,7 +240,7 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   private _lastValueValid = false;
 
   constructor(
-      private _elementRef: ElementRef,
+      private _elementRef: ElementRef<HTMLInputElement>,
       @Optional() public _dateAdapter: DateAdapter<D>,
       @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
       @Optional() private _formField: MatFormField) {

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -93,7 +93,7 @@ export class MatDialogContainer extends BasePortalOutlet {
   _id: string;
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _focusTrapFactory: FocusTrapFactory,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(DOCUMENT) private _document: any,

--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -44,7 +44,7 @@ export class MatDialogClose implements OnInit, OnChanges {
 
   constructor(
     @Optional() public dialogRef: MatDialogRef<any>,
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _dialog: MatDialog) {}
 
   ngOnInit() {
@@ -83,7 +83,7 @@ export class MatDialogTitle implements OnInit {
 
   constructor(
     @Optional() private _dialogRef: MatDialogRef<any>,
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _dialog: MatDialog) {}
 
   ngOnInit() {
@@ -130,7 +130,7 @@ export class MatDialogActions {}
  * @param element Element relative to which to look for a dialog.
  * @param openDialogs References to the currently-open dialogs.
  */
-function getClosestDialog(element: ElementRef, openDialogs: MatDialogRef<any>[]) {
+function getClosestDialog(element: ElementRef<HTMLElement>, openDialogs: MatDialogRef<any>[]) {
   let parent: HTMLElement | null = element.nativeElement.parentElement;
 
   while (parent && !parent.classList.contains('mat-dialog-container')) {

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -230,7 +230,7 @@ export class MatFormField extends _MatFormFieldMixinBase
    */
   @ViewChild('underline') underlineRef: ElementRef;
 
-  @ViewChild('connectionContainer') _connectionContainerRef: ElementRef<HTMLElement>;
+  @ViewChild('connectionContainer') _connectionContainerRef: ElementRef;
   @ViewChild('inputContainer') _inputContainerRef: ElementRef;
   @ViewChild('label') private _label: ElementRef;
   @ContentChild(MatFormFieldControl) _control: MatFormFieldControl<any>;
@@ -471,9 +471,9 @@ export class MatFormField extends _MatFormFieldMixinBase
 
     let startWidth = 0;
     let gapWidth = 0;
-    const startEls = this._connectionContainerRef.nativeElement.querySelectorAll<HTMLElement>(
+    const startEls = this._connectionContainerRef.nativeElement.querySelectorAll(
       '.mat-form-field-outline-start');
-    const gapEls = this._connectionContainerRef.nativeElement.querySelectorAll<HTMLElement>(
+    const gapEls = this._connectionContainerRef.nativeElement.querySelectorAll(
         '.mat-form-field-outline-gap');
     if (this._label && this._label.nativeElement.children.length) {
       const containerStart = this._getStartEnd(

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -64,7 +64,8 @@ export class MatGridList implements OnInit, AfterContentChecked {
   /** Query list of tiles that are being rendered. */
   @ContentChildren(MatGridTile) _tiles: QueryList<MatGridTile>;
 
-  constructor(private _element: ElementRef, @Optional() private _dir: Directionality) {}
+  constructor(private _element: ElementRef<HTMLElement>,
+              @Optional() private _dir: Directionality) {}
 
   /** Amount of columns in the grid list. */
   @Input()

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -36,7 +36,7 @@ export class MatGridTile {
   _rowspan: number = 1;
   _colspan: number = 1;
 
-  constructor(private _element: ElementRef) {}
+  constructor(private _element: ElementRef<HTMLElement>) {}
 
   /** Amount of rows that the grid tile takes up. */
   @Input()
@@ -72,7 +72,7 @@ export class MatGridTileText implements AfterContentInit {
   _lineSetter: MatLineSetter;
   @ContentChildren(MatLine) _lines: QueryList<MatLine>;
 
-  constructor(private _element: ElementRef) {}
+  constructor(private _element: ElementRef<HTMLElement>) {}
 
   ngAfterContentInit() {
     this._lineSetter = new MatLineSetter(this._lines, this._element);

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -110,7 +110,7 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Can
   private _previousFontIconClass: string;
 
   constructor(
-      elementRef: ElementRef,
+      elementRef: ElementRef<HTMLElement>,
       private _iconRegistry: MatIconRegistry,
       @Attribute('aria-hidden') ariaHidden: string) {
     super(elementRef);

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -211,7 +211,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     'week'
   ].filter(t => getSupportedInputTypes().has(t));
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLInputElement>,
               protected _platform: Platform,
               /** @docs-private */
               @Optional() @Self() public ngControl: NgControl,

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -115,7 +115,7 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
   @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
   @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
 
-  constructor(private _element: ElementRef,
+  constructor(private _element: ElementRef<HTMLElement>,
               @Optional() private _navList: MatNavList) {
     super();
     this._isNavList = !!_navList;

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -137,7 +137,7 @@ export class MatListOption extends _MatListOptionMixinBase
     }
   }
 
-  constructor(private _element: ElementRef,
+  constructor(private _element: ElementRef<HTMLElement>,
               private _changeDetector: ChangeDetectorRef,
               /** @docs-private */
               @Inject(forwardRef(() => MatSelectionList)) public selectionList: MatSelectionList) {
@@ -191,7 +191,7 @@ export class MatListOption extends _MatListOptionMixinBase
    * @docs-private
    */
   getLabel() {
-    return this._text ? this._text.nativeElement.textContent : '';
+    return this._text ? (this._text.nativeElement.textContent || '') : '';
   }
 
   /** Whether this list item should show a ripple effect when clicked. */
@@ -329,7 +329,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
   /** View to model callback that should be called if the list or its options lost focus. */
   _onTouched: () => void = () => {};
 
-  constructor(private _element: ElementRef, @Attribute('tabindex') tabIndex: string) {
+  constructor(private _element: ElementRef<HTMLElement>, @Attribute('tabindex') tabIndex: string) {
     super();
     this.tabIndex = parseInt(tabIndex) || 0;
   }

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -229,7 +229,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   @Output() close = this.closed;
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _ngZone: NgZone,
     @Inject(MAT_MENU_DEFAULT_OPTIONS) private _defaultOptions: MatMenuDefaultOptions) { }
 

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -70,7 +70,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   _triggersSubmenu: boolean = false;
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     @Inject(DOCUMENT) document?: any,
     private _focusMonitor?: FocusMonitor,
     @Inject(MAT_MENU_PANEL) @Optional() private _parentMenu?: MatMenuPanel<MatMenuItem>) {

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -130,7 +130,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   @Output() readonly onMenuClose: EventEmitter<void> = this.menuClosed;
 
   constructor(private _overlay: Overlay,
-              private _element: ElementRef,
+              private _element: ElementRef<HTMLElement>,
               private _viewContainerRef: ViewContainerRef,
               @Inject(MAT_MENU_SCROLL_STRATEGY) private _scrollStrategy,
               @Optional() private _parentMenu: MatMenu,

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1716,7 +1716,7 @@ describe('MatMenu default overrides', () => {
 })
 class SimpleMenu {
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
   @ViewChild(MatMenu) menu: MatMenu;
   @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
   extraItems: string[] = [];
@@ -1734,14 +1734,14 @@ class SimpleMenu {
 })
 class PositionedMenu {
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
   xPosition: MenuPositionX = 'before';
   yPosition: MenuPositionY = 'above';
 }
 
 interface TestableMenu {
   trigger: MatMenuTrigger;
-  triggerEl: ElementRef;
+  triggerEl: ElementRef<HTMLElement>;
 }
 @Component({
   template: `
@@ -1754,7 +1754,7 @@ interface TestableMenu {
 class OverlapMenu implements TestableMenu {
   @Input() overlapTrigger: boolean;
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
 }
 
 @Component({
@@ -1843,7 +1843,7 @@ class CustomMenu {
 class NestedMenu {
   @ViewChild('root') rootMenu: MatMenu;
   @ViewChild('rootTrigger') rootTrigger: MatMenuTrigger;
-  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef;
+  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef<HTMLElement>;
   @ViewChild('alternateTrigger') alternateTrigger: MatMenuTrigger;
   readonly rootCloseCallback = jasmine.createSpy('root menu closed callback');
 
@@ -1899,7 +1899,9 @@ class NestedMenuCustomElevation {
   `
 })
 class NestedMenuRepeater {
-  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef;
+  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef<HTMLElement>;
+  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+
   items = ['one', 'two', 'three'];
 }
 
@@ -1943,7 +1945,7 @@ class FakeIcon {}
 })
 class SimpleLazyMenu {
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef;
+  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
   @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 }
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -469,7 +469,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   private _removeUniqueSelectionListener: () => void = () => {};
 
   /** The native `<input type=radio>` element */
-  @ViewChild('input') _inputElement: ElementRef;
+  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
   constructor(@Optional() radioGroup: MatRadioGroup,
               elementRef: ElementRef,

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -785,9 +785,9 @@ class BasicTestApp {
   hasBackdrop: boolean | null = null;
 
   @ViewChild('drawer') drawer: MatDrawer;
-  @ViewChild('drawerButton') drawerButton: ElementRef;
-  @ViewChild('openButton') openButton: ElementRef;
-  @ViewChild('closeButton') closeButton: ElementRef;
+  @ViewChild('drawerButton') drawerButton: ElementRef<HTMLButtonElement>;
+  @ViewChild('openButton') openButton: ElementRef<HTMLButtonElement>;
+  @ViewChild('closeButton') closeButton: ElementRef<HTMLButtonElement>;
 
   open() {
     this.openCount++;

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -221,7 +221,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     return this.opened && this.mode !== 'side';
   }
 
-  constructor(private _elementRef: ElementRef,
+  constructor(private _elementRef: ElementRef<HTMLElement>,
               private _focusTrapFactory: FocusTrapFactory,
               private _focusMonitor: FocusMonitor,
               private _platform: Platform,
@@ -484,7 +484,7 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
   }
 
   constructor(@Optional() private _dir: Directionality,
-              private _element: ElementRef,
+              private _element: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef,
               @Inject(MAT_DRAWER_DEFAULT_AUTOSIZE) defaultAutosize = false,

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -115,10 +115,10 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   private _dragPercentage: number;
 
   /** Reference to the thumb HTMLElement. */
-  @ViewChild('thumbContainer') _thumbEl: ElementRef<HTMLElement>;
+  @ViewChild('thumbContainer') _thumbEl: ElementRef;
 
   /** Reference to the thumb bar HTMLElement. */
-  @ViewChild('toggleBar') _thumbBarEl: ElementRef<HTMLElement>;
+  @ViewChild('toggleBar') _thumbBarEl: ElementRef;
 
   /** Name value will be applied to the input element if present */
   @Input() name: string | null = null;
@@ -172,7 +172,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
   /** Reference to the underlying input element. */
-  @ViewChild('input') _inputElement: ElementRef;
+  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
   constructor(elementRef: ElementRef,
               /**

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -68,7 +68,7 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
 
   constructor(
     private _ngZone: NgZone,
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
     /** The snack bar configuration. */
     public snackBarConfig: MatSnackBarConfig) {

--- a/src/lib/sort/sort.spec.ts
+++ b/src/lib/sort/sort.spec.ts
@@ -474,14 +474,14 @@ class SimpleMatSortApp {
   @ViewChild('overrideStart') overrideStart: MatSortHeader;
   @ViewChild('overrideDisableClear') overrideDisableClear: MatSortHeader;
 
-  constructor (public elementRef: ElementRef) { }
+  constructor (public elementRef: ElementRef<HTMLElement>) { }
 
   sort(id: SimpleMatSortAppColumnIds) {
     this.dispatchMouseEvent(id, 'click');
   }
 
   dispatchMouseEvent(id: SimpleMatSortAppColumnIds, event: string) {
-    const sortElement = this.elementRef.nativeElement.querySelector(`#${id}`);
+    const sortElement = this.elementRef.nativeElement.querySelector(`#${id}`)!;
     dispatchMouseEvent(sortElement, event);
   }
 

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -62,7 +62,7 @@ export class MatStepHeader implements OnDestroy {
   constructor(
     public _intl: MatStepperIntl,
     private _focusMonitor: FocusMonitor,
-    private _element: ElementRef,
+    private _element: ElementRef<HTMLElement>,
     changeDetectorRef: ChangeDetectorRef) {
     _focusMonitor.monitor(_element, true);
     this._intlSubscription = _intl.changes.subscribe(() => changeDetectorRef.markForCheck());

--- a/src/lib/table/cell.ts
+++ b/src/lib/table/cell.ts
@@ -79,7 +79,7 @@ export class MatColumnDef extends CdkColumnDef {
 })
 export class MatHeaderCell extends CdkHeaderCell {
   constructor(columnDef: CdkColumnDef,
-              elementRef: ElementRef) {
+              elementRef: ElementRef<HTMLElement>) {
     super(columnDef, elementRef);
     elementRef.nativeElement.classList.add(`mat-column-${columnDef.cssClassFriendlyName}`);
   }
@@ -111,7 +111,7 @@ export class MatFooterCell extends CdkFooterCell {
 })
 export class MatCell extends CdkCell {
   constructor(columnDef: CdkColumnDef,
-              elementRef: ElementRef) {
+              elementRef: ElementRef<HTMLElement>) {
     super(columnDef, elementRef);
     elementRef.nativeElement.classList.add(`mat-column-${columnDef.cssClassFriendlyName}`);
   }

--- a/src/lib/tabs/ink-bar.ts
+++ b/src/lib/tabs/ink-bar.ts
@@ -50,7 +50,7 @@ export function _MAT_INK_BAR_POSITIONER_FACTORY(): _MatInkBarPositioner {
 })
 export class MatInkBar {
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _ngZone: NgZone,
     @Inject(_MAT_INK_BAR_POSITIONER) private _inkBarPositioner: _MatInkBarPositioner) { }
 

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -153,7 +153,7 @@ export class MatTabBody implements OnInit, OnDestroy {
     this._computePositionAnimationState();
   }
 
-  constructor(private _elementRef: ElementRef,
+  constructor(private _elementRef: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality,
               /**
                * @breaking-change 7.0.0 changeDetectorRef to be made required.

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -434,6 +434,6 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
         this._labelWrappers.toArray()[this.selectedIndex].elementRef.nativeElement :
         null;
 
-    this._inkBar.alignToElement(selectedLabelWrapper);
+    this._inkBar.alignToElement(selectedLabelWrapper!);
   }
 }

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -78,7 +78,7 @@ export class MatTabNav extends _MatTabNavMixinBase
   private readonly _onDestroy = new Subject<void>();
 
   private _activeLinkChanged: boolean;
-  private _activeLinkElement: ElementRef | null;
+  private _activeLinkElement: ElementRef<HTMLElement> | null;
 
   @ViewChild(MatInkBar) _inkBar: MatInkBar;
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -858,7 +858,7 @@ class BasicTooltipDemo {
   showButton: boolean = true;
   showTooltipClass = false;
   @ViewChild(MatTooltip) tooltip: MatTooltip;
-  @ViewChild('button') button: ElementRef;
+  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
 }
 
 @Component({
@@ -917,7 +917,7 @@ class OnPushTooltipDemo {
 class DynamicTooltipsDemo {
   tooltips: Array<string> = [];
 
-  constructor(private _elementRef: ElementRef) {}
+  constructor(private _elementRef: ElementRef<HTMLElement>) {}
 
   getButtons() {
     return this._elementRef.nativeElement.querySelectorAll('button');
@@ -938,8 +938,8 @@ class DynamicTooltipsDemo {
   `,
 })
 class TooltipOnTextFields {
-  @ViewChild('input') input: ElementRef;
-  @ViewChild('textarea') textarea: ElementRef;
+  @ViewChild('input') input: ElementRef<HTMLInputElement>;
+  @ViewChild('textarea') textarea: ElementRef<HTMLTextAreaElement>;
 }
 
 @Component({

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -196,7 +196,7 @@ export class MatTooltip implements OnDestroy {
 
   constructor(
     private _overlay: Overlay,
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _scrollDispatcher: ScrollDispatcher,
     private _viewContainerRef: ViewContainerRef,
     private _ngZone: NgZone,

--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -46,7 +46,7 @@ export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T>
     implements CanDisable, HasTabIndex {
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,
               @Attribute('tabindex') tabIndex: string) {
     super(_elementRef, _tree);
@@ -93,7 +93,7 @@ export class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T>
 
   @ContentChildren(MatTreeNodeOutlet) nodeOutlet: QueryList<MatTreeNodeOutlet>;
 
-  constructor(protected _elementRef: ElementRef,
+  constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,
               protected _differs: IterableDiffers,
               @Attribute('tabindex') tabIndex: string) {

--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -24,7 +24,7 @@ export class ChipsAutocompleteExample {
   fruits: string[] = ['Lemon'];
   allFruits: string[] = ['Apple', 'Lemon', 'Lime', 'Orange', 'Strawberry'];
 
-  @ViewChild('fruitInput') fruitInput: ElementRef;
+  @ViewChild('fruitInput') fruitInput: ElementRef<HTMLInputElement>;
 
   constructor() {
     this.filteredFruits = this.fruitCtrl.valueChanges.pipe(

--- a/src/material-examples/focus-monitor-focus-via/focus-monitor-focus-via-example.ts
+++ b/src/material-examples/focus-monitor-focus-via/focus-monitor-focus-via-example.ts
@@ -16,7 +16,7 @@ import {
   styleUrls: ['focus-monitor-focus-via-example.css']
 })
 export class FocusMonitorFocusViaExample implements OnDestroy, OnInit {
-  @ViewChild('monitored') monitoredEl: ElementRef;
+  @ViewChild('monitored') monitoredEl: ElementRef<HTMLElement>;
 
   origin = this.formatOrigin(null);
 

--- a/src/material-examples/focus-monitor-overview/focus-monitor-overview-example.ts
+++ b/src/material-examples/focus-monitor-overview/focus-monitor-overview-example.ts
@@ -16,8 +16,8 @@ import {
   styleUrls: ['focus-monitor-overview-example.css']
 })
 export class FocusMonitorOverviewExample implements OnDestroy, OnInit {
-  @ViewChild('element') element: ElementRef;
-  @ViewChild('subtree') subtree: ElementRef;
+  @ViewChild('element') element: ElementRef<HTMLElement>;
+  @ViewChild('subtree') subtree: ElementRef<HTMLElement>;
 
   elementOrigin = this.formatOrigin(null);
   subtreeOrigin = this.formatOrigin(null);

--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
@@ -81,7 +81,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
     this.stateChanges.next();
   }
 
-  constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef) {
+  constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef<HTMLElement>) {
     this.parts = fb.group({
       area: '',
       exchange: '',
@@ -105,7 +105,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
 
   onContainerClick(event: MouseEvent) {
     if ((event.target as Element).tagName.toLowerCase() != 'input') {
-      this.elRef.nativeElement.querySelector('input').focus();
+      this.elRef.nativeElement.querySelector('input')!.focus();
     }
   }
 }

--- a/src/material-examples/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
+++ b/src/material-examples/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
@@ -8,8 +8,8 @@ import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core
   styleUrls: ['./text-field-autofill-monitor-example.css'],
 })
 export class TextFieldAutofillMonitorExample implements OnDestroy, OnInit {
-  @ViewChild('first', {read: ElementRef}) firstName: ElementRef;
-  @ViewChild('last', {read: ElementRef}) lastName: ElementRef;
+  @ViewChild('first', {read: ElementRef}) firstName: ElementRef<HTMLElement>;
+  @ViewChild('last', {read: ElementRef}) lastName: ElementRef<HTMLElement>;
   firstNameAutofilled: boolean;
   lastNameAutofilled: boolean;
 


### PR DESCRIPTION
Currently the `nativeElement` in all of the `ElementRef` usages is typed to be `any`. These changes add proper typing to help us catch some errors at compile time.

**Note:** this could technically cause compilation errors, however most of these `ElementRef` usages are internal. We can judge based on the presubmit whether to make the changes a bit more conservative.