### PR TITLE
fix(menu): svg icons not aligned inside menu item

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -47,6 +47,10 @@ $mat-menu-icon-margin: 16px !default;
     margin-right: $mat-menu-icon-margin;
     vertical-align: middle;
 
+    svg {
+      vertical-align: top;
+    }
+
     [dir='rtl'] & {
       margin-left: $mat-menu-icon-margin;
       margin-right: 0;


### PR DESCRIPTION
Fixes SVG icons placed inside a `mat-menu-item` not being aligned vertically.

Fixes #10832.