### PR TITLE
Export ConnectedPosition as part of public API

### DIFF
--- a/src/cdk/overlay/public-api.ts
+++ b/src/cdk/overlay/public-api.ts
@@ -24,5 +24,5 @@ export {OverlayPositionBuilder} from './position/overlay-position-builder';
 export {PositionStrategy} from './position/position-strategy';
 export {GlobalPositionStrategy} from './position/global-position-strategy';
 export {ConnectedPositionStrategy} from './position/connected-position-strategy';
-export {FlexibleConnectedPositionStrategy} from './position/flexible-connected-position-strategy';
+export {ConnectedPosition, FlexibleConnectedPositionStrategy} from './position/flexible-connected-position-strategy';
 export {VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';


### PR DESCRIPTION
chore(overlay): export ConnectedPosition interface

it is used as part of FlexibleConnectedPositionStrategy but not currently exported to be used as a type