### PR TITLE
fix(schematics): make v6 migration work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="6.0.0-rc.11"></a>
+# [6.0.0-rc.11](https://github.com/angular/material2/compare/6.0.0-rc.5...6.0.0-rc.11) (2018-04-13)
+
+
+### Bug Fixes
+
+* **schematics:** Fix a number of issues with ng-update schematic for v5 -> v6 migration
+
+
+
 <a name="6.0.0-rc.5"></a>
 # [6.0.0-rc.5](https://github.com/angular/material2/compare/6.0.0-rc.4...6.0.0-rc.5) (2018-04-13)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs": "gulp docs",
     "api": "gulp api-docs"
   },
-  "version": "6.0.0-rc.5",
+  "version": "6.0.0-rc.11",
   "license": "MIT",
   "engines": {
     "node": ">= 5.4.1"

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -29,5 +29,12 @@
   "dependencies": {
     "tslib": "^1.7.1"
   },
+  "ng-update": {
+    "packageGroup": [
+      "@angular/material",
+      "@angular/cdk",
+      "@angular/material-moment-adapter"
+    ]
+  },
   "sideEffects": false
 }

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -31,7 +31,7 @@
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {
-    "migrations": "schematics/migration.json",
+    "migrations": "./schematics/migration.json",
     "packageGroup": [
       "@angular/material",
       "@angular/cdk",

--- a/src/lib/schematics/BUILD.bazel
+++ b/src/lib/schematics/BUILD.bazel
@@ -16,6 +16,6 @@ npm_package(
   name = "npm_package",
   srcs = [
     ":collection.json",
-  ] + glob(["**/files/**/*", "**/data/**/*", "**/schema.json"]),
+  ] + glob(["**/files/**/*", "**/data/**/*", "**/schema.json", "**/migration.json"]),
   deps = [":schematics"],
 )

--- a/src/lib/schematics/collection.json
+++ b/src/lib/schematics/collection.json
@@ -10,22 +10,6 @@
       "aliases": ["material-shell"]
     },
 
-    // Group of schematics used to update Angular CDK and Angular Material.
-    "ng-update": {
-      "description": "Updates API usage for the most recent major version of Angular CDK and Angular Material",
-      "factory": "./update/update"
-    },
-    "ng-post-update": {
-      "description": "Performs cleanup after ng-update.",
-      "factory": "./update/update#postUpdate",
-      "private": true
-    },
-    "ng-post-post-update": {
-      "description": "Logs completion message for ng-update after ng-post-update.",
-      "factory": "./update/update#postPostUpdate",
-      "private": true
-    },
-
     // Create a dashboard component
     "materialDashboard": {
       "description": "Create a card-based dashboard component",

--- a/src/lib/schematics/migration.json
+++ b/src/lib/schematics/migration.json
@@ -4,7 +4,18 @@
     // Update from v5 to v6
     "migration-01": {
       "version": "6",
+      "description": "Updates Angular Material from v5 to v6",
       "factory": "./update/update"
+    },
+    "ng-post-update": {
+      "description": "Performs cleanup after ng-update.",
+      "factory": "./update/update#postUpdate",
+      "private": true
+    },
+    "ng-post-post-update": {
+      "description": "Logs completion message for ng-update after ng-post-update.",
+      "factory": "./update/update#postPostUpdate",
+      "private": true
     }
   }
 }

--- a/src/lib/schematics/update/update.ts
+++ b/src/lib/schematics/update/update.ts
@@ -59,7 +59,7 @@ export default function(): Rule {
     }, {
       silent: false,
       ignoreErrors: true,
-      tsConfigPath: './tsconfig.json',
+      tsConfigPath: './src/tsconfig.json',
     }), [downgradeTask]);
 
     // Upgrade @angular/material back to 6.x.

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -22,5 +22,12 @@
   },
   "dependencies": {
     "tslib": "^1.7.1"
+  },
+  "ng-update": {
+    "packageGroup": [
+      "@angular/material",
+      "@angular/cdk",
+      "@angular/material-moment-adapter"
+    ]
   }
 }

--- a/tools/gulp/tasks/material-release.ts
+++ b/tools/gulp/tasks/material-release.ts
@@ -32,7 +32,7 @@ const allScssGlob = join(buildConfig.packagesDir, '**/*.scss');
 const schematicsGlobs = [
   // File templates and schemas are copied as-is from source.
   join(schematicsDir, '**/+(data|files)/**/*'),
-  join(schematicsDir, '**/+(schema|collection).json'),
+  join(schematicsDir, '**/+(schema|collection|migration).json'),
 
   // JavaScript files compiled from the TypeScript sources.
   join(distDir, 'schematics', '**/*.js?(.map)'),


### PR DESCRIPTION
This includes:
* Adding missing schema json to package
* Add missing packageGroup entries to material, cdk, and moment-adapter
* Move schematics for migration to the migrate-specific schema
* Bump version to 6.0.0-rc.11