### PR TITLE
fix(chips): unable to bind to chip input placeholder

### DIFF
--- a/src/lib/chips/chip-input.spec.ts
+++ b/src/lib/chips/chip-input.spec.ts
@@ -16,7 +16,6 @@ describe('MatChipInput', () => {
   let inputDebugElement: DebugElement;
   let inputNativeElement: HTMLElement;
   let chipInputDirective: MatChipInput;
-
   let dir = 'ltr';
 
   beforeEach(async(() => {
@@ -55,6 +54,15 @@ describe('MatChipInput', () => {
 
     it('should have a default id', () => {
       expect(inputNativeElement.getAttribute('id')).toBeTruthy();
+    });
+
+    it('should allow binding to the `placeholder` input', () => {
+      expect(inputNativeElement.hasAttribute('placeholder')).toBe(false);
+
+      testChipInput.placeholder = 'bound placeholder';
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('placeholder')).toBe('bound placeholder');
     });
   });
 
@@ -142,11 +150,13 @@ describe('MatChipInput', () => {
     </mat-chip-list>
     <input matInput [matChipInputFor]="chipList"
               [matChipInputAddOnBlur]="addOnBlur"
-              (matChipInputTokenEnd)="add($event)" />
+              (matChipInputTokenEnd)="add($event)"
+              [placeholder]="placeholder" />
   `
 })
 class TestChipInput {
   addOnBlur: boolean = false;
+  placeholder = '';
 
   add(_: MatChipInputEvent) {
   }

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -38,6 +38,7 @@ let nextUniqueId = 0;
     '(focus)': '_focus()',
     '(input)': '_onInput()',
     '[id]': 'id',
+    '[attr.placeholder]': 'placeholder || null',
   }
 })
 export class MatChipInput {
@@ -75,7 +76,11 @@ export class MatChipInput {
   @Output('matChipInputTokenEnd')
   chipEnd: EventEmitter<MatChipInputEvent> = new EventEmitter<MatChipInputEvent>();
 
-  /** The input's placeholder text. */
+  /**
+   * The input's placeholder text.
+   * @deprecated Bind to the `placeholder` attribute directly.
+   * @deletion-target 7.0.0
+   */
   @Input() placeholder: string = '';
 
   /** Unique id for the input. */


### PR DESCRIPTION
Fixes the value that is bound to the `placeholder` input not being assigned to the `placeholder` attribute.

Fixes #10848.