### PR TITLE
fix(accordion): complete accordion item emitters on destroy

### DIFF
--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -132,6 +132,45 @@ describe('CdkAccordionItem', () => {
         expect(item.destroyed.emit).toHaveBeenCalled();
       });
     });
+
+    it('should emit to and complete the `destroyed` stream on destroy', () => {
+      const emitSpy = jasmine.createSpy('emit spy');
+      const completeSpy = jasmine.createSpy('complete spy');
+      const subscription = item.destroyed.subscribe(emitSpy, undefined, completeSpy);
+
+      fixture.detectChanges();
+      fixture.destroy();
+
+      expect(emitSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
+
+    it('should complete the `opened` stream on destroy', () => {
+      const completeSpy = jasmine.createSpy('complete spy');
+      const subscription = item.opened.subscribe(() => {}, undefined, completeSpy);
+
+      fixture.detectChanges();
+      fixture.destroy();
+
+      expect(completeSpy).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
+
+    it('should complete the `closed` stream on destroy', () => {
+      const completeSpy = jasmine.createSpy('complete spy');
+      const subscription = item.closed.subscribe(() => {}, undefined, completeSpy);
+
+      fixture.detectChanges();
+      fixture.destroy();
+
+      expect(completeSpy).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    });
+
   });
 
   describe('items without accordion', () => {

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -109,7 +109,10 @@ export class CdkAccordionItem implements OnDestroy {
 
   /** Emits an event for the accordion item being destroyed. */
   ngOnDestroy() {
+    this.opened.complete();
+    this.closed.complete();
     this.destroyed.emit();
+    this.destroyed.complete();
     this._removeUniqueSelectionListener();
     this._openCloseAllSubscription.unsubscribe();
   }


### PR DESCRIPTION
The `CdkAccordionItem` currently has a handful of event emitters that are being subscribed to internally, but are never being completed and their subscriptions are never dropped. These changes complete the emitters in order to avoid hanging subscriptions.