### PR TITLE
fix(select): don't emit change event multiple times when a reset option is selected twice in a row

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2840,6 +2840,40 @@ describe('MatSelect', () => {
       expect(spy).toHaveBeenCalledWith('steak-0');
     }));
 
+    it('should not emit the change event multiple times when a reset option is ' +
+      'selected twice in a row', fakeAsync(() => {
+        const fixture = TestBed.createComponent(BasicSelectWithoutForms);
+        const instance = fixture.componentInstance;
+        const spy = jasmine.createSpy('change spy');
+
+        instance.foods[0].value = null;
+        fixture.detectChanges();
+
+        const subscription = instance.select.selectionChange.subscribe(spy);
+
+        fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+        fixture.detectChanges();
+        flush();
+
+        (overlayContainerElement.querySelector('mat-option') as HTMLElement).click();
+        fixture.detectChanges();
+        flush();
+
+        expect(spy).not.toHaveBeenCalled();
+
+        fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+        fixture.detectChanges();
+        flush();
+
+        (overlayContainerElement.querySelector('mat-option') as HTMLElement).click();
+        fixture.detectChanges();
+        flush();
+
+        expect(spy).not.toHaveBeenCalled();
+
+        subscription.unsubscribe();
+      }));
+
   });
 
   describe('with option centering disabled', () => {

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -897,11 +897,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   private _onSelect(option: MatOption, isUserInput: boolean): void {
     const wasSelected = this._selectionModel.isSelected(option);
 
-    if (option.value == null && !this._multiple) {
-      option.deselect();
-      this._selectionModel.clear();
-      this._propagateChanges(option.value);
-    } else {
+    if (option.value != null || this._multiple) {
       option.selected ? this._selectionModel.select(option) : this._selectionModel.deselect(option);
 
       if (isUserInput) {
@@ -919,6 +915,10 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
           this.focus();
         }
       }
+    } else if (option.value == null && this.value != option.value) {
+      option.deselect();
+      this._selectionModel.clear();
+      this._propagateChanges(option.value);
     }
 
     if (wasSelected !== this._selectionModel.isSelected(option)) {


### PR DESCRIPTION
Fixes the select's change events being fired when a reset option is selected twice in a row.

Fixes #10675.