### PR TITLE
chore: remove class re-export workaround

### DIFF
--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -33,9 +33,6 @@ import {takeUntil} from 'rxjs/operators';
 import {matStepperAnimations} from './stepper-animations';
 import {MatStepperIcon, MatStepperIconContext} from './stepper-icon';
 
-/** Workaround for https://github.com/angular/angular/issues/17849 */
-export const _MatStep = CdkStep;
-export const _MatStepper = CdkStepper;
 
 @Component({
   moduleId: module.id,


### PR DESCRIPTION
This removes a leftover from #8641. That PR removed all workarounds, however #7482 accidentally added it again for `Stepper`.