### PR TITLE
refactor: remove usages of deprecated rxjs apis

### DIFF
--- a/src/cdk/layout/breakpoints-observer.ts
+++ b/src/cdk/layout/breakpoints-observer.ts
@@ -59,11 +59,11 @@ export class BreakpointObserver implements OnDestroy {
     const queries = splitQueries(coerceArray(value));
     const observables = queries.map(query => this._registerQuery(query).observable);
 
-    return combineLatest(observables, (a: BreakpointState, b: BreakpointState) => {
+    return combineLatest(observables).pipe(map((breakpointStates: BreakpointState[]) => {
       return {
-        matches: !!((a && a.matches) || (b && b.matches)),
+        matches: breakpointStates.some(state => state && state.matches)
       };
-    });
+    }));
   }
 
   /** Registers a specific query to be listened for. */

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
     ":table",
     "//src/cdk/collections",
     "@rxjs",
+    "@rxjs//operators"
   ],
   tsconfig = "//src/cdk:tsconfig-build.json",
 )

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -11,6 +11,7 @@ import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing
 import {CdkTable} from './table';
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {combineLatest, BehaviorSubject, Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 import {CdkTableModule} from './index';
 import {
   getTableDuplicateColumnNameError,
@@ -832,7 +833,7 @@ class FakeDataSource extends DataSource<TestData> {
   connect(collectionViewer: CollectionViewer) {
     this.isConnected = true;
     const streams = [this._dataChange, collectionViewer.viewChange];
-    return combineLatest(streams, (data, _) => data);
+    return combineLatest<TestData[]>(streams).pipe(map(data => data[0]));
   }
 
   disconnect() {

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -9,7 +9,7 @@
 import {supportsPassiveEventListeners} from '@angular/cdk/platform';
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
-import {empty as observableEmpty} from 'rxjs';
+import {EMPTY} from 'rxjs';
 import {AutofillEvent, AutofillMonitor} from './autofill';
 import {TextFieldModule} from './text-field-module';
 
@@ -166,7 +166,7 @@ describe('cdkAutofill', () => {
 
   beforeEach(inject([AutofillMonitor], (afm: AutofillMonitor) => {
     autofillMonitor = afm;
-    spyOn(autofillMonitor, 'monitor').and.returnValue(observableEmpty());
+    spyOn(autofillMonitor, 'monitor').and.returnValue(EMPTY);
     spyOn(autofillMonitor, 'stopMonitoring');
     fixture = TestBed.createComponent(InputWithCdkAutofilled);
     testComponent = fixture.componentInstance;

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -17,7 +17,7 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import {empty, Observable, Subject} from 'rxjs';
+import {EMPTY, Observable, Subject} from 'rxjs';
 
 
 /** An event that is emitted when the autofill state of an input changes. */
@@ -58,7 +58,7 @@ export class AutofillMonitor implements OnDestroy {
    */
   monitor(element: Element): Observable<AutofillEvent> {
     if (!this._platform.isBrowser) {
-      return empty();
+      return EMPTY;
     }
 
     const info = this._monitoredElements.get(element);

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -10,7 +10,7 @@ import {_isNumberValue} from '@angular/cdk/coercion';
 import {DataSource} from '@angular/cdk/table';
 import {MatPaginator, PageEvent} from '@angular/material/paginator';
 import {MatSort, Sort} from '@angular/material/sort';
-import {BehaviorSubject, combineLatest, empty, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, combineLatest, EMPTY, Observable, Subscription} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
 
 
@@ -175,8 +175,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
   _updateChangeSubscription() {
     // Sorting and/or pagination should be watched if MatSort and/or MatPaginator are provided.
     // Otherwise, use an empty observable stream to take their place.
-    const sortChange: Observable<Sort> = this._sort ? this._sort.sortChange : empty();
-    const pageChange: Observable<PageEvent> = this._paginator ? this._paginator.page : empty();
+    const sortChange: Observable<Sort> = this._sort ? this._sort.sortChange : EMPTY;
+    const pageChange: Observable<PageEvent> = this._paginator ? this._paginator.page : EMPTY;
 
     if (this._renderChangesSubscription) {
       this._renderChangesSubscription.unsubscribe();


### PR DESCRIPTION
Removes the following APIs that are deprecated as of RxJS 6.0:

* Replaces usages of `empty()` with `EMPTY`.
* Replaces uses of the `resultSelector` parameter of `combineLatest` with calls to `map`.