### PR TITLE
fix(select,autocomplete): mat-option theme not being applied correctly when nested inside a selector

### DIFF
--- a/src/lib/core/option/_option-theme.scss
+++ b/src/lib/core/option/_option-theme.scss
@@ -17,18 +17,6 @@
       background: mat-color($background, hover);
     }
 
-    .mat-primary &.mat-selected:not(.mat-option-disabled) {
-      color: mat-color($primary);
-    }
-
-    .mat-accent &.mat-selected:not(.mat-option-disabled) {
-      color: mat-color($accent);
-    }
-
-    .mat-warn &.mat-selected:not(.mat-option-disabled) {
-      color: mat-color($warn);
-    }
-
     // In multiple mode there is a checkbox to show that the option is selected.
     &.mat-selected:not(.mat-option-multiple):not(.mat-option-disabled) {
       background: mat-color($background, hover);
@@ -42,6 +30,18 @@
     &.mat-option-disabled {
       color: mat-color($foreground, hint-text);
     }
+  }
+
+  .mat-primary .mat-option.mat-selected:not(.mat-option-disabled) {
+    color: mat-color($primary);
+  }
+
+  .mat-accent .mat-option.mat-selected:not(.mat-option-disabled) {
+    color: mat-color($accent);
+  }
+
+  .mat-warn .mat-option.mat-selected:not(.mat-option-disabled) {
+    color: mat-color($warn);
   }
 }
 


### PR DESCRIPTION
Fixes the theme for the individual `mat-option` instances producing the wrong selector when it's nested inside a selector, e.g.

```scss
.dark-theme {
  @include angular-material-theme($dark-theme);
}
```

For reference:
<img width="578" alt="screenshot at apr 16 14-12-48" src="https://user-images.githubusercontent.com/4450522/38858298-5e5a9b04-41f9-11e8-9ec5-e35406930d21.png">
