### PR TITLE
fix(tabs): handle long tab labels in mat-tab-nav-bar

### DIFF
--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -14,10 +14,15 @@
 // Wraps each link in the header
 .mat-tab-link {
   @include tab-label;
-  vertical-align: top;
+  line-height: $mat-tab-bar-height;
   text-decoration: none;  // Removes anchor underline styling
   position: relative;
   overflow: hidden;  // Keeps the ripple from extending outside the element bounds
+
+  // Allows for the ellipsis overflow to work. We truncate the
+  // text since we don't support pagination on nav bars.
+  display: block;
+  text-overflow: ellipsis;
 
   [mat-stretch-tabs] & {
     flex-basis: 0;


### PR DESCRIPTION
Fixes the `mat-tab-link` not handling long text strings.