### PR TITLE
(WIP) => fix(date-picker): Updates avalible years to be dynamic to min and max

### DIFF
--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -132,7 +132,20 @@ export class MatMultiYearView<D> implements AfterContentInit {
   _init() {
     this._todayYear = this._dateAdapter.getYear(this._dateAdapter.today());
     let activeYear = this._dateAdapter.getYear(this._activeDate);
+
+    // Default Behavior for Offset
     let activeOffset = activeYear % yearsPerPage;
+
+    if (!this._maxDate && this._minDate) {
+      activeOffset = 0;
+    }
+
+    if (this._maxDate) {
+      const yearOffset = activeYear - this._dateAdapter.getYear(this._maxDate);
+      const currentYearOffsetFromEnd = (yearOffset - Math.floor(yearOffset)) * yearsPerPage;
+      activeOffset = this._minDate ? 0 : currentYearOffsetFromEnd;
+    }
+
     this._years = [];
     for (let i = 0, row: number[] = []; i < yearsPerPage; i++) {
       row.push(activeYear - activeOffset + i);

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -141,9 +141,15 @@ export class MatMultiYearView<D> implements AfterContentInit {
     }
 
     if (this._maxDate) {
-      const yearOffset = activeYear - this._dateAdapter.getYear(this._maxDate);
-      const currentYearOffsetFromEnd = (yearOffset - Math.floor(yearOffset)) * yearsPerPage;
-      activeOffset = this._minDate ? 0 : currentYearOffsetFromEnd;
+      const maxYear = this._dateAdapter.getYear(this._maxDate);
+
+        const yearOffset = (maxYear - activeYear) / yearsPerPage;
+        const currentYearOffsetFromEnd = (yearOffset - Math.floor(yearOffset)) * yearsPerPage;
+        const currentYearOffsetFromStart = yearsPerPage - 1 - currentYearOffsetFromEnd;
+
+        activeOffset = this._minDate
+          ? currentYearOffsetFromStart
+          : (24 % currentYearOffsetFromEnd) - 1;
     }
 
     this._years = [];


### PR DESCRIPTION
This fixes #10646.

This removes the years which were originally greyed out. Brings in 4 edge cases:
1. No min / max: Standard Behavior
2. Only min: offset to 0 (display min year as first)
3. Only max: Display all paged years minus 1.
4. Both min and max: Same as 3.