### PR TITLE
fix(icon): log full error message when icon set fails to load

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {
   Inject,
   Injectable,
@@ -353,12 +353,12 @@ export class MatIconRegistry {
       .filter(iconSetConfig => !iconSetConfig.svgElement)
       .map(iconSetConfig => {
         return this._loadSvgIconSetFromConfig(iconSetConfig).pipe(
-          catchError((err: any): Observable<SVGElement | null> => {
-            let url = this._sanitizer.sanitize(SecurityContext.RESOURCE_URL, iconSetConfig.url);
+          catchError((err: HttpErrorResponse): Observable<SVGElement | null> => {
+            const url = this._sanitizer.sanitize(SecurityContext.RESOURCE_URL, iconSetConfig.url);
 
-            // Swallow errors fetching individual URLs so the combined Observable won't
-            // necessarily fail.
-            console.log(`Loading icon set URL: ${url} failed: ${err}`);
+            // Swallow errors fetching individual URLs so the
+            // combined Observable won't necessarily fail.
+            console.error(`Loading icon set URL: ${url} failed: ${err.message}`);
             return observableOf(null);
           })
         );

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -428,9 +428,9 @@ describe('MatIcon', () => {
     }));
 
     it('should throw an error when using untrusted HTML', () => {
-      // Stub out console.warn so we don't pollute our logs with Angular's warnings.
+      // Stub out console.error so we don't pollute our logs with Angular's warnings.
       // Jasmine will tear the spy down at the end of the test.
-      spyOn(console, 'warn');
+      spyOn(console, 'error');
 
       expect(() => {
         iconRegistry.addSvgIconLiteral('circle', '<svg><circle></svg>');


### PR DESCRIPTION
Currently when an icon request fails, we log something along the lines of `"Loading icon set URL: {{url}} failed: [object Object]"`. These changes switch to logging out the error message rather than the entire object.