### PR TITLE
fix(tree): remove invalid aria attribute

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -46,7 +46,7 @@ import {
   exportAs: 'cdkTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'level',
+    '[attr.aria-level]': 'role === "treeitem" ? level : null',
     '[attr.role]': 'role',
     'class': 'cdk-tree-node',
   },

--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -37,7 +37,7 @@ export const _MatNestedTreeNodeMixinBase = mixinTabIndex(mixinDisabled(CdkNested
   inputs: ['disabled', 'tabIndex'],
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'level',
+    '[attr.aria-level]': 'role === "treeitem" ? level : null',
     '[attr.role]': 'role',
     'class': 'mat-tree-node'
   },


### PR DESCRIPTION
Currently we always add an `aria-level` to the tree nodes, however the attribute is only [valid when the node has a role of `treeitem`](https://www.w3.org/TR/wai-aria-1.1/#aria-level). This was being caught by aXe as well. With the following changes the `aria-level` will only be added if the node is a `treeitem`.