### PR TITLE
refactor(tabs): expose _activeLinkChanged and _activeLinkElement as protected properties

### DIFF
--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -124,6 +124,7 @@ export class MatTabNav extends _MatTabNavMixinBase implements AfterContentInit, 
    */
   updateActiveLink(element: ElementRef) {
     // Note: keeping the `element` for backwards-compat, but isn't being used for anything.
+    // @deletion-target 7.0.0
     this._activeLinkChanged = !!element;
     this._changeDetectorRef.markForCheck();
   }
@@ -200,10 +201,10 @@ export class MatTabLink extends _MatTabLinkMixinBase
     implements OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget {
 
   /** Whether the tab link is active or not. */
-  private _isActive: boolean = false;
+  protected _isActive: boolean = false;
 
   /** Reference to the RippleRenderer for the tab-link. */
-  private _tabLinkRipple: RippleRenderer;
+  protected _tabLinkRipple: RippleRenderer;
 
   /** Whether the link is active. */
   @Input()


### PR DESCRIPTION
In #9701 we made the `_activeLinkChanged` and `_activeLinkElement` properties private which makes them inaccessible when extending. These changes switch them to be protected.

Fixes #10939.