### PR TITLE
refactor(slide-toggle): remove SlideToggleRenderer

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -1,6 +1,6 @@
 <label class="mat-slide-toggle-label" #label>
 
-  <div class="mat-slide-toggle-bar"
+  <div #toggleBar class="mat-slide-toggle-bar"
        [class.mat-slide-toggle-bar-no-side-margin]="!labelContent.textContent || !labelContent.textContent.trim()">
 
     <input #input class="mat-slide-toggle-input cdk-visually-hidden" type="checkbox"
@@ -16,6 +16,7 @@
            (click)="_onInputClick($event)">
 
     <div class="mat-slide-toggle-thumb-container"
+         #thumbContainer
          (slidestart)="_onDragStart()"
          (slide)="_onDrag($event)"
          (slideend)="_onDragEnd()">


### PR DESCRIPTION
Removes the `SlideToggleRenderer` class and moves all of its logic into the `MatSlideToggle`. After the switch to Domino, it no longer makes sense to keep all of the DOM manipulation separately. Furthermore, this ends up being less code and makes everything easier to follow.