### PR TITLE
refactor(layout): use single style tag for dynamically-created media queries

### DIFF
--- a/src/cdk/layout/media-matcher.spec.ts
+++ b/src/cdk/layout/media-matcher.spec.ts
@@ -28,16 +28,24 @@ describe('MediaMatcher', () => {
     expect(mediaMatcher.matchMedia('(max-width: 1px)').matches).toBeFalsy();
   });
 
-  it('adds css rules for provided queries when the platform is webkit, otherwise adds nothing.',
+  it('should add CSS rules for provided queries when the platform is webkit',
     inject([Platform], (platform: Platform) => {
-      let randomWidth = Math.random();
-      expect(document.head.textContent).not.toContain(randomWidth);
+      const randomWidth = `${Math.random()}px`;
+
+      expect(getStyleTagByString(randomWidth)).toBeFalsy();
       mediaMatcher.matchMedia(`(width: ${randomWidth})`);
 
       if (platform.WEBKIT) {
-        expect(document.head.textContent).toContain(randomWidth);
+        expect(getStyleTagByString(randomWidth)).toBeTruthy();
       } else {
-        expect(document.head.textContent).not.toContain(randomWidth);
+        expect(getStyleTagByString(randomWidth)).toBeFalsy();
+      }
+
+      function getStyleTagByString(str: string): HTMLStyleElement | undefined {
+        return Array.from(document.head.querySelectorAll('style')).find(tag => {
+          const rules = tag.sheet ? Array.from((tag.sheet as CSSStyleSheet).cssRules) : [];
+          return !!rules.find(rule => rule.cssText.includes(str));
+        });
       }
   }));
 });


### PR DESCRIPTION
Switches to using a single `style` tag for managing all of the dynamically-created media queries in the `MediaMatcher`. This has the advantage of having less DOM elements to manage, making it easier to clean up if necessary, as well as having to touch the DOM less in general.