### PR TITLE
fix(slider): truncate long decimal values

### DIFF
--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -480,6 +480,16 @@ describe('MatSlider', () => {
 
       expect(sliderDebugElement.componentInstance.displayValue).toBe(100);
     });
+
+    it('should truncate long decimal values when using a decimal step', () => {
+      fixture.componentInstance.step = 0.1;
+      fixture.detectChanges();
+
+      dispatchSlideEventSequence(sliderNativeElement, 0, 0.333333, gestureConfig);
+
+      expect(sliderInstance.value).toBe(33.3);
+    });
+
   });
 
   describe('slider with auto ticks', () => {


### PR DESCRIPTION
When a slider has a decimal step, we can end up with a value being assigned to the model that looks like 33.300000000000004. These changes ensure that the value is rounded to the same amount of decimals as the step.

Fixes #10951.