### PR TITLE
fix(datepicker): calendar stateChanges not being completed

### DIFF
--- a/src/lib/datepicker/calendar.spec.ts
+++ b/src/lib/datepicker/calendar.spec.ts
@@ -120,6 +120,16 @@ describe('MatCalendar', () => {
       expect(invalidButtons.length).toBe(0);
     });
 
+    it('should complete the stateChanges stream', () => {
+      const spy = jasmine.createSpy('complete spy');
+      const subscription = calendarInstance.stateChanges.subscribe(undefined, undefined, spy);
+
+      fixture.destroy();
+
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    });
+
     describe('a11y', () => {
       describe('calendar body', () => {
         let calendarBodyEl: HTMLElement;


### PR DESCRIPTION
* Fixes the `stateChanges` stream on the calendar not being completed.
* Switches the `stateChanges` to a Subject in order to get rid of the getter which produces a fair bit of ES5 code.
* Removes the `_destroyed` stream on the calendar header since it isn't necessary anymore.