### PR TITLE
feat(table): enable multiple data rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4489,7 +4489,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -13291,7 +13291,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
   module_name = "@angular/cdk/table",
   deps = [
     "//src/cdk/collections",
+    "//src/cdk/coercion",
     "@rxjs",
   ],
   tsconfig = "//src/cdk:tsconfig-build.json",

--- a/src/cdk/table/render-rows.md
+++ b/src/cdk/table/render-rows.md
@@ -1,0 +1,51 @@
+# Rendering Data Rows
+
+The table's primary responsibility is to render rows of cells. The types of rows that may be rendered are header,
+footer, and data rows. This document focuses on how the table tries to efficienctly render the data rows.
+
+## Background
+
+Each table's template is defined as a set of row and column templates. The row template defines the template that should
+be rendered for a header, footer, or data row. The column templates include the cell templates that will be inserted
+into each rendered row.
+
+Each data object may be rendered with one or more row templates. When new data in provided to the table, the table
+determines which rows need to be rendered. In order to be efficient, the table attempts to understand how the new list
+of rendered rows differs from the previous list of rendered rows so that it can re-use the current list of rendered rows
+if possible.
+
+## Rendering
+
+Each time data is provided, the table needs to create the list of rows that will be rendered and keep track of which
+data object will be provided as context for each row. For each item in the list, this pair is combined into an object
+that uses the `RenderRow` interface. The interface also helps keep track of the data object's index in the provided
+data array input.
+
+```ts
+export interface RenderRow<T> {
+  data: T;
+  dataIndex: number;
+  rowDef: CdkRowDef<T>;
+}
+```
+
+When possible, `RenderRow` objects are re-used from the previous rendering. That is, if a particular data object and row
+template pairing was previously rendered, it should be used for the new list as well. This makes sure that the
+differ can use check-by-reference logic to find the changes between two lists. Note that if a `RenderRow` object is
+reused, it should be updated with the correct data index, in case it has moved since last used.
+
+Once the list of `RenderRow` objects has been created, it should be compared to the previous list of `RenderRow`
+objects to find the difference in terms of inserts/deletions/moves. This is trivially done using the `IterableDiffer`
+logic provided by Angular Core.
+
+Finally, the table uses the list of operations and manipulates the rows through add/remove/move operations.
+
+## Caching `RenderRow` objects
+
+Each `RenderRow` should be cached such that it is a constant-time lookup and retrieval based on the data object and
+row template pairing.
+
+In order to achieve this, the cache is built as a map of maps where the key of the outer map is the data object and
+the key of the inner map is the row template. The value of the inner map should be an array of the matching cached
+`RenderRow` objects that were previously rendered.
+

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -154,7 +154,11 @@ export interface CdkCellOutletRowContext<T> {
   odd?: boolean;
 }
 
-/** Context provided to the row cells when `multiTemplateDataRows` is true */
+/**
+ * Context provided to the row cells when `multiTemplateDataRows` is true. This context is the same
+ * as CdkCellOutletRowContext except that the single `index` value is replaced by `dataIndex` and
+ * `renderIndex`.
+ */
 export interface CdkCellOutletMultiRowContext<T> {
   /** Data for the row that this cell is located within. */
   $implicit?: T;
@@ -164,9 +168,6 @@ export interface CdkCellOutletMultiRowContext<T> {
 
   /** Index location of the rendered row that this cell is located within. */
   renderIndex?: number;
-
-  /** Index of the data object in the provided data array. */
-  index?: number;
 
   /** Length of the number of total rows. */
   count?: number;

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -130,13 +130,40 @@ export class CdkRowDef<T> extends BaseRowDef {
   }
 }
 
-/** Context provided to the row cells */
+/** Context provided to the row cells when `multiTemplateDataRows` is false */
 export interface CdkCellOutletRowContext<T> {
   /** Data for the row that this cell is located within. */
   $implicit?: T;
 
-  /** Index location of the row that this cell is located within. */
-  rowIndex?: number;
+  /** Index of the data object in the provided data array. */
+  index?: number;
+
+  /** Length of the number of total rows. */
+  count?: number;
+
+  /** True if this cell is contained in the first row. */
+  first?: boolean;
+
+  /** True if this cell is contained in the last row. */
+  last?: boolean;
+
+  /** True if this cell is contained in a row with an even-numbered index. */
+  even?: boolean;
+
+  /** True if this cell is contained in a row with an odd-numbered index. */
+  odd?: boolean;
+}
+
+/** Context provided to the row cells when `multiTemplateDataRows` is true */
+export interface CdkCellOutletMultiRowContext<T> {
+  /** Data for the row that this cell is located within. */
+  $implicit?: T;
+
+  /** Index of the data object in the provided data array. */
+  dataIndex?: number;
+
+  /** Index location of the rendered row that this cell is located within. */
+  renderIndex?: number;
 
   /** Index of the data object in the provided data array. */
   index?: number;

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -136,6 +136,9 @@ export interface CdkCellOutletRowContext<T> {
   $implicit?: T;
 
   /** Index location of the row that this cell is located within. */
+  rowIndex?: number;
+
+  /** Index of the data object in the provided data array. */
   index?: number;
 
   /** Length of the number of total rows. */

--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -35,8 +35,9 @@ export function getTableMultipleDefaultRowDefsError() {
  * Returns an error to be thrown when there are no matching row defs for a particular set of data.
  * @docs-private
  */
-export function getTableMissingMatchingRowDefError() {
-  return Error(`Could not find a matching row definition for the provided row data.`);
+export function getTableMissingMatchingRowDefError(data: any) {
+  return Error(`Could not find a matching row definition for the` +
+      `provided row data: ${JSON.stringify(data)}`);
 }
 
 /**

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1004,8 +1004,8 @@ class BooleanRowCdkTableApp {
 
       <cdk-header-row *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
       <cdk-row *cdkRowDef="let row; columns: columnsToRender"></cdk-row>
-      <cdk-row *cdkRowDef="let row; columns: isIndex1Columns; when: isIndex1"></cdk-row>
-      <cdk-row *cdkRowDef="let row; columns: hasC3Columns; when: hasC3"></cdk-row>
+      <cdk-row *cdkRowDef="let row; columns: columnsForIsIndex1Row; when: isIndex1"></cdk-row>
+      <cdk-row *cdkRowDef="let row; columns: columnsForHasC3Row; when: hasC3"></cdk-row>
     </cdk-table>
   `
 })
@@ -1013,8 +1013,8 @@ class WhenRowCdkTableApp {
   multiTemplateRows = false;
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
-  isIndex1Columns = ['index1Column'];
-  hasC3Columns = ['c3Column'];
+  columnsForIsIndex1Row = ['index1Column'];
+  columnsForHasC3Row = ['c3Column'];
   isIndex1 = (index: number, _rowData: TestData) => index == 1;
   hasC3 = (_index: number, rowData: TestData) => rowData.c == 'c_3';
 
@@ -1025,8 +1025,8 @@ class WhenRowCdkTableApp {
   showIndexColumns() {
     const indexColumns = ['index', 'dataIndex', 'renderIndex'];
     this.columnsToRender = indexColumns;
-    this.isIndex1Columns = indexColumns;
-    this.hasC3Columns = indexColumns;
+    this.columnsForIsIndex1Row = indexColumns;
+    this.columnsForHasC3Row = indexColumns;
   }
 }
 

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -10,7 +10,7 @@ import {
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {CdkTable} from './table';
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
-import {combineLatest, BehaviorSubject, Observable} from 'rxjs';
+import {combineLatest, BehaviorSubject, Observable, of as observableOf} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {CdkTableModule} from './index';
 import {
@@ -238,6 +238,13 @@ describe('CdkTable', () => {
     });
   });
 
+  it('should render no rows when the data is null', fakeAsync(() => {
+    setupTableTestApp(NullDataCdkTableApp);
+    fixture.detectChanges();
+
+    expect(getRows(tableElement).length).toBe(0);
+  }));
+
   describe('with different data inputs other than data source', () => {
     let baseData: TestData[] = [
       {a: 'a_1', b: 'b_1', c: 'c_1'},
@@ -247,7 +254,6 @@ describe('CdkTable', () => {
 
     beforeEach(() => {
       setupTableTestApp(CdkTableWithDifferentDataInputsApp);
-      component = fixture.componentInstance;
     });
 
     it('should render with data array input', () => {
@@ -957,6 +963,24 @@ class CdkTableWithDifferentDataInputsApp {
 })
 class BooleanRowCdkTableApp {
   dataSource = new BooleanDataSource();
+}
+
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef></cdk-header-cell>
+        <cdk-cell *cdkCellDef="let data"> {{data}} </cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="['column_a']"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: ['column_a']"></cdk-row>
+    </cdk-table>
+  `
+})
+class NullDataCdkTableApp {
+  dataSource = observableOf(null);
 }
 
 @Component({

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -618,7 +618,8 @@ describe('CdkTable', () => {
         ]);
       });
 
-      it('should have the correct data and row indicies when data is homogeneous', () => {
+      it('should have the correct data and row indicies when data contains multiple instances of ' +
+          'the same object instance', () => {
         setupTableTestApp(WhenRowCdkTableApp);
         component.multiTemplateDataRows = true;
         component.showIndexColumns();

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -576,7 +576,7 @@ describe('CdkTable', () => {
           }).toThrowError(getTableMissingMatchingRowDefError(data[0]).message);
         }));
 
-    it('should fail when multiple rows match data without multiTemplateRows', fakeAsync(() => {
+    it('should fail when multiple rows match data without multiTemplateDataRows', fakeAsync(() => {
       let whenFixture = createComponent(WhenRowMultipleDefaultsCdkTableApp);
       expect(() => {
         whenFixture.detectChanges();
@@ -584,10 +584,10 @@ describe('CdkTable', () => {
       }).toThrowError(getTableMultipleDefaultRowDefsError().message);
     }));
 
-    describe('with multiTemplateRows', () => {
+    describe('with multiTemplateDataRows', () => {
       it('should be able to render multiple rows per data object', () => {
         setupTableTestApp(WhenRowCdkTableApp);
-        component.multiTemplateRows = true;
+        component.multiTemplateDataRows = true;
         fixture.detectChanges();
 
         const data = component.dataSource.data;
@@ -604,7 +604,7 @@ describe('CdkTable', () => {
 
       it('should have the correct data and row indicies', () => {
         setupTableTestApp(WhenRowCdkTableApp);
-        component.multiTemplateRows = true;
+        component.multiTemplateDataRows = true;
         component.showIndexColumns();
         fixture.detectChanges();
 
@@ -621,7 +621,7 @@ describe('CdkTable', () => {
 
       it('should have the correct data and row indicies when data is homogeneous', () => {
         setupTableTestApp(WhenRowCdkTableApp);
-        component.multiTemplateRows = true;
+        component.multiTemplateDataRows = true;
         component.showIndexColumns();
 
         const obj = {value: true};
@@ -1054,7 +1054,7 @@ class NullDataCdkTableApp {
 
 @Component({
   template: `
-    <cdk-table [dataSource]="dataSource" [multiTemplateRows]="multiTemplateRows">
+    <cdk-table [dataSource]="dataSource" [multiTemplateDataRows]="multiTemplateDataRows">
       <ng-container cdkColumnDef="column_a">
         <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
         <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
@@ -1103,7 +1103,7 @@ class NullDataCdkTableApp {
   `
 })
 class WhenRowCdkTableApp {
-  multiTemplateRows = false;
+  multiTemplateDataRows = false;
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
   columnsForIsIndex1Row = ['index1Column'];

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -536,7 +536,7 @@ describe('CdkTable', () => {
         }).toThrowError(getTableMissingMatchingRowDefError(data[0]).message);
     }));
 
-    it('should fail when multiple rows match data without enableRowMultiplex', fakeAsync(() => {
+    it('should fail when multiple rows match data without multiTemplateRows', fakeAsync(() => {
       let whenFixture = createComponent(WhenRowMultipleDefaultsCdkTableApp);
       expect(() => {
         whenFixture.detectChanges();
@@ -544,10 +544,10 @@ describe('CdkTable', () => {
       }).toThrowError(getTableMultipleDefaultRowDefsError().message);
     }));
 
-    describe('with enableRowMultiplex', () => {
+    describe('with multiTemplateRows', () => {
       it('should be able to render multiple rows per data object', () => {
         let whenFixture = createComponent(WhenRowCdkTableApp);
-        whenFixture.componentInstance.enableRowMultiplex = true;
+        whenFixture.componentInstance.multiTemplateRows = true;
         whenFixture.detectChanges();
 
         const data = whenFixture.componentInstance.dataSource.data;
@@ -564,7 +564,7 @@ describe('CdkTable', () => {
 
       it('should have the correct data and row indicies', () => {
         let whenFixture = createComponent(WhenRowCdkTableApp);
-        whenFixture.componentInstance.enableRowMultiplex = true;
+        whenFixture.componentInstance.multiTemplateRows = true;
         whenFixture.componentInstance.showIndexColumns();
         whenFixture.detectChanges();
 
@@ -961,7 +961,7 @@ class BooleanRowCdkTableApp {
 
 @Component({
   template: `
-    <cdk-table [dataSource]="dataSource" [enableRowMultiplex]="enableRowMultiplex">
+    <cdk-table [dataSource]="dataSource" [multiTemplateRows]="multiTemplateRows">
       <ng-container cdkColumnDef="column_a">
         <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
         <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
@@ -1005,7 +1005,7 @@ class BooleanRowCdkTableApp {
   `
 })
 class WhenRowCdkTableApp {
-  enableRowMultiplex = false;
+  multiTemplateRows = false;
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
   isIndex1Columns = ['index1Column'];

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -171,8 +171,7 @@ describe('CdkTable', () => {
         expect(changedRows[2].getAttribute('initialIndex')).toBe(null);
       });
 
-      it('when the data is homogeneous', () => {
-        // Change default data to be one that is a list of homogeneous data.
+      it('when the data contains multiple occurrences of the same object instance', () => {
         const obj = {value: true};
         component.dataSource!.data = [obj, obj, obj];
         addInitialIndexAttribute();

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -569,13 +569,13 @@ describe('CdkTable', () => {
         whenFixture.detectChanges();
 
         expectTableToMatchContent(whenFixture.nativeElement.querySelector('cdk-table'), [
-          ['Data Index', 'Row Index'],
-          ['0', '0'],
-          ['1', '1'],
-          ['1', '2'],
-          ['2', '3'],
-          ['2', '4'],
-          ['3', '5'],
+          ['Index', 'Data Index', 'Render Index'],
+          ['', '0', '0'],
+          ['', '1', '1'],
+          ['', '1', '2'],
+          ['', '2', '3'],
+          ['', '2', '4'],
+          ['', '3', '5'],
         ]);
       });
     });
@@ -987,14 +987,19 @@ class BooleanRowCdkTableApp {
         <cdk-cell *cdkCellDef="let row"> c3_special_row</cdk-cell>
       </ng-container>
 
-      <ng-container cdkColumnDef="dataIndex">
-        <cdk-header-cell *cdkHeaderCellDef> Data Index</cdk-header-cell>
+      <ng-container cdkColumnDef="index">
+        <cdk-header-cell *cdkHeaderCellDef> Index</cdk-header-cell>
         <cdk-cell *cdkCellDef="let row; let index = index"> {{index}}</cdk-cell>
       </ng-container>
 
-      <ng-container cdkColumnDef="rowIndex">
-        <cdk-header-cell *cdkHeaderCellDef> Row Index</cdk-header-cell>
-        <cdk-cell *cdkCellDef="let row; let rowIndex = rowIndex"> {{rowIndex}}</cdk-cell>
+      <ng-container cdkColumnDef="dataIndex">
+        <cdk-header-cell *cdkHeaderCellDef> Data Index</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row; let dataIndex = dataIndex"> {{dataIndex}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="renderIndex">
+        <cdk-header-cell *cdkHeaderCellDef> Render Index</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row; let renderIndex = renderIndex"> {{renderIndex}}</cdk-cell>
       </ng-container>
 
       <cdk-header-row *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
@@ -1018,7 +1023,7 @@ class WhenRowCdkTableApp {
   @ViewChild(CdkTable) table: CdkTable<TestData>;
 
   showIndexColumns() {
-    const indexColumns = ['dataIndex', 'rowIndex'];
+    const indexColumns = ['index', 'dataIndex', 'renderIndex'];
     this.columnsToRender = indexColumns;
     this.isIndex1Columns = indexColumns;
     this.hasC3Columns = indexColumns;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -504,7 +504,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
   }
 
   /**
-   * Returns a list of `RenderRow<T>` for the provided data object and any `CdkRowDef` objects that
+   * Gets a list of `RenderRow<T>` for the provided data object and any `CdkRowDef` objects that
    * should be rendered for this data. Reuses the cached RenderRow objects if they match the same
    * `(T, CdkRowDef)` pair.
    */
@@ -665,14 +665,15 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
    * predicate that returns true with the data. If none return true, return the default row
    * definition.
    */
-  _getRowDefs(data: T, i: number): CdkRowDef<T>[] {
+  _getRowDefs(data: T, dataIndex: number): CdkRowDef<T>[] {
     if (this._rowDefs.length == 1) { return [this._rowDefs[0]]; }
 
     let rowDefs: CdkRowDef<T>[] = [];
     if (this.multiTemplateDataRows) {
-      rowDefs = this._rowDefs.filter(def => !def.when || def.when(i, data));
+      rowDefs = this._rowDefs.filter(def => !def.when || def.when(dataIndex, data));
     } else {
-      let rowDef = this._rowDefs.find(def => def.when && def.when(i, data)) || this._defaultRowDef;
+      let rowDef =
+          this._rowDefs.find(def => def.when && def.when(dataIndex, data)) || this._defaultRowDef;
       if (rowDef) {
         rowDefs.push(rowDef);
       }

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -616,7 +616,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
     this._renderChangeSubscription = dataStream
         .pipe(takeUntil(this._onDestroy))
         .subscribe(data => {
-          this._data = data;
+          this._data = data || [];
           this.renderRows();
         });
   }

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -112,8 +112,8 @@ abstract class RowViewRef<T> extends EmbeddedViewRef<RowContext<T>> { }
  * Set of properties that represents the identity of a single rendered row.
  *
  * When the table needs to determine the list of rows to render, it will do so by iterating through
- * each data object and evaluating its list of row templates to display (when multiTemplateRows is
- * false, there is only one template per data object). For each pair of data object and row
+ * each data object and evaluating its list of row templates to display (when multiTemplateDataRows
+ * is false, there is only one template per data object). For each pair of data object and row
  * template, a `RenderRow` is added to the list of rows to render. If the data object and row
  * template pair has already been rendered, the previously used `RenderRow` is added; else a new
  * `RenderRow` is * created. Once the list is complete and all data objects have been itereated
@@ -258,19 +258,19 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
 
   /**
    * Whether to allow multiple rows per data object by evaluating which rows evaluate their 'when'
-   * predicate to true. If `multiTemplateRows` is false, which is the default value, then each data
-   * object will render the first row that evaluates its when predicate to true, in the order
+   * predicate to true. If `multiTemplateDataRows` is false, which is the default value, then each
+   * dataobject will render the first row that evaluates its when predicate to true, in the order
    * defined in the table, or otherwise the default row which does not have a when predicate.
    */
   @Input()
-  get multiTemplateRows(): boolean { return this._multiTemplateRows; }
-  set multiTemplateRows(v: boolean) {
-    this._multiTemplateRows = coerceBooleanProperty(v);
+  get multiTemplateDataRows(): boolean { return this._multiTemplateDataRows; }
+  set multiTemplateDataRows(v: boolean) {
+    this._multiTemplateDataRows = coerceBooleanProperty(v);
     if (this._rowOutlet.viewContainer.length) {
       this._forceRenderRows();
     }
   }
-  _multiTemplateRows: boolean = false;
+  _multiTemplateDataRows: boolean = false;
 
   // TODO(andrewseguin): Remove max value as the end index
   //   and instead calculate the view on init and scroll.
@@ -545,7 +545,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
     this._customRowDefs.forEach(rowDef => this._rowDefs.push(rowDef));
 
     const defaultRowDefs = this._rowDefs.filter(def => !def.when);
-    if (!this.multiTemplateRows && defaultRowDefs.length > 1) {
+    if (!this.multiTemplateDataRows && defaultRowDefs.length > 1) {
       throw getTableMultipleDefaultRowDefsError();
     }
     this._defaultRowDef = defaultRowDefs[0];
@@ -669,7 +669,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
     if (this._rowDefs.length == 1) { return [this._rowDefs[0]]; }
 
     let rowDefs: CdkRowDef<T>[] = [];
-    if (this.multiTemplateRows) {
+    if (this.multiTemplateDataRows) {
       rowDefs = this._rowDefs.filter(def => !def.when || def.when(i, data));
     } else {
       let rowDef = this._rowDefs.find(def => def.when && def.when(i, data)) || this._defaultRowDef;
@@ -720,10 +720,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
    */
   private _updateRowIndexContext() {
     const viewContainer = this._rowOutlet.viewContainer;
-    const dataIndex = 0;
-
     for (let renderIndex = 0, count = viewContainer.length; renderIndex < count; renderIndex++) {
-
       const viewRef = viewContainer.get(renderIndex) as RowViewRef<T>;
       const context = viewRef.context as RowContext<T>;
       context.count = count;
@@ -732,7 +729,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
       context.even = renderIndex % 2 === 0;
       context.odd = !context.even;
 
-      if (this.multiTemplateRows) {
+      if (this.multiTemplateDataRows) {
         context.dataIndex = this._renderRows[renderIndex].dataIndex;
         context.renderIndex = renderIndex;
       } else {
@@ -773,7 +770,7 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
   /**
    * Forces a re-render of the data rows. Should be called in cases where there has been an input
    * change that affects the evaluation of which rows should be rendered, e.g. toggling
-   * `multiTemplateRows` or adding/removing row definitions.
+   * `multiTemplateDataRows` or adding/removing row definitions.
    */
   private _forceRenderRows() {
     this._dataDiffer.diff([]);

--- a/src/demo-app/table/expandable-rows/expandable-rows.html
+++ b/src/demo-app/table/expandable-rows/expandable-rows.html
@@ -1,5 +1,5 @@
 <mat-card>
-  <table mat-table [dataSource]="dataSource" multiTemplateRows matSort [trackBy]="trackBy">
+  <table mat-table [dataSource]="dataSource" multiTemplateDataRows matSort [trackBy]="trackBy">
     <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column]}} </td>

--- a/src/demo-app/table/expandable-rows/expandable-rows.html
+++ b/src/demo-app/table/expandable-rows/expandable-rows.html
@@ -1,5 +1,5 @@
 <mat-card>
-  <table mat-table [dataSource]="dataSource" multiTemplateDataRows matSort [trackBy]="trackBy">
+  <table mat-table [dataSource]="dataSource" multiTemplateDataRows matSort>
     <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column]}} </td>

--- a/src/demo-app/table/expandable-rows/expandable-rows.html
+++ b/src/demo-app/table/expandable-rows/expandable-rows.html
@@ -1,5 +1,5 @@
 <mat-card>
-  <table mat-table [dataSource]="dataSource" enableRowMultiplex matSort [trackBy]="trackBy">
+  <table mat-table [dataSource]="dataSource" multiTemplateRows matSort [trackBy]="trackBy">
     <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column]}} </td>

--- a/src/demo-app/table/expandable-rows/expandable-rows.html
+++ b/src/demo-app/table/expandable-rows/expandable-rows.html
@@ -1,0 +1,28 @@
+<mat-card>
+  <table mat-table [dataSource]="dataSource" enableRowMultiplex matSort [trackBy]="trackBy">
+    <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
+      <td mat-cell *matCellDef="let element"> {{element[column]}} </td>
+    </ng-container>
+
+    <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->
+    <ng-container matColumnDef="expandedDetail">
+      <td colspan="4" mat-cell *matCellDef="let element">
+        <div style="overflow: hidden"
+             [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+          The symbol for {{element.name}} is {{element.symbol}}
+        </div>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+    <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"
+        class="demo-element-row"
+        [class.demo-expanded]="expandedElement == row"
+        (click)="expandedElement = expandedElement === row ? undefined : row"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['expandedDetail']"
+        class="demo-detail-row"></tr>
+  </table>
+
+  <mat-paginator pageSize="20" [pageSizeOptions]="[5, 20]"></mat-paginator>
+</mat-card>

--- a/src/demo-app/table/expandable-rows/expandable-rows.ts
+++ b/src/demo-app/table/expandable-rows/expandable-rows.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewChild} from '@angular/core';
+import {Element, ELEMENT_DATA} from 'table/element-data';
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
+
+@Component({
+  moduleId: module.id,
+  selector: 'expandable-rows',
+  templateUrl: 'expandable-rows.html',
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed',
+          animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
+  styles: [`
+    table {
+      width: 100%;
+    }
+
+    tr.demo-detail-row {
+      height: 0;
+    }
+
+    tr.demo-element-row:not(.demo-expanded):hover {
+      background: #F5F5F5;
+    }
+
+    tr.demo-element-row:not(.demo-expanded):active {
+      background: #EFEFEF;
+    }
+
+    .demo-element-row td {
+      border-bottom-width: 0;
+    }
+  `]
+})
+export class ExpandableRowsDemo {
+  dataSource = new MatTableDataSource(ELEMENT_DATA.slice());
+  columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
+  expandedElement: Element;
+
+  @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  ngOnInit() {
+    this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
+  }
+}

--- a/src/demo-app/table/routes.ts
+++ b/src/demo-app/table/routes.ts
@@ -14,6 +14,7 @@ import {MatTableDataSourceDemo} from './mat-table-data-source/mat-table-data-sou
 import {DynamicColumnsDemo} from './dynamic-columns/dynamic-columns';
 import {RowContextDemo} from './row-context/row-context';
 import {WhenRowsDemo} from './when-rows/when-rows';
+import {ExpandableRowsDemo} from './expandable-rows/expandable-rows';
 
 export const TABLE_DEMO_ROUTES: Routes = [
   {path: '', redirectTo: 'main-demo', pathMatch: 'full'},
@@ -23,5 +24,6 @@ export const TABLE_DEMO_ROUTES: Routes = [
   {path: 'mat-table-data-source', component: MatTableDataSourceDemo},
   {path: 'dynamic-columns', component: DynamicColumnsDemo},
   {path: 'row-context', component: RowContextDemo},
-  {path: 'when-rows', component: WhenRowsDemo}
+  {path: 'when-rows', component: WhenRowsDemo},
+  {path: 'expandable-rows', component: ExpandableRowsDemo}
 ];

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -16,11 +16,14 @@ import {
   MatCardModule,
   MatCheckboxModule,
   MatIconModule,
-  MatInputModule, MatMenuModule,
+  MatInputModule,
+  MatMenuModule,
   MatPaginatorModule,
   MatRadioModule,
+  MatSlideToggleModule,
   MatSortModule,
-  MatTableModule, MatTabsModule
+  MatTableModule,
+  MatTabsModule
 } from '@angular/material';
 import {FormsModule} from '@angular/forms';
 import {CdkTableModule} from '@angular/cdk/table';
@@ -33,6 +36,7 @@ import {MatTableDataSourceDemo} from './mat-table-data-source/mat-table-data-sou
 import {DynamicColumnsDemo} from './dynamic-columns/dynamic-columns';
 import {RowContextDemo} from './row-context/row-context';
 import {WhenRowsDemo} from './when-rows/when-rows';
+import {ExpandableRowsDemo} from 'table/expandable-rows/expandable-rows';
 
 
 @NgModule({
@@ -48,6 +52,7 @@ import {WhenRowsDemo} from './when-rows/when-rows';
     MatMenuModule,
     MatPaginatorModule,
     MatRadioModule,
+    MatSlideToggleModule,
     MatSortModule,
     MatTableModule,
     MatTabsModule,
@@ -64,6 +69,7 @@ import {WhenRowsDemo} from './when-rows/when-rows';
     DynamicColumnsDemo,
     RowContextDemo,
     WhenRowsDemo,
+    ExpandableRowsDemo
   ],
   providers: [
     PeopleDatabase

--- a/src/demo-app/table/table-demo-page.ts
+++ b/src/demo-app/table/table-demo-page.ts
@@ -21,6 +21,7 @@ export class TableDemoPage {
     {name: 'MatTableDataSource', link: 'mat-table-data-source'},
     {name: 'Dynamic Columns', link: 'dynamic-columns'},
     {name: 'Row Context', link: 'row-context'},
-    {name: 'When Rows', link: 'when-rows'}
+    {name: 'When Rows', link: 'when-rows'},
+    {name: 'Expandable Rows', link: 'expandable-rows'}
   ];
 }

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -8,7 +8,7 @@
 </div>
 
 <div>
-  <mat-slide-toggle (change)="multiTemplateRows = $event.checked">
+  <mat-slide-toggle (change)="multiTemplateDataRows = $event.checked">
     Enable multiple data rows
   </mat-slide-toggle>
 </div>
@@ -24,7 +24,7 @@
 
   <table mat-table style="width: 100%"
          [trackBy]="useTrackByValue ? trackByValue : undefined"
-         [multiTemplateRows]="multiTemplateRows"
+         [multiTemplateDataRows]="multiTemplateDataRows"
          [dataSource]="data">
     <!-- Data column -->
     <ng-container matColumnDef="data">

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -51,7 +51,7 @@
     </ng-container>
 
     <!-- Row Index column -->
-    <ng-container matColumnDef="rowIndex">
+    <ng-container matColumnDef="renderIndex">
       <th mat-header-cell *matHeaderCellDef> Render Index </th>
       <td mat-cell *matCellDef="let data; let renderIndex = renderIndex">
         {{renderIndex}}

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -8,7 +8,7 @@
 </div>
 
 <div>
-  <mat-slide-toggle (change)="enableRowMultiplex = $event.checked">
+  <mat-slide-toggle (change)="multiTemplateRows = $event.checked">
     Enable row multiplex
   </mat-slide-toggle>
 </div>
@@ -24,7 +24,7 @@
 
   <table mat-table style="width: 100%"
          [trackBy]="useTrackByValue ? trackByValue : undefined"
-         [enableRowMultiplex]="enableRowMultiplex"
+         [multiTemplateRows]="multiTemplateRows"
          [dataSource]="data">
     <!-- Data column -->
     <ng-container matColumnDef="data">
@@ -34,19 +34,27 @@
       </td>
     </ng-container>
 
-    <!-- Data index column -->
-    <ng-container matColumnDef="dataIndex">
-      <th mat-header-cell *matHeaderCellDef> Data Index </th>
+    <!-- Index column -->
+    <ng-container matColumnDef="index">
+      <th mat-header-cell *matHeaderCellDef> Index </th>
       <td mat-cell *matCellDef="let data; let index = index">
         {{index}}
       </td>
     </ng-container>
 
+    <!-- Data index column -->
+    <ng-container matColumnDef="dataIndex">
+      <th mat-header-cell *matHeaderCellDef> Data Index </th>
+      <td mat-cell *matCellDef="let data; let dataIndex = dataIndex">
+        {{dataIndex}}
+      </td>
+    </ng-container>
+
     <!-- Row Index column -->
     <ng-container matColumnDef="rowIndex">
-      <th mat-header-cell *matHeaderCellDef> Row Index </th>
-      <td mat-cell *matCellDef="let data; let rowIndex = rowIndex">
-        {{rowIndex}}
+      <th mat-header-cell *matHeaderCellDef> Render Index </th>
+      <td mat-cell *matCellDef="let data; let renderIndex = renderIndex">
+        {{renderIndex}}
       </td>
     </ng-container>
 

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -9,7 +9,7 @@
 
 <div>
   <mat-slide-toggle (change)="multiTemplateRows = $event.checked">
-    Enable row multiplex
+    Enable multiple data rows
   </mat-slide-toggle>
 </div>
 

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -1,13 +1,60 @@
+<div>
+  <button mat-raised-button (click)="shuffleArray()">Shuffle array</button>
+</div>
+
+<div>
+  <button mat-raised-button (click)="changeRandomNumber()">Randomize</button>
+  Highlighted rows: {{randomNumber}}
+</div>
+
+<div>
+  <mat-slide-toggle (change)="enableRowMultiplex = $event.checked">
+    Enable row multiplex
+  </mat-slide-toggle>
+</div>
+
+<div>
+  <mat-slide-toggle (change)="useTrackByValue = $event.checked">
+    Enable track by value
+  </mat-slide-toggle>
+</div>
+
 <mat-card>
-  <table cdk-table [dataSource]="dataSource">
-    <ng-container cdkColumnDef="{{column}}" *ngFor="let column of columns">
-      <th cdk-header-cell *cdkHeaderCellDef> {{column}} </th>
-      <td cdk-cell *cdkCellDef="let element"> {{element[column]}} </td>
+  <h3> MatTable </h3>
+
+  <table mat-table style="width: 100%"
+         [trackBy]="useTrackByValue ? trackByValue : undefined"
+         [enableRowMultiplex]="enableRowMultiplex"
+         [dataSource]="data">
+    <!-- Data column -->
+    <ng-container matColumnDef="data">
+      <th mat-header-cell *matHeaderCellDef> Data </th>
+      <td mat-cell *matCellDef="let data">
+        {{data.value}}
+      </td>
     </ng-container>
 
-    <tr cdk-header-row *cdkHeaderRowDef="columns"></tr>
+    <!-- Data index column -->
+    <ng-container matColumnDef="dataIndex">
+      <th mat-header-cell *matHeaderCellDef> Data Index </th>
+      <td mat-cell *matCellDef="let data; let index = index">
+        {{index}}
+      </td>
+    </ng-container>
 
-    <tr cdk-row *cdkRowDef="let row; let odd = odd; columns: ['position']; when: isOdd"></tr>
-    <tr cdk-row *cdkRowDef="let row; columns: columns;"></tr>
+    <!-- Row Index column -->
+    <ng-container matColumnDef="rowIndex">
+      <th mat-header-cell *matHeaderCellDef> Row Index </th>
+      <td mat-cell *matCellDef="let data; let rowIndex = rowIndex">
+        {{rowIndex}}
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+
+    <tr mat-row style="background: rgba(255, 0, 0, .2);"
+        *matRowDef="let data; columns: columnsToDisplay; when: whenFn"></tr>
+    <tr mat-row style="background: rgba(0, 255, 0, .2);"
+        *matRowDef="let data; columns: columnsToDisplay;"></tr>
   </table>
 </mat-card>

--- a/src/demo-app/table/when-rows/when-rows.ts
+++ b/src/demo-app/table/when-rows/when-rows.ts
@@ -24,7 +24,7 @@ export class WhenRowsDemo {
   data: DemoDataObject[] =
       (new Array(DATA_LENGTH) as DemoDataObject[]).fill({value: false}, 0, DATA_LENGTH);
   randomNumber = 0;
-  multiTemplateRows = false;
+  multiTemplateDataRows = false;
   useTrackByValue = false;
 
   whenFn = (_i: number, d: DemoDataObject) => d.value;

--- a/src/demo-app/table/when-rows/when-rows.ts
+++ b/src/demo-app/table/when-rows/when-rows.ts
@@ -20,11 +20,11 @@ export interface DemoDataObject {
   templateUrl: 'when-rows.html',
 })
 export class WhenRowsDemo {
-  columnsToDisplay = ['data', 'dataIndex', 'rowIndex'];
+  columnsToDisplay = ['data', 'index', 'dataIndex', 'rowIndex'];
   data: DemoDataObject[] =
       (new Array(DATA_LENGTH) as DemoDataObject[]).fill({value: false}, 0, DATA_LENGTH);
   randomNumber = 0;
-  enableRowMultiplex = false;
+  multiTemplateRows = false;
   useTrackByValue = false;
 
   whenFn = (_i: number, d: DemoDataObject) => d.value;

--- a/src/demo-app/table/when-rows/when-rows.ts
+++ b/src/demo-app/table/when-rows/when-rows.ts
@@ -6,16 +6,57 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {Element, ELEMENT_DATA} from '../element-data';
+import {Component, ViewChild} from '@angular/core';
+import {MatTable} from '@angular/material';
+
+const DATA_LENGTH = 10;
+
+export interface DemoDataObject {
+  value: boolean;
+}
 
 @Component({
   moduleId: module.id,
   templateUrl: 'when-rows.html',
 })
 export class WhenRowsDemo {
-  columns = ['name', 'weight', 'symbol', 'position'];
-  dataSource: Element[] = ELEMENT_DATA.slice();
+  columnsToDisplay = ['data', 'dataIndex', 'rowIndex'];
+  data: DemoDataObject[] =
+      (new Array(DATA_LENGTH) as DemoDataObject[]).fill({value: false}, 0, DATA_LENGTH);
+  randomNumber = 0;
+  enableRowMultiplex = false;
+  useTrackByValue = false;
 
-  isOdd = (i: number, _d: Element) => i % 2 !== 0;
+  whenFn = (_i: number, d: DemoDataObject) => d.value;
+  trackByValue = (_i: number, d: DemoDataObject) => d.value;
+
+  @ViewChild(MatTable) table: MatTable<any>;
+
+  constructor() {
+    this.changeRandomNumber();
+  }
+
+  changeRandomNumber() {
+    this.randomNumber = Math.floor(Math.random() * DATA_LENGTH);
+    this.data = this.data.map((_d: DemoDataObject, i: number) => ({value: i < this.randomNumber}));
+    if (this.table) {
+      this.table.renderRows();
+    }
+  }
+
+  shuffleArray() {
+    let dataToShuffle = this.data.slice();
+    let currentIndex = dataToShuffle.length;
+    while (0 !== currentIndex) {
+      let randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+
+      // Swap
+      let temp = dataToShuffle[currentIndex];
+      dataToShuffle[currentIndex] = dataToShuffle[randomIndex];
+      dataToShuffle[randomIndex] = temp;
+    }
+
+    this.data = dataToShuffle;
+  }
 }

--- a/src/demo-app/table/when-rows/when-rows.ts
+++ b/src/demo-app/table/when-rows/when-rows.ts
@@ -20,7 +20,7 @@ export interface DemoDataObject {
   templateUrl: 'when-rows.html',
 })
 export class WhenRowsDemo {
-  columnsToDisplay = ['data', 'index', 'dataIndex', 'rowIndex'];
+  columnsToDisplay = ['data', 'index', 'dataIndex', 'renderIndex'];
   data: DemoDataObject[] =
       (new Array(DATA_LENGTH) as DemoDataObject[]).fill({value: false}, 0, DATA_LENGTH);
   randomNumber = 0;

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -57,7 +57,7 @@ describe('MatTable', () => {
       ]);
     });
 
-    it('should create a table with row multiplex', () => {
+    it('should create a table with multiTemplateRows true', () => {
       let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
       fixture.componentInstance.multiTemplateRows = true;
       fixture.detectChanges();
@@ -68,7 +68,7 @@ describe('MatTable', () => {
         ['a_1'],
         ['a_2'],
         ['a_3'],
-        ['a_4'], // With multiplex, this row shows up along with the special 'when' fourth_row
+        ['a_4'], // With multiple rows, this row shows up along with the special 'when' fourth_row
         ['fourth_row'],
         ['Footer A', 'Footer B', 'Footer C'],
       ]);

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -57,9 +57,9 @@ describe('MatTable', () => {
       ]);
     });
 
-    it('should create a table with multiTemplateRows true', () => {
+    it('should create a table with multiTemplateDataRows true', () => {
       let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
-      fixture.componentInstance.multiTemplateRows = true;
+      fixture.componentInstance.multiTemplateDataRows = true;
       fixture.detectChanges();
 
       const tableElement = fixture.nativeElement.querySelector('.mat-table');
@@ -503,7 +503,7 @@ class NativeHtmlTableApp {
 
 @Component({
   template: `
-    <mat-table [dataSource]="dataSource" [multiTemplateRows]="multiTemplateRows">
+    <mat-table [dataSource]="dataSource" [multiTemplateDataRows]="multiTemplateDataRows">
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
@@ -522,7 +522,7 @@ class NativeHtmlTableApp {
   `
 })
 class MatTableWithWhenRowApp {
-  multiTemplateRows = false;
+  multiTemplateDataRows = false;
   dataSource: FakeDataSource | null = new FakeDataSource();
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -59,7 +59,7 @@ describe('MatTable', () => {
 
     it('should create a table with row multiplex', () => {
       let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
-      fixture.componentInstance.enableRowMultiplex = true;
+      fixture.componentInstance.multiTemplateRows = true;
       fixture.detectChanges();
 
       const tableElement = fixture.nativeElement.querySelector('.mat-table');
@@ -503,7 +503,7 @@ class NativeHtmlTableApp {
 
 @Component({
   template: `
-    <mat-table [dataSource]="dataSource" [enableRowMultiplex]="enableRowMultiplex">
+    <mat-table [dataSource]="dataSource" [multiTemplateRows]="multiTemplateRows">
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
@@ -522,7 +522,7 @@ class NativeHtmlTableApp {
   `
 })
 class MatTableWithWhenRowApp {
-  enableRowMultiplex = false;
+  multiTemplateRows = false;
   dataSource: FakeDataSource | null = new FakeDataSource();
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -56,6 +56,23 @@ describe('MatTable', () => {
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
+
+    it('should create a table with row multiplex', () => {
+      let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
+      fixture.componentInstance.enableRowMultiplex = true;
+      fixture.detectChanges();
+
+      const tableElement = fixture.nativeElement.querySelector('.mat-table');
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['a_1'],
+        ['a_2'],
+        ['a_3'],
+        ['a_4'], // With multiplex, this row shows up along with the special 'when' fourth_row
+        ['fourth_row'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+    });
   });
 
   it('should be able to render a table correctly with native elements', () => {
@@ -486,7 +503,7 @@ class NativeHtmlTableApp {
 
 @Component({
   template: `
-    <mat-table [dataSource]="dataSource">
+    <mat-table [dataSource]="dataSource" [enableRowMultiplex]="enableRowMultiplex">
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
@@ -505,6 +522,7 @@ class NativeHtmlTableApp {
   `
 })
 class MatTableWithWhenRowApp {
+  enableRowMultiplex = false;
   dataSource: FakeDataSource | null = new FakeDataSource();
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 


### PR DESCRIPTION
Introduces a new table input `multiTemplateDataRows` which allows the table to have multiple data rows per data object.

**Old paradigm**

Each data object passed to the table is rendered as a data row. Since the mapping is 1:1, the data array itself can be used with the `IterableDiffer` to determine which rows need to change.

**New paradigm**

Each data object passed to the table may be rendered by one or more rows. The `IterableDiffer` cannot use the data array itself anymore since it will not correctly understand add/remove/move operations in the rows. 

Instead, the `IterableDiffer` will be diffed with a `DataRow` object that represents a pair containing a data object and row template. When the data changes, the list of `DataRow` objects will be constructed and diffed to get the list of changes.

**Caveats for discussion**

1. The row context previously contained an `index` value that represented both the row index and data object index (they were the same. Now, that `index` value represents the index of the data. To get the row index, there is an additional context property called `rowIndex`.

_Should it be swapped such that `index` is the row index and the data index can be stored in `dataIndex`?_ 

2. Similarly, the `trackBy` function receives an index value. Previously the index matched both the data and row. Now, its explicitly the data index.

_Should `trackBy` receive the row index?_ 

