### PR TITLE
fix(ripple): only persist top ripple on pointer down

### DIFF
--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -231,6 +231,18 @@ describe('MatRipple', () => {
       subscription.unsubscribe();
     });
 
+    it('should only persist the latest ripple on pointer down', fakeAsync(() => {
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
+
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
+
+      tick(enterDuration + exitDuration);
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
+    }));
+
     describe('when page is scrolled', () => {
       let veryLargeElement: HTMLDivElement = document.createElement('div');
       let pageScrollTop = 500;


### PR DESCRIPTION
Currently when the user has their pointer down, we persist all of the currently-active ripples, which may be more than one, if there were multiple clicks in quick succession. These changes ensure that only the latest ripple is persisted.

Fixes #10973.