### PR TITLE
build(table): explicitly define MatTable ctor

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -23,7 +23,8 @@ import {
   IterableDiffer,
   IterableDiffers,
   OnInit,
-  QueryList, TemplateRef,
+  QueryList,
+  TemplateRef,
   TrackByFunction,
   ViewChild,
   ViewContainerRef,
@@ -39,7 +40,7 @@ import {
   CdkRowDef
 } from './row';
 import {takeUntil} from 'rxjs/operators';
-import {of as observableOf, BehaviorSubject, Observable, Subscription, Subject} from 'rxjs';
+import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {CdkColumnDef} from './cell';
 import {
   getTableDuplicateColumnNameError,
@@ -248,9 +249,9 @@ export class CdkTable<T> implements CollectionViewer, OnInit, AfterContentChecke
    */
   @ContentChild(CdkFooterRowDef) _footerRowDef: CdkFooterRowDef;
 
-  constructor(private readonly _differs: IterableDiffers,
-              private readonly _changeDetectorRef: ChangeDetectorRef,
-              private readonly _elementRef: ElementRef,
+  constructor(protected readonly _differs: IterableDiffers,
+              protected readonly _changeDetectorRef: ChangeDetectorRef,
+              protected readonly _elementRef: ElementRef,
               @Attribute('role') role: string) {
     if (!role) {
       this._elementRef.nativeElement.setAttribute('role', 'grid');

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {
+  Attribute,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  IterableDiffers,
+  ViewEncapsulation
+} from '@angular/core';
 import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
 
 /**
@@ -24,4 +32,15 @@ import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatTable<T> extends CdkTable<T> { }
+export class MatTable<T> extends CdkTable<T> {
+  // TODO(andrewseguin): Remove this explicitly set ctor when the compiler knows how to properly
+  // build the es6 version of the class. Currently sets ctorParameters to empty due to a fixed bug.
+  // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
+  // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
+  constructor(protected _differs: IterableDiffers,
+              protected _changeDetectorRef: ChangeDetectorRef,
+              protected _elementRef: ElementRef,
+              @Attribute('role') role: string) {
+    super(_differs, _changeDetectorRef, _elementRef, role);
+  }
+}

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -33,8 +33,9 @@ import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatTable<T> extends CdkTable<T> {
-  // TODO(andrewseguin): Remove this explicitly set ctor when the compiler knows how to properly
-  // build the es6 version of the class. Currently sets ctorParameters to empty due to a fixed bug.
+  // TODO(andrewseguin): Remove this explicitly set constructor when the compiler knows how to
+  // properly build the es6 version of the class. Currently sets ctorParameters to empty due to a
+  // fixed bug.
   // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
   // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
   constructor(protected _differs: IterableDiffers,


### PR DESCRIPTION
Explicitly define the ctor due to a tsickle issue which is depended on by compiler-cli.

Fixes #9329 