### PR TITLE
fix(schematics): support basic style asset string

### DIFF
--- a/src/lib/schematics/shell/theming.ts
+++ b/src/lib/schematics/shell/theming.ts
@@ -71,7 +71,7 @@ function addStyleToTarget(target: any, host: Tree, asset: string, workspace: Wor
   } else if (!target.options.styles) {
     target.options.styles = [styleEntry];
   } else {
-    const existingStyles = target.options.styles.map(s => s.input);
+    const existingStyles = target.options.styles.map(s => typeof s === 'string' ? s : s.input);
     const hasGivenTheme = existingStyles.find(s => s.includes(asset));
     const hasOtherTheme = existingStyles.find(s => s.includes('material/prebuilt'));
 


### PR DESCRIPTION
From cli rc.4 to rc.5, the default format for style assets changed. This
change makes the theme addition support either format.

Fixes #10912