### PR TITLE
build: bump to rxjs 6.0 final

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "requires": {
         "ajv": "5.5.2",
         "chokidar": "1.7.0",
-        "rxjs": "6.0.0-uncanny-rc.7",
+        "rxjs": "6.0.0",
         "source-map": "0.5.7"
       },
       "dependencies": {
@@ -32,7 +32,7 @@
       "requires": {
         "@angular-devkit/core": "0.5.6",
         "@ngtools/json-schema": "1.1.0",
-        "rxjs": "6.0.0-uncanny-rc.7"
+        "rxjs": "6.0.0"
       }
     },
     "@angular/animations": {
@@ -4476,7 +4476,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -13268,7 +13268,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -15424,9 +15424,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.0.0-uncanny-rc.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-uncanny-rc.7.tgz",
-      "integrity": "sha512-mXBJnSpbrotKF83b1sd5uSa7q/J/y99yBArB02l6B1v2QAP18FCn2BwRXfC9O4A+75mfwUAIUWJyLilboF5z2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0.tgz",
+      "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
       "requires": {
         "tslib": "1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/forms": "6.0.0-rc.5",
     "@angular/platform-browser": "6.0.0-rc.5",
     "core-js": "^2.4.1",
-    "rxjs": "6.0.0-uncanny-rc.7",
+    "rxjs": "6.0.0",
     "systemjs": "0.19.43",
     "tsickle": "^0.27.2",
     "tslib": "^1.9.0",


### PR DESCRIPTION
Bumps to the stable version of rxjs 6.0.