### PR TITLE
fix(card): flat card selector not working

### DIFF
--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -32,13 +32,14 @@ $mat-card-header-size: 40px !default;
     }
   }
 
+  // Needs extra specificity to be able to override the elevation selectors.
+  &.mat-card-flat {
+    box-shadow: none;
+  }
+
   @include cdk-high-contrast {
     outline: solid 1px;
   }
-}
-
-.mat-card-flat {
-  box-shadow: none;
 }
 
 // base styles for each card section preset (mat-card-content, etc)


### PR DESCRIPTION
Fixes the `.mat-flat-card` selector not working due to its specificity being too low.

Fixes #11014.