### PR TITLE
fix(paginator): removed bad CSS rule

### DIFF
--- a/src/demo-app/grid-list/grid-list-demo.scss
+++ b/src/demo-app/grid-list/grid-list-demo.scss
@@ -1,5 +1,4 @@
 .demo-grid-list {
-  width: 1100px;
 
   .mat-card {
     margin: 16px 0;

--- a/src/demo-app/paginator/paginator-demo.scss
+++ b/src/demo-app/paginator/paginator-demo.scss
@@ -1,7 +1,6 @@
 .demo-section {
   max-width: 500px;
   margin-bottom: 24px;
-  background: #efefef !important;
 
   & > * {
     margin: 32px 0;


### PR DESCRIPTION
this rule with "!important" was not working well when switching from Light theme to Dark theme