### PR TITLE
chore: fix test leaking overlay elements

### DIFF
--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -484,10 +484,11 @@ describe('MatMenu', () => {
     });
 
     it('should default to the "below" and "after" positions', () => {
+      overlayContainer.ngOnDestroy();
       fixture.destroy();
       TestBed.resetTestingModule();
 
-      let newFixture = createComponent(SimpleMenu, [], [FakeIcon]);
+      const newFixture = createComponent(SimpleMenu, [], [FakeIcon]);
 
       newFixture.detectChanges();
       newFixture.componentInstance.trigger.openMenu();


### PR DESCRIPTION
Fixes a menu test that wasn't cleaning up properly and was leaking overlay elements into other tests.