### PR TITLE
fix(datepicker): don't autofocus calendar cell if used outside of overlay

### DIFF
--- a/src/lib/datepicker/calendar.spec.ts
+++ b/src/lib/datepicker/calendar.spec.ts
@@ -2,8 +2,13 @@ import {
   ENTER,
   RIGHT_ARROW,
 } from '@angular/cdk/keycodes';
-import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing';
-import {Component} from '@angular/core';
+import {
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  dispatchMouseEvent,
+  MockNgZone,
+} from '@angular/cdk/testing';
+import {Component, NgZone} from '@angular/core';
 import {ComponentFixture, TestBed, async, inject} from '@angular/core/testing';
 import {DEC, FEB, JAN, MatNativeDateModule, NOV} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
@@ -14,6 +19,7 @@ import {MatDatepickerModule} from './datepicker-module';
 
 describe('MatCalendar', () => {
   let dir: {value: Direction};
+  let zone: MockNgZone;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -29,6 +35,7 @@ describe('MatCalendar', () => {
       ],
       providers: [
         MatDatepickerIntl,
+        {provide: NgZone, useFactory: () => zone = new MockNgZone()},
         {provide: Directionality, useFactory: () => dir = {value: 'ltr'}}
       ],
     });
@@ -148,6 +155,34 @@ describe('MatCalendar', () => {
 
         it('should make the calendar body focusable', () => {
           expect(calendarBodyEl.getAttribute('tabindex')).toBe('-1');
+        });
+
+        it('should not move focus to the active cell on init', () => {
+          const activeCell =
+              calendarBodyEl.querySelector('.mat-calendar-body-active')! as HTMLElement;
+
+          spyOn(activeCell, 'focus').and.callThrough();
+          fixture.detectChanges();
+          zone.simulateZoneExit();
+
+          expect(activeCell.focus).not.toHaveBeenCalled();
+        });
+
+        it('should move focus to the active cell when the view changes', () => {
+          const activeCell =
+              calendarBodyEl.querySelector('.mat-calendar-body-active')! as HTMLElement;
+
+          spyOn(activeCell, 'focus').and.callThrough();
+          fixture.detectChanges();
+          zone.simulateZoneExit();
+
+          expect(activeCell.focus).not.toHaveBeenCalled();
+
+          calendarInstance.currentView = 'multi-year';
+          fixture.detectChanges();
+          zone.simulateZoneExit();
+
+          expect(activeCell.focus).toHaveBeenCalled();
         });
 
         describe('year view', () => {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -21,7 +21,7 @@ import {ComponentPortal, ComponentType} from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
 import {take, filter} from 'rxjs/operators';
 import {
-  AfterContentInit,
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -97,7 +97,7 @@ export const _MatDatepickerContentMixinBase = mixinColor(MatDatepickerContentBas
   inputs: ['color'],
 })
 export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
-  implements AfterContentInit, CanColor, OnInit, OnDestroy {
+  implements AfterViewInit, CanColor, OnInit, OnDestroy {
 
   /** Subscription to changes in the overlay's position. */
   private _positionChange: Subscription|null;
@@ -138,17 +138,8 @@ export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
     });
   }
 
-  ngAfterContentInit() {
-    this._focusActiveCell();
-  }
-
-  /** Focuses the active cell after the microtask queue is empty. */
-  private _focusActiveCell() {
-    this._ngZone.runOutsideAngular(() => {
-      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
-        this._elementRef.nativeElement.querySelector('.mat-calendar-body-active').focus();
-      });
-    });
+  ngAfterViewInit() {
+    this._calendar.focusActiveCell();
   }
 
   ngOnDestroy() {

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -106,7 +106,7 @@ export class MatMonthView<D> implements AfterContentInit {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody;
+  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
 
   /** The label for this month (e.g. "January 2017"). */
   _monthLabel: string;
@@ -155,7 +155,6 @@ export class MatMonthView<D> implements AfterContentInit {
 
   ngAfterContentInit() {
     this._init();
-    this._focusActiveCell();
   }
 
   /** Handles when a new date is selected. */
@@ -253,7 +252,7 @@ export class MatMonthView<D> implements AfterContentInit {
   }
 
   /** Focuses the active cell after the microtask queue is empty. */
-  private _focusActiveCell() {
+  _focusActiveCell() {
     this._matCalendarBody._focusActiveCell();
   }
 

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -102,7 +102,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   @Output() readonly yearSelected: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody;
+  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the currently displayed years. */
   _years: MatCalendarCell[][];
@@ -125,7 +125,6 @@ export class MatMultiYearView<D> implements AfterContentInit {
 
   ngAfterContentInit() {
     this._init();
-    this._focusActiveCell();
   }
 
   /** Initializes this multi-year view. */
@@ -211,7 +210,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   }
 
   /** Focuses the active cell after the microtask queue is empty. */
-  private _focusActiveCell() {
+  _focusActiveCell() {
     this._matCalendarBody._focusActiveCell();
   }
 

--- a/src/lib/datepicker/year-view.ts
+++ b/src/lib/datepicker/year-view.ts
@@ -97,7 +97,7 @@ export class MatYearView<D> implements AfterContentInit {
   @Output() readonly monthSelected: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody;
+  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the months of the year. */
   _months: MatCalendarCell[][];
@@ -130,7 +130,6 @@ export class MatYearView<D> implements AfterContentInit {
 
   ngAfterContentInit() {
     this._init();
-    this._focusActiveCell();
   }
 
   /** Handles when a new month is selected. */
@@ -211,7 +210,7 @@ export class MatYearView<D> implements AfterContentInit {
   }
 
   /** Focuses the active cell after the microtask queue is empty. */
-  private _focusActiveCell() {
+  _focusActiveCell() {
     this._matCalendarBody._focusActiveCell();
   }
 


### PR DESCRIPTION
Currently the `mat-calendar` component assumes that it'll be used inside an overlay which means that it always tries to move focus to the active date on init. This means that if the component is used on its own, it would steal the user's focus and scroll the page to the calendar. These changes rework the logic so that focus isn't moved on init, unless the calendar is part of a datepicker.

Fixes #11023.