### PR TITLE
fix(dialog): add generic parameter for the dialog result to open method

### DIFF
--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -114,8 +114,8 @@ export class MatDialog {
    * @param config Extra configuration options.
    * @returns Reference to the newly-opened dialog.
    */
-  open<T, D = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig<D>): MatDialogRef<T> {
+  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+          config?: MatDialogConfig<D>): MatDialogRef<T, R> {
 
     config = _applyConfigDefaults(config, this._defaultOptions || new MatDialogConfig());
 
@@ -125,8 +125,10 @@ export class MatDialog {
 
     const overlayRef = this._createOverlay(config);
     const dialogContainer = this._attachDialogContainer(overlayRef, config);
-    const dialogRef =
-        this._attachDialogContent<T>(componentOrTemplateRef, dialogContainer, overlayRef, config);
+    const dialogRef = this._attachDialogContent<T, R>(componentOrTemplateRef,
+                                                      dialogContainer,
+                                                      overlayRef,
+                                                      config);
 
     // If this is the first dialog that we're opening, hide all the non-overlay content.
     if (!this.openDialogs.length) {
@@ -221,15 +223,16 @@ export class MatDialog {
    * @param config The dialog configuration.
    * @returns A promise resolving to the MatDialogRef that should be returned to the user.
    */
-  private _attachDialogContent<T>(
+  private _attachDialogContent<T, R>(
       componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
       dialogContainer: MatDialogContainer,
       overlayRef: OverlayRef,
-      config: MatDialogConfig): MatDialogRef<T> {
+      config: MatDialogConfig): MatDialogRef<T, R> {
 
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
-    const dialogRef = new MatDialogRef<T>(overlayRef, dialogContainer, this._location, config.id);
+    const dialogRef =
+        new MatDialogRef<T, R>(overlayRef, dialogContainer, this._location, config.id);
 
     // When the dialog backdrop is clicked, we want to close it.
     if (config.hasBackdrop) {


### PR DESCRIPTION
Adds the `R` generic parameter to `MatDialog.open` which allows for the dialog result to be strongly typed.

Fixes #11052.