### PR TITLE
fix(paginator): handle negative pageSize and pageIndex correctly

### DIFF
--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -157,6 +157,16 @@ describe('MatPaginator', () => {
     expect(isMarkedInitialized).toBeTruthy();
   }));
 
+  it('should not allow a negative pageSize', () => {
+    paginator.pageSize = -1337;
+    expect(paginator.pageSize).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should not allow a negative pageIndex', () => {
+    paginator.pageSize = -42;
+    expect(paginator.pageIndex).toBeGreaterThanOrEqual(0);
+  });
+
   describe('when showing the first and last button', () => {
 
     beforeEach(() => {

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -76,7 +76,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   @Input()
   get pageIndex(): number { return this._pageIndex; }
   set pageIndex(value: number) {
-    this._pageIndex = coerceNumberProperty(value);
+    this._pageIndex = Math.max(coerceNumberProperty(value), 0);
     this._changeDetectorRef.markForCheck();
   }
   _pageIndex: number = 0;
@@ -94,7 +94,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   @Input()
   get pageSize(): number { return this._pageSize; }
   set pageSize(value: number) {
-    this._pageSize = coerceNumberProperty(value);
+    this._pageSize = Math.max(coerceNumberProperty(value), 0);
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSize: number;


### PR DESCRIPTION
Doesn't allow for the `pageSize` or `pageIndex` of the paginator to be set to negative numbers. It doesn't make sense for them to be negative and allowing it ends up displaying some weird values in the view.