### PR TITLE
fix(checkbox): update MatCheckbox disabled setter to trigger change detection

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -110,7 +110,7 @@ export const _MatCheckboxMixinBase =
     '[class.mat-checkbox-label-before]': 'labelPosition == "before"',
   },
   providers: [MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR],
-  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
+  inputs: ['disableRipple', 'color', 'tabIndex'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -214,6 +214,20 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   private _checked: boolean = false;
 
   /**
+   * Whether the checkbox is disabled. This fully overrides the implementation provided by
+   * mixinDisabled, but the mixin is still required because mixinTabIndex requires it.
+   */
+  @Input()
+  get disabled() { return this._disabled; }
+  set disabled(value: any) {
+    if (value != this.disabled) {
+      this._disabled = value;
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+  private _disabled: boolean = false;
+
+  /**
    * Whether the checkbox is indeterminate. This is also known as "mixed" mode and can be used to
    * represent a checkbox with three states, e.g. a checkbox that represents a nested list of
    * checkable items. Note that whenever checkbox is manually clicked, indeterminate is immediately
@@ -267,7 +281,6 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   // Implemented as part of ControlValueAccessor.
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
-    this._changeDetectorRef.markForCheck();
   }
 
   _getAriaChecked(): 'true' | 'false' | 'mixed' {


### PR DESCRIPTION
This is related to https://github.com/angular/material2/pull/11056, which is a similar fix for MatRadioButton.

The MatCheckbox component instance may be accessed directly by a parent component using
ViewChild/ContentChild. Since MatCheckbox uses OnPush change detection setting the disabled property
directly currently doesn't cause change detection leading to a stale or broken state. Accessing it
through a template binding does correctly trigger change detection on MatCheckbox (there are already
test cases for this method). We need to add a manual call to markForCheck, or else MatCheckbox will
never get kicked if disabled is set directly on the component instance.

Related open Angular bug: https://github.com/angular/angular/issues/20611