### PR TITLE
fix(tree) make change detection less often

### DIFF
--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -607,6 +607,8 @@ describe('CdkTree', () => {
           flush();
         } catch {
           flush();
+        } finally {
+          flush();
         }
       }).toThrowError(getTreeControlFunctionsMissingError().message);
     }));

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -287,6 +287,8 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
           viewContainer.move(view!, currentIndex);
         }
       });
+
+    this._changeDetectorRef.detectChanges();
   }
 
   /**
@@ -336,7 +338,5 @@ export class CdkTree<T> implements CollectionViewer, OnInit, OnDestroy {
     if (CdkTreeNode.mostRecentTreeNode) {
       CdkTreeNode.mostRecentTreeNode.data = nodeData;
     }
-
-    this._changeDetectorRef.detectChanges();
   }
 }


### PR DESCRIPTION
The CdkTree component calls change detection after each node insert, which has impact
on performance. The fix is to call change detection only once, when a set of nodes
is rendered.

Related bug: angular/material2#11101