### PR TITLE
fix(form-field): error on IE11 when using outline appearance

### DIFF
--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -420,7 +420,7 @@ export class MatFormField extends _MatFormFieldMixinBase
         this._initialGapCalculated = true;
         return;
       }
-      if (!document.contains(this._elementRef.nativeElement)) {
+      if (!document.documentElement.contains(this._elementRef.nativeElement)) {
         return;
       }
 


### PR DESCRIPTION
Fixes an error that is being thrown by IE when a form field has the "outline" appearance. The error is due to IE not having a `contains` method on the `Document`.