### PR TITLE
fix(autosize): error thrown by IE in some cases when component is destroyed

### DIFF
--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -204,7 +204,13 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     if (typeof requestAnimationFrame !== 'undefined') {
       this._ngZone.runOutsideAngular(() => requestAnimationFrame(() => {
         const {selectionStart, selectionEnd} = textarea;
-        textarea.setSelectionRange(selectionStart, selectionEnd);
+
+        // IE will throw an "Unspecified error" if we try to set the selection range after the
+        // element has been removed from the DOM. Assert that the directive hasn't been destroyed
+        // between the time we requested the animation frame and when it was executed.
+        if (!this._destroyed.isStopped) {
+          textarea.setSelectionRange(selectionStart, selectionEnd);
+        }
       }));
     }
 


### PR DESCRIPTION
Fixes IE throwing an "Unspecified error" if an autosize textarea is destroyed between the time it requests an animation frame and when the animation frame is executed. The error manifested itself in our unit tests where the last animation frame usually fires after the test case has run.