### PR TITLE
feat(table): enable multiple data rows

### DIFF
--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -9,6 +9,7 @@ ng_module(
   module_name = "@angular/cdk/table",
   deps = [
     "//src/cdk/collections",
+    "//src/cdk/coercion",
     "@rxjs",
   ],
   tsconfig = "//src/cdk:tsconfig-build.json",

--- a/src/cdk/table/render-rows.md
+++ b/src/cdk/table/render-rows.md
@@ -1,0 +1,51 @@
+# Rendering Data Rows
+
+The table's primary responsibility is to render rows of cells. The types of rows that may be rendered are header,
+footer, and data rows. This document focuses on how the table tries to efficienctly render the data rows.
+
+## Background
+
+Each table's template is defined as a set of row and column templates. The row template defines the template that should
+be rendered for a header, footer, or data row. The column templates include the cell templates that will be inserted
+into each rendered row.
+
+Each data object may be rendered with one or more row templates. When new data in provided to the table, the table
+determines which rows need to be rendered. In order to be efficient, the table attempts to understand how the new list
+of rendered rows differs from the previous list of rendered rows so that it can re-use the current list of rendered rows
+if possible.
+
+## Rendering
+
+Each time data is provided, the table needs to create the list of rows that will be rendered and keep track of which
+data object will be provided as context for each row. For each item in the list, this pair is combined into an object
+that uses the `RenderRow` interface. The interface also helps keep track of the data object's index in the provided
+data array input.
+
+```ts
+export interface RenderRow<T> {
+  data: T;
+  dataIndex: number;
+  rowDef: CdkRowDef<T>;
+}
+```
+
+When possible, `RenderRow` objects are re-used from the previous rendering. That is, if a particular data object and row
+template pairing was previously rendered, it should be used for the new list as well. This makes sure that the
+differ can use check-by-reference logic to find the changes between two lists. Note that if a `RenderRow` object is
+reused, it should be updated with the correct data index, in case it has moved since last used.
+
+Once the list of `RenderRow` objects has been created, it should be compared to the previous list of `RenderRow`
+objects to find the difference in terms of inserts/deletions/moves. This is trivially done using the `IterableDiffer`
+logic provided by Angular Core.
+
+Finally, the table uses the list of operations and manipulates the rows through add/remove/move operations.
+
+## Caching `RenderRow` objects
+
+Each `RenderRow` should be cached such that it is a constant-time lookup and retrieval based on the data object and
+row template pairing.
+
+In order to achieve this, the cache is built as a map of maps where the key of the outer map is the data object and
+the key of the inner map is the row template. The value of the inner map should be an array of the matching cached
+`RenderRow` objects that were previously rendered.
+

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -130,13 +130,44 @@ export class CdkRowDef<T> extends BaseRowDef {
   }
 }
 
-/** Context provided to the row cells */
+/** Context provided to the row cells when `multiTemplateDataRows` is false */
 export interface CdkCellOutletRowContext<T> {
   /** Data for the row that this cell is located within. */
   $implicit?: T;
 
-  /** Index location of the row that this cell is located within. */
+  /** Index of the data object in the provided data array. */
   index?: number;
+
+  /** Length of the number of total rows. */
+  count?: number;
+
+  /** True if this cell is contained in the first row. */
+  first?: boolean;
+
+  /** True if this cell is contained in the last row. */
+  last?: boolean;
+
+  /** True if this cell is contained in a row with an even-numbered index. */
+  even?: boolean;
+
+  /** True if this cell is contained in a row with an odd-numbered index. */
+  odd?: boolean;
+}
+
+/**
+ * Context provided to the row cells when `multiTemplateDataRows` is true. This context is the same
+ * as CdkCellOutletRowContext except that the single `index` value is replaced by `dataIndex` and
+ * `renderIndex`.
+ */
+export interface CdkCellOutletMultiRowContext<T> {
+  /** Data for the row that this cell is located within. */
+  $implicit?: T;
+
+  /** Index of the data object in the provided data array. */
+  dataIndex?: number;
+
+  /** Index location of the rendered row that this cell is located within. */
+  renderIndex?: number;
 
   /** Length of the number of total rows. */
   count?: number;

--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -35,8 +35,9 @@ export function getTableMultipleDefaultRowDefsError() {
  * Returns an error to be thrown when there are no matching row defs for a particular set of data.
  * @docs-private
  */
-export function getTableMissingMatchingRowDefError() {
-  return Error(`Could not find a matching row definition for the provided row data.`);
+export function getTableMissingMatchingRowDefError(data: any) {
+  return Error(`Could not find a matching row definition for the` +
+      `provided row data: ${JSON.stringify(data)}`);
 }
 
 /**

--- a/src/demo-app/table/expandable-rows/expandable-rows.html
+++ b/src/demo-app/table/expandable-rows/expandable-rows.html
@@ -1,0 +1,28 @@
+<mat-card>
+  <table mat-table [dataSource]="dataSource" multiTemplateDataRows matSort>
+    <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
+      <td mat-cell *matCellDef="let element"> {{element[column]}} </td>
+    </ng-container>
+
+    <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->
+    <ng-container matColumnDef="expandedDetail">
+      <td colspan="4" mat-cell *matCellDef="let element">
+        <div style="overflow: hidden"
+             [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+          The symbol for {{element.name}} is {{element.symbol}}
+        </div>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+    <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"
+        class="demo-element-row"
+        [class.demo-expanded]="expandedElement == row"
+        (click)="expandedElement = expandedElement === row ? undefined : row"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['expandedDetail']"
+        class="demo-detail-row"></tr>
+  </table>
+
+  <mat-paginator pageSize="20" [pageSizeOptions]="[5, 20]"></mat-paginator>
+</mat-card>

--- a/src/demo-app/table/expandable-rows/expandable-rows.ts
+++ b/src/demo-app/table/expandable-rows/expandable-rows.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewChild} from '@angular/core';
+import {Element, ELEMENT_DATA} from 'table/element-data';
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
+
+@Component({
+  moduleId: module.id,
+  selector: 'expandable-rows',
+  templateUrl: 'expandable-rows.html',
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed',
+          animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
+  styles: [`
+    table {
+      width: 100%;
+    }
+
+    tr.demo-detail-row {
+      height: 0;
+    }
+
+    tr.demo-element-row:not(.demo-expanded):hover {
+      background: #F5F5F5;
+    }
+
+    tr.demo-element-row:not(.demo-expanded):active {
+      background: #EFEFEF;
+    }
+
+    .demo-element-row td {
+      border-bottom-width: 0;
+    }
+  `]
+})
+export class ExpandableRowsDemo {
+  dataSource = new MatTableDataSource(ELEMENT_DATA.slice());
+  columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
+  expandedElement: Element;
+
+  @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  ngOnInit() {
+    this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
+  }
+}

--- a/src/demo-app/table/routes.ts
+++ b/src/demo-app/table/routes.ts
@@ -14,6 +14,7 @@ import {MatTableDataSourceDemo} from './mat-table-data-source/mat-table-data-sou
 import {DynamicColumnsDemo} from './dynamic-columns/dynamic-columns';
 import {RowContextDemo} from './row-context/row-context';
 import {WhenRowsDemo} from './when-rows/when-rows';
+import {ExpandableRowsDemo} from './expandable-rows/expandable-rows';
 
 export const TABLE_DEMO_ROUTES: Routes = [
   {path: '', redirectTo: 'main-demo', pathMatch: 'full'},
@@ -23,5 +24,6 @@ export const TABLE_DEMO_ROUTES: Routes = [
   {path: 'mat-table-data-source', component: MatTableDataSourceDemo},
   {path: 'dynamic-columns', component: DynamicColumnsDemo},
   {path: 'row-context', component: RowContextDemo},
-  {path: 'when-rows', component: WhenRowsDemo}
+  {path: 'when-rows', component: WhenRowsDemo},
+  {path: 'expandable-rows', component: ExpandableRowsDemo}
 ];

--- a/src/demo-app/table/table-demo-module.ts
+++ b/src/demo-app/table/table-demo-module.ts
@@ -16,11 +16,14 @@ import {
   MatCardModule,
   MatCheckboxModule,
   MatIconModule,
-  MatInputModule, MatMenuModule,
+  MatInputModule,
+  MatMenuModule,
   MatPaginatorModule,
   MatRadioModule,
+  MatSlideToggleModule,
   MatSortModule,
-  MatTableModule, MatTabsModule
+  MatTableModule,
+  MatTabsModule
 } from '@angular/material';
 import {FormsModule} from '@angular/forms';
 import {CdkTableModule} from '@angular/cdk/table';
@@ -33,6 +36,7 @@ import {MatTableDataSourceDemo} from './mat-table-data-source/mat-table-data-sou
 import {DynamicColumnsDemo} from './dynamic-columns/dynamic-columns';
 import {RowContextDemo} from './row-context/row-context';
 import {WhenRowsDemo} from './when-rows/when-rows';
+import {ExpandableRowsDemo} from 'table/expandable-rows/expandable-rows';
 
 
 @NgModule({
@@ -48,6 +52,7 @@ import {WhenRowsDemo} from './when-rows/when-rows';
     MatMenuModule,
     MatPaginatorModule,
     MatRadioModule,
+    MatSlideToggleModule,
     MatSortModule,
     MatTableModule,
     MatTabsModule,
@@ -64,6 +69,7 @@ import {WhenRowsDemo} from './when-rows/when-rows';
     DynamicColumnsDemo,
     RowContextDemo,
     WhenRowsDemo,
+    ExpandableRowsDemo
   ],
   providers: [
     PeopleDatabase

--- a/src/demo-app/table/table-demo-page.ts
+++ b/src/demo-app/table/table-demo-page.ts
@@ -21,6 +21,7 @@ export class TableDemoPage {
     {name: 'MatTableDataSource', link: 'mat-table-data-source'},
     {name: 'Dynamic Columns', link: 'dynamic-columns'},
     {name: 'Row Context', link: 'row-context'},
-    {name: 'When Rows', link: 'when-rows'}
+    {name: 'When Rows', link: 'when-rows'},
+    {name: 'Expandable Rows', link: 'expandable-rows'}
   ];
 }

--- a/src/demo-app/table/when-rows/when-rows.html
+++ b/src/demo-app/table/when-rows/when-rows.html
@@ -1,13 +1,68 @@
+<div>
+  <button mat-raised-button (click)="shuffleArray()">Shuffle array</button>
+</div>
+
+<div>
+  <button mat-raised-button (click)="changeRandomNumber()">Randomize</button>
+  Highlighted rows: {{randomNumber}}
+</div>
+
+<div>
+  <mat-slide-toggle (change)="multiTemplateDataRows = $event.checked">
+    Enable multiple data rows
+  </mat-slide-toggle>
+</div>
+
+<div>
+  <mat-slide-toggle (change)="useTrackByValue = $event.checked">
+    Enable track by value
+  </mat-slide-toggle>
+</div>
+
 <mat-card>
-  <table cdk-table [dataSource]="dataSource">
-    <ng-container cdkColumnDef="{{column}}" *ngFor="let column of columns">
-      <th cdk-header-cell *cdkHeaderCellDef> {{column}} </th>
-      <td cdk-cell *cdkCellDef="let element"> {{element[column]}} </td>
+  <h3> MatTable </h3>
+
+  <table mat-table style="width: 100%"
+         [trackBy]="useTrackByValue ? trackByValue : undefined"
+         [multiTemplateDataRows]="multiTemplateDataRows"
+         [dataSource]="data">
+    <!-- Data column -->
+    <ng-container matColumnDef="data">
+      <th mat-header-cell *matHeaderCellDef> Data </th>
+      <td mat-cell *matCellDef="let data">
+        {{data.value}}
+      </td>
     </ng-container>
 
-    <tr cdk-header-row *cdkHeaderRowDef="columns"></tr>
+    <!-- Index column -->
+    <ng-container matColumnDef="index">
+      <th mat-header-cell *matHeaderCellDef> Index </th>
+      <td mat-cell *matCellDef="let data; let index = index">
+        {{index}}
+      </td>
+    </ng-container>
 
-    <tr cdk-row *cdkRowDef="let row; let odd = odd; columns: ['position']; when: isOdd"></tr>
-    <tr cdk-row *cdkRowDef="let row; columns: columns;"></tr>
+    <!-- Data index column -->
+    <ng-container matColumnDef="dataIndex">
+      <th mat-header-cell *matHeaderCellDef> Data Index </th>
+      <td mat-cell *matCellDef="let data; let dataIndex = dataIndex">
+        {{dataIndex}}
+      </td>
+    </ng-container>
+
+    <!-- Row Index column -->
+    <ng-container matColumnDef="renderIndex">
+      <th mat-header-cell *matHeaderCellDef> Render Index </th>
+      <td mat-cell *matCellDef="let data; let renderIndex = renderIndex">
+        {{renderIndex}}
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+
+    <tr mat-row style="background: rgba(255, 0, 0, .2);"
+        *matRowDef="let data; columns: columnsToDisplay; when: whenFn"></tr>
+    <tr mat-row style="background: rgba(0, 255, 0, .2);"
+        *matRowDef="let data; columns: columnsToDisplay;"></tr>
   </table>
 </mat-card>

--- a/src/demo-app/table/when-rows/when-rows.ts
+++ b/src/demo-app/table/when-rows/when-rows.ts
@@ -6,16 +6,57 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {Element, ELEMENT_DATA} from '../element-data';
+import {Component, ViewChild} from '@angular/core';
+import {MatTable} from '@angular/material';
+
+const DATA_LENGTH = 10;
+
+export interface DemoDataObject {
+  value: boolean;
+}
 
 @Component({
   moduleId: module.id,
   templateUrl: 'when-rows.html',
 })
 export class WhenRowsDemo {
-  columns = ['name', 'weight', 'symbol', 'position'];
-  dataSource: Element[] = ELEMENT_DATA.slice();
+  columnsToDisplay = ['data', 'index', 'dataIndex', 'renderIndex'];
+  data: DemoDataObject[] =
+      (new Array(DATA_LENGTH) as DemoDataObject[]).fill({value: false}, 0, DATA_LENGTH);
+  randomNumber = 0;
+  multiTemplateDataRows = false;
+  useTrackByValue = false;
 
-  isOdd = (i: number, _d: Element) => i % 2 !== 0;
+  whenFn = (_i: number, d: DemoDataObject) => d.value;
+  trackByValue = (_i: number, d: DemoDataObject) => d.value;
+
+  @ViewChild(MatTable) table: MatTable<any>;
+
+  constructor() {
+    this.changeRandomNumber();
+  }
+
+  changeRandomNumber() {
+    this.randomNumber = Math.floor(Math.random() * DATA_LENGTH);
+    this.data = this.data.map((_d: DemoDataObject, i: number) => ({value: i < this.randomNumber}));
+    if (this.table) {
+      this.table.renderRows();
+    }
+  }
+
+  shuffleArray() {
+    let dataToShuffle = this.data.slice();
+    let currentIndex = dataToShuffle.length;
+    while (0 !== currentIndex) {
+      let randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+
+      // Swap
+      let temp = dataToShuffle[currentIndex];
+      dataToShuffle[currentIndex] = dataToShuffle[randomIndex];
+      dataToShuffle[randomIndex] = temp;
+    }
+
+    this.data = dataToShuffle;
+  }
 }

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -56,6 +56,23 @@ describe('MatTable', () => {
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
+
+    it('should create a table with multiTemplateDataRows true', () => {
+      let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
+      fixture.componentInstance.multiTemplateDataRows = true;
+      fixture.detectChanges();
+
+      const tableElement = fixture.nativeElement.querySelector('.mat-table');
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['a_1'],
+        ['a_2'],
+        ['a_3'],
+        ['a_4'], // With multiple rows, this row shows up along with the special 'when' fourth_row
+        ['fourth_row'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+    });
   });
 
   it('should be able to render a table correctly with native elements', () => {
@@ -486,7 +503,7 @@ class NativeHtmlTableApp {
 
 @Component({
   template: `
-    <mat-table [dataSource]="dataSource">
+    <mat-table [dataSource]="dataSource" [multiTemplateDataRows]="multiTemplateDataRows">
       <ng-container matColumnDef="column_a">
         <mat-header-cell *matHeaderCellDef> Column A</mat-header-cell>
         <mat-cell *matCellDef="let row"> {{row.a}}</mat-cell>
@@ -505,6 +522,7 @@ class NativeHtmlTableApp {
   `
 })
 class MatTableWithWhenRowApp {
+  multiTemplateDataRows = false;
   dataSource: FakeDataSource | null = new FakeDataSource();
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 


### PR DESCRIPTION
Originally at #10964

Introduces a new table input `multiTemplateDataRows` which allows the table to have multiple data rows per data object.

**Old paradigm**

Each data object passed to the table is rendered as a data row. Since the mapping is 1:1, the data array itself can be used with the `IterableDiffer` to determine which rows need to change.

**New paradigm**

Each data object passed to the table may be rendered by one or more rows. The `IterableDiffer` cannot use the data array itself anymore since it will not correctly understand add/remove/move operations in the rows. 

Instead, the `IterableDiffer` will be diffed with a `DataRow` object that represents a pair containing a data object and row template. When the data changes, the list of `DataRow` objects will be constructed and diffed to get the list of changes.

**Caveats for discussion**

1. The row context previously contained an `index` value that represented both the row index and data object index (they were the same. Now, that `index` value represents the index of the data. To get the row index, there is an additional context property called `rowIndex`.

_Should it be swapped such that `index` is the row index and the data index can be stored in `dataIndex`?_ 

2. Similarly, the `trackBy` function receives an index value. Previously the index matched both the data and row. Now, its explicitly the data index.

_Should `trackBy` receive the row index?_ 

