### PR TITLE
fix(chips): stacked chips overflowing chip list

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -23,6 +23,7 @@ $mat-chip-remove-size: 18px;
 .mat-chip {
   position: relative;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 .mat-standard-chip {


### PR DESCRIPTION
Fixes the stacked chips overflowing their parent due to them having the wrong `box-sizing` by default. 

For reference (red outline added by me):
![angular_material_-_google_chrome_2018-05-03_23-18-56](https://user-images.githubusercontent.com/4450522/39603496-ec45828a-4f28-11e8-9734-a9a9c9ac3a42.png)
