### PR TITLE
feat(cdk-input): change autosize to be bindable (#9884)

### DIFF
--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -8,6 +8,7 @@ ng_module(
   module_name = "@angular/cdk/text-field",
   deps = [
     "@rxjs",
+    "//src/cdk/coercion",
     "//src/cdk/platform",
   ],
   tsconfig = "//src/lib:tsconfig-build.json",

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -24,6 +24,7 @@ describe('CdkTextareaAutosize', () => {
         AutosizeTextAreaWithContent,
         AutosizeTextAreaWithValue,
         AutosizeTextareaWithNgModel,
+        AutosizeTextareaWithoutAutosize,
       ],
     });
 
@@ -217,6 +218,50 @@ describe('CdkTextareaAutosize', () => {
 
     expect(autosize.resizeToFitContent).toHaveBeenCalled();
   }));
+
+  it('should not trigger a resize when it is disabled', fakeAsync(() => {
+    const fixtureWithoutAutosize = TestBed.createComponent(AutosizeTextareaWithoutAutosize);
+    textarea = fixtureWithoutAutosize.nativeElement.querySelector('textarea');
+    autosize = fixtureWithoutAutosize.debugElement.query(By.css('textarea'))
+        .injector.get(CdkTextareaAutosize);
+
+    fixtureWithoutAutosize.detectChanges();
+
+    let previousHeight = textarea.clientHeight;
+
+    fixtureWithoutAutosize.componentInstance.content = `
+    Line
+    Line
+    Line
+    Line
+    Line`;
+
+    // Manually call resizeToFitContent instead of faking an `input` event.
+    fixtureWithoutAutosize.detectChanges();
+
+    expect(textarea.clientHeight)
+        .toEqual(previousHeight, 'Expected textarea to still have the same size.');
+    expect(textarea.clientHeight)
+        .toBeLessThan(textarea.scrollHeight,
+          'Expected textarea height to be less than its scrollHeight');
+
+    autosize.enabled = true;
+    fixtureWithoutAutosize.detectChanges();
+
+    expect(textarea.clientHeight)
+        .toBeGreaterThan(previousHeight, 'Expected textarea to have grown after enabling.');
+    expect(textarea.clientHeight)
+        .toBe(textarea.scrollHeight, 'Expected textarea height to match its scrollHeight');
+
+    autosize.enabled = false;
+    fixtureWithoutAutosize.detectChanges();
+
+    expect(textarea.clientHeight)
+        .toEqual(previousHeight, 'Expected textarea to again have the original size.');
+    expect(textarea.clientHeight)
+        .toBeLessThan(textarea.scrollHeight,
+            'Expected textarea height to be less than its scrollHeight again');
+  }));
 });
 
 // Styles to reset padding and border to make measurement comparisons easier.
@@ -257,3 +302,12 @@ class AutosizeTextAreaWithValue {
 class AutosizeTextareaWithNgModel {
   model = '';
 }
+
+@Component({
+  template: `<textarea [cdkTextareaAutosize]="false">{{content}}</textarea>`,
+  styles: [textareaStyleReset],
+})
+class AutosizeTextareaWithoutAutosize {
+  content: string = '';
+}
+

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -227,7 +227,7 @@ describe('CdkTextareaAutosize', () => {
 
     fixtureWithoutAutosize.detectChanges();
 
-    let previousHeight = textarea.clientHeight;
+    const previousHeight = textarea.clientHeight;
 
     fixtureWithoutAutosize.componentInstance.content = `
     Line
@@ -242,25 +242,24 @@ describe('CdkTextareaAutosize', () => {
     expect(textarea.clientHeight)
         .toEqual(previousHeight, 'Expected textarea to still have the same size.');
     expect(textarea.clientHeight)
-        .toBeLessThan(textarea.scrollHeight,
-          'Expected textarea height to be less than its scrollHeight');
+        .toBeLessThan(textarea.scrollHeight, 'Expected textarea to a have scrollbar.');
 
     autosize.enabled = true;
     fixtureWithoutAutosize.detectChanges();
 
     expect(textarea.clientHeight)
-        .toBeGreaterThan(previousHeight, 'Expected textarea to have grown after enabling.');
+        .toBeGreaterThan(previousHeight,
+            'Expected textarea to have grown after enabling autosize.');
     expect(textarea.clientHeight)
-        .toBe(textarea.scrollHeight, 'Expected textarea height to match its scrollHeight');
+        .toBe(textarea.scrollHeight, 'Expected textarea not to have a scrollbar');
 
     autosize.enabled = false;
     fixtureWithoutAutosize.detectChanges();
 
     expect(textarea.clientHeight)
-        .toEqual(previousHeight, 'Expected textarea to again have the original size.');
+        .toEqual(previousHeight, 'Expected textarea to have the original size.');
     expect(textarea.clientHeight)
-        .toBeLessThan(textarea.scrollHeight,
-            'Expected textarea height to be less than its scrollHeight again');
+        .toBeLessThan(textarea.scrollHeight, 'Expected textarea to have a scrollbar.');
   }));
 });
 

--- a/src/demo-app/input/input-demo.html
+++ b/src/demo-app/input/input-demo.html
@@ -559,6 +559,12 @@
       Plain textarea with auto size
       <textarea cdkTextareaAutosize [(ngModel)]="textareaNgModelValue"></textarea>
     </label>
+
+    <h3>&lt;textarea&gt; with bindable autosize </h3>
+    <mat-checkbox [(ngModel)]="textareaAutosizeEnabled" name="autosizeEnabledCheckbox">
+      Autosize enabled
+    </mat-checkbox>
+    <textarea [cdkTextareaAutosize]="textareaAutosizeEnabled"></textarea>
   </mat-card-content>
 </mat-card>
 

--- a/src/demo-app/input/input-demo.ts
+++ b/src/demo-app/input/input-demo.ts
@@ -29,6 +29,7 @@ export class InputDemo {
   hideRequiredMarker: boolean;
   ctrlDisabled = false;
   textareaNgModelValue: string;
+  textareaAutosizeEnabled = false;
   placeholderTestControl = new FormControl('', Validators.required);
 
   name: string;

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -34,4 +34,12 @@ export class MatTextareaAutosize extends CdkTextareaAutosize {
   @Input()
   get matAutosizeMaxRows(): number { return this.maxRows; }
   set matAutosizeMaxRows(value: number) { this.maxRows = value; }
+
+  @Input('mat-autosize')
+  get matAutosize(): boolean { return this.enabled; }
+  set matAutosize(value: boolean) { this.enabled = value; }
+
+  @Input()
+  get matTextareaAutosize(): boolean { return this.enabled; }
+  set matTextareaAutosize(value: boolean) { this.enabled = value; }
 }


### PR DESCRIPTION
This allows cdkTextareaAutosize selector to be bindable and toggle the internal
enabled / disabled state.

Upon disabling the initial height is restored (textarea.style.height before any changes
were applied).

Also added wrapper into (to be discontinued) matTextareaAutosize.

Fixes #9884