### PR TITLE
Fix(icon): add asynchronous support for adding icons to registry (#3304)

### DIFF
--- a/src/demo-app/icon/icon-demo.html
+++ b/src/demo-app/icon/icon-demo.html
@@ -22,6 +22,10 @@
   </p>
 
   <p>
+    Asynchronous loading (This will appear after 3 seconds):
+    <mat-icon color="warn" svgIcon="custom:thumbup"></mat-icon>
+  </p>
+  <p>
     Using a theme:
     <mat-icon color="primary">home</mat-icon>
     <mat-icon color="accent">home</mat-icon>

--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -9,6 +9,10 @@
 import {Component, ViewEncapsulation} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {MatIconRegistry} from '@angular/material';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/delay';
+
 
 @Component({
   moduleId: module.id,
@@ -26,5 +30,14 @@ export class IconDemo {
         .addSvgIconSetInNamespace('core',
             sanitizer.bypassSecurityTrustResourceUrl('/icon/assets/core-icon-set.svg'))
         .registerFontClassAlias('fontawesome', 'fa');
+
+    // create an empty observable to simulate asynchronous adding of an icon after initial load
+    Observable
+      .of({})
+      .delay(3000)
+      .subscribe(() => {
+            const path = sanitizer.bypassSecurityTrustResourceUrl('/icon/assets/thumbup-icon.svg');
+            iconRegistry.addSvgIconInNamespace('custom', 'thumbup', path);
+      });
   }
 }

--- a/src/lib/icon/fake-svgs.ts
+++ b/src/lib/icon/fake-svgs.ts
@@ -14,6 +14,7 @@
 export const FAKE_SVGS = {
   cat: '<svg><path id="meow" name="meow"></path></svg>',
   dog: '<svg><path id="woof" name="woof"></path></svg>',
+  mouse: '<svg><path id="squeak" name="squeak"></path></svg>',
   farmSet1: `
     <svg>
       <defs>

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -146,6 +146,18 @@ describe('MatIcon', () => {
       svgElement = verifyAndGetSingleSvgChild(iconElement);
       verifyPathChildElement(svgElement, 'woof');
 
+      // Assert that an unregistered icon is rendered when eventually registered
+      testComponent.iconName = 'morris';
+      fixture.detectChanges();
+      // No request should be made as the svg was not added to the registry
+      http.expectNone('mouse.svg');
+      // Now that the icon is added, the http request will be made almost immediately
+      iconRegistry.addSvgIcon('morris', trust('mouse.svg'))
+      http.expectOne('mouse.svg').flush(FAKE_SVGS.mouse);
+      svgElement = verifyAndGetSingleSvgChild(iconElement);
+      verifyPathChildElement(svgElement, 'squeak');
+
+
       // Assert that a registered icon can be looked-up by url.
       iconRegistry.getSvgIconFromUrl(trust('cat.svg')).subscribe(element => {
         verifyPathChildElement(element, 'meow');

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -142,7 +142,18 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Can
 
         this._iconRegistry.getNamedSvgIcon(iconName, namespace).pipe(take(1)).subscribe(
           svg => this._setSvgElement(svg),
-          (err: Error) => console.log(`Error retrieving icon: ${err.message}`)
+          (err: Error) => {
+            console.log(`Error retrieving icon: ${err.message}`);
+            // Set up a nested subscription to be notified if this icon is ever added to the registry
+            this._iconRegistry.subscribeForIcon(iconName, namespace)
+              .subscribe(
+                svg2 => {
+                  this._setSvgElement(svg2);
+                },
+                (err: Error) => {
+                  console.log(`Error retrieving icon from subscription: ${err.message}`);
+              });
+          }
         );
       } else {
         this._clearSvgElement();


### PR DESCRIPTION
Change the icon-registry to provide a method of subscribing for icons. Allow icons to subscribe for an icon being added to registry asynchronously.