### PR TITLE
chore: fix syntax error in tree readme

### DIFF
--- a/src/cdk/tree/tree.md
+++ b/src/cdk/tree/tree.md
@@ -40,8 +40,8 @@ a node outlet into which children are projected.
 <cdk-tree>
   <cdk-nested-tree-node>
     parent node
-    <cdk-nested-tree-node> -- child node1 </cdk-tree-node>
-    <cdk-nested-tree-node> -- child node2 </cdk-tree-node>
+    <cdk-nested-tree-node> -- child node1 </cdk-nested-tree-node>
+    <cdk-nested-tree-node> -- child node2 </cdk-nested-tree-node>
   </cdk-nested-tree-node>
 </cdk-tree>
 ```

--- a/src/lib/tree/tree.md
+++ b/src/lib/tree/tree.md
@@ -39,8 +39,8 @@ outlet to keep all the children nodes.
 <mat-tree>
    <mat-nested-tree-node>
      parent node
-     <mat-nested-tree-node> -- child node1 </mat-tree-node>
-     <mat-nested-tree-node> -- child node2 </mat-tree-node>
+     <mat-nested-tree-node> -- child node1 </mat-nested-tree-node>
+     <mat-nested-tree-node> -- child node2 </mat-nested-tree-node>
    </mat-nested-tree-node>
 </mat-tree>
 ```


### PR DESCRIPTION
Fixes a couple of mismatched closing tags in the tree readme.

Fixes #11182.