### PR TITLE
fix(scrolling): scrollbar jump when data change on scroll

### DIFF
--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -133,7 +133,7 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   onDataLengthChanged() {
     if (this._viewport) {
       this._setScrollOffset();
-      this._updateRenderedContentAfterScroll();
+      this._checkRenderedContentSize();
     }
   }
 

--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -134,6 +134,7 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     if (this._viewport) {
       // TODO(mmalebra): Do something smarter here.
       this._setScrollOffset();
+      this._updateRenderedContentAfterScroll();
     }
   }
 

--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -132,7 +132,6 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   /** Implemented as part of VirtualScrollStrategy. */
   onDataLengthChanged() {
     if (this._viewport) {
-      // TODO(mmalebra): Do something smarter here.
       this._setScrollOffset();
       this._updateRenderedContentAfterScroll();
     }


### PR DESCRIPTION
Fixes the scrollbar not updating when data is lazily loaded in as a result when you begin to scroll the scrollbar size jumps.

Demo of issue: https://stackblitz.com/edit/angular-c7vsdg