### PR TITLE
virtual-scroll: Fixes scroll gap with autosize

### DIFF
--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -355,6 +355,14 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   private _updateTotalContentSize(renderedContentSize: number) {
     const viewport = this._viewport!;
     const renderedRange = viewport.getRenderedRange();
+
+    // once we hit the bottom, we need to resample our range
+    // based on the items in view so we don't create a gap
+    if (renderedRange.end === viewport.getDataLength()) {
+      this._averager.reset();
+      this._averager.addSample(renderedRange, viewport.getDataLength());
+    }
+
     const totalSize = renderedContentSize +
         (viewport.getDataLength() - (renderedRange.end - renderedRange.start)) *
         this._averager.getAverageItemSize();


### PR DESCRIPTION
This PR fixes the scroll gap that occurs at the end of a auto-sized scrolled. This resets the range and creates a new sample based on whats in view so we aren't 'predicting' the size and ending up with a gap.

Demo of issue: https://stackblitz.com/edit/angular-soc77e