### PR TITLE
fix(sidenav-demo): trigger event opened

### DIFF
--- a/src/demo-app/sidenav/sidenav-demo.html
+++ b/src/demo-app/sidenav/sidenav-demo.html
@@ -5,7 +5,7 @@
 <div class="demo-sidenav-area" *ngIf="isLaunched">
   <mat-toolbar *ngIf="showHeader && !coverHeader">Header</mat-toolbar>
   <mat-sidenav-container [hasBackdrop]="hasBackdrop">
-    <mat-sidenav #start (open)="myinput.focus()" [mode]="mode"
+    <mat-sidenav #start (opened)="myinput.focus()" [mode]="mode"
                  [fixedInViewport]="fixed" [fixedTopGap]="fixedTop" [fixedBottomGap]="fixedBottom">
       Start Side Sidenav
       <br>


### PR DESCRIPTION
Fix for `demo-sidenav` behaviour after the `drawer` opened . For correct set focus on `input` after  `#start` sidenav was opened.