### PR TITLE
fix(dialog): min-height and max-height not having an effect on dialog container

### DIFF
--- a/src/lib/dialog/dialog.scss
+++ b/src/lib/dialog/dialog.scss
@@ -22,6 +22,11 @@ $mat-dialog-button-margin: 8px !default;
   width: 100%;
   height: 100%;
 
+  // Since the dialog won't stretch to fit the parent, if the height
+  // isn't set, we have to inherit the min and max values explicitly.
+  min-height: inherit;
+  max-height: inherit;
+
   @include cdk-high-contrast {
     outline: solid 1px;
   }


### PR DESCRIPTION
When setting the `min-height` or `max-height` on a dialog, the properties get applied to the overlay pane, however the dialog's `height: 100%` won't apply if the parent's height isn't known which breaks the min and max values. These changes ensure that the dialog matches the `min-height` and `max-height` from the config.