### PR TITLE
Apply styling to .mat-tab-label-content which is a child element

### DIFF
--- a/src/lib/tabs/_tabs-common.scss
+++ b/src/lib/tabs/_tabs-common.scss
@@ -30,7 +30,7 @@ $mat-tab-animation-duration: 500ms !default;
     cursor: default;
   }
 
-  &.mat-tab-label-content {
+  .mat-tab-label-content {
     display: inline-flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Fixing https://github.com/angular/material2/commit/eebfce4247b622857b7ac68ea0b562a1effe1dd5
Basically `.mat-tab-label-content` is a child of `.mat-tab-label` (and NOT the same element).

Currently `.mat-tab-label-content` is unstyled div, which causes all sorts of unwanted behavior.

@jelbourn 