### PR TITLE
refactor: remove deprecated injector.get signature usages

### DIFF
--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -266,7 +266,7 @@ export class Dialog {
       .set(this.injector.get(DIALOG_CONTAINER), dialogContainer)
       .set(DIALOG_DATA, config.data);
 
-    if (!userInjector || !userInjector.get(Directionality, null)) {
+    if (!userInjector || !userInjector.get<Directionality | null>(Directionality, null)) {
       injectionTokens.set(Directionality, {
         value: config.direction,
         change: observableOf()

--- a/src/lib/bottom-sheet/bottom-sheet.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.ts
@@ -146,7 +146,7 @@ export class MatBottomSheet {
     injectionTokens.set(MatBottomSheetRef, bottomSheetRef);
     injectionTokens.set(MAT_BOTTOM_SHEET_DATA, config.data);
 
-    if (!userInjector || !userInjector.get(Directionality, null)) {
+    if (!userInjector || !userInjector.get<Directionality | null>(Directionality, null)) {
       injectionTokens.set(Directionality, {
         value: config.direction,
         change: observableOf()

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -289,7 +289,7 @@ export class MatDialog {
       .set(MAT_DIALOG_DATA, config.data)
       .set(MatDialogRef, dialogRef);
 
-    if (!userInjector || !userInjector.get(Directionality, null)) {
+    if (!userInjector || !userInjector.get<Directionality | null>(Directionality, null)) {
       injectionTokens.set(Directionality, {
         value: config.direction,
         change: observableOf()


### PR DESCRIPTION
Removes a few usages of a deprecated signature of `Injector.get`.