### PR TITLE
Revert "fix(tabs): handle long tab labels in mat-tab-nav-bar (#10903)"

### DIFF
--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -14,15 +14,10 @@
 // Wraps each link in the header
 .mat-tab-link {
   @include tab-label;
-  line-height: $mat-tab-bar-height;
+  vertical-align: top;
   text-decoration: none;  // Removes anchor underline styling
   position: relative;
   overflow: hidden;  // Keeps the ripple from extending outside the element bounds
-
-  // Allows for the ellipsis overflow to work. We truncate the
-  // text since we don't support pagination on nav bars.
-  display: block;
-  text-overflow: ellipsis;
 
   [mat-stretch-tabs] & {
     flex-basis: 0;


### PR DESCRIPTION
This reverts commit 61dd937eef61d817ea9b7282f321f38632b7a166.

@crisbeto this interferes with some places that customize the height of the mat-tab-link, reverting to unblock syncing