### PR TITLE
build: fix and re-enable bazel unit tests for the cdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       # This may be unnecessary once rules_nodejs uses nodejs 8
       - run: bazel run @nodejs//:npm run postinstall
       - run: bazel build src/...
+      - run: bazel test src/...
       - save_cache:
           key: material2-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,28 @@
 # To validate changes, use an online parser, eg.
 # http://yaml-online-parser.appspot.com/
 
+## IMPORTANT
+# If you change the `docker_image` version, also change the `cache_key` suffix and the version of
+# `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
+var_1: &docker_image angular/ngcontainer:0.3.0
+var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.3.0
+
+# Define common ENV vars
+var_3: &define_env_vars
+  run: echo "export PROJECT_ROOT=$(pwd)" >> $BASH_ENV
+
+# See remote cache documentation in /docs/BAZEL.md
+var_4: &setup-bazel-remote-cache
+  run:
+    name: Start up bazel remote cache proxy
+    command: ~/bazel-remote-proxy -backend circleci://
+    background: true
+
 # Settings common to each job
 anchor_1: &job_defaults
   working_directory: ~/ng
   docker:
-    - image: angular/ngcontainer:0.1.0
+    - image: *docker_image
 
 # After checkout, rebase on top of master.
 # Similar to travis behavior, but not quite the same.
@@ -29,7 +46,7 @@ jobs:
       - checkout:
           <<: *post_checkout
       - restore_cache:
-          key: material2-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: *cache_key
 
       - run: bazel run @nodejs//:npm install
       # For some reason, circleci needs the postinstall to be run explicitly.
@@ -38,7 +55,7 @@ jobs:
       - run: bazel build src/...
       - run: bazel test src/...
       - save_cache:
-          key: material2-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: *cache_key
           paths:
             - "node_modules"
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,10 +76,7 @@ filegroup(
   srcs = [
     "//:node_modules/reflect-metadata/Reflect.js",
     "//:node_modules/zone.js/dist/zone.js",
-    "//:node_modules/zone.js/dist/async-test.js",
-    "//:node_modules/zone.js/dist/sync-test.js",
-    "//:node_modules/zone.js/dist/fake-async-test.js",
-    "//:node_modules/zone.js/dist/proxy.js",
-    "//:node_modules/zone.js/dist/jasmine-patch.js",
+    "//:node_modules/zone.js/dist/zone-testing.js",
+    "//:node_modules/zone.js/dist/task-tracking.js",
   ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,3 +48,9 @@ local_repository(
   name = "rxjs",
   path = "node_modules/rxjs/src",
 )
+
+
+# This commit matches the version of buildifier in angular/ngcontainer
+# If you change this, also check if it matches the version in the angular/ngcontainer
+# version in /.circleci/config.yml
+BAZEL_BUILDTOOLS_VERSION = "fd9878fd5de921e0bbab3dcdcb932c2627812ee1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,16 +3,16 @@ workspace(name = "angular_material")
 # Add nodejs rules
 http_archive(
   name = "build_bazel_rules_nodejs",
-  url = "https://github.com/bazelbuild/rules_nodejs/archive/1931156c232a08356dfda02e9c8b0275c2e63c00.zip",
-  strip_prefix = "rules_nodejs-1931156c232a08356dfda02e9c8b0275c2e63c00",
-  sha256 = "9cfe33276a6ac0076ee9ee159c4a2576f9851c0f437435b5ac19b2e592493078",
+  url = "https://github.com/bazelbuild/rules_nodejs/archive/0.8.0.zip",
+  strip_prefix = "rules_nodejs-0.8.0",
+  sha256 = "4e40dd49ae7668d245c3107645f2a138660fcfd975b9310b91eda13f0c973953",
 )
 
 # NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
 # your npm dependencies. You must still run the package manager.
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
-check_bazel_version("0.9.0")
+check_bazel_version("0.13.0")
 node_repositories(package_json = ["//:package.json"])
 
 # Add sass rules
@@ -28,9 +28,9 @@ sass_repositories()
 # Add TypeScript rules
 http_archive(
   name = "build_bazel_rules_typescript",
-  url = "https://github.com/bazelbuild/rules_typescript/archive/0.12.1.zip",
-  strip_prefix = "rules_typescript-0.12.1",
-  sha256 = "24e2c36f60508c6d270ae4265b89b381e3f66d550e70c367ed3755ad8d7ce3b0",
+  url = "https://github.com/bazelbuild/rules_typescript/archive/0.12.3.zip",
+  strip_prefix = "rules_typescript-0.12.3",
+  sha256 = "967068c3540f59407716fbeb49949c1600dbf387faeeab3089085784dd21f60c",
 )
 
 # Setup TypeScript Bazel workspace

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "systemjs": "0.19.43",
     "tsickle": "^0.27.2",
     "tslib": "^1.9.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.8.26"
   },
   "devDependencies": {
     "@angular-devkit/core": "^0.5.12",

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -48,7 +48,6 @@ ts_web_test(
   bootstrap = [
     "//:web_test_bootstrap_scripts",
   ],
-  tags = ["manual"],
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/accordion/BUILD.bazel
+++ b/src/cdk/accordion/BUILD.bazel
@@ -29,8 +29,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/bidi/BUILD.bazel
+++ b/src/cdk/bidi/BUILD.bazel
@@ -27,8 +27,6 @@ ts_web_test(
   bootstrap = [
     "//:web_test_bootstrap_scripts",
   ],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -22,6 +22,5 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
   deps = [":coercion_test_sources"],
 )

--- a/src/cdk/collections/BUILD.bazel
+++ b/src/cdk/collections/BUILD.bazel
@@ -25,8 +25,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/layout/BUILD.bazel
+++ b/src/cdk/layout/BUILD.bazel
@@ -30,8 +30,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/observers/BUILD.bazel
+++ b/src/cdk/observers/BUILD.bazel
@@ -28,8 +28,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/portal/BUILD.bazel
+++ b/src/cdk/portal/BUILD.bazel
@@ -25,7 +25,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/scrolling/BUILD.bazel
+++ b/src/cdk/scrolling/BUILD.bazel
@@ -31,8 +31,6 @@ ts_web_test(
   bootstrap = [
     "//:web_test_bootstrap_scripts",
   ],
-  tags = ["manual"],
-
   # Do not sort
   deps = [
     "//:tslib_bundle",

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -31,7 +31,6 @@ ts_library(
 ts_web_test(
   name = "unit_tests",
   bootstrap = ["//:web_test_bootstrap_scripts"],
-  tags = ["manual"],
   # Do not sort
   deps = [
     "//:tslib_bundle",


### PR DESCRIPTION
These were broken by rxjs 6.0, but the problem has since been fixed upstream

Overlay and tree still don't work for different reasons.