### PR TITLE
build: fix tests crashing IE test runs

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -67,8 +67,13 @@ describe('FlexibleConnectedPositionStrategy', () => {
           originY: 'bottom'
         }]);
 
+    // Needs to be in the DOM for IE not to throw an "Unspecified error".
+    document.body.appendChild(origin.nativeElement);
     attachOverlay({positionStrategy});
+
     expect(() => attachOverlay({positionStrategy})).toThrow();
+
+    document.body.removeChild(origin.nativeElement);
   });
 
   it('should not throw when trying to apply after being disposed', () => {
@@ -82,10 +87,14 @@ describe('FlexibleConnectedPositionStrategy', () => {
           originY: 'bottom'
         }]);
 
+    // Needs to be in the DOM for IE not to throw an "Unspecified error".
+    document.body.appendChild(origin.nativeElement);
     attachOverlay({positionStrategy});
     overlayRef.dispose();
 
     expect(() => positionStrategy.apply()).not.toThrow();
+
+    document.body.removeChild(origin.nativeElement);
   });
 
   it('should not throw when trying to re-apply the last position after being disposed', () => {
@@ -99,10 +108,14 @@ describe('FlexibleConnectedPositionStrategy', () => {
           originY: 'bottom'
         }]);
 
+    // Needs to be in the DOM for IE not to throw an "Unspecified error".
+    document.body.appendChild(origin.nativeElement);
     attachOverlay({positionStrategy});
     overlayRef.dispose();
 
     expect(() => positionStrategy.reapplyLastPosition()).not.toThrow();
+
+    document.body.removeChild(origin.nativeElement);
   });
 
   describe('without flexible dimensions and pushing', () => {
@@ -1604,6 +1617,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
+      document.body.removeChild(originElement);
       positionStrategy.dispose();
     });
 


### PR DESCRIPTION
This is another step towards re-enabling test runs against IE11. Fixes the tests that outright crashed the test run due to an "Unspecified error". The error was being thrown, because we were attempting to get the client rect of an element that wasn't in the DOM. These changes also fix a handful of tests that were leaking DOM elements. We should now be able to do an uninterrupted test run on IE, although there are still a handful of failing tests that might require code changes.