### PR TITLE
fix(radio): disable animations when using NoopAnimationsModule

### DIFF
--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -47,6 +47,10 @@ $mat-radio-ripple-radius: 25px;
     style: solid;
     radius: 50%;
   }
+
+  ._mat-animation-noopable & {
+    transition: none;
+  }
 }
 
 // The inner circle for the radio, shown when checked.
@@ -63,6 +67,10 @@ $mat-radio-ripple-radius: 25px;
   // Note: This starts from 0.001 instead of 0, because transitioning from 0 to 0.5 causes
   // IE to flash the entire circle for a couple of frames, throwing off the entire animation.
   transform: scale(0.001);
+
+  ._mat-animation-noopable & {
+    transition: none;
+  }
 
   .mat-radio-checked & {
     transform: scale(0.5);

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -28,6 +28,7 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  Inject,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
@@ -42,6 +43,8 @@ import {
   mixinTabIndex,
   RippleRef,
 } from '@angular/material/core';
+import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
+
 
 // Increasing integer for generating unique ids for radio components.
 let nextUniqueId = 0;
@@ -324,6 +327,7 @@ export const _MatRadioButtonMixinBase =
     'class': 'mat-radio-button',
     '[class.mat-radio-checked]': 'checked',
     '[class.mat-radio-disabled]': 'disabled',
+    '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
     '[attr.id]': 'id',
     // Note: under normal conditions focus shouldn't land on this element, however it may be
     // programmatically set, for example inside of a focus trap, in this case we want to forward
@@ -467,7 +471,8 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
               elementRef: ElementRef,
               private _changeDetector: ChangeDetectorRef,
               private _focusMonitor: FocusMonitor,
-              private _radioDispatcher: UniqueSelectionDispatcher) {
+              private _radioDispatcher: UniqueSelectionDispatcher,
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(elementRef);
 
     // Assertions. Ideally these should be stripped out by the compiler.


### PR DESCRIPTION
Disables the CSS-based animations in the radio buttons when the `NoopAnimationsModule` is used.