### PR TITLE
docs(chips): fix autocomplete-chips example

### DIFF
--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -58,6 +58,8 @@ export class ChipsAutocompleteExample {
     if (input) {
       input.value = '';
     }
+
+    this.fruitCtrl.setValue(null);
   }
 
   remove(fruit: any): void {
@@ -76,5 +78,6 @@ export class ChipsAutocompleteExample {
   selected(event: MatAutocompleteSelectedEvent): void {
     this.fruits.push(event.option.viewValue);
     this.fruitInput.nativeElement.value = '';
+    this.fruitCtrl.setValue(null);
   }
 }


### PR DESCRIPTION
Fixes #11291.

Although #11233 fixes the issue that prevented the chips removal, #11291 points to another issue: when the user pressed enter (or selected a chip from the autocomplete panel) to create the new chip, the autocomplete associated input wasn't cleared appropriately: it kept the last typed/selected item.

### Current Behavior:
![image](https://media.giphy.com/media/oyQfvFTkyJkryymDXV/giphy.gif)

### After fixing it
![image](https://media.giphy.com/media/QgjluXF1nMkkqL2GMI/giphy.gif)

Fix suggested by @CurtisDS.