### PR TITLE
chore(sort): include sort theme and typography in theme mixin

### DIFF
--- a/src/lib/core/theming/_all-theme.scss
+++ b/src/lib/core/theming/_all-theme.scss
@@ -27,6 +27,7 @@
 @import '../../slide-toggle/slide-toggle-theme';
 @import '../../slider/slider-theme';
 @import '../../stepper/stepper-theme';
+@import '../../sort/sort-theme';
 @import '../../tabs/tabs-theme';
 @import '../../toolbar/toolbar-theme';
 @import '../../tooltip/tooltip-theme';
@@ -66,6 +67,7 @@
   @include mat-slide-toggle-theme($theme);
   @include mat-slider-theme($theme);
   @include mat-stepper-theme($theme);
+  @include mat-sort-theme($theme);
   @include mat-tabs-theme($theme);
   @include mat-toolbar-theme($theme);
   @include mat-tooltip-theme($theme);

--- a/src/lib/core/typography/_all-typography.scss
+++ b/src/lib/core/typography/_all-typography.scss
@@ -25,6 +25,7 @@
 @import '../../slide-toggle/slide-toggle-theme';
 @import '../../slider/slider-theme';
 @import '../../stepper/stepper-theme';
+@import '../../sort/sort-theme';
 @import '../../tabs/tabs-theme';
 @import '../../toolbar/toolbar-theme';
 @import '../../tooltip/tooltip-theme';
@@ -68,6 +69,7 @@
   @include mat-slide-toggle-typography($config);
   @include mat-slider-typography($config);
   @include mat-stepper-typography($config);
+  @include mat-sort-typography($config);
   @include mat-tabs-typography($config);
   @include mat-toolbar-typography($config);
   @include mat-tooltip-typography($config);

--- a/src/lib/sort/_sort-theme.scss
+++ b/src/lib/sort/_sort-theme.scss
@@ -1,3 +1,4 @@
-
-// Empty mixin to be consistent with all other components.
+// Empty mixins to be consistent with all other components.
 @mixin mat-sort-theme($theme) { }
+
+@mixin mat-sort-typography($config) { }


### PR DESCRIPTION
Fixes the sort theme not being included in the theme mixin. While the theme doesn't have any styling now, it would've broken if we decided to add some styling. Also add an empty typography mixin.