### PR TITLE
fix(expansion-panel): inconsistent margin for nested panels

### DIFF
--- a/src/lib/expansion/expansion-panel.scss
+++ b/src/lib/expansion/expansion-panel.scss
@@ -26,12 +26,12 @@
   margin: 16px 0;
 
   .mat-accordion > &:first-child,
-  .mat-accordion > *:first-child & {
+  .mat-accordion > *:first-child:not(.mat-expansion-panel) & {
     margin-top: 0;
   }
 
   .mat-accordion > &:last-child,
-  .mat-accordion > *:last-child & {
+  .mat-accordion > *:last-child:not(.mat-expansion-panel) & {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
Fixes some inconsistent margin when expansion panels are nested inside other expansion panels.

Fixes #11254.