### PR TITLE
docs(toolbar): set proper `role` value

### DIFF
--- a/src/lib/toolbar/toolbar.md
+++ b/src/lib/toolbar/toolbar.md
@@ -68,7 +68,7 @@ By default, the toolbar assumes that it will be used in a purely decorative fash
 no roles, ARIA attributes, or keyboard shortcuts. This is equivalent to having a sequence of `<div>`
 elements on the page.
 
-Generally, the toolbar is used as a header where `role="header"` would be appropriate.
+Generally, the toolbar is used as a header where `role="heading"` would be appropriate.
 
 Only if the use-case of the toolbar match that of role="toolbar", the user should add the role and
 an appropriate label via `aria-label` or `aria-labelledby`.


### PR DESCRIPTION
Based on https://www.w3.org/TR/wai-aria/#role_definitions there is no such role as `header`, but rather it should `heading`