### PR TITLE
Correct mat-list padding

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -10,6 +10,7 @@ $mat-list-avatar-size: 40px;
 
 // Normal list variables
 $mat-list-top-padding: 8px;
+$mat-list-bottom-padding: 8px;
 // height for single-line lists
 $mat-list-base-height: 48px;
 // height for single-line lists with avatars
@@ -198,6 +199,7 @@ $mat-list-item-inset-divider-offset: 72px;
 
 .mat-list, .mat-nav-list, .mat-selection-list {
   padding-top: $mat-list-top-padding;
+  padding-bottom: $mat-list-bottom-padding;
   display: block;
 
   .mat-subheader {


### PR DESCRIPTION
Ref: [https://material.io/design/components/lists.html?image=https%3A%2F%2Fmaterial.io%2Fdesign%2Fassets%2F1gTGgqK5WK9w0RAqKgixTdodljG3oI2I1%2Flist-spec-threeline-group.png#specs](https://material.io/design/components/lists.html?image=https%3A%2F%2Fmaterial.io%2Fdesign%2Fassets%2F1gTGgqK5WK9w0RAqKgixTdodljG3oI2I1%2Flist-spec-threeline-group.png#specs)

![screenshot_4](https://user-images.githubusercontent.com/24437654/40041046-6290eca4-5825-11e8-80a8-691c0a9f5c0f.png)
