### PR TITLE
feat(moment-dateadapter): add option to create utc dates

### DIFF
--- a/src/lib/datepicker/datepicker.md
+++ b/src/lib/datepicker/datepicker.md
@@ -246,6 +246,17 @@ export class MyComponent {
 
 <!-- example(datepicker-moment) -->
 
+By default the `MomentDateAdapter` will creates dates in your time zone specific locale. You can change the default behaviour to parse dates as UTC by providing the `MAT_MOMENT_DATA_ADAPTER_OPTIONS` and setting it to `useUtc: true`.
+
+```ts
+@NgModule({
+  imports: [MatDatepickerModule, MatMomentDateModule],
+  providers: [
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }
+  ]
+})
+```
+
 It is also possible to create your own `DateAdapter` that works with any date format your app
 requires. This is accomplished by subclassing `DateAdapter` and providing your subclass as the
 `DateAdapter` implementation. You will also want to make sure that the `MAT_DATE_FORMATS` provided

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/material';
 import {
   MomentDateAdapter,
-  MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY, 
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS
 } from './moment-date-adapter';
 import {MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
@@ -25,8 +25,15 @@ export * from './moment-date-formats';
 
 @NgModule({
   providers: [
-    {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]},
-    {provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useFactory: MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY}
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]
+    },
+    {
+      provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+      useFactory: MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY
+    }
   ],
 })
 export class MomentDateModule {}

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -12,7 +12,11 @@ import {
   MAT_DATE_LOCALE,
   MAT_DATE_FORMATS
 } from '@angular/material';
-import {MomentDateAdapter} from './moment-date-adapter';
+import {
+  MomentDateAdapter,
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY, 
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS
+} from './moment-date-adapter';
 import {MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
 
 export * from './moment-date-adapter';
@@ -21,7 +25,8 @@ export * from './moment-date-formats';
 
 @NgModule({
   providers: [
-    {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]}
+    {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]},
+    {provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useFactory: MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY}
   ],
 })
 export class MomentDateModule {}

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -14,7 +14,6 @@ import {
 } from '@angular/material';
 import {
   MomentDateAdapter,
-  MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS
 } from './moment-date-adapter';
 import {MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
@@ -29,10 +28,6 @@ export * from './moment-date-formats';
       provide: DateAdapter,
       useClass: MomentDateAdapter,
       deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]
-    },
-    {
-      provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS,
-      useFactory: MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY
     }
   ],
 })

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -143,7 +143,8 @@ describe('MomentDateAdapter', () => {
   });
 
   it('should create Moment date', () => {
-    expect(adapter.createDate(2017, JAN, 1).format()).toEqual(moment.utc([2017,  JAN,  1]).format());
+    expect(adapter.createDate(2017, JAN, 1).format())
+      .toEqual(moment.utc([2017,  JAN,  1]).format());
   });
 
   it('should not create Moment date with month over/under-flow', () => {

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -143,7 +143,7 @@ describe('MomentDateAdapter', () => {
   });
 
   it('should create Moment date', () => {
-    expect(adapter.createDate(2017, JAN, 1).format()).toEqual(moment([2017,  JAN,  1]).format());
+    expect(adapter.createDate(2017, JAN, 1).format()).toEqual(moment.utc([2017,  JAN,  1]).format());
   });
 
   it('should not create Moment date with month over/under-flow', () => {
@@ -162,6 +162,10 @@ describe('MomentDateAdapter', () => {
     expect(adapter.createDate(50, JAN, 1).year()).toBe(50);
     expect(adapter.createDate(99, JAN, 1).year()).toBe(99);
     expect(adapter.createDate(100, JAN, 1).year()).toBe(100);
+  });
+
+  it('should create Moment date in utc format', () => {
+    expect(adapter.createDate(2017, JAN, 5).isUTC()).toBeTruthy();
   });
 
   it("should get today's date", () => {

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -11,7 +11,7 @@ import {async, inject, TestBed} from '@angular/core/testing';
 import {DateAdapter, DEC, FEB, JAN, MAR, MAT_DATE_LOCALE} from '@angular/material/core';
 import * as moment from 'moment';
 import {MomentDateModule} from './index';
-import {MomentDateAdapter} from './moment-date-adapter';
+import {MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS} from './moment-date-adapter';
 
 
 describe('MomentDateAdapter', () => {
@@ -144,7 +144,7 @@ describe('MomentDateAdapter', () => {
 
   it('should create Moment date', () => {
     expect(adapter.createDate(2017, JAN, 1).format())
-      .toEqual(moment.utc([2017,  JAN,  1]).format());
+      .toEqual(moment([2017,  JAN,  1]).format());
   });
 
   it('should not create Moment date with month over/under-flow', () => {
@@ -165,8 +165,8 @@ describe('MomentDateAdapter', () => {
     expect(adapter.createDate(100, JAN, 1).year()).toBe(100);
   });
 
-  it('should create Moment date in utc format', () => {
-    expect(adapter.createDate(2017, JAN, 5).isUTC()).toBeTruthy();
+  it('should not create Moment date in utc format', () => {
+    expect(adapter.createDate(2017, JAN, 5).isUTC()).toEqual(false);
   });
 
   it("should get today's date", () => {
@@ -411,5 +411,26 @@ describe('MomentDateAdapter with LOCALE_ID override', () => {
 
   it('should take the default locale id from the LOCALE_ID injection token', () => {
     expect(adapter.format(moment([2017,  JAN,  2]), 'll')).toEqual('2 janv. 2017');
+  });
+});
+
+describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () => {
+  let adapter: MomentDateAdapter;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MomentDateModule],
+      providers: [
+        { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {
+    adapter = d;
+  }));
+
+  it('should create Moment date in utc format if option useUtc is set', () => {
+    expect(adapter.createDate(2017, JAN, 5).isUTC()).toBeTruthy();
   });
 });

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -130,7 +130,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
       throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
     }
 
-    let result = moment({year, month, date}).locale(this.locale);
+    let result = moment.utc({year, month, date}).locale(this.locale);
 
     // If the result isn't valid, the date must have been out of bounds for this month.
     if (!result.isValid()) {

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -74,7 +74,9 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
   };
 
   constructor(@Optional() @Inject(MAT_DATE_LOCALE) dateLocale: string,
-    @Inject(MAT_MOMENT_DATE_ADAPTER_OPTIONS) private options: MatMomentDateAdapterOptions) {
+    @Optional() @Inject(MAT_MOMENT_DATE_ADAPTER_OPTIONS)
+    private options?: MatMomentDateAdapterOptions) {
+
     super();
     this.setLocale(dateLocale || moment.locale());
   }
@@ -157,7 +159,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     }
 
     let result;
-    if (this.options.useUtc) {
+    if (this.options && this.options.useUtc) {
       result = moment.utc({ year, month, date }).locale(this.locale);
     } else {
       result = moment({ year, month, date }).locale(this.locale);

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional} from '@angular/core';
+import {Inject, Injectable, Optional, InjectionToken} from '@angular/core';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material';
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
@@ -18,6 +18,31 @@ import * as _moment from 'moment';
 import {default as _rollupMoment, Moment} from 'moment';
 
 const moment = _rollupMoment || _moment;
+
+/** Configurable options for {@see MomentDateAdapter}. */
+export interface MatMomentDateAdapterOptions {
+  /** 
+   * Turns the use of utc dates on or off.
+   * Changing this will change how Angular Material components like DatePicker output dates.
+   * {@default false}
+   */
+  useUtc: boolean;
+}
+
+/** InjectionToken for moment date adapter to configure options. */
+export const MAT_MOMENT_DATE_ADAPTER_OPTIONS = new InjectionToken<MatMomentDateAdapterOptions>(
+  'MAT_MOMENT_DATE_ADAPTER_OPTIONS', {
+    providedIn: 'root',
+    factory: MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY
+});
+
+
+/** @docs-private */
+export function MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY(): MatMomentDateAdapterOptions {
+  return {
+    useUtc: false
+  };
+}
 
 
 /** Creates an array and fills it with values. */
@@ -48,7 +73,8 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     narrowDaysOfWeek: string[]
   };
 
-  constructor(@Optional() @Inject(MAT_DATE_LOCALE) dateLocale: string) {
+  constructor(@Optional() @Inject(MAT_DATE_LOCALE) dateLocale: string,
+    @Inject(MAT_MOMENT_DATE_ADAPTER_OPTIONS) private options: MatMomentDateAdapterOptions) {
     super();
     this.setLocale(dateLocale || moment.locale());
   }
@@ -130,7 +156,12 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
       throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
     }
 
-    let result = moment.utc({year, month, date}).locale(this.locale);
+    let result;
+    if (this.options.useUtc) {
+      result = moment.utc({ year, month, date }).locale(this.locale);
+    } else {
+      result = moment({ year, month, date }).locale(this.locale);
+    }
 
     // If the result isn't valid, the date must have been out of bounds for this month.
     if (!result.isValid()) {

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -21,7 +21,7 @@ const moment = _rollupMoment || _moment;
 
 /** Configurable options for {@see MomentDateAdapter}. */
 export interface MatMomentDateAdapterOptions {
-  /** 
+  /**
    * Turns the use of utc dates on or off.
    * Changing this will change how Angular Material components like DatePicker output dates.
    * {@default false}


### PR DESCRIPTION
Moment DateAdapter should create dates in utc format to avoid time zone
collisions when passing date to servers.
To avoid a breaking change a new injection token `MAT_MOMENT_DATE_ADAPTER_OPTIONS` has been created with the option `useUtc: boolean`. The option defaults to `false`.

See https://github.com/angular/material2/issues/7167#issuecomment-385627217 for more details on the issue.

Closes #7167 