### PR TITLE
fix(checkbox,radio): remove webkit tap highlights

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -187,6 +187,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
               mat-elevation-transition-property-value();
 
   cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .mat-checkbox-layout {

--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -9,6 +9,7 @@ $mat-radio-ripple-radius: 25px;
 // Top-level host container.
 .mat-radio-button {
   display: inline-block;
+  -webkit-tap-highlight-color: transparent;
 }
 
 // Inner label container, wrapping entire element.


### PR DESCRIPTION
Removes the overlays that get added by mobile Webkit browsers when tapping on checkboxes and radio buttons. The overlays look weird, especially when combined with our ripples.