### PR TITLE
build: fix rollup global name in umd bundle

### DIFF
--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -54,6 +54,6 @@ export const rollupGlobals = {
   ...rollupCdkEntryPoints,
   ...rollupMatEntryPoints,
 
-  'rxjs': 'Rx',
-  'rxjs/operators': 'Rx.operators',
+  'rxjs': 'rxjs',
+  'rxjs/operators': 'rxjs.operators',
 };


### PR DESCRIPTION
Between rxjs 5.5 and 6.0 the global name changed from `Rx` to `rxjs`, however ours is still set to `Rx`. These changes switch to using the correct name.

Fixes #11299.