### PR TITLE
fix(form-field): fix wrong underline color in error state

### DIFF
--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -86,6 +86,10 @@
 
     .mat-form-field-ripple {
       background-color: $underline-color-warn;
+
+      &.mat-accent {
+        background-color: $underline-color-warn;
+      }
     }
   }
 

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -84,12 +84,9 @@
       }
     }
 
-    .mat-form-field-ripple {
+    .mat-form-field-ripple,
+    .mat-form-field-ripple.mat-accent {
       background-color: $underline-color-warn;
-
-      &.mat-accent {
-        background-color: $underline-color-warn;
-      }
     }
   }
 


### PR DESCRIPTION
Fix wrong color of the form-field undeline when using color=accent and the field is in an invalid state and focused.
Previously when a form-field using the accent color had an error it would show on focus the accent color instead of the warn color.
All other visual elements of the form-field (borders, labels etc) use the warn color in this state.

Closes #11436