### PR TITLE
feat(stepper): Create MAT_STEPPER_GLOBAL_OPTIONS InjectionToken

### DIFF
--- a/e2e/components/stepper-e2e.spec.ts
+++ b/e2e/components/stepper-e2e.spec.ts
@@ -18,12 +18,12 @@ describe('stepper', () => {
       const nextButton = element.all(by.buttonText('Next'));
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('create\nFill out your name');
+          .toBe('1\nFill out your name');
 
       nextButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('create\nFill out your address');
+          .toBe('2\nFill out your address');
 
       await browser.wait(ExpectedConditions.not(
           ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
@@ -31,7 +31,7 @@ describe('stepper', () => {
       previousButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('create\nFill out your name');
+          .toBe('1\nFill out your name');
 
       await browser.wait(ExpectedConditions.not(
           ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
@@ -73,7 +73,7 @@ describe('stepper', () => {
       nextButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('create\nFill out your name');
+          .toBe('1\nFill out your name');
     });
   });
 });

--- a/e2e/components/stepper-e2e.spec.ts
+++ b/e2e/components/stepper-e2e.spec.ts
@@ -18,12 +18,12 @@ describe('stepper', () => {
       const nextButton = element.all(by.buttonText('Next'));
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('1\nFill out your name');
+          .toBe('create\nFill out your name');
 
       nextButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('2\nFill out your address');
+          .toBe('create\nFill out your address');
 
       await browser.wait(ExpectedConditions.not(
           ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
@@ -31,7 +31,7 @@ describe('stepper', () => {
       previousButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('1\nFill out your name');
+          .toBe('create\nFill out your name');
 
       await browser.wait(ExpectedConditions.not(
           ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
@@ -73,7 +73,7 @@ describe('stepper', () => {
       nextButton.get(0).click();
 
       expect(await element(by.css('mat-step-header[aria-selected="true"]')).getText())
-          .toBe('1\nFill out your name');
+          .toBe('create\nFill out your name');
     });
   });
 });

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -112,6 +112,9 @@ export class CdkStep implements OnChanges {
    */
   @Input('aria-labelledby') ariaLabelledby: string;
 
+  /** Alert message when there's an error. */
+  @Input() alertMessage: string;
+
   /** Whether the user can return to this step once it has been marked as complted. */
   @Input()
   get editable(): boolean { return this._editable; }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -170,7 +170,7 @@ export class CdkStep implements OnChanges {
     return this.stepControl ? this.stepControl.valid && this.interacted : this.interacted;
   }
 
-  /** Whether step has error. */
+  /** Whether step has an error. */
   @Input()
   get hasError(): boolean {
     return this._customError || this._getDefaultError();
@@ -186,8 +186,7 @@ export class CdkStep implements OnChanges {
 
   constructor(
     @Inject(forwardRef(() => CdkStepper)) private _stepper: CdkStepper,
-    @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions
-  ) {
+    @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions) {
     this._stepperOptions = stepperOptions ? stepperOptions : {};
     this._showError = !!this._stepperOptions.showError;
     this._useGuidelines = !!this._stepperOptions.useGuidelines;
@@ -392,8 +391,7 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
   private _getGuidelineLogic(
     step: CdkStep,
     isCurrentStep: boolean,
-    state: StepState = STEP_STATE.NUMBER
-  ): StepState {
+    state: StepState = STEP_STATE.NUMBER): StepState {
     if (step._showError && step.hasError && !isCurrentStep) {
       return STEP_STATE.ERROR;
     } else if (step.completed && !isCurrentStep) {

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -392,7 +392,8 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
   private _getGuidelineLogic(
     step: CdkStep,
     isCurrentStep: boolean,
-    state: StepState = STEP_STATE.NUMBER): StepState {
+    state: StepState = STEP_STATE.NUMBER
+  ): StepState {
     if (step._showError && step.hasError && !isCurrentStep) {
       return STEP_STATE.ERROR;
     } else if (step.completed && !isCurrentStep) {

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -181,7 +181,7 @@ export class CdkStep implements OnChanges {
   private _customError: boolean | null = null;
 
   private _getDefaultError() {
-    return this.stepControl && this.stepControl.invalid;
+    return this.stepControl && this.stepControl.invalid && this.interacted;
   }
 
   /** @breaking-change 8.0.0 remove the `?` after `stepperOptions` */
@@ -189,8 +189,8 @@ export class CdkStep implements OnChanges {
     @Inject(forwardRef(() => CdkStepper)) private _stepper: CdkStepper,
     @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions?: StepperOptions) {
     this._stepperOptions = stepperOptions ? stepperOptions : {};
-    this._showError = !!this._stepperOptions.showError;
     this._displayDefaultIndicatorType = this._stepperOptions.displayDefaultIndicatorType !== false;
+    this._showError = !!this._stepperOptions.showError;
   }
 
   /** Selects this step component. */

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -81,7 +81,7 @@ export const STEP_STATE = {
 export const MAT_STEPPER_GLOBAL_OPTIONS =
   new InjectionToken<StepperOptions>('mat-stepper-global-options');
 
-/** Configurable options for floating labels. */
+/** Configurable options for stepper. */
 export interface StepperOptions {
   /**
    * Whether the stepper should display an error state or not.

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -184,9 +184,10 @@ export class CdkStep implements OnChanges {
     return this.stepControl && this.stepControl.invalid;
   }
 
+  /** @breaking-change 8.0.0 remove the `?` after `stepperOptions` */
   constructor(
     @Inject(forwardRef(() => CdkStepper)) private _stepper: CdkStepper,
-    @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions) {
+    @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions?: StepperOptions) {
     this._stepperOptions = stepperOptions ? stepperOptions : {};
     this._showError = !!this._stepperOptions.showError;
     this._displayDefaultIndicatorType = this._stepperOptions.displayDefaultIndicatorType !== false;

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -100,8 +100,8 @@ export class CdkStep implements OnChanges {
   /** Plain text label of the step. */
   @Input() label: string;
 
-  /** Alert message when there's an error. */
-  @Input() alertMessage: string;
+  /** Error message to display when there's an error. */
+  @Input() errorMessage: string;
 
   /** Aria label for the tab. */
   @Input('aria-label') ariaLabel: string;
@@ -111,9 +111,6 @@ export class CdkStep implements OnChanges {
    * Will be cleared if `aria-label` is set at the same time.
    */
   @Input('aria-labelledby') ariaLabelledby: string;
-
-  /** Alert message when there's an error. */
-  @Input() alertMessage: string;
 
   /** Whether the user can return to this step once it has been marked as complted. */
   @Input()
@@ -139,7 +136,16 @@ export class CdkStep implements OnChanges {
   }
   private _state: StepState | string | null = null;
 
+  /** Whether to show the step is in an error state. */
+  @Input()
+  get showError(): boolean { return this._showError; }
+  set showError(value: boolean) {
+    this._showError = value;
+  }
+  private _showError: boolean = false;
+
   /** Whether step is marked as completed. */
+  @Input()
   get completed(): boolean {
     return this._customCompleted == null ? this._defaultCompleted() : this._customCompleted;
   }
@@ -153,15 +159,16 @@ export class CdkStep implements OnChanges {
   }
 
   /** Whether step has error. */
+  @Input()
   get hasError(): boolean {
-    return this._customError == null ? this._defaultError : this._customError;
+    return this._customError == null ? this._getDefaultError : this._customError;
   }
   set hasError(value: boolean) {
     this._customError = coerceBooleanProperty(value);
   }
   private _customError: boolean | null = null;
 
-  private get _defaultError() {
+  private get _getDefaultError() {
     return this.stepControl && this.stepControl.invalid;
   }
 
@@ -346,7 +353,7 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
     const step = this._steps.toArray()[index];
     const isCurrentStep = this._isCurrentStep(index);
 
-    if (step.hasError && !isCurrentStep) {
+    if (step.showError && step.hasError && !isCurrentStep) {
       return STEP_STATE.ERROR;
     } else if (step.completed && !isCurrentStep) {
       return STEP_STATE.DONE;

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -90,11 +90,11 @@ export interface StepperOptions {
   showError?: boolean;
 
   /**
-   * Whether the stepper should use the Material UI guidelines when
-   * displaying the icons or not.
-   * Default behavior is assumed to be false.
+   * Whether the stepper should display the default indicator type
+   * or not.
+   * Default behavior is assumed to be true.
    */
-  useGuidelines?: boolean;
+  displayDefaultIndicatorType?: boolean;
 }
 
 @Component({
@@ -108,7 +108,7 @@ export interface StepperOptions {
 export class CdkStep implements OnChanges {
   private _stepperOptions: StepperOptions;
   _showError: boolean;
-  _useGuidelines: boolean;
+  _displayDefaultIndicatorType: boolean;
 
   /** Template for step label if it exists. */
   @ContentChild(CdkStepLabel) stepLabel: CdkStepLabel;
@@ -189,7 +189,7 @@ export class CdkStep implements OnChanges {
     @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions) {
     this._stepperOptions = stepperOptions ? stepperOptions : {};
     this._showError = !!this._stepperOptions.showError;
-    this._useGuidelines = !!this._stepperOptions.useGuidelines;
+    this._displayDefaultIndicatorType = this._stepperOptions.displayDefaultIndicatorType !== false;
   }
 
   /** Selects this step component. */
@@ -371,11 +371,9 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
     const step = this._steps.toArray()[index];
     const isCurrentStep = this._isCurrentStep(index);
 
-    if (step._useGuidelines) {
-      return this._getGuidelineLogic(step, isCurrentStep, state);
-    } else {
-      return this._getDefaultIndicatorLogic(step, isCurrentStep);
-    }
+    return step._displayDefaultIndicatorType
+      ? this._getDefaultIndicatorLogic(step, isCurrentStep)
+      : this._getGuidelineLogic(step, isCurrentStep, state);
   }
 
   private _getDefaultIndicatorLogic(step: CdkStep, isCurrentStep: boolean): StepState {

--- a/src/demo-app/stepper/stepper-demo.html
+++ b/src/demo-app/stepper/stepper-demo.html
@@ -3,12 +3,7 @@
 <h3>Linear Vertical Stepper Demo using a single form</h3>
 <form [formGroup]="formGroup">
   <mat-vertical-stepper #linearVerticalStepper="matVerticalStepper" formArrayName="formArray" [linear]="!isNonLinear">
-    <mat-step
-      formGroupName="0"
-      [stepControl]="formArray?.get([0])"
-      errorMessage="Some fields are required"
-      [completed]="true"
-    >
+    <mat-step formGroupName="0" [stepControl]="formArray?.get([0])">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
         <mat-label>First name</mat-label>
@@ -26,13 +21,7 @@
       </div>
     </mat-step>
 
-    <mat-step
-      formGroupName="1"
-      [stepControl]="formArray?.get([1])"
-      optional
-      errorMessage="The input is invalid"
-      [showError]="true"
-    >
+    <mat-step formGroupName="1" [stepControl]="formArray?.get([1])" optional>
       <ng-template matStepLabel>
         <div>Fill out your email address</div>
       </ng-template>
@@ -109,7 +98,7 @@
 <h3>Vertical Stepper Demo</h3>
 <mat-checkbox [(ngModel)]="isNonEditable">Make steps non-editable</mat-checkbox>
 <mat-vertical-stepper>
-  <mat-step [editable]="!isNonEditable" [completed]="false">
+  <mat-step [editable]="!isNonEditable">
     <ng-template matStepLabel>Fill out your name</ng-template>
     <mat-form-field>
       <mat-label>First name</mat-label>
@@ -125,7 +114,7 @@
     </div>
   </mat-step>
 
-  <mat-step [editable]="!isNonEditable" [completed]="false">
+  <mat-step [editable]="!isNonEditable">
     <ng-template matStepLabel>
       <div>Fill out your phone number</div>
     </ng-template>
@@ -139,7 +128,7 @@
     </div>
   </mat-step>
 
-  <mat-step [editable]="!isNonEditable" [completed]="false">
+  <mat-step [editable]="!isNonEditable">
     <ng-template matStepLabel>
       <div>Fill out your address</div>
     </ng-template>
@@ -153,7 +142,7 @@
     </div>
   </mat-step>
 
-  <mat-step [editable]="!isNonEditable" [completed]="false">
+  <mat-step>
     <ng-template matStepLabel>Confirm your information</ng-template>
     Everything seems correct.
     <div>
@@ -234,64 +223,3 @@
   </mat-step>
 </mat-horizontal-stepper>
 
-<h3>Stepper with customized state</h3>
-<mat-horizontal-stepper [linear]="true">
-  <mat-step label="Step 1" state="shopping_cart">
-    <p>Go to your shopping cart.</p>
-    <div>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 2" state="credit_card">
-    <p>Enter your credit card information.</p>
-    <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 3" state="receipt">
-    <p>Get your receipt.</p>
-    <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 4" state="print">
-    <p>Print your receipt.</p>
-    <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 5">
-    <p>You've successfully completed your purchase!</p>
-  </mat-step>
-</mat-horizontal-stepper>
-
-<h3>Stepper with customized state with icon overrides</h3>
-<mat-horizontal-stepper [linear]="true">
-  <mat-step label="Step 1" state="phone">
-    <p>Put down your phones.</p>
-    <div>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 2" state="chat">
-    <p>Socialize with each other.</p>
-    <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-  <mat-step label="Step 3">
-    <p>You're welcome.</p>
-  </mat-step>
-
-  <!-- Icon overrides. -->
-  <ng-template matStepperIcon="phone">
-    <mat-icon>call_end</mat-icon>
-  </ng-template>
-  <ng-template matStepperIcon="chat">
-    <mat-icon>forum</mat-icon>
-  </ng-template>
-</mat-horizontal-stepper>

--- a/src/demo-app/stepper/stepper-demo.html
+++ b/src/demo-app/stepper/stepper-demo.html
@@ -3,7 +3,11 @@
 <h3>Linear Vertical Stepper Demo using a single form</h3>
 <form [formGroup]="formGroup">
   <mat-vertical-stepper #linearVerticalStepper="matVerticalStepper" formArrayName="formArray" [linear]="!isNonLinear">
-    <mat-step formGroupName="0" [stepControl]="formArray?.get([0])">
+    <mat-step
+      formGroupName="0"
+      [stepControl]="formArray?.get([0])"
+      alertMessage="Some fields are required"
+    >
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
         <mat-label>First name</mat-label>
@@ -21,7 +25,12 @@
       </div>
     </mat-step>
 
-    <mat-step formGroupName="1" [stepControl]="formArray?.get([1])" optional>
+    <mat-step
+      formGroupName="1"
+      [stepControl]="formArray?.get([1])"
+      optional
+      alertMessage="The input is invalid"
+    >
       <ng-template matStepLabel>
         <div>Fill out your email address</div>
       </ng-template>
@@ -223,3 +232,64 @@
   </mat-step>
 </mat-horizontal-stepper>
 
+<h3>Stepper with customized state</h3>
+<mat-horizontal-stepper [linear]="true">
+  <mat-step label="Step 1" state="shopping_cart">
+    <p>Go to your shopping cart.</p>
+    <div>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 2" state="credit_card">
+    <p>Enter your credit card information.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 3" state="receipt">
+    <p>Get your receipt.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 4" state="print">
+    <p>Print your receipt.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 5">
+    <p>You've successfully completed your purchase!</p>
+  </mat-step>
+</mat-horizontal-stepper>
+
+<h3>Stepper with customized state with icon overrides</h3>
+<mat-horizontal-stepper [linear]="true">
+  <mat-step label="Step 1" state="phone">
+    <p>Put down your phones.</p>
+    <div>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 2" state="chat">
+    <p>Socialize with each other.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 3">
+    <p>You're welcome.</p>
+  </mat-step>
+
+  <!-- Icon overrides. -->
+  <ng-template matStepperIcon="phone">
+    <mat-icon>call_end</mat-icon>
+  </ng-template>
+  <ng-template matStepperIcon="chat">
+    <mat-icon>forum</mat-icon>
+  </ng-template>
+</mat-horizontal-stepper>

--- a/src/demo-app/stepper/stepper-demo.html
+++ b/src/demo-app/stepper/stepper-demo.html
@@ -6,7 +6,8 @@
     <mat-step
       formGroupName="0"
       [stepControl]="formArray?.get([0])"
-      alertMessage="Some fields are required"
+      errorMessage="Some fields are required"
+      [completed]="true"
     >
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
@@ -29,7 +30,8 @@
       formGroupName="1"
       [stepControl]="formArray?.get([1])"
       optional
-      alertMessage="The input is invalid"
+      errorMessage="The input is invalid"
+      [showError]="true"
     >
       <ng-template matStepLabel>
         <div>Fill out your email address</div>
@@ -107,7 +109,7 @@
 <h3>Vertical Stepper Demo</h3>
 <mat-checkbox [(ngModel)]="isNonEditable">Make steps non-editable</mat-checkbox>
 <mat-vertical-stepper>
-  <mat-step [editable]="!isNonEditable">
+  <mat-step [editable]="!isNonEditable" [completed]="false">
     <ng-template matStepLabel>Fill out your name</ng-template>
     <mat-form-field>
       <mat-label>First name</mat-label>
@@ -123,7 +125,7 @@
     </div>
   </mat-step>
 
-  <mat-step [editable]="!isNonEditable">
+  <mat-step [editable]="!isNonEditable" [completed]="false">
     <ng-template matStepLabel>
       <div>Fill out your phone number</div>
     </ng-template>
@@ -137,7 +139,7 @@
     </div>
   </mat-step>
 
-  <mat-step [editable]="!isNonEditable">
+  <mat-step [editable]="!isNonEditable" [completed]="false">
     <ng-template matStepLabel>
       <div>Fill out your address</div>
     </ng-template>
@@ -151,7 +153,7 @@
     </div>
   </mat-step>
 
-  <mat-step>
+  <mat-step [editable]="!isNonEditable" [completed]="false">
     <ng-template matStepLabel>Confirm your information</ng-template>
     Everything seems correct.
     <div>

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -25,30 +25,16 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-selected {
+    .mat-step-icon-selected,
+    .mat-step-icon-state-done,
+    .mat-step-icon-state-edit {
       background-color: mat-color($primary);
-      color: mat-color($primary, default-contrast);
-    }
-
-    .mat-step-icon-state-number {
-      background-color: mat-color($primary);
-      color: mat-color($primary, default-contrast);
-    }
-
-    .mat-step-icon-not-selected {
-      background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }
 
     .mat-step-icon-state-error {
       background-color: transparent;
       color: mat-color($warn);
-    }
-
-    .mat-step-icon-state-done,
-    .mat-step-icon-state-edit {
-      background-color: mat-color($primary);
-      color: mat-color($primary, default-contrast);
     }
 
     .mat-step-label.mat-step-label-active {

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -6,6 +6,7 @@
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
   $primary: map-get($theme, primary);
+  $warn: map-get($theme, warn);
 
   .mat-step-header {
     &.cdk-keyboard-focused,
@@ -20,17 +21,30 @@
     }
 
     .mat-step-icon {
+      color: mat-color($primary, default-contrast);
+    }
+
+    .mat-step-icon-selected {
       background-color: mat-color($primary);
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-not-touched {
+    .mat-step-icon-not-selected {
       background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }
 
+    .mat-step-icon-error {
+      background-color: transparent;
+      color: mat-color($warn);
+    }
+
     .mat-step-label.mat-step-label-active {
       color: mat-color($foreground, text);
+    }
+
+    .mat-step-label.mat-step-label-error {
+      color: mat-color($warn);
     }
   }
 
@@ -57,6 +71,14 @@
       size: mat-font-size($config, body-1);
       weight: mat-font-weight($config, body-1);
     };
+  }
+
+  .mat-step-sub-label-error {
+    font-weight: normal;
+  }
+
+  .mat-step-label-error {
+    font-size: mat-font-size($config, body-2);
   }
 
   .mat-step-label-selected {

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -29,8 +29,13 @@
       color: mat-color($primary, default-contrast);
     }
 
-    /** @breaking-change 8.0.0 rename `mat-step-icon-not-touched` to `mat-step-icon-not-selected` */
+    /** @breaking-change 8.0.0 remove `mat-step-icon-not-touched` */
     .mat-step-icon-not-touched {
+      background-color: mat-color($foreground, disabled-text);
+      color: mat-color($primary, default-contrast);
+    }
+
+    .mat-step-icon-not-selected {
       background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -24,14 +24,15 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-selected {
-      background-color: mat-color($primary);
+    .mat-step-icon-selected,
+    .mat-step-icon-state-done,
+    .mat-step-icon-state-edit {
+      background-color: mat-color($primary) !important;
       color: mat-color($primary, default-contrast);
     }
 
-    /** @breaking-change 8.0.0 remove `mat-step-icon-not-touched` */
-    .mat-step-icon-not-touched {
-      background-color: mat-color($foreground, disabled-text);
+    .mat-step-icon-state-number {
+      background-color: mat-color($primary);
       color: mat-color($primary, default-contrast);
     }
 
@@ -40,7 +41,7 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-error {
+    .mat-step-icon-state-error {
       background-color: transparent;
       color: mat-color($warn);
     }

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -29,7 +29,8 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-not-selected {
+    /** @breaking-change 8.0.0 rename `mat-step-icon-not-touched` to `mat-step-icon-not-selected` */
+    .mat-step-icon-not-touched {
       background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -21,13 +21,12 @@
     }
 
     .mat-step-icon {
+      background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-selected,
-    .mat-step-icon-state-done,
-    .mat-step-icon-state-edit {
-      background-color: mat-color($primary) !important;
+    .mat-step-icon-selected {
+      background-color: mat-color($primary);
       color: mat-color($primary, default-contrast);
     }
 
@@ -36,14 +35,20 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon:not(.mat-step-icon-selected) {
+    .mat-step-icon-not-selected {
       background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }
 
     .mat-step-icon-state-error {
-      background-color: transparent !important;
-      color: mat-color($warn) !important;
+      background-color: transparent;
+      color: mat-color($warn);
+    }
+
+    .mat-step-icon-state-done,
+    .mat-step-icon-state-edit {
+      background-color: mat-color($primary);
+      color: mat-color($primary, default-contrast);
     }
 
     .mat-step-label.mat-step-label-active {

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -36,14 +36,14 @@
       color: mat-color($primary, default-contrast);
     }
 
-    .mat-step-icon-not-selected {
+    .mat-step-icon:not(.mat-step-icon-selected) {
       background-color: mat-color($foreground, disabled-text);
       color: mat-color($primary, default-contrast);
     }
 
     .mat-step-icon-state-error {
-      background-color: transparent;
-      color: mat-color($warn);
+      background-color: transparent !important;
+      color: mat-color($warn) !important;
     }
 
     .mat-step-label.mat-step-label-active {

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,7 +1,8 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
+<!-- @breaking-change 8.0.0 rename `mat-step-icon-not-touched` to `mat-step-icon-not-selected` -->
 <div class="mat-step-icon"
      [class.mat-step-icon-selected]="selected || state == 'done'"
-     [class.mat-step-icon-not-selected]="!selected && state != 'done'"
+     [class.mat-step-icon-not-touched]="!selected && state != 'done'"
      [class.mat-step-icon-error]="state == 'error'"
      [ngSwitch]="state">
 

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,6 +1,5 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<div [ngClass]="{'mat-step-icon-selected': selected}"
-     class="mat-step-icon-state-{{state}} mat-step-icon"
+<div class="mat-step-icon-{{selected ? 'selected': 'not-selected'}} mat-step-icon-state-{{state}} mat-step-icon"
      [ngSwitch]="state">
 
   <ng-container *ngSwitchCase="'number'" [ngSwitch]="!!(iconOverrides && iconOverrides.number)">

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,7 +1,6 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<div class="mat-step-icon-{{selected ? 'selected': 'not-selected'}} mat-step-icon-state-{{state}} mat-step-icon"
+<div class="mat-step-icon-state-{{state}} mat-step-icon" [class.mat-step-icon-selected]="selected"
      [ngSwitch]="state">
-
   <ng-container *ngSwitchCase="'number'" [ngSwitch]="!!(iconOverrides && iconOverrides.number)">
     <ng-container
       *ngSwitchCase="true"

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,5 +1,6 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<div class="mat-step-icon-{{selected ? 'selected' : 'not-selected'}} mat-step-icon-state-{{state}} mat-step-icon"
+<div [ngClass]="{'mat-step-icon-selected': selected}"
+     class="mat-step-icon-state-{{state}} mat-step-icon"
      [ngSwitch]="state">
 
   <ng-container *ngSwitchCase="'number'" [ngSwitch]="!!(iconOverrides && iconOverrides.number)">

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,8 +1,9 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<!-- @breaking-change 8.0.0 rename `mat-step-icon-not-touched` to `mat-step-icon-not-selected` -->
+<!-- @breaking-change 8.0.0 remove `mat-step-icon-not-touched` -->
 <div class="mat-step-icon"
      [class.mat-step-icon-selected]="selected || state == 'done'"
-     [class.mat-step-icon-not-touched]="!selected && state != 'done'"
+     [class.mat-step-icon-not-touched]="state == 'number' && !selected"
+     [class.mat-step-icon-not-selected]="!selected && state != 'done'"
      [class.mat-step-icon-error]="state == 'error'"
      [ngSwitch]="state">
 

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -57,6 +57,6 @@
   <div class="mat-step-text-label" *ngIf="_stringLabel()">{{label}}</div>
 
   <div class="mat-step-optional" *ngIf="optional && state != 'error'">{{_intl.optionalLabel}}</div>
-  <div class="mat-step-sub-label-error" *ngIf="state == 'error'">{{alertMessage}}</div>
+  <div class="mat-step-sub-label-error" *ngIf="state == 'error'">{{errorMessage}}</div>
 </div>
 

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,6 +1,8 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<div [class.mat-step-icon]="state !== 'number' || selected"
-     [class.mat-step-icon-not-touched]="state == 'number' && !selected"
+<div class="mat-step-icon"
+     [class.mat-step-icon-selected]="selected || state == 'done'"
+     [class.mat-step-icon-not-selected]="!selected && state != 'done'"
+     [class.mat-step-icon-error]="state == 'error'"
      [ngSwitch]="state">
 
   <ng-container *ngSwitchCase="'number'" [ngSwitch]="!!(iconOverrides && iconOverrides.number)">
@@ -26,16 +28,35 @@
       [ngTemplateOutletContext]="_getIconContext()"></ng-container>
     <mat-icon *ngSwitchDefault>done</mat-icon>
   </ng-container>
+
+  <ng-container *ngSwitchCase="'error'" [ngSwitch]="!!(iconOverrides && iconOverrides.error)">
+    <ng-container
+      *ngSwitchCase="true"
+      [ngTemplateOutlet]="iconOverrides.error"
+      [ngTemplateOutletContext]="_getIconContext()"></ng-container>
+    <mat-icon *ngSwitchDefault>warning</mat-icon>
+  </ng-container>
+
+  <!-- Custom state. -->
+  <ng-container *ngSwitchDefault [ngSwitch]="!!(iconOverrides && iconOverrides[state])">
+    <ng-container
+      *ngSwitchCase="true"
+      [ngTemplateOutlet]="iconOverrides[state]"
+      [ngTemplateOutletContext]="_getIconContext()"></ng-container>
+    <mat-icon *ngSwitchDefault>{{state}}</mat-icon>
+  </ng-container>
 </div>
 <div class="mat-step-label"
      [class.mat-step-label-active]="active"
-     [class.mat-step-label-selected]="selected">
+     [class.mat-step-label-selected]="selected"
+     [class.mat-step-label-error]="state == 'error'">
   <!-- If there is a label template, use it. -->
   <ng-container *ngIf="_templateLabel()" [ngTemplateOutlet]="_templateLabel()!.template">
   </ng-container>
-  <!-- It there is no label template, fall back to the text label. -->
+  <!-- If there is no label template, fall back to the text label. -->
   <div class="mat-step-text-label" *ngIf="_stringLabel()">{{label}}</div>
 
-  <div class="mat-step-optional" *ngIf="optional">{{_intl.optionalLabel}}</div>
+  <div class="mat-step-optional" *ngIf="optional && state != 'error'">{{_intl.optionalLabel}}</div>
+  <div class="mat-step-sub-label-error" *ngIf="state == 'error'">{{alertMessage}}</div>
 </div>
 

--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -1,10 +1,5 @@
 <div class="mat-step-header-ripple" mat-ripple [matRippleTrigger]="_getHostElement()"></div>
-<!-- @breaking-change 8.0.0 remove `mat-step-icon-not-touched` -->
-<div class="mat-step-icon"
-     [class.mat-step-icon-selected]="selected || state == 'done'"
-     [class.mat-step-icon-not-touched]="state == 'number' && !selected"
-     [class.mat-step-icon-not-selected]="!selected && state != 'done'"
-     [class.mat-step-icon-error]="state == 'error'"
+<div class="mat-step-icon-{{selected ? 'selected' : 'not-selected'}} mat-step-icon-state-{{state}} mat-step-icon"
      [ngSwitch]="state">
 
   <ng-container *ngSwitchCase="'number'" [ngSwitch]="!!(iconOverrides && iconOverrides.number)">

--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -5,7 +5,7 @@ $mat-stepper-label-min-width: 50px !default;
 $mat-stepper-side-gap: 24px !default;
 $mat-vertical-stepper-content-margin: 36px !default;
 $mat-stepper-line-gap: 8px !default;
-$mat-step-optional-font-size: 12px;
+$mat-step-sub-label-font-size: 12px;
 $mat-step-header-icon-size: 16px !default;
 
 .mat-step-header {
@@ -17,12 +17,12 @@ $mat-step-header-icon-size: 16px !default;
   -webkit-tap-highlight-color: transparent;
 }
 
-.mat-step-optional {
-  font-size: $mat-step-optional-font-size;
+.mat-step-optional,
+.mat-step-sub-label-error {
+  font-size: $mat-step-sub-label-font-size;
 }
 
-.mat-step-icon,
-.mat-step-icon-not-touched {
+.mat-step-icon {
   border-radius: 50%;
   height: $mat-stepper-label-header-height;
   width: $mat-stepper-label-header-height;
@@ -36,6 +36,12 @@ $mat-step-header-icon-size: 16px !default;
   font-size: $mat-step-header-icon-size;
   height: $mat-step-header-icon-size;
   width: $mat-step-header-icon-size;
+}
+
+.mat-step-icon-error .mat-icon {
+  font-size: $mat-step-header-icon-size+8;
+  height: $mat-step-header-icon-size+8;
+  width: $mat-step-header-icon-size+8;
 }
 
 .mat-step-label {

--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -39,9 +39,9 @@ $mat-step-header-icon-size: 16px !default;
 }
 
 .mat-step-icon-error .mat-icon {
-  font-size: $mat-step-header-icon-size+8;
-  height: $mat-step-header-icon-size+8;
-  width: $mat-step-header-icon-size+8;
+  font-size: $mat-step-header-icon-size + 8;
+  height: $mat-step-header-icon-size + 8;
+  width: $mat-step-header-icon-size + 8;
 }
 
 .mat-step-label {

--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -38,7 +38,7 @@ $mat-step-header-icon-size: 16px !default;
   width: $mat-step-header-icon-size;
 }
 
-.mat-step-icon-error .mat-icon {
+.mat-step-icon-state-error .mat-icon {
   font-size: $mat-step-header-icon-size + 8;
   height: $mat-step-header-icon-size + 8;
   width: $mat-step-header-icon-size + 8;

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -39,7 +39,7 @@ export class MatStepHeader implements OnDestroy {
   private _intlSubscription: Subscription;
 
   /** State of the given step. */
-  @Input() state: StepState | string;
+  @Input() state: StepState;
 
   /** Label of the given step. */
   @Input() label: MatStepLabel | string;

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -21,7 +21,7 @@ import {Subscription} from 'rxjs';
 import {MatStepLabel} from './step-label';
 import {MatStepperIntl} from './stepper-intl';
 import {MatStepperIconContext} from './stepper-icon';
-
+import {StepState} from '@angular/cdk/stepper';
 
 @Component({
   moduleId: module.id,
@@ -39,10 +39,13 @@ export class MatStepHeader implements OnDestroy {
   private _intlSubscription: Subscription;
 
   /** State of the given step. */
-  @Input() state: string;
+  @Input() state: StepState | string;
 
   /** Label of the given step. */
   @Input() label: MatStepLabel | string;
+
+  /** Alert message when there's an error. */
+  @Input() alertMessage: string;
 
   /** Overrides for the header icons, passed in via the stepper. */
   @Input() iconOverrides: {[key: string]: TemplateRef<MatStepperIconContext>};

--- a/src/lib/stepper/step-header.ts
+++ b/src/lib/stepper/step-header.ts
@@ -44,8 +44,8 @@ export class MatStepHeader implements OnDestroy {
   /** Label of the given step. */
   @Input() label: MatStepLabel | string;
 
-  /** Alert message when there's an error. */
-  @Input() alertMessage: string;
+  /** Error message to display when there's an error. */
+  @Input() errorMessage: string;
 
   /** Overrides for the header icons, passed in via the stepper. */
   @Input() iconOverrides: {[key: string]: TemplateRef<MatStepperIconContext>};

--- a/src/lib/stepper/stepper-horizontal.html
+++ b/src/lib/stepper/stepper-horizontal.html
@@ -12,11 +12,12 @@
                      [attr.aria-label]="step.ariaLabel || null"
                      [attr.aria-labelledby]="(!step.ariaLabel && step.ariaLabelledby) ? step.ariaLabelledby : null"
                      [index]="i"
-                     [state]="_getIndicatorType(i)"
+                     [state]="_getIndicatorType(i, step.state)"
                      [label]="step.stepLabel || step.label"
                      [selected]="selectedIndex === i"
                      [active]="step.completed || selectedIndex === i || !linear"
                      [optional]="step.optional"
+                     [alertMessage]="step.alertMessage"
                      [iconOverrides]="_iconOverrides">
     </mat-step-header>
     <div *ngIf="!isLast" class="mat-stepper-horizontal-line"></div>

--- a/src/lib/stepper/stepper-horizontal.html
+++ b/src/lib/stepper/stepper-horizontal.html
@@ -17,7 +17,7 @@
                      [selected]="selectedIndex === i"
                      [active]="step.completed || selectedIndex === i || !linear"
                      [optional]="step.optional"
-                     [alertMessage]="step.alertMessage"
+                     [errorMessage]="step.errorMessage"
                      [iconOverrides]="_iconOverrides">
     </mat-step-header>
     <div *ngIf="!isLast" class="mat-stepper-horizontal-line"></div>

--- a/src/lib/stepper/stepper-icon.ts
+++ b/src/lib/stepper/stepper-icon.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, Input, TemplateRef} from '@angular/core';
+import {StepState} from '@angular/cdk/stepper';
 
 /** Template context available to an attached `matStepperIcon`. */
 export interface MatStepperIconContext {
@@ -26,7 +27,7 @@ export interface MatStepperIconContext {
 })
 export class MatStepperIcon {
   /** Name of the icon to be overridden. */
-  @Input('matStepperIcon') name: 'edit' | 'done' | 'number';
+  @Input('matStepperIcon') name: StepState | string;
 
   constructor(public templateRef: TemplateRef<MatStepperIconContext>) {}
 }

--- a/src/lib/stepper/stepper-icon.ts
+++ b/src/lib/stepper/stepper-icon.ts
@@ -27,7 +27,7 @@ export interface MatStepperIconContext {
 })
 export class MatStepperIcon {
   /** Name of the icon to be overridden. */
-  @Input('matStepperIcon') name: StepState | string;
+  @Input('matStepperIcon') name: StepState;
 
   constructor(public templateRef: TemplateRef<MatStepperIconContext>) {}
 }

--- a/src/lib/stepper/stepper-vertical.html
+++ b/src/lib/stepper/stepper-vertical.html
@@ -11,11 +11,12 @@
                    [attr.aria-label]="step.ariaLabel || null"
                    [attr.aria-labelledby]="(!step.ariaLabel && step.ariaLabelledby) ? step.ariaLabelledby : null"
                    [index]="i"
-                   [state]="_getIndicatorType(i)"
+                   [state]="_getIndicatorType(i, step.state)"
                    [label]="step.stepLabel || step.label"
                    [selected]="selectedIndex === i"
                    [active]="step.completed || selectedIndex === i || !linear"
                    [optional]="step.optional"
+                   [alertMessage]="step.alertMessage"
                    [iconOverrides]="_iconOverrides">
   </mat-step-header>
 

--- a/src/lib/stepper/stepper-vertical.html
+++ b/src/lib/stepper/stepper-vertical.html
@@ -16,7 +16,7 @@
                    [selected]="selectedIndex === i"
                    [active]="step.completed || selectedIndex === i || !linear"
                    [optional]="step.optional"
-                   [alertMessage]="step.alertMessage"
+                   [errorMessage]="step.errorMessage"
                    [iconOverrides]="_iconOverrides">
   </mat-step-header>
 

--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -157,7 +157,7 @@ by placing a `matStepperIcon` for each of the icons that you want to override. T
 Note that you aren't limited to using the `mat-icon` component when providing custom icons.
 
 #### Step States
-You can set the state of a step to whatever you want. The given state by default maps to an icon. However, it can be overridden the same way as metioned above.
+You can set the state of a step to whatever you want. The given state by default maps to an icon. However, it can be overridden the same way as mentioned above.
 
 ```html
 <mat-horizontal-stepper>
@@ -186,6 +186,35 @@ You can set the state of a step to whatever you want. The given state by default
     <mat-icon>forum</mat-icon>
   </ng-template>
 </mat-horizontal-stepper>
+```
+
+In order to use the custom step states, you must add the `useGuidelines` option to the global default stepper options which can be specified by providing a value for
+`MAT_STEPPER_GLOBAL_OPTIONS` in your application's root module.
+
+```ts
+@NgModule({
+  providers: [
+    {
+      provide: MAT_STEPPER_GLOBAL_OPTIONS,
+      useValue: { useGuidelines: true }
+    }
+  ]
+})
+```
+
+### Error State
+
+The stepper can now show error states by simply providing the `showError` option to the `MAT_STEPPER_GLOBAL_OPTIONS` in your application's root module as mentioned above.
+
+```ts
+@NgModule({
+  providers: [
+    {
+      provide: MAT_STEPPER_GLOBAL_OPTIONS,
+      useValue: { showError: true }
+    }
+  ]
+})
 ```
 
 ### Keyboard interaction

--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -202,6 +202,8 @@ In order to use the custom step states, you must add the `displayDefaultIndicato
 })
 ```
 
+<!-- example(stepper-states) -->
+
 ### Error State
 
 The stepper can now show error states by simply providing the `showError` option to the `MAT_STEPPER_GLOBAL_OPTIONS` in your application's root module as mentioned above.
@@ -216,6 +218,8 @@ The stepper can now show error states by simply providing the `showError` option
   ]
 })
 ```
+
+<!-- example(stepper-errors) -->
 
 ### Keyboard interaction
 - <kbd>LEFT_ARROW</kbd>: Focuses the previous step header

--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -156,6 +156,38 @@ by placing a `matStepperIcon` for each of the icons that you want to override. T
 
 Note that you aren't limited to using the `mat-icon` component when providing custom icons.
 
+#### Step States
+You can set the state of a step to whatever you want. The given state by default maps to an icon. However, it can be overridden the same way as metioned above.
+
+```html
+<mat-horizontal-stepper>
+  <mat-step label="Step 1" state="phone">
+    <p>Put down your phones.</p>
+    <div>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 2" state="chat">
+    <p>Socialize with each other.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 3">
+    <p>You're welcome.</p>
+  </mat-step>
+
+  <!-- Icon overrides. -->
+  <ng-template matStepperIcon="phone">
+    <mat-icon>call_end</mat-icon>
+  </ng-template>
+  <ng-template matStepperIcon="chat">
+    <mat-icon>forum</mat-icon>
+  </ng-template>
+</mat-horizontal-stepper>
+```
+
 ### Keyboard interaction
 - <kbd>LEFT_ARROW</kbd>: Focuses the previous step header
 - <kbd>RIGHT_ARROW</kbd>: Focuses the next step header

--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -188,7 +188,7 @@ You can set the state of a step to whatever you want. The given state by default
 </mat-horizontal-stepper>
 ```
 
-In order to use the custom step states, you must add the `useGuidelines` option to the global default stepper options which can be specified by providing a value for
+In order to use the custom step states, you must add the `displayDefaultIndicatorType` option to the global default stepper options which can be specified by providing a value for
 `MAT_STEPPER_GLOBAL_OPTIONS` in your application's root module.
 
 ```ts
@@ -196,7 +196,7 @@ In order to use the custom step states, you must add the `useGuidelines` option 
   providers: [
     {
       provide: MAT_STEPPER_GLOBAL_OPTIONS,
-      useValue: { useGuidelines: true }
+      useValue: { displayDefaultIndicatorType: false }
     }
   ]
 })

--- a/src/lib/stepper/stepper.scss
+++ b/src/lib/stepper/stepper.scss
@@ -34,8 +34,7 @@ $mat-stepper-line-gap: 8px !default;
   align-items: center;
   padding: 0 $mat-stepper-side-gap;
 
-  .mat-step-icon,
-  .mat-step-icon-not-touched {
+  .mat-step-icon {
     margin-right: $mat-stepper-line-gap;
     flex: none;
 
@@ -52,8 +51,7 @@ $mat-stepper-line-gap: 8px !default;
   padding: $mat-stepper-side-gap;
   max-height: $mat-stepper-label-header-height;
 
-  .mat-step-icon,
-  .mat-step-icon-not-touched {
+  .mat-step-icon {
     margin-right: $mat-vertical-stepper-content-margin - $mat-stepper-side-gap;
 
     [dir='rtl'] & {

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -923,7 +923,7 @@ describe('MatStepper', () => {
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
 
       stepper.selectedIndex = 1;
-      stepper._steps.toArray()[0].hasError = true;
+      stepper._steps.first.hasError = true;
       nextButtonNativeEl.click();
       fixture.detectChanges();
 
@@ -940,7 +940,7 @@ describe('MatStepper', () => {
         MatHorizontalStepperWithErrorsApp,
         [{
           provide: MAT_STEPPER_GLOBAL_OPTIONS,
-          useValue: {useGuidelines: true}
+          useValue: {displayDefaultIndicatorType: false}
         }],
         [MatFormFieldModule, MatInputModule]
       );
@@ -954,7 +954,7 @@ describe('MatStepper', () => {
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
 
       stepper.selectedIndex = 1;
-      stepper._steps.toArray()[0].completed = true;
+      stepper._steps.first.completed = true;
       nextButtonNativeEl.click();
       fixture.detectChanges();
 

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -9,10 +9,10 @@ import {
   SPACE,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {StepperOrientation} from '@angular/cdk/stepper';
+import {StepperOrientation, MAT_STEPPER_GLOBAL_OPTIONS, STEP_STATE} from '@angular/cdk/stepper';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
-import {Component, DebugElement, EventEmitter, OnInit} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
+import {Component, DebugElement, EventEmitter, OnInit, Type, Provider} from '@angular/core';
+import {ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {
   AbstractControl,
   AsyncValidatorFn,
@@ -20,7 +20,8 @@ import {
   FormGroup,
   ReactiveFormsModule,
   ValidationErrors,
-  Validators
+  Validators,
+  FormBuilder
 } from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -30,45 +31,26 @@ import {MatStepperModule} from './index';
 import {MatHorizontalStepper, MatStep, MatStepper, MatVerticalStepper} from './stepper';
 import {MatStepperNext, MatStepperPrevious} from './stepper-button';
 import {MatStepperIntl} from './stepper-intl';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '../input/input-module';
 
 
 const VALID_REGEX = /valid/;
+let dir: {value: Direction, change: EventEmitter<Direction>};
 
 describe('MatStepper', () => {
-  let dir: {value: Direction, change: EventEmitter<Direction>};
-
-  beforeEach(async(() => {
+  beforeEach(() => {
     dir = {
       value: 'ltr',
       change: new EventEmitter()
     };
-
-    TestBed.configureTestingModule({
-      imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule],
-      declarations: [
-        SimpleMatVerticalStepperApp,
-        LinearMatVerticalStepperApp,
-        IconOverridesStepper,
-        SimplePreselectedMatHorizontalStepperApp,
-        SimpleStepperWithoutStepControl,
-        SimpleStepperWithStepControlAndCompletedBinding,
-        SimpleMatHorizontalStepperApp,
-        LinearStepperWithValidOptionalStep,
-        StepperWithAriaInputs,
-      ],
-      providers: [
-        {provide: Directionality, useFactory: () => dir}
-      ]
-    });
-
-    TestBed.compileComponents();
-  }));
+  });
 
   describe('basic stepper', () => {
     let fixture: ComponentFixture<SimpleMatVerticalStepperApp>;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
     });
 
@@ -316,69 +298,27 @@ describe('MatStepper', () => {
       expect(stepperComponent._getIndicatorType(0)).toBe('done');
     });
 
-    it('should re-render when the i18n labels change', inject([MatStepperIntl],
-      (intl: MatStepperIntl) => {
-        fixture.destroy();
+    it('should emit an event when the enter animation is done', fakeAsync(() => {
+      let stepper = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let selectionChangeSpy = jasmine.createSpy('selectionChange spy');
+      let animationDoneSpy = jasmine.createSpy('animationDone spy');
+      let selectionChangeSubscription = stepper.selectionChange.subscribe(selectionChangeSpy);
+      let animationDoneSubscription = stepper.animationDone.subscribe(animationDoneSpy);
 
-        const i18nFixture = TestBed.createComponent(SimpleMatHorizontalStepperApp);
-        i18nFixture.detectChanges();
+      stepper.selectedIndex = 1;
+      fixture.detectChanges();
 
-        const header =
-            i18nFixture.debugElement.queryAll(By.css('mat-step-header'))[2].nativeElement;
-        const optionalLabel = header.querySelector('.mat-step-optional');
+      expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+      expect(animationDoneSpy).not.toHaveBeenCalled();
 
-        expect(optionalLabel).toBeTruthy();
-        expect(optionalLabel.textContent).toBe('Optional');
+      flush();
 
-        intl.optionalLabel = 'Valgfri';
-        intl.changes.next();
-        i18nFixture.detectChanges();
+      expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+      expect(animationDoneSpy).toHaveBeenCalledTimes(1);
 
-        expect(optionalLabel.textContent).toBe('Valgfri');
-      }));
-
-      it('should emit an event when the enter animation is done', fakeAsync(() => {
-        let stepper = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
-        let selectionChangeSpy = jasmine.createSpy('selectionChange spy');
-        let animationDoneSpy = jasmine.createSpy('animationDone spy');
-        let selectionChangeSubscription = stepper.selectionChange.subscribe(selectionChangeSpy);
-        let animationDoneSubscription = stepper.animationDone.subscribe(animationDoneSpy);
-
-        stepper.selectedIndex = 1;
-        fixture.detectChanges();
-
-        expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-        expect(animationDoneSpy).not.toHaveBeenCalled();
-
-        flush();
-
-        expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-        expect(animationDoneSpy).toHaveBeenCalledTimes(1);
-
-        selectionChangeSubscription.unsubscribe();
-        animationDoneSubscription.unsubscribe();
-      }));
-
-    it('should not throw when attempting to get the selected step too early', () => {
-      fixture.destroy();
-      fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
-
-      const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
-
-      expect(() => stepperComponent.selected).not.toThrow();
-    });
-
-    it('should not throw when attempting to set the selected step too early', () => {
-      fixture.destroy();
-      fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
-
-      const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
-
-      expect(() => stepperComponent.selected = null!).not.toThrow();
-      expect(stepperComponent.selectedIndex).toBe(-1);
-    });
+      selectionChangeSubscription.unsubscribe();
+      animationDoneSubscription.unsubscribe();
+    }));
 
     it('should set the correct aria-posinset and aria-setsize', () => {
       const headers =
@@ -405,14 +345,59 @@ describe('MatStepper', () => {
 
       expect(stepperComponent.selectedIndex).toBe(1);
     });
+  });
 
+  describe('basic stepper when attempting to set the selected step too early', () => {
+    it('should not throw', () => {
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
+      const stepperComponent: MatVerticalStepper = fixture.debugElement
+          .query(By.css('mat-vertical-stepper')).componentInstance;
+
+      expect(() => stepperComponent.selected).not.toThrow();
+    });
+  });
+
+  describe('basic stepper when attempting to set the selected step too early', () => {
+    it('should not throw', () => {
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
+      const stepperComponent: MatVerticalStepper = fixture.debugElement
+          .query(By.css('mat-vertical-stepper')).componentInstance;
+
+      expect(() => stepperComponent.selected = null!).not.toThrow();
+      expect(stepperComponent.selectedIndex).toBe(-1);
+    });
+  });
+
+  describe('basic stepper with i18n label change', () => {
+    let i18nFixture;
+
+    beforeEach(() => {
+      i18nFixture = createComponent(SimpleMatHorizontalStepperApp);
+      i18nFixture.detectChanges();
+    });
+
+    it('should re-render when the i18n labels change', inject([MatStepperIntl],
+      (intl: MatStepperIntl) => {
+        const header =
+            i18nFixture.debugElement.queryAll(By.css('mat-step-header'))[2].nativeElement;
+        const optionalLabel = header.querySelector('.mat-step-optional');
+
+        expect(optionalLabel).toBeTruthy();
+        expect(optionalLabel.textContent).toBe('Optional');
+
+        intl.optionalLabel = 'Valgfri';
+        intl.changes.next();
+        i18nFixture.detectChanges();
+
+        expect(optionalLabel.textContent).toBe('Valgfri');
+    }));
   });
 
   describe('icon overrides', () => {
     let fixture: ComponentFixture<IconOverridesStepper>;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(IconOverridesStepper);
+      fixture = createComponent(IconOverridesStepper);
       fixture.detectChanges();
     });
 
@@ -455,7 +440,7 @@ describe('MatStepper', () => {
 
     beforeEach(() => {
       dir.value = 'rtl';
-      fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
     });
 
@@ -488,7 +473,7 @@ describe('MatStepper', () => {
     let stepperComponent: MatVerticalStepper;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(LinearMatVerticalStepperApp);
+      fixture = createComponent(LinearMatVerticalStepperApp);
       fixture.detectChanges();
 
       testComponent = fixture.componentInstance;
@@ -700,66 +685,71 @@ describe('MatStepper', () => {
       expect(steps[2].completed).toBe(true,
           'Expected third step to be considered complete when doing a run after a reset.');
     });
+  });
 
-    it('should not throw when there is a pre-defined selectedIndex', () => {
-      fixture.destroy();
-
-      let preselectedFixture = TestBed.createComponent(SimplePreselectedMatHorizontalStepperApp);
-      expect(() => preselectedFixture.detectChanges()).not.toThrow();
+  describe('linear stepper with a pre-defined selectedIndex', () => {
+    let preselectedFixture;
+    beforeEach(() => {
+      preselectedFixture = createComponent(SimplePreselectedMatHorizontalStepperApp);
     });
 
-    it('should not move to the next step if the current one is not completed ' +
-      'and there is no `stepControl`', () => {
-        fixture.destroy();
+    it('should not throw', () => {
+      expect(() => preselectedFixture.detectChanges()).not.toThrow();
+    });
+  });
 
-        const noStepControlFixture = TestBed.createComponent(SimpleStepperWithoutStepControl);
+  describe('linear stepper with no `stepControl`', () => {
+    let noStepControlFixture;
+    beforeEach(() => {
+      noStepControlFixture = createComponent(SimpleStepperWithoutStepControl);
+      noStepControlFixture.detectChanges();
+    });
+    it('should not move to the next step if the current one is not completed ', () => {
+      const stepper: MatHorizontalStepper = noStepControlFixture.debugElement
+          .query(By.directive(MatHorizontalStepper)).componentInstance;
 
-        noStepControlFixture.detectChanges();
+      const headers = noStepControlFixture.debugElement
+          .queryAll(By.css('.mat-horizontal-stepper-header'));
 
-        const stepper: MatHorizontalStepper = noStepControlFixture.debugElement
+      expect(stepper.selectedIndex).toBe(0);
+
+      headers[1].nativeElement.click();
+      noStepControlFixture.detectChanges();
+
+      expect(stepper.selectedIndex).toBe(0);
+    });
+  });
+
+  describe('linear stepper with `stepControl`', () => {
+    let controlAndBindingFixture;
+    beforeEach(() => {
+      controlAndBindingFixture =
+      createComponent(SimpleStepperWithStepControlAndCompletedBinding);
+      controlAndBindingFixture.detectChanges();
+    });
+
+    it('should have the `stepControl` take precedence when `completed` is set', () => {
+        expect(controlAndBindingFixture.componentInstance.steps[0].control.valid).toBe(true);
+        expect(controlAndBindingFixture.componentInstance.steps[0].completed).toBe(false);
+
+        const stepper: MatHorizontalStepper = controlAndBindingFixture.debugElement
             .query(By.directive(MatHorizontalStepper)).componentInstance;
 
-        const headers = noStepControlFixture.debugElement
+        const headers = controlAndBindingFixture.debugElement
             .queryAll(By.css('.mat-horizontal-stepper-header'));
 
         expect(stepper.selectedIndex).toBe(0);
 
         headers[1].nativeElement.click();
-        noStepControlFixture.detectChanges();
+        controlAndBindingFixture.detectChanges();
 
-        expect(stepper.selectedIndex).toBe(0);
+        expect(stepper.selectedIndex).toBe(1);
       });
-
-      it('should have the `stepControl` take precedence when both `completed` and ' +
-        '`stepControl` are set', () => {
-          fixture.destroy();
-
-          const controlAndBindingFixture =
-              TestBed.createComponent(SimpleStepperWithStepControlAndCompletedBinding);
-
-          controlAndBindingFixture.detectChanges();
-
-          expect(controlAndBindingFixture.componentInstance.steps[0].control.valid).toBe(true);
-          expect(controlAndBindingFixture.componentInstance.steps[0].completed).toBe(false);
-
-          const stepper: MatHorizontalStepper = controlAndBindingFixture.debugElement
-              .query(By.directive(MatHorizontalStepper)).componentInstance;
-
-          const headers = controlAndBindingFixture.debugElement
-              .queryAll(By.css('.mat-horizontal-stepper-header'));
-
-          expect(stepper.selectedIndex).toBe(0);
-
-          headers[1].nativeElement.click();
-          controlAndBindingFixture.detectChanges();
-
-          expect(stepper.selectedIndex).toBe(1);
-        });
   });
 
   describe('vertical stepper', () => {
     it('should set the aria-orientation to "vertical"', () => {
-      let fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
       let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper')).nativeElement;
@@ -767,7 +757,7 @@ describe('MatStepper', () => {
     });
 
     it('should support using the left/right arrows to move focus', () => {
-      let fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
@@ -775,7 +765,7 @@ describe('MatStepper', () => {
     });
 
     it('should support using the up/down arrows to move focus', () => {
-      let fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
@@ -784,7 +774,7 @@ describe('MatStepper', () => {
 
     it('should reverse arrow key focus in RTL mode', () => {
       dir.value = 'rtl';
-      let fixture = TestBed.createComponent(SimpleMatVerticalStepperApp);
+      let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
@@ -794,7 +784,7 @@ describe('MatStepper', () => {
 
   describe('horizontal stepper', () => {
     it('should set the aria-orientation to "horizontal"', () => {
-      let fixture = TestBed.createComponent(SimpleMatHorizontalStepperApp);
+      let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
       let stepperEl = fixture.debugElement.query(By.css('mat-horizontal-stepper')).nativeElement;
@@ -802,7 +792,7 @@ describe('MatStepper', () => {
     });
 
     it('should support using the left/right arrows to move focus', () => {
-      let fixture = TestBed.createComponent(SimpleMatHorizontalStepperApp);
+      let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
@@ -811,7 +801,7 @@ describe('MatStepper', () => {
 
     it('should reverse arrow key focus in RTL mode', () => {
       dir.value = 'rtl';
-      let fixture = TestBed.createComponent(SimpleMatHorizontalStepperApp);
+      let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
@@ -819,7 +809,7 @@ describe('MatStepper', () => {
     });
 
     it('should reverse arrow key focus when switching into RTL after init', () => {
-      let fixture = TestBed.createComponent(SimpleMatHorizontalStepperApp);
+      let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
@@ -833,13 +823,13 @@ describe('MatStepper', () => {
     });
   });
 
-  describe('valid step in linear stepper', () => {
+  describe('linear stepper with valid step', () => {
     let fixture: ComponentFixture<LinearStepperWithValidOptionalStep>;
     let testComponent: LinearStepperWithValidOptionalStep;
     let stepper: MatStepper;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(LinearStepperWithValidOptionalStep);
+      fixture = createComponent(LinearStepperWithValidOptionalStep);
       fixture.detectChanges();
 
       testComponent = fixture.componentInstance;
@@ -875,7 +865,7 @@ describe('MatStepper', () => {
     let stepHeader: HTMLElement;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(StepperWithAriaInputs);
+      fixture = createComponent(StepperWithAriaInputs);
       fixture.detectChanges();
       stepHeader = fixture.nativeElement.querySelector('.mat-step-header');
     });
@@ -908,6 +898,76 @@ describe('MatStepper', () => {
       expect(stepHeader.hasAttribute('aria-labelledby')).toBe(false);
     });
 
+  });
+
+  describe('stepper with error state', () => {
+    let fixture: ComponentFixture<MatHorizontalStepperWithErrorsApp>;
+    let stepper: MatStepper;
+
+    beforeEach(() => {
+      fixture = createComponent(
+        MatHorizontalStepperWithErrorsApp,
+        [{
+          provide: MAT_STEPPER_GLOBAL_OPTIONS,
+          useValue: {showError: true}
+        }],
+        [MatFormFieldModule, MatInputModule]
+      );
+      fixture.detectChanges();
+      stepper = fixture.debugElement
+          .query(By.css('mat-horizontal-stepper')).componentInstance;
+    });
+
+    it('should show error state', () => {
+      let nextButtonNativeEl = fixture.debugElement
+          .queryAll(By.directive(MatStepperNext))[0].nativeElement;
+
+      stepper.selectedIndex = 1;
+      stepper._steps.toArray()[0].hasError = true;
+      nextButtonNativeEl.click();
+      fixture.detectChanges();
+
+      expect(stepper._getIndicatorType(0)).toBe(STEP_STATE.ERROR);
+    });
+  });
+
+  describe('stepper using Material UI Guideline logic', () => {
+    let fixture: ComponentFixture<MatHorizontalStepperWithErrorsApp>;
+    let stepper: MatStepper;
+
+    beforeEach(() => {
+      fixture = createComponent(
+        MatHorizontalStepperWithErrorsApp,
+        [{
+          provide: MAT_STEPPER_GLOBAL_OPTIONS,
+          useValue: {useGuidelines: true}
+        }],
+        [MatFormFieldModule, MatInputModule]
+      );
+      fixture.detectChanges();
+      stepper = fixture.debugElement
+          .query(By.css('mat-horizontal-stepper')).componentInstance;
+    });
+
+    it('should show done state when step is completed and its not the current step', () => {
+      let nextButtonNativeEl = fixture.debugElement
+          .queryAll(By.directive(MatStepperNext))[0].nativeElement;
+
+      stepper.selectedIndex = 1;
+      stepper._steps.toArray()[0].completed = true;
+      nextButtonNativeEl.click();
+      fixture.detectChanges();
+
+      expect(stepper._getIndicatorType(0)).toBe(STEP_STATE.DONE);
+    });
+
+    it('should show edit state when step is editable and its the current step', () => {
+      stepper.selectedIndex = 1;
+      stepper._steps.toArray()[1].editable = true;
+      fixture.detectChanges();
+
+      expect(stepper._getIndicatorType(1)).toBe(STEP_STATE.EDIT);
+    });
   });
 });
 
@@ -1010,6 +1070,67 @@ function asyncValidator(minLength: number, validationTrigger: Subject<void>): As
       take(1)
     );
   };
+}
+
+function createComponent<T>(component: Type<T>,
+  providers: Provider[] = [],
+  imports: any[] = []): ComponentFixture<T> {
+  TestBed.configureTestingModule({
+    imports: [
+      MatStepperModule,
+      NoopAnimationsModule,
+      ReactiveFormsModule,
+      ...imports
+    ],
+    declarations: [component],
+    providers: [
+      {provide: Directionality, useFactory: () => dir},
+      ...providers
+    ],
+  }).compileComponents();
+
+  return TestBed.createComponent<T>(component);
+}
+
+@Component({
+  template: `
+  <form [formGroup]="formGroup">
+    <mat-horizontal-stepper>
+      <mat-step errorMessage="This field is required" [stepControl]="formArray?.get([0])">
+        <ng-template matStepLabel>Step 1</ng-template>
+        <mat-form-field>
+          <mat-label>First name</mat-label>
+          <input matInput formControlName="firstNameCtrl" required>
+          <mat-error>This field is required</mat-error>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Back</button>
+          <button mat-button matStepperNext>Next</button>
+        </div>
+      </mat-step>
+      <mat-step>
+        <ng-template matStepLabel>Step 2</ng-template>
+        Content 2
+        <div>
+          <button mat-button matStepperPrevious>Back</button>
+          <button mat-button matStepperNext>Next</button>
+        </div>
+      </mat-step>
+    </mat-horizontal-stepper>
+  </form>
+  `
+})
+class MatHorizontalStepperWithErrorsApp implements OnInit {
+  formGroup: FormGroup;
+
+  constructor(private _formBuilder: FormBuilder) { }
+
+  ngOnInit() {
+    this.formGroup = this._formBuilder.group({
+      firstNameCtrl: ['', Validators.required],
+      lastNameCtrl: ['', Validators.required],
+    });
+  }
 }
 
 @Component({

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -9,7 +9,7 @@ import {
   SPACE,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {StepperOrientation, STEP_STATE} from '@angular/cdk/stepper';
+import {StepperOrientation} from '@angular/cdk/stepper';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {Component, DebugElement, EventEmitter, OnInit} from '@angular/core';
 import {async, ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
@@ -292,62 +292,28 @@ describe('MatStepper', () => {
       expect(stepperComponent.selectedIndex).toBe(0);
     });
 
-    describe('with custom state', () => {
-      it('should set the custom icon when the step is completed and on selected step', () => {
-        let stepperComponent = fixture.debugElement
-          .query(By.directive(MatStepper)).componentInstance;
-        const firstStep = stepperComponent._steps.toArray()[0];
-
-        expect(stepperComponent._getIndicatorType(0, 'warning')).toBe(STEP_STATE.EDIT);
-
-        stepperComponent.selectedIndex = 0;
-        firstStep.completed = true;
-        fixture.detectChanges();
-
-        expect(stepperComponent._getIndicatorType(0, 'warning')).toBe('warning');
-      });
-    });
-
-    it('should set error icon if step has error', () => {
+    it('should set create icon if step is editable and completed', () => {
       let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
-      const firstStep = stepperComponent._steps.toArray()[0];
-
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.EDIT);
-
-      firstStep.hasError = true;
+      expect(stepperComponent._getIndicatorType(0)).toBe('number');
+      stepperComponent._steps.toArray()[0].editable = true;
       nextButtonNativeEl.click();
       fixture.detectChanges();
 
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.ERROR);
+      expect(stepperComponent._getIndicatorType(0)).toBe('edit');
     });
 
-    it('should set done icon if step is completed', () => {
+    it('should set done icon if step is not editable and is completed', () => {
       let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
-      const firstStep = stepperComponent._steps.toArray()[0];
-
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.EDIT);
-
-      firstStep.completed = true;
+      expect(stepperComponent._getIndicatorType(0)).toBe('number');
+      stepperComponent._steps.toArray()[0].editable = false;
       nextButtonNativeEl.click();
       fixture.detectChanges();
 
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.DONE);
-    });
-
-    it('should set number icon if step is completed and on selected step', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
-      const firstStep = stepperComponent._steps.toArray()[0];
-
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.EDIT);
-
-      firstStep.completed = true;
-      fixture.detectChanges();
-
-      expect(stepperComponent._getIndicatorType(0)).toBe(STEP_STATE.NUMBER);
+      expect(stepperComponent._getIndicatorType(0)).toBe('done');
     });
 
     it('should re-render when the i18n labels change', inject([MatStepperIntl],
@@ -450,23 +416,12 @@ describe('MatStepper', () => {
       fixture.detectChanges();
     });
 
-    it('should override any icon', () => {
-      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper));
-      const stepperComponent: MatStepper = stepperDebugElement.componentInstance;
-
-      stepperComponent._steps.toArray()[3].completed = true;
-      fixture.detectChanges();
-
-      const headers = stepperDebugElement.nativeElement.querySelectorAll('mat-step-header');
-
-      expect(headers[3].textContent).toContain('Custom warning');
-    });
-
     it('should allow for the `edit` icon to be overridden', () => {
       const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper));
       const stepperComponent: MatStepper = stepperDebugElement.componentInstance;
 
       stepperComponent._steps.toArray()[0].editable = true;
+      stepperComponent.next();
       fixture.detectChanges();
 
       const header = stepperDebugElement.nativeElement.querySelector('mat-step-header');
@@ -763,13 +718,12 @@ describe('MatStepper', () => {
 
         const stepper: MatHorizontalStepper = noStepControlFixture.debugElement
             .query(By.directive(MatHorizontalStepper)).componentInstance;
-        const firstStep = stepper._steps.toArray()[0];
+
         const headers = noStepControlFixture.debugElement
             .queryAll(By.css('.mat-horizontal-stepper-header'));
 
         expect(stepper.selectedIndex).toBe(0);
 
-        firstStep.completed = false;
         headers[1].nativeElement.click();
         noStepControlFixture.detectChanges();
 
@@ -786,16 +740,16 @@ describe('MatStepper', () => {
           controlAndBindingFixture.detectChanges();
 
           expect(controlAndBindingFixture.componentInstance.steps[0].control.valid).toBe(true);
+          expect(controlAndBindingFixture.componentInstance.steps[0].completed).toBe(false);
 
           const stepper: MatHorizontalStepper = controlAndBindingFixture.debugElement
               .query(By.directive(MatHorizontalStepper)).componentInstance;
-          const firstStep = stepper._steps.toArray()[0];
+
           const headers = controlAndBindingFixture.debugElement
               .queryAll(By.css('.mat-horizontal-stepper-header'));
 
           expect(stepper.selectedIndex).toBe(0);
 
-          firstStep.completed = false;
           headers[1].nativeElement.click();
           controlAndBindingFixture.detectChanges();
 
@@ -1202,16 +1156,16 @@ class SimplePreselectedMatHorizontalStepperApp {
     <mat-horizontal-stepper linear>
       <mat-step
         *ngFor="let step of steps"
-        [label]="step.label">
-      </mat-step>
+        [label]="step.label"
+        [completed]="step.completed"></mat-step>
     </mat-horizontal-stepper>
   `
 })
 class SimpleStepperWithoutStepControl {
   steps = [
-    {label: 'One'},
-    {label: 'Two'},
-    {label: 'Three'}
+    {label: 'One', completed: false},
+    {label: 'Two', completed: false},
+    {label: 'Three', completed: false}
   ];
 }
 
@@ -1221,16 +1175,16 @@ class SimpleStepperWithoutStepControl {
       <mat-step
         *ngFor="let step of steps"
         [label]="step.label"
-        [stepControl]="step.control">
-      </mat-step>
+        [stepControl]="step.control"
+        [completed]="step.completed"></mat-step>
     </mat-horizontal-stepper>
   `
 })
 class SimpleStepperWithStepControlAndCompletedBinding {
   steps = [
-    {label: 'One', control: new FormControl()},
-    {label: 'Two', control: new FormControl()},
-    {label: 'Three', control: new FormControl()}
+    {label: 'One', completed: false, control: new FormControl()},
+    {label: 'Two', completed: false, control: new FormControl()},
+    {label: 'Three', completed: false, control: new FormControl()}
   ];
 }
 
@@ -1242,12 +1196,10 @@ class SimpleStepperWithStepControlAndCompletedBinding {
       <ng-template matStepperIcon="number" let-index="index">
         {{getRomanNumeral(index + 1)}}
       </ng-template>
-      <ng-template matStepperIcon="warning">Custom warning</ng-template>
 
       <mat-step>Content 1</mat-step>
       <mat-step>Content 2</mat-step>
       <mat-step>Content 3</mat-step>
-      <mat-step state="warning">Content 4</mat-step>
     </mat-horizontal-stepper>
 `
 })

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -60,9 +60,10 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
   /** Content for step label given by `<ng-template matStepLabel>`. */
   @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
 
+  /** @breaking-change 8.0.0 remove the `?` after `stepperOptions` */
   constructor(@Inject(forwardRef(() => MatStepper)) stepper: MatStepper,
               @SkipSelf() private _errorStateMatcher: ErrorStateMatcher,
-              @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions) {
+              @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions?: StepperOptions) {
     super(stepper, stepperOptions);
   }
 

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -7,7 +7,13 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {CdkStep, CdkStepper, StepContentPositionState, MAT_STEPPER_GLOBAL_OPTIONS, StepperOptions} from '@angular/cdk/stepper';
+import {
+  CdkStep,
+  CdkStepper,
+  StepContentPositionState,
+  MAT_STEPPER_GLOBAL_OPTIONS,
+  StepperOptions
+} from '@angular/cdk/stepper';
 import {AnimationEvent} from '@angular/animations';
 import {
   AfterContentInit,

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -94,14 +94,7 @@ export class MatStepper extends _CdkStepper implements AfterContentInit {
 
   ngAfterContentInit() {
     const icons = this._icons.toArray();
-
-    ['edit', 'done', 'number'].forEach(name => {
-      const override = icons.find(icon => icon.name === name);
-
-      if (override) {
-        this._iconOverrides[name] = override.templateRef;
-      }
-    });
+    icons.forEach(({name, templateRef}) => this._iconOverrides[name] = templateRef);
 
     // Mark the component for change detection whenever the content children query changes
     this._steps.changes.pipe(takeUntil(this._destroyed)).subscribe(() => this._stateChanged());

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {CdkStep, CdkStepper, StepContentPositionState} from '@angular/cdk/stepper';
+import {CdkStep, CdkStepper, StepContentPositionState, MAT_STEPPER_GLOBAL_OPTIONS, StepperOptions} from '@angular/cdk/stepper';
 import {AnimationEvent} from '@angular/animations';
 import {
   AfterContentInit,
@@ -55,8 +55,9 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
   @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
 
   constructor(@Inject(forwardRef(() => MatStepper)) stepper: MatStepper,
-              @SkipSelf() private _errorStateMatcher: ErrorStateMatcher) {
-    super(stepper);
+              @SkipSelf() private _errorStateMatcher: ErrorStateMatcher,
+              @Optional() @Inject(MAT_STEPPER_GLOBAL_OPTIONS) stepperOptions: StepperOptions) {
+    super(stepper, stepperOptions);
   }
 
   /** Custom error state matcher that additionally checks for validity of interacted form. */

--- a/src/material-examples/stepper-errors/stepper-errors-example.html
+++ b/src/material-examples/stepper-errors/stepper-errors-example.html
@@ -1,0 +1,33 @@
+<mat-horizontal-stepper linear #stepper>
+  <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
+    <form [formGroup]="firstFormGroup">
+      <ng-template matStepLabel>Fill out your name</ng-template>
+      <mat-form-field>
+        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step [stepControl]="secondFormGroup" errorMessage="Address is required.">
+    <form [formGroup]="secondFormGroup">
+      <ng-template matStepLabel>Fill out your address</ng-template>
+      <mat-form-field>
+        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperPrevious>Back</button>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Done</ng-template>
+    You are now done.
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button (click)="stepper.reset()">Reset</button>
+    </div>
+  </mat-step>
+</mat-horizontal-stepper>

--- a/src/material-examples/stepper-errors/stepper-errors-example.ts
+++ b/src/material-examples/stepper-errors/stepper-errors-example.ts
@@ -1,0 +1,30 @@
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {MAT_STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
+
+/**
+ * @title Stepper that displays errors in the steps
+ */
+@Component({
+  selector: 'stepper-errors-example',
+  templateUrl: 'stepper-errors-example.html',
+  styleUrls: ['stepper-errors-example.css'],
+  providers: [{
+    provide: MAT_STEPPER_GLOBAL_OPTIONS, useValue: {showError: true}
+  }]
+})
+export class StepperErrorsExample implements OnInit {
+  firstFormGroup: FormGroup;
+  secondFormGroup: FormGroup;
+
+  constructor(private _formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.firstFormGroup = this._formBuilder.group({
+      firstCtrl: ['', Validators.required]
+    });
+    this.secondFormGroup = this._formBuilder.group({
+      secondCtrl: ['', Validators.required]
+    });
+  }
+}

--- a/src/material-examples/stepper-states/stepper-states-example.html
+++ b/src/material-examples/stepper-states/stepper-states-example.html
@@ -1,0 +1,60 @@
+<mat-horizontal-stepper #stepper>
+  <mat-step [stepControl]="firstFormGroup">
+    <form [formGroup]="firstFormGroup">
+      <ng-template matStepLabel>Fill out your name</ng-template>
+      <mat-form-field>
+        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step [stepControl]="secondFormGroup">
+    <form [formGroup]="secondFormGroup">
+      <ng-template matStepLabel>Fill out your address</ng-template>
+      <mat-form-field>
+        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperPrevious>Back</button>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Done</ng-template>
+    You are now done.
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button (click)="stepper.reset()">Reset</button>
+    </div>
+  </mat-step>
+</mat-horizontal-stepper>
+
+<mat-horizontal-stepper>
+  <mat-step label="Step 1" state="phone">
+    <p>Put down your phones.</p>
+    <div>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 2" state="chat">
+    <p>Socialize with each other.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step label="Step 3">
+    <p>You're welcome.</p>
+  </mat-step>
+
+  <!-- Icon overrides. -->
+  <ng-template matStepperIcon="phone">
+    <mat-icon>call_end</mat-icon>
+  </ng-template>
+  <ng-template matStepperIcon="chat">
+    <mat-icon>forum</mat-icon>
+  </ng-template>
+</mat-horizontal-stepper>

--- a/src/material-examples/stepper-states/stepper-states-example.ts
+++ b/src/material-examples/stepper-states/stepper-states-example.ts
@@ -1,0 +1,30 @@
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {MAT_STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
+
+/**
+ * @title Stepper with customized states
+ */
+@Component({
+  selector: 'stepper-states-example',
+  templateUrl: 'stepper-states-example.html',
+  styleUrls: ['stepper-states-example.css'],
+  providers: [{
+    provide: MAT_STEPPER_GLOBAL_OPTIONS, useValue: {displayDefaultIndicatorType: false}
+  }]
+})
+export class StepperStatesExample implements OnInit {
+  firstFormGroup: FormGroup;
+  secondFormGroup: FormGroup;
+
+  constructor(private _formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.firstFormGroup = this._formBuilder.group({
+      firstCtrl: ['', Validators.required]
+    });
+    this.secondFormGroup = this._formBuilder.group({
+      secondCtrl: ['', Validators.required]
+    });
+  }
+}


### PR DESCRIPTION
## Changes

### Major
- Create `MAT_STEPPER_GLOBAL_OPTIONS` InjectionToken to easily configure the stepper to either `showError` for the steps and/or `useGuidelines` to either use the existing logic or new logic to display the icons.
- Create a `state` input for the step so that the developer can set their own state if necessary.
- Refactor the `_getIndicatorType` logic to adhere to Material UI Guidelines if `useGuidelines` is set to true.
- Add an error state! 🎉

~### Breaking~
~- Removed `completed` as an input. However, the developer should still be able to override this attribute through the controller.~

---

**This PR will resolve the following opened issues:**
1. Linear stepper shows edit icons instead of done icons https://github.com/angular/material2/issues/8997
2. [FR] Allow theming a step when invalid+dirty https://github.com/angular/material2/issues/8950

**Acknowledgments:** 
- Big thanks to [@zackarychapple](https://github.com/zackarychapple) for kick-starting this! 🙌