### PR TITLE
fix(select): inconsistent openedChange event dispatched between browsers

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -35,7 +35,7 @@
     class="mat-select-panel {{ _getPanelTheme() }}"
     [ngClass]="panelClass"
     [@transformPanel]="multiple ? 'showing-multiple' : 'showing'"
-    (@transformPanel.done)="_onPanelDone()"
+    (@transformPanel.done)="_panelDoneAnimatingStream.next($event.toState)"
     [style.transformOrigin]="_transformOrigin"
     [class.mat-select-panel-done-animating]="_panelDoneAnimating"
     [style.font-size.px]="_triggerFontSize"


### PR DESCRIPTION
Fixes the `openedChange` event being dispatched once when a select is closed on most browsers, but twice in IE and Edge.

Fixes #11444.