### PR TITLE
chore: minor cleanup in icon tests and virtual scrolling

### DIFF
--- a/src/cdk-experimental/scrolling/tsconfig-build.json
+++ b/src/cdk-experimental/scrolling/tsconfig-build.json
@@ -6,7 +6,7 @@
   ],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
-    "strictMetadataEmit": false, // Workaround for Angular #22210
+    "strictMetadataEmit": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@angular/cdk-experimental/scrolling",
     "skipTemplateCodegen": true,

--- a/src/cdk-experimental/scrolling/typings.d.ts
+++ b/src/cdk-experimental/scrolling/typings.d.ts
@@ -1,1 +1,0 @@
-declare var module: {id: string};

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -428,9 +428,9 @@ describe('MatIcon', () => {
     }));
 
     it('should throw an error when using untrusted HTML', () => {
-      // Stub out console.error so we don't pollute our logs with Angular's warnings.
+      // Stub out console.warn so we don't pollute our logs with Angular's warnings.
       // Jasmine will tear the spy down at the end of the test.
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       expect(() => {
         iconRegistry.addSvgIconLiteral('circle', '<svg><circle></svg>');


### PR DESCRIPTION
* Removes a file that wasn't being used for anything under `cdk-experimental/scrolling`.
* Enables `strictMetadataEmit` for the scrolling package.
* Fixes a test for the icons which was leaking out a warning message.