### PR TITLE
chore: fix bazel failure

### DIFF
--- a/src/cdk-experimental/scrolling/tsconfig-build.json
+++ b/src/cdk-experimental/scrolling/tsconfig-build.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig-build",
   "files": [
     "public-api.ts",
-    "../typings.d.ts"
+    "./typings.d.ts"
   ],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,

--- a/src/cdk-experimental/scrolling/typings.d.ts
+++ b/src/cdk-experimental/scrolling/typings.d.ts
@@ -1,0 +1,1 @@
+declare var module: {id: string};


### PR DESCRIPTION
Restores a file that was removed in #11481 and ended up breaking the Bazel build.