### PR TITLE
fix(dialog): not closing correctly when detached externally

### DIFF
--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -68,13 +68,16 @@ export class MatDialogRef<T, R = any> {
     _containerInstance._animationStateChanged.pipe(
       filter(event => event.phaseName === 'done' && event.toState === 'exit'),
       take(1)
-    )
-    .subscribe(() => {
-      this._overlayRef.dispose();
+    ).subscribe(() => this._overlayRef.dispose());
+
+    _overlayRef.detachments().subscribe(() => {
+      this._beforeClose.next(this._result);
+      this._beforeClose.complete();
       this._locationChanges.unsubscribe();
       this._afterClosed.next(this._result);
       this._afterClosed.complete();
       this.componentInstance = null!;
+      this._overlayRef.dispose();
     });
 
     _overlayRef.keydownEvents()


### PR DESCRIPTION
Fixes the dialog not being closed correctly (the overlay not being detached completely and the close events not being fired), if the underlying overlay is detached externally, e.g. by a scroll strategy.

Fixes #11507.