### PR TITLE
fix(tabs): scale tabs to the height of tab group

### DIFF
--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,6 +1,11 @@
 @import '../core/style/vendor-prefixes';
 
 .mat-tab-body-content {
+  // Avoids repainting while scrolling.
+  @include backface-visibility(hidden);
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
   height: 100%;
   overflow: auto;
 

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -39,13 +39,15 @@
   position: relative;
   overflow: hidden;
   display: flex;
+  flex-grow: 1;
   transition: height $mat-tab-animation-duration $ease-in-out-curve-function;
 }
 
 // Wraps each tab body
 .mat-tab-body {
   @include mat-fill;
-  display: block;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 
   // Fix for auto content wrapping in IE11


### PR DESCRIPTION
Implements the fix by @RobJacobs to correctly scale the contents of mat-tab-group to the group's height. Replaces PR #9180.

Fixes #4591