### PR TITLE
build: add tslint rule to ensure that setters are declared after getters

### DIFF
--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -47,11 +47,11 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
 
   /** Minimum amount of rows in the textarea. */
   @Input('cdkAutosizeMinRows')
+  get minRows(): number { return this._minRows; }
   set minRows(value: number) {
     this._minRows = value;
     this._setMinHeight();
   }
-  get minRows(): number { return this._minRows; }
 
   /** Maximum amount of rows in the textarea. */
   @Input('cdkAutosizeMaxRows')

--- a/src/demo-app/example/example-list.ts
+++ b/src/demo-app/example/example-list.ts
@@ -59,8 +59,8 @@ export class ExampleList {
   @Input() ids: string[];
 
   @Input()
-  set expandAll(v: boolean) { this._expandAll = coerceBooleanProperty(v); }
   get expandAll(): boolean { return this._expandAll; }
+  set expandAll(v: boolean) { this._expandAll = coerceBooleanProperty(v); }
   _expandAll: boolean;
 
   exampleComponents = EXAMPLE_COMPONENTS;

--- a/src/demo-app/example/example.ts
+++ b/src/demo-app/example/example.ts
@@ -48,8 +48,8 @@ export class Example implements OnInit {
   @Input() id: string;
 
   @Input()
-  set showLabel(v: boolean) { this._showLabel = coerceBooleanProperty(v); }
   get showLabel(): boolean { return this._showLabel; }
+  set showLabel(v: boolean) { this._showLabel = coerceBooleanProperty(v); }
   _showLabel: boolean;
 
   title: string;

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -402,8 +402,8 @@ interface TestData {
 
 class FakeDataSource extends DataSource<TestData> {
   _dataChange = new BehaviorSubject<TestData[]>([]);
-  set data(data: TestData[]) { this._dataChange.next(data); }
   get data() { return this._dataChange.getValue(); }
+  set data(data: TestData[]) { this._dataChange.next(data); }
 
   constructor() {
     super();

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -225,6 +225,11 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this._updateTabScrollPosition();
   }
 
+  /** Tracks which element has focus; used for keyboard navigation */
+  get focusIndex(): number {
+    return this._focusIndex;
+  }
+
   /** When the focus index is set, we must manually send focus to the correct label */
   set focusIndex(value: number) {
     if (!this._isValidIndex(value) || this._focusIndex == value) { return; }
@@ -233,9 +238,6 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     this.indexFocused.emit(value);
     this._setTabFocus(value);
   }
-
-  /** Tracks which element has focus; used for keyboard navigation */
-  get focusIndex(): number { return this._focusIndex; }
 
   /**
    * Determines if an index is valid.  If the tabs are not ready yet, we assume that the user is

--- a/tools/tslint-rules/settersAfterGettersRule.ts
+++ b/tools/tslint-rules/settersAfterGettersRule.ts
@@ -1,0 +1,29 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+
+/**
+ * Rule that enforces that property setters are declared after getters.
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  visitGetAccessor(getter: ts.GetAccessorDeclaration) {
+    if (getter.parent && tsutils.isClassDeclaration(getter.parent)) {
+      const getterName = getter.name.getText();
+      const setter = getter.parent.members.find(member => {
+        return tsutils.isSetAccessorDeclaration(member) && member.name.getText() === getterName;
+      }) as ts.SetAccessorDeclaration | undefined;
+
+      if (setter && setter.pos < getter.pos) {
+        this.addFailureAtNode(setter, 'Setters must be declared after getters.');
+      }
+    }
+
+    super.visitGetAccessor(getter);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -97,6 +97,7 @@
     // Custom Rules
     "ts-loader": true,
     "no-exposed-todo": true,
+    "setters-after-getters": true,
     "no-host-decorator-in-concrete": [
       true,
       "HostBinding",


### PR DESCRIPTION
Based on https://github.com/angular/material2/pull/11483#discussion_r190681292. Adds a custom tslint rule to enforce that we put getters before setters.