### PR TITLE
fix(datepicker): inconsistent arrow color between popup and touch modes

### DIFF
--- a/src/lib/datepicker/_datepicker-theme.scss
+++ b/src/lib/datepicker/_datepicker-theme.scss
@@ -36,8 +36,8 @@ $mat-calendar-weekday-table-font-size: 11px !default;
   // The prev/next buttons need a bit more specificity to
   // avoid being overwritten by the .mat-icon-button.
   .mat-datepicker-toggle,
-  .mat-datepicker-popup .mat-calendar-next-button,
-  .mat-datepicker-popup .mat-calendar-previous-button {
+  .mat-datepicker-content .mat-calendar-next-button,
+  .mat-datepicker-content .mat-calendar-previous-button {
     color: mat-color($foreground, icon);
   }
 


### PR DESCRIPTION
Fixes the arrow color selector only targeting the next/prev buttons in popup mode, which meant that they had a different color when in touch mode.