### PR TITLE
feat(collections): add isMultipleSelection function to SelectionModel

### DIFF
--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -269,4 +269,12 @@ describe('SelectionModel', () => {
   it('should be empty if an empty array is passed for the preselected values', () => {
     expect(new SelectionModel(false, []).selected).toEqual([]);
   });
+
+  it('should be able to determine whether multiple values can be selected', () => {
+    let multipleSelectionModel = new SelectionModel(true);
+    expect(multipleSelectionModel.isMultipleSelection()).toBe(true);
+
+    let singleSelectionModel = new SelectionModel();
+    expect(singleSelectionModel.isMultipleSelection()).toBe(false);
+  });
 });

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -116,8 +116,8 @@ export class SelectionModel<T> {
     }
   }
 
-  /** 
-   * Determines whether multiple values can be selected. 
+  /**
+   * Determines whether multiple values can be selected.
    */
   isMultipleSelection() {
     return this._multiple;

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -121,7 +121,6 @@ export class SelectionModel<T> {
    */
   isMultipleSelection() {
     return this._multiple;
-    
   }
 
   /** Emits a change event and clears the records of selected and deselected values. */

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -121,6 +121,7 @@ export class SelectionModel<T> {
    */
   isMultipleSelection() {
     return this._multiple;
+    
   }
 
   /** Emits a change event and clears the records of selected and deselected values. */

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -33,6 +33,11 @@ export class SelectionModel<T> {
     return this._selected;
   }
 
+  /** Whether multiple values can be selected. */
+  get multiple() {
+    return this._multiple;
+  }
+
   /** Event emitted when the value has changed. */
   onChange: Subject<SelectionChange<T>> | null = this._emitChanges ? new Subject() : null;
 
@@ -111,7 +116,7 @@ export class SelectionModel<T> {
    * Sorts the selected values based on a predicate function.
    */
   sort(predicate?: (a: T, b: T) => number): void {
-    if (this._multiple && this._selected) {
+    if (this.multiple && this._selected) {
       this._selected.sort(predicate);
     }
   }
@@ -138,7 +143,7 @@ export class SelectionModel<T> {
   /** Selects a value. */
   private _markSelected(value: T) {
     if (!this.isSelected(value)) {
-      if (!this._multiple) {
+      if (!this.multiple) {
         this._unmarkAll();
       }
 
@@ -173,7 +178,7 @@ export class SelectionModel<T> {
    * including multiple values while the selection model is not supporting multiple values.
    */
   private _verifyValueAssignment(values: T[]) {
-    if (values.length > 1 && !this._multiple) {
+    if (values.length > 1 && !this.multiple) {
       throw getMultipleValuesInSingleSelectionError();
     }
   }

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -33,11 +33,6 @@ export class SelectionModel<T> {
     return this._selected;
   }
 
-  /** Whether multiple values can be selected. */
-  get multiple() {
-    return this._multiple;
-  }
-
   /** Event emitted when the value has changed. */
   onChange: Subject<SelectionChange<T>> | null = this._emitChanges ? new Subject() : null;
 
@@ -116,9 +111,16 @@ export class SelectionModel<T> {
    * Sorts the selected values based on a predicate function.
    */
   sort(predicate?: (a: T, b: T) => number): void {
-    if (this.multiple && this._selected) {
+    if (this._multiple && this._selected) {
       this._selected.sort(predicate);
     }
+  }
+
+  /** 
+   * Determines whether multiple values can be selected. 
+   */
+  isMultipleSelection() {
+    return this._multiple;
   }
 
   /** Emits a change event and clears the records of selected and deselected values. */
@@ -143,7 +145,7 @@ export class SelectionModel<T> {
   /** Selects a value. */
   private _markSelected(value: T) {
     if (!this.isSelected(value)) {
-      if (!this.multiple) {
+      if (!this._multiple) {
         this._unmarkAll();
       }
 
@@ -178,7 +180,7 @@ export class SelectionModel<T> {
    * including multiple values while the selection model is not supporting multiple values.
    */
   private _verifyValueAssignment(values: T[]) {
-    if (values.length > 1 && !this.multiple) {
+    if (values.length > 1 && !this._multiple) {
       throw getMultipleValuesInSingleSelectionError();
     }
   }

--- a/src/cdk/collections/selection.ts
+++ b/src/cdk/collections/selection.ts
@@ -117,7 +117,7 @@ export class SelectionModel<T> {
   }
 
   /**
-   * Determines whether multiple values can be selected.
+   * Gets whether multiple values can be selected.
    */
   isMultipleSelection() {
     return this._multiple;


### PR DESCRIPTION
If your component receives a SelectionModel instance through Input, it was previously not possible to have different behavior based on whether multiple selected items is allowed (e.g.: rendering radio buttons instead of checkboxes). You had to use a second Input property to the component. This pull request allows developers to check the SelectionModel isMultipleSelection function.