### PR TITLE
refactor(dialog): remove unused config property

### DIFF
--- a/src/cdk-experimental/dialog/dialog-config.ts
+++ b/src/cdk-experimental/dialog/dialog-config.ts
@@ -42,9 +42,6 @@ export class DialogConfig<D = any> {
   /** Custom class(es) for the overlay panel. */
   panelClass?: string | string[] = '';
 
-  /** Custom class(es) for the dialog container. */
-  containerClass?: string | string[] = '';
-
   /** Whether the dialog has a background. */
   hasBackdrop?: boolean = true;
 


### PR DESCRIPTION
Removes the `containerClass` property from the `DialogConfig` in `cdk-experimental` since it isn't being used anywhere in code. The property is being removed, rather than being made to do something, because we already have the `panelClass` property. The consumer can achieve the same outcome as `containerClass` by setting a `panelClass` and targeting the `cdk-dialog-container` (e.g. `.custom-panel-class cdk-dialog-container { color: red }`).

Fixes #11591.