### PR TITLE
fix(badge): remove badge margins

### DIFF
--- a/src/demo-app/badge/badge-demo.scss
+++ b/src/demo-app/badge/badge-demo.scss
@@ -1,3 +1,12 @@
 .demo-badge {
   margin-bottom: 25px;
 }
+
+.mat-badge {
+  margin-right: 22px;
+
+  [dir='rtl'] & {
+    margin-right: 0;
+    margin-left: 22px;
+  }
+}

--- a/src/lib/badge/_badge-theme.scss
+++ b/src/lib/badge/_badge-theme.scss
@@ -38,17 +38,12 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
   }
 
   &.mat-badge-before {
-    margin-left: $size;
-
     .mat-badge-content {
       left: -$size;
     }
   }
 
   [dir='rtl'] &.mat-badge-before {
-    margin-left: 0;
-    margin-right: $size;
-
     .mat-badge-content {
       left: auto;
       right: -$size;
@@ -56,17 +51,12 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
   }
 
   &.mat-badge-after {
-    margin-right: $size;
-
     .mat-badge-content {
       right: -$size;
     }
   }
 
   [dir='rtl'] &.mat-badge-after {
-    margin-right: 0;
-    margin-left: $size;
-
     .mat-badge-content {
       right: auto;
       left: -$size;
@@ -75,17 +65,12 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
 
   &.mat-badge-overlap {
     &.mat-badge-before {
-      margin-left: $size / 2;
-
       .mat-badge-content {
         left: -$size / 2;
       }
     }
 
     [dir='rtl'] &.mat-badge-before {
-      margin-left: 0;
-      margin-right: $size / 2;
-
       .mat-badge-content {
         left: auto;
         right: -$size / 2;
@@ -93,17 +78,12 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
     }
 
     &.mat-badge-after {
-      margin-right: $size / 2;
-
       .mat-badge-content {
         right: -$size / 2;
       }
     }
 
     [dir='rtl'] &.mat-badge-after {
-      margin-right: 0;
-      margin-left: $size;
-
       .mat-badge-content {
         right: auto;
         left: -$size / 2;


### PR DESCRIPTION
Removes the margins that are being added to an element that has a badge. Having the margin was problematic, because it can influence the user's layout and it doesn't handle toggling between a visible and hidden badge very well.

Fixes #11596.