### PR TITLE
fix(mat-input): add a check for the current platform

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -254,10 +254,12 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   }
 
   ngOnInit() {
-    this._autofillMonitor.monitor(this._elementRef).subscribe(event => {
-      this.autofilled = event.isAutofilled;
-      this.stateChanges.next();
-    });
+    if (this._platform.isBrowser) {
+      this._autofillMonitor.monitor(this._elementRef.nativeElement).subscribe(event => {
+        this.autofilled = event.isAutofilled;
+        this.stateChanges.next();
+      });
+    }
   }
 
   ngOnChanges() {
@@ -266,7 +268,10 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
 
   ngOnDestroy() {
     this.stateChanges.complete();
-    this._autofillMonitor.stopMonitoring(this._elementRef);
+
+    if (this._platform.isBrowser) {
+      this._autofillMonitor.stopMonitoring(this._elementRef.nativeElement);
+    }
   }
 
   ngDoCheck() {


### PR DESCRIPTION
Allow `AutofillMonitor.monitor` and `AutofillMonitor.stopMonitoring` methods to be called only on the client side.

Fixes [#11603](https://github.com/angular/material2/issues/11603)