### PR TITLE
fix(button-toggle): underlying input not disabled when group is disabled

### DIFF
--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -286,6 +286,17 @@ describe('MatButtonToggle without forms', () => {
       expect(groupNativeElement.getAttribute('aria-disabled')).toBe('true');
     });
 
+    it('should disable the underlying button when the group is disabled', () => {
+      const buttons = buttonToggleNativeElements.map(toggle => toggle.querySelector('button')!);
+
+      expect(buttons.every(input => input.disabled)).toBe(false);
+
+      testComponent.isGroupDisabled = true;
+      fixture.detectChanges();
+
+      expect(buttons.every(input => input.disabled)).toBe(true);
+    });
+
     it('should update the group value when one of the toggles changes', () => {
       expect(groupInstance.value).toBeFalsy();
       buttonToggleLabelElements[0].click();


### PR DESCRIPTION
Fixes the underlying `input` element inside a `mat-button-toggle` not being disabled when the parent toggle group is disabled via a data binding.

Fixes #11608.