### PR TITLE
fix(overlay): flexible overlay with push not handling scroll offset and position locking

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1101,6 +1101,165 @@ describe('FlexibleConnectedPositionStrategy', () => {
       expect(Math.floor(overlayRect.top)).toBe(15);
     });
 
+    it('should not mess with the left offset when pushing from the top', () => {
+      originElement.style.top = `${-OVERLAY_HEIGHT * 2}px`;
+      originElement.style.left = '200px';
+
+      positionStrategy.withPositions([{
+        originX: 'start',
+        originY: 'bottom',
+        overlayX: 'start',
+        overlayY: 'top'
+      }]);
+
+      attachOverlay({positionStrategy});
+
+      const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+      expect(Math.floor(overlayRect.left)).toBe(200);
+    });
+
+    it('should align to the trigger if the overlay is wider than the viewport, but the trigger ' +
+      'is still within the viewport', () => {
+        originElement.style.top = '200px';
+        originElement.style.left = '200px';
+
+        positionStrategy.withPositions([
+          {
+            originX: 'start',
+            originY: 'bottom',
+            overlayX: 'start',
+            overlayY: 'top'
+          },
+          {
+            originX: 'end',
+            originY: 'bottom',
+            overlayX: 'end',
+            overlayY: 'top'
+          }
+        ]);
+
+        attachOverlay({
+          width: viewport.getViewportRect().width + 100,
+          positionStrategy
+        });
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        const originRect = originElement.getBoundingClientRect();
+
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
+      });
+
+    it('should push into the viewport if the overlay is wider than the viewport and the trigger' +
+      'out of the viewport', () => {
+        originElement.style.top = '200px';
+        originElement.style.left = `-${DEFAULT_WIDTH / 2}px`;
+
+        positionStrategy.withPositions([
+          {
+            originX: 'start',
+            originY: 'bottom',
+            overlayX: 'start',
+            overlayY: 'top'
+          },
+          {
+            originX: 'end',
+            originY: 'bottom',
+            overlayX: 'end',
+            overlayY: 'top'
+          }
+        ]);
+
+        attachOverlay({
+          width: viewport.getViewportRect().width + 100,
+          positionStrategy
+        });
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.left)).toBe(0);
+      });
+
+    it('should keep the element inside the viewport as the user is scrolling, ' +
+      'with position locking disabled', () => {
+        const veryLargeElement = document.createElement('div');
+
+        originElement.style.top = `${-OVERLAY_HEIGHT * 2}px`;
+        originElement.style.left = '200px';
+
+        veryLargeElement.style.width = '100%';
+        veryLargeElement.style.height = '2000px';
+        document.body.appendChild(veryLargeElement);
+
+        positionStrategy
+          .withLockedPosition(false)
+          .withViewportMargin(0)
+          .withPositions([{
+            overlayY: 'top',
+            overlayX: 'start',
+            originY: 'top',
+            originX: 'start'
+          }]);
+
+        attachOverlay({positionStrategy});
+
+        let overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top))
+            .toBe(0, 'Expected overlay to be in the viewport initially.');
+
+        window.scroll(0, 100);
+        overlayRef.updatePosition();
+        zone.simulateZoneExit();
+
+        overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top))
+            .toBe(0, 'Expected overlay to stay in the viewport after scrolling.');
+
+        window.scroll(0, 0);
+        document.body.removeChild(veryLargeElement);
+      });
+
+      it('should not continue pushing the overlay as the user scrolls, if position ' +
+        'locking is enabled', () => {
+        const veryLargeElement = document.createElement('div');
+
+        originElement.style.top = `${-OVERLAY_HEIGHT * 2}px`;
+        originElement.style.left = '200px';
+
+        veryLargeElement.style.width = '100%';
+        veryLargeElement.style.height = '2000px';
+        document.body.appendChild(veryLargeElement);
+
+        positionStrategy
+          .withLockedPosition()
+          .withViewportMargin(0)
+          .withPositions([{
+            overlayY: 'top',
+            overlayX: 'start',
+            originY: 'top',
+            originX: 'start'
+          }]);
+
+        attachOverlay({positionStrategy});
+
+        const scrollBy = 100;
+        let initialOverlayTop = Math.floor(overlayRef.overlayElement.getBoundingClientRect().top);
+
+        expect(initialOverlayTop).toBe(0, 'Expected overlay to be inside the viewport initially.');
+
+        window.scroll(0, scrollBy);
+        overlayRef.updatePosition();
+        zone.simulateZoneExit();
+
+        let currentOverlayTop = Math.floor(overlayRef.overlayElement.getBoundingClientRect().top);
+
+        expect(currentOverlayTop).toBeLessThan(0,
+            'Expected overlay to no longer be completely inside the viewport.');
+        expect(currentOverlayTop).toBe(initialOverlayTop - scrollBy,
+            'Expected overlay to maintain its previous position.');
+
+        window.scroll(0, 0);
+        document.body.removeChild(veryLargeElement);
+      });
+
   });
 
   describe('with flexible dimensions', () => {

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -14,6 +14,12 @@ import {auditTime} from 'rxjs/operators';
 /** Time in ms to throttle the resize events by default. */
 export const DEFAULT_RESIZE_TIME = 20;
 
+/** Object that holds the scroll position of the viewport in each direction. */
+export interface ViewportScrollPosition {
+  top: number;
+  left: number;
+}
+
 /**
  * Simple utility for getting the bounds of the browser viewport.
  * @docs-private
@@ -82,7 +88,7 @@ export class ViewportRuler implements OnDestroy {
   }
 
   /** Gets the (top, left) scroll position of the viewport. */
-  getViewportScrollPosition() {
+  getViewportScrollPosition(): ViewportScrollPosition {
     // While we can get a reference to the fake document
     // during SSR, it doesn't have getBoundingClientRect.
     if (!this._platform.isBrowser) {

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -353,6 +353,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     return new OverlayConfig({
       positionStrategy: this._overlay.position()
           .flexibleConnectedTo(this._element)
+          .withLockedPosition()
           .withTransformOriginOn('.mat-menu-panel'),
       hasBackdrop: this.menu.hasBackdrop == null ? !this.triggersSubmenu() : this.menu.hasBackdrop,
       backdropClass: this.menu.backdropClass || 'cdk-overlay-transparent-backdrop',


### PR DESCRIPTION
This is a resubmit of #11421.

* Fixes the position of flexible overlays with pushing enabled being thrown off once the user starts scrolling.
* Fixes flexible overlays with pushing not handling locked positioning. With these changes locked overlays will only be pushed when they're opened, whereas non-locked overlays will stay in the viewport, even when the user scrolls down.
* Fixes a potential issue due to a couple of variables being initialized together where one is set to zero and the other one is undefined.

Fixes #11365.