### PR TITLE
build: add tslint rule to enforce consistent rxjs imports

### DIFF
--- a/src/demo-app/virtual-scroll/virtual-scroll-demo.ts
+++ b/src/demo-app/virtual-scroll/virtual-scroll-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, ViewEncapsulation} from '@angular/core';
-import {BehaviorSubject} from 'rxjs/index';
+import {BehaviorSubject} from 'rxjs';
 
 
 type State = {

--- a/tools/tslint-rules/rxjsImportsRule.ts
+++ b/tools/tslint-rules/rxjsImportsRule.ts
@@ -1,0 +1,23 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+/**
+ * Rule that ensures that all rxjs imports come only from `rxjs` and `rxjs/operators`.
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile) {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  visitImportDeclaration(node: ts.ImportDeclaration) {
+    const specifier = node.moduleSpecifier.getText().slice(1, -1);
+
+    if (specifier.startsWith('rxjs') && specifier !== 'rxjs' && specifier !== 'rxjs/operators') {
+      this.addFailureAtNode(node, 'RxJS imports are only allowed from `rxjs` or `rxjs/operators`.');
+    }
+
+    super.visitImportDeclaration(node);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -98,6 +98,7 @@
     "ts-loader": true,
     "no-exposed-todo": true,
     "setters-after-getters": true,
+    "rxjs-imports": true,
     "no-host-decorator-in-concrete": [
       true,
       "HostBinding",


### PR DESCRIPTION
Adds a small tslint rule that will help us catch cases like [this one](https://github.com/angular/material2/blob/master/src/demo-app/virtual-scroll/virtual-scroll-demo.ts#L10), which can come up when the IDE auto-imports something from rjxs.