### PR TITLE
fix(expansion): expansion panel blending in with background in high contrast mode

### DIFF
--- a/src/lib/expansion/expansion-panel.scss
+++ b/src/lib/expansion/expansion-panel.scss
@@ -1,5 +1,6 @@
 @import '../core/style/variables';
 @import '../core/style/elevation';
+@import '../../cdk/a11y/a11y';
 
 .mat-expansion-panel {
   @include mat-elevation-transition;
@@ -8,6 +9,10 @@
   display: block;
   margin: 0;
   transition: margin 225ms $mat-fast-out-slow-in-timing-function;
+
+  @include cdk-high-contrast {
+    outline: solid 1px;
+  }
 }
 
 .mat-expansion-panel-content {


### PR DESCRIPTION
Fixes the expansion panel blending in with the background for high contrast users, because it doesn't have any borders or outlines (currently we're distinguishing only with a shadow and a background color).