### PR TITLE
chore: focus monitor directives example not working

### DIFF
--- a/src/material-examples/material-module.ts
+++ b/src/material-examples/material-module.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 
 import {ScrollDispatchModule} from '@angular/cdk/scrolling';
+import {A11yModule} from '@angular/cdk/a11y';
 import {CdkTableModule} from '@angular/cdk/table';
 import {CdkTreeModule} from '@angular/cdk/tree';
 import {
@@ -15,6 +16,7 @@ import {
 
 @NgModule({
   imports: [
+    A11yModule,
     CdkTableModule,
     CdkTreeModule,
     MatAutocompleteModule,
@@ -55,6 +57,7 @@ import {
     ScrollDispatchModule,
   ],
   exports: [
+    A11yModule,
     CdkTableModule,
     CdkTreeModule,
     MatAutocompleteModule,


### PR DESCRIPTION
Fixes the `focus-monitor-directives` example not working due to the `A11yModule` not being imported in the examples.