### PR TITLE
fix(autocomplete): model not being updated when typing in input with disabled autocomplete

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -358,11 +358,13 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     // filter out all of the extra events, we save the value on focus and between
     // `input` events, and we check whether it changed.
     // See: https://connect.microsoft.com/IE/feedback/details/885747/
-    if (this._canOpen() && this._previousValue !== value &&
-      document.activeElement === event.target) {
+    if (this._previousValue !== value && document.activeElement === event.target) {
       this._previousValue = value;
       this._onChange(value);
-      this.openPanel();
+
+      if (this._canOpen()) {
+        this.openPanel();
+      }
     }
   }
 

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -470,6 +470,16 @@ describe('MatAutocomplete', () => {
           .toBe(false, `Expected panel to remain closed.`);
     });
 
+    it('should continue to update the model if the autocomplete is disabled', () => {
+      fixture.componentInstance.autocompleteDisabled = true;
+      fixture.detectChanges();
+
+      typeInElement('hello', input);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value).toBe('hello');
+    });
+
   });
 
   it('should have the correct text direction in RTL', () => {


### PR DESCRIPTION
Fixes the model of an input with `matAutocompleteDisabled=true` not being updated while typing.

Fixes #11678.