### PR TITLE
fix(stepper): reading out wrong amount of steps with NVDA on Firefox

### DIFF
--- a/src/lib/stepper/stepper-horizontal.html
+++ b/src/lib/stepper/stepper-horizontal.html
@@ -5,6 +5,8 @@
                      (keydown)="_onKeydown($event)"
                      [tabIndex]="_getFocusIndex() === i ? 0 : -1"
                      [id]="_getStepLabelId(i)"
+                     [attr.aria-posinset]="i + 1"
+                     [attr.aria-setsize]="_steps.length"
                      [attr.aria-controls]="_getStepContentId(i)"
                      [attr.aria-selected]="selectedIndex == i"
                      [index]="i"

--- a/src/lib/stepper/stepper-vertical.html
+++ b/src/lib/stepper/stepper-vertical.html
@@ -4,6 +4,8 @@
                    (keydown)="_onKeydown($event)"
                    [tabIndex]="_getFocusIndex() == i ? 0 : -1"
                    [id]="_getStepLabelId(i)"
+                   [attr.aria-posinset]="i + 1"
+                   [attr.aria-setsize]="_steps.length"
                    [attr.aria-controls]="_getStepContentId(i)"
                    [attr.aria-selected]="selectedIndex === i"
                    [index]="i"

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -365,6 +365,14 @@ describe('MatStepper', () => {
       expect(stepperComponent.selectedIndex).toBe(-1);
     });
 
+    it('should set the correct aria-posinset and aria-setsize', () => {
+      const headers =
+          Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('.mat-step-header'));
+
+      expect(headers.map(header => header.getAttribute('aria-posinset'))).toEqual(['1', '2', '3']);
+      expect(headers.every(header => header.getAttribute('aria-setsize') === '3')).toBe(true);
+    });
+
   });
 
   describe('icon overrides', () => {


### PR DESCRIPTION
Fixes NVDA on Firefox reading out "Tab 1 of 1" for vertical steppers. Seems to be a similar issue to  #11694.