### PR TITLE
fix(dialog): inconsistently resetting dimensions

### DIFF
--- a/src/lib/dialog/dialog-ref.ts
+++ b/src/lib/dialog/dialog-ref.ts
@@ -181,7 +181,7 @@ export class MatDialogRef<T, R = any> {
    * @param width New width of the dialog.
    * @param height New height of the dialog.
    */
-  updateSize(width: string = 'auto', height: string = 'auto'): this {
+  updateSize(width: string = '', height: string = ''): this {
     this._getPositionStrategy().width(width).height(height);
     this._overlayRef.updatePosition();
     return this;

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -537,6 +537,27 @@ describe('MatDialog', () => {
     expect(overlayPane.style.width).toBe('200px');
   });
 
+  it('should reset the overlay dimensions to their initial size', () => {
+    let dialogRef = dialog.open(PizzaMsg);
+
+    viewContainerFixture.detectChanges();
+
+    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(overlayPane.style.width).toBeFalsy();
+    expect(overlayPane.style.height).toBeFalsy();
+
+    dialogRef.updateSize('200px', '200px');
+
+    expect(overlayPane.style.width).toBe('200px');
+    expect(overlayPane.style.height).toBe('200px');
+
+    dialogRef.updateSize();
+
+    expect(overlayPane.style.width).toBeFalsy();
+    expect(overlayPane.style.height).toBeFalsy();
+  });
+
   it('should allow setting the layout direction', () => {
     dialog.open(PizzaMsg, { direction: 'rtl' });
 


### PR DESCRIPTION
Currently when no dialog dimensions are set, no CSS properties will be passed on to the overlay panel, however if the dialog dimensions are reset via the `DialogRef`, the overlay's `width` and `height` will be set explicitly to `auto`. This is inconsistent and could break some edge cases.