### PR TITLE
feat(snack-bar): add 'stretch' horizontalPosition option

### DIFF
--- a/src/demo-app/snack-bar/snack-bar-demo.html
+++ b/src/demo-app/snack-bar/snack-bar-demo.html
@@ -12,6 +12,7 @@
         <mat-option value="left">Left</mat-option>
         <mat-option value="right">Right</mat-option>
         <mat-option value="center">Center</mat-option>
+        <mat-option value="stretch">Stretch</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-form-field>

--- a/src/lib/snack-bar/snack-bar-config.ts
+++ b/src/lib/snack-bar/snack-bar-config.ts
@@ -14,7 +14,8 @@ import {Direction} from '@angular/cdk/bidi';
 export const MAT_SNACK_BAR_DATA = new InjectionToken<any>('MatSnackBarData');
 
 /** Possible values for horizontalPosition on MatSnackBarConfig. */
-export type MatSnackBarHorizontalPosition = 'start' | 'center' | 'end' | 'left' | 'right';
+export type MatSnackBarHorizontalPosition =
+  'start' | 'center' | 'end' | 'left' | 'right' | 'stretch';
 
 /** Possible values for verticalPosition on MatSnackBarConfig. */
 export type MatSnackBarVerticalPosition = 'top' | 'bottom';

--- a/src/lib/snack-bar/snack-bar-container.scss
+++ b/src/lib/snack-bar/snack-bar-container.scss
@@ -49,7 +49,8 @@ $mat-snack-bar-spacing-margin: 24px !default;
  * The mat-snack-bar-handset class will be applied to the overlay
  * element causing styling to both it and the snack bar container.
  */
-.mat-snack-bar-handset {
+.mat-snack-bar-handset,
+.mat-snack-bar-stretch {
   width: 100%;
 
   .mat-snack-bar-container {

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -713,6 +713,22 @@ describe('MatSnackBar Positioning', () => {
     expect(overlayPaneEl.style.marginLeft).toBe('', 'Expected margin-left  to be ""');
    }));
 
+   it('should be in the bottom and stretched across the screen', fakeAsync(() => {
+    snackBar.open(simpleMessage, simpleActionLabel, {
+      verticalPosition: 'bottom',
+      horizontalPosition: 'stretch'
+    });
+
+    viewContainerFixture.detectChanges();
+    flush();
+
+    const containerEl = overlayContainerEl.querySelector('snack-bar-container') as HTMLElement;
+    const overlayPaneEl = overlayContainerEl.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(containerEl.classList.contains('mat-snack-bar-top')).toBeFalsy();
+    expect(overlayPaneEl.classList.contains('mat-snack-bar-stretch')).toBeTruthy();
+   }));
+
    it('should be in the top left corner', fakeAsync(() => {
     snackBar.open(simpleMessage, simpleActionLabel, {
       verticalPosition: 'top',
@@ -772,6 +788,23 @@ describe('MatSnackBar Positioning', () => {
     expect(overlayPaneEl.style.marginRight).toBe('', 'Expected margin-right to be ""');
     expect(overlayPaneEl.style.marginLeft).toBe('', 'Expected margin-left  to be ""');
    }));
+
+   it('should be in the top and stretched across the screen', fakeAsync(() => {
+    snackBar.open(simpleMessage, simpleActionLabel, {
+      verticalPosition: 'top',
+      horizontalPosition: 'stretch'
+    });
+
+    viewContainerFixture.detectChanges();
+    flush();
+
+    const containerEl = overlayContainerEl.querySelector('snack-bar-container') as HTMLElement;
+    const overlayPaneEl = overlayContainerEl.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(containerEl.classList.contains('mat-snack-bar-top')).toBeTruthy();
+    expect(overlayPaneEl.classList.contains('mat-snack-bar-stretch')).toBeTruthy();
+   }));
+
 
    it('should handle start based on direction (rtl)', fakeAsync(() => {
     snackBar.open(simpleMessage, simpleActionLabel, {

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -236,7 +236,9 @@ export class MatSnackBar {
       config.horizontalPosition === 'left' ||
       (config.horizontalPosition === 'start' && !isRtl) ||
       (config.horizontalPosition === 'end' && isRtl));
-    const isRight = !isLeft && config.horizontalPosition !== 'center';
+    const isRight = (!isLeft &&
+      config.horizontalPosition !== 'center' &&
+      config.horizontalPosition !== 'stretch');
     if (isLeft) {
       positionStrategy.left('0');
     } else if (isRight) {
@@ -244,11 +246,15 @@ export class MatSnackBar {
     } else {
       positionStrategy.centerHorizontally();
     }
-    // Set horizontal position.
+    // Set vertical position.
     if (config.verticalPosition === 'top') {
       positionStrategy.top('0');
     } else {
       positionStrategy.bottom('0');
+    }
+
+    if (config.horizontalPosition === 'stretch') {
+      overlayConfig.panelClass = 'mat-snack-bar-stretch';
     }
 
     overlayConfig.positionStrategy = positionStrategy;


### PR DESCRIPTION
This adds a 'stretch' horizontalPosition option to make the snackbar stretch across the screen.

With any other option the overlay container has a max-width which prevents the snackbar container element to expand beyond the width of its content. Basically this option sets the width of the container to 100% so it can stretch across the screen regardless of its content.

Hopefully this feature can be useful to some people :)