### PR TITLE
chore(overlay): remove unused properties from checks

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -232,7 +232,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (this._position) {
-      if (changes['positions'] || changes['_deprecatedPositions']) {
+      if (changes['positions']) {
         this._position.withPositions(this.positions);
       }
 
@@ -240,7 +240,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
         this._position.withLockedPosition(this.lockPosition);
       }
 
-      if (changes['origin'] || changes['_deprecatedOrigin']) {
+      if (changes['origin']) {
         this._position.setOrigin(this.origin.elementRef);
 
         if (this.open) {
@@ -249,7 +249,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       }
     }
 
-    if (changes['open'] || changes['_deprecatedOpen']) {
+    if (changes['open']) {
       this.open ? this._attachOverlay() : this._detachOverlay();
     }
   }


### PR DESCRIPTION
Removes a few properties that were left in the `ngOnChanges` checks, because the `SimpleChanges` isn't typed and didn't catch that the properties were removed.