### PR TITLE
docs(dialog): emphasize clicking on backdrop in disableClose docs

### DIFF
--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -56,7 +56,7 @@ export class MatDialogConfig<D = any> {
   /** Custom class for the backdrop, */
   backdropClass?: string = '';
 
-  /** Whether the user can use escape or clicking outside to close a modal. */
+  /** Whether the user can use escape or clicking on the backdrop to close the modal. */
   disableClose?: boolean = false;
 
   /** Width of the dialog. */


### PR DESCRIPTION
Mentions the backdrop explicitly in the `disableClose` docs in order to avoid confusion.

Fixes #11750.