### PR TITLE
feat(tabs): Added option for minimal animation (#2706)

### DIFF
--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -24,6 +24,7 @@ export class TabsDemo {
     'tab-group-theme',
     'tab-group-lazy-loaded',
     'tab-group-dynamic',
+    'tab-group-minimal-animation',
     'tab-nav-bar-basic',
   ];
 }

--- a/src/lib/tabs/tab-body.html
+++ b/src/lib/tabs/tab-body.html
@@ -1,6 +1,17 @@
-<div class="mat-tab-body-content" #content
-     [@translateTab]="_position"
-     (@translateTab.start)="_onTranslateTabStarted($event)"
-     (@translateTab.done)="_onTranslateTabComplete($event)">
-  <ng-template matTabBodyHost></ng-template>
-</div>
+<div *ngIf="_minimalAnimation;then min else full" class="mat-tab-body-content" #content></div>
+
+<ng-template #min>
+  <div [@translateTabMinimalAnimation]="_position"
+    (@translateTabMinimalAnimation.start)="_onTranslateTabStarted($event)"
+    (@translateTabMinimalAnimation.done)="_onTranslateTabComplete($event)">
+    <ng-template matTabBodyHost></ng-template>
+  </div>
+</ng-template>
+
+<ng-template #full>
+  <div [@translateTab]="_position"
+    (@translateTab.start)="_onTranslateTabStarted($event)"
+    (@translateTab.done)="_onTranslateTabComplete($event)">
+    <ng-template matTabBodyHost></ng-template>
+  </div>
+</ng-template>

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -108,7 +108,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   styleUrls: ['tab-body.css'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [matTabsAnimations.translateTab],
+  animations: [matTabsAnimations.translateTab, matTabsAnimations.translateTabMinimalAnimation],
   host: {
     'class': 'mat-tab-body',
   },
@@ -131,6 +131,9 @@ export class MatTabBody implements OnInit {
 
   /** The tab body content to display. */
   @Input('content') _content: TemplatePortal;
+
+  /** Whether to use full animation or minimal one */
+  @Input('minimalAnimation') _minimalAnimation: boolean;
 
   /** The shifted index position of the tab body, where zero represents the active center tab. */
   @Input()

--- a/src/lib/tabs/tab-group.html
+++ b/src/lib/tabs/tab-group.html
@@ -33,6 +33,7 @@
   <mat-tab-body role="tabpanel"
                *ngFor="let tab of _tabs; let i = index"
                [id]="_getTabContentId(i)"
+               [minimalAnimation]="minimalAnimation"
                [attr.aria-labelledby]="_getTabLabelId(i)"
                [class.mat-tab-body-active]="selectedIndex == i"
                [content]="tab.content"

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -103,6 +103,12 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   set dynamicHeight(value: boolean) { this._dynamicHeight = coerceBooleanProperty(value); }
   private _dynamicHeight: boolean = false;
 
+  /** Whether to use full animation or minimal one */
+  @Input()
+  get minimalAnimation(): boolean { return this._minimalAnimation; }
+  set minimalAnimation(value: boolean) { this._minimalAnimation = coerceBooleanProperty(value); }
+  private _minimalAnimation: boolean = false;
+
   /** The index of the active tab. */
   @Input()
   get selectedIndex(): number | null { return this._selectedIndex; }

--- a/src/lib/tabs/tabs-animations.ts
+++ b/src/lib/tabs/tabs-animations.ts
@@ -17,6 +17,7 @@ import {
 /** Animations used by the Material tabs. */
 export const matTabsAnimations: {
   readonly translateTab: AnimationTriggerMetadata;
+  readonly translateTabMinimalAnimation: AnimationTriggerMetadata;
 } = {
   /** Animation translates a tab along the X axis. */
   translateTab: trigger('translateTab', [
@@ -33,6 +34,22 @@ export const matTabsAnimations: {
     transition('void => right-origin-center', [
       style({transform: 'translate3d(100%, 0, 0)'}),
       animate('500ms cubic-bezier(0.35, 0, 0.25, 1)')
+    ])
+  ]),
+  translateTabMinimalAnimation: trigger('translateTabMinimalAnimation', [
+    // Note: 1ms animation to give the illusion of no animation, but still triggers events
+    state('center, void, left-origin-center, right-origin-center', style({transform: 'none'})),
+    state('left', style({transform: 'translate3d(-100%, 0, 0)'})),
+    state('right', style({transform: 'translate3d(100%, 0, 0)'})),
+    transition('* => left, * => right, left => center, right => center',
+        animate('1ms cubic-bezier(0.35, 0, 0.25, 1)')),
+    transition('void => left-origin-center', [
+      style({transform: 'translate3d(-100%, 0, 0)'}),
+      animate('1ms cubic-bezier(0.35, 0, 0.25, 1)')
+    ]),
+    transition('void => right-origin-center', [
+      style({transform: 'translate3d(100%, 0, 0)'}),
+      animate('1ms cubic-bezier(0.35, 0, 0.25, 1)')
     ])
   ])
 };

--- a/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.css
+++ b/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.html
+++ b/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.html
@@ -1,0 +1,5 @@
+<mat-tab-group [minimalAnimation]="true">
+  <mat-tab label="First"> Content 1 </mat-tab>
+  <mat-tab label="Second"> Content 2 </mat-tab>
+  <mat-tab label="Third"> Content 3 </mat-tab>
+</mat-tab-group>

--- a/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.ts
+++ b/src/material-examples/tab-group-minimal-animation/tab-group-minimal-animation-example.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Basic use of the no animation selector
+ */
+@Component({
+  selector: 'tab-group-minimal-animation-example',
+  templateUrl: 'tab-group-minimal-animation-example.html',
+  styleUrls: ['tab-group-minimal-animation-example.css'],
+})
+export class TabGroupMinimalAnimationExample {}


### PR DESCRIPTION
This is an attempt at #2706.

I was weary of out right disabling the tab animation because there is a lot of state around it and I didn't want it to propagate to the child components in any way.  However I believe the desired functionality can be achieved by adding a separate animation with an update of 1ms instead of 500ms.
 
I didn't want to be misleading so I named this new input `minimalAnimation`, but thats not the clearest property; `disabledAnimation` is certainly more clear (but again, its misleading).  So please let me know which is better.

Also I was unsure what exactly to spec for, so I copied the basic functionality tests in mat-tab-group.  I also tested every single tab-group in the demo app with and without the minimal animations and they all worked.