### PR TITLE
fix: default config check is not  checking test builder

### DIFF
--- a/src/lib/schematics/install/theming.ts
+++ b/src/lib/schematics/install/theming.ts
@@ -95,10 +95,11 @@ function assertDefaultProjectConfig(project: Project) {
 /** Gets whether the Angular CLI project is using the default build configuration. */
 function isProjectUsingDefaultConfig(project: Project) {
   const defaultBuilder = '@angular-devkit/build-angular:browser';
+  const defaultTestBuilder = '@angular-devkit/build-angular:karma';
 
   return project.architect &&
       project.architect['build'] &&
       project.architect['build']['builder'] === defaultBuilder &&
       project.architect['test'] &&
-      project.architect['build']['builder'] === defaultBuilder;
+      project.architect['test']['builder'] === defaultTestBuilder;
 }


### PR DESCRIPTION
Previous version checked ['build']['builder'] twice
instead of checking ['test']['builder']

(#11815)