### PR TITLE
fix(overlay): explicitly implement OverlayReference.

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -14,6 +14,7 @@ import {take} from 'rxjs/operators';
 import {OverlayKeyboardDispatcher} from './keyboard/overlay-keyboard-dispatcher';
 import {OverlayConfig} from './overlay-config';
 import {coerceCssPixelValue, coerceArray} from '@angular/cdk/coercion';
+import {OverlayReference} from './overlay-reference';
 
 
 /** An object where all of its properties cannot be written. */
@@ -25,7 +26,7 @@ export type ImmutableObject<T> = {
  * Reference to an overlay that has been created with the Overlay service.
  * Used to manipulate or dispose of said overlay.
  */
-export class OverlayRef implements PortalOutlet {
+export class OverlayRef implements PortalOutlet, OverlayReference {
   private _backdropElement: HTMLElement | null = null;
   private _backdropClick: Subject<MouseEvent> = new Subject();
   private _attachments = new Subject<void>();


### PR DESCRIPTION
`OverlayRef` structurally matches `OverlayReference`, but does not
explicitly implement it. That works in TypeScript, and should work in
Closure Compiler through the use of `@record`, but for unclear reasons
doesn't.

Explicitly implementing the interface makes this code clearer, and works
around the problem in Closure Compiler while that is being fixed.