### PR TITLE
docs(chips): make separatorKeysCodes readonly

### DIFF
--- a/src/material-examples/chips-input/chips-input-example.ts
+++ b/src/material-examples/chips-input/chips-input-example.ts
@@ -17,7 +17,7 @@ export class ChipsInputExample {
   addOnBlur: boolean = true;
 
   // Enter, comma
-  separatorKeysCodes = [ENTER, COMMA];
+  readonly separatorKeysCodes = [ENTER, COMMA];
 
   fruits = [
     { name: 'Lemon' },


### PR DESCRIPTION
Make separatorKeysCodes readonly because it isn't changed after component is intialized.