### PR TITLE
fix(tab-nav-bar): ripples still showing up when globally disabled

### DIFF
--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -189,6 +189,9 @@ export class MatTabLink extends _MatTabLinkMixinBase
   /** Reference to the RippleRenderer for the tab-link. */
   protected _tabLinkRipple: RippleRenderer;
 
+  /** Whether the ripples are globally disabled through the RippleGlobalOptions */
+  private _ripplesGloballyDisabled = false;
+
   /** Whether the link is active. */
   @Input()
   get active(): boolean { return this._isActive; }
@@ -210,7 +213,8 @@ export class MatTabLink extends _MatTabLinkMixinBase
    * @docs-private
    */
   get rippleDisabled(): boolean {
-    return this.disabled || this.disableRipple || this._tabNavBar.disableRipple;
+    return this.disabled || this.disableRipple || this._tabNavBar.disableRipple ||
+      this._ripplesGloballyDisabled;
   }
 
   constructor(private _tabNavBar: MatTabNav,
@@ -227,6 +231,7 @@ export class MatTabLink extends _MatTabLinkMixinBase
     this.tabIndex = parseInt(tabIndex) || 0;
 
     if (globalOptions) {
+      this._ripplesGloballyDisabled = !!globalOptions.disabled;
       // TODO(paul): Once the speedFactor is removed, we no longer need to copy each single option.
       this.rippleConfig = {
         terminateOnPointerUp: globalOptions.terminateOnPointerUp,

--- a/tools/gulp/tasks/screenshots.ts
+++ b/tools/gulp/tasks/screenshots.ts
@@ -89,7 +89,7 @@ function setFileResult(database: Database, prNumber: string, fileName: string, r
 
 /** Sets the full diff result for the current Pull Request that runs inside of Travis. */
 function setPullRequestResult(database: Database, prNumber: string, result: boolean) {
-  return getPullRequestRef(database, prNumber).child('result').child(pullRequestSha).set(result);
+  return getPullRequestRef(database, prNumber).child('result').child(pullRequestSha!).set(result);
 }
 
 /** Returns the Firebase Reference that contains all data related to the specified PR. */


### PR DESCRIPTION
* If someone disables the ripples globally using the `MAT_RIPPLE_GLOBAL_OPTIONS`, the `<mat-tab-nav-bar>` still shows ripples. Ripples should be disabled for that custom `RippleTarget` as well.
* By cloning and reinstalling the whole project, I ran into a runtime exception when running Gulp

Fixes #11847