### PR TITLE
fix(GlobalPositionStrategy): justifyContent center ignored when direction is RTL

### DIFF
--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -270,6 +270,20 @@ describe('GlobalPositonStrategy', () => {
       expect(elementStyle.height).toBe('300px');
     });
 
+  it('should center the element in RTL', () => {
+      attachOverlay({
+          direction: 'rtl',
+          positionStrategy: overlay.position()
+              .global()
+              .centerHorizontally()
+              .centerVertically()
+      });
+
+      const parentStyle = (overlayRef.overlayElement.parentNode as HTMLElement).style;
+      expect(parentStyle.justifyContent).toBe('center');
+      expect(parentStyle.alignItems).toBe('center');
+  });
+
   it('should invert `justify-content` when using `left` in RTL', () => {
     attachOverlay({
       positionStrategy: overlay.position().global().left('0'),

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -169,8 +169,9 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
     if (config.width === '100%') {
       parentStyles.justifyContent = 'flex-start';
-    } else if (this._overlayRef.getConfig().direction === 'rtl'
-      && this._justifyContent.startsWith('flex-')) {
+    } else if (this._justifyContent === 'center') {
+        parentStyles.justifyContent = 'center';
+    } else if (this._overlayRef.getConfig().direction === 'rtl') {
       // In RTL the browser will invert `flex-start` and `flex-end` automatically, but we
       // don't want that because our positioning is explicitly `left` and `right`, hence
       // why we do another inversion to ensure that the overlay stays in the same position.

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -169,7 +169,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
     if (config.width === '100%') {
       parentStyles.justifyContent = 'flex-start';
-    } else if (this._overlayRef.getConfig().direction === 'rtl' && this._justifyContent.startsWith('flex-')) {
+    } else if (this._overlayRef.getConfig().direction === 'rtl' &&
+        this._justifyContent.startsWith('flex-')) {
       // In RTL the browser will invert `flex-start` and `flex-end` automatically, but we
       // don't want that because our positioning is explicitly `left` and `right`, hence
       // why we do another inversion to ensure that the overlay stays in the same position.

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -169,8 +169,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
     if (config.width === '100%') {
       parentStyles.justifyContent = 'flex-start';
-    } else if (this._overlayRef.getConfig().direction === 'rtl' &&
-        this._justifyContent.startsWith('flex-')) {
+    } else if (this._overlayRef.getConfig().direction === 'rtl') {
       // In RTL the browser will invert `flex-start` and `flex-end` automatically, but we
       // don't want that because our positioning is explicitly `left` and `right`, hence
       // why we do another inversion to ensure that the overlay stays in the same position.
@@ -180,7 +179,9 @@ export class GlobalPositionStrategy implements PositionStrategy {
       } else if (this._justifyContent === 'flex-end') {
         parentStyles.justifyContent = 'flex-start';
       }
-    } else {
+    }
+
+    if (!parentStyles.justifyContent) {
       parentStyles.justifyContent = this._justifyContent;
     }
 

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -169,7 +169,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
     if (config.width === '100%') {
       parentStyles.justifyContent = 'flex-start';
-    } else if (this._overlayRef.getConfig().direction === 'rtl') {
+    } else if (this._overlayRef.getConfig().direction === 'rtl' && this._justifyContent.startsWith('flex-')) {
       // In RTL the browser will invert `flex-start` and `flex-end` automatically, but we
       // don't want that because our positioning is explicitly `left` and `right`, hence
       // why we do another inversion to ensure that the overlay stays in the same position.

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -169,7 +169,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
 
     if (config.width === '100%') {
       parentStyles.justifyContent = 'flex-start';
-    } else if (this._overlayRef.getConfig().direction === 'rtl') {
+    } else if (this._overlayRef.getConfig().direction === 'rtl'
+      && this._justifyContent.startsWith('flex-')) {
       // In RTL the browser will invert `flex-start` and `flex-end` automatically, but we
       // don't want that because our positioning is explicitly `left` and `right`, hence
       // why we do another inversion to ensure that the overlay stays in the same position.
@@ -179,9 +180,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
       } else if (this._justifyContent === 'flex-end') {
         parentStyles.justifyContent = 'flex-start';
       }
-    }
-
-    if (!parentStyles.justifyContent) {
+    } else {
       parentStyles.justifyContent = this._justifyContent;
     }
 


### PR DESCRIPTION
In https://github.com/angular/material2/pull/11412/commits/d3a313603a296d76f47b941f13af3096548ae8ac @crisbeto makes `justify-content` invert when the direction is RTL, but he forgot to to it only if the `justify-content` is `flex-start` or `flex-end`.