### PR TITLE
fix(autocomplete): error when typing in input with disabled autocomplete and no panel

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -334,7 +334,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
       this.activeOption._selectViaInteraction();
       this._resetActiveItem();
       event.preventDefault();
-    } else {
+    } else if (this.autocomplete) {
       const prevActiveItem = this.autocomplete._keyManager.activeItem;
       const isArrowKey = keyCode === UP_ARROW || keyCode === DOWN_ARROW;
 

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -531,6 +531,16 @@ describe('MatAutocomplete', () => {
     expect(input.getAttribute('autocomplete')).toBe('changed');
   });
 
+  it('should not throw when typing in an element with a null and disabled autocomplete', () => {
+    const fixture = createComponent(InputWithoutAutocompleteAndDisabled);
+    fixture.detectChanges();
+
+    expect(() => {
+      dispatchKeyboardEvent(fixture.nativeElement.querySelector('input'), 'keydown', SPACE);
+      fixture.detectChanges();
+    }).not.toThrow();
+  });
+
   describe('forms integration', () => {
     let fixture: ComponentFixture<SimpleAutocomplete>;
     let input: HTMLInputElement;
@@ -2464,7 +2474,6 @@ class AutocompleteWithDifferentOrigin {
   values = ['one', 'two', 'three'];
 }
 
-
 @Component({
   template: `
     <input autocomplete="changed" [(ngModel)]="value" [matAutocomplete]="auto"/>
@@ -2473,4 +2482,10 @@ class AutocompleteWithDifferentOrigin {
 })
 class AutocompleteWithNativeAutocompleteAttribute {
   value: string;
+}
+
+@Component({
+  template: '<input [matAutocomplete]="null" matAutocompleteDisabled>'
+})
+class InputWithoutAutocompleteAndDisabled {
 }


### PR DESCRIPTION
Fixes an edge case where the input will throw an error if it has a disabled autocomplete and no autocomplete panel.

Fixes #11876.