### PR TITLE
fix(schematics): error in generated unit test

### DIFF
--- a/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -1,6 +1,6 @@
 
 import { fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 
 describe('<%= classify(name) %>Component', () => {
@@ -9,7 +9,8 @@ describe('<%= classify(name) %>Component', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ <%= classify(name) %>Component ]
+      imports: [MatSidenavModule],
+      declarations: [<%= classify(name) %>Component]
     })
     .compileComponents();
 


### PR DESCRIPTION
Fixes an error in the unit test that is generated by the `nav` schematic due to a missing import.

Fixes #11873.