### PR TITLE
build: include cdk-experimental/dialog in various configs

### DIFF
--- a/src/cdk-experimental/public-api.ts
+++ b/src/cdk-experimental/public-api.ts
@@ -7,4 +7,3 @@
  */
 
 export * from './version';
-export * from '@angular/cdk-experimental/scrolling';

--- a/src/demo-app/demo-material-module.ts
+++ b/src/demo-app/demo-material-module.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ScrollingModule} from '@angular/cdk-experimental';
+import {ScrollingModule} from '@angular/cdk-experimental/scrolling';
+import {DialogModule} from '@angular/cdk-experimental/dialog';
 import {A11yModule} from '@angular/cdk/a11y';
 import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {BidiModule} from '@angular/cdk/bidi';
@@ -110,6 +111,7 @@ import {
     PlatformModule,
     PortalModule,
     ScrollingModule,
+    DialogModule,
   ]
 })
 export class DemoMaterialModule {}

--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -63,6 +63,7 @@ System.config({
     '@angular/cdk/tree': 'dist/packages/cdk/tree/index.js',
 
     '@angular/cdk-experimental/scrolling': 'dist/packages/cdk-experimental/scrolling/index.js',
+    '@angular/cdk-experimental/dialog': 'dist/packages/cdk-experimental/dialog/index.js',
 
     '@angular/material/autocomplete': 'dist/packages/material/autocomplete/index.js',
     '@angular/material/bottom-sheet': 'dist/packages/material/bottom-sheet/index.js',

--- a/src/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app-module.ts
@@ -1,4 +1,5 @@
-import {ScrollingModule} from '@angular/cdk-experimental';
+import {ScrollingModule} from '@angular/cdk-experimental/scrolling';
+import {DialogModule} from '@angular/cdk-experimental/dialog';
 import {FullscreenOverlayContainer, OverlayContainer} from '@angular/cdk/overlay';
 import {NgModule} from '@angular/core';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -69,6 +70,7 @@ import {VirtualScrollE2E} from './virtual-scroll/virtual-scroll-e2e';
     MatTabsModule,
     MatNativeDateModule,
     ScrollingModule,
+    DialogModule,
   ]
 })
 export class E2eMaterialModule {}

--- a/src/e2e-app/system-config.ts
+++ b/src/e2e-app/system-config.ts
@@ -53,6 +53,7 @@ System.config({
     '@angular/cdk/text-field': 'dist/bundles/cdk-text-field.umd.js',
 
     '@angular/cdk-experimental/scrolling': 'dist/bundles/cdk-experimental-scrolling.umd.js',
+    '@angular/cdk-experimental/dialog': 'dist/bundles/cdk-experimental-dialog.umd.js',
 
     '@angular/material/autocomplete': 'dist/bundles/material-autocomplete.umd.js',
     '@angular/material/bottom-sheet': 'dist/bundles/material-bottom-sheet.umd.js',

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -73,6 +73,7 @@ System.config({
     '@angular/cdk/tree': 'dist/packages/cdk/tree/index.js',
 
     '@angular/cdk-experimental/scrolling': 'dist/packages/cdk-experimental/scrolling/index.js',
+    '@angular/cdk-experimental/dialog': 'dist/packages/cdk-experimental/dialog/index.js',
 
     '@angular/material/autocomplete': 'dist/packages/material/autocomplete/index.js',
     '@angular/material/badge': 'dist/packages/material/badge/index.js',


### PR DESCRIPTION
* Removes the exports of `cdk-experimental/scrolling` from the root `cdk-experimental`.
* Adds the dialog package to a handful of configs that didn't have it. Mostly for consistency.