### PR TITLE
feat(docs): show additional type aliases in docs.

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -12,7 +12,8 @@ import {Directive, Input} from '@angular/core';
 
 /**
  * Directive to automatically resize a textarea to fit its content.
- * @deletion-target 7.0.0 deprecate in favor of `cdkTextareaAutosize`.
+ * @deprecated Use `cdkTextareaAutosize` from `@angular/cdk/text-field` instead.
+ * @deletion-target 7.0.0
  */
 @Directive({
   selector: 'textarea[mat-autosize], textarea[matTextareaAutosize]',

--- a/tools/dgeni/processors/component-grouper.ts
+++ b/tools/dgeni/processors/component-grouper.ts
@@ -1,7 +1,8 @@
 import {DocCollection, Document, Processor} from 'dgeni';
 import {InterfaceExportDoc} from 'dgeni-packages/typescript/api-doc-types/InterfaceExportDoc';
-import * as path from 'path';
+import {TypeAliasExportDoc} from 'dgeni-packages/typescript/api-doc-types/TypeAliasExportDoc';
 import {CategorizedClassDoc} from '../common/dgeni-definitions';
+import * as path from 'path';
 
 /** Component group data structure. */
 export class ComponentGroup {
@@ -41,6 +42,9 @@ export class ComponentGroup {
 
   /** Additional interfaces that belong to the component group. */
   additionalInterfaces: InterfaceExportDoc[] = [];
+
+  /** Additional type aliases that belong to the component group. */
+  additionalTypeAliases: TypeAliasExportDoc[] = [];
 
   /** NgModule that defines the current component group. */
   ngModule: CategorizedClassDoc | null = null;
@@ -93,10 +97,12 @@ export class ComponentGrouper implements Processor {
         group.services.push(doc);
       } else if (doc.isNgModule) {
         group.ngModule = doc;
-      } else if (doc.docType == 'class') {
+      } else if (doc.docType === 'class') {
         group.additionalClasses.push(doc);
-      } else if (doc.docType == 'interface') {
+      } else if (doc.docType === 'interface') {
         group.additionalInterfaces.push(doc);
+      } else if (doc.docType === 'type-alias') {
+        group.additionalTypeAliases.push(doc);
       }
     });
 

--- a/tools/dgeni/templates/componentGroup.template.html
+++ b/tools/dgeni/templates/componentGroup.template.html
@@ -23,6 +23,10 @@
   {% include 'interface.template.html' %}
 {% endmacro %}
 
+{% macro typeAlias(alias) -%}
+  {% include 'type-alias.template.html' %}
+{% endmacro %}
+
 <div class="docs-api">
   <h2>
     API reference for Angular {$ doc.packageDisplayName $} {$ doc.displayName $}
@@ -72,6 +76,16 @@
     </h3>
     {% for item in doc.additionalInterfaces %}
       {$ interface(item) $}
+    {% endfor %}
+  {%- endif -%}
+
+  {%- if doc.additionalTypeAliases.length -%}
+    <h3 id="additional_type_aliases" class="docs-header-link docs-api-h3">
+      <span header-link="additional_type_aliases"></span>
+      Additional type aliases
+    </h3>
+    {% for item in doc.additionalTypeAliases %}
+      {$ typeAlias(item) $}
     {% endfor %}
   {%- endif -%}
 </div>

--- a/tools/dgeni/templates/type-alias.template.html
+++ b/tools/dgeni/templates/type-alias.template.html
@@ -1,0 +1,15 @@
+{% import "macros.html" as macros %}
+
+<h4 id="{$ alias.name $}" class="docs-header-link docs-api-h4 docs-api-type-alias-name">
+  <span header-link="{$ alias.name $}"></span>
+  <code>{$ alias.name $}</code>
+</h4>
+
+{%- if alias.description -%}
+  <p class="docs-api-type-alias-description">{$ alias.description | marked | safe $}</p>
+{%- endif -%}
+
+<p class="docs-api-type-alias-value">
+  <span class="docs-api-type-alias-value-label">Type:</span>
+  <code class="docs-api-type-alias-value">{$ alias.typeDefinition $}</code>
+</p>


### PR DESCRIPTION
* Shows type aliases that belong to specific components in the documentation (e.g. `MatSnackBarHorizontalPosition`)

Closes #10468