### PR TITLE
fix(autocomplete): form control being marked as touched too early when clicking on an option

### DIFF
--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -699,9 +699,7 @@ describe('MatAutocomplete', () => {
           .toBe(false, `Expected control to stay pristine if value is set programmatically.`);
     });
 
-    it('should mark the autocomplete control as touched on blur', () => {
-      fixture.componentInstance.trigger.openPanel();
-      fixture.detectChanges();
+    it('should mark the autocomplete control as touched on blur while panel is closed', () => {
       expect(fixture.componentInstance.stateCtrl.touched)
           .toBe(false, `Expected control to start out untouched.`);
 
@@ -710,6 +708,28 @@ describe('MatAutocomplete', () => {
 
       expect(fixture.componentInstance.stateCtrl.touched)
           .toBe(true, `Expected control to become touched on blur.`);
+    });
+
+    it('should defer marking the control as touched if it is blurred while open', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      expect(fixture.componentInstance.stateCtrl.touched)
+          .toBe(false, 'Expected control to start out untouched.');
+
+      dispatchFakeEvent(input, 'blur');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.touched)
+          .toBe(false, 'Expected control to stay untouched.');
+
+      // Simulate clicking outside the panel.
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.touched)
+          .toBe(true, 'Expected control to become touched once panel closes.');
     });
 
     it('should disable the input when used with a value accessor and without `matInput`', () => {


### PR DESCRIPTION
Currently we mark the autocomplete form control as touched on every blur event. This can be an issue for the case where a control is being validated on blur, because the input becomes blurred as soon as the user has their pointer down on something else (e.g. one of the options). This will cause validation to run before the value has been assigned. With these changes we switch to marking the control as touched once the panel has been closed.

Fixes #11903.