### PR TITLE
fix(button): not resetting all outlines on firefox

### DIFF
--- a/src/lib/core/style/_button-common.scss
+++ b/src/lib/core/style/_button-common.scss
@@ -7,4 +7,11 @@
   outline: none;
   border: none;
   -webkit-tap-highlight-color: transparent;
+
+  // The `outline: none` from above works on all browsers, however Firefox also
+  // adds a special `focus-inner` which we have to disable explicitly. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Firefox
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }


### PR DESCRIPTION
Fixes some button outlines not being reset on Firefox due to the special `::-moz-focus-inner` user agent style.

For reference:
![benn5el](https://user-images.githubusercontent.com/4450522/41818918-0dda3cee-77b8-11e8-91f0-aea29901ca0f.png)
