### PR TITLE
fix(chips): ripples still showing up when globally disabled

### DIFF
--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -114,21 +114,25 @@ export class MatChipTrailingIcon {}
 })
 export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDestroy, CanColor,
     CanDisable, CanDisableRipple, RippleTarget {
+
+  /** Reference to the RippleRenderer for the chip. */
+  private _chipRipple: RippleRenderer;
+
+  /** Whether the ripples are globally disabled through the RippleGlobalOptions */
+  private _ripplesGloballyDisabled = false;
+
   /**
    * Ripple configuration for ripples that are launched on pointer down.
    * @docs-private
    */
   rippleConfig: RippleConfig = {};
 
-  /** Reference to the RippleRenderer for the chip. */
-  private _chipRipple: RippleRenderer;
-
   /**
    * Whether ripples are disabled on interaction
    * @docs-private
    */
   get rippleDisabled(): boolean {
-    return this.disabled || this.disableRipple;
+    return this.disabled || this.disableRipple || this._ripplesGloballyDisabled;
   }
 
   /** Whether the chip has focus. */
@@ -225,6 +229,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     this._chipRipple.setupTriggerEvents(_elementRef.nativeElement);
 
     if (globalOptions) {
+      this._ripplesGloballyDisabled = !!globalOptions.disabled;
+      // TODO(paul): Once the speedFactor is removed, we no longer need to copy each single option.
       this.rippleConfig = {
         speedFactor: globalOptions.baseSpeedFactor,
         animation: globalOptions.animation,

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -227,6 +227,7 @@ export class MatTabLink extends _MatTabLinkMixinBase
     this.tabIndex = parseInt(tabIndex) || 0;
 
     if (globalOptions) {
+      // TODO(paul): Once the speedFactor is removed, we no longer need to copy each single option.
       this.rippleConfig = {
         terminateOnPointerUp: globalOptions.terminateOnPointerUp,
         speedFactor: globalOptions.baseSpeedFactor,


### PR DESCRIPTION
* If someone disables the ripples globally using the `MAT_RIPPLE_GLOBAL_OPTIONS`, chips will still shows ripples. Ripples should be disabled for that custom `RippleTarget` as well.

References #11847