### PR TITLE
fix(list-key-manager): allow withWrap to be disabled

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -526,6 +526,20 @@ describe('Key managers', () => {
 
         keyManager.onKeydown(fakeKeyEvents.downArrow);
       });
+
+      it('should be able to disable wrapping', () => {
+        keyManager.withWrap();
+        keyManager.setFirstItemActive();
+        keyManager.onKeydown(fakeKeyEvents.upArrow);
+
+        expect(keyManager.activeItemIndex).toBe(itemList.items.length - 1);
+
+        keyManager.withWrap(false);
+        keyManager.setFirstItemActive();
+        keyManager.onKeydown(fakeKeyEvents.upArrow);
+
+        expect(keyManager.activeItemIndex).toBe(0);
+      });
     });
 
     describe('skip predicate', () => {

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -90,11 +90,12 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   }
 
   /**
-   * Turns on wrapping mode, which ensures that the active item will wrap to
+   * Configures wrapping mode, which determines whether the active item will wrap to
    * the other end of list when there are no more items in the given direction.
+   * @param shouldWrap Whether the list should wrap when reaching the end.
    */
-  withWrap(): this {
-    this._wrap = true;
+  withWrap(shouldWrap = true): this {
+    this._wrap = shouldWrap;
     return this;
   }
 


### PR DESCRIPTION
This is for convenience and consistency with the other key manager APIs. Adds a parameter that allows for wrapping to be disabled after it has been enabled.