### PR TITLE
fix(select): reset option being marked as selected

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2580,6 +2580,18 @@ describe('MatSelect', () => {
       expect(trigger.textContent).not.toContain('None');
     }));
 
+    it('should not mark the reset option as selected ', fakeAsync(() => {
+      options[5].click();
+      fixture.detectChanges();
+      flush();
+
+      fixture.componentInstance.select.open();
+      fixture.detectChanges();
+      flush();
+
+      expect(options[5].classList).not.toContain('mat-selected');
+    }));
+
     it('should not reset when any other falsy option is selected', fakeAsync(() => {
       options[3].click();
       fixture.detectChanges();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -881,6 +881,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     const wasSelected = this._selectionModel.isSelected(option);
 
     if (option.value == null && !this._multiple) {
+      option.deselect();
       this._selectionModel.clear();
       this._propagateChanges(option.value);
     } else {


### PR DESCRIPTION
Fixes the `mat-select` reset option being displayed as selected when it's clicked and not being deselected when another option is selected.

Fixes #11928.