### PR TITLE
fix(overlay): take scroll position into account on iOS (#6341)

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -468,11 +468,26 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       overlayStartY = pos.overlayY == 'top' ? 0 : -overlayRect.height;
     }
 
+    // On iOS, the .cdk-overlay-container will be positioned absolute instead of fixed.
+    // Adjust the y coordinate in that case by the scroll amount.
+    const overlayScrollY = this._getOverlayScrollY();
+
     // The (x, y) coordinates of the overlay.
     return {
       x: originPoint.x + overlayStartX,
-      y: originPoint.y + overlayStartY,
+      y: originPoint.y + overlayScrollY + overlayStartY,
     };
+  }
+
+  /**
+   * Gets the y coordinates of the overlay host element. On iOS when the keyboard is visible,
+   * .cdk-overlay-container will have an absolute position instead of fixed. When that happens,
+   * this will return a non-zero value.
+   */
+  private _getOverlayScrollY(): number {
+    const clientRect = this._overlayRef.hostElement.getBoundingClientRect();
+
+    return Math.abs(clientRect.top);
   }
 
   /** Gets how well an overlay at the given point will fit within the viewport. */


### PR DESCRIPTION
When the keyboard is visible on iOS, the ```.cdk-overlay-container``` will be positioned absolutely instead of fixed. The can be seen by checking the ```top``` value of the bounding client rect of the overlay container. When scrolled + keyboard, this will have a negative value on iOS. This PR adds the absolute top value to the y coordinate of the overlay point.

Note: unfortunately, "npm install" in material2 fails locally so i cannot test it on my own code :(