### PR TITLE
build: index file for cdk-experimental/scrolling not being generated

### DIFF
--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -3,9 +3,7 @@ import {dispatchFakeEvent} from '@angular/cdk/testing';
 import {Component, Input, ViewChild, ViewContainerRef, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {animationFrameScheduler, Subject} from 'rxjs';
-import {ScrollingModule} from './scrolling-module';
-import {CdkVirtualForOf} from './virtual-for-of';
-import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+import {CdkVirtualScrollViewport, CdkVirtualForOf, ScrollingModule} from './index';
 
 
 describe('CdkVirtualScrollViewport', () => {

--- a/src/cdk-experimental/tsconfig-tests.json
+++ b/src/cdk-experimental/tsconfig-tests.json
@@ -19,7 +19,8 @@
     "emitDecoratorMetadata": true
   },
   "include": [
-    "**/*.spec.ts",
-    "index.ts"
+    // Include the index.ts for each secondary entry-point
+    "./*/index.ts",
+    "**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
Fixes the `index.js` and `public-api.js` files for the `cdk-experimental/scrolling` packages not being generated. The issue seems to come from the fact that the files aren't referenced by any other files which causes them to not be output. This ended up breaking the demo app.