### PR TITLE
Docs: Adds new button examples

### DIFF
--- a/src/material-examples/button-types/button-types-example.html
+++ b/src/material-examples/button-types/button-types-example.html
@@ -28,6 +28,16 @@
   <a mat-stroked-button routerLink=".">Link</a>
 </div>
 
+<h3>Flat Buttons</h3>
+<div class="button-row">
+  <button mat-flat-button>Basic</button>
+  <button mat-flat-button color="primary">Primary</button>
+  <button mat-flat-button color="accent">Accent</button>
+  <button mat-flat-button color="warn">Warn</button>
+  <button mat-flat-button disabled>Disabled</button>
+  <a mat-flat-button routerLink=".">Link</a>
+</div>
+
 <h3>Icon Buttons</h3>
 <div class="button-row">
   <button mat-icon-button>


### PR DESCRIPTION
Examples for the new buttons (stroked & flat) where missing in the documentation.

Fixes #11974