### PR TITLE
fix(button-toggle): parent margin and padding being propagated to underlying button

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -105,8 +105,8 @@ $mat-button-toggle-border-radius: 2px !default;
   border: 0;
   background: none;
   color: inherit;
-  padding: inherit;
-  margin: inherit;
+  padding: 0;
+  margin: 0;
   font: inherit;
   outline: none;
 }


### PR DESCRIPTION
Fixes the button inside a button toggle inheriting the margin and padding from its parent.

Fixes #11976.