### PR TITLE
fix(select): blank option label throwing off alignment

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -7,7 +7,7 @@
   <div class="mat-select-value" [ngSwitch]="empty">
     <span class="mat-select-placeholder" *ngSwitchCase="true">{{placeholder || '\u00A0'}}</span>
     <span class="mat-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
-      <span *ngSwitchDefault>{{triggerValue}}</span>
+      <span *ngSwitchDefault>{{triggerValue || '\u00A0'}}</span>
       <ng-content select="mat-select-trigger" *ngSwitchCase="true"></ng-content>
     </span>
   </div>


### PR DESCRIPTION
Fixes selecting an option that has a blank string as a label throwing off the alignment of `mat-select`.

Fixes #11969.