### PR TITLE
build: use index file from material package

### DIFF
--- a/src/demo-app/system-config.ts
+++ b/src/demo-app/system-config.ts
@@ -37,8 +37,7 @@ System.config({
     '@angular/platform-browser-dynamic':
       'node:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
 
-    // TODO(devversion): replace once the index.ts file for the Material package has been added.
-    '@angular/material': 'dist/packages/material/public-api.js',
+    '@angular/material': 'dist/packages/material/index.js',
     '@angular/material-experimental': 'dist/packages/material-experimental/index.js',
     '@angular/material-examples': 'dist/packages/material-examples/index.js',
     '@angular/material-moment-adapter': 'dist/packages/material-moment-adapter/index.js',

--- a/src/demo-app/tsconfig-build.json
+++ b/src/demo-app/tsconfig-build.json
@@ -25,7 +25,7 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material/public-api"],
+      "@angular/material": ["../../dist/packages/material"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"],
       "@angular/cdk": ["../../dist/packages/cdk"],
       "@angular/material-experimental/*": ["../../dist/packages/material-experimental/*"],

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -23,7 +23,7 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material/public-api"],
+      "@angular/material": ["../../dist/packages/material"],
       "@angular/material-moment-adapter": ["../../dist/packages/material-moment-adapter"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"]
     }

--- a/src/material-experimental/tsconfig-build.json
+++ b/src/material-experimental/tsconfig-build.json
@@ -25,7 +25,7 @@
     "types": [],
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material/public-api"],
+      "@angular/material": ["../../dist/packages/material"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"],
       "@angular/cdk": ["../../dist/packages/cdk"],
       "@angular/cdk-experimental/*": ["../../dist/packages/cdk-experimental/*"],

--- a/src/material-moment-adapter/tsconfig-build.json
+++ b/src/material-moment-adapter/tsconfig-build.json
@@ -23,7 +23,7 @@
     "types": [],
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material/public-api"],
+      "@angular/material": ["../../dist/packages/material"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"]
     }
   },

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -48,8 +48,7 @@ System.config({
       'node:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
 
     // Path mappings for local packages that can be imported inside of tests.
-    // TODO(devversion): replace once the index.ts file for the Material package has been added.
-    '@angular/material': 'dist/packages/material/public-api.js',
+    '@angular/material': 'dist/packages/material/index.js',
     '@angular/material-experimental': 'dist/packages/material-experimental/index.js',
     '@angular/cdk-experimental': 'dist/packages/cdk-experimental/index.js',
 


### PR DESCRIPTION
* A `index.ts` file for the Material package has been added at some point. To be consistent, we switch away from `public-api.ts` to `index.ts` for the output of the individual packages.