### PR TITLE
fix(moment-date-adapter): not returning utc date when parsing

### DIFF
--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -420,9 +420,10 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
-      providers: [
-        { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }
-      ]
+      providers: [{
+        provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+        useValue: {useUtc: true}
+      }]
     }).compileComponents();
   }));
 
@@ -430,7 +431,22 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
     adapter = d;
   }));
 
-  it('should create Moment date in utc format if option useUtc is set', () => {
-    expect(adapter.createDate(2017, JAN, 5).isUTC()).toBeTruthy();
+  describe('use UTC', () => {
+    it('should create Moment date in UTC', () => {
+      expect(adapter.createDate(2017, JAN, 5).isUtc()).toBe(true);
+    });
+
+    it('should create today in UTC', () => {
+      expect(adapter.today().isUtc()).toBe(true);
+    });
+
+    it('should parse dates to UTC', () => {
+      expect(adapter.parse('1/2/2017', 'MM/DD/YYYY')!.isUtc()).toBe(true);
+    });
+
+    it('should return UTC date when deserializing', () => {
+      expect(adapter.deserialize('1985-04-12T23:20:50.52Z')!.isUtc()).toBe(true);
+    });
   });
+
 });

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -158,12 +158,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
       throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
     }
 
-    let result;
-    if (this.options && this.options.useUtc) {
-      result = moment.utc({ year, month, date }).locale(this.locale);
-    } else {
-      result = moment({ year, month, date }).locale(this.locale);
-    }
+    const result = this._createMoment({year, month, date}).locale(this.locale);
 
     // If the result isn't valid, the date must have been out of bounds for this month.
     if (!result.isValid()) {
@@ -174,14 +169,14 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
   }
 
   today(): Moment {
-    return moment().locale(this.locale);
+    return this._createMoment().locale(this.locale);
   }
 
   parse(value: any, parseFormat: string | string[]): Moment | null {
     if (value && typeof value == 'string') {
-      return moment(value, parseFormat, this.locale);
+      return this._createMoment(value, parseFormat, this.locale);
     }
-    return value ? moment(value).locale(this.locale) : null;
+    return value ? this._createMoment(value).locale(this.locale) : null;
   }
 
   format(date: Moment, displayFormat: string): string {
@@ -216,13 +211,13 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
   deserialize(value: any): Moment | null {
     let date;
     if (value instanceof Date) {
-      date = moment(value);
+      date = this._createMoment(value);
     }
     if (typeof value === 'string') {
       if (!value) {
         return null;
       }
-      date = moment(value, moment.ISO_8601).locale(this.locale);
+      date = this._createMoment(value, moment.ISO_8601).locale(this.locale);
     }
     if (date && this.isValid(date)) {
       return date;
@@ -240,5 +235,10 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
 
   invalid(): Moment {
     return moment.invalid();
+  }
+
+  /** Creates a Moment instance while respecting the current UTC settings. */
+  private _createMoment(...args: any[]): Moment {
+    return (this.options && this.options.useUtc) ? moment.utc(...args) : moment(...args);
   }
 }


### PR DESCRIPTION
Currently when `useUtc` is passed, only `createDate` will return a UTC date. These changes rework the rest of the methods (`parse`, `deserialize`, `today`) to return UTC dates as well.

Fixes #12023.