### PR TITLE
fix(button): don't show hover overlay on devices that don't support hovering

### DIFF
--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -22,6 +22,16 @@
   opacity: 1;
 }
 
+// Disable the hover styles on non-hover devices. Since this is more of a progressive
+// enhancement and not all desktop browsers support this kind of media query, we can't
+// use something like `@media (hover)`.
+@media (hover: none) {
+  .mat-button:hover .mat-button-focus-overlay,
+  .mat-stroked-button:hover .mat-button-focus-overlay {
+    opacity: 0;
+  }
+}
+
 .mat-raised-button {
   @include mat-raised-button;
 }


### PR DESCRIPTION
Fixes the hover overlay persisting on touch devices after tapping on a button.

Fixes #12022.