### PR TITLE
fix: sanity checks throwing an error if scripts are set in the head

### DIFF
--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -72,7 +72,9 @@ export class MatCommonModule {
   }
 
   private _checkThemeIsPresent(): void {
-    if (this._document && typeof getComputedStyle === 'function') {
+    // We need to assert that the `body` is defined, because these checks run very early
+    // and the `body` won't be defined if the consumer put their scripts in the `head`.
+    if (this._document && this._document.body && typeof getComputedStyle === 'function') {
       const testElement = this._document.createElement('div');
 
       testElement.classList.add('mat-theme-loaded-marker');
@@ -80,7 +82,7 @@ export class MatCommonModule {
 
       const computedStyle = getComputedStyle(testElement);
 
-      // In some situations, the computed style of the test element can be null. For example in
+      // In some situations the computed style of the test element can be null. For example in
       // Firefox, the computed style is null if an application is running inside of a hidden iframe.
       // See: https://bugzilla.mozilla.org/show_bug.cgi?id=548397
       if (computedStyle && computedStyle.display !== 'none') {


### PR DESCRIPTION
Fixes the sanity checks throwing an error if they run too early and they're inserted before the `body`.

Fixes #12026.