### PR TITLE
build: don't allow duplicate scss imports

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -2,7 +2,6 @@
 @import '../core/style/button-common';
 @import '../core/style/layout-common';
 @import '../core/style/menu-common';
-@import '../core/style/layout-common';
 @import '../../cdk/a11y/a11y';
 
 $mat-menu-vertical-padding: 8px !default;

--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -49,6 +49,7 @@
     "shorthand-property-no-redundant-values": true,
 
     "property-case": "lower",
+    "no-duplicate-at-import-rules": true,
 
     "declaration-block-no-duplicate-properties": [true, {
       "ignore": ["consecutive-duplicates-with-different-values"]


### PR DESCRIPTION
Enables a rule that doesn't allow duplicate `@import` statements. Also fixes a failure.

Fixes #12069.