### PR TITLE
build: fix invalid required angular version

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -13,7 +13,7 @@ const buildVersion = packageJson.version;
  * Required Angular version for all Angular Material packages. This version will be used
  * as the peer dependency version for Angular in all release packages.
  */
-const angularVersion = '>=6.0.0-beta.0 <7.0.0';
+const angularVersion = packageJson.requiredAngularVersion;
 
 /** License that will be placed inside of all created bundles. */
 const buildLicense = `/**

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/angular/material2.git"
   },
+  "license": "MIT",
+  "engines": {
+    "node": ">= 5.4.1"
+  },
   "scripts": {
     "postinstall": "ngc -p angular.tsconfig.json",
     "build": "gulp :publish:build-releases",
@@ -21,10 +25,7 @@
     "api": "gulp api-docs"
   },
   "version": "6.4.2",
-  "license": "MIT",
-  "engines": {
-    "node": ">= 5.4.1"
-  },
+  "requiredAngularVersion": ">=6.0.0 <7.0.0",
   "dependencies": {
     "@angular/animations": "6.0.0",
     "@angular/common": "6.0.0",


### PR DESCRIPTION
Right now the `package.json` of the release packages accepts every Angular 6.0.0 beta as a working dependency. 

This is not really correct since we depend on the `preserveWhitespaces` change from `beta.6` and also depend on the new `Injectable` / `provider` API changes which are spread across the beta versions.

---
Also makes it easier to change the required angular version (right now it's easy to forget about the property in the build config)

References https://github.com/angular/material2/pull/10301 and https://github.com/angular/material2/pull/10216