### PR TITLE
fix(drag-drop): Use correct drop event

### DIFF
--- a/src/demo-app/drag-drop/drag-drop-demo.html
+++ b/src/demo-app/drag-drop/drag-drop-demo.html
@@ -2,7 +2,7 @@
   <h2>To do</h2>
   <cdk-drop
     #one
-    (cdkDragDropped)="drop($event)"
+    (dropped)="drop($event)"
     [data]="todo"
     [connectedTo]="[two]">
     <div *ngFor="let item of todo" cdkDrag>
@@ -16,7 +16,7 @@
   <h2>Done</h2>
   <cdk-drop
     #two
-    (cdkDragDropped)="drop($event)"
+    (dropped)="drop($event)"
     [data]="done"
     [connectedTo]="[one]">
     <div *ngFor="let item of done" cdkDrag>


### PR DESCRIPTION
Fixes the drop event name in the drag-drop demo. See #12086