### PR TITLE
fix(datepicker): showing dot in high contrast mode after popup has closed

### DIFF
--- a/src/lib/datepicker/calendar-body.scss
+++ b/src/lib/datepicker/calendar-body.scss
@@ -68,7 +68,7 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
 
 
 @include cdk-high-contrast {
-  .mat-datepicker-popup,
+  .mat-datepicker-popup:not(:empty),
   .mat-calendar-body-selected {
     outline: solid 1px;
   }


### PR DESCRIPTION
Fixes the datepicker's popup showing a 1x1 pixel dot in high contrast mode, after the calendar has been closed. The dot comes from the outline that we add to the popup which collapses after we detach the overlay.

For reference:
![angular_material_ -_microsoft_edge_2018-07-07_18-15-16](https://user-images.githubusercontent.com/4450522/42412783-2afdaabc-8213-11e8-8bb2-459a8ddde206.png)
