### PR TITLE
feat(drag-drop): add support for multiple handles and handles that are added after init

### DIFF
--- a/src/cdk/testing/event-objects.ts
+++ b/src/cdk/testing/event-objects.ts
@@ -11,7 +11,7 @@ export function createMouseEvent(type: string, x = 0, y = 0) {
   const event = document.createEvent('MouseEvent');
 
   event.initMouseEvent(type,
-    false, /* canBubble */
+    true, /* canBubble */
     false, /* cancelable */
     window, /* view */
     0, /* detail */


### PR DESCRIPTION
* Fixes a TODO about supporting handles that are added after init.
* Adds the ability to have more than one handle in a draggable.
* Enables bubbling for the fake mouse events.