### PR TITLE
build: fix random ngc resolve failures

### DIFF
--- a/src/lib/tsconfig-tests.json
+++ b/src/lib/tsconfig-tests.json
@@ -10,7 +10,7 @@
     "types": ["jasmine"],
     "paths": {
       "@angular/material/*": ["./*"],
-      "@angular/cdk/*": ["../../dist/packages/cdk/*/public-api"]
+      "@angular/cdk/*": ["../../dist/packages/cdk/*"]
     }
   },
   "angularCompilerOptions": {
@@ -24,6 +24,6 @@
     "index.ts"
   ],
   "exclude": [
-    "**/schematics/**/*.ts",
-  ],
+    "**/schematics/**/*.ts"
+  ]
 }

--- a/tools/package-tools/gulp/build-tasks-gulp.ts
+++ b/tools/package-tools/gulp/build-tasks-gulp.ts
@@ -60,8 +60,11 @@ export function createPackageBuildTasks(buildPackage: BuildPackage, preBuildTask
   ));
 
   task(`${taskName}:build-no-bundles`, sequenceTask(
+    // Build assets before building the ESM output. Since we compile with NGC, the compiler
+    // tries to resolve all required assets.
+    `${taskName}:assets`,
     // Build the ESM output that includes all test files. Also build assets for the package.
-    [`${taskName}:build:esm:tests`, `${taskName}:assets`],
+    `${taskName}:build:esm:tests`,
     // Inline assets into ESM output.
     `${taskName}:assets:inline`
   ));


### PR DESCRIPTION
Depending on the timing for building the assets and building the ESM output (kind of randomly), building the Material package will result in NGC failures.

This happens when running the `material:build-no-bundles` task (e.g. unit testing; serving the dev-app) because the assets are built in parallel with the ESM output.

Also removes a duplicated function in the package-tools.

<img width="1181" alt="0e0999b506a3e8b427cc327645c84fbf" src="https://user-images.githubusercontent.com/4987015/42419377-292f7e44-82b4-11e8-922d-a8fa300d288a.png">
