### PR TITLE
feat(drag-drop): support sorting items horizontally

### DIFF
--- a/src/cdk-experimental/drag-drop/BUILD.bazel
+++ b/src/cdk-experimental/drag-drop/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
     "@rxjs",
     "//src/cdk/platform",
     "//src/cdk/overlay",
+    "//src/cdk/bidi",
   ],
   tsconfig = "//src/cdk-experimental:tsconfig-build.json",
 )
@@ -25,6 +26,7 @@ ts_library(
   deps = [
     ":drag-drop",
     "//src/cdk/testing",
+    "//src/cdk/bidi",
   ],
   tsconfig = "//src/cdk-experimental:tsconfig-build.json",
 )

--- a/src/cdk-experimental/drag-drop/drag.ts
+++ b/src/cdk-experimental/drag-drop/drag.ts
@@ -23,8 +23,9 @@ import {
   ContentChildren,
   QueryList,
 } from '@angular/core';
-import {CdkDragHandle} from './drag-handle';
 import {DOCUMENT} from '@angular/platform-browser';
+import {Directionality} from '@angular/cdk/bidi';
+import {CdkDragHandle} from './drag-handle';
 import {CdkDropContainer, CDK_DROP_CONTAINER} from './drop-container';
 import {supportsPassiveEventListeners} from '@angular/cdk/platform';
 import {CdkDragStart, CdkDragEnd, CdkDragExit, CdkDragEnter, CdkDragDrop} from './drag-events';
@@ -126,7 +127,8 @@ export class CdkDrag implements AfterContentInit, OnDestroy {
     @Inject(DOCUMENT) document: any,
     private _ngZone: NgZone,
     private _viewContainerRef: ViewContainerRef,
-    private _viewportRuler: ViewportRuler) {
+    private _viewportRuler: ViewportRuler,
+    @Optional() private _dir: Directionality) {
       this._document = document;
     }
 
@@ -302,7 +304,7 @@ export class CdkDrag implements AfterContentInit, OnDestroy {
       });
     }
 
-    this.dropContainer._sortItem(this, y);
+    this.dropContainer._sortItem(this, x, y);
     this._setTransform(this._preview,
                        x - this._pickupPositionInElement.x,
                        y - this._pickupPositionInElement.y);
@@ -333,6 +335,8 @@ export class CdkDrag implements AfterContentInit, OnDestroy {
     }
 
     preview.classList.add('cdk-drag-preview');
+    preview.setAttribute('dir', this._dir ? this._dir.value : 'ltr');
+
     return preview;
   }
 

--- a/src/cdk-experimental/drag-drop/drop-container.ts
+++ b/src/cdk-experimental/drag-drop/drop-container.ts
@@ -14,6 +14,9 @@ export interface CdkDropContainer<T = any> {
   /** Arbitrary data to attach to all events emitted by this container. */
   data: T;
 
+  /** Direction in which the list is oriented. */
+  orientation: 'horizontal' | 'vertical';
+
   /** Starts dragging an item. */
   start(): void;
 
@@ -42,7 +45,7 @@ export interface CdkDropContainer<T = any> {
    * @param item Item whose index should be determined.
    */
   getItemIndex(item: CdkDrag): number;
-  _sortItem(item: CdkDrag, yOffset: number): void;
+  _sortItem(item: CdkDrag, xOffset: number, yOffset: number): void;
   _draggables: QueryList<CdkDrag>;
   _getSiblingContainerFromPosition(x: number, y: number): CdkDropContainer | null;
 }

--- a/src/cdk-experimental/drag-drop/drop.ts
+++ b/src/cdk-experimental/drag-drop/drop.ts
@@ -22,7 +22,6 @@ import {CdkDrag} from './drag';
 import {CdkDragExit, CdkDragEnter, CdkDragDrop} from './drag-events';
 import {CDK_DROP_CONTAINER} from './drop-container';
 
-
 /** Container that wraps a set of draggable items. */
 @Component({
   moduleId: module.id,
@@ -52,6 +51,9 @@ export class CdkDrop<T = any> {
 
   /** Arbitrary data to attach to all events emitted by this container. */
   @Input() data: T;
+
+  /** Direction in which the list is oriented. */
+  @Input() orientation: 'horizontal' | 'vertical' = 'vertical';
 
   /** Emits when the user drops an item inside the container. */
   @Output() dropped = new EventEmitter<CdkDragDrop<T, any>>();
@@ -132,13 +134,19 @@ export class CdkDrop<T = any> {
   /**
    * Sorts an item inside the container based on its position.
    * @param item Item to be sorted.
+   * @param xOffset Position of the item along the X axis.
    * @param yOffset Position of the item along the Y axis.
    */
-  _sortItem(item: CdkDrag, yOffset: number): void {
-    // TODO: only covers Y axis sorting.
+  _sortItem(item: CdkDrag, xOffset: number, yOffset: number): void {
     const siblings = this._positionCache.items;
     const newPosition = siblings.find(({drag, clientRect}) => {
-      return drag !== item && yOffset > clientRect.top && yOffset < clientRect.bottom;
+      if (drag === item) {
+        return false;
+      }
+
+      return this.orientation === 'horizontal' ?
+          xOffset > clientRect.left && xOffset < clientRect.right :
+          yOffset > clientRect.top && yOffset < clientRect.bottom;
     });
 
     if (!newPosition && siblings.length > 0) {

--- a/src/demo-app/drag-drop/drag-drop-demo.html
+++ b/src/demo-app/drag-drop/drag-drop-demo.html
@@ -1,35 +1,53 @@
-<div class="list">
-  <h2>To do</h2>
-  <cdk-drop
-    #one
-    (cdkDragDropped)="drop($event)"
-    [data]="todo"
-    [connectedTo]="[two]">
-    <div *ngFor="let item of todo" cdkDrag>
-      {{item}}
-      <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
-    </div>
-  </cdk-drop>
+<div>
+  <div class="list">
+    <h2>To do</h2>
+    <cdk-drop
+      #one
+      (dropped)="drop($event)"
+      [data]="todo"
+      [connectedTo]="[two]">
+      <div *ngFor="let item of todo" cdkDrag>
+        {{item}}
+        <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
+      </div>
+    </cdk-drop>
+  </div>
+
+  <div class="list">
+    <h2>Done</h2>
+    <cdk-drop
+      #two
+      (dropped)="drop($event)"
+      [data]="done"
+      [connectedTo]="[one]">
+      <div *ngFor="let item of done" cdkDrag>
+        {{item}}
+        <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
+      </div>
+    </cdk-drop>
+  </div>
 </div>
 
-<div class="list">
-  <h2>Done</h2>
-  <cdk-drop
-    #two
-    (cdkDragDropped)="drop($event)"
-    [data]="done"
-    [connectedTo]="[one]">
-    <div *ngFor="let item of done" cdkDrag>
-      {{item}}
-      <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
-    </div>
-  </cdk-drop>
+<div>
+  <div class="list horizontal">
+    <h2>Horizontal list</h2>
+    <cdk-drop
+      orientation="horizontal"
+      (dropped)="drop($event)"
+      [data]="horizontalData">
+      <div *ngFor="let item of horizontalData" cdkDrag>
+        {{item}}
+        <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
+      </div>
+    </cdk-drop>
+  </div>
 </div>
 
-<div class="list">
+<div>
   <h2>Data</h2>
   <pre>{{todo.join(', ')}}</pre>
   <pre>{{done.join(', ')}}</pre>
+  <pre>{{horizontalData.join(', ')}}</pre>
 </div>
 
 <div class="list">

--- a/src/demo-app/drag-drop/drag-drop-demo.scss
+++ b/src/demo-app/drag-drop/drag-drop-demo.scss
@@ -5,12 +5,28 @@
   display: inline-block;
   margin-right: 25px;
   vertical-align: top;
+
+  [dir='rtl'] & {
+    margin-right: 0;
+    margin-left: 25px;
+  }
+
+  &.horizontal {
+    width: 1000px;
+    margin-right: 0;
+    margin-left: 0;
+  }
 }
 
 .cdk-drop {
   border: solid 1px #ccc;
   min-height: 60px;
   display: block;
+
+  .horizontal & {
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .cdk-drag {
@@ -22,12 +38,24 @@
   justify-content: space-between;
   box-sizing: border-box;
 
-  .cdk-drop &:last-child {
-    border: none;
-  }
-
   .cdk-drop-dragging & {
     transition: transform 500ms ease;
+  }
+
+  .horizontal & {
+    border: none;
+    border-right: solid 1px #ccc;
+    flex-grow: 1;
+    flex-basis: 0;
+
+    [dir='rtl'] & {
+      border-right: none;
+      border-left: solid 1px #ccc;
+    }
+  }
+
+  .cdk-drop &:last-child {
+    border: none;
   }
 }
 

--- a/src/demo-app/drag-drop/drag-drop-demo.ts
+++ b/src/demo-app/drag-drop/drag-drop-demo.ts
@@ -33,6 +33,14 @@ export class DragAndDropDemo {
     'Check reddit'
   ];
 
+  horizontalData = [
+    'Bronze age',
+    'Iron age',
+    'Middle ages',
+    'Early modern period',
+    'Long nineteenth century'
+  ];
+
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {
     iconRegistry.addSvgIconLiteral('dnd-move', sanitizer.bypassSecurityTrustHtml(`
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">


### PR DESCRIPTION
* Adds support for sorting items horizontally.
* Fixes some tests going into an infinite loop if they fail.
* Fixes the drag item's directionality not propagating to its preview.

Fixes #12066.