### PR TITLE
chore(toolbar): deprecate unused landscape row-height variable

### DIFF
--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -2,10 +2,14 @@
 @import '../../cdk/a11y/a11y';
 
 $mat-toolbar-height-desktop: 64px !default;
+$mat-toolbar-height-mobile: 56px !default;
+$mat-toolbar-row-padding: 16px !default;
+
+/** @deprecated @deletion-target 8.0.0 */
 $mat-toolbar-height-mobile-portrait: 56px !default;
+/** @deprecated @deletion-target 8.0.0 */
 $mat-toolbar-height-mobile-landscape: 48px !default;
 
-$mat-toolbar-row-padding: 16px !default;
 
 
 @mixin mat-toolbar-height($height) {
@@ -49,10 +53,9 @@ $mat-toolbar-row-padding: 16px !default;
 // Set the default height for the toolbar.
 @include mat-toolbar-height($mat-toolbar-height-desktop);
 
-// As per specs, mobile devices will use a different height for toolbars than for desktop.
-// The height for mobile landscape devices has been ignored since relying on `@media orientation`
-// is causing issues on devices with a soft-keyboard.
-// See: https://material.io/guidelines/layout/structure.html#structure-app-bar
+// As per specs, toolbars should have a different height in mobile devices. This has been
+// specified in the old guidelines and is still observable in the new specifications by looking at
+// the spec images. See: https://material.io/design/components/app-bars-top.html#anatomy
 @media ($mat-xsmall) {
-  @include mat-toolbar-height($mat-toolbar-height-mobile-portrait);
+  @include mat-toolbar-height($mat-toolbar-height-mobile);
 }

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -45,8 +45,8 @@ export class MatToolbarRow {}
   inputs: ['color'],
   host: {
     'class': 'mat-toolbar',
-    '[class.mat-toolbar-multiple-rows]': 'this._toolbarRows.length',
-    '[class.mat-toolbar-single-row]': '!this._toolbarRows.length'
+    '[class.mat-toolbar-multiple-rows]': '_toolbarRows.length > 0',
+    '[class.mat-toolbar-single-row]': '_toolbarRows.length === 0',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
* Deprecates the unused landscape row-height variable. The logic for this has been removed a long time ago, and the SCSS variable should be removed at some point.

* Makes the host bindings more clear by expanding the truthy and falsy check.