### PR TITLE
chore: invalid jsdoc in focus-monitor

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -147,7 +147,7 @@ export class FocusMonitor implements OnDestroy {
    * Focuses the element via the specified focus origin.
    * @param element Element to focus.
    * @param origin Focus origin.
-   * @param focusOption Options that can be used to configure the focus behavior.
+   * @param options Options that can be used to configure the focus behavior.
    */
   focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void {
     this._setOriginForCurrentEventQueue(origin);


### PR DESCRIPTION
Marking as patch since we want to have the JSDoc show up properly in the docs next patch.