### PR TITLE
fix(menu): showing scrollbars on first open in Edge if item width is set

### DIFF
--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -35,6 +35,9 @@ $mat-menu-icon-margin: 16px !default;
   text-align: left;
   text-decoration: none;   // necessary to reset anchor tags
 
+  // Required for Edge not to show scrollbars when setting the width manually. See #12112.
+  max-width: 100%;
+
   &[disabled] {
     cursor: default;
   }


### PR DESCRIPTION
Fixes the menu panel showing scrollbars the first time it's opened on Edge, if the width of the menu items has been overwritten.

Fixes #12112.