### PR TITLE
fix(tabs): unable to distinguish disabled tab in high contrast mode

### DIFF
--- a/src/lib/tabs/_tabs-common.scss
+++ b/src/lib/tabs/_tabs-common.scss
@@ -24,10 +24,18 @@ $mat-tab-animation-duration: 500ms !default;
     &:not(.mat-tab-disabled) {
       opacity: 1;
     }
+
+    @include cdk-high-contrast {
+      outline: dotted 2px;
+    }
   }
 
   &.mat-tab-disabled {
     cursor: default;
+
+    @include cdk-high-contrast {
+      opacity: 0.5;
+    }
   }
 
   .mat-tab-label-content {
@@ -35,6 +43,10 @@ $mat-tab-animation-duration: 500ms !default;
     justify-content: center;
     align-items: center;
     white-space: nowrap;
+  }
+
+  @include cdk-high-contrast {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
Fixes disabled tabs being indistinguishable from enabled ones in high contrast mode.