### PR TITLE
fix(ripple): don't hide directive host in high contrast

### DIFF
--- a/src/lib/core/ripple/_ripple.scss
+++ b/src/lib/core/ripple/_ripple.scss
@@ -8,11 +8,6 @@ $mat-ripple-color-opacity: 0.1;
   // "relative" so that the ripple divs it creates inside itself are correctly positioned.
   .mat-ripple {
     overflow: hidden;
-
-    // In high contrast mode the ripple is opaque, causing it to obstruct the content.
-    @include cdk-high-contrast {
-      display: none;
-    }
   }
 
   .mat-ripple.mat-ripple-unbounded {
@@ -26,6 +21,11 @@ $mat-ripple-color-opacity: 0.1;
 
     transition: opacity, transform 0ms cubic-bezier(0, 0, 0.2, 1);
     transform: scale(0);
+
+    // In high contrast mode the ripple is opaque, causing it to obstruct the content.
+    @include cdk-high-contrast {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
* The `matRipple` directive can be applied on various HTML elements. In high contrast mode we currently hide the host element. It's **wrong to assume** that the element with `matRipple` applied can be just made invisible. In order to keep the high contrast mode working, we just hide the ripple elements instead of the host element.

* Fixes that components using their own `RippleTarget` (chips, tab-nav-bar) are still showing ripples in high contrast mode that obstruct the actual content.