### PR TITLE
fix(tabs): only target direct descendants with mat-stretch-tabs

### DIFF
--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -29,7 +29,8 @@
   }
 }
 
-.mat-tab-group[mat-stretch-tabs] .mat-tab-label {
+// Note that we only want to target direct descendant tabs.
+.mat-tab-group[mat-stretch-tabs] > .mat-tab-header .mat-tab-label {
   flex-basis: 0;
   flex-grow: 1;
 }


### PR DESCRIPTION
Fixes `mat-stretch-tabs` applying to all descendant tab headers, rather than direct descendants only.

Fixes #12196.