### PR TITLE
fix(card): images in title-group overlapping content

### DIFF
--- a/src/demo-app/card/card-demo.html
+++ b/src/demo-app/card/card-demo.html
@@ -4,19 +4,11 @@
   </mat-card>
 
   <mat-card>
-    <mat-card-title-group>
-        <mat-card-title>Card with title</mat-card-title>
-        <mat-card-subtitle>Subtitle</mat-card-subtitle>
-        <img mat-card-md-image>
-    </mat-card-title-group>
-  </mat-card>
-
-  <mat-card>
     <mat-card-subtitle>Subtitle</mat-card-subtitle>
     <mat-card-title>Card with title and footer</mat-card-title>
     <mat-card-content>
       <p>This is supporting text.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p>{{longText}}</p>
     </mat-card-content>
     <mat-card-actions>
       <button mat-button>LIKE</button>
@@ -32,7 +24,7 @@
     <mat-card-title>Card with title, footer, and inset-divider</mat-card-title>
     <mat-card-content>
       <p>This is supporting text.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p>{{longText}}</p>
     </mat-card-content>
     <mat-divider [inset]="true"></mat-divider>
     <mat-card-actions>
@@ -74,5 +66,52 @@
       <button mat-button>First</button>
       <button mat-button>Second</button>
     </mat-card-actions>
+  </mat-card>
+
+  <hr>
+  <h2>Cards with media area</h2>
+
+  <mat-card>
+    <mat-card-title-group>
+      <mat-card-title>Card</mat-card-title>
+      <mat-card-subtitle>Small</mat-card-subtitle>
+      <img mat-card-sm-image>
+    </mat-card-title-group>
+    <mat-card-content>
+      {{longText}}
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-title-group>
+      <mat-card-title>Card</mat-card-title>
+      <mat-card-subtitle>Medium</mat-card-subtitle>
+      <img mat-card-md-image>
+    </mat-card-title-group>
+    <mat-card-content>
+      {{longText}}
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-title-group>
+      <mat-card-title>Card</mat-card-title>
+      <mat-card-subtitle>Large</mat-card-subtitle>
+      <img mat-card-lg-image>
+    </mat-card-title-group>
+    <mat-card-content>
+      {{longText}}
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-title-group>
+      <mat-card-title>Card</mat-card-title>
+      <mat-card-subtitle>Extra large</mat-card-subtitle>
+      <img mat-card-xl-image>
+    </mat-card-title-group>
+    <mat-card-content>
+      {{longText}}
+    </mat-card-content>
   </mat-card>
 </div>

--- a/src/demo-app/card/card-demo.ts
+++ b/src/demo-app/card/card-demo.ts
@@ -15,4 +15,11 @@ import {Component} from '@angular/core';
   templateUrl: 'card-demo.html',
   styleUrls: ['card-demo.css'],
 })
-export class CardDemo {}
+export class CardDemo {
+  longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ' +
+    'incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ' +
+    'exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor' +
+    ' in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur' +
+    ' sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id ' +
+    'est laborum.';
+}

--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -69,12 +69,6 @@ $mat-card-header-size: 40px !default;
   margin: 0 -24px 16px -24px;
 }
 
-.mat-card-xl-image {
-  width: 240px;
-  height: 240px;
-  margin: -8px;
-}
-
 .mat-card-footer {
   // The negative margins pulls out the element, countering the padding
   // to get the footer to be flush against the side of the card.
@@ -112,7 +106,10 @@ $mat-card-header-size: 40px !default;
 
 // images grouped with title in title-group layout
 %mat-card-title-img {
-  margin: -8px 0;
+  // As per Material Design specifications, the images exceed the *top* content-box and take
+  // up some space. The margin below is necessary because otherwise space of the actual card
+  // content will be overlapped.
+  margin: -8px 0 8px 0;
 }
 
 .mat-card-title-group {
@@ -137,6 +134,21 @@ $mat-card-header-size: 40px !default;
   @extend %mat-card-title-img;
   width: 152px;
   height: 152px;
+}
+
+// This should normally also extend the `%mat-card-title-img`, but in order to avoid breaking
+// changes, we need to keep the horizontal margin reversion for now.
+// See: https://github.com/angular/material2/issues/12203
+.mat-card-xl-image {
+  width: 240px;
+  height: 240px;
+  margin: -8px;
+
+  // Special treatment inside title group in order to fix the media areas inside of a title-group.
+  // This can be removed once #12203 has been addressed.
+  .mat-card-title-group > & {
+    @extend %mat-card-title-img;
+  }
 }
 
 // MEDIA QUERIES


### PR DESCRIPTION
* Fixes that `mat-card-$breakpoint-image` images overlap the card content when placed inside of the title group.

@jelbourn Made it in a way that should be non-breaking for those using the `xl-image` outside of the `mat-card-title-group`. For those who use it inside of the title-group it can be considered a normal issue fix.

Fixes #10031