### PR TITLE
chore: gesture config test logging out warnings

### DIFF
--- a/src/lib/core/gestures/gesture-config.spec.ts
+++ b/src/lib/core/gestures/gesture-config.spec.ts
@@ -49,6 +49,9 @@ describe('GestureConfig', () => {
     const hammerGlobal = (window as any).Hammer;
     (window as any).Hammer = undefined;
 
+    // Stub out `console.warn` so the warnings don't pollute our logs.
+    spyOn(console, 'warn');
+
     TestBed
       .resetTestingModule()
       .configureTestingModule({


### PR DESCRIPTION
Fixes an error being logged out, because we're testing the case where Hammer isn't loaded.