### PR TITLE
fix(menu): changed after checked error when toggling quickly between triggers for same submenu

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -501,8 +501,10 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         // while the new trigger tries to re-open it. Wait for the animation to finish
         // before doing so. Also interrupt if the user moves to another item.
         if (this.menu instanceof MatMenu && this.menu._isAnimating) {
+          // We need the `delay(0)` here in order to avoid
+          // 'changed after checked' errors in some cases. See #12194.
           this.menu._animationDone
-            .pipe(take(1), takeUntil(this._parentMenu._hovered()))
+            .pipe(take(1), delay(0, asapScheduler), takeUntil(this._parentMenu._hovered()))
             .subscribe(() => this.openMenu());
         } else {
           this.openMenu();


### PR DESCRIPTION
Fixes `mat-menu` throwing a "changed after checked" error when moving quickly between triggers for the same sub-menu.

Fixes #12194.

**Note:** I wasn't able to get the same error to be thrown during unit tests, potentially because change detection and animations are being triggered manually during tests.