### PR TITLE
fix(menu): collapse empty menu panel

### DIFF
--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -19,7 +19,8 @@ $mat-menu-submenu-indicator-size: 10px !default;
   }
 }
 
-.mat-menu-content {
+// `:not(:empty)` allows for the menu to collapse to 0x0 when it doesn't have content.
+.mat-menu-content:not(:empty) {
   padding-top: $mat-menu-vertical-padding;
   padding-bottom: $mat-menu-vertical-padding;
 }


### PR DESCRIPTION
Changes up the selector for the menu panel, in order to have it collapse when it's empty. This avoids weird blank panels being left behind when `mat-menu` instances are reused between triggers.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/42727095-6aaa2130-87a0-11e8-8419-da02d1a76e46.gif)
