### PR TITLE
build: e2e and test init files not being linted

### DIFF
--- a/e2e/components/tabs-e2e.spec.ts
+++ b/e2e/components/tabs-e2e.spec.ts
@@ -3,7 +3,6 @@ import {
   by,
   element,
   ElementArrayFinder,
-  ElementFinder,
   Key,
   ExpectedConditions
 } from 'protractor';
@@ -11,13 +10,11 @@ import {pressKeys} from '../util/index';
 
 describe('tabs', () => {
   describe('basic behavior', () => {
-    let tabGroup: ElementFinder;
     let tabLabels: ElementArrayFinder;
     let tabBodies: ElementArrayFinder;
 
     beforeEach(() => {
       browser.get('/tabs');
-      tabGroup = element(by.css('mat-tab-group'));
       tabLabels = element.all(by.css('.mat-tab-label'));
       tabBodies = element.all(by.css('mat-tab-body'));
     });
@@ -39,8 +36,8 @@ describe('tabs', () => {
     });
 
     it('should change focus with keyboard interaction', async () => {
-      let right = Key.RIGHT;
-      let left = Key.LEFT;
+      const right = Key.RIGHT;
+      const left = Key.LEFT;
 
       tabLabels.get(0).click();
       expect(await getFocusStates(tabLabels)).toEqual([true, false, false]);
@@ -71,8 +68,8 @@ describe('tabs', () => {
  */
 async function getFocusStates(elements: ElementArrayFinder) {
   return elements.map(async el => {
-    let elementText = await el!.getText();
-    let activeText = await browser.driver.switchTo().activeElement().getText();
+    const elementText = await el!.getText();
+    const activeText = await browser.driver.switchTo().activeElement().getText();
 
     return activeText === elementText;
   });
@@ -94,7 +91,7 @@ function getBodyActiveStates(elements: ElementArrayFinder) {
  */
 async function getClassStates(elements: ElementArrayFinder, className: string) {
   return elements.map(async el => {
-    let classes = await el!.getAttribute('class');
-    return classes.split(/ +/g).indexOf(className) >= 0;
+    const classes = await el!.getAttribute('class');
+    return classes.split(/ +/g).indexOf(className) > -1;
   });
 }

--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -31,14 +31,14 @@ patchTestBedToDestroyFixturesAfterEveryTest(testBed);
  *    aforementioned errors were thrown, they would be reported for the wrong test (the test that's
  *    about to start, not the test that just finished).
  */
-function patchTestBedToDestroyFixturesAfterEveryTest(testBed) {
+function patchTestBedToDestroyFixturesAfterEveryTest(testBedInstance) {
   // Original resetTestingModule function of the TestBed.
-  const _resetTestingModule = testBed.resetTestingModule;
+  const _resetTestingModule = testBedInstance.resetTestingModule;
 
   // Monkey-patch the resetTestingModule to destroy fixtures outside of a try/catch block.
   // With https://github.com/angular/angular/commit/2c5a67134198a090a24f6671dcdb7b102fea6eba
   // errors when destroying components are no longer causing Jasmine to fail.
-  testBed.resetTestingModule = function() {
+  testBedInstance.resetTestingModule = function() {
     try {
       this._activeFixtures.forEach(fixture => fixture.destroy());
     } finally {
@@ -52,5 +52,5 @@ function patchTestBedToDestroyFixturesAfterEveryTest(testBed) {
   // for us because it doesn't allow developers to see what test actually failed.
   // Fixing this by resetting the testing module after each test.
   // https://github.com/angular/angular/blob/master/packages/core/testing/src/before_each.ts#L25
-  afterEach(() => testBed.resetTestingModule());
+  afterEach(() => testBedInstance.resetTestingModule());
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
-// TypeScript config file that matches all source files in the project. This file is read by 
+// TypeScript config file that matches all source files in the project. This file is read by
 // IDEs and TSLint. For IDEs it ensures that `experimentalDecorator` warnings are not showing up.
 {
   "compilerOptions": {
@@ -15,6 +15,8 @@
   },
   "include": [
     "src/**/*.ts",
+    "e2e/**/*.ts",
+    "test/**/*.ts",
     "tools/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
Fixes the e2e tests and the `test` directory not being linted. Also fixes the lint warnings that got through.