### PR TITLE
fix(overlay): avoid same overlay being added to the keyboard event stack multiple times

### DIFF
--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
@@ -157,6 +157,27 @@ describe('OverlayKeyboardDispatcher', () => {
     expect(overlayOneSpy).toHaveBeenCalled();
   });
 
+  it('should not add the same overlay to the stack multiple times', () => {
+    const overlayOne = overlay.create();
+    const overlayTwo = overlay.create();
+    const overlayOneSpy = jasmine.createSpy('overlayOne keyboard event spy');
+    const overlayTwoSpy = jasmine.createSpy('overlayTwo keyboard event spy');
+
+    overlayOne.keydownEvents().subscribe(overlayOneSpy);
+    overlayTwo.keydownEvents().subscribe(overlayTwoSpy);
+
+    keyboardDispatcher.add(overlayOne);
+    keyboardDispatcher.add(overlayTwo);
+    keyboardDispatcher.add(overlayOne);
+
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+
+    expect(keyboardDispatcher._attachedOverlays).toEqual([overlayTwo, overlayOne]);
+
+    expect(overlayTwoSpy).not.toHaveBeenCalled();
+    expect(overlayOneSpy).toHaveBeenCalled();
+  });
+
 });
 
 

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
@@ -42,6 +42,9 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
 
   /** Add a new overlay to the list of attached overlay refs. */
   add(overlayRef: OverlayRef): void {
+    // Ensure that we don't get the same overlay multiple times.
+    this.remove(overlayRef);
+
     // Lazily start dispatcher once first overlay is added
     if (!this._isAttached) {
       this._document.body.addEventListener('keydown', this._keydownListener, true);


### PR DESCRIPTION
Adds an extra check that ensures that the same overlay can't be added to the overlay stack multiple times. Previously it was possible to add it, which meant that it would never be removed.