### PR TITLE
docs(stepper): Fix Stackblitz example for mat-vertical-stepper

### DIFF
--- a/src/material-examples/stepper-vertical/stepper-vertical-example.ts
+++ b/src/material-examples/stepper-vertical/stepper-vertical-example.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 /**
  * @title Stepper vertical

--- a/src/material-examples/stepper-vertical/stepper-vertical-example.ts
+++ b/src/material-examples/stepper-vertical/stepper-vertical-example.ts
@@ -1,11 +1,11 @@
-import {Component, OnInit} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 /**
  * @title Stepper vertical
  */
 @Component({
-  selector: 'stepper-vertical',
+  selector: 'stepper-vertical-example',
   templateUrl: 'stepper-vertical-example.html',
   styleUrls: ['stepper-vertical-example.css']
 })


### PR DESCRIPTION
Append `-example` to stepper vertical selector which causes the Stackblitz example to error out.