### PR TITLE
fix(chips): ripple not clipping correctly in safari

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -25,6 +25,9 @@ $mat-chip-remove-size: 18px;
   overflow: hidden;
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
+
+  // Required for the ripple to clip properly in Safari.
+  transform: translateZ(0);
 }
 
 .mat-standard-chip {


### PR DESCRIPTION
Fixes the ripple on a `mat-chip` not being clipped to the rounded corners on Safari.