### PR TITLE
chore(examples): fix tab group example title

### DIFF
--- a/src/material-examples/tab-group-dynamic/tab-group-dynamic-example.ts
+++ b/src/material-examples/tab-group-dynamic/tab-group-dynamic-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
 /**
- * @title Tag group with dynamically changing tabs
+ * @title Tab group with dynamically changing tabs
  */
 @Component({
   selector: 'tab-group-dynamic-example',


### PR DESCRIPTION
* Fixes the title for the `tab-group-dynamic` example.