### PR TITLE
fix(drag-drop): unable to drag last item back into initial container

### DIFF
--- a/src/cdk-experimental/drag-drop/drag.ts
+++ b/src/cdk-experimental/drag-drop/drag.ts
@@ -82,7 +82,7 @@ export class CdkDrag implements AfterContentInit, OnDestroy {
   private _activeTransform: Point = {x: 0, y: 0};
 
   /** Whether the element is being dragged. */
-  private _isDragging = false;
+  _isDragging = false;
 
   /** Whether the element has moved since the user started dragging it. */
   private _hasMoved = false;

--- a/src/cdk-experimental/drag-drop/drop.ts
+++ b/src/cdk-experimental/drag-drop/drop.ts
@@ -141,7 +141,9 @@ export class CdkDrop<T = any> {
     const siblings = this._positionCache.items;
     const newPosition = siblings.find(({drag, clientRect}) => {
       if (drag === item) {
-        return false;
+        // If there's only one left item in the container, it must be
+        // the dragged item itself so we use it as a reference.
+        return siblings.length < 2;
       }
 
       return this.orientation === 'horizontal' ?
@@ -153,7 +155,10 @@ export class CdkDrop<T = any> {
       return;
     }
 
-    const element = newPosition ? newPosition.drag.element.nativeElement : null;
+    // Don't take the element of a dragged item as a reference,
+    // because it has been moved down to the end of the body.
+    const element = (newPosition && !newPosition.drag._isDragging) ?
+        newPosition.drag.element.nativeElement : null;
     const next = element ? element!.nextSibling : null;
     const parent = element ? element.parentElement! : this.element.nativeElement;
     const placeholder = item.getPlaceholderElement();


### PR DESCRIPTION
Fixes not being able to take the last item in a drag container, move it into a new container and then move it back into its initial container.

Fixes #12251.