### PR TITLE
refactor(menu): remove 7.0.0 deletion targets, part 1

### DIFF
--- a/src/demo-app/menu/menu-demo.html
+++ b/src/demo-app/menu/menu-demo.html
@@ -140,7 +140,7 @@
     <p>overlapTrigger: true</p>
 
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="menuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="menuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -156,7 +156,7 @@
       Position x: before, overlapTrigger: true
     </p>
     <mat-toolbar class="demo-end-icon">
-      <button mat-icon-button [mat-menu-trigger-for]="posXMenuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="posXMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -173,7 +173,7 @@
       Position y: above, overlapTrigger: true
     </p>
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="posYMenuOverlay">
+      <button mat-icon-button [matMenuTriggerFor]="posYMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>

--- a/src/lib/menu/menu-animations.ts
+++ b/src/lib/menu/menu-animations.ts
@@ -61,15 +61,3 @@ export const matMenuAnimations: {
     ])
   ])
 };
-
-/**
- * @deprecated
- * @breaking-change 7.0.0
- */
-export const fadeInItems = matMenuAnimations.fadeInItems;
-
-/**
- * @deprecated
- * @breaking-change 7.0.0
- */
-export const transformMenu = matMenuAnimations.transformMenu;

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -206,17 +206,6 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     }
   }
 
-  /**
-   * This method takes classes set on the host mat-menu element and applies them on the
-   * menu template that displays in the overlay container.  Otherwise, it's difficult
-   * to style the containing menu from outside the component.
-   * @deprecated Use `panelClass` instead.
-   * @breaking-change 7.0.0
-   */
-  @Input()
-  get classList(): string { return this.panelClass; }
-  set classList(classes: string) { this.panelClass = classes; }
-
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void | 'click' | 'keydown' | 'tab'> =
       new EventEmitter<void | 'click' | 'keydown' | 'tab'>();

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -72,19 +72,16 @@ export class MatMenuItem extends _MatMenuItemMixinBase
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,
-    @Inject(DOCUMENT) document?: any,
-    private _focusMonitor?: FocusMonitor,
+    @Inject(DOCUMENT) document: any,
+    private _focusMonitor: FocusMonitor,
     @Inject(MAT_MENU_PANEL) @Optional() private _parentMenu?: MatMenuPanel<MatMenuItem>) {
 
-    // @breaking-change 7.0.0 make `_focusMonitor` and `document` required params.
     super();
 
-    if (_focusMonitor) {
-      // Start monitoring the element so it gets the appropriate focused classes. We want
-      // to show the focus style for menu items only when the focus was not caused by a
-      // mouse or touch interaction.
-      _focusMonitor.monitor(this._elementRef, false);
-    }
+    // Start monitoring the element so it gets the appropriate focused classes. We want
+    // to show the focus style for menu items only when the focus was not caused by a
+    // mouse or touch interaction.
+    _focusMonitor.monitor(this._elementRef, false);
 
     if (_parentMenu && _parentMenu.addItem) {
       _parentMenu.addItem(this);
@@ -103,9 +100,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   }
 
   ngOnDestroy() {
-    if (this._focusMonitor) {
-      this._focusMonitor.stopMonitoring(this._elementRef);
-    }
+    this._focusMonitor.stopMonitoring(this._elementRef);
 
     if (this._parentMenu && this._parentMenu.removeItem) {
       this._parentMenu.removeItem(this);

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -67,7 +67,7 @@ export const MENU_PANEL_TOP_PADDING = 8;
  * responsible for toggling the display of the provided menu instance.
  */
 @Directive({
-  selector: `[mat-menu-trigger-for], [matMenuTriggerFor]`,
+  selector: `[matMenuTriggerFor]`,
   host: {
     'aria-haspopup': 'true',
     '[attr.aria-expanded]': 'menuOpen || null',
@@ -88,19 +88,6 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   // the first item of the list when the menu is opened via the keyboard
   private _openedByMouse: boolean = false;
 
-  /**
-   * @deprecated
-   * @breaking-change 7.0.0
-   */
-  @Input('mat-menu-trigger-for')
-  get _deprecatedMatMenuTriggerFor(): MatMenuPanel {
-    return this.menu;
-  }
-
-  set _deprecatedMatMenuTriggerFor(v: MatMenuPanel) {
-    this.menu = v;
-  }
-
   /** References the menu instance that the trigger is associated with. */
   @Input('matMenuTriggerFor') menu: MatMenuPanel;
 
@@ -110,24 +97,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   /** Event emitted when the associated menu is opened. */
   @Output() readonly menuOpened: EventEmitter<void> = new EventEmitter<void>();
 
-  /**
-   * Event emitted when the associated menu is opened.
-   * @deprecated Switch to `menuOpened` instead
-   * @breaking-change 7.0.0
-   */
-  // tslint:disable-next-line:no-output-on-prefix
-  @Output() readonly onMenuOpen: EventEmitter<void> = this.menuOpened;
-
   /** Event emitted when the associated menu is closed. */
   @Output() readonly menuClosed: EventEmitter<void> = new EventEmitter<void>();
-
-  /**
-   * Event emitted when the associated menu is closed.
-   * @deprecated Switch to `menuClosed` instead
-   * @breaking-change 7.0.0
-   */
-  // tslint:disable-next-line:no-output-on-prefix
-  @Output() readonly onMenuClose: EventEmitter<void> = this.menuClosed;
 
   constructor(private _overlay: Overlay,
               private _element: ElementRef<HTMLElement>,
@@ -136,9 +107,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
               @Optional() private _parentMenu: MatMenu,
               @Optional() @Self() private _menuItemInstance: MatMenuItem,
               @Optional() private _dir: Directionality,
-              // TODO(crisbeto): make the _focusMonitor required when doing breaking changes.
-              // @breaking-change 7.0.0
-              private _focusMonitor?: FocusMonitor) {
+              private _focusMonitor: FocusMonitor) {
 
     if (_menuItemInstance) {
       _menuItemInstance._triggersSubmenu = this.triggersSubmenu();
@@ -223,11 +192,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * @param origin Source of the menu trigger's focus.
    */
   focus(origin: FocusOrigin = 'program') {
-    if (this._focusMonitor) {
-      this._focusMonitor.focusVia(this._element, origin);
-    } else {
-      this._element.nativeElement.focus();
-    }
+    this._focusMonitor.focusVia(this._element, origin);
   }
 
   /** Closes the menu and does the necessary cleanup. */


### PR DESCRIPTION
Does an initial pass of removing the deletion targets from `material/menu`. Note that these aren't all the planned breaking changes, but they should be the ones that are easier to sync into G3.

BREAKING CHANGES:
* `mat-menu-trigger-for` which was deprecated in 5.0.0 has been removed. Use `matMenuTriggerFor` instead.
* `onMenuClose` which was deprecated in 5.0.0 has been removed. Use `menuClosed` instead.
* `onMenuOpen` which was deprecated in 5.0.0 has been removed. Use `menuOpened` instead.
* `classList` which was deprecated in 5.0.0 has been removed. Use the `panelClass` property or pass in the classes via the `class` attribute.
* `fadeInItems` which was deprecated in 6.0.0 has been removed. Use `matMenuAnimations.fadeInItems` instead.
* `transformMenu` which was deprecated in 6.0.0 has been removed. Use `matMenuAnimations.transformMenu` instead.
* The `_focusMonitor` and `document` parameters on the `MatMenuItem` constructor are now required.
* The `_focusMonitor` parameter on the `MatMenuTrigger` constructor is now required.