### PR TITLE
chore: cleanup schematics

### DIFF
--- a/src/lib/schematics/address-form/index.ts
+++ b/src/lib/schematics/address-form/index.ts
@@ -1,4 +1,12 @@
-import {chain, Rule, noop, Tree, SchematicContext} from '@angular-devkit/schematics';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {chain, Rule, noop, Tree} from '@angular-devkit/schematics';
 import {Schema} from './schema';
 import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 import {buildComponent} from '../utils/devkit-utils/component';

--- a/src/lib/schematics/address-form/schema.ts
+++ b/src/lib/schematics/address-form/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Schema as ComponentSchema} from '@schematics/angular/component/schema';
 
 export interface Schema extends ComponentSchema {}

--- a/src/lib/schematics/dashboard/index.spec.ts
+++ b/src/lib/schematics/dashboard/index.spec.ts
@@ -1,12 +1,11 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {join} from 'path';
-import {Tree} from '@angular-devkit/schematics';
 import {createTestApp} from '../utils/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 
 const collectionPath = join(__dirname, '../collection.json');
 
-describe('material-nav-schematic', () => {
+describe('material-dashboard-schematic', () => {
   let runner: SchematicTestRunner;
   const options = {
     name: 'foo',
@@ -27,8 +26,8 @@ describe('material-nav-schematic', () => {
     runner = new SchematicTestRunner('schematics', collectionPath);
   });
 
-  it('should create nav files and add them to module', () => {
-    const tree = runner.runSchematic('nav', { ...options }, createTestApp());
+  it('should create dashboard files and add them to module', () => {
+    const tree = runner.runSchematic('dashboard', { ...options }, createTestApp());
     const files = tree.files;
 
     expect(files).toContain('/src/app/foo/foo.component.css');
@@ -41,21 +40,19 @@ describe('material-nav-schematic', () => {
     expect(moduleContent).toMatch(/declarations:\s*\[[^\]]+?,\r?\n\s+FooComponent\r?\n/m);
   });
 
-  it('should add nav imports to module', () => {
-    const tree = runner.runSchematic('nav', { ...options }, createTestApp());
+  it('should add dashboard imports to module', () => {
+    const tree = runner.runSchematic('materialDashboard', { ...options }, createTestApp());
     const moduleContent = getFileContent(tree, '/src/app/app.module.ts');
 
-    expect(moduleContent).toContain('LayoutModule');
-    expect(moduleContent).toContain('MatToolbarModule');
-    expect(moduleContent).toContain('MatButtonModule');
-    expect(moduleContent).toContain('MatSidenavModule');
+    expect(moduleContent).toContain('MatGridListModule');
+    expect(moduleContent).toContain('MatCardModule');
+    expect(moduleContent).toContain('MatMenuModule');
     expect(moduleContent).toContain('MatIconModule');
-    expect(moduleContent).toContain('MatListModule');
+    expect(moduleContent).toContain('MatButtonModule');
 
-    expect(moduleContent).toContain(`import { LayoutModule } from '@angular/cdk/layout';`);
     expect(moduleContent).toContain(
       // tslint:disable-next-line
-      `import { MatToolbarModule, MatButtonModule, MatSidenavModule, MatIconModule, MatListModule } from '@angular/material';`);
+      `import { MatGridListModule, MatCardModule, MatMenuModule, MatIconModule, MatButtonModule } from '@angular/material';`);
   });
 
 });

--- a/src/lib/schematics/dashboard/index.ts
+++ b/src/lib/schematics/dashboard/index.ts
@@ -1,4 +1,12 @@
-import {chain, Rule, noop, Tree, SchematicContext} from '@angular-devkit/schematics';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {chain, Rule, noop, Tree} from '@angular-devkit/schematics';
 import {Schema} from './schema';
 import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 import {buildComponent} from '../utils/devkit-utils/component';

--- a/src/lib/schematics/dashboard/schema.ts
+++ b/src/lib/schematics/dashboard/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Schema as ComponentSchema} from '@schematics/angular/component/schema';
 
 export interface Schema extends ComponentSchema {}

--- a/src/lib/schematics/install/custom-theme.ts
+++ b/src/lib/schematics/install/custom-theme.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Project} from '../utils/devkit-utils/config';
 
 /** Create custom theme for the given application configuration. */

--- a/src/lib/schematics/install/index.spec.ts
+++ b/src/lib/schematics/install/index.spec.ts
@@ -57,8 +57,8 @@ describe('material-shell-schematic', () => {
     const config: any = getConfig(tree);
     const workspace = getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, config.project.name);
-  
-    const indexPath = getIndexHtmlPath(tree, project);
+
+    const indexPath = getIndexHtmlPath(project);
     const buffer: any = tree.read(indexPath);
     const indexSrc = buffer.toString();
     expect(indexSrc.indexOf('fonts.googleapis.com')).toBeGreaterThan(-1);

--- a/src/lib/schematics/install/index.ts
+++ b/src/lib/schematics/install/index.ts
@@ -1,4 +1,19 @@
-import {chain, noop, Rule, Tree, SchematicContext, SchematicsException} from '@angular-devkit/schematics';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  chain,
+  noop,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
 import {addModuleImportToRootModule, getStylesPath} from '../utils/ast';
 import {InsertChange} from '../utils/devkit-utils/change';
@@ -10,7 +25,6 @@ import {Schema} from './schema';
 import {addThemeToAppStyles} from './theming';
 import * as parse5 from 'parse5';
 
-
 /**
  * Scaffolds the basics of a Angular Material application, this includes:
  *  - Add Packages to package.json
@@ -19,7 +33,8 @@ import * as parse5 from 'parse5';
  */
 export default function(options: Schema): Rule {
   if (!parse5) {
-    throw new SchematicsException('parse5 depedency not found! Please install parse5 from npm to continue.');
+    throw new SchematicsException('Parse5 is required but could not be found! Please install ' +
+      '"parse5" manually in order to continue.');
   }
 
   return chain([
@@ -80,7 +95,7 @@ function addBodyMarginToStyles(options: Schema) {
     const workspace = getWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
 
-    const stylesPath = getStylesPath(host, project);
+    const stylesPath = getStylesPath(project);
 
     const buffer = host.read(stylesPath);
     if (buffer) {

--- a/src/lib/schematics/install/schema.ts
+++ b/src/lib/schematics/install/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export interface Schema {
   /** Whether to skip package.json install. */
   skipPackageJson: boolean;

--- a/src/lib/schematics/install/theming.ts
+++ b/src/lib/schematics/install/theming.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {SchematicsException, Tree} from '@angular-devkit/schematics';
 import {getStylesPath} from '../utils/ast';
 import {InsertChange} from '../utils/devkit-utils/change';
@@ -34,7 +42,7 @@ export function addThemeToAppStyles(options: Schema): (host: Tree) => Tree {
 
 /** Insert a custom theme to styles.scss file. */
 function insertCustomTheme(project: Project, host: Tree) {
-  const stylesPath = getStylesPath(host, project);
+  const stylesPath = getStylesPath(project);
 
   const buffer = host.read(stylesPath);
   if (buffer) {

--- a/src/lib/schematics/nav/index.spec.ts
+++ b/src/lib/schematics/nav/index.spec.ts
@@ -1,12 +1,11 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {join} from 'path';
-import {Tree} from '@angular-devkit/schematics';
 import {createTestApp} from '../utils/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 
 const collectionPath = join(__dirname, '../collection.json');
 
-describe('material-dashboard-schematic', () => {
+describe('material-nav-schematic', () => {
   let runner: SchematicTestRunner;
   const options = {
     name: 'foo',
@@ -27,8 +26,8 @@ describe('material-dashboard-schematic', () => {
     runner = new SchematicTestRunner('schematics', collectionPath);
   });
 
-  it('should create dashboard files and add them to module', () => {
-    const tree = runner.runSchematic('dashboard', { ...options }, createTestApp());
+  it('should create nav files and add them to module', () => {
+    const tree = runner.runSchematic('nav', { ...options }, createTestApp());
     const files = tree.files;
 
     expect(files).toContain('/src/app/foo/foo.component.css');
@@ -41,19 +40,21 @@ describe('material-dashboard-schematic', () => {
     expect(moduleContent).toMatch(/declarations:\s*\[[^\]]+?,\r?\n\s+FooComponent\r?\n/m);
   });
 
-  it('should add dashboard imports to module', () => {
-    const tree = runner.runSchematic('materialDashboard', { ...options }, createTestApp());
+  it('should add nav imports to module', () => {
+    const tree = runner.runSchematic('nav', { ...options }, createTestApp());
     const moduleContent = getFileContent(tree, '/src/app/app.module.ts');
 
-    expect(moduleContent).toContain('MatGridListModule');
-    expect(moduleContent).toContain('MatCardModule');
-    expect(moduleContent).toContain('MatMenuModule');
-    expect(moduleContent).toContain('MatIconModule');
+    expect(moduleContent).toContain('LayoutModule');
+    expect(moduleContent).toContain('MatToolbarModule');
     expect(moduleContent).toContain('MatButtonModule');
+    expect(moduleContent).toContain('MatSidenavModule');
+    expect(moduleContent).toContain('MatIconModule');
+    expect(moduleContent).toContain('MatListModule');
 
+    expect(moduleContent).toContain(`import { LayoutModule } from '@angular/cdk/layout';`);
     expect(moduleContent).toContain(
       // tslint:disable-next-line
-      `import { MatGridListModule, MatCardModule, MatMenuModule, MatIconModule, MatButtonModule } from '@angular/material';`);
+      `import { MatToolbarModule, MatButtonModule, MatSidenavModule, MatIconModule, MatListModule } from '@angular/material';`);
   });
 
 });

--- a/src/lib/schematics/nav/index.ts
+++ b/src/lib/schematics/nav/index.ts
@@ -1,4 +1,12 @@
-import {chain, Rule, noop, Tree, SchematicContext} from '@angular-devkit/schematics';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {chain, Rule, noop, Tree} from '@angular-devkit/schematics';
 import {Schema} from './schema';
 import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 import {buildComponent} from '../utils/devkit-utils/component';

--- a/src/lib/schematics/nav/schema.ts
+++ b/src/lib/schematics/nav/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Schema as ComponentSchema} from '@schematics/angular/component/schema';
 
 export interface Schema extends ComponentSchema {}

--- a/src/lib/schematics/table/index.spec.ts
+++ b/src/lib/schematics/table/index.spec.ts
@@ -1,6 +1,5 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {join} from 'path';
-import {Tree} from '@angular-devkit/schematics';
 import {createTestApp} from '../utils/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 

--- a/src/lib/schematics/table/index.ts
+++ b/src/lib/schematics/table/index.ts
@@ -1,4 +1,12 @@
-import {chain, Rule, noop, Tree, SchematicContext} from '@angular-devkit/schematics';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {chain, Rule, noop, Tree} from '@angular-devkit/schematics';
 import {Schema} from './schema';
 import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 import {buildComponent} from '../utils/devkit-utils/component';

--- a/src/lib/schematics/table/schema.ts
+++ b/src/lib/schematics/table/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Schema as ComponentSchema} from '@schematics/angular/component/schema';
 
 export interface Schema extends ComponentSchema {}

--- a/src/lib/schematics/tree/index.ts
+++ b/src/lib/schematics/tree/index.ts
@@ -1,7 +1,15 @@
-import {chain, Rule, noop, Tree, SchematicContext} from '@angular-devkit/schematics';
-import {Schema} from './schema';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {chain, noop, Rule, Tree} from '@angular-devkit/schematics';
 import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 import {buildComponent} from '../utils/devkit-utils/component';
+import {Schema} from './schema';
 
 /**
  * Scaffolds a new tree component.

--- a/src/lib/schematics/tree/schema.ts
+++ b/src/lib/schematics/tree/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Schema as ComponentSchema} from '@schematics/angular/component/schema';
 
 export interface Schema extends ComponentSchema {}

--- a/src/lib/schematics/update/material/color.ts
+++ b/src/lib/schematics/update/material/color.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green, red} from 'chalk';
 
 const colorFns = {
@@ -8,7 +16,7 @@ const colorFns = {
 
 export function color(message: string): string {
   // 'r{{text}}' with red 'text', 'g{{text}}' with green 'text', and 'b{{text}}' with bold 'text'.
-  return message.replace(/(.)\{\{(.*?)\}\}/g, (m, fnName, text) => {
+  return message.replace(/(.)\{\{(.*?)\}\}/g, (_m, fnName, text) => {
     const fn = colorFns[fnName];
     return fn ? fn(text) : text;
   });

--- a/src/lib/schematics/update/material/component-data.ts
+++ b/src/lib/schematics/update/material/component-data.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export interface MaterialExportAsNameData {
   /** The exportAs name to replace. */
   replace: string;
@@ -25,7 +33,7 @@ export interface MaterialCssNameData {
     html?: boolean,
     /** Replace this name in TypeScript strings. */
     strings?: boolean
-  }
+  };
 }
 
 export interface MaterialAttributeSelectorData {
@@ -44,7 +52,7 @@ export interface MaterialPropertyNameData {
   whitelist: {
     /** Replace the property only when its type is one of the given Classes. */
     classes?: string[];
-  }
+  };
 }
 
 export interface MaterialClassNameData {
@@ -67,7 +75,7 @@ export interface MaterialInputNameData {
     attributes?: string[],
     /** Whether to ignore CSS attribute selectors when doing this replacement. */
     css?: boolean,
-  }
+  };
 }
 
 export interface MaterialOutputNameData {
@@ -83,7 +91,7 @@ export interface MaterialOutputNameData {
     attributes?: string[],
     /** Whether to ignore CSS attribute selectors when doing this replacement. */
     css?: boolean,
-  }
+  };
 }
 
 export interface MaterialMethodCallData {
@@ -92,13 +100,13 @@ export interface MaterialMethodCallData {
   invalidArgCounts: {
     count: number,
     message: string
-  }[]
+  }[];
 }
 
 type Changes<T> = {
   pr: string;
   changes: T[]
-}
+};
 
 function getChanges<T>(allChanges: Changes<T>[]): T[] {
   return allChanges.reduce((result, changes) => result.concat(changes.changes), []);

--- a/src/lib/schematics/update/material/extra-stylsheets.ts
+++ b/src/lib/schematics/update/material/extra-stylsheets.ts
@@ -1,1 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export const EXTRA_STYLESHEETS_GLOB_KEY = 'MD_EXTRA_STYLESHEETS_GLOB';

--- a/src/lib/schematics/update/material/typescript-specifiers.ts
+++ b/src/lib/schematics/update/material/typescript-specifiers.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 import {getExportDeclaration, getImportDeclaration} from '../typescript/imports';
 
@@ -20,6 +28,6 @@ export function isMaterialExportDeclaration(node: ts.Node) {
 /** Whether the declaration is part of Angular Material. */
 function isMaterialDeclaration(declaration: ts.ImportDeclaration | ts.ExportDeclaration) {
   const moduleSpecifier = declaration.moduleSpecifier.getText();
-  return moduleSpecifier.indexOf(materialModuleSpecifier) !== -1||
+  return moduleSpecifier.indexOf(materialModuleSpecifier) !== -1 ||
       moduleSpecifier.indexOf(cdkModuleSpecifier) !== -1;
 }

--- a/src/lib/schematics/update/rules/checkClassDeclarationMiscRule.ts
+++ b/src/lib/schematics/update/rules/checkClassDeclarationMiscRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
@@ -27,7 +35,7 @@ export class CheckClassDeclarationMiscWalker extends ProgramAwareRuleWalker {
                 `Found class "${bold(declaration.name.text)}" which extends` +
                 ` "${bold('MatFormFieldControl')}". This class must define` +
                 ` "${green('shouldLabelFloat')}" which is now a required property.`
-            )
+            );
           }
         }
       });

--- a/src/lib/schematics/update/rules/checkIdentifierMiscRule.ts
+++ b/src/lib/schematics/update/rules/checkIdentifierMiscRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, red} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/checkImportMiscRule.ts
+++ b/src/lib/schematics/update/rules/checkImportMiscRule.ts
@@ -1,4 +1,12 @@
-import {bold, green, red} from 'chalk';
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {red} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 import {isMaterialImportDeclaration} from '../material/typescript-specifiers';

--- a/src/lib/schematics/update/rules/checkInheritanceRule.ts
+++ b/src/lib/schematics/update/rules/checkInheritanceRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green, red} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/checkMethodCallsRule.ts
+++ b/src/lib/schematics/update/rules/checkMethodCallsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
@@ -26,15 +34,17 @@ export class CheckMethodCallsWalker extends ProgramAwareRuleWalker {
 
   visitCallExpression(expression: ts.CallExpression) {
     if (expression.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
-      const methodName = expression.getFirstToken().getText();
+      const functionName = expression.getFirstToken().getText();
 
-      if (methodName === 'super') {
-        const type = this.getTypeChecker().getTypeAtLocation(expression.expression);
-        const className = type.symbol && type.symbol.name;
-        if (className) {
-          this.checkConstructor(expression, className);
+      if (functionName === 'super') {
+        const superClassType = this.getTypeChecker().getTypeAtLocation(expression.expression);
+        const superClassName = superClassType.symbol && superClassType.symbol.name;
+
+        if (superClassType) {
+          this.checkConstructor(expression, superClassName);
         }
       }
+
       return;
     }
 

--- a/src/lib/schematics/update/rules/checkPropertyAccessMiscRule.ts
+++ b/src/lib/schematics/update/rules/checkPropertyAccessMiscRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green, red} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/checkTemplateMiscRule.ts
+++ b/src/lib/schematics/update/rules/checkTemplateMiscRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green, red} from 'chalk';
 import {RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
@@ -71,7 +79,7 @@ export class CheckTemplateMiscWalker extends ComponentWalker {
             .map(offset => ({
               start: offset,
               end: offset + 'selected'.length,
-              message: `Found deprecated @Input() "${red('selected')}" on`+
+              message: `Found deprecated @Input() "${red('selected')}" on` +
                   ` "${bold('mat-radio-button-group')}". Use "${green('value')}" instead`
             })));
 

--- a/src/lib/schematics/update/rules/switchIdentifiersRule.ts
+++ b/src/lib/schematics/update/rules/switchIdentifiersRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {relative} from 'path';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
@@ -38,7 +46,7 @@ export class SwitchIdentifiersWalker extends ProgramAwareRuleWalker {
 
   /** Method that is called for every identifier inside of the specified project. */
   visitIdentifier(identifier: ts.Identifier) {
-    // Store Angular Material namespace identifers in a list of declarations.
+    // Store Angular Material namespace identifiers in a list of declarations.
     // Namespace identifiers can be: `import * as md from '@angular/material';`
     this._storeNamespaceImports(identifier);
 
@@ -54,7 +62,7 @@ export class SwitchIdentifiersWalker extends ProgramAwareRuleWalker {
     // checks.
     if (!symbol || !symbol.name || symbol.name === 'unknown') {
       console.error(`Could not resolve symbol for identifier "${identifier.text}" ` +
-          `in file ${this._getRelativeFileName()}`);
+        `in file ${this._getRelativeFileName()}`);
       return;
     }
 
@@ -68,12 +76,11 @@ export class SwitchIdentifiersWalker extends ProgramAwareRuleWalker {
     // should be stored so that other identifiers in the file can be compared.
     if (isImportSpecifierNode(identifier) && isMaterialImportDeclaration(identifier)) {
       this.materialDeclarations.push(symbol.valueDeclaration);
-    }
 
     // For identifiers that are not part of an import or export, the list of Material declarations
     // should be checked to ensure that only identifiers of Angular Material are updated.
     // Identifiers that are imported through an Angular Material namespace will be updated.
-    else if (this.materialDeclarations.indexOf(symbol.valueDeclaration) === -1 &&
+    } else if (this.materialDeclarations.indexOf(symbol.valueDeclaration) === -1 &&
               !this._isIdentifierFromNamespace(identifier)) {
       return;
     }

--- a/src/lib/schematics/update/rules/switchPropertyNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchPropertyNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {bold, green, red} from 'chalk';
 import {ProgramAwareRuleWalker, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchStringLiteralAttributeSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchStringLiteralAttributeSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules, RuleWalker} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchStringLiteralCssNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchStringLiteralCssNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules, RuleWalker} from 'tslint';
 import * as ts from 'typescript';
@@ -31,7 +39,7 @@ export class SwitchStringLiteralCssNamesWalker extends RuleWalker {
               stringLiteral,
               `Found deprecated CSS class "${red(name.replace)}" which has been renamed to` +
               ` "${green(name.replaceWith)}"`,
-              replacement)
+              replacement);
         });
       }
     });

--- a/src/lib/schematics/update/rules/switchStringLiteralElementSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchStringLiteralElementSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules, RuleWalker} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchStylesheetAttributeSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchStylesheetAttributeSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {sync as globSync} from 'glob';
 import {IOptions, Replacement, RuleFailure, Rules} from 'tslint';

--- a/src/lib/schematics/update/rules/switchStylesheetCssNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchStylesheetCssNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {sync as globSync} from 'glob';
 import {IOptions, Replacement, RuleFailure, Rules} from 'tslint';

--- a/src/lib/schematics/update/rules/switchStylesheetElementSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchStylesheetElementSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {sync as globSync} from 'glob';
 import {IOptions, Replacement, RuleFailure, Rules} from 'tslint';

--- a/src/lib/schematics/update/rules/switchStylesheetInputNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchStylesheetInputNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {sync as globSync} from 'glob';
 import {IOptions, Replacement, RuleFailure, Rules} from 'tslint';

--- a/src/lib/schematics/update/rules/switchStylesheetOutputNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchStylesheetOutputNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {sync as globSync} from 'glob';
 import {IOptions, Replacement, RuleFailure, Rules} from 'tslint';

--- a/src/lib/schematics/update/rules/switchTemplateAttributeSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateAttributeSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchTemplateCssNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateCssNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchTemplateElementSelectorsRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateElementSelectorsRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchTemplateExportAsNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateExportAsNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
@@ -51,7 +59,7 @@ export class SwitchTemplateExportAsNamesWalker extends ComponentWalker {
               ` renamed to "${green(name.replaceWith)}"`,
               replacement
             });
-          })
+          });
     });
 
     return replacements;

--- a/src/lib/schematics/update/rules/switchTemplateInputNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateInputNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/rules/switchTemplateOutputNamesRule.ts
+++ b/src/lib/schematics/update/rules/switchTemplateOutputNamesRule.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {green, red} from 'chalk';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';

--- a/src/lib/schematics/update/tslint/component-file.ts
+++ b/src/lib/schematics/update/tslint/component-file.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 export type ExternalResource = ts.SourceFile;

--- a/src/lib/schematics/update/tslint/component-walker.ts
+++ b/src/lib/schematics/update/tslint/component-walker.ts
@@ -1,12 +1,20 @@
 /**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
  * TSLint custom walker implementation that also visits external and inline templates.
  */
-import {existsSync, readFileSync} from 'fs'
+import {existsSync, readFileSync} from 'fs';
 import {dirname, join, resolve} from 'path';
 import {Fix, IOptions, RuleFailure, RuleWalker} from 'tslint';
 import * as ts from 'typescript';
 import {getLiteralTextWithoutQuotes} from '../typescript/literal';
-import {createComponentFile, ExternalResource} from "./component-file";
+import {createComponentFile, ExternalResource} from './component-file';
 
 /**
  * Custom TSLint rule walker that identifies Angular components and visits specific parts of
@@ -14,11 +22,11 @@ import {createComponentFile, ExternalResource} from "./component-file";
  */
 export class ComponentWalker extends RuleWalker {
 
-  protected visitInlineTemplate(template: ts.StringLiteral) {}
-  protected visitInlineStylesheet(stylesheet: ts.StringLiteral) {}
+  protected visitInlineTemplate(_template: ts.StringLiteral) {}
+  protected visitInlineStylesheet(_stylesheet: ts.StringLiteral) {}
 
-  protected visitExternalTemplate(template: ExternalResource) {}
-  protected visitExternalStylesheet(stylesheet: ExternalResource) {}
+  protected visitExternalTemplate(_template: ExternalResource) {}
+  protected visitExternalStylesheet(_stylesheet: ExternalResource) {}
 
   private skipFiles: Set<string>;
 
@@ -52,7 +60,7 @@ export class ComponentWalker extends RuleWalker {
       const initializerKind = property.initializer.kind;
 
       if (propertyName === 'template') {
-        this.visitInlineTemplate(property.initializer as ts.StringLiteral)
+        this.visitInlineTemplate(property.initializer as ts.StringLiteral);
       }
 
       if (propertyName === 'templateUrl' && initializerKind === ts.SyntaxKind.StringLiteral) {
@@ -63,7 +71,8 @@ export class ComponentWalker extends RuleWalker {
         this._reportInlineStyles(property.initializer as ts.ArrayLiteralExpression);
       }
 
-      if (propertyName === 'styleUrls' && initializerKind === ts.SyntaxKind.ArrayLiteralExpression) {
+      if (propertyName === 'styleUrls' &&
+          initializerKind === ts.SyntaxKind.ArrayLiteralExpression) {
         this._visitExternalStylesArrayLiteral(property.initializer as ts.ArrayLiteralExpression);
       }
     }
@@ -83,7 +92,7 @@ export class ComponentWalker extends RuleWalker {
       if (!this.skipFiles.has(stylePath)) {
         this._reportExternalStyle(stylePath);
       }
-    })
+    });
   }
 
   private _reportExternalTemplate(templateUrlLiteral: ts.StringLiteral) {
@@ -107,7 +116,7 @@ export class ComponentWalker extends RuleWalker {
     this.visitExternalTemplate(templateFile);
   }
 
-  public _reportExternalStyle(stylePath: string) {
+  _reportExternalStyle(stylePath: string) {
     // Check if the external stylesheet file exists before proceeding.
     if (!existsSync(stylePath)) {
       console.error(`PARSE ERROR: ${this.getSourceFile().fileName}:` +

--- a/src/lib/schematics/update/tslint/find-tslint-binary.ts
+++ b/src/lib/schematics/update/tslint/find-tslint-binary.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {resolve} from 'path';
 import {existsSync} from 'fs';
 

--- a/src/lib/schematics/update/typescript/identifiers.ts
+++ b/src/lib/schematics/update/typescript/identifiers.ts
@@ -1,9 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 /** Returns the original symbol from an node. */
 export function getOriginalSymbolFromNode(node: ts.Node, checker: ts.TypeChecker) {
   const baseSymbol = checker.getSymbolAtLocation(node);
 
+  // tslint:disable-next-line:no-bitwise
   if (baseSymbol && baseSymbol.flags & ts.SymbolFlags.Alias) {
     return checker.getAliasedSymbol(baseSymbol);
   }

--- a/src/lib/schematics/update/typescript/imports.ts
+++ b/src/lib/schematics/update/typescript/imports.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 /** Checks whether the given node is part of an import specifier node. */

--- a/src/lib/schematics/update/typescript/literal.ts
+++ b/src/lib/schematics/update/typescript/literal.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 
 /** Returns the text of a string literal without the quotes. */
@@ -7,7 +15,7 @@ export function getLiteralTextWithoutQuotes(literal: ts.StringLiteral) {
 
 /** Method that can be used to replace all search occurrences in a string. */
 export function findAll(str: string, search: string): number[] {
-  const result = [];
+  const result: number[] = [];
   let i = -1;
   while ((i = str.indexOf(search, i + 1)) !== -1) {
     result.push(i);
@@ -42,8 +50,9 @@ export function findAllOutputsInElWithAttr(html: string, name: string, attrs: st
   return findAllIoInElWithAttr(html, name, attrs, String.raw`\(`, String.raw`\)`);
 }
 
-function findAllIoInElWithTag(html:string, name: string, tagNames: string[], startIoPattern: string,
-                              endIoPattern: string): number[] {
+function findAllIoInElWithTag(html: string, name: string, tagNames: string[],
+                              startIoPattern: string, endIoPattern: string): number[] {
+
   const skipPattern = String.raw`[^>]*\s`;
   const openTagPattern = String.raw`<\s*`;
   const tagNamesPattern = String.raw`(?:${tagNames.join('|')})`;
@@ -52,11 +61,13 @@ function findAllIoInElWithTag(html:string, name: string, tagNames: string[], sta
       ${name}
       ${endIoPattern}[=\s>]`;
   const replaceIoRegex = new RegExp(replaceIoPattern.replace(/\s/g, ''), 'g');
-  const result = [];
+  const result: number[] = [];
+
   let match;
   while (match = replaceIoRegex.exec(html)) {
     result.push(match.index + match[1].length);
   }
+
   return result;
 }
 

--- a/src/lib/schematics/update/update.spec.ts
+++ b/src/lib/schematics/update/update.spec.ts
@@ -1,8 +1,6 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {join} from 'path';
-import {Tree} from '@angular-devkit/schematics';
 import {createTestApp} from '../utils/testing';
-import {getFileContent} from '@schematics/angular/utility/test';
 
 const collectionPath = join(__dirname, '../collection.json');
 

--- a/src/lib/schematics/update/update.ts
+++ b/src/lib/schematics/update/update.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {FileEntry, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {
   NodePackageInstallTask,
@@ -39,31 +47,31 @@ export default function(): Rule {
         rulesDirectory: path.join(schematicsTmpPath, 'update/rules'),
         rules: {
           // Automatic fixes.
-          "switch-identifiers": true,
-          "switch-property-names": true,
-          "switch-string-literal-attribute-selectors": true,
-          "switch-string-literal-css-names": true,
-          "switch-string-literal-element-selectors": true,
-          "switch-stylesheet-attribute-selectors": true,
-          "switch-stylesheet-css-names": true,
-          "switch-stylesheet-element-selectors": true,
-          "switch-stylesheet-input-names": true,
-          "switch-stylesheet-output-names": true,
-          "switch-template-attribute-selectors": true,
-          "switch-template-css-names": true,
-          "switch-template-element-selectors": true,
-          "switch-template-export-as-names": true,
-          "switch-template-input-names": true,
-          "switch-template-output-names": true,
+          'switch-identifiers': true,
+          'switch-property-names': true,
+          'switch-string-literal-attribute-selectors': true,
+          'switch-string-literal-css-names': true,
+          'switch-string-literal-element-selectors': true,
+          'switch-stylesheet-attribute-selectors': true,
+          'switch-stylesheet-css-names': true,
+          'switch-stylesheet-element-selectors': true,
+          'switch-stylesheet-input-names': true,
+          'switch-stylesheet-output-names': true,
+          'switch-template-attribute-selectors': true,
+          'switch-template-css-names': true,
+          'switch-template-element-selectors': true,
+          'switch-template-export-as-names': true,
+          'switch-template-input-names': true,
+          'switch-template-output-names': true,
 
           // Additional issues we can detect but not automatically fix.
-          "check-class-declaration-misc": true,
-          "check-identifier-misc": true,
-          "check-import-misc": true,
-          "check-inheritance": true,
-          "check-method-calls": true,
-          "check-property-access-misc": true,
-          "check-template-misc": true
+          'check-class-declaration-misc': true,
+          'check-identifier-misc': true,
+          'check-import-misc': true,
+          'check-inheritance': true,
+          'check-method-calls': true,
+          'check-property-access-misc': true,
+          'check-template-misc': true
         }
       }, {
         silent: false,

--- a/src/lib/schematics/utils/ast.ts
+++ b/src/lib/schematics/utils/ast.ts
@@ -1,11 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {normalize} from '@angular-devkit/core';
 import {SchematicsException, Tree} from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 import {addImportToModule} from './devkit-utils/ast-utils';
 import {InsertChange} from './devkit-utils/change';
 import {Project, getWorkspace} from './devkit-utils/config';
-import {findBootstrapModulePath, getAppModulePath} from './devkit-utils/ng-ast-utils';
-import {ModuleOptions, findModuleFromOptions as internalFindModule} from './devkit-utils/find-module';
+import {getAppModulePath} from './devkit-utils/ng-ast-utils';
+import {findModuleFromOptions as internalFindModule} from './devkit-utils/find-module';
 
 
 /** Reads file given path and returns TypeScript source file. */
@@ -19,7 +27,9 @@ export function getSourceFile(host: Tree, path: string): ts.SourceFile {
 }
 
 /** Import and add module to root app module. */
-export function addModuleImportToRootModule(host: Tree, moduleName: string, src: string, project: Project) {
+export function addModuleImportToRootModule(host: Tree, moduleName: string, src: string,
+                                            project: Project) {
+
   const modulePath = getAppModulePath(host, project.architect.build.options.main);
   addModuleImportToModule(host, modulePath, moduleName, src);
 }
@@ -52,7 +62,7 @@ export function addModuleImportToModule(
 }
 
 /** Gets the app index.html file */
-export function getIndexHtmlPath(host: Tree, project: Project): string {
+export function getIndexHtmlPath(project: Project): string {
   const buildTarget = project.architect.build.options;
 
   if (buildTarget.index && buildTarget.index.endsWith('index.html')) {
@@ -63,7 +73,7 @@ export function getIndexHtmlPath(host: Tree, project: Project): string {
 }
 
 /** Get the root stylesheet file. */
-export function getStylesPath(host: Tree, project: Project): string {
+export function getStylesPath(project: Project): string {
   const buildTarget = project.architect['build'];
 
   if (buildTarget.options && buildTarget.options.styles && buildTarget.options.styles.length) {

--- a/src/lib/schematics/utils/devkit-utils/ast-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/ast-utils.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 import { Change, InsertChange } from './change';
 import { insertImport } from './route-utils';

--- a/src/lib/schematics/utils/devkit-utils/ast-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/ast-utils.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import * as ts from 'typescript';
 import { Change, InsertChange } from './change';
 import { insertImport } from './route-utils';

--- a/src/lib/schematics/utils/devkit-utils/change.ts
+++ b/src/lib/schematics/utils/devkit-utils/change.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 export interface Host {
   write(path: string, content: string): Promise<void>;
   read(path: string): Promise<string>;

--- a/src/lib/schematics/utils/devkit-utils/change.ts
+++ b/src/lib/schematics/utils/devkit-utils/change.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export interface Host {
   write(path: string, content: string): Promise<void>;
   read(path: string): Promise<string>;

--- a/src/lib/schematics/utils/devkit-utils/component.ts
+++ b/src/lib/schematics/utils/devkit-utils/component.ts
@@ -1,4 +1,6 @@
-import {normalize, strings} from '@angular-devkit/core';
+/* tslint:disable */
+
+import {strings} from '@angular-devkit/core';
 import {
   apply,
   branchAndMerge,

--- a/src/lib/schematics/utils/devkit-utils/component.ts
+++ b/src/lib/schematics/utils/devkit-utils/component.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {strings} from '@angular-devkit/core';
 import {
   apply,

--- a/src/lib/schematics/utils/devkit-utils/config.ts
+++ b/src/lib/schematics/utils/devkit-utils/config.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {SchematicsException, Tree} from '@angular-devkit/schematics';
 
 export const ANGULAR_CLI_WORKSPACE_PATH = '/angular.json';

--- a/src/lib/schematics/utils/devkit-utils/config.ts
+++ b/src/lib/schematics/utils/devkit-utils/config.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import {SchematicsException, Tree} from '@angular-devkit/schematics';
 
 export const ANGULAR_CLI_WORKSPACE_PATH = '/angular.json';

--- a/src/lib/schematics/utils/devkit-utils/find-module.ts
+++ b/src/lib/schematics/utils/devkit-utils/find-module.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import { Path, join, normalize, relative, strings } from '@angular-devkit/core';
 import { DirEntry, Tree } from '@angular-devkit/schematics';
 

--- a/src/lib/schematics/utils/devkit-utils/find-module.ts
+++ b/src/lib/schematics/utils/devkit-utils/find-module.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import { Path, join, normalize, relative, strings } from '@angular-devkit/core';
 import { DirEntry, Tree } from '@angular-devkit/schematics';
 

--- a/src/lib/schematics/utils/devkit-utils/ng-ast-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/ng-ast-utils.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import { normalize } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { dirname } from 'path';

--- a/src/lib/schematics/utils/devkit-utils/ng-ast-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/ng-ast-utils.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import { normalize } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { dirname } from 'path';

--- a/src/lib/schematics/utils/devkit-utils/parse-name.ts
+++ b/src/lib/schematics/utils/devkit-utils/parse-name.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import { Path, basename, dirname, normalize } from '@angular-devkit/core';
 
 export interface Location {

--- a/src/lib/schematics/utils/devkit-utils/parse-name.ts
+++ b/src/lib/schematics/utils/devkit-utils/parse-name.ts
@@ -1,11 +1,5 @@
+/* tslint:disable */
 
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 import { Path, basename, dirname, normalize } from '@angular-devkit/core';
 
 export interface Location {

--- a/src/lib/schematics/utils/devkit-utils/route-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/route-utils.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import * as ts from 'typescript';
 import { findNodes, insertAfterLastOccurrence } from './ast-utils';
 import { Change, NoopChange } from './change';

--- a/src/lib/schematics/utils/devkit-utils/route-utils.ts
+++ b/src/lib/schematics/utils/devkit-utils/route-utils.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import * as ts from 'typescript';
 import { findNodes, insertAfterLastOccurrence } from './ast-utils';
 import { Change, NoopChange } from './change';

--- a/src/lib/schematics/utils/devkit-utils/validation.ts
+++ b/src/lib/schematics/utils/devkit-utils/validation.ts
@@ -1,10 +1,5 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
+/* tslint:disable */
+
 import { tags } from '@angular-devkit/core';
 import { SchematicsException } from '@angular-devkit/schematics';
 

--- a/src/lib/schematics/utils/devkit-utils/validation.ts
+++ b/src/lib/schematics/utils/devkit-utils/validation.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import { tags } from '@angular-devkit/core';
 import { SchematicsException } from '@angular-devkit/schematics';
 

--- a/src/lib/schematics/utils/html.ts
+++ b/src/lib/schematics/utils/html.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Tree, SchematicsException} from '@angular-devkit/schematics';
 import * as parse5 from 'parse5';
 import {getIndexHtmlPath} from './ast';
@@ -6,10 +14,9 @@ import {Project} from './devkit-utils/config';
 
 /**
  * Parses the index.html file to get the HEAD tag position.
- * @param host the tree we are traversing
  * @param src the src path of the html file to parse
  */
-export function getHeadTag(host: Tree, src: string) {
+export function getHeadTag(src: string) {
   const document = parse5.parse(src,
     {sourceCodeLocationInfo: true}) as parse5.AST.Default.Document;
 
@@ -46,7 +53,7 @@ export function getHeadTag(host: Tree, src: string) {
  * @param link html element string we are inserting.
  */
 export function addHeadLink(host: Tree, project: Project, link: string) {
-  const indexPath = getIndexHtmlPath(host, project);
+  const indexPath = getIndexHtmlPath(project);
   const buffer = host.read(indexPath);
   if (!buffer) {
     throw new SchematicsException(`Could not find file for path: ${indexPath}`);
@@ -54,7 +61,7 @@ export function addHeadLink(host: Tree, project: Project, link: string) {
 
   const src = buffer.toString();
   if (src.indexOf(link) === -1) {
-    const node = getHeadTag(host, src);
+    const node = getHeadTag(src);
     const insertion = new InsertChange(indexPath, node.position, link);
     const recorder = host.beginUpdate(indexPath);
     recorder.insertLeft(insertion.pos, insertion.toAdd);

--- a/src/lib/schematics/utils/lib-versions.ts
+++ b/src/lib/schematics/utils/lib-versions.ts
@@ -1,2 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export const materialVersion = '^6.2.0';
 export const angularVersion = '^6.0.0';

--- a/src/lib/schematics/utils/package.ts
+++ b/src/lib/schematics/utils/package.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Tree} from '@angular-devkit/schematics';
 
 /**

--- a/src/lib/schematics/utils/testing.ts
+++ b/src/lib/schematics/utils/testing.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {join} from 'path';
 import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
 

--- a/tslint.json
+++ b/tslint.json
@@ -124,12 +124,13 @@
     "missing-rollup-globals": [
       true,
       "./tools/package-tools/rollup-globals.ts",
-      "src/+(lib|cdk|material-examples|material-experimental|cdk-experimental)/**/*.ts"
+      "src/+(lib|cdk|material-examples|material-experimental|cdk-experimental)/!(schematics)**/*.ts"
     ],
     "deletion-target": true,
     "no-unescaped-html-tag": true
   },
   "linterOptions": {
-    "exclude": ["src/lib/schematics/**/*"]
+    // Exclude schematic template files that can't be linted.
+    "exclude": ["src/lib/schematics/**/files/**/*"]
   }
 }


### PR DESCRIPTION
* Add licenses to all source files for the schematics & update-tool
* Enables linting for schematics folder (except template files; and utils taken verbatim from devkit)
* Fixes wrong file extension for tests inside of schematics
* Fixes IDE warnings in schematics folder (related: https://youtrack.jetbrains.com/issue/WEB-33060)