### PR TITLE
Integrated material datepicker and datepicker inputs with CDK datepicker and datepicker inputs

### DIFF
--- a/src/cdk/datetime/datepicker-input.ts
+++ b/src/cdk/datetime/datepicker-input.ts
@@ -174,10 +174,12 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   private _disabled: boolean;
 
   /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() readonly dateChange = new EventEmitter<DatepickerInputEvent<D>>();
+  @Output() readonly dateChange: EventEmitter<DatepickerInputEvent<D>> =
+      new EventEmitter<DatepickerInputEvent<D>>();
 
   /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() readonly dateInput = new EventEmitter<DatepickerInputEvent<D>>();
+  @Output() readonly dateInput: EventEmitter<DatepickerInputEvent<D>>  =
+      new EventEmitter<DatepickerInputEvent<D>>();
 
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D | null>();
@@ -203,7 +205,8 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
     return this._lastValueValid ?
-        null : {[`${this._formControlValidatorPrefix}DatepickerParse`]: {'text': this._elementRef.nativeElement.value}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerParse`]:
+            {'text': this._elementRef.nativeElement.value}};
   }
 
   /** The form control validator for the min date. */
@@ -211,7 +214,8 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.min || !controlValue ||
         this._dateAdapter.compareDate(this.min, controlValue) <= 0) ?
-        null : {[`${this._formControlValidatorPrefix}DatepickerMin`]: {'min': this.min, 'actual': controlValue}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerMin`]:
+            {'min': this.min, 'actual': controlValue}};
   }
 
   /** The form control validator for the max date. */
@@ -219,7 +223,8 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.max || !controlValue ||
         this._dateAdapter.compareDate(this.max, controlValue) >= 0) ?
-        null : {[`${this._formControlValidatorPrefix}DatepickerMax`]: {'max': this.max, 'actual': controlValue}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerMax`]:
+            {'max': this.max, 'actual': controlValue}};
   }
 
   /** The form control validator for the date filter. */

--- a/src/cdk/datetime/datepicker-input.ts
+++ b/src/cdk/datetime/datepicker-input.ts
@@ -198,12 +198,12 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   private readonly _subscriptions = new Subscription();
 
   /** Prefix for form control validator properties. */
-  protected _prefix = 'cdk';
+  protected _formControlValidatorPrefix = 'cdk';
 
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
     return this._lastValueValid ?
-        null : {[`${this._prefix}DatepickerParse`]: {'text': this._elementRef.nativeElement.value}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerParse`]: {'text': this._elementRef.nativeElement.value}};
   }
 
   /** The form control validator for the min date. */
@@ -211,7 +211,7 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.min || !controlValue ||
         this._dateAdapter.compareDate(this.min, controlValue) <= 0) ?
-        null : {[`${this._prefix}DatepickerMin`]: {'min': this.min, 'actual': controlValue}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerMin`]: {'min': this.min, 'actual': controlValue}};
   }
 
   /** The form control validator for the max date. */
@@ -219,14 +219,14 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.max || !controlValue ||
         this._dateAdapter.compareDate(this.max, controlValue) >= 0) ?
-        null : {[`${this._prefix}DatepickerMax`]: {'max': this.max, 'actual': controlValue}};
+        null : {[`${this._formControlValidatorPrefix}DatepickerMax`]: {'max': this.max, 'actual': controlValue}};
   }
 
   /** The form control validator for the date filter. */
   private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
-        null : {[`${this._prefix}DatepickerFilter`]: true};
+        null : {[`${this._formControlValidatorPrefix}DatepickerFilter`]: true};
   }
 
   /** The combined form control validator for this input. */

--- a/src/cdk/datetime/datepicker-input.ts
+++ b/src/cdk/datetime/datepicker-input.ts
@@ -38,7 +38,7 @@ import {CDK_DATE_FORMATS, CdkDateFormats} from './date-formats';
 /**
  * Provider that allows the datepicker to register as a ControlValueAccessor.
  */
-export const DATEPICKER_VALUE_ACCESSOR: any = {
+const DATEPICKER_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => CdkDatepickerInput),
   multi: true
@@ -48,7 +48,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
 /**
  * Provider that allows the datepicker to register as a ControlValueAccessor.
  */
-export const DATEPICKER_VALIDATORS: any = {
+const DATEPICKER_VALIDATORS: any = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => CdkDatepickerInput),
   multi: true
@@ -174,10 +174,10 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   private _disabled: boolean;
 
   /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() readonly dateChange: EventEmitter<DatepickerInputEvent<D>>;
+  @Output() readonly dateChange = new EventEmitter<DatepickerInputEvent<D>>();
 
   /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() readonly dateInput: EventEmitter<DatepickerInputEvent<D>>;
+  @Output() readonly dateInput = new EventEmitter<DatepickerInputEvent<D>>();
 
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D | null>();
@@ -197,10 +197,13 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   /** Implemented for datepicker CDK and locale subscriptions. */
   private readonly _subscriptions = new Subscription();
 
+  /** Prefix for form control validator properties. */
+  protected _prefix = 'cdk';
+
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
     return this._lastValueValid ?
-        null : {'cdkDatepickerParse': {'text': this._elementRef.nativeElement.value}};
+        null : {[`${this._prefix}DatepickerParse`]: {'text': this._elementRef.nativeElement.value}};
   }
 
   /** The form control validator for the min date. */
@@ -208,7 +211,7 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.min || !controlValue ||
         this._dateAdapter.compareDate(this.min, controlValue) <= 0) ?
-        null : {'cdkDatepickerMin': {'min': this.min, 'actual': controlValue}};
+        null : {[`${this._prefix}DatepickerMin`]: {'min': this.min, 'actual': controlValue}};
   }
 
   /** The form control validator for the max date. */
@@ -216,14 +219,14 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return (!this.max || !controlValue ||
         this._dateAdapter.compareDate(this.max, controlValue) >= 0) ?
-        null : {'cdkDatepickerMax': {'max': this.max, 'actual': controlValue}};
+        null : {[`${this._prefix}DatepickerMax`]: {'max': this.max, 'actual': controlValue}};
   }
 
   /** The form control validator for the date filter. */
   private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
     const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
     return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
-        null : {'cdkDatepickerFilter': true};
+        null : {[`${this._prefix}DatepickerFilter`]: true};
   }
 
   /** The combined form control validator for this input. */
@@ -237,7 +240,7 @@ export class CdkDatepickerInput<D> implements AfterContentInit, ControlValueAcce
   constructor(
       protected _elementRef: ElementRef,
       @Optional() public _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(CDK_DATE_FORMATS) private _dateFormats: CdkDateFormats) {
+      @Optional() @Inject(CDK_DATE_FORMATS) protected _dateFormats: CdkDateFormats) {
     if (!this._dateAdapter) {
       throw Error('CdkDatepicker: No provider found for DateAdapter.');
     }

--- a/src/cdk/datetime/public-api.ts
+++ b/src/cdk/datetime/public-api.ts
@@ -11,5 +11,7 @@ export * from './datetime-module';
 export * from './native-date-adapter';
 export * from './calendar-view';
 export * from './datepicker-module';
+export * from './datepicker';
+export * from './datepicker-input';
 export * from './date-formats';
 export * from './native-date-formats';

--- a/src/demo-app/datepicker/datepicker-demo.ts
+++ b/src/demo-app/datepicker/datepicker-demo.ts
@@ -17,7 +17,7 @@ import {
 import {FormControl} from '@angular/forms';
 import {MatCalendar} from '@angular/material';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
-import {MatDatepickerInputEvent} from '@angular/material/datepicker';
+import {DatepickerInputEvent} from '@angular/cdk/datetime';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -48,8 +48,8 @@ export class DatepickerDemo {
   dateFilter =
       (date: Date) => !(date.getFullYear() % 2) && (date.getMonth() % 2) && !(date.getDate() % 2)
 
-  onDateInput = (e: MatDatepickerInputEvent<Date>) => this.lastDateInput = e.value;
-  onDateChange = (e: MatDatepickerInputEvent<Date>) => this.lastDateChange = e.value;
+  onDateInput = (e: DatepickerInputEvent<Date>) => this.lastDateInput = e.value;
+  onDateChange = (e: DatepickerInputEvent<Date>) => this.lastDateChange = e.value;
 
   // pass custom header component type as input
   customHeader = CustomHeader;

--- a/src/lib/core/datetime/date-formats.ts
+++ b/src/lib/core/datetime/date-formats.ts
@@ -10,7 +10,19 @@ import {InjectionToken} from '@angular/core';
 
 
 export type MatDateFormats = {
+  /**
+   * @deprecated Remove `parse` and use `CdkDateFormats` instead.
+   * @deletion-target 8.0.0
+   */
+  parse: {
+    dateInput: any,
+  },
   display: {
+    /**
+     * @deprecated Remove `dateInput` and use `CdkDateFormats` instead.
+     * @deletion-target 8.0.0
+     */
+    dateInput: any,
     monthYearLabel: any,
     dateA11yLabel: any,
     monthYearA11yLabel: any,

--- a/src/lib/core/datetime/date-formats.ts
+++ b/src/lib/core/datetime/date-formats.ts
@@ -7,10 +7,9 @@
  */
 
 import {InjectionToken} from '@angular/core';
-import {CdkDateFormats} from '@angular/cdk/datetime';
 
 
-export type MatDateFormats = CdkDateFormats & {
+export type MatDateFormats = {
   display: {
     monthYearLabel: any,
     dateA11yLabel: any,

--- a/src/lib/core/datetime/datetime-module.ts
+++ b/src/lib/core/datetime/datetime-module.ts
@@ -9,13 +9,13 @@
 import {NgModule} from '@angular/core';
 import {MAT_DATE_FORMATS} from './date-formats';
 import {MAT_NATIVE_DATE_FORMATS} from './native-date-formats';
-import {NativeDateModule, CDK_DATE_FORMATS} from '@angular/cdk/datetime';
+import {NativeDateModule, CDK_DATE_FORMATS, CDK_NATIVE_DATE_FORMATS} from '@angular/cdk/datetime';
 
 @NgModule({
   imports: [NativeDateModule],
   providers: [
     {provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS},
-    {provide: CDK_DATE_FORMATS, useValue: undefined},
+    {provide: CDK_DATE_FORMATS, useValue: CDK_NATIVE_DATE_FORMATS},
   ],
 })
 export class MatNativeDateModule {}

--- a/src/lib/core/datetime/datetime-module.ts
+++ b/src/lib/core/datetime/datetime-module.ts
@@ -9,10 +9,13 @@
 import {NgModule} from '@angular/core';
 import {MAT_DATE_FORMATS} from './date-formats';
 import {MAT_NATIVE_DATE_FORMATS} from './native-date-formats';
-import {NativeDateModule} from '@angular/cdk/datetime';
+import {NativeDateModule, CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
 @NgModule({
   imports: [NativeDateModule],
-  providers: [{provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS}],
+  providers: [
+    {provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: undefined},
+  ],
 })
 export class MatNativeDateModule {}

--- a/src/lib/core/datetime/native-date-formats.ts
+++ b/src/lib/core/datetime/native-date-formats.ts
@@ -10,7 +10,19 @@ import {MatDateFormats} from './date-formats';
 
 
 export const MAT_NATIVE_DATE_FORMATS: MatDateFormats = {
+  /**
+   * @deprecated Removing `parse` and use `CDK_NATIVE_DATE_FORMATS` instead.
+   * @deletion-target 8.0.0
+   */
+  parse: {
+    dateInput: null,
+  },
   display: {
+    /**
+     * @deprecated Removing `dateInput` and use `CDK_NATIVE_DATE_FORMATS` instead.
+     * @deletion-target 8.0.0
+     */
+    dateInput: {year: 'numeric', month: 'numeric', day: 'numeric'},
     monthYearLabel: {year: 'numeric', month: 'short'},
     dateA11yLabel: {year: 'numeric', month: 'long', day: 'numeric'},
     monthYearA11yLabel: {year: 'numeric', month: 'long'},

--- a/src/lib/core/datetime/native-date-formats.ts
+++ b/src/lib/core/datetime/native-date-formats.ts
@@ -10,11 +10,7 @@ import {MatDateFormats} from './date-formats';
 
 
 export const MAT_NATIVE_DATE_FORMATS: MatDateFormats = {
-  parse: {
-    dateInput: null,
-  },
   display: {
-    dateInput: {year: 'numeric', month: 'numeric', day: 'numeric'},
     monthYearLabel: {year: 'numeric', month: 'short'},
     dateA11yLabel: {year: 'numeric', month: 'long', day: 'numeric'},
     monthYearA11yLabel: {year: 'numeric', month: 'long'},

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -23,6 +23,10 @@ import {
   NG_VALUE_ACCESSOR,
   Validator,
 } from '@angular/forms';
+import {
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+} from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
 import {MatDatepicker} from './datepicker';
@@ -122,9 +126,14 @@ export class MatDatepickerInput<D> extends CdkDatepickerInput<D> implements Afte
   constructor(
       _elementRef: ElementRef,
       @Optional() _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(CDK_DATE_FORMATS) _dateFormats: CdkDateFormats,
+      @Optional() @Inject(CDK_DATE_FORMATS) _cdkDateFormats: CdkDateFormats,
+      /**
+       * @deprecated Removing `MAT_DATE_FORMATS`.
+       * @deletion-target 8.0.0
+       */
+      @Optional() @Inject(MAT_DATE_FORMATS) _matDateFormats: MatDateFormats,
       @Optional() private _formField: MatFormField) {
-    super(_elementRef, _dateAdapter, _dateFormats);
+    super(_elementRef, _dateAdapter, _cdkDateFormats || _matDateFormats);
   }
 
   /**

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -86,8 +86,7 @@ export class MatDatepickerInputEvent<D> {
     MAT_DATEPICKER_VALIDATORS,
     {provide: MAT_INPUT_VALUE_ACCESSOR, useExisting: MatDatepickerInput},
   ],
-  inputs: ['value', 'min', 'max', 'disabled', 'matDatepickerFilter: cdkDatepickerFilter',
-      'matDatepicker: cdkDatepicker'],
+  inputs: ['value', 'min', 'max', 'disabled'],
   outputs: ['dateChange', 'dateInput'],
   host: {
     '[attr.aria-haspopup]': 'true',

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -35,8 +35,8 @@ import {
 
 
 /**
- * @deprecated
- * @deletion-target 8.0.0 Removing export.
+ * @deprecated Removing export.
+ * @deletion-target 8.0.0
  */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -46,8 +46,8 @@ export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
 
 
 /**
- * @deprecated
- * @deletion-target 8.0.0 Removing export.
+ * @deprecated Removing export.
+ * @deletion-target 8.0.0
  */
 export const MAT_DATEPICKER_VALIDATORS: any = {
   provide: NG_VALIDATORS,
@@ -57,8 +57,8 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
 
 
 /**
- * @deprecated
- * @deletion-target 8.0.0 Use `DatepickerInputEvent<D>` instead.
+ * @deprecated Use `DatepickerInputEvent<D>` instead.
+ * @deletion-target 8.0.0
  *
  * An event used for datepicker input and change events. We don't always have access to a native
  * input or change event because the event may have been triggered by the user clicking on the
@@ -128,8 +128,8 @@ export class MatDatepickerInput<D> extends CdkDatepickerInput<D> implements Afte
   }
 
   /**
-   * @deprecated
-   * @deletion-target 7.0.0 Use `getConnectedOverlayOrigin` instead
+   * @deprecated Use `getConnectedOverlayOrigin` instead.
+   * @deletion-target 7.0.0
    */
   getPopupConnectionElementRef(): ElementRef {
     return this.getConnectedOverlayOrigin();

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -6,38 +6,38 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {DOWN_ARROW} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
   Directive,
   ElementRef,
-  EventEmitter,
   forwardRef,
   Inject,
   Input,
   OnDestroy,
   Optional,
-  Output,
 } from '@angular/core';
 import {
-  AbstractControl,
   ControlValueAccessor,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
-  ValidationErrors,
   Validator,
-  ValidatorFn,
-  Validators
 } from '@angular/forms';
-import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
-import {Subscription} from 'rxjs';
 import {MatDatepicker} from './datepicker';
-import {createMissingDateImplError} from './datepicker-errors';
+import {
+  CDK_DATE_FORMATS,
+  CdkDatepickerInput,
+  CdkDateFormats,
+  DateAdapter,
+} from '@angular/cdk/datetime';
 
 
+/**
+ * @deprecated
+ * @deletion-target 8.0.0 Removing export.
+ */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => MatDatepickerInput),
@@ -45,6 +45,10 @@ export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
 };
 
 
+/**
+ * @deprecated
+ * @deletion-target 8.0.0 Removing export.
+ */
 export const MAT_DATEPICKER_VALIDATORS: any = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => MatDatepickerInput),
@@ -53,6 +57,9 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
 
 
 /**
+ * @deprecated
+ * @deletion-target 8.0.0 Use `DatepickerInputEvent<D>` instead.
+ *
  * An event used for datepicker input and change events. We don't always have access to a native
  * input or change event because the event may have been triggered by the user clicking on the
  * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
@@ -79,6 +86,8 @@ export class MatDatepickerInputEvent<D> {
     MAT_DATEPICKER_VALIDATORS,
     {provide: MAT_INPUT_VALUE_ACCESSOR, useExisting: MatDatepickerInput},
   ],
+  inputs: ['value', 'min', 'max', 'disabled', 'cdkDatepickerFilter', 'cdkDatepicker'],
+  outputs: ['dateChange', 'dateInput'],
   host: {
     '[attr.aria-haspopup]': 'true',
     '[attr.aria-owns]': '(_datepicker?.opened && _datepicker.id) || null',
@@ -92,193 +101,30 @@ export class MatDatepickerInputEvent<D> {
   },
   exportAs: 'matDatepickerInput',
 })
-export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAccessor, OnDestroy,
-    Validator {
+export class MatDatepickerInput<D> extends CdkDatepickerInput<D> implements AfterContentInit,
+    ControlValueAccessor, OnDestroy, Validator {
+  /** Prefix for form control validator properties. */
+  protected _prefix = 'mat';
+
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(value: MatDatepicker<D>) {
-    this.registerDatepicker(value);
+    this.datepicker = value;
   }
   _datepicker: MatDatepicker<D>;
-
-  private registerDatepicker(value: MatDatepicker<D>) {
-    if (value) {
-      this._datepicker = value;
-      this._datepicker._registerInput(this);
-    }
-  }
 
   /** Function that can be used to filter out dates within the datepicker. */
   @Input()
   set matDatepickerFilter(value: (date: D | null) => boolean) {
-    this._dateFilter = value;
-    this._validatorOnChange();
+    this.filter = value;
   }
-  _dateFilter: (date: D | null) => boolean;
-
-  /** The value of the input. */
-  @Input()
-  get value(): D | null { return this._value; }
-  set value(value: D | null) {
-    value = this._dateAdapter.deserialize(value);
-    this._lastValueValid = !value || this._dateAdapter.isValid(value);
-    value = this._getValidDateOrNull(value);
-    const oldDate = this.value;
-    this._value = value;
-    this._formatValue(value);
-
-    if (!this._dateAdapter.sameDate(oldDate, value)) {
-      this._valueChange.emit(value);
-    }
-  }
-  private _value: D | null;
-
-  /** The minimum valid date. */
-  @Input()
-  get min(): D | null { return this._min; }
-  set min(value: D | null) {
-    this._min = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._validatorOnChange();
-  }
-  private _min: D | null;
-
-  /** The maximum valid date. */
-  @Input()
-  get max(): D | null { return this._max; }
-  set max(value: D | null) {
-    this._max = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._validatorOnChange();
-  }
-  private _max: D | null;
-
-  /** Whether the datepicker-input is disabled. */
-  @Input()
-  get disabled(): boolean { return !!this._disabled; }
-  set disabled(value: boolean) {
-    const newValue = coerceBooleanProperty(value);
-    const element = this._elementRef.nativeElement;
-
-    if (this._disabled !== newValue) {
-      this._disabled = newValue;
-      this._disabledChange.emit(newValue);
-    }
-
-    // We need to null check the `blur` method, because it's undefined during SSR.
-    if (newValue && element.blur) {
-      // Normally, native input elements automatically blur if they turn disabled. This behavior
-      // is problematic, because it would mean that it triggers another change detection cycle,
-      // which then causes a changed after checked error if the input element was focused before.
-      element.blur();
-    }
-  }
-  private _disabled: boolean;
-
-  /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when the value changes (either due to user input or programmatic change). */
-  _valueChange = new EventEmitter<D | null>();
-
-  /** Emits when the disabled state has changed */
-  _disabledChange = new EventEmitter<boolean>();
-
-  _onTouched = () => {};
-
-  private _cvaOnChange: (value: any) => void = () => {};
-
-  private _validatorOnChange = () => {};
-
-  private _datepickerSubscription = Subscription.EMPTY;
-
-  private _localeSubscription = Subscription.EMPTY;
-
-  /** The form control validator for whether the input parses. */
-  private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
-    return this._lastValueValid ?
-        null : {'matDatepickerParse': {'text': this._elementRef.nativeElement.value}};
-  }
-
-  /** The form control validator for the min date. */
-  private _minValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-    return (!this.min || !controlValue ||
-        this._dateAdapter.compareDate(this.min, controlValue) <= 0) ?
-        null : {'matDatepickerMin': {'min': this.min, 'actual': controlValue}};
-  }
-
-  /** The form control validator for the max date. */
-  private _maxValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-    return (!this.max || !controlValue ||
-        this._dateAdapter.compareDate(this.max, controlValue) >= 0) ?
-        null : {'matDatepickerMax': {'max': this.max, 'actual': controlValue}};
-  }
-
-  /** The form control validator for the date filter. */
-  private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-    return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
-        null : {'matDatepickerFilter': true};
-  }
-
-  /** The combined form control validator for this input. */
-  private _validator: ValidatorFn | null =
-      Validators.compose(
-          [this._parseValidator, this._minValidator, this._maxValidator, this._filterValidator]);
-
-  /** Whether the last value set on the input was valid. */
-  private _lastValueValid = false;
 
   constructor(
-      private _elementRef: ElementRef,
-      @Optional() public _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
+      _elementRef: ElementRef,
+      @Optional() _dateAdapter: DateAdapter<D>,
+      @Optional() @Inject(CDK_DATE_FORMATS) _dateFormats: CdkDateFormats,
       @Optional() private _formField: MatFormField) {
-    if (!this._dateAdapter) {
-      throw createMissingDateImplError('DateAdapter');
-    }
-    if (!this._dateFormats) {
-      throw createMissingDateImplError('MAT_DATE_FORMATS');
-    }
-
-    // Update the displayed date when the locale changes.
-    this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
-      this.value = this.value;
-    });
-  }
-
-  ngAfterContentInit() {
-    if (this._datepicker) {
-      this._datepickerSubscription = this._datepicker._selectedChanged.subscribe((selected: D) => {
-        this.value = selected;
-        this._cvaOnChange(selected);
-        this._onTouched();
-        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-      });
-    }
-  }
-
-  ngOnDestroy() {
-    this._datepickerSubscription.unsubscribe();
-    this._localeSubscription.unsubscribe();
-    this._valueChange.complete();
-    this._disabledChange.complete();
-  }
-
-  /** @docs-private */
-  registerOnValidatorChange(fn: () => void): void {
-    this._validatorOnChange = fn;
-  }
-
-  /** @docs-private */
-  validate(c: AbstractControl): ValidationErrors | null {
-    return this._validator ? this._validator(c) : null;
+    super(_elementRef, _dateAdapter, _dateFormats);
   }
 
   /**
@@ -297,26 +143,6 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     return this._formField ? this._formField.getConnectedOverlayOrigin() : this._elementRef;
   }
 
-  // Implemented as part of ControlValueAccessor.
-  writeValue(value: D): void {
-    this.value = value;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnChange(fn: (value: any) => void): void {
-    this._cvaOnChange = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnTouched(fn: () => void): void {
-    this._onTouched = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-  }
-
   _onKeydown(event: KeyboardEvent) {
     if (event.altKey && event.keyCode === DOWN_ARROW) {
       this._datepicker.open();
@@ -324,49 +150,8 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     }
   }
 
-  _onInput(value: string) {
-    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-    this._lastValueValid = !date || this._dateAdapter.isValid(date);
-    date = this._getValidDateOrNull(date);
-
-    if (!this._dateAdapter.sameDate(date, this._value)) {
-      this._value = date;
-      this._cvaOnChange(date);
-      this._valueChange.emit(date);
-      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-    }
-  }
-
-  _onChange() {
-    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-  }
-
   /** Returns the palette used by the input's form field, if any. */
   _getThemePalette() {
     return this._formField ? this._formField.color : undefined;
-  }
-
-  /** Handles blur events on the input. */
-  _onBlur() {
-    // Reformat the input only if we have a valid value.
-    if (this.value) {
-      this._formatValue(this.value);
-    }
-
-    this._onTouched();
-  }
-
-  /** Formats a value and sets it on the input element. */
-  private _formatValue(value: D | null) {
-    this._elementRef.nativeElement.value =
-        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
-  }
-
-  /**
-   * @param obj The object to check.
-   * @returns The given object if it is both a date instance and valid, otherwise null.
-   */
-  private _getValidDateOrNull(obj: any): D | null {
-    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
 }

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -126,13 +126,14 @@ export class MatDatepickerInput<D> extends CdkDatepickerInput<D> implements Afte
   constructor(
       _elementRef: ElementRef,
       @Optional() _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(CDK_DATE_FORMATS) _cdkDateFormats: CdkDateFormats,
       /**
        * @deprecated Removing `MAT_DATE_FORMATS`.
        * @deletion-target 8.0.0
        */
       @Optional() @Inject(MAT_DATE_FORMATS) _matDateFormats: MatDateFormats,
-      @Optional() private _formField: MatFormField) {
+      @Optional() private _formField: MatFormField,
+      /** @deletion-target 8.0.0 Make required. */
+      @Optional() @Inject(CDK_DATE_FORMATS) _cdkDateFormats?: CdkDateFormats) {
     super(_elementRef, _dateAdapter, _cdkDateFormats || _matDateFormats);
   }
 

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -104,7 +104,7 @@ export class MatDatepickerInputEvent<D> {
 export class MatDatepickerInput<D> extends CdkDatepickerInput<D> implements AfterContentInit,
     ControlValueAccessor, OnDestroy, Validator {
   /** Prefix for form control validator properties. */
-  protected _prefix = 'mat';
+  protected _formControlValidatorPrefix = 'mat';
 
   /** The datepicker that this input is associated with. */
   @Input()

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -86,7 +86,8 @@ export class MatDatepickerInputEvent<D> {
     MAT_DATEPICKER_VALIDATORS,
     {provide: MAT_INPUT_VALUE_ACCESSOR, useExisting: MatDatepickerInput},
   ],
-  inputs: ['value', 'min', 'max', 'disabled', 'cdkDatepickerFilter', 'cdkDatepicker'],
+  inputs: ['value', 'min', 'max', 'disabled', 'matDatepickerFilter: cdkDatepickerFilter',
+      'matDatepicker: cdkDatepicker'],
   outputs: ['dateChange', 'dateInput'],
   host: {
     '[attr.aria-haspopup]': 'true',

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1379,6 +1379,13 @@ describe('MatDatepicker', () => {
 
   });
 
+  describe('with missing DateAdapter and CDK_DATE_FORMATS', () => {
+    it('should throw when created', () => {
+      expect(() => createComponent(StandardDatepicker))
+          .toThrowError(/CdkDatepicker: No provider found for .*/);
+    });
+  });
+
   describe('popup positioning', () => {
     let fixture: ComponentFixture<StandardDatepicker>;
     let testComponent: StandardDatepicker;

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1379,13 +1379,6 @@ describe('MatDatepicker', () => {
 
   });
 
-  describe('with missing DateAdapter and MAT_DATE_FORMATS', () => {
-    it('should throw when created', () => {
-      expect(() => createComponent(StandardDatepicker))
-        .toThrowError(/MatDatepicker: No provider found for .*/);
-    });
-  });
-
   describe('popup positioning', () => {
     let fixture: ComponentFixture<StandardDatepicker>;
     let testComponent: StandardDatepicker;

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -209,7 +209,7 @@ export class MatDatepicker<D> extends CdkDatepicker<D> implements OnDestroy, Can
               private _ngZone: NgZone,
               private _viewContainerRef: ViewContainerRef,
               @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) private _scrollStrategy,
-              @Optional() protected _dateAdapter: DateAdapter<D>,
+              @Optional() _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,
               @Optional() @Inject(DOCUMENT) private _document: any) {
     super(_dateAdapter);

--- a/src/material-examples/datepicker-events/datepicker-events-example.ts
+++ b/src/material-examples/datepicker-events/datepicker-events-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatDatepickerInputEvent} from '@angular/material/datepicker';
+import {DatepickerInputEvent} from '@angular/cdk/datetime';
 
 /** @title Datepicker input and change events */
 @Component({
@@ -10,7 +10,7 @@ import {MatDatepickerInputEvent} from '@angular/material/datepicker';
 export class DatepickerEventsExample {
   events: string[] = [];
 
-  addEvent(type: string, event: MatDatepickerInputEvent<Date>) {
+  addEvent(type: string, event: DatepickerInputEvent<Date>) {
     this.events.push(`${type}: ${event.value}`);
   }
 }

--- a/src/material-examples/datepicker-formats/datepicker-formats-example.ts
+++ b/src/material-examples/datepicker-formats/datepicker-formats-example.ts
@@ -16,15 +16,20 @@ const moment = _rollupMoment || _moment;
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/
-export const MY_FORMATS = {
+export const MY_MAT_FORMATS = {
+  display: {
+    monthYearLabel: 'MMM YYYY',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'MMMM YYYY',
+  },
+};
+
+export const MY_CDK_FORMATS = {
   parse: {
     dateInput: 'LL',
   },
   display: {
     dateInput: 'LL',
-    monthYearLabel: 'MMM YYYY',
-    dateA11yLabel: 'LL',
-    monthYearA11yLabel: 'MMMM YYYY',
   },
 };
 
@@ -39,8 +44,8 @@ export const MY_FORMATS = {
     // our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
 
-    {provide: MAT_DATE_FORMATS, useValue: MY_FORMATS},
-    {provide: CDK_DATE_FORMATS, useValue: undefined},
+    {provide: MAT_DATE_FORMATS, useValue: MY_MAT_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: MY_CDK_FORMATS},
   ],
 })
 export class DatepickerFormatsExample {

--- a/src/material-examples/datepicker-formats/datepicker-formats-example.ts
+++ b/src/material-examples/datepicker-formats/datepicker-formats-example.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
@@ -39,6 +40,7 @@ export const MY_FORMATS = {
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
 
     {provide: MAT_DATE_FORMATS, useValue: MY_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: undefined},
   ],
 })
 export class DatepickerFormatsExample {

--- a/src/material-examples/datepicker-locale/datepicker-locale-example.ts
+++ b/src/material-examples/datepicker-locale/datepicker-locale-example.ts
@@ -1,5 +1,9 @@
 import {Component} from '@angular/core';
-import {MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
+import {
+  MAT_MOMENT_DATE_FORMATS,
+  MomentDateAdapter,
+  CDK_MOMENT_DATE_FORMATS,
+} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
@@ -18,7 +22,7 @@ import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
     // here, due to limitations of our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
-    {provide: CDK_DATE_FORMATS, useValue: undefined},
+    {provide: CDK_DATE_FORMATS, useValue: CDK_MOMENT_DATE_FORMATS},
   ],
 })
 export class DatepickerLocaleExample {

--- a/src/material-examples/datepicker-locale/datepicker-locale-example.ts
+++ b/src/material-examples/datepicker-locale/datepicker-locale-example.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 import {MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
 /** @title Datepicker with different locale */
 @Component({
@@ -17,6 +18,7 @@ import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/
     // here, due to limitations of our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: undefined},
   ],
 })
 export class DatepickerLocaleExample {

--- a/src/material-examples/datepicker-moment/datepicker-moment-example.ts
+++ b/src/material-examples/datepicker-moment/datepicker-moment-example.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
@@ -24,6 +25,7 @@ const moment = _rollupMoment || _moment;
     // here, due to limitations of our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: undefined},
   ],
 })
 export class DatepickerMomentExample {

--- a/src/material-examples/datepicker-moment/datepicker-moment-example.ts
+++ b/src/material-examples/datepicker-moment/datepicker-moment-example.ts
@@ -1,6 +1,10 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
+import {
+  MAT_MOMENT_DATE_FORMATS,
+  MomentDateAdapter,
+  CDK_MOMENT_DATE_FORMATS
+} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
@@ -25,7 +29,7 @@ const moment = _rollupMoment || _moment;
     // here, due to limitations of our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
-    {provide: CDK_DATE_FORMATS, useValue: undefined},
+    {provide: CDK_DATE_FORMATS, useValue: CDK_MOMENT_DATE_FORMATS},
   ],
 })
 export class DatepickerMomentExample {

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -3,6 +3,7 @@ import {FormControl} from '@angular/forms';
 import {MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import {MatDatepicker} from '@angular/material/datepicker';
+import {CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
@@ -40,6 +41,7 @@ export const MY_FORMATS = {
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
 
     {provide: MAT_DATE_FORMATS, useValue: MY_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: undefined},
   ],
 })
 export class DatepickerViewsSelectionExample {

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -17,15 +17,20 @@ const moment = _rollupMoment || _moment;
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/
-export const MY_FORMATS = {
+export const MY_MAT_FORMATS = {
+  display: {
+    monthYearLabel: 'MMM YYYY',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'MMMM YYYY',
+  },
+};
+
+export const MY_CDK_FORMATS = {
   parse: {
     dateInput: 'MM/YYYY',
   },
   display: {
     dateInput: 'MM/YYYY',
-    monthYearLabel: 'MMM YYYY',
-    dateA11yLabel: 'LL',
-    monthYearA11yLabel: 'MMMM YYYY',
   },
 };
 
@@ -40,8 +45,8 @@ export const MY_FORMATS = {
     // our example generation script.
     {provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE]},
 
-    {provide: MAT_DATE_FORMATS, useValue: MY_FORMATS},
-    {provide: CDK_DATE_FORMATS, useValue: undefined},
+    {provide: MAT_DATE_FORMATS, useValue: MY_MAT_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: MY_CDK_FORMATS},
   ],
 })
 export class DatepickerViewsSelectionExample {

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -7,10 +7,10 @@
  */
 
 import {NgModule} from '@angular/core';
-import {DateAdapter} from '@angular/cdk/datetime';
+import {DateAdapter, CDK_DATE_FORMATS} from '@angular/cdk/datetime';
 import {MAT_DATE_LOCALE, MAT_DATE_FORMATS} from '@angular/material';
 import {MAT_MOMENT_DATE_ADAPTER_OPTIONS, MomentDateAdapter} from './moment-date-adapter';
-import {MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
+import {CDK_MOMENT_DATE_FORMATS, MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
 
 export * from './moment-date-adapter';
 export * from './moment-date-formats';
@@ -30,6 +30,9 @@ export class MomentDateModule {}
 
 @NgModule({
   imports: [MomentDateModule],
-  providers: [{provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS}],
+  providers: [
+    {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
+    {provide: CDK_DATE_FORMATS, useValue: CDK_MOMENT_DATE_FORMATS},
+  ],
 })
 export class MatMomentDateModule {}

--- a/src/material-moment-adapter/adapter/moment-date-formats.ts
+++ b/src/material-moment-adapter/adapter/moment-date-formats.ts
@@ -10,14 +10,31 @@ import {MatDateFormats} from '@angular/material';
 import {CdkDateFormats} from '@angular/cdk/datetime';
 
 
-export const MAT_MOMENT_DATE_FORMATS: CdkDateFormats & MatDateFormats = {
+export const MAT_MOMENT_DATE_FORMATS: MatDateFormats = {
+  /**
+   * @deprecated Remove `parse` and use `CDK_MOMENT_DATE_FORMATS` instead.
+   * @deletion-target 8.0.0
+   */
   parse: {
     dateInput: 'l',
   },
   display: {
+    /**
+     * @deprecated Remove `parse` and use `CDK_MOMENT_DATE_FORMATS` instead.
+     * @deletion-target 8.0.0
+     */
     dateInput: 'l',
     monthYearLabel: 'MMM YYYY',
     dateA11yLabel: 'LL',
     monthYearA11yLabel: 'MMMM YYYY',
   },
+};
+
+export const CDK_MOMENT_DATE_FORMATS: CdkDateFormats = {
+  parse: {
+    dateInput: 'l',
+  },
+  display: {
+    dateInput: 'l',
+  }
 };

--- a/src/material-moment-adapter/adapter/moment-date-formats.ts
+++ b/src/material-moment-adapter/adapter/moment-date-formats.ts
@@ -7,9 +7,10 @@
  */
 
 import {MatDateFormats} from '@angular/material';
+import {CdkDateFormats} from '@angular/cdk/datetime';
 
 
-export const MAT_MOMENT_DATE_FORMATS: MatDateFormats = {
+export const MAT_MOMENT_DATE_FORMATS: CdkDateFormats & MatDateFormats = {
   parse: {
     dateInput: 'l',
   },


### PR DESCRIPTION
Removed a test that the compiler threw errors on in the `datepicker.spec.ts` in material that I will add back in the CDK in next PR. 

BREAKING CHANGES:
- `MAT_DATE_FORMATS` has been split into `MAT_DATE_FORMATS` and `CDK_DATE_FORMATS`. In most cases this will not effect existing apps, as components that use `CDK_DATE_FORMATS` currentlly fall back to looking at `MAT_DATE_FORMATS` if it is not found. However, if you are overriding `MAT_DATE_FORMATS` for some portion of your app, you must now also override `CDK_DATE_FORMATS`. A quick fix is to override it to undefined, thus forcing components to fall back to `MAT_DATE_FORMATS` again. (e.g. `{provide: CDK_DATE_FORMATS, useValue: undefined}`). Ideally you should split out a `CDK_DATE_FORMATS` value from your existing `MAT_DATE_FORMATS` value however, as this fallback behavior will be removed in the future.