### PR TITLE
fix(datepicker): screenreaders report editable grid cells

### DIFF
--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -42,7 +42,7 @@ export class MatCalendarCell {
   host: {
     'class': 'mat-calendar-body',
     'role': 'grid',
-    'attr.aria-readonly': 'true'
+    'aria-readonly': 'true'
   },
   exportAs: 'matCalendarBody',
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
* Since the `aria-readonly` attribute is not set properly, screenreaders announce (e.g. Firefox with NVDA) that every date (grid cell) is editable. This is not true, because those cells are just selectable.