### PR TITLE
fix(card): incorrectly inverting inset divider in rtl

### DIFF
--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -29,6 +29,11 @@ $mat-card-header-size: 40px !default;
     &.mat-divider-inset {
       position: static;
       margin: 0;
+
+      [dir='rtl'] & {
+        // Needs to be reset explicitly since the divider set `margin-right` in particular in RTL.
+        margin-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the inset divider on a card in RTL being pushed outside the card.

For reference:
![angular_material_-_google_chrome_2018-07-19_22-06-27](https://user-images.githubusercontent.com/4450522/42967741-869ac566-8ba1-11e8-9e8a-61cf8fabc1fb.png)
