### PR TITLE
chore(autocomplete): fix image spacing on overview example

### DIFF
--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.css
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.css
@@ -10,4 +10,10 @@
 
 .example-option-img {
   vertical-align: middle;
+  margin-right: 8px;
+}
+
+[dir='rtl'] .example-option-img {
+  margin-right: 0;
+  margin-left: 8px;
 }


### PR DESCRIPTION
Fixes the images on the autocomplete overview being flush against their text.