### PR TITLE
refactor(table): remove redundant constructors

### DIFF
--- a/src/lib/table/cell.ts
+++ b/src/lib/table/cell.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Input, TemplateRef} from '@angular/core';
+import {Directive, ElementRef, Input} from '@angular/core';
 import {
   CdkCell,
   CdkCellDef,
@@ -23,12 +23,7 @@ import {
   selector: '[matCellDef]',
   providers: [{provide: CdkCellDef, useExisting: MatCellDef}]
 })
-export class MatCellDef extends CdkCellDef {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {
-    super(template);
-  }
-}
+export class MatCellDef extends CdkCellDef {}
 
 /**
  * Header cell definition for the mat-table.
@@ -38,12 +33,7 @@ export class MatCellDef extends CdkCellDef {
   selector: '[matHeaderCellDef]',
   providers: [{provide: CdkHeaderCellDef, useExisting: MatHeaderCellDef}]
 })
-export class MatHeaderCellDef extends CdkHeaderCellDef {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {
-    super(template);
-  }
-}
+export class MatHeaderCellDef extends CdkHeaderCellDef {}
 
 /**
  * Footer cell definition for the mat-table.
@@ -53,12 +43,7 @@ export class MatHeaderCellDef extends CdkHeaderCellDef {
   selector: '[matFooterCellDef]',
   providers: [{provide: CdkFooterCellDef, useExisting: MatFooterCellDef}]
 })
-export class MatFooterCellDef extends CdkFooterCellDef {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {
-    super(template);
-  }
-}
+export class MatFooterCellDef extends CdkFooterCellDef {}
 
 /**
  * Column definition for the mat-table.

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -10,7 +10,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   Directive,
-  IterableDiffers, TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
 import {
@@ -30,12 +29,7 @@ import {
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
   inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
 })
-export class MatHeaderRowDef extends CdkHeaderRowDef {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
-    super(template, _differs);
-  }
-}
+export class MatHeaderRowDef extends CdkHeaderRowDef {}
 
 /**
  * Footer row definition for the mat-table.
@@ -46,12 +40,7 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {
   providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
   inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
 })
-export class MatFooterRowDef extends CdkFooterRowDef {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
-    super(template, _differs);
-  }
-}
+export class MatFooterRowDef extends CdkFooterRowDef {}
 
 /**
  * Data row definition for the mat-table.
@@ -63,12 +52,7 @@ export class MatFooterRowDef extends CdkFooterRowDef {
   providers: [{provide: CdkRowDef, useExisting: MatRowDef}],
   inputs: ['columns: matRowDefColumns', 'when: matRowDefWhen'],
 })
-export class MatRowDef<T> extends CdkRowDef<T> {
-  // TODO(andrewseguin): Remove this constructor after compiler-cli is updated; see issue #9329
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
-    super(template, _differs);
-  }
-}
+export class MatRowDef<T> extends CdkRowDef<T> {}
 
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({


### PR DESCRIPTION
Removes some redundant constructors that were added as a workaround for a compiler issue that's been fixed since 6.0.