### PR TITLE
docs(ripple): fix missing jsdoc descriptions

### DIFF
--- a/src/lib/core/ripple/ripple-ref.ts
+++ b/src/lib/core/ripple/ripple-ref.ts
@@ -18,12 +18,14 @@ export enum RippleState {
  */
 export class RippleRef {
 
-  /** Current state of the ripple reference. */
+  /** Current state of the ripple. */
   state: RippleState = RippleState.HIDDEN;
 
   constructor(
     private _renderer: RippleRenderer,
+    /** Reference to the ripple HTML element. */
     public element: HTMLElement,
+    /** Ripple configuration used for the ripple. */
     public config: RippleConfig) {
   }
 

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -163,7 +163,10 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
     this._rippleRenderer.fadeOutAll();
   }
 
-  /** Ripple configuration from the directive's input values. */
+  /**
+   * Ripple configuration from the directive's input values.
+   * @docs-private Implemented as part of RippleTarget
+   */
   get rippleConfig(): RippleConfig {
     return {
       centered: this.centered,
@@ -175,7 +178,10 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
     };
   }
 
-  /** Whether ripples on pointer-down are disabled or not. */
+  /**
+   * Whether ripples on pointer-down are disabled or not.
+   * @docs-private Implemented as part of RippleTarget
+   */
   get rippleDisabled(): boolean {
     return this.disabled || !!this._globalOptions.disabled;
   }


### PR DESCRIPTION
* Fixes missing JSDoc descriptions for the ripple API that will be shown in the docs
* Hides the public methods that are implemented as part of the `RippleTarget`.