### PR TITLE
build: avoid manually-maintained example lists

### DIFF
--- a/src/demo-app/table/table-demo.ts
+++ b/src/demo-app/table/table-demo.ts
@@ -7,6 +7,7 @@
  */
 
 import {Component} from '@angular/core';
+import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 
 @Component({
@@ -14,25 +15,6 @@ import {Component} from '@angular/core';
   templateUrl: 'table-demo.html',
 })
 export class TableDemo {
-  examples = [
-    'table-basic',
-    'table-basic-flex',
-    'cdk-table-basic',
-    'cdk-table-basic-flex',
-    'table-dynamic-columns',
-    'table-filtering',
-    'table-footer-row',
-    'table-http',
-    'table-overview',
-    'table-pagination',
-    'table-row-context',
-    'table-selection',
-    'table-sorting',
-    'table-expandable-rows',
-    'table-sticky-header',
-    'table-sticky-columns',
-    'table-sticky-footer',
-    'table-sticky-complex',
-    'table-sticky-complex-flex',
-  ];
+  examples = Object.keys(EXAMPLE_COMPONENTS)
+      .filter(example => example.startsWith('table-') || example.startsWith('cdk-table-'));
 }

--- a/src/demo-app/tabs/tabs-demo.ts
+++ b/src/demo-app/tabs/tabs-demo.ts
@@ -7,6 +7,7 @@
  */
 
 import {Component} from '@angular/core';
+import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 @Component({
   moduleId: module.id,
@@ -14,16 +15,5 @@ import {Component} from '@angular/core';
   templateUrl: 'tabs-demo.html',
 })
 export class TabsDemo {
-  examples = [
-    'tab-group-basic',
-    'tab-group-dynamic-height',
-    'tab-group-stretched',
-    'tab-group-async',
-    'tab-group-custom-label',
-    'tab-group-header-below',
-    'tab-group-theme',
-    'tab-group-lazy-loaded',
-    'tab-group-dynamic',
-    'tab-nav-bar-basic',
-  ];
+  examples = Object.keys(EXAMPLE_COMPONENTS).filter(example => example.startsWith('tab-'));
 }

--- a/src/demo-app/tooltip/tooltip-demo.ts
+++ b/src/demo-app/tooltip/tooltip-demo.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Component} from '@angular/core';
+import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 @Component({
   moduleId: module.id,
@@ -13,15 +14,5 @@ import {Component} from '@angular/core';
   templateUrl: 'tooltip-demo.html',
 })
 export class TooltipDemo {
-  examples = [
-    'tooltip-overview',
-    'tooltip-position',
-    'tooltip-disabled',
-    'tooltip-message',
-    'tooltip-delay',
-    'tooltip-manual',
-    'tooltip-modified-defaults',
-    'tooltip-auto-hide',
-    'tooltip-custom-class',
-  ];
+  examples = Object.keys(EXAMPLE_COMPONENTS).filter(example => example.startsWith('tooltip-'));
 }


### PR DESCRIPTION
Reworks the demos that were using the docs examples to avoid having to hard-code the list of examples for each component.