### PR TITLE
build: update bazel repositories

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -1,0 +1,23 @@
+# These options are enabled when running on CI
+# We do this by copying this file to /etc/bazel.bazelrc at the start of the build.
+
+# Print all the options that apply to the build.
+# This helps us diagnose which options override others
+# (e.g. /etc/bazel.bazelrc vs. tools/bazel.rc)
+build --announce_rc
+
+# Prevent unstable environment variables from tainting cache keys
+build --experimental_strict_action_env
+
+# Save downloaded repositories. This directory is included in the CircleCI cache and should save
+# time running the first build
+build --experimental_repository_cache=/home/circleci/bazel_repository_cache
+
+# Workaround https://github.com/bazelbuild/bazel/issues/3645
+# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
+# Limit Bazel to consuming resources that fit in CircleCI "xlarge" class
+# https://circleci.com/docs/2.0/configuration-reference/#resource_class
+build --local_resources=14336,8.0,1.0
+
+# Retry in the event of flakes, eg. https://circleci.com/gh/angular/angular/31309
+test --flaky_test_attempts=2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.3.0
-var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.3.0
+var_1: &docker_image angular/ngcontainer:0.3.3
+var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.3.3
 
 # Define common ENV vars
 var_3: &define_env_vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,19 +13,8 @@
 var_1: &docker_image angular/ngcontainer:0.3.3
 var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "package-lock.json" }}-0.3.3
 
-# Define common ENV vars
-var_3: &define_env_vars
-  run: echo "export PROJECT_ROOT=$(pwd)" >> $BASH_ENV
-
-# See remote cache documentation in /docs/BAZEL.md
-var_4: &setup-bazel-remote-cache
-  run:
-    name: Start up bazel remote cache proxy
-    command: ~/bazel-remote-proxy -backend circleci://
-    background: true
-
 # Settings common to each job
-anchor_1: &job_defaults
+var_3: &job_defaults
   working_directory: ~/ng
   docker:
     - image: *docker_image
@@ -34,8 +23,12 @@ anchor_1: &job_defaults
 # Similar to travis behavior, but not quite the same.
 # By default, PRs are not rebased on top of master, which we want.
 # See https://discuss.circleci.com/t/1662
-anchor_2: &post_checkout
+var_4: &post_checkout
   post: git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+
+# Run task that sets up the .circleci/bazel.rc file that should be specifically used
+# when running inside of Circle.
+var_5: &setup-circle-bazel-rc sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
 
 version: 2
 jobs:
@@ -48,16 +41,17 @@ jobs:
       - restore_cache:
           key: *cache_key
 
+      - run: *setup-circle-bazel-rc
+
       - run: bazel run @nodejs//:npm install
-      # For some reason, circleci needs the postinstall to be run explicitly.
-      # This may be unnecessary once rules_nodejs uses nodejs 8
-      - run: bazel run @nodejs//:npm run postinstall
       - run: bazel build src/...
       - run: bazel test src/...
+
       - save_cache:
           key: *cache_key
           paths:
             - "node_modules"
+            - "~/bazel_repository_cache"
 
 workflows:
   version: 2

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,18 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_modules_filegroup")
+
 # TODO(jelbourn): figure out if these workarounds are still needed
 
 # This rule belongs in node_modules/BUILD
 # It's here as a workaround for
 # https://github.com/bazelbuild/bazel/issues/374#issuecomment-296217940
-filegroup(
+node_modules_filegroup(
   name = "node_modules",
   # Performance workaround: list individual files
   # Reduces the number of files as inputs to nodejs_binary:
   # bazel query "deps(:node_modules)" | wc -l
   # This won't scale in the general case.
   # TODO(alexeagle): figure out what to do
-  srcs = glob(["/".join(["node_modules", pkg, "**", ext]) for pkg in [
+  packages = [
     "@angular",
     "@angular-devkit",
     "@schematics",
@@ -32,15 +34,11 @@ filegroup(
     "tslint",
     "typescript",
     "zone.js",
-  ] for ext in [
-    "*.js",
-    "*.json",
-    "*.d.ts",
-  ]] + [
+  ],
+  patterns = [
     "node_modules/http-server/**",
-  ]),
+  ],
 )
-
 
 # Glob pattern that matches all Angular testing bundles.
 ANGULAR_TESTING = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,37 +1,61 @@
 workspace(name = "angular_material")
 
 # Add nodejs rules
-http_archive(
+git_repository(
   name = "build_bazel_rules_nodejs",
-  url = "https://github.com/bazelbuild/rules_nodejs/archive/0.8.0.zip",
-  strip_prefix = "rules_nodejs-0.8.0",
-  sha256 = "4e40dd49ae7668d245c3107645f2a138660fcfd975b9310b91eda13f0c973953",
+  remote = "https://github.com/bazelbuild/rules_nodejs.git",
+  tag = "0.10.1",
 )
 
 # NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
 # your npm dependencies. You must still run the package manager.
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
-check_bazel_version("0.13.0")
-node_repositories(package_json = ["//:package.json"])
+check_bazel_version("0.15.0")
+node_repositories(
+  package_json = ["//:package.json"],
+  # Keep this disabled for now. As soon as there is a performant and simple way to load the
+  # node_modules, we can enable this option in order to improve hermeticity.
+  # e.g. blocked on: https://github.com/angular/angular/pull/24663
+  preserve_symlinks = False
+)
+
+# Setup go rules in order to use the webtesting rules
+git_repository(
+  name = "io_bazel_rules_go",
+  remote = "https://github.com/bazelbuild/rules_go.git",
+  tag = "0.13.0"
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
+
+# Add web testing rules
+git_repository(
+  name = "io_bazel_rules_webtesting",
+  remote = "https://github.com/bazelbuild/rules_webtesting.git",
+  tag = "0.2.1"
+)
+
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
+web_test_repositories();
 
 # Add sass rules
-http_archive(
+git_repository(
   name = "io_bazel_rules_sass",
-  url = "https://github.com/bazelbuild/rules_sass/archive/0.1.0.zip",
-  strip_prefix = "rules_sass-0.1.0",
-  sha256 = "b243c4d64f054c174051785862ab079050d90b37a1cef7da93821c6981cb9ad4",
+  remote = "https://github.com/bazelbuild/rules_sass.git",
+  tag = "0.1.0"
 )
 
 load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
 sass_repositories()
 
 # Add TypeScript rules
-http_archive(
+git_repository(
   name = "build_bazel_rules_typescript",
-  url = "https://github.com/bazelbuild/rules_typescript/archive/0.12.3.zip",
-  strip_prefix = "rules_typescript-0.12.3",
-  sha256 = "967068c3540f59407716fbeb49949c1600dbf387faeeab3089085784dd21f60c",
+  remote = "https://github.com/bazelbuild/rules_typescript.git",
+  tag = "0.12.3"
 )
 
 # Setup TypeScript Bazel workspace
@@ -50,8 +74,7 @@ local_repository(
   path = "node_modules/rxjs/src",
 )
 
-
 # This commit matches the version of buildifier in angular/ngcontainer
 # If you change this, also check if it matches the version in the angular/ngcontainer
 # version in /.circleci/config.yml
-BAZEL_BUILDTOOLS_VERSION = "fd9878fd5de921e0bbab3dcdcb932c2627812ee1"
+BAZEL_BUILDTOOLS_VERSION = "82b21607e00913b16fe1c51bec80232d9d6de31c"


### PR DESCRIPTION
* Updates the Bazel repositories and switches to `git_repository` that has been recommended by the `bazelbuild/rules_nodejs` project (easier version bumping, more readable)

* Switches to a new rule that makes it easy to reference the `node_module` files.