### PR TITLE
fix(select): pointing to non-existent element via aria-labelledby

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -126,6 +126,7 @@ describe('MatSelect', () => {
         SelectWithGroups,
         SelectWithGroupsAndNgContainer,
         SelectWithFormFieldLabel,
+        SelectWithChangeEvent,
       ]);
     }));
 
@@ -249,6 +250,16 @@ describe('MatSelect', () => {
 
           const labelFixture = TestBed.createComponent(SelectWithFormFieldLabel);
           labelFixture.componentInstance.placeholder = 'Thing selector';
+          labelFixture.detectChanges();
+          select = labelFixture.debugElement.query(By.css('mat-select')).nativeElement;
+
+          expect(select.getAttribute('aria-labelledby')).toBeFalsy();
+        });
+
+        it('should not set `aria-labelledby` if there is no form field label', () => {
+          fixture.destroy();
+
+          const labelFixture = TestBed.createComponent(SelectWithChangeEvent);
           labelFixture.detectChanges();
           select = labelFixture.debugElement.query(By.css('mat-select')).nativeElement;
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -1059,7 +1059,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
     // Note: we use `_getAriaLabel` here, because we want to check whether there's a
     // computed label. `this.ariaLabel` is only the user-specified label.
-    if (!this._parentFormField || this._getAriaLabel()) {
+    if (!this._parentFormField || !this._parentFormField._hasFloatingLabel() ||
+      this._getAriaLabel()) {
       return null;
     }
 


### PR DESCRIPTION
Fixes `mat-select` referring to an element that doesn't exist, through `aria-labelledby`, if the select is inside a form field that doesn't have a label.

Fixes #12405.