### PR TITLE
build: rename @deletion-target to @breaking-change

### DIFF
--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -225,12 +225,12 @@ export class AriaDescriber implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function ARIA_DESCRIBER_PROVIDER_FACTORY(parentDispatcher: AriaDescriber, _document: any) {
   return parentDispatcher || new AriaDescriber(_document);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const ARIA_DESCRIBER_PROVIDER = {
   // If there is already an AriaDescriber available, use that. Otherwise, provide a new one.
   provide: AriaDescriber,

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -402,13 +402,13 @@ export class CdkMonitorFocus implements OnDestroy {
   }
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function FOCUS_MONITOR_PROVIDER_FACTORY(
     parentDispatcher: FocusMonitor, ngZone: NgZone, platform: Platform) {
   return parentDispatcher || new FocusMonitor(ngZone, platform);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const FOCUS_MONITOR_PROVIDER = {
   // If there is already a FocusMonitor available, use that. Otherwise, provide a new one.
   provide: FocusMonitor,

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -152,7 +152,7 @@ export class FocusTrap {
                                                  `[cdk-focus-${bound}]`) as NodeListOf<HTMLElement>;
 
     for (let i = 0; i < markers.length; i++) {
-      // @deletion-target 7.0.0
+      // @breaking-change 7.0.0
       if (markers[i].hasAttribute(`cdk-focus-${bound}`)) {
         console.warn(`Found use of deprecated attribute 'cdk-focus-${bound}', ` +
                      `use 'cdkFocusRegion${bound}' instead. The deprecated ` +
@@ -181,7 +181,7 @@ export class FocusTrap {
                                                           `[cdkFocusInitial]`) as HTMLElement;
 
     if (redirectToElement) {
-      // @deletion-target 7.0.0
+      // @breaking-change 7.0.0
       if (redirectToElement.hasAttribute(`cdk-focus-initial`)) {
         console.warn(`Found use of deprecated attribute 'cdk-focus-initial', ` +
                     `use 'cdkFocusInitial' instead. The deprecated attribute ` +

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -305,7 +305,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
    * Allows setting of the activeItemIndex without any other effects.
    * @param index The new activeItemIndex.
    * @deprecated Use `updateActiveItem` instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   updateActiveItemIndex(index: number): void {
     this.updateActiveItem(index);

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -132,14 +132,14 @@ export class CdkAriaLive implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function LIVE_ANNOUNCER_PROVIDER_FACTORY(
     parentDispatcher: LiveAnnouncer, liveElement: any, _document: any) {
   return parentDispatcher || new LiveAnnouncer(liveElement, _document);
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const LIVE_ANNOUNCER_PROVIDER: Provider = {
   // If there is already a LiveAnnouncer available, use that. Otherwise, provide a new one.
   provide: LiveAnnouncer,

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
@@ -96,13 +96,13 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function OVERLAY_KEYBOARD_DISPATCHER_PROVIDER_FACTORY(
     dispatcher: OverlayKeyboardDispatcher, _document: any) {
   return dispatcher || new OverlayKeyboardDispatcher(_document);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const OVERLAY_KEYBOARD_DISPATCHER_PROVIDER = {
   // If there is already an OverlayKeyboardDispatcher available, use that.
   // Otherwise, provide a new one.

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -55,13 +55,13 @@ export class OverlayContainer implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function OVERLAY_CONTAINER_PROVIDER_FACTORY(parentContainer: OverlayContainer,
   _document: any) {
   return parentContainer || new OverlayContainer(_document);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const OVERLAY_CONTAINER_PROVIDER = {
   // If there is already an OverlayContainer available, use that. Otherwise, provide a new one.
   provide: OverlayContainer,

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -73,7 +73,7 @@ const defaultPositionList: ConnectedPosition[] = [
 export const CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY =
     new InjectionToken<() => ScrollStrategy>('cdk-connected-overlay-scroll-strategy');
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_FACTORY(overlay: Overlay):
   () => ScrollStrategy {
   return (config?: RepositionScrollStrategyConfig) => overlay.scrollStrategies.reposition(config);

--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -35,7 +35,7 @@ export class OverlayModule {}
 
 /**
  * @deprecated Use `OverlayModule` instead.
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const OVERLAY_PROVIDERS: Provider[] = [
   Overlay,

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -28,7 +28,7 @@ import {OverlayReference} from '../overlay-reference';
  * a basic dropdown is connecting the bottom-left corner of the origin to the top-left corner
  * of the overlay.
  * @deprecated Use `FlexibleConnectedPositionStrategy` instead.
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export class ConnectedPositionStrategy implements PositionStrategy {
   /**
@@ -61,7 +61,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
       connectedTo: ElementRef,
       viewportRuler: ViewportRuler,
       document: Document,
-      // @deletion-target 7.0.0 `platform` parameter to be made required.
+      // @breaking-change 7.0.0 `platform` parameter to be made required.
       platform?: Platform) {
 
     // Since the `ConnectedPositionStrategy` is deprecated and we don't want to maintain

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -132,7 +132,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     connectedTo: ElementRef | HTMLElement,
     private _viewportRuler: ViewportRuler,
     private _document: Document,
-    // @deletion-target 7.0.0 `_platform` and `_overlayContainer` parameters to be made required.
+    // @breaking-change 7.0.0 `_platform` and `_overlayContainer` parameters to be made required.
     private _platform?: Platform,
     private _overlayContainer?: OverlayContainer) {
     this.setOrigin(connectedTo);
@@ -171,7 +171,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
    */
   apply(): void {
     // We shouldn't do anything if the strategy was disposed or we're on the server.
-    // @deletion-target 7.0.0 Remove `_platform` null check once it's guaranteed to be defined.
+    // @breaking-change 7.0.0 Remove `_platform` null check once it's guaranteed to be defined.
     if (this._isDisposed || (this._platform && !this._platform.isBrowser)) {
       return;
     }
@@ -842,7 +842,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       overlayPoint = this._pushOverlayOnScreen(overlayPoint, this._overlayRect);
     }
 
-    // @deletion-target 7.0.0 Currently the `_overlayContainer` is optional in order to avoid a
+    // @breaking-change 7.0.0 Currently the `_overlayContainer` is optional in order to avoid a
     // breaking change. The null check here can be removed once the `_overlayContainer` becomes
     // a required parameter.
     let virtualKeyboardOffset = this._overlayContainer ?

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -93,7 +93,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the overlay width and clears any previously set width.
    * @param value New width for the overlay
    * @deprecated Pass the `width` through the `OverlayConfig`.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   width(value: string = ''): this {
     if (this._overlayRef) {
@@ -109,7 +109,7 @@ export class GlobalPositionStrategy implements PositionStrategy {
    * Sets the overlay height and clears any previously set height.
    * @param value New height for the overlay
    * @deprecated Pass the `height` through the `OverlayConfig`.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   height(value: string = ''): this {
     if (this._overlayRef) {

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -23,7 +23,7 @@ export class OverlayPositionBuilder {
   constructor(
     private _viewportRuler: ViewportRuler,
     @Inject(DOCUMENT) private _document: any,
-    // @deletion-target 7.0.0 `_platform` and `_overlayContainer` parameters to be made required.
+    // @breaking-change 7.0.0 `_platform` and `_overlayContainer` parameters to be made required.
     @Optional() private _platform?: Platform,
     @Optional() private _overlayContainer?: OverlayContainer) { }
 
@@ -40,7 +40,7 @@ export class OverlayPositionBuilder {
    * @param originPos
    * @param overlayPos
    * @deprecated Use `flexibleConnectedTo` instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   connectedTo(
       elementRef: ElementRef,

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -68,7 +68,7 @@ export class Platform {
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
   /**
-   * @deletion-target v7.0.0 remove optional decorator
+   * @breaking-change v7.0.0 remove optional decorator
    */
   constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {
   }

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -170,13 +170,13 @@ export class ScrollDispatcher implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function SCROLL_DISPATCHER_PROVIDER_FACTORY(
     parentDispatcher: ScrollDispatcher, ngZone: NgZone, platform: Platform) {
   return parentDispatcher || new ScrollDispatcher(ngZone, platform);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const SCROLL_DISPATCHER_PROVIDER = {
   // If there is already a ScrollDispatcher available, use that. Otherwise, provide a new one.
   provide: ScrollDispatcher,

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -123,14 +123,14 @@ export class ViewportRuler implements OnDestroy {
 }
 
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export function VIEWPORT_RULER_PROVIDER_FACTORY(parentRuler: ViewportRuler,
                                                 platform: Platform,
                                                 ngZone: NgZone) {
   return parentRuler || new ViewportRuler(platform, ngZone);
 }
 
-/** @docs-private @deprecated @deletion-target 7.0.0 */
+/** @docs-private @deprecated @breaking-change 7.0.0 */
 export const VIEWPORT_RULER_PROVIDER = {
   // If there is already a ViewportRuler available, use that. Otherwise, provide a new one.
   provide: ViewportRuler,

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -200,7 +200,7 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
   /** The step that is selected. */
   @Input()
   get selected(): CdkStep {
-    // @deletion-target 7.0.0 Change return type to `CdkStep | undefined`.
+    // @breaking-change 7.0.0 Change return type to `CdkStep | undefined`.
     return this._steps ? this._steps.toArray()[this.selectedIndex] : undefined!;
   }
   set selected(step: CdkStep) {

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -478,7 +478,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * table's content is checked.
    * @docs-private
    * @deprecated Use `addHeaderRowDef` and `removeHeaderRowDef` instead
-   * @deletion-target 8.0.0
+   * @breaking-change 8.0.0
    */
   setHeaderRowDef(headerRowDef: CdkHeaderRowDef) {
     this._customHeaderRowDefs = new Set([headerRowDef]);
@@ -491,7 +491,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * table's content is checked.
    * @docs-private
    * @deprecated Use `addFooterRowDef` and `removeFooterRowDef` instead
-   * @deletion-target 8.0.0
+   * @breaking-change 8.0.0
    */
   setFooterRowDef(footerRowDef: CdkFooterRowDef) {
     this._customFooterRowDefs = new Set([footerRowDef]);

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -177,7 +177,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
               @Optional() private _dir: Directionality,
               @Optional() @Host() private _formField: MatFormField,
               @Optional() @Inject(DOCUMENT) private _document: any,
-              // @deletion-target 7.0.0 Make `_viewportRuler` required.
+              // @breaking-change 7.0.0 Make `_viewportRuler` required.
               private _viewportRuler?: ViewportRuler) {}
 
   ngOnDestroy() {

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -57,7 +57,7 @@ export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
 
 /**
  * @deprecated Use `MatButtonToggleGroup` instead.
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export class MatButtonToggleGroupMultiple {}
 

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -92,12 +92,12 @@ export class MatButton extends _MatButtonMixinBase
   constructor(elementRef: ElementRef,
               /**
                * @deprecated Platform checks for SSR are no longer needed
-               * @deletion-target 7.0.0
+               * @breaking-change 7.0.0
                */
               // tslint:disable-next-line:no-unused-variable
               private _platform: Platform,
               private _focusMonitor: FocusMonitor,
-              // @deletion-target 7.0.0 `_animationMode` parameter to be made required.
+              // @breaking-change 7.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(elementRef);
 
@@ -173,7 +173,7 @@ export class MatAnchor extends MatButton {
     platform: Platform,
     focusMonitor: FocusMonitor,
     elementRef: ElementRef,
-    // @deletion-target 7.0.0 `animationMode` parameter to be made required.
+    // @breaking-change 7.0.0 `animationMode` parameter to be made required.
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, focusMonitor, animationMode);
   }

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -79,7 +79,7 @@ export class MatChipInput {
   /**
    * The input's placeholder text.
    * @deprecated Bind to the `placeholder` attribute directly.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @Input() placeholder: string = '';
 

--- a/src/lib/core/datetime/date-adapter.ts
+++ b/src/lib/core/datetime/date-adapter.ts
@@ -24,7 +24,7 @@ export function MAT_DATE_LOCALE_FACTORY(): string {
  * No longer needed since MAT_DATE_LOCALE has been changed to a scoped injectable.
  * If you are importing and providing this in your code you can simply remove it.
  * @deprecated
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const MAT_DATE_LOCALE_PROVIDER = {provide: MAT_DATE_LOCALE, useExisting: LOCALE_ID};
 

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -80,7 +80,7 @@ export class GestureConfig extends HammerGestureConfig {
       // `this.events` to the set we support, instead of conditionally setting it to `[]` if
       // `HAMMER_LOADER` is present (and then throwing an Error here if `window.Hammer` is
       // undefined).
-      // @deletion-target 7.0.0
+      // @breaking-change 7.0.0
       return noopHammerInstance;
     }
 

--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -18,7 +18,7 @@ export type RippleConfig = {
   terminateOnPointerUp?: boolean;
   /**
    * @deprecated Use the `animation` property instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   speedFactor?: number;
 };

--- a/src/lib/core/ripple/ripple.ts
+++ b/src/lib/core/ripple/ripple.ts
@@ -42,7 +42,7 @@ export interface RippleGlobalOptions {
    * setting it to 0.5 will cause the ripple fade-in animation to take twice as long.
    * A changed speedFactor will not affect the fade-out duration of the ripples.
    * @deprecated Use the `animation` global option instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   baseSpeedFactor?: number;
 
@@ -91,7 +91,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
    * setting it to 0.5 will cause the animations to take twice as long.
    * A changed speedFactor will not modify the fade-out duration of the ripples.
    * @deprecated Use the [matRippleAnimation] binding instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @Input('matRippleSpeedFactor') speedFactor: number = 1;
 

--- a/src/lib/core/theming/_palette.scss
+++ b/src/lib/core/theming/_palette.scss
@@ -7,22 +7,22 @@
 
 
 // @deprecated renamed to $dark-primary-text.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $black-87-opacity: rgba(black, 0.87);
 // @deprecated renamed to $light-primary-text.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $white-87-opacity: rgba(white, 0.87);
 // @deprecated use $dark-[secondary-text,disabled-text,dividers,focused] instead.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $black-12-opacity: rgba(black, 0.12);
 // @deprecated use $light-[secondary-text,disabled-text,dividers,focused] instead.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $white-12-opacity: rgba(white, 0.12);
 // @deprecated use $dark-[secondary-text,disabled-text,dividers,focused] instead.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $black-6-opacity: rgba(black, 0.06);
 // @deprecated use $light-[secondary-text,disabled-text,dividers,focused] instead.
-// @deletion-target 7.0.0
+// @breaking-change 7.0.0
 $white-6-opacity: rgba(white, 0.06);
 
 $dark-primary-text: rgba(black, 0.87);

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -283,7 +283,7 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
 
   /**
    * @deprecated
-   * @deletion-target 7.0.0 Use `getConnectedOverlayOrigin` instead
+   * @breaking-change 7.0.0 Use `getConnectedOverlayOrigin` instead
    */
   getPopupConnectionElementRef(): ElementRef {
     return this.getConnectedOverlayOrigin();

--- a/src/lib/form-field/_form-field-legacy-theme.scss
+++ b/src/lib/form-field/_form-field-legacy-theme.scss
@@ -96,7 +96,7 @@ $mat-form-field-legacy-dedupe: 0;
                 $subscript-font-scale, $infix-padding, $infix-margin-top);
       }
 
-      // @deletion-target 7.0.0 will rely on AutofillMonitor instead.
+      // @breaking-change 7.0.0 will rely on AutofillMonitor instead.
       .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _mat-form-field-legacy-label-floating(

--- a/src/lib/form-field/form-field.html
+++ b/src/lib/form-field/form-field.html
@@ -38,7 +38,7 @@
                *ngIf="_hasFloatingLabel()"
                [ngSwitch]="_hasLabel()">
 
-          <!-- @deletion-target 8.0.0 remove in favor of mat-label element an placeholder attr. -->
+          <!-- @breaking-change 8.0.0 remove in favor of mat-label element an placeholder attr. -->
           <ng-container *ngSwitchCase="false">
             <ng-content select="mat-placeholder"></ng-content>
             {{_control.placeholder}}
@@ -46,7 +46,7 @@
 
           <ng-content select="mat-label" *ngSwitchCase="true"></ng-content>
 
-          <!-- @deletion-target 8.0.0 remove `mat-placeholder-required` class -->
+          <!-- @breaking-change 8.0.0 remove `mat-placeholder-required` class -->
           <span
             class="mat-placeholder-required mat-form-field-required-marker"
             aria-hidden="true"

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -116,7 +116,7 @@ $mat-form-field-default-infix-width: 180px !default;
 // This is necessary because these browsers do not actually fire any events when a form auto-fill is
 // occurring. Once the autofill is committed, a change event happen and the regular mat-form-field
 // classes take over to fulfill this behaviour.
-// @deletion-target 7.0.0 will rely on AutofillMonitor instead.
+// @breaking-change 7.0.0 will rely on AutofillMonitor instead.
 .mat-form-field-autofill-control:-webkit-autofill + .mat-form-field-label-wrapper
     .mat-form-field-label {
   // The form field will be considered empty if it is autofilled, and therefore the label will

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -223,7 +223,7 @@ export class MatFormField extends _MatFormFieldMixinBase
 
   /**
    * @deprecated
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @ViewChild('underline') underlineRef: ElementRef;
 
@@ -245,7 +245,7 @@ export class MatFormField extends _MatFormFieldMixinBase
       @Optional() private _dir: Directionality,
       @Optional() @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS) private _defaultOptions:
           MatFormFieldDefaultOptions,
-      // @deletion-target 7.0.0 _platform, _ngZone and _animationMode to be made required.
+      // @breaking-change 7.0.0 _platform, _ngZone and _animationMode to be made required.
       private _platform?: Platform,
       private _ngZone?: NgZone,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) _animationMode?: string) {
@@ -300,7 +300,7 @@ export class MatFormField extends _MatFormFieldMixinBase
     this._validateControlChild();
 
     if (!this._initialGapCalculated) {
-      // @deletion-target 7.0.0 Remove this check and else block once _ngZone is required.
+      // @breaking-change 7.0.0 Remove this check and else block once _ngZone is required.
       if (this._ngZone) {
         // It's important that we run this outside the `_ngZone`, because the `Promise.resolve`
         // can kick us into an infinite change detection loop, if the `_initialGapCalculated`

--- a/src/lib/form-field/placeholder.ts
+++ b/src/lib/form-field/placeholder.ts
@@ -13,7 +13,7 @@ import {Directive} from '@angular/core';
  * The placeholder text for an `MatFormField`.
  * @deprecated Use `<mat-label>` to specify the label and the `placeholder` attribute to specify the
  *     placeholder.
- * @deletion-target 8.0.0
+ * @breaking-change 8.0.0
  */
 @Directive({
   selector: 'mat-placeholder'

--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -13,7 +13,7 @@ import {Directive, Input} from '@angular/core';
 /**
  * Directive to automatically resize a textarea to fit its content.
  * @deprecated Use `cdkTextareaAutosize` from `@angular/cdk/text-field` instead.
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 @Directive({
   selector: 'textarea[mat-autosize], textarea[matTextareaAutosize]',

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -62,7 +62,7 @@ export const _MatInputMixinBase = mixinErrorState(MatInputBase);
   exportAs: 'matInput',
   host: {
     /**
-     * @deletion-target 7.0.0 remove .mat-form-field-autofill-control in favor of AutofillMonitor.
+     * @breaking-change 7.0.0 remove .mat-form-field-autofill-control in favor of AutofillMonitor.
      */
     'class': 'mat-input-element mat-form-field-autofill-control',
     '[class.mat-input-server]': '_isServer',

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -96,7 +96,7 @@ export class MatListSubheaderCssMatStyler {}
   exportAs: 'matListItem',
   host: {
     'class': 'mat-list-item',
-    // @deletion-target 7.0.0 Remove `mat-list-item-avatar` in favor of `mat-list-item-with-avatar`.
+    // @breaking-change 7.0.0 Remove `mat-list-item-avatar` in favor of `mat-list-item-with-avatar`.
     '[class.mat-list-item-avatar]': '_avatar || _icon',
     '[class.mat-list-item-with-avatar]': '_avatar || _icon',
     '(focus)': '_handleFocus()',

--- a/src/lib/menu/menu-animations.ts
+++ b/src/lib/menu/menu-animations.ts
@@ -73,12 +73,12 @@ export const matMenuAnimations: {
 
 /**
  * @deprecated
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const fadeInItems = matMenuAnimations.fadeInItems;
 
 /**
  * @deprecated
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const transformMenu = matMenuAnimations.transformMenu;

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -162,7 +162,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   /**
    * List of the items inside of a menu.
    * @deprecated
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 
@@ -211,7 +211,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
    * menu template that displays in the overlay container.  Otherwise, it's difficult
    * to style the containing menu from outside the component.
    * @deprecated Use `panelClass` instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @Input()
   get classList(): string { return this.panelClass; }
@@ -224,7 +224,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   /**
    * Event emitted when the menu is closed.
    * @deprecated Switch to `closed` instead
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @Output() close = this.closed;
 
@@ -371,13 +371,13 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
 
   /** Starts the enter animation. */
   _startAnimation() {
-    // @deletion-target 7.0.0 Combine with _resetAnimation.
+    // @breaking-change 7.0.0 Combine with _resetAnimation.
     this._panelAnimationState = 'enter';
   }
 
   /** Resets the panel animation to its initial state. */
   _resetAnimation() {
-    // @deletion-target 7.0.0 Combine with _startAnimation.
+    // @breaking-change 7.0.0 Combine with _startAnimation.
     this._panelAnimationState = 'void';
   }
 

--- a/src/lib/menu/menu-item.ts
+++ b/src/lib/menu/menu-item.ts
@@ -75,7 +75,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
     private _focusMonitor?: FocusMonitor,
     @Inject(MAT_MENU_PANEL) @Optional() private _parentMenu?: MatMenuPanel<MatMenuItem>) {
 
-    // @deletion-target 7.0.0 make `_focusMonitor` and `document` required params.
+    // @breaking-change 7.0.0 make `_focusMonitor` and `document` required params.
     super();
 
     if (_focusMonitor) {

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -90,7 +90,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
   /**
    * @deprecated
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   @Input('mat-menu-trigger-for')
   get _deprecatedMatMenuTriggerFor(): MatMenuPanel {
@@ -113,7 +113,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   /**
    * Event emitted when the associated menu is opened.
    * @deprecated Switch to `menuOpened` instead
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onMenuOpen: EventEmitter<void> = this.menuOpened;
@@ -124,7 +124,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   /**
    * Event emitted when the associated menu is closed.
    * @deprecated Switch to `menuClosed` instead
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onMenuClose: EventEmitter<void> = this.menuClosed;
@@ -137,7 +137,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
               @Optional() @Self() private _menuItemInstance: MatMenuItem,
               @Optional() private _dir: Directionality,
               // TODO(crisbeto): make the _focusMonitor required when doing breaking changes.
-              // @deletion-target 7.0.0
+              // @breaking-change 7.0.0
               private _focusMonitor?: FocusMonitor) {
 
     if (_menuItemInstance) {

--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -9,7 +9,7 @@ $mat-paginator-selector-trigger-width: 56px;
 $mat-paginator-selector-trigger-outline-width: 64px;
 $mat-paginator-selector-trigger-fill-width: 64px;
 
-/** @deprecated Use `$mat-paginator-selector-trigger-width` instead. @deletion-target 8.0.0 */
+/** @deprecated Use `$mat-paginator-selector-trigger-width` instead. @breaking-change 8.0.0 */
 $mat-paginator-selector-trigger-min-width: $mat-paginator-selector-trigger-width;
 
 $mat-paginator-range-actions-min-height: 48px;

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -35,7 +35,7 @@ export class PageEvent {
 
   /**
    * Index of the page that was selected previously.
-   * @deletion-target 7.0.0 To be made into a required property.
+   * @breaking-change 7.0.0 To be made into a required property.
    */
   previousPageIndex?: number;
 

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -59,7 +59,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
               /**
                * @deprecated `location` parameter to be made required.
-               * @deletion-target 8.0.0
+               * @breaking-change 8.0.0
                */
               @Optional() location?: Location) {
     super(_elementRef);

--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -176,7 +176,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   constructor(public _elementRef: ElementRef,
               platform: Platform,
               @Optional() @Inject(DOCUMENT) private _document: any,
-              // @deletion-target 7.0.0 animationMode and defaults parameters to be made required.
+              // @breaking-change 7.0.0 animationMode and defaults parameters to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) private animationMode?: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
                   private defaults?: MatProgressSpinnerDefaultOptions) {
@@ -291,7 +291,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
 export class MatSpinner extends MatProgressSpinner {
   constructor(elementRef: ElementRef, platform: Platform,
               @Optional() @Inject(DOCUMENT) document: any,
-              // @deletion-targets 7.0.0 animationMode and defaults parameters to be made required.
+              // @breaking-changes 7.0.0 animationMode and defaults parameters to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
                   defaults?: MatProgressSpinnerDefaultOptions) {

--- a/src/lib/select/select-animations.ts
+++ b/src/lib/select/select-animations.ts
@@ -79,12 +79,12 @@ export const matSelectAnimations: {
 
 /**
  * @deprecated
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const transformPanel = matSelectAnimations.transformPanel;
 
 /**
  * @deprecated
- * @deletion-target 7.0.0
+ * @breaking-change 7.0.0
  */
 export const fadeInContent = matSelectAnimations.fadeInContent;

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -316,7 +316,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   }
   /**
    * @deprecated Setter to be removed as this property is intended to be readonly.
-   * @deletion-target 8.0.0
+   * @breaking-change 8.0.0
    */
   set focused(value: boolean) {
     this._focused = value;

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -185,7 +185,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   constructor(elementRef: ElementRef,
               /**
                * @deprecated The `_platform` parameter to be removed.
-               * @deletion-target 7.0.0
+               * @breaking-change 7.0.0
                */
               _platform: Platform,
               private _focusMonitor: FocusMonitor,

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -456,7 +456,7 @@ export class MatSlider extends _MatSliderMixinBase
               private _changeDetectorRef: ChangeDetectorRef,
               @Optional() private _dir: Directionality,
               @Attribute('tabindex') tabIndex: string,
-              // @deletion-target 7.0.0 `_animationMode` parameter to be made required.
+              // @breaking-change 7.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(elementRef);
 

--- a/src/lib/snack-bar/snack-bar-ref.ts
+++ b/src/lib/snack-bar/snack-bar-ref.ts
@@ -77,7 +77,7 @@ export class MatSnackBarRef<T> {
   /**
    * Marks the snackbar action clicked.
    * @deprecated Use `dismissWithAction` instead.
-   * @deletion-target 7.0.0
+   * @breaking-change 7.0.0
    */
   closeWithAction(): void {
     this.dismissWithAction();

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -156,7 +156,7 @@ export class MatTabBody implements OnInit, OnDestroy {
   constructor(private _elementRef: ElementRef,
               @Optional() private _dir: Directionality,
               /**
-               * @deletion-target 7.0.0 changeDetectorRef to be made required.
+               * @breaking-change 7.0.0 changeDetectorRef to be made required.
                */
               changeDetectorRef?: ChangeDetectorRef) {
 

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -112,11 +112,11 @@ export class MatTabNav extends _MatTabNavMixinBase
 
   /**
    * Notifies the component that the active link has been changed.
-   * @deletion-target 7.0.0 `element` parameter to be removed.
+   * @breaking-change 7.0.0 `element` parameter to be removed.
    */
   updateActiveLink(element: ElementRef) {
     // Note: keeping the `element` for backwards-compat, but isn't being used for anything.
-    // @deletion-target 7.0.0
+    // @breaking-change 7.0.0
     this._activeLinkChanged = !!element;
     this._changeDetectorRef.markForCheck();
   }
@@ -226,7 +226,7 @@ export class MatTabLink extends _MatTabLinkMixinBase
               @Attribute('tabindex') tabIndex: string,
               /**
                * @deprecated
-               * @deletion-target 7.0.0 `_focusMonitor` parameter to be made required.
+               * @breaking-change 7.0.0 `_focusMonitor` parameter to be made required.
                */
               private _focusMonitor?: FocusMonitor) {
     super();

--- a/src/lib/toolbar/toolbar.scss
+++ b/src/lib/toolbar/toolbar.scss
@@ -5,9 +5,9 @@ $mat-toolbar-height-desktop: 64px !default;
 $mat-toolbar-height-mobile: 56px !default;
 $mat-toolbar-row-padding: 16px !default;
 
-/** @deprecated @deletion-target 8.0.0 */
+/** @deprecated @breaking-change 8.0.0 */
 $mat-toolbar-height-mobile-portrait: 56px !default;
-/** @deprecated @deletion-target 8.0.0 */
+/** @deprecated @breaking-change 8.0.0 */
 $mat-toolbar-height-mobile-landscape: 48px !default;
 
 

--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -82,14 +82,13 @@ export function hasDecorator(doc: HasDecoratorsDoc, decoratorName: string) {
     doc.decorators.some(d => d.name == decoratorName);
 }
 
-export function getDeletionTarget(doc: any): string | null {
+export function getBreakingChange(doc: any): string | null {
   if (!doc.tags) {
     return null;
   }
 
-  const deletionTarget = doc.tags.tags.find((t: any) => t.tagName === 'deletion-target');
-
-  return deletionTarget ? deletionTarget.description : null;
+  const breakingChange = doc.tags.tags.find((t: any) => t.tagName === 'breaking-change');
+  return breakingChange ? breakingChange.description : null;
 }
 
 /**
@@ -98,12 +97,12 @@ export function getDeletionTarget(doc: any): string | null {
  */
 export function decorateDeprecatedDoc(doc: DeprecationDoc) {
   doc.isDeprecated = isDeprecatedDoc(doc);
-  doc.deletionTarget = getDeletionTarget(doc);
+  doc.breakingChange = getBreakingChange(doc);
 
-  if (doc.isDeprecated && !doc.deletionTarget) {
-    console.warn('Warning: There is a deprecated item without a @deletion-target tag.', doc.id);
-  } else if  (doc.deletionTarget && !doc.isDeprecated) {
-    console.warn('Warning: There is an item with a @deletion-target which is not deprecated.',
+  if (doc.isDeprecated && !doc.breakingChange) {
+    console.warn('Warning: There is a deprecated item without a @breaking-change tag.', doc.id);
+  } else if  (doc.breakingChange && !doc.isDeprecated) {
+    console.warn('Warning: There is an item with a @breaking-change which is not deprecated.',
       doc.id);
   }
 }

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -8,7 +8,7 @@ import {NormalizedMethodMemberDoc} from './normalize-method-parameters';
 /** Interface that describes categorized docs that can be deprecated. */
 export interface DeprecationDoc extends ApiDoc {
   isDeprecated: boolean;
-  deletionTarget: string | null;
+  breakingChange: string | null;
 }
 
 /** Interface that describes Dgeni documents that have decorators. */

--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -91,7 +91,7 @@ apiDocsPackage.config((computePathsProcessor: any) => {
 apiDocsPackage.config((parseTagsProcessor: any) => {
   parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat([
     {name: 'docs-private'},
-    {name: 'deletion-target'}
+    {name: 'breaking-change'}
   ]);
 });
 

--- a/tools/dgeni/templates/macros.html
+++ b/tools/dgeni/templates/macros.html
@@ -1,5 +1,5 @@
 {% macro deprecationTitle(doc) %}
-  {%- if doc.deletionTarget -%}
-    title="Will be deleted in v{$ doc.deletionTarget $}"
+  {%- if doc.breakingChange -%}
+    title="Will be deleted in v{$ doc.breakingChange $}"
   {%- endif -%}
 {% endmacro %}

--- a/tslint.json
+++ b/tslint.json
@@ -126,7 +126,7 @@
       "./tools/package-tools/rollup-globals.ts",
       "src/+(lib|cdk|material-examples|material-experimental|cdk-experimental)/!(schematics)**/*.ts"
     ],
-    "deletion-target": true,
+    "breaking-change": true,
     "no-unescaped-html-tag": true
   },
   "linterOptions": {


### PR DESCRIPTION
As discussed, renames the `@deletion-target` tag to `@breaking-change` to make the intentions of the tag clearer. Also adds an extra check to the tslint rule to catch any leftover `@deletion-target` tags.