### PR TITLE
refactor(material-moment-adapter): use updated moment import style

### DIFF
--- a/src/material-examples/datepicker-formats/datepicker-formats-example.ts
+++ b/src/material-examples/datepicker-formats/datepicker-formats-example.ts
@@ -3,15 +3,7 @@ import {FormControl} from '@angular/forms';
 import {MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 
-// Depending on whether rollup is used, moment needs to be imported differently.
-// Since Moment.js doesn't have a default export, we normally need to import using the `* as`
-// syntax. However, rollup creates a synthetic default module and we thus need to import it using
-// the `default as` syntax.
-import * as _moment from 'moment';
-// tslint:disable-next-line:no-duplicate-imports
-import {default as _rollupMoment} from 'moment';
-
-const moment = _rollupMoment || _moment;
+import moment from 'moment';
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/

--- a/src/material-examples/datepicker-moment/datepicker-moment-example.ts
+++ b/src/material-examples/datepicker-moment/datepicker-moment-example.ts
@@ -3,15 +3,7 @@ import {FormControl} from '@angular/forms';
 import {MAT_MOMENT_DATE_FORMATS, MomentDateAdapter} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 
-// Depending on whether rollup is used, moment needs to be imported differently.
-// Since Moment.js doesn't have a default export, we normally need to import using the `* as`
-// syntax. However, rollup creates a synthetic default module and we thus need to import it using
-// the `default as` syntax.
-import * as _moment from 'moment';
-// tslint:disable-next-line:no-duplicate-imports
-import {default as _rollupMoment} from 'moment';
-
-const moment = _rollupMoment || _moment;
+import moment from 'moment';
 
 /** @title Datepicker that uses Moment.js dates */
 @Component({

--- a/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/material-examples/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -8,11 +8,7 @@ import {MatDatepicker} from '@angular/material/datepicker';
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using
 // the `default as` syntax.
-import * as _moment from 'moment';
-// tslint:disable-next-line:no-duplicate-imports
-import {default as _rollupMoment, Moment} from 'moment';
-
-const moment = _rollupMoment || _moment;
+import moment, { Moment } from 'moment';
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -9,7 +9,7 @@
 import {LOCALE_ID} from '@angular/core';
 import {async, inject, TestBed} from '@angular/core/testing';
 import {DateAdapter, DEC, FEB, JAN, MAR, MAT_DATE_LOCALE} from '@angular/material/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import {MomentDateModule} from './index';
 import {MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS} from './moment-date-adapter';
 

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -8,16 +8,9 @@
 
 import {Inject, Injectable, Optional, InjectionToken} from '@angular/core';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material';
-// Depending on whether rollup is used, moment needs to be imported differently.
-// Since Moment.js doesn't have a default export, we normally need to import using the `* as`
-// syntax. However, rollup creates a synthetic default module and we thus need to import it using
-// the `default as` syntax.
-// TODO(mmalerba): See if we can clean this up at some point.
-import * as _moment from 'moment';
-// tslint:disable-next-line:no-duplicate-imports
-import {default as _rollupMoment, Moment} from 'moment';
 
-const moment = _rollupMoment || _moment;
+// TODO(mmalerba): See if we can clean this up at some point.
+import moment, { Moment } from 'moment';
 
 /** Configurable options for {@see MomentDateAdapter}. */
 export interface MatMomentDateAdapterOptions {


### PR DESCRIPTION
I don't know since which version you can use moment's defaults exports but you can.
I refactored the calendar examples with moment to reflect the actual way to import moment.