### PR TITLE
fix(chips): focus indication not visible in high contrast mode

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -47,6 +47,11 @@ $mat-chip-remove-size: 18px;
 
   @include cdk-high-contrast {
     outline: solid 1px;
+
+    &:focus {
+      // Use 2px here since the dotted outline is a little thinner.
+      outline: dotted 2px;
+    }
   }
 
   &.mat-chip-with-trailing-icon.mat-chip-with-avatar,


### PR DESCRIPTION
Fixes not being able to tell which chip is focused in high contrast mode. For reference:

![angular_material_ -_microsoft_edge_2018-07-29_22-39-01](https://user-images.githubusercontent.com/4450522/43370563-5ff541e2-9381-11e8-9466-16e31d431b6d.png)
