### PR TITLE
fix(schematics): properly detect tsconfig files

### DIFF
--- a/src/lib/schematics/update/update.spec.ts
+++ b/src/lib/schematics/update/update.spec.ts
@@ -8,16 +8,12 @@ describe('material-nav-schematic', () => {
     runner = new SchematicTestRunner('schematics', migrationCollection);
   });
 
-  describe('migration v5 to v6', () => {
+  it('should remove the temp directory', () => {
+    const tree = runner.runSchematic('migration-01', {}, createTestApp());
+    const files = tree.files;
 
-    it('should remove the temp directory', () => {
-      const tree = runner.runSchematic('migration-01', {}, createTestApp());
-      const files = tree.files;
-
-      expect(files.find(file => file.includes('angular_material_temp_schematics')))
-        .toBeFalsy('Expected the temporary directory for the schematics to be deleted');
-    });
-
+    expect(files.find(file => file.includes('angular_material_temp_schematics')))
+      .toBeFalsy('Expected the temporary directory for the schematics to be deleted');
   });
 
 });

--- a/src/lib/schematics/update/update.ts
+++ b/src/lib/schematics/update/update.ts
@@ -41,6 +41,7 @@ export default function(): Rule {
 
     const allTsConfigPaths = getTsConfigPaths(tree);
     const allUpdateTasks = [];
+
     for (const tsconfig of allTsConfigPaths) {
       // Run the update tslint rules.
       allUpdateTasks.push(context.addTask(new TslintFixTask({
@@ -119,12 +120,13 @@ function getTsConfigPaths(tree: Tree): string[] {
 
   // Add any tsconfig directly referenced in a build or test task of the angular.json workspace.
   const workspace = getWorkspace(tree);
+
   for (const project of Object.values(workspace.projects)) {
     if (project && project.architect) {
       for (const taskName of ['build', 'test']) {
         const task = project.architect[taskName];
         if (task && task.options && task.options.tsConfig) {
-          const tsConfigOption = project.architect.tsConfig;
+          const tsConfigOption = task.options.tsConfig;
           if (typeof tsConfigOption === 'string') {
             tsconfigPaths.push(tsConfigOption);
           } else if (Array.isArray(tsConfigOption)) {

--- a/tslint.json
+++ b/tslint.json
@@ -131,7 +131,11 @@
   },
   "linterOptions": {
     // Exclude schematic template files that can't be linted.
-    // TODO(paul) re-renable specs once the devkit schematics properly work with Bazel.
-    "exclude": ["src/lib/schematics/**/files/**/*", "src/lib/schematics/**/*.spec.ts"]
+    "exclude": [
+      "src/lib/schematics/**/files/**/*",
+      // TODO(paul) re-renable specs once the devkit schematics properly work with Bazel and we
+      // can remove the `xit` calls.
+      "src/lib/schematics/**/*.spec.ts"
+    ]
   }
 }


### PR DESCRIPTION
* Currently the `tsconfig` files are not being detected properly with the latest Angular CLI version.
* Improves tslint config comment