### PR TITLE
feat(button-toggle): align with 2018 material design spec

### DIFF
--- a/src/demo-app/button-toggle/button-toggle-demo.html
+++ b/src/demo-app/button-toggle/button-toggle-demo.html
@@ -25,6 +25,23 @@
   </mat-button-toggle-group>
 </section>
 
+<section>
+  <mat-button-toggle-group appearance="legacy" name="alignment" [vertical]="isVertical">
+    <mat-button-toggle value="left" [disabled]="isDisabled">
+      <mat-icon>format_align_left</mat-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="center" [disabled]="isDisabled">
+      <mat-icon>format_align_center</mat-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="right" [disabled]="isDisabled">
+      <mat-icon>format_align_right</mat-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="justify" [disabled]="isDisabled">
+      <mat-icon>format_align_justify</mat-icon>
+    </mat-button-toggle>
+  </mat-button-toggle-group>
+</section>
+
 <h1>Disabled Group</h1>
 
 <section>
@@ -50,9 +67,18 @@
     <mat-button-toggle [disabled]="isDisabled">Milk</mat-button-toggle>
   </mat-button-toggle-group>
 </section>
+<section>
+  <mat-button-toggle-group appearance="legacy" multiple [vertical]="isVertical">
+    <mat-button-toggle>Flour</mat-button-toggle>
+    <mat-button-toggle>Eggs</mat-button-toggle>
+    <mat-button-toggle>Sugar</mat-button-toggle>
+    <mat-button-toggle [disabled]="isDisabled">Milk</mat-button-toggle>
+  </mat-button-toggle-group>
+</section>
 
 <h1>Single Toggle</h1>
 <mat-button-toggle>Yes</mat-button-toggle>
+<mat-button-toggle appearance="legacy">Yes</mat-button-toggle>
 
 <h1>Dynamic Exclusive Selection</h1>
 <section>

--- a/src/demo-app/button-toggle/button-toggle-demo.scss
+++ b/src/demo-app/button-toggle/button-toggle-demo.scss
@@ -1,0 +1,3 @@
+section {
+  margin-bottom: 16px;
+}

--- a/src/demo-app/button-toggle/button-toggle-demo.ts
+++ b/src/demo-app/button-toggle/button-toggle-demo.ts
@@ -13,6 +13,7 @@ import {Component} from '@angular/core';
   moduleId: module.id,
   selector: 'button-toggle-demo',
   templateUrl: 'button-toggle-demo.html',
+  styleUrls: ['button-toggle-demo.css'],
 })
 export class ButtonToggleDemo {
   isVertical = false;

--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -6,9 +6,16 @@
 @mixin mat-button-toggle-theme($theme) {
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
+  $divider-color: mat-color($foreground, divider);
 
-  .mat-button-toggle-standalone, .mat-button-toggle-group {
+  .mat-button-toggle-standalone,
+  .mat-button-toggle-group {
     @include _mat-theme-elevation(2, $theme);
+  }
+
+  .mat-button-toggle-standalone.mat-button-toggle-appearance-standard,
+  .mat-button-toggle-group-appearance-standard {
+    box-shadow: none;
   }
 
   .mat-button-toggle {
@@ -19,18 +26,55 @@
     }
   }
 
+  .mat-button-toggle-appearance-standard {
+    color: mat-color($foreground, text);
+    background: mat-color($background, card);
+
+    .mat-button-toggle-focus-overlay {
+      background-color: mat-color($background, focused-button, 1);
+    }
+  }
+
+  .mat-button-toggle-group-appearance-standard .mat-button-toggle + .mat-button-toggle {
+    border-left: solid 1px $divider-color;
+  }
+
+  [dir='rtl'] .mat-button-toggle-group-appearance-standard .mat-button-toggle + .mat-button-toggle {
+    border-left: none;
+    border-right: solid 1px $divider-color;
+  }
+
+  .mat-button-toggle-vertical-appearance-standard .mat-button-toggle + .mat-button-toggle {
+    border-left: none;
+    border-right: none;
+    border-top: solid 1px $divider-color;
+  }
+
   .mat-button-toggle-checked {
     background-color: mat-color($background, selected-button);
     color: mat-color($foreground, secondary-text);
+
+    &.mat-button-toggle-appearance-standard {
+      color: mat-color($foreground, text);
+    }
   }
 
   .mat-button-toggle-disabled {
-    background-color: mat-color($background, disabled-button-toggle);
     color: mat-color($foreground, disabled-button);
+    background-color: mat-color($background, disabled-button-toggle);
+
+    &.mat-button-toggle-appearance-standard {
+      background: mat-color($background, card);
+    }
 
     &.mat-button-toggle-checked {
       background-color: mat-color($background, selected-disabled-button);
     }
+  }
+
+  .mat-button-toggle-standalone.mat-button-toggle-appearance-standard,
+  .mat-button-toggle-group-appearance-standard {
+    border: solid 1px $divider-color;
   }
 }
 

--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -2,24 +2,35 @@
 @import '../core/style/layout-common';
 @import '../../cdk/a11y/a11y';
 
-$mat-button-toggle-padding: 0 16px !default;
-$mat-button-toggle-height: 36px !default;
-$mat-button-toggle-border-radius: 2px !default;
+$mat-button-toggle-standard-padding: 0 12px !default;
+$mat-button-toggle-standard-height: 48px !default;
+$mat-button-toggle-standard-border-radius: 4px !default;
+
+$mat-button-toggle-legacy-padding: 0 16px !default;
+$mat-button-toggle-legacy-height: 36px !default;
+$mat-button-toggle-legacy-border-radius: 2px !default;
 
 .mat-button-toggle-standalone,
 .mat-button-toggle-group {
   position: relative;
   display: inline-flex;
   flex-direction: row;
-
-  border-radius: $mat-button-toggle-border-radius;
-
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
+  border-radius: $mat-button-toggle-legacy-border-radius;
 
   @include cdk-high-contrast {
     outline: solid 1px;
+  }
+}
+
+.mat-button-toggle-standalone.mat-button-toggle-appearance-standard,
+.mat-button-toggle-group-appearance-standard {
+  border-radius: $mat-button-toggle-standard-border-radius;
+
+  @include cdk-high-contrast {
+    outline: 0;
   }
 }
 
@@ -38,10 +49,6 @@ $mat-button-toggle-border-radius: 2px !default;
   position: relative;
   -webkit-tap-highlight-color: transparent;
 
-  // Similar to components like the checkbox, slide-toggle and radio, we cannot show the focus
-  // overlay for `.cdk-program-focused` because mouse clicks on the <label> element would be always
-  // treated as programmatic focus.
-  // TODO(paul): support `program` as well. See https://github.com/angular/material2/issues/9889
   &.cdk-keyboard-focused {
     .mat-button-toggle-focus-overlay {
       opacity: 1;
@@ -54,11 +61,35 @@ $mat-button-toggle-border-radius: 2px !default;
   }
 }
 
+.mat-button-toggle-appearance-standard {
+  &:not(.mat-button-toggle-disabled):hover .mat-button-toggle-focus-overlay {
+    opacity: 0.04;
+  }
+
+  // Similar to components like the checkbox, slide-toggle and radio, we cannot show the focus
+  // overlay for `.cdk-program-focused` because mouse clicks on the <label> element would be always
+  // treated as programmatic focus. Note that it needs the extra `:not` in order to have more
+  // specificity than the `:hover` above.
+  // TODO(paul): support `program` as well. See https://github.com/angular/material2/issues/9889
+  &.cdk-keyboard-focused:not(.mat-button-toggle-disabled) .mat-button-toggle-focus-overlay {
+    opacity: 0.12;
+
+    @include cdk-high-contrast {
+      opacity: 0.5;
+    }
+  }
+}
+
 .mat-button-toggle-label-content {
   @include user-select(none);
   display: inline-block;
-  line-height: $mat-button-toggle-height;
-  padding: $mat-button-toggle-padding;
+  line-height: $mat-button-toggle-legacy-height;
+  padding: $mat-button-toggle-legacy-padding;
+
+  .mat-button-toggle-appearance-standard & {
+    line-height: $mat-button-toggle-standard-height;
+    padding: $mat-button-toggle-standard-padding;
+  }
 }
 
 .mat-button-toggle-label-content > * {
@@ -75,13 +106,22 @@ $mat-button-toggle-border-radius: 2px !default;
   @include mat-fill;
 
   .mat-button-toggle-checked & {
+    border-bottom: solid $mat-button-toggle-legacy-height;
+
     // Changing the background color for the selected item won't be visible in high contrast mode.
     // We fall back to using the overlay to draw a brighter, semi-transparent tint on top instead.
     // It uses a border, because the browser will render it using a brighter color.
     @include cdk-high-contrast {
       opacity: 0.5;
       height: 0;
-      border-bottom: solid $mat-button-toggle-height;
+    }
+  }
+}
+
+@include cdk-high-contrast {
+  .mat-button-toggle-checked {
+    &.mat-button-toggle-appearance-standard .mat-button-toggle-focus-overlay {
+      border-bottom: solid $mat-button-toggle-standard-height;
     }
   }
 }

--- a/src/lib/form-field/_form-field-legacy-theme.scss
+++ b/src/lib/form-field/_form-field-legacy-theme.scss
@@ -142,7 +142,7 @@ $mat-form-field-legacy-dedupe: 0;
     }
   }
 
-  // translateZ causes the label to not appear while printing, so we override it to not 
+  // translateZ causes the label to not appear while printing, so we override it to not
   // apply translateZ while printing
   @media print {
     .mat-form-field-appearance-legacy {


### PR DESCRIPTION
Aligns the button toggle component with the latest Material design spec.

![angular_material_-_google_chrome_2018-07-30_22-03-24](https://user-images.githubusercontent.com/4450522/43422681-cb990680-944a-11e8-9550-7bd2cbaaff41.png)
![angular_material_-_google_chrome_2018-07-30_22-45-06](https://user-images.githubusercontent.com/4450522/43422682-cbb98c98-944a-11e8-9466-495c8a7bfa9c.png)
