### PR TITLE
fix(form-field): unable to distinguish disabled form field in high contrast mode

### DIFF
--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -58,6 +58,11 @@ $mat-form-field-legacy-underline-height: 1px !default;
   &.mat-form-field-disabled .mat-form-field-underline {
     background-position: 0;
     background-color: transparent;
+
+    @include cdk-high-contrast {
+      border-top-style: dotted;
+      border-top-width: 2px;
+    }
   }
 
   &.mat-form-field-invalid:not(.mat-focused) .mat-form-field-ripple {

--- a/src/lib/form-field/form-field-standard.scss
+++ b/src/lib/form-field/form-field-standard.scss
@@ -42,6 +42,11 @@ $mat-form-field-standard-padding-top: 0.75em !default;
   &.mat-form-field-disabled .mat-form-field-underline {
     background-position: 0;
     background-color: transparent;
+
+    @include cdk-high-contrast {
+      border-top-style: dotted;
+      border-top-width: 2px;
+    }
   }
 
   // Note that we need this specific of a selector because we don't want


### PR DESCRIPTION
Fixes the disabled form field being indistinguishable from enabled ones in high contrast mode, due to the dotted gradient not being rendered.