### PR TITLE
docs(ripple): ripple example not working correctly

### DIFF
--- a/src/material-examples/ripple-overview/ripple-overview-example.css
+++ b/src/material-examples/ripple-overview/ripple-overview-example.css
@@ -5,6 +5,7 @@
   width: 300px;
   height: 300px;
   line-height: 300px;
+  position: relative;
 }
 
 /** Styles to make the demo look better. */


### PR DESCRIPTION
Fixes the ripple example not working due to the container not getting `position: relative`.

For reference:

![demo](https://user-images.githubusercontent.com/4450522/43482684-ac05d612-9509-11e8-9972-9330c04a8a0c.gif)
