### PR TITLE
docs - add ng add as alternative to npm/yarn

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -17,7 +17,7 @@ yarn add @angular/material @angular/cdk @angular/animations
 ```
 
 
-#### Alternative: Snapshot Build
+#### Alternative 1: Snapshot Build
 
 A snapshot build with the latest changes from master is also available. Note that this snapshot
 build should not be considered stable and may break between releases.
@@ -30,6 +30,13 @@ npm install --save angular/material2-builds angular/cdk-builds angular/animation
 #### Yarn
 ```bash
 yarn add angular/material2-builds angular/cdk-builds angular/animations-builds
+```
+#### Alternative 2: Angular Devkit 6+
+
+Using the Angular CLI `ng add` command will update your Angular project with the correct dependencies, perform configuration changes and execute initialization code. 
+
+```bash
+ng add @angular/material
 ```
 
 ### Step 2: Configure animations


### PR DESCRIPTION
Letting users know that the `ng add` command will simplify the install process if they are not on the latest versions of Angular. I found that by doing the stock npm install, the @angular/cdk and @angular/animations versions did not match what was already installed causing conflicts in the dependencies.