### PR TITLE
fix(menu): menu content data being cleared when lazy-loaded content is reused between nested triggers

### DIFF
--- a/src/lib/menu/menu-content.ts
+++ b/src/lib/menu/menu-content.ts
@@ -18,6 +18,7 @@ import {
 } from '@angular/core';
 import {TemplatePortal, DomPortalOutlet} from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
+import {Subject} from 'rxjs';
 
 /**
  * Menu content that will be rendered lazily once the menu is opened.
@@ -28,6 +29,9 @@ import {DOCUMENT} from '@angular/common';
 export class MatMenuContent implements OnDestroy {
   private _portal: TemplatePortal<any>;
   private _outlet: DomPortalOutlet;
+
+  /** Emits when the menu content has been attached. */
+  _attached = new Subject<void>();
 
   constructor(
     private _template: TemplateRef<any>,
@@ -60,6 +64,7 @@ export class MatMenuContent implements OnDestroy {
     // risk it staying attached to a pane that's no longer in the DOM.
     element.parentNode!.insertBefore(this._outlet.outletElement, element);
     this._portal.attach(this._outlet, context);
+    this._attached.next();
   }
 
   /**

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -245,9 +245,14 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       if (menu.lazyContent) {
         // Wait for the exit animation to finish before detaching the content.
         menu._animationDone
-          .pipe(filter(event => event.toState === 'void'), take(1))
-          .subscribe(() => {
-            menu.lazyContent!.detach();
+          .pipe(
+            filter(event => event.toState === 'void'),
+            take(1),
+            // Interrupt if the content got re-attached.
+            takeUntil(menu.lazyContent._attached)
+          )
+          .subscribe(() => menu.lazyContent!.detach(), undefined, () => {
+            // No matter whether the content got re-attached, reset the menu.
             this._resetMenu();
           });
       } else {


### PR DESCRIPTION
Fixes an issue where a nested menu with lazy-loaded that is reused between multiple triggers will clear its content once an alternate trigger is hovered. The issue comes from the fact that we wait for the exit animation to finish before we detach the content, which ends up detaching the content of the new trigger as well.

**Note:** I spent some time on trying to get a proper test that covers this issue, but I wasn't able to get something that fails when we expect it to. The issue is very closely tied to the animations module and the async animations which are being flushed synchronously in tests.

Fixes #12467.