### PR TITLE
build: inline resources for demo-app

### DIFF
--- a/tools/package-tools/index.ts
+++ b/tools/package-tools/index.ts
@@ -4,6 +4,7 @@ export * from './build-bundles';
 export * from './build-release';
 export * from './build-package';
 export * from './copy-files';
+export * from './inline-resources';
 
 // Expose gulp utilities.
 export * from './gulp/build-tasks-gulp';


### PR DESCRIPTION
* Inlines the HTML and CSS files when serving the demo-app. This makes loading the demo-app faster.

Shouldn't be any more difficult to debug the SCSS and HTML files of the demo-app. We already inline resources for the normal release packages as well.