### PR TITLE
fix(datepicker): add 'multi-year' to union type for startView property

### DIFF
--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -148,7 +148,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   private _startAt: D | null;
 
   /** The view that the calendar should start in. */
-  @Input() startView: 'month' | 'year' = 'month';
+  @Input() startView: 'month' | 'year' | 'multi-year' = 'month';
 
   /** Color palette to use on the datepicker's calendar. */
   @Input()


### PR DESCRIPTION
Adds missing literal to union type. The issue pointed out that the possible value 'multi-year' is not listed on API page.

Fixes #11700