### PR TITLE
fix(tree): throw error if expanding all nodes when no data is set

### DIFF
--- a/src/cdk/tree/control/flat-tree-control.spec.ts
+++ b/src/cdk/tree/control/flat-tree-control.spec.ts
@@ -1,3 +1,4 @@
+import {getTreeControlMissingDataNodesError} from '../tree-errors';
 import {FlatTreeControl} from './flat-tree-control';
 
 describe('CdkFlatTreeControl', () => {
@@ -138,6 +139,21 @@ describe('CdkFlatTreeControl', () => {
           + numNodes * numChildren * numGrandChildren;
       expect(treeControl.expansionModel.selected.length)
         .toBe(totalNumber, `Expect ${totalNumber} expanded nodes`);
+    });
+  });
+
+  describe('with no data nodes', () => {
+
+    it('should throw if control tries to expand all nodes', () => {
+      expect(() => treeControl.expandAll())
+        .toThrowError(getTreeControlMissingDataNodesError().message);
+    });
+
+    it('should throw if tree control tries to find all descendants', () => {
+      const nodes = generateData(2, 2, 2);
+
+      expect(() => treeControl.getDescendants(nodes[0]))
+        .toThrowError(getTreeControlMissingDataNodesError().message);
     });
   });
 });

--- a/src/cdk/tree/control/flat-tree-control.ts
+++ b/src/cdk/tree/control/flat-tree-control.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {getTreeControlMissingDataNodesError} from '../tree-errors';
 import {BaseTreeControl} from './base-tree-control';
 
 /** Flat tree control. Able to expand/collapse a subtree recursively for flattened tree. */
@@ -24,6 +25,10 @@ export class FlatTreeControl<T> extends BaseTreeControl<T> {
    * with correct levels.
    */
   getDescendants(dataNode: T): T[] {
+    if (!this.dataNodes) {
+      throw getTreeControlMissingDataNodesError();
+    }
+
     const startIndex = this.dataNodes.indexOf(dataNode);
     const results: T[] = [];
 
@@ -48,6 +53,10 @@ export class FlatTreeControl<T> extends BaseTreeControl<T> {
    * data nodes of the tree.
    */
   expandAll(): void {
+    if (!this.dataNodes) {
+      throw getTreeControlMissingDataNodesError();
+    }
+
     this.expansionModel.select(...this.dataNodes);
   }
 }

--- a/src/cdk/tree/control/nested-tree-control.spec.ts
+++ b/src/cdk/tree/control/nested-tree-control.spec.ts
@@ -1,4 +1,5 @@
 import {of as observableOf} from 'rxjs';
+import {getTreeControlMissingDataNodesError} from '../tree-errors';
 import {NestedTreeControl} from './nested-tree-control';
 
 
@@ -90,6 +91,14 @@ describe('CdkNestedTreeControl', () => {
         + numNodes * numChildren * numGrandChildren;
       expect(treeControl.expansionModel.selected.length)
         .toBe(totalNumber, `Expect ${totalNumber} expanded nodes`);
+    });
+
+    describe('with no data nodes', () => {
+
+      it('should throw if control tries to expand all nodes', () => {
+        expect(() => treeControl.expandAll())
+          .toThrowError(getTreeControlMissingDataNodesError().message);
+      });
     });
 
     describe('with children array', () => {

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -7,6 +7,7 @@
  */
 import {Observable} from 'rxjs';
 import {take} from 'rxjs/operators';
+import {getTreeControlMissingDataNodesError} from '../tree-errors';
 import {BaseTreeControl} from './base-tree-control';
 
 /** Nested tree control. Able to expand/collapse a subtree recursively for NestedNode type. */
@@ -24,6 +25,10 @@ export class NestedTreeControl<T> extends BaseTreeControl<T> {
    * data nodes of the tree.
    */
   expandAll(): void {
+    if (!this.dataNodes) {
+      throw getTreeControlMissingDataNodesError();
+    }
+
     this.expansionModel.clear();
     const allNodes = this.dataNodes.reduce((accumulator, dataNode) =>
         [...accumulator, ...this.getDescendants(dataNode), dataNode], []);

--- a/src/cdk/tree/tree-errors.ts
+++ b/src/cdk/tree/tree-errors.ts
@@ -45,3 +45,13 @@ export function getTreeControlMissingError() {
 export function getTreeControlFunctionsMissingError() {
   return Error(`Could not find functions for nested/flat tree in tree control.`);
 }
+
+/**
+ * Returns an error that should be thrown when the tree control tries to expand all nodes
+ * or determine descendants if no data nodes are being set.
+ * @docs-private
+ */
+export function getTreeControlMissingDataNodesError() {
+  return Error('Data nodes are not set in tree control. Cannot expand all nodes or get ' +
+    'descendants.');
+}

--- a/src/lib/tree/data-source/nested-data-source.ts
+++ b/src/lib/tree/data-source/nested-data-source.ts
@@ -7,6 +7,7 @@
  */
 
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
+import {NestedTreeControl} from '@angular/cdk/tree';
 import {BehaviorSubject, merge, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -18,13 +19,24 @@ import {map} from 'rxjs/operators';
  * or collapse. The expansion/collapsion will be handled by TreeControl and each non-leaf node.
  */
 export class MatTreeNestedDataSource<T> extends DataSource<T> {
-  _data = new BehaviorSubject<T[]>([]);
+  _data: BehaviorSubject<T[]>;
 
   /**
    * Data for the nested tree
    */
   get data() { return this._data.value; }
-  set data(value: T[]) { this._data.next(value); }
+  set data(value: T[]) {
+    this._data.next(value);
+
+    if (this.treeControl) {
+      this.treeControl.dataNodes = value;
+    }
+  }
+
+  constructor(private treeControl?: NestedTreeControl<T>, initialData: T[] = []) {
+    super();
+    this._data = new BehaviorSubject<T[]>(initialData);
+  }
 
   connect(collectionViewer: CollectionViewer): Observable<T[]> {
     return merge(...[collectionViewer.viewChange, this._data])

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -408,6 +408,33 @@ describe('MatTree', () => {
           [`topping_2 - cheese_2 + base_2`],
           [`topping_3 - cheese_3 + base_3`]);
       });
+
+      it('should be able to expand all nodes from tree control', () => {
+        const treeControl = component.treeControl;
+        const data = underlyingDataSource.data;
+
+        component.toggleRecursively = false;
+        fixture.detectChanges();
+
+        // Adds a child node to the first and second root node.
+        underlyingDataSource.addChild(data[0]);
+        underlyingDataSource.addChild(data[1]);
+
+        expectNestedTreeToMatch(treeElement,
+          [`topping_1 - cheese_1 + base_1`],
+          [`topping_2 - cheese_2 + base_2`],
+          [`topping_3 - cheese_3 + base_3`]);
+
+        treeControl.expandAll();
+        fixture.detectChanges();
+
+        expectNestedTreeToMatch(treeElement,
+          [`topping_1 - cheese_1 + base_1`],
+          [_, `topping_4 - cheese_4 + base_4`],
+          [`topping_2 - cheese_2 + base_2`],
+          [_, `topping_5 - cheese_5 + base_5`],
+          [`topping_3 - cheese_3 + base_3`]);
+      });
     });
   });
 });
@@ -655,7 +682,7 @@ class NestedMatTreeApp {
   `
 })
 class WhenNodeNestedMatTreeApp {
-  isSpecial = (_: number, node: TestData) =>  node.isSpecial;
+  isSpecial = (_: number, node: TestData) => node.isSpecial;
 
   getChildren = (node: TestData) => node.observableChildren;
 
@@ -732,7 +759,7 @@ class NestedMatTreeAppWithToggle {
   getChildren = (node: TestData) => node.observableChildren;
 
   treeControl = new NestedTreeControl(this.getChildren);
-  dataSource = new MatTreeNestedDataSource();
+  dataSource = new MatTreeNestedDataSource(this.treeControl);
   underlyingDataSource = new FakeDataSource();
 
   @ViewChild(MatTree) tree: MatTree<TestData>;

--- a/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
+++ b/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
@@ -118,7 +118,7 @@ export class CdkTreeNestedExample {
 
   constructor(database: FileDatabase) {
     this.nestedTreeControl = new NestedTreeControl<FileNode>(this._getChildren);
-    this.nestedDataSource = new MatTreeNestedDataSource();
+    this.nestedDataSource = new MatTreeNestedDataSource(this.nestedTreeControl);
 
     database.dataChange.subscribe(data => this.nestedDataSource.data = data);
   }

--- a/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
+++ b/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
@@ -118,7 +118,7 @@ export class TreeNestedOverviewExample {
 
   constructor(database: FileDatabase) {
     this.nestedTreeControl = new NestedTreeControl<FileNode>(this._getChildren);
-    this.nestedDataSource = new MatTreeNestedDataSource();
+    this.nestedDataSource = new MatTreeNestedDataSource(this.nestedTreeControl);
 
     database.dataChange.subscribe(data => this.nestedDataSource.data = data);
   }


### PR DESCRIPTION
* Currently when a developer uses `NestedTreeControl` with `MatTreeNestedDataSource` and calls `treeControl.expandAll`, a runtime exception will be thrown because no data nodes are set. This issue isn't an issue if someone uses `MatTreeFlatDataSource` because the data source requires the control to be passed to the data source.

* Similarly should the `MatTreeNestedDataSource` also accept a tree control as constructor parameter. The data source should then delegate the data to the tree control in order to properly set up the tree control (similar to the flat data source)

* Also adds safety checks and throws a more user-friendly error if someone implements his own `DataSource` and does not set the data nodes on the tree control and calls `expandAll` or `getDescendants`

Fixes  #12469