### PR TITLE
fix(snackbar): remove border-radius for snackbars in handset mode

### DIFF
--- a/src/lib/snack-bar/snack-bar-container.scss
+++ b/src/lib/snack-bar/snack-bar-container.scss
@@ -54,6 +54,7 @@ $mat-snack-bar-spacing-margin: 24px !default;
 
   .mat-snack-bar-container {
     margin: 0;
+    border-radius: 0;
     max-width: inherit;
     width: 100%;
   }


### PR DESCRIPTION
* Based on the specs and on the MDC reference implementation, snack bars should not have a border-radius when being in handset mode.

Fixes #12525