### PR TITLE
build: add tslint rule to enforce import spacing

### DIFF
--- a/tools/tslint-rules/noImportSpacingRule.ts
+++ b/tools/tslint-rules/noImportSpacingRule.ts
@@ -1,0 +1,29 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+/**
+ * Rule that ensures that there are no spaces before/after the braces in import clauses.
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile) {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  visitImportDeclaration(node: ts.ImportDeclaration) {
+    if (!node.importClause) {
+      return super.visitImportDeclaration(node);
+    }
+
+    const importClause = node.importClause.getText();
+
+    if (importClause.startsWith('{') && importClause.endsWith('}') && (
+        importClause.includes('{ ') || importClause.includes(' }'))) {
+      this.addFailureAtNode(node.importClause, 'Import clauses should not have spaces after the ' +
+                                                'opening brace or before the closing one.');
+    }
+
+    super.visitImportDeclaration(node);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -97,6 +97,7 @@
     // Custom Rules
     "ts-loader": true,
     "no-exposed-todo": true,
+    "no-import-spacing": true,
     "setters-after-getters": true,
     "rxjs-imports": true,
     "no-host-decorator-in-concrete": [


### PR DESCRIPTION
This is something that comes up on a semi-regular basis during review. Ensures that imports don't have spaces after the opening brace and before the closing one.