### PR TITLE
build: remove madge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,12 +1470,6 @@
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-      "dev": true
-    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -1485,12 +1479,6 @@
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
       }
-    },
-    "app-module-path": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
-      "dev": true
     },
     "app-root-path": {
       "version": "2.1.0",
@@ -1712,12 +1700,6 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
-    "ast-module-types": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.3.2.tgz",
-      "integrity": "sha1-S7HeLXKWeIJEKeIqYo0D6H30rRE=",
-      "dev": true
-    },
     "ast-types": {
       "version": "0.11.5",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
@@ -1826,22 +1808,6 @@
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
       }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
@@ -2965,12 +2931,6 @@
       "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "compare-func": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
@@ -4043,18 +4003,6 @@
       "integrity": "sha1-MC5YIY2FxRqXY4cw2/m32FKhlpM=",
       "dev": true
     },
-    "dependency-tree": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-5.11.0.tgz",
-      "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
-      "dev": true,
-      "requires": {
-        "commander": "^2.6.0",
-        "debug": "^2.2.0",
-        "filing-cabinet": "^1.9.0",
-        "precinct": "^3.8.0"
-      }
-    },
     "deprecated": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
@@ -4072,152 +4020,6 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
-    },
-    "detective-amd": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-2.4.0.tgz",
-      "integrity": "sha1-XrDfTvXBipQDOwfa8TbbzV/HXNU=",
-      "dev": true,
-      "requires": {
-        "ast-module-types": "^2.3.1",
-        "escodegen": "^1.8.0",
-        "get-amd-module-type": "^2.0.4",
-        "node-source-walk": "^3.0.0"
-      }
-    },
-    "detective-cjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-2.0.0.tgz",
-      "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
-      "dev": true,
-      "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.0.0"
-      }
-    },
-    "detective-es6": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.2.0.tgz",
-      "integrity": "sha1-a5s71Uf9jyH4lQL2JuRe0qMnb9w=",
-      "dev": true,
-      "requires": {
-        "node-source-walk": "^3.3.0"
-      }
-    },
-    "detective-less": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.0.tgz",
-      "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
-      "dev": true,
-      "requires": {
-        "debug": "~2.2.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "detective-sass": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-2.0.1.tgz",
-      "integrity": "sha1-BWYKoblc/Yf1dGQ7+s4+iiaBEqE=",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "detective-scss": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-1.0.1.tgz",
-      "integrity": "sha1-dDJGoN01jZ2R/0ElQX9qd/vPJw8=",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "gonzales-pe": "^3.4.4",
-        "node-source-walk": "^3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "detective-stylus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
-      "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=",
-      "dev": true
-    },
-    "detective-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
-      "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
-      "dev": true,
-      "requires": {
-        "node-source-walk": "3.2.0",
-        "typescript": "2.0.10",
-        "typescript-eslint-parser": "1.0.2"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.0.0"
-          }
-        },
-        "node-source-walk": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
-          "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
-          "dev": true,
-          "requires": {
-            "babylon": "~6.8.1"
-          }
-        },
-        "typescript": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-          "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
-          "dev": true
-        }
-      }
     },
     "dgeni": {
       "version": "0.4.9",
@@ -4611,17 +4413,6 @@
         "has-binary2": "~1.0.2"
       }
     },
-    "enhanced-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-      "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "tapable": "^1.0.0"
-      }
-    },
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -4633,15 +4424,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5284,12 +5066,6 @@
         "object-assign": "^4.0.1"
       }
     },
-    "file-exists": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-2.0.0.tgz",
-      "integrity": "sha1-okFQZlFQ5i1VvFRJKB2I0rCBDco=",
-      "dev": true
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -5308,37 +5084,6 @@
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
-    },
-    "filing-cabinet": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.14.3.tgz",
-      "integrity": "sha512-UIPZII8rPTUDRmLNCXbu/326xK13k3OK2CW0aA7gI1POSYdwCeBEi4FwD6i3NUN0ZS3dFFkJDYRYyv9+HkPI/w==",
-      "dev": true,
-      "requires": {
-        "app-module-path": "^2.2.0",
-        "commander": "^2.13.0",
-        "debug": "^3.1.0",
-        "enhanced-resolve": "^4.1.0",
-        "is-relative-path": "^1.0.2",
-        "module-definition": "^2.2.4",
-        "module-lookup-amd": "^5.0.1",
-        "resolve": "^1.5.0",
-        "resolve-dependency-path": "^1.0.2",
-        "sass-lookup": "^2.0.0",
-        "stylus-lookup": "^2.0.0",
-        "typescript": "^2.4.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5390,15 +5135,6 @@
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
-      }
-    },
-    "find": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
-      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
-      "dev": true,
-      "requires": {
-        "traverse-chain": "~0.1.0"
       }
     },
     "find-index": {
@@ -6704,26 +6440,10 @@
         "is-property": "^1.0.0"
       }
     },
-    "get-amd-module-type": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-2.0.5.tgz",
-      "integrity": "sha1-5nHsWpatX79To6IqKJ6SOMdy3bA=",
-      "dev": true,
-      "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.2.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-pkg-repo": {
@@ -7305,23 +7025,6 @@
         "sparkles": "^1.0.0"
       }
     },
-    "gonzales-pe": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
-      "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
-      "dev": true,
-      "requires": {
-        "minimist": "1.1.x"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
-          "dev": true
-        }
-      }
-    },
     "google-auth-library": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
@@ -7582,21 +7285,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
-    "graphviz": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.8.tgz",
-      "integrity": "sha1-5ZnkBzPvgOFlO/6JpfAx7PKqSqo=",
-      "dev": true,
-      "requires": {
-        "temp": "~0.4.0"
-      }
     },
     "grpc": {
       "version": "1.10.1",
@@ -10456,12 +10144,6 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-relative-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY=",
-      "dev": true
-    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -11778,21 +11460,6 @@
         "lodash.escape": "^3.0.0"
       }
     },
-    "lodash.tostring": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
-      "dev": true
-    },
-    "lodash.unescape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-      "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-      "dev": true,
-      "requires": {
-        "lodash.tostring": "^4.0.0"
-      }
-    },
     "lodash.values": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
@@ -11807,15 +11474,6 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0"
-      }
     },
     "log4js": {
       "version": "2.11.0",
@@ -12150,122 +11808,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "madge": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/madge/-/madge-2.2.0.tgz",
-      "integrity": "sha512-5UoX9n8od0UmKPcZo4KydgQch+oKvlywsee+60ochES6Uo1UDaHnt6yx+SOIZMt007R0F/ZNq03vhxlaJPep+g==",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.9.0",
-        "commondir": "1.0.1",
-        "debug": "2.2.0",
-        "dependency-tree": "5.11.0",
-        "graphviz": "0.0.8",
-        "mz": "2.4.0",
-        "ora": "1.2.0",
-        "pluralize": "4.0.0",
-        "pretty-ms": "2.1.0",
-        "rc": "1.1.6",
-        "walkdir": "0.0.11"
-      },
-      "dependencies": {
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "cli-spinners": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-          "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "ora": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-1.2.0.tgz",
-          "integrity": "sha1-Mvsxg1AO/oP16okQF4Xw7mBg/sk=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "cli-cursor": "^2.1.0",
-            "cli-spinners": "^1.0.0",
-            "log-symbols": "^1.0.2"
-          }
-        },
-        "rc": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~1.0.4"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true
-        }
-      }
-    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -12595,16 +12137,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
-      "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      }
-    },
     "meow": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -12819,41 +12351,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "module-definition": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-2.2.4.tgz",
-      "integrity": "sha1-wKN3HeWM9rzxKu0kdnBsWWrUsss=",
-      "dev": true,
-      "requires": {
-        "ast-module-types": "^2.3.2",
-        "node-source-walk": "^3.0.0"
-      }
-    },
-    "module-lookup-amd": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-5.0.1.tgz",
-      "integrity": "sha512-rmljyiMrPqEfeOD1myMULVgnv1pRUqq1Dv/Xn0f9g36wCDWvqj07arG0fCEbKqU1sYFXptnaC1o+0oR7JpwOtg==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.8.1",
-        "debug": "^3.1.0",
-        "file-exists": "^2.0.0",
-        "find": "^0.2.8",
-        "requirejs": "^2.3.5",
-        "requirejs-config-file": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "moment": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
@@ -12935,17 +12432,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true,
       "optional": true
-    },
-    "mz": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.4.0.tgz",
-      "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
-      "dev": true,
-      "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "nan": {
       "version": "2.10.0",
@@ -13466,15 +12952,6 @@
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
           "dev": true
         }
-      }
-    },
-    "node-source-walk": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.3.0.tgz",
-      "integrity": "sha1-rRjjW/2z0Lb34OSv8eePhGo7iHM=",
-      "dev": true,
-      "requires": {
-        "babylon": "^6.17.0"
       }
     },
     "node-status-codes": {
@@ -14240,12 +13717,6 @@
         "error-ex": "^1.2.0"
       }
     },
-    "parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-      "dev": true
-    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -14446,18 +13917,6 @@
         "arr-union": "^3.1.0",
         "extend-shallow": "^3.0.2"
       }
-    },
-    "plur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
-      "dev": true
-    },
-    "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
-      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
@@ -14935,37 +14394,6 @@
         "eastasianwidth": "^0.2.0"
       }
     },
-    "precinct": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
-      "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
-      "dev": true,
-      "requires": {
-        "commander": "^2.11.0",
-        "debug": "^3.0.1",
-        "detective-amd": "^2.4.0",
-        "detective-cjs": "^2.0.0",
-        "detective-es6": "^1.2.0",
-        "detective-less": "1.0.0",
-        "detective-sass": "^2.0.0",
-        "detective-scss": "^1.0.0",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^1.0.0",
-        "module-definition": "^2.2.4",
-        "node-source-walk": "^3.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -14995,17 +14423,6 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
-    },
-    "pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
-      }
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -15264,12 +14681,6 @@
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
       "dev": true,
       "optional": true
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -15603,12 +15014,6 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
-    },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -15827,51 +15232,6 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "requirejs": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.5.tgz",
-      "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw==",
-      "dev": true
-    },
-    "requirejs-config-file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-3.0.0.tgz",
-      "integrity": "sha512-pssKfw0KhafnpOHA1+qWlDXcCEgf0p+qfTI8xOhqOhhdtz7m7VqhEorauKZOqv1GGA8ML3eKFU3sxGq5p4ZaEw==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.0",
-        "fs-extra": "^5.0.0",
-        "stringify-object": "^3.2.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
-      }
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15895,12 +15255,6 @@
       "requires": {
         "find-parent-dir": "~0.3.0"
       }
-    },
-    "resolve-dependency-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-1.0.2.tgz",
-      "integrity": "sha1-ar6Tpt4+T53Oe16CYeH0eqGvTcI=",
-      "dev": true
     },
     "resolve-dir": {
       "version": "1.0.1",
@@ -16261,15 +15615,6 @@
             "camelcase": "^3.0.0"
           }
         }
-      }
-    },
-    "sass-lookup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-2.0.0.tgz",
-      "integrity": "sha512-DZEg7g605XNZX3rxQMkndPmlSzaGR3ld33Rvx3XPTxP8hXBPErmCTrL2CPItzjCJqvjgt9kXhxQrzkbdJZToaA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.16.0"
       }
     },
     "sauce-connect-launcher": {
@@ -17332,17 +16677,6 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
-    "stringify-object": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
-      "dev": true,
-      "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      }
-    },
     "stringmap": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
@@ -17677,27 +17011,6 @@
         }
       }
     },
-    "stylus-lookup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-2.0.0.tgz",
-      "integrity": "sha512-ZPwVUITlzCIgq1NBNl1xVX1grfFnJUBq9zzG9YOj/V3GrOCnpWuxGh6zUL8JTaVs0nMS9Eyok1qgOW9mUFx9kg==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.8.1",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "sugarss": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
@@ -18028,12 +17341,6 @@
         }
       }
     },
-    "tapable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-      "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
-      "dev": true
-    },
     "tar": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
@@ -18072,12 +17379,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "temp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
-      "dev": true
-    },
     "ternary-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
@@ -18095,24 +17396,6 @@
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
       "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
       "dev": true
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
-      "requires": {
-        "thenify": ">= 3.1.0 < 4"
-      }
     },
     "through": {
       "version": "2.3.8",
@@ -18388,12 +17671,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
-    },
-    "traverse-chain": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
-      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
       "dev": true
     },
     "trim": {
@@ -18710,16 +17987,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
       "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
-      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.0",
-        "object-assign": "^4.0.1"
-      }
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -19645,12 +18912,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
-      "dev": true
-    },
-    "walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
       "dev": true
     },
     "wd": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "karma-jasmine": "^1.1.0",
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
-    "madge": "^2.2.0",
     "magic-string": "^0.22.4",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0",

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -1,14 +1,11 @@
 import {Platform} from '@angular/cdk/platform';
 import {InteractivityChecker} from './interactivity-checker';
 
-
 describe('InteractivityChecker', () => {
+  const platform: Platform = new Platform();
+
   let testContainerElement: HTMLElement;
   let checker: InteractivityChecker;
-  // TODO: refactor this to be injected with the platformId
-  // Needs to be done carefully due to the runIf checks below executing
-  // before injection
-  let platform: Platform = new Platform();
 
   beforeEach(() => {
     testContainerElement = document.createElement('div');

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -112,14 +112,18 @@ export class PackageBundler {
       context: 'this',
       external: Object.keys(rollupGlobals),
       input: config.entry,
-      onwarn: (message: string) => {
+      onwarn: (warning: any) => {
         // TODO(jelbourn): figure out *why* rollup warns about certain symbols not being found
         // when those symbols don't appear to be in the input file in the first place.
-        if (/but never used/.test(message)) {
+        if (/but never used/.test(warning.message)) {
           return false;
         }
 
-        console.warn(message);
+        if (warning.code === 'CIRCULAR_DEPENDENCY') {
+          throw Error(warning.message);
+        }
+
+        console.warn(warning.message);
       },
       plugins: [
         rollupRemoveLicensesPlugin,


### PR DESCRIPTION
Removes `madge` that doesn't seem to run properly. Madge claims to support `.ts` files, but from testing this does not work properly (also doesn't respect entry-points/packages). 

Right now, we always transpile the files and then run Madge to check for circular dependencies.

**But**, Due to the fact that we run `rollup` to bundle entry-points, we have another circular dependency check that also respects entry-points/packages. 

Sample rollup output:

```
{ code: 'CIRCULAR_DEPENDENCY',
  importer: 'dist\\packages\\material\\core\\A\\B.js',
  message: 'Circular dependency: A.js -> B.js -> A.js',
}
```