### PR TITLE
fix(select): skip disabled options when using ctrl + a

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -3989,6 +3989,33 @@ describe('MatSelect', () => {
       ]);
     });
 
+    it('should skip disabled options when using ctrl + a', () => {
+      const selectElement = fixture.nativeElement.querySelector('mat-select');
+      const options = fixture.componentInstance.options.toArray();
+
+      for (let i = 0; i < 3; i++) {
+        options[i].disabled = true;
+      }
+
+      expect(testInstance.control.value).toBeFalsy();
+
+      fixture.componentInstance.select.open();
+      fixture.detectChanges();
+
+      const event = createKeyboardEvent('keydown', A, selectElement);
+      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      dispatchEvent(selectElement, event);
+      fixture.detectChanges();
+
+      expect(testInstance.control.value).toEqual([
+        'sandwich-3',
+        'chips-4',
+        'eggs-5',
+        'pasta-6',
+        'sushi-7'
+      ]);
+    });
+
     it('should select all options when pressing ctrl + a when some options are selected', () => {
       const selectElement = fixture.nativeElement.querySelector('mat-select');
       const options = fixture.componentInstance.options.toArray();

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -714,8 +714,13 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       manager.activeItem._selectViaInteraction();
     } else if (this._multiple && keyCode === A && event.ctrlKey) {
       event.preventDefault();
-      const hasDeselectedOptions = this.options.some(option => !option.selected);
-      this.options.forEach(option => hasDeselectedOptions ? option.select() : option.deselect());
+      const hasDeselectedOptions = this.options.some(opt => !opt.disabled && !opt.selected);
+
+      this.options.forEach(option => {
+        if (!option.disabled) {
+          hasDeselectedOptions ? option.select() : option.deselect();
+        }
+      });
     } else {
       const previouslyFocusedIndex = manager.activeItemIndex;
 


### PR DESCRIPTION
Along the same lines as #12543. Currently `mat-select` will select all options when pressing ctrl + a, no matter whether they're disabled. These changes add an extra check to ensure that the disabled ones are skipped.