### PR TITLE
fix(drag-drop): remove circular dependencies

### DIFF
--- a/src/cdk-experimental/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk-experimental/drag-drop/drag-drop-registry.spec.ts
@@ -6,7 +6,7 @@ import {
   createTouchEvent,
   dispatchTouchEvent,
 } from '@angular/cdk/testing';
-import {CdkDragDropRegistry} from './drag-drop-registry';
+import {DragDropRegistry} from './drag-drop-registry';
 import {DragDropModule} from './drag-drop-module';
 import {CdkDrag} from './drag';
 import {CdkDrop} from './drop';
@@ -14,7 +14,7 @@ import {CdkDrop} from './drop';
 describe('DragDropRegistry', () => {
   let fixture: ComponentFixture<SimpleDropZone>;
   let testComponent: SimpleDropZone;
-  let registry: CdkDragDropRegistry;
+  let registry: DragDropRegistry<CdkDrag, CdkDrop>;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -26,7 +26,7 @@ describe('DragDropRegistry', () => {
     testComponent = fixture.componentInstance;
     fixture.detectChanges();
 
-    inject([CdkDragDropRegistry], (c: CdkDragDropRegistry) => {
+    inject([DragDropRegistry], (c: DragDropRegistry<CdkDrag, CdkDrop>) => {
       registry = c;
     })();
   }));
@@ -59,7 +59,7 @@ describe('DragDropRegistry', () => {
     registry.startDragging(firstItem, createMouseEvent('mousedown'));
     expect(registry.isDragging(firstItem)).toBe(true);
 
-    registry.remove(firstItem);
+    registry.removeDragItem(firstItem);
     expect(registry.isDragging(firstItem)).toBe(false);
   });
 
@@ -130,7 +130,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should not throw when trying to register the same container again', () => {
-    expect(() => registry.register(testComponent.dropInstances.first)).not.toThrow();
+    expect(() => registry.registerDropContainer(testComponent.dropInstances.first)).not.toThrow();
   });
 
   it('should throw when trying to register a different container with the same id', () => {

--- a/src/cdk-experimental/drag-drop/drag.ts
+++ b/src/cdk-experimental/drag-drop/drag.ts
@@ -31,7 +31,7 @@ import {CdkDragStart, CdkDragEnd, CdkDragExit, CdkDragEnter, CdkDragDrop} from '
 import {CdkDragPreview} from './drag-preview';
 import {CdkDragPlaceholder} from './drag-placeholder';
 import {ViewportRuler} from '@angular/cdk/overlay';
-import {CdkDragDropRegistry} from './drag-drop-registry';
+import {DragDropRegistry} from './drag-drop-registry';
 import {Subject, merge} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -138,10 +138,10 @@ export class CdkDrag<T = any> implements OnDestroy {
     private _ngZone: NgZone,
     private _viewContainerRef: ViewContainerRef,
     private _viewportRuler: ViewportRuler,
-    private _dragDropRegistry: CdkDragDropRegistry,
+    private _dragDropRegistry: DragDropRegistry<CdkDrag<T>, CdkDropContainer>,
     @Optional() private _dir: Directionality) {
       this._document = document;
-      _dragDropRegistry.register(this);
+      _dragDropRegistry.registerDragItem(this);
     }
 
   /**
@@ -165,7 +165,7 @@ export class CdkDrag<T = any> implements OnDestroy {
     }
 
     this._nextSibling = null;
-    this._dragDropRegistry.remove(this);
+    this._dragDropRegistry.removeDragItem(this);
     this._destroyed.next();
     this._destroyed.complete();
   }

--- a/src/cdk-experimental/drag-drop/drop-container.ts
+++ b/src/cdk-experimental/drag-drop/drop-container.ts
@@ -13,6 +13,9 @@ export interface CdkDropContainer<T = any> {
   /** Arbitrary data to attach to all events emitted by this container. */
   data: T;
 
+  /** Unique ID for the drop zone. */
+  id: string;
+
   /** Direction in which the list is oriented. */
   orientation: 'horizontal' | 'vertical';
 

--- a/src/cdk-experimental/drag-drop/drop.ts
+++ b/src/cdk-experimental/drag-drop/drop.ts
@@ -23,7 +23,7 @@ import {
 import {CdkDrag} from './drag';
 import {CdkDragExit, CdkDragEnter, CdkDragDrop} from './drag-events';
 import {CDK_DROP_CONTAINER} from './drop-container';
-import {CdkDragDropRegistry} from './drag-drop-registry';
+import {DragDropRegistry} from './drag-drop-registry';
 
 /** Counter used to generate unique ids for drop zones. */
 let _uniqueIdCounter = 0;
@@ -85,14 +85,14 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
 
   constructor(
     public element: ElementRef<HTMLElement>,
-    private _dragDropRegistry: CdkDragDropRegistry) {}
+    private _dragDropRegistry: DragDropRegistry<CdkDrag, CdkDrop<T>>) {}
 
   ngOnInit() {
-    this._dragDropRegistry.register(this);
+    this._dragDropRegistry.registerDropContainer(this);
   }
 
   ngOnDestroy() {
-    this._dragDropRegistry.remove(this);
+    this._dragDropRegistry.removeDropContainer(this);
   }
 
   /** Whether an item in the container is being dragged. */


### PR DESCRIPTION
Currently we've got the following circular dependencies in master, after the `CdkDragDropRegistry` got introduced:

```
drop.ts -> drag.ts -> drag-drop-registry.ts -> drop.ts
drag.ts -> drag-drop-registry.ts -> drag.ts
drop.ts -> drag-drop-registry.ts -> drop.ts
```

These changes rework the registry to avoid importing `CdkDrag` and `CdkDrop`, in order to break the circular references.