### PR TITLE
fix(tree): include constructors on MatTree classes to allow es6 builds

### DIFF
--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -21,7 +21,8 @@ import {
   Input,
   IterableDiffers,
   OnDestroy,
-  QueryList
+  QueryList,
+  TemplateRef,
 } from '@angular/core';
 import {CanDisable, HasTabIndex, mixinDisabled, mixinTabIndex} from '@angular/material/core';
 import {MatTreeNodeOutlet} from './outlet';
@@ -70,6 +71,15 @@ export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T>
 })
 export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   @Input('matTreeNode') data: T;
+
+  // TODO(andrewseguin): Remove this explicitly set constructor when the compiler knows how to
+  // properly build the es6 version of the class. Currently sets ctorParameters to empty due to a
+  // fixed bug.
+  // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
+  // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
+  constructor(template: TemplateRef<any>) {
+    super(template);
+  }
 }
 
 /**

--- a/src/lib/tree/padding.ts
+++ b/src/lib/tree/padding.ts
@@ -5,8 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CdkTreeNodePadding} from '@angular/cdk/tree';
-import {Directive, Input} from '@angular/core';
+import {CdkTreeNodePadding, CdkTreeNode, CdkTree} from '@angular/cdk/tree';
+import {Directionality} from '@angular/cdk/bidi';
+import {Directive, Input, Optional, Renderer2, ElementRef} from '@angular/core';
 
 
 /**
@@ -23,4 +24,17 @@ export class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
 
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   @Input('matTreeNodePaddingIndent') indent: number;
+
+  // TODO(andrewseguin): Remove this explicitly set constructor when the compiler knows how to
+  // properly build the es6 version of the class. Currently sets ctorParameters to empty due to a
+  // fixed bug.
+  // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
+  // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
+  constructor(_treeNode: CdkTreeNode<T>,
+              _tree: CdkTree<T>,
+              _renderer: Renderer2,
+              _element: ElementRef,
+              @Optional() _dir: Directionality) {
+      super(_treeNode, _tree, _renderer, _element, _dir);
+    }
 }

--- a/src/lib/tree/toggle.ts
+++ b/src/lib/tree/toggle.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive, Input} from '@angular/core';
-import {CdkTreeNodeToggle} from '@angular/cdk/tree';
+import {CdkTreeNodeToggle, CdkTree, CdkTreeNode} from '@angular/cdk/tree';
 
 /**
  * Wrapper for the CdkTree's toggle with Material design styles.
@@ -21,4 +21,13 @@ import {CdkTreeNodeToggle} from '@angular/cdk/tree';
 })
 export class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
   @Input('matTreeNodeToggleRecursive') recursive: boolean = false;
+
+  // TODO(andrewseguin): Remove this explicitly set constructor when the compiler knows how to
+  // properly build the es6 version of the class. Currently sets ctorParameters to empty due to a
+  // fixed bug.
+  // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
+  // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
+  constructor(_tree: CdkTree<T>, _treeNode: CdkTreeNode<T>) {
+    super(_tree, _treeNode);
+  }
 }

--- a/src/lib/tree/tree.ts
+++ b/src/lib/tree/tree.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ViewChild,
+  ViewEncapsulation,
+  IterableDiffers,
+} from '@angular/core';
 import {CdkTree} from '@angular/cdk/tree';
 import {MatTreeNodeOutlet} from './outlet';
 
@@ -30,5 +37,14 @@ import {MatTreeNodeOutlet} from './outlet';
 export class MatTree<T> extends CdkTree<T> {
   // Outlets within the tree's template where the dataNodes will be inserted.
   @ViewChild(MatTreeNodeOutlet) _nodeOutlet: MatTreeNodeOutlet;
+
+  // TODO(andrewseguin): Remove this explicitly set constructor when the compiler knows how to
+  // properly build the es6 version of the class. Currently sets ctorParameters to empty due to a
+  // fixed bug.
+  // https://github.com/angular/tsickle/pull/760 - tsickle PR that fixed this
+  // https://github.com/angular/angular/pull/23531 - updates compiler-cli to fixed version
+  constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef) {
+    super(_differs, _changeDetectorRef);
+  }
 }
 


### PR DESCRIPTION
Fixes #11580