### PR TITLE
fix(radio): ng-touched incorrectly being set on click

### DIFF
--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -444,6 +444,14 @@ describe('MatRadio', () => {
 
       expect(groupNgModel.valid).toBe(true);
       expect(groupNgModel.pristine).toBe(false);
+      expect(groupNgModel.touched).toBe(false);
+
+      // Blur the input element in order to verify that the ng-touched state has been set to true.
+      // The touched state should be only set to true after the form control has been blurred.
+      dispatchFakeEvent(innerRadios[2].nativeElement, 'blur');
+
+      expect(groupNgModel.valid).toBe(true);
+      expect(groupNgModel.pristine).toBe(false);
       expect(groupNgModel.touched).toBe(true);
     });
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -566,7 +566,6 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
     if (this.radioGroup) {
       this.radioGroup._controlValueAccessorChangeFn(this.value);
-      this.radioGroup._touch();
       if (groupValueChanged) {
         this.radioGroup._emitChangeEvent();
       }


### PR DESCRIPTION
* The `ControlValueAccessor` `onTouched` should be just called if a radio-button blurred. Right now, the `ng-touched` state will be immediately set if someone presses <kbd>SPACE</kbd> or clicks on a radio-button.