### PR TITLE
fix(cdk-text-field): prevent keyframes from getting stripped by LibSass

### DIFF
--- a/src/cdk/text-field/_text-field.scss
+++ b/src/cdk/text-field/_text-field.scss
@@ -1,10 +1,11 @@
 // Core styles that enable monitoring autofill state of text fields.
 @mixin cdk-text-field {
   // Keyframes that apply no styles, but allow us to monitor when an text field becomes autofilled
-  // by watching for the animation events that are fired when they start.
+  // by watching for the animation events that are fired when they start. Note: the /*!*/ comment is
+  // needed to prevent LibSass from stripping the keyframes out.
   // Based on: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
-  @keyframes cdk-text-field-autofill-start {}
-  @keyframes cdk-text-field-autofill-end {}
+  @keyframes cdk-text-field-autofill-start {/*!*/}
+  @keyframes cdk-text-field-autofill-end {/*!*/}
 
   .cdk-text-field-autofill-monitored:-webkit-autofill {
     animation-name: cdk-text-field-autofill-start;


### PR DESCRIPTION
fixes #12564 #12627