### PR TITLE
build: test against angular snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 node_js:
   # Use the explicit NodeJS LTS version 8.9.4 to avoid any automatic upgrade of the version.
   # This ensures that all Travis jobs run consistently and don't have different Node versions.
-  - '8.9.4'
+  - '8.11.3'
 
 addons:
   jwt:
@@ -39,9 +39,6 @@ jobs:
       if: type = push
     - env: "DEPLOY_MODE=dashboard"
       if: type = cron
-    # Closure Compiler CI check is temporarily disabled until a new version of
-    # the tool is released with https://github.com/google/closure-compiler/pull/2600
-    # - env: "MODE=closure-compiler"
 env:
   global:
   - LOGS_DIR=/tmp/angular-material2-build/logs
@@ -53,6 +50,7 @@ env:
 
 before_install:
   - source ./scripts/ci/travis-env.sh
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then ./scripts/install-angular-snapshot.sh --only-save; fi
 
 install:
   - npm install

--- a/scripts/install-angular-snapshot.sh
+++ b/scripts/install-angular-snapshot.sh
@@ -12,6 +12,8 @@ cd $(dirname $0)/../
 searchRegex='(@angular\/(.*))":\s+".*"'
 searchReplace='\1": "github:angular\/\2-builds"'
 
+# Replace the Angular versions in `package.json` with their corresponding
+# build snapshots so that we only have to run `npm install` once.
 sed -i -r "s/${searchRegex}/${searchReplace}/g" package.json
 
 if [[ ${*} != *--only-save* ]]; then

--- a/scripts/install-angular-snapshot.sh
+++ b/scripts/install-angular-snapshot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Script that modifies the project `package.json` by setting the version for all Angular
+# dependencies to the Github snapshot builds. Afterwards, if the `--only-save` flag is not set,
+# the script will also run NPM to install the new versions.
+
+set -e
+
+# Go to the project root directory
+cd $(dirname $0)/../
+
+searchRegex='(@angular\/(.*))":\s+".*"'
+searchReplace='\1": "github:angular\/\2-builds"'
+
+sed -i -r "s/${searchRegex}/${searchReplace}/g" package.json
+
+if [[ ${*} != *--only-save* ]]; then
+  npm install
+fi

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -38,11 +38,17 @@ function isMaterialSpecFile(path) {
 /** Configures Angular's TestBed. */
 function configureTestBed() {
   return Promise.all([
+    System.import('@angular/core'),
     System.import('@angular/core/testing'),
     System.import('@angular/platform-browser-dynamic/testing')
   ]).then(function (providers) {
-    var testing = providers[0];
-    var testingBrowser = providers[1];
+    var core = providers[0];
+    var testing = providers[1];
+    var testingBrowser = providers[2];
+
+    console.log('----------');
+    console.log('Running tests using Angular version: ' + core.VERSION.full);
+    console.log('----------');
 
     var testBed = testing.TestBed.initTestEnvironment(
       testingBrowser.BrowserDynamicTestingModule,


### PR DESCRIPTION
* Runs the whole Travis CI test suite with the latest Angular snapshot from GitHub in the CI nightly cronjob.

**Note**: CircleCI will be a follow-up that uses the new script. 