### PR TITLE
fix(slider): thumb label blending in with background in high contrast mode

### DIFF
--- a/src/lib/slider/slider.scss
+++ b/src/lib/slider/slider.scss
@@ -142,6 +142,10 @@ $mat-slider-focus-ring-size: 30px !default;
   transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
               border-radius  $swift-ease-out-duration $swift-ease-out-timing-function,
               background-color  $swift-ease-out-duration $swift-ease-out-timing-function;
+
+  @include cdk-high-contrast {
+    outline: solid 1px;
+  }
 }
 
 .mat-slider-thumb-label-text {
@@ -338,6 +342,13 @@ $mat-slider-focus-ring-size: 30px !default;
   &.cdk-focused {
     .mat-slider-thumb-label {
       transform: rotate(45deg);
+    }
+
+    @include cdk-high-contrast {
+      .mat-slider-thumb-label,
+      .mat-slider-thumb-label-text {
+        transform: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes the slider's thumb label not having an outline and blending in with the background in high contrast mode.

![angular_material_ -_microsoft_edge_2018-08-09_22-14-21](https://user-images.githubusercontent.com/4450522/43923752-ed40bf50-9c22-11e8-8299-728efa88f952.png)
