### PR TITLE
fix(drag-drop): ignore self inside connectedTo

### DIFF
--- a/src/cdk-experimental/drag-drop/drop.ts
+++ b/src/cdk-experimental/drag-drop/drop.ts
@@ -291,11 +291,9 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
       })
       .sort((a, b) => a.clientRect.top - b.clientRect.top);
 
-    // TODO(crisbeto): add filter here that ensures that the
-    // current container isn't being passed to itself.
     this._positionCache.siblings = this.connectedTo
       .map(drop => typeof drop === 'string' ? this._dragDropRegistry.getDropContainer(drop)! : drop)
-      .filter(Boolean)
+      .filter(drop => drop && drop !== this)
       .map(drop => ({drop, clientRect: drop.element.nativeElement.getBoundingClientRect()}));
   }
 


### PR DESCRIPTION
Ignores the `CdkDrop` instance if it is passed to itself via `connectedTo`. This could happen if the drop container is rendered inside a repeater and can lead to some weird dragging behavior.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/43978465-9ecc97d4-9ce7-11e8-8060-a950353741ae.gif)
