### PR TITLE
feat(stepper): align with 2018 material design spec

### DIFF
--- a/src/lib/stepper/stepper.scss
+++ b/src/lib/stepper/stepper.scss
@@ -1,4 +1,5 @@
 @import '../core/style/variables';
+@import '../core/style/elevation';
 
 $mat-horizontal-stepper-header-height: 72px !default;
 $mat-stepper-label-header-height: 24px !default;
@@ -9,7 +10,9 @@ $mat-stepper-line-gap: 8px !default;
 
 .mat-stepper-vertical,
 .mat-stepper-horizontal {
+  @include mat-overridable-elevation(2);
   display: block;
+  border-radius: 4px;
 }
 
 .mat-horizontal-stepper-header-container {


### PR DESCRIPTION
Aligns the stepper with the latest Material Design spec. Since there aren't any designs in the spec anymore, these changes only add an elevation and a border radius, based on the other card-like components.

![angular_material_-_google_chrome_2018-08-10_22-11-25](https://user-images.githubusercontent.com/4450522/43979734-fd868984-9ceb-11e8-9c84-2179656238b9.png)
![angular_material_-_google_chrome_2018-08-10_22-19-53](https://user-images.githubusercontent.com/4450522/43979733-fd6960ac-9ceb-11e8-82a6-9b3fc5c8f09f.png)
