### PR TITLE
fix(schematics): do not allow specifying native view encapsulation 

### DIFF
--- a/src/lib/schematics/address-form/schema.json
+++ b/src/lib/schematics/address-form/schema.json
@@ -39,7 +39,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None"],
       "type": "string",
       "alias": "v"
     },

--- a/src/lib/schematics/dashboard/schema.json
+++ b/src/lib/schematics/dashboard/schema.json
@@ -39,7 +39,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None"],
       "type": "string",
       "alias": "v"
     },

--- a/src/lib/schematics/nav/schema.json
+++ b/src/lib/schematics/nav/schema.json
@@ -39,7 +39,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None"],
       "type": "string",
       "alias": "v"
     },

--- a/src/lib/schematics/table/schema.json
+++ b/src/lib/schematics/table/schema.json
@@ -39,7 +39,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None"],
       "type": "string",
       "alias": "v"
     },

--- a/src/lib/schematics/tree/schema.json
+++ b/src/lib/schematics/tree/schema.json
@@ -39,7 +39,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None"],
       "type": "string",
       "alias": "v"
     },


### PR DESCRIPTION
No longer allows developers to specify the `--viewEncapsulation Native` when creating components through the Angular Material schematics. Since Angular Material does not work properly with Native / ShadowDom view encapsulation, we should not support these as valid schematic options.