### PR TITLE
build: sync bazel angular version placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "stylelint": "gulp lint",
     "e2e": "gulp e2e",
     "deploy": "gulp deploy:devapp",
-    "webdriver-manager": "webdriver-manager",
     "docs": "gulp docs",
     "api": "gulp api-docs"
   },

--- a/packages.bzl
+++ b/packages.bzl
@@ -72,11 +72,15 @@ MATERIAL_PACKAGES = [
 MATERIAL_TARGETS = ["//src/lib:material"] + ["//src/lib/%s" % p for p in MATERIAL_PACKAGES]
 
 # Each individual package uses a placeholder for the version of Angular to ensure they're
-# all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
+# all in-sync.
+ANGULAR_PACKAGE_VERSION = ">=6.0.0 <7.0.0"
+
+# This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = ">=6.0.0-beta.0 <7.0.0"
 VERSION_PLACEHOLDER_REPLACEMENTS = {
   "0.0.0-NG": ANGULAR_PACKAGE_VERSION,
+  # Note that the "0.0.0-PLACEHOLDER" for the project version is automatically being replaced.
+  # https://github.com/bazelbuild/rules_nodejs/blob/master/internal/npm_package/npm_package.bzl#L94
 }
 
 # Base rollup globals for everything in the repo.

--- a/tools/bazel-stamp-vars.sh
+++ b/tools/bazel-stamp-vars.sh
@@ -11,6 +11,19 @@ function onError {
   echo ""
 }
 
+# Function that throws an error if the Bazel Angular version does not match the
+# required Angular version in the project package.json file.
+function checkBazelAngularVersion {
+  requiredAngularVersion=$(node -p 'require("./package.json").requiredAngularVersion')
+  bazelAngularVersion=$(sed -nr 's/ANGULAR_PACKAGE_VERSION = "(.*)"/\1/p' ./packages.bzl)
+
+  if [[ "${requiredAngularVersion}" != "${bazelAngularVersion}" ]]; then
+    echo "ERROR: The required Angular version that has been specified in the 'package.json' file " \
+         "does not match the given Angular version in the //:packages.bzl file."
+    exit 1
+  fi
+}
+
 # Setup crash trap
 trap 'onError' ERR
 
@@ -22,6 +35,9 @@ if [[ "$(git tag)" == "" ]]; then
   echo "       bazel build --workspace_status_command= ..."
   echo ""
 fi
+
+# Check the Bazel Angular version to be in sync with the angular version in the package.json
+checkBazelAngularVersion
 
 # Gets a human-readable name for HEAD, e.g. "6.0.0-rc.0-15-g846ddfa"
 git_version_raw=$(git describe --abbrev=7 --tags HEAD)


### PR DESCRIPTION
* Updates the Bazel Angular version that will be replaced within the `npm_package` rule to the required Angular version that has been changed with #12089.
* Removes an unused NPM script
* Adds a small check to the Bazel workspace status script that ensures that both Angular versions are in sync.