### PR TITLE
feat(drag-drop): add move event

### DIFF
--- a/src/cdk-experimental/drag-drop/drag-events.ts
+++ b/src/cdk-experimental/drag-drop/drag-events.ts
@@ -55,3 +55,13 @@ export interface CdkDragDrop<T, O = T> {
   /** Container from which the item was picked up. Can be the same as the `container`. */
   previousContainer: CdkDropContainer<O>;
 }
+
+/** Event emitted as the user is dragging a draggable item. */
+export interface CdkDragMove<T = any> {
+  /** Item that is being dragged. */
+  source: CdkDrag<T>;
+  /** Position of the user's pointer on the page. */
+  pointerPosition: {x: number, y: number};
+  /** Native event that is causing the dragging. */
+  event: MouseEvent | TouchEvent;
+}


### PR DESCRIPTION
This is something that came up during a discussion in #8963. Adds the `cdkDragMoved` event which will emit as an item is being dragged. Also adds some extra precautions to make sure that we're not doing extra work unless the consumer opted into the event.