### PR TITLE
fix(form-field): legacy ripple underline jumps in edge

### DIFF
--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -49,6 +49,10 @@ $mat-form-field-legacy-underline-height: 1px !default;
     top: 0;
     height: $height;
 
+    // In some browsers like Microsoft Edge, the `scaleX` transform causes overflow that exceeds
+    // the desired form-field ripple height. See: angular/material2#6351
+    overflow: hidden;
+
     @include cdk-high-contrast {
       height: 0;
       border-top: solid $height;


### PR DESCRIPTION
* The ripple underline jumps in Microsoft Edge inside legacy form-fields.

Fixes #6351