### PR TITLE
fix(list): improved image scaling in avatar

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -143,6 +143,10 @@ $mat-list-item-inset-divider-offset: 72px;
     height: $avatar-size;
     border-radius: 50%;
 
+    // Not supported in IE11, but we're using this as a
+    // progressive enhancement to get better image scaling.
+    object-fit: cover;
+
     ~ .mat-divider-inset {
       @include mat-inset-divider-offset($avatar-size, $mat-list-side-padding);
     }


### PR DESCRIPTION
Improves the scaling for list avatar images that aren't exact squares.

Fixes #8131.

For reference:
![angular_material_-_google_chrome_2018-08-13_22-07-35](https://user-images.githubusercontent.com/4450522/44056082-7a22584e-9f47-11e8-804a-269956e0bda0.png)
![angular_material_-_google_chrome_2018-08-13_22-14-17](https://user-images.githubusercontent.com/4450522/44056089-7d3fef6e-9f47-11e8-883a-334b1f4e7591.png)
