### PR TITLE
feat(expansion-panel): align with 2018 material design spec

### DIFF
--- a/src/lib/expansion/expansion-panel-header.scss
+++ b/src/lib/expansion/expansion-panel-header.scss
@@ -4,6 +4,7 @@
   flex-direction: row;
   align-items: center;
   padding: 0 24px;
+  border-radius: inherit;
 
   &:focus,
   &:hover {

--- a/src/lib/expansion/expansion-panel.scss
+++ b/src/lib/expansion/expansion-panel.scss
@@ -3,12 +3,31 @@
 @import '../../cdk/a11y/a11y';
 
 .mat-expansion-panel {
+  $border-radius: 4px;
+
   @include mat-elevation-transition;
   @include mat-overridable-elevation(2);
   box-sizing: content-box;
   display: block;
   margin: 0;
   transition: margin 225ms $mat-fast-out-slow-in-timing-function;
+  border-radius: $border-radius;
+
+  .mat-accordion & {
+    &:not(.mat-expanded), &:not(.mat-expansion-panel-spacing) {
+      border-radius: 0;
+    }
+
+    &:first-of-type {
+      border-top-right-radius: $border-radius;
+      border-top-left-radius: $border-radius;
+    }
+
+    &:last-of-type {
+      border-bottom-right-radius: $border-radius;
+      border-bottom-left-radius: $border-radius;
+    }
+  }
 
   @include cdk-high-contrast {
     outline: solid 1px;


### PR DESCRIPTION
Aligns the expansion panel with the latest Material Design spec.

<img width="621" alt="screenshot at aug 14 15-55-44" src="https://user-images.githubusercontent.com/4450522/44096270-2dc7dfe8-9fdb-11e8-956c-1482ba70a450.png">
<img width="620" alt="screenshot at aug 14 15-55-09" src="https://user-images.githubusercontent.com/4450522/44096276-3057e7c6-9fdb-11e8-890c-3bad8a190791.png">
