### PR TITLE
fix(menu): throw better error when trying to open undefined menu

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -195,6 +195,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       return;
     }
 
+    this._checkMenu();
+
     const overlayRef = this._createOverlay();
     this._setPosition(overlayRef.getConfig().positionStrategy as FlexibleConnectedPositionStrategy);
     overlayRef.attach(this._portal);

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -427,6 +427,19 @@ describe('MatMenu', () => {
     expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
   });
 
+  it('should throw the correct error if the menu is not defined after init', () => {
+    const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.menu = null!;
+    fixture.detectChanges();
+
+    expect(() => {
+      fixture.componentInstance.trigger.openMenu();
+      fixture.detectChanges();
+    }).toThrowError(/must pass in an mat-menu instance/);
+  });
+
   describe('lazy rendering', () => {
     it('should be able to render the menu content lazily', fakeAsync(() => {
       const fixture = createComponent(SimpleLazyMenu);


### PR DESCRIPTION
Throws a better error than "Unable to read property templateRef of undefined" when clicking on a trigger with an undefined menu. We have a check for this already in one of the lifecycle hooks, but people can skip it when unit testing.

Fixes #12649.