### PR TITLE
build: update saucelabs tunnel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ version: 2
 jobs:
   build:
     <<: *job_defaults
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout:
           <<: *post_checkout

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-TUNNEL_FILE="sc-4.4.12-linux.tar.gz"
+TUNNEL_FILE="sc-4.5.0-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 


### PR DESCRIPTION
* Updates the Saucelabs Connect Tunnel to the most recent version that includes a major bug fix that should improve tunnel stability 

  (see  https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Version+4.5.0)
* Changes the CircleCI resource class to the `xlarge` (similar as in angular/angular). This should speed up the Bazel builds due to more CPU threads and more RAM.