### PR TITLE
build: fix docs-content branch publish

### DIFF
--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -56,23 +56,24 @@ echo "Starting deployment of the docs-content for ${buildVersionName} in ${branc
 # Remove the docs-content repository if the directory exists
 rm -Rf ${docsContentPath}
 
-# Clone the docs-content repository.
-git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1
+echo "Starting cloning process of ${docsContentRepoUrl} into ${docsContentPath}.."
 
-echo "Successfully cloned docs-content repository."
+if [[ $(git ls-remote --heads ${docsContentRepoUrl} ${branchName}) ]]; then
+  echo "Branch ${branchName} already exists. Cloning that branch."
+  git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1 --branch ${branchName}
 
-# Go into the repository directory.
-cd ${docsContentPath}
-
-echo "Switched into the repository directory."
-
-if [[ $(git ls-remote --heads origin ${branchName}) ]]; then
-  git checkout ${branchName}
-  echo "Switched to ${branchName} branch."
+  cd ${docsContentPath}
+  echo "Cloned repository and switched into the repository directory (${docsContentPath})."
 else
-  echo "Branch ${branchName} does not exist on the docs-content repo yet. Creating ${branchName}.."
+  echo "Branch ${branchName} does not exist yet."
+  echo "Cloning default branch and creating branch '${branchName}' on top of it."
+
+  git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1
+  cd ${docsContentPath}
+
+  echo "Cloned repository and switched into directory. Creating new branch now.."
+
   git checkout -b ${branchName}
-  echo "Branch created and checked out."
 fi
 
 # Remove everything inside of the docs-content repository.
@@ -123,6 +124,6 @@ echo "Credentials for docs-content repository are now set up. Publishing.."
 git add -A
 git commit --allow-empty -m "${buildCommitMessage}"
 git tag "${buildTagName}"
-git push origin master --tags
+git push origin ${branchName} --tags
 
 echo "Published docs-content for ${buildVersionName} into ${branchName} successfully"


### PR DESCRIPTION
Currently the docs-content output will be overwritten each time a Travis job runs in another branch (e.g. `master`, `6.4.x`, `6.x`). 

This is because the given branches cannot be created in the `material2-docs-content` repository and we **always** only publish to `origin/master`.

---

**Scenario:** We want to release a new patch version, but have no way to properly pull the docs-content data that matches the given new version. Meaning that the docs-content and the `@angular/material-examples` package is based on the next `major` version and we run into runtime exceptions due to the breaking changes.

---

**Note**: This should go into the patch branches because we want to fix the docs-content repository.