### PR TITLE
fix(expansion-panel): focus lost if focused element is inside closing panel

### DIFF
--- a/src/lib/expansion/expansion-panel-header.ts
+++ b/src/lib/expansion/expansion-panel-header.ts
@@ -83,7 +83,12 @@ export class MatExpansionPanelHeader implements OnDestroy {
     )
     .subscribe(() => this._changeDetectorRef.markForCheck());
 
-    _focusMonitor.monitor(_element);
+    // Avoids focus being lost if the panel contained the focused element and was closed.
+    panel.closed
+      .pipe(filter(() => panel._containsFocus()))
+      .subscribe(() => _focusMonitor.focusVia(_element.nativeElement, 'program'));
+
+      _focusMonitor.monitor(_element);
   }
 
   /** Height of the header while the panel is expanded. */

--- a/src/lib/expansion/expansion.spec.ts
+++ b/src/lib/expansion/expansion.spec.ts
@@ -162,6 +162,25 @@ describe('MatExpansionPanel', () => {
     expect(document.activeElement).not.toBe(button, 'Expected button to no longer be focusable.');
   }));
 
+  it('should restore focus to header if focused element is inside panel on close', fakeAsync(() => {
+    const fixture = TestBed.createComponent(PanelWithContent);
+    fixture.componentInstance.expanded = true;
+    fixture.detectChanges();
+    tick(250);
+
+    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header')).nativeElement;
+
+    button.focus();
+    expect(document.activeElement).toBe(button, 'Expected button to start off focusable.');
+
+    fixture.componentInstance.expanded = false;
+    fixture.detectChanges();
+    tick(250);
+
+    expect(document.activeElement).toBe(header, 'Expected header to be focused.');
+  }));
+
   it('should not override the panel margin if it is not inside an accordion', fakeAsync(() => {
     const fixture = TestBed.createComponent(PanelWithCustomMargin);
     fixture.detectChanges();


### PR DESCRIPTION
Currently when an expansion panel is closed, we make the content non-focusable using `visibility: hidden`, but that means that if the focused element was inside the panel, focus will be returned back to the body. These changes add a listener that will restore focus to the panel header, if the focused element is inside the panel when it is closed.