### PR TITLE
test: fix slide-toggle e2e failures

### DIFF
--- a/e2e/components/slide-toggle-e2e.spec.ts
+++ b/e2e/components/slide-toggle-e2e.spec.ts
@@ -1,4 +1,4 @@
-import {browser, element, by, Key, ExpectedConditions} from 'protractor';
+import {browser, element, by, Key} from 'protractor';
 import {expectToExist} from '../util/index';
 
 
@@ -13,59 +13,49 @@ describe('slide-toggle', () => {
   });
 
   it('should change the checked state on click', async () => {
-    let inputEl = getInput();
+    const inputEl = getInput();
 
     expect(inputEl.getAttribute('checked')).toBeFalsy('Expect slide-toggle to be unchecked');
 
     getNormalToggle().click();
 
     expect(inputEl.getAttribute('checked')).toBeTruthy('Expect slide-toggle to be checked');
-
-    await browser.wait(ExpectedConditions.not(
-      ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
   });
 
   it('should change the checked state on click', async () => {
-    let inputEl = getInput();
+    const inputEl = getInput();
 
     expect(inputEl.getAttribute('checked')).toBeFalsy('Expect slide-toggle to be unchecked');
 
     getNormalToggle().click();
 
     expect(inputEl.getAttribute('checked')).toBeTruthy('Expect slide-toggle to be checked');
-    await browser.wait(ExpectedConditions.not(
-      ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
   });
 
   it('should not change the checked state on click when disabled', async () => {
-    let inputEl = getInput();
+    const inputEl = getInput();
 
     expect(inputEl.getAttribute('checked')).toBeFalsy('Expect slide-toggle to be unchecked');
 
     element(by.css('#disabled-slide-toggle')).click();
 
     expect(inputEl.getAttribute('checked')).toBeFalsy('Expect slide-toggle to be unchecked');
-    await browser.wait(ExpectedConditions.not(
-      ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
   });
 
   it('should move the thumb on state change', async () => {
-    let slideToggleEl = getNormalToggle();
-    let thumbEl = element(by.css('#normal-slide-toggle .mat-slide-toggle-thumb-container'));
-    let previousPosition = await thumbEl.getLocation();
+    const slideToggleEl = getNormalToggle();
+    const thumbEl = element(by.css('#normal-slide-toggle .mat-slide-toggle-thumb-container'));
+    const previousPosition = await thumbEl.getLocation();
 
     slideToggleEl.click();
 
-    let position = await thumbEl.getLocation();
+    const position = await thumbEl.getLocation();
 
     expect(position.x).not.toBe(previousPosition.x);
-
-    await browser.wait(ExpectedConditions.not(
-      ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
   });
 
   it('should toggle the slide-toggle on space key', () => {
-    let inputEl = getInput();
+    const inputEl = getInput();
 
     expect(inputEl.getAttribute('checked')).toBeFalsy('Expect slide-toggle to be unchecked');
 


### PR DESCRIPTION
Fixes some e2e failures in the slide toggle after the new design got in. The tests expect the ripples to go away at some point, however we introduced a permanent ripple.