### PR TITLE
build: do not e2e tests on saucelabs

### DIFF
--- a/scripts/ci/sources/tunnel.sh
+++ b/scripts/ci/sources/tunnel.sh
@@ -8,7 +8,7 @@ WAIT_RETRIES=2
 
 start_tunnel() {
   case "$MODE" in
-    e2e*|saucelabs*)
+    saucelabs*)
       ./scripts/saucelabs/start-tunnel.sh
       ;;
     browserstack*)
@@ -21,7 +21,7 @@ start_tunnel() {
 
 wait_for_tunnel() {
   case "$MODE" in
-    e2e*|saucelabs*)
+    saucelabs*)
       retryCall ${WAIT_RETRIES} ./scripts/saucelabs/wait-tunnel.sh
       ;;
     browserstack*)
@@ -34,7 +34,7 @@ wait_for_tunnel() {
 
 teardown_tunnel() {
   case "$MODE" in
-    e2e*|saucelabs*)
+    saucelabs*)
       ./scripts/saucelabs/stop-tunnel.sh
       ;;
     browserstack*)

--- a/scripts/ci/travis-testing.sh
+++ b/scripts/ci/travis-testing.sh
@@ -34,7 +34,9 @@ wait_for_tunnel
 if is_lint; then
   $(npm bin)/gulp ci:lint
 elif is_e2e; then
-  $(npm bin)/gulp ci:e2e
+  # Run e2e tests inside of Xvfb because we need to test the HTML Fullscreen API's that cannot
+  # be tested within Chrome headless.
+  xvfb-run -a --server-args='-screen 0, 1024x768x16' $(npm bin)/gulp ci:e2e
 elif is_aot; then
   $(npm bin)/gulp ci:aot
 elif is_payload; then

--- a/scripts/saucelabs/sauce_config.js
+++ b/scripts/saucelabs/sauce_config.js
@@ -1,1 +1,0 @@
-module.exports = process.env.SAUCE_ACCESS_KEY.split('').reverse().join('');

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -5,9 +5,9 @@ require('ts-node').register({
   project: path.join(__dirname, '../e2e/')
 });
 
-
 const E2E_BASE_URL = process.env['E2E_BASE_URL'] || 'http://localhost:4200';
-const config = {
+
+exports.config = {
   useAllAngular2AppRoots: true,
   specs: [ path.join(__dirname, '../e2e/**/*.spec.ts') ],
   baseUrl: E2E_BASE_URL,
@@ -27,34 +27,23 @@ const config = {
         // Exclude mat-menu elements because those are empty if not active.
         { id: 'aria-required-children', selector: '*:not(mat-menu)' },
 
-        // Disable color constrast checks since the final colors will vary based on the theme.
+        // Disable color contrast checks since the final colors will vary based on the theme.
         { id: 'color-contrast', enabled: false },
       ]
     }
-  ]
-};
+  ],
 
-if (process.env['TRAVIS']) {
-  const key = require('../scripts/saucelabs/sauce_config');
+  capabilities: {
+    browserName: 'chrome',
 
-  config.sauceUser = process.env['SAUCE_USERNAME'];
-  config.sauceKey = key;
-  config.capabilities = {
-    'browserName': 'chrome',
-    'version': 'latest',
-    'tunnel-identifier': process.env['TRAVIS_JOB_ID'],
-    'build': process.env['TRAVIS_JOB_ID'],
-    'name': 'Material E2E Tests',
+    chromeOptions: {
+      // Inside of Travis, we need to specify `--no-sandbox` because otherwise Chrome cannot
+      // be launched properly due to insufficient permissions in a non-sudo environment.
+      args: process.env['TRAVIS'] ? ['--no-sandbox'] : [],
+    },
 
     // Enables concurrent testing in the Webdriver. Currently runs five e2e files in parallel.
-    'maxInstances': 5,
-    'shardTestFiles': true,
-
-    // By default Saucelabs tries to record the whole e2e run. This can slow down the builds.
-    'recordVideo': false,
-    'recordScreenshots': false
-  };
-}
-
-
-exports.config = config;
+    shardTestFiles: true,
+    maxInstances: 5,
+  }
+};


### PR DESCRIPTION
* No longer runs e2e tests inside of Saucelabs because Chrome is also installed on Travis CI and we should keep Saucelabs available for other browsers that don't run inside of Dockers or Travis.