### PR TITLE
fix(stepper): improved alignment for step icons

### DIFF
--- a/src/lib/stepper/step-header.html
+++ b/src/lib/stepper/step-header.html
@@ -8,7 +8,7 @@
       *ngSwitchCase="true"
       [ngTemplateOutlet]="iconOverrides.number"
       [ngTemplateOutletContext]="_getIconContext()"></ng-container>
-    <span *ngSwitchDefault>{{index + 1}}</span>
+    <span class="mat-step-icon-content" *ngSwitchDefault>{{index + 1}}</span>
   </ng-container>
 
   <ng-container *ngSwitchCase="'edit'" [ngSwitch]="!!(iconOverrides && iconOverrides.edit)">
@@ -16,7 +16,7 @@
       *ngSwitchCase="true"
       [ngTemplateOutlet]="iconOverrides.edit"
       [ngTemplateOutletContext]="_getIconContext()"></ng-container>
-    <mat-icon *ngSwitchDefault>create</mat-icon>
+    <mat-icon class="mat-step-icon-content" *ngSwitchDefault>create</mat-icon>
   </ng-container>
 
   <ng-container *ngSwitchCase="'done'" [ngSwitch]="!!(iconOverrides && iconOverrides.done)">
@@ -24,7 +24,7 @@
       *ngSwitchCase="true"
       [ngTemplateOutlet]="iconOverrides.done"
       [ngTemplateOutletContext]="_getIconContext()"></ng-container>
-    <mat-icon *ngSwitchDefault>done</mat-icon>
+    <mat-icon class="mat-step-icon-content" *ngSwitchDefault>done</mat-icon>
   </ng-container>
 </div>
 <div class="mat-step-label"

--- a/src/lib/stepper/step-header.scss
+++ b/src/lib/stepper/step-header.scss
@@ -26,10 +26,16 @@ $mat-step-header-icon-size: 16px !default;
   border-radius: 50%;
   height: $mat-stepper-label-header-height;
   width: $mat-stepper-label-header-height;
-  align-items: center;
-  justify-content: center;
-  display: flex;
   flex-shrink: 0;
+  position: relative;
+}
+
+.mat-step-icon-content {
+  // Use absolute positioning to center the content, because it works better with text.
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .mat-step-icon .mat-icon {


### PR DESCRIPTION
Switches to using absolute positioning to center the stepper icons. This works better with the text-based icons.

Fixes #12696.

For reference, the first screenshot is what it looks like in master:

![angular_material_-_google_chrome_2018-08-16_20-02-56](https://user-images.githubusercontent.com/4450522/44227018-e2129a80-a191-11e8-9032-51f23daecbbf.png)
![angular_material_-_google_chrome_2018-08-16_20-01-46](https://user-images.githubusercontent.com/4450522/44227027-e5a62180-a191-11e8-8303-1dc2346cf0a0.png)
