### PR TITLE
fix(ng-add): do not incorrectly insert custom-theme into CSS files

### DIFF
--- a/src/lib/schematics/install/index.spec.ts
+++ b/src/lib/schematics/install/index.spec.ts
@@ -19,10 +19,12 @@ describe('material-install-schematic', () => {
 
   /** Expects the given file to be in the styles of the specified workspace project. */
   function expectProjectStyleFile(project: WorkspaceProject, filePath: string) {
-    expect(project.architect!['build']).toBeTruthy();
-    expect(project.architect!['build']['options']).toBeTruthy();
-    expect(project.architect!['build']['options']['styles']).toContain(
-      filePath, `Expected "${filePath}" to be added to the project styles in the workspace.`);
+    const architect = project.architect!;
+
+    expect(architect!['build']).toBeTruthy();
+    expect(architect!['build']['options']).toBeTruthy();
+    expect(architect!['build']['options']['styles']).toContain(filePath,
+        `Expected "${filePath}" to be added to the project styles in the workspace.`);
   }
 
   it('should update package.json', () => {

--- a/src/lib/schematics/install/index.spec.ts
+++ b/src/lib/schematics/install/index.spec.ts
@@ -1,10 +1,11 @@
 import {Tree} from '@angular-devkit/schematics';
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import {getProjectStyleFile} from '@angular/material/schematics/utils/project-style-file';
 import {getIndexHtmlPath} from './fonts/project-index-html';
 import {getProjectFromWorkspace} from '../utils/get-project';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {collectionPath, createTestApp} from '../test-setup/test-app';
-import {getWorkspace} from '@schematics/angular/utility/config';
+import {getWorkspace, WorkspaceProject} from '@schematics/angular/utility/config';
 import {normalize} from '@angular-devkit/core';
 
 describe('material-install-schematic', () => {
@@ -15,6 +16,14 @@ describe('material-install-schematic', () => {
     appTree = createTestApp();
     runner = new SchematicTestRunner('schematics', collectionPath);
   });
+
+  /** Expects the given file to be in the styles of the specified workspace project. */
+  function expectProjectStyleFile(project: WorkspaceProject, filePath: string) {
+    expect(project.architect!['build']).toBeTruthy();
+    expect(project.architect!['build']['options']).toBeTruthy();
+    expect(project.architect!['build']['options']['styles']).toContain(
+      filePath, `Expected "${filePath}" to be added to the project styles in the workspace.`);
+  }
 
   it('should update package.json', () => {
     const tree = runner.runSchematic('ng-add', {}, appTree);
@@ -33,17 +42,11 @@ describe('material-install-schematic', () => {
     const workspace = getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace);
 
-    console.log(tree.files);
-
-    expect(project.architect!['build']).toBeTruthy();
-    expect(project.architect!['build']['options']).toBeTruthy();
-    expect(project.architect!['build']['options']['styles']).toContain(
-      './node_modules/@angular/material/prebuilt-themes/indigo-pink.css');
+    expectProjectStyleFile(project,
+        './node_modules/@angular/material/prebuilt-themes/indigo-pink.css');
   });
 
   it('should support adding a custom theme', () => {
-    // TODO(devversion): currently a "custom" theme does only work for projects using SCSS.
-    // TODO(devversion): Throw an error if a custom theme is being installed in a CSS project.
     appTree = createTestApp({style: 'scss'});
 
     const tree = runner.runSchematic('ng-add', {theme: 'custom'}, appTree);
@@ -57,6 +60,18 @@ describe('material-install-schematic', () => {
 
     expect(src.indexOf(`@import '~@angular/material/theming';`)).toBeGreaterThan(-1);
     expect(src.indexOf(`$app-primary`)).toBeGreaterThan(-1);
+  });
+
+  it('should create a custom theme file if no SCSS file could be found', () => {
+    appTree = createTestApp({style: 'css'});
+
+    const tree = runner.runSchematic('ng-add', {theme: 'custom'}, appTree);
+    const workspace = getWorkspace(tree);
+    const project = getProjectFromWorkspace(workspace);
+    const expectedStylesPath = normalize(`/${project.root}/src/custom-theme.scss`);
+
+    expect(tree.files).toContain(expectedStylesPath, 'Expected a custom theme file to be created');
+    expectProjectStyleFile(project, 'projects/material/src/custom-theme.scss');
   });
 
   it('should add font links', () => {
@@ -75,5 +90,18 @@ describe('material-install-schematic', () => {
       '  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"');
     expect(htmlContent).toContain(
       '  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"');
+  });
+
+  it('should add material app styles', () => {
+    const tree = runner.runSchematic('ng-add', {}, appTree);
+    const workspace = getWorkspace(tree);
+    const project = getProjectFromWorkspace(workspace);
+
+    const defaultStylesPath = getProjectStyleFile(project);
+    const htmlContent = tree.read(defaultStylesPath)!.toString();
+
+    expect(htmlContent).toContain('html, body { height: 100%; }');
+    expect(htmlContent).toContain(
+        'body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }');
   });
 });

--- a/src/lib/schematics/install/index.ts
+++ b/src/lib/schematics/install/index.ts
@@ -99,7 +99,7 @@ function addMaterialAppStyles(options: Schema) {
     const htmlContent = buffer.toString();
     const insertion = '\n' +
       `html, body { height: 100%; }\n` +
-      `body { margin: 0; font-family: 'Roboto', sans-serif; }\n`;
+      `body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }\n`;
 
     if (htmlContent.includes(insertion)) {
       return;

--- a/src/lib/schematics/utils/project-style-file.ts
+++ b/src/lib/schematics/utils/project-style-file.ts
@@ -7,29 +7,43 @@
  */
 
 import {normalize} from '@angular-devkit/core';
-import {SchematicsException} from '@angular-devkit/schematics';
 import {WorkspaceProject} from '@schematics/angular/utility/config';
 
-/** Looks for the primary style file for a given project and returns its path. */
-export function getProjectStyleFile(project: WorkspaceProject): string {
+/** Regular expression that matches all possible Angular CLI default style files. */
+const defaultStyleFileRegex = /styles\.(c|le|sc)ss/;
+
+/** Regular expression that matches all files that have a proper stylesheet extension. */
+const validStyleFileRegex = /\.(c|le|sc)ss/;
+
+/**
+ * Gets a style file with the given extension in a project and returns its path. If no
+ * extension is specified, any style file with a valid extension will be returned.
+ */
+export function getProjectStyleFile(project: WorkspaceProject, extension?: string): string | null {
   const buildTarget = project.architect['build'];
 
   if (buildTarget.options && buildTarget.options.styles && buildTarget.options.styles.length) {
     const styles = buildTarget.options.styles.map(s => typeof s === 'string' ? s : s.input);
 
-    // First, see if any of the assets is called "styles.(le|sc|c)ss", which is the default
-    // "main" style sheet.
-    const defaultMainStylePath = styles.find(a => /styles\.(c|le|sc)ss/.test(a));
+    // Look for the default style file that is generated for new projects by the Angular CLI. This
+    // default style file is usually called `styles.ext` unless it has been changed explicitly.
+    const defaultMainStylePath = styles
+      .find(file => extension ? file === `styles.${extension}` : defaultStyleFileRegex.test(file));
+
     if (defaultMainStylePath) {
       return normalize(defaultMainStylePath);
     }
 
-    // If there was no obvious default file, use the first style asset.
-    const fallbackStylePath = styles.find(a => /\.(c|le|sc)ss/.test(a));
+    // If no default style file could be found, use the first style file that matches the given
+    // extension. If no extension specified explicitly, we look for any file with a valid style
+    // file extension.
+    const fallbackStylePath = styles
+      .find(file => extension ? file.endsWith(`.${extension}`) : validStyleFileRegex.test(file));
+
     if (fallbackStylePath) {
       return normalize(fallbackStylePath);
     }
   }
 
-  throw new SchematicsException('No style files could be found into which a theme could be added.');
+  return null;
 }


### PR DESCRIPTION
* Currently the schematics add the custom-theme SCSS code to any project style file (`styles.EXT`). This is incorrect because the SCSS needs to be placed inside of a SCSS file. Instead of throwing an error we just create a new SCSS file with the theme and add it to the workspace config.
* Aligns the global font-family statement with the current Angular Material typography font-family.
* Adds missing tests for the global app styles.
* Removes an accidentally committed `console.log()`.