### PR TITLE
build: reduce e2e parallel instances

### DIFF
--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -42,8 +42,8 @@ exports.config = {
       args: process.env['TRAVIS'] ? ['--no-sandbox'] : [],
     },
 
-    // Enables concurrent testing in the Webdriver. Currently runs five e2e files in parallel.
+    // Enables concurrent testing in the Webdriver. Currently runs three e2e files in parallel.
     shardTestFiles: true,
-    maxInstances: 5,
+    maxInstances: 3,
   }
 };


### PR DESCRIPTION
* Reduces the protractor parallel instances because it seems to be flaky if we run a lot of processes inside of the Travis.