### PR TITLE
chore(menu): errors referencing old input and directive names

### DIFF
--- a/src/lib/menu/menu-errors.ts
+++ b/src/lib/menu/menu-errors.ts
@@ -11,7 +11,7 @@
  * @docs-private
  */
 export function throwMatMenuMissingError() {
-  throw Error(`mat-menu-trigger: must pass in an mat-menu instance.
+  throw Error(`matMenuTriggerFor: must pass in an mat-menu instance.
 
     Example:
       <mat-menu #menu="matMenu"></mat-menu>
@@ -24,8 +24,8 @@ export function throwMatMenuMissingError() {
  * @docs-private
  */
 export function throwMatMenuInvalidPositionX() {
-  throw Error(`x-position value must be either 'before' or after'.
-      Example: <mat-menu x-position="before" #menu="matMenu"></mat-menu>`);
+  throw Error(`xPosition value must be either 'before' or after'.
+      Example: <mat-menu xPosition="before" #menu="matMenu"></mat-menu>`);
 }
 
 /**
@@ -34,6 +34,6 @@ export function throwMatMenuInvalidPositionX() {
  * @docs-private
  */
 export function throwMatMenuInvalidPositionY() {
-  throw Error(`y-position value must be either 'above' or below'.
-      Example: <mat-menu y-position="above" #menu="matMenu"></mat-menu>`);
+  throw Error(`yPosition value must be either 'above' or below'.
+      Example: <mat-menu yPosition="above" #menu="matMenu"></mat-menu>`);
 }


### PR DESCRIPTION
Fixes the errors for `mat-menu` which are referencing the camel-cased selectors or the deprecated names for some of the inputs.