### PR TITLE
fix(slide-toggle): blended ripples do not match spec

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -191,7 +191,10 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   pointer-events: none;
 
   .mat-ripple-element:not(.mat-slide-toggle-persistent-ripple) {
-    opacity: 0.16;
+    // Although the specs describe an opacity of 16% for ripples if the slide-toggle is being
+    // pressed, we need to reduce the opacity a bit because besides the transient ripples,
+    // the persistent ripple will still show up and blend with the transient ripple.
+    opacity: 0.12;
   }
 }
 


### PR DESCRIPTION
* In order to fully align the slide-toggle with the 2018 specs, we need to reduce the opacity of the transient ripples because those blend together with the persistent ripple that has been introduced for hover/focus.

**Note**: Marked as P2 because it should be part of the 2018 spec alignment.