### PR TITLE
build: print saucelabs output to console

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -6,8 +6,6 @@ TUNNEL_FILE="sc-4.5.0-linux.tar.gz"
 TUNNEL_URL="https://saucelabs.com/downloads/${TUNNEL_FILE}"
 TUNNEL_DIR="/tmp/saucelabs-connect"
 
-TUNNEL_LOG="${LOGS_DIR}/saucelabs-tunnel.log"
-
 SAUCE_ACCESS_KEY=`echo ${SAUCE_ACCESS_KEY} | rev`
 
 # Cleanup and create the folder structure for the tunnel connector.
@@ -36,6 +34,6 @@ if [ ! -z "${BROWSER_PROVIDER_READY_FILE}" ]; then
   ARGS="${ARGS} --readyfile ${BROWSER_PROVIDER_READY_FILE}"
 fi
 
-echo "Starting Sauce Connect in the background, logging into: ${TUNNEL_LOG}"
+echo "Starting Sauce Connect in the background, logging to dev/stdout."
 
-sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${ARGS} 2>&1 >> ${TUNNEL_LOG} &
+sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${ARGS} &

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-TUNNEL_LOG="$LOGS_DIR/saucelabs-tunnel.log"
 WAIT_DELAY=30
-
-# Method that prints the logfile output of the saucelabs tunnel.
-printLog() {
-  echo "Logfile output of Saucelabs tunnel (${TUNNEL_LOG}):"
-  echo ""
-  cat ${TUNNEL_LOG}
-}
 
 # Wait for Saucelabs Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
@@ -22,7 +14,6 @@ while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   if [ $counter -gt $[${WAIT_DELAY} * 2] ]; then
     echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
-    printLog
     exit 5
   fi
 


### PR DESCRIPTION
* Instead of printing all the Saucelabs logging messages into a text file that will be never accessible on `TravisCI`, we just print the few messages that could be helpful for debugging into `/dev/stdout`.