### PR TITLE
fix(sidenav): not positioning correctly in rtl

### DIFF
--- a/src/lib/sidenav/drawer.html
+++ b/src/lib/sidenav/drawer.html
@@ -1,0 +1,3 @@
+<div class="mat-drawer-inner-container">
+  <ng-content></ng-content>
+</div>

--- a/src/lib/sidenav/drawer.scss
+++ b/src/lib/sidenav/drawer.scss
@@ -155,6 +155,17 @@ $mat-drawer-over-drawer-z-index: 4;
   }
 }
 
+// Note that this div isn't strictly necessary on all browsers, however we need it in
+// order to avoid a layout issue in Chrome. The issue is that in RTL mode the browser doesn't
+// account for the sidenav's scrollbar while positioning, which ends up pushing it partially
+// out of the screen. We work around the issue by having the scrollbar be on this inner container.
+.mat-drawer-inner-container {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .mat-sidenav-fixed {
   position: fixed;
 }

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -100,7 +100,7 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
   moduleId: module.id,
   selector: 'mat-drawer',
   exportAs: 'matDrawer',
-  template: '<ng-content></ng-content>',
+  templateUrl: 'drawer.html',
   animations: [matDrawerAnimations.transformDrawer],
   host: {
     'class': 'mat-drawer',

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -54,7 +54,7 @@ export class MatSidenavContent extends MatDrawerContent {
   moduleId: module.id,
   selector: 'mat-sidenav',
   exportAs: 'matSidenav',
-  template: '<ng-content></ng-content>',
+  templateUrl: 'drawer.html',
   animations: [matDrawerAnimations.transformDrawer],
   host: {
     'class': 'mat-drawer mat-sidenav',


### PR DESCRIPTION
Adds a workaround for a Chrome issue where the sidenav content is partially cut off when `dir='rtl'` is set on the `body` or `html` nodes.

**Note:** this shouldn't be much of a breaking change for components that derive from the sidenav, because we're still keeping the original `overflow-y: auto`.  Here's the issue for reference:
![angular_material_-_google_chrome_2018-08-19_20-57-18](https://user-images.githubusercontent.com/4450522/44312439-5cdcef00-a3f8-11e8-9b7b-77e6c9cba02d.png)
