### PR TITLE
build(dgeni): do not warn if @breaking-change is used without @deprecated

### DIFF
--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -101,8 +101,5 @@ export function decorateDeprecatedDoc(doc: DeprecationDoc) {
 
   if (doc.isDeprecated && !doc.breakingChange) {
     console.warn('Warning: There is a deprecated item without a @breaking-change tag.', doc.id);
-  } else if  (doc.breakingChange && !doc.isDeprecated) {
-    console.warn('Warning: There is an item with a @breaking-change which is not deprecated.',
-      doc.id);
   }
 }

--- a/tools/dgeni/patch-log-service.ts
+++ b/tools/dgeni/patch-log-service.ts
@@ -1,4 +1,7 @@
 
+/** Regular expression that matches TypeScript mixin names inside of the project. */
+const mixinNameRegex = /_\w+Base/;
+
 /**
  * Function that patches Dgeni's instantiated log service. The patch will hide warnings about
  * unresolved TypeScript symbols for the mixin base classes.
@@ -15,7 +18,7 @@ export function patchLogService(log: any) {
   const _warnFn = log.warn;
 
   log.warn = function(message: string) {
-    if (message.includes('Unresolved TypeScript symbol') && message.includes('MixinBase')) {
+    if (message.includes('Unresolved TypeScript symbol') && mixinNameRegex.test(message)) {
       return;
     }
 


### PR DESCRIPTION
* Similarly to the TSLint rule, we should only warn (on `gulp docs`) if there is a `@deprecated` tag without a `@breaking-change` tag. If there is a `@breaking-change` tag, but no `@deprecated` tag, it's valid because a breaking change does not always involve a deprecation (e.g. "to be made required").
* Updates the log patching for the Dgeni package to also hide warnings for mixins that don't end with `MixinBase`.