### PR TITLE
build(schematics): missing schema files in bazel npm package

### DIFF
--- a/src/lib/schematics/BUILD.bazel
+++ b/src/lib/schematics/BUILD.bazel
@@ -6,7 +6,7 @@ load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
 
 filegroup(
   name = "schematics_assets",
-  srcs = glob(["**/files/**/*"]) + ["README.md", "collection.json", "migration.json"],
+  srcs = glob(["**/files/**/*", "**/*.json"]) + ["README.md"],
 )
 
 ts_library(


### PR DESCRIPTION
* If some builds the `npm_package` of the schematics through Bazel, the `schema.json` files won't be available.
