### PR TITLE
perf(table): prevent unnecessary reflow with sticky row

### DIFF
--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -133,6 +133,10 @@ export class StickyStyler {
         this._addStickyStyle(row, position, stickyHeight);
       }
 
+      if (rowIndex === rows.length - 1) {
+        // prevent unnecessary reflow from getBoundingClientRect()
+        return;
+      }
       stickyHeight += row.getBoundingClientRect().height;
     }
   }


### PR DESCRIPTION
In `StickyStyle` `getBoundingClientRect()` is called to calculate the offset of the next sticky row. This causes a forced reflow([link](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)). However this is not needed when there is only one sticky row.