### PR TITLE
refactor(schematics): remove type checker for inheritance rule

### DIFF
--- a/src/lib/schematics/update/update.spec.ts
+++ b/src/lib/schematics/update/update.spec.ts
@@ -1,1 +1,1 @@
-describe('material-nav-schematic', () => {});
+describe('Material Update Tool', () => {});


### PR DESCRIPTION
* No longer depends on type checking when checking the heritage clauses of a `ClassDeclaration`.

I really want to get tests for such things in. But this involves another concept for testing the output of TSLint. Might be something to consider once everything is ready.