### PR TITLE
docs: update links to Material Design spec

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -16,7 +16,7 @@ a theme consists of:
 In Angular Material, all theme styles are generated _statically_ at build-time so that your
 app doesn't have to spend cycles generating theme styles on startup.
 
-[1]: https://material.google.com/style/color.html#color-color-palette
+[1]: https://material.io/archive/guidelines/style/color.html#color-color-palette
 
 ### Using a pre-built theme
 Angular Material comes prepackaged with several pre-built theme css files. These theme files also

--- a/src/lib/select/select.md
+++ b/src/lib/select/select.md
@@ -1,6 +1,6 @@
 `<mat-select>` is a form control for selecting a value from a set of options, similar to the native
 `<select>` element. You can read more about selects in the
-[Material Design spec](https://material.google.com/components/menus.html). It is designed to work
+[Material Design spec](https://material.io/design/components/menus.html). It is designed to work
 inside of a [`<mat-form-field>`](https://material.angular.io/components/form-field/overview)
 element.
 

--- a/src/lib/slider/slider.md
+++ b/src/lib/slider/slider.md
@@ -38,7 +38,7 @@ value on bottom.
 By default, the exact selected value of a slider is not visible to the user. However, this value can
 be added to the thumb by adding the `thumbLabel` attribute.
 
-The [Material Design spec](https://material.google.com/components/sliders.html) recommends using the
+The [Material Design spec](https://material.io/design/components/sliders.html#discrete-slider) recommends using the
 `thumbLabel` attribute (along with `tickInterval="1"`) only for sliders that are used to display a
 discrete value (such as a 1-5 rating).
 
@@ -74,7 +74,7 @@ The slider will always show a tick at the beginning and end of the track. If the
 doesn't add up perfectly the last interval will be shortened or lengthened so that the tick can be
 shown at the end of the track.
 
-The [Material Design spec](https://material.google.com/components/sliders.html) recommends using the
+The [Material Design spec](https://material.io/design/components/sliders.html#discrete-slider) recommends using the
 `tickInterval` attribute (set to `1` along with the `thumbLabel` attribute) only for sliders that
 are used to display a discrete value (such as a 1-5 rating).
 

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -103,7 +103,7 @@ export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions 
  * Directive that attaches a material design tooltip to the host element. Animates the showing and
  * hiding of a tooltip provided position (defaults to below the element).
  *
- * https://material.google.com/components/tooltips.html
+ * https://material.io/design/components/tooltips.html
  */
 @Directive({
   selector: '[matTooltip]',
@@ -612,7 +612,7 @@ export class TooltipComponent {
   /**
    * Interactions on the HTML body should close the tooltip immediately as defined in the
    * material design spec.
-   * https://material.google.com/components/tooltips.html#tooltips-interaction
+   * https://material.io/design/components/tooltips.html#behavior
    */
   _handleBodyInteraction(): void {
     if (this._closeOnInteraction) {


### PR DESCRIPTION
For color palettes, link to the archived spec since there isn't an equivalent in the 2018 revision.