### PR TITLE
fix(progress-bar): avoid error on SSR if pathname is undefined

### DIFF
--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -94,7 +94,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
     // `Location` from `@angular/common` since we can't tell the difference between whether
     // the consumer is using the hash location strategy or not, because `Location` normalizes
     // both `/#/foo/bar` and `/foo/bar` to the same thing.
-    const path = location ? location.pathname.split('#')[0] : '';
+    const path = location && location.pathname ? location.pathname.split('#')[0] : '';
     this._rectangleFillValue = `url('${path}#${this.progressbarId}')`;
   }
 


### PR DESCRIPTION
@crisbeto this was causing a problem in Google Shopping Express; for some reason `pathname` was undefined in the SSR environment. I'm not sure why our kitchen-sink test didn't encounter the same thing.