### PR TITLE
fix(drag-drop): item not being restored to its initial DOM position when using custom preview

### DIFF
--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -788,6 +788,25 @@ describe('CdkDrag', () => {
       expect(preview.textContent!.trim()).toContain('Custom preview');
     }));
 
+    it('should revert the element back to its parent after dragging with a custom ' +
+      'preview has stopped', fakeAsync(() => {
+        const fixture = createComponent(DraggableInDropZoneWithCustomPreview);
+        fixture.detectChanges();
+
+        const dragContainer = fixture.componentInstance.dropInstance.element.nativeElement;
+        const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+        expect(dragContainer.contains(item)).toBe(true, 'Expected item to be in container.');
+
+        // The coordinates don't matter.
+        dragElementViaMouse(fixture, item, 10, 10);
+        flush();
+        fixture.detectChanges();
+
+        expect(dragContainer.contains(item))
+            .toBe(true, 'Expected item to be returned to container.');
+      }));
+
     it('should position custom previews next to the pointer', fakeAsync(() => {
       const fixture = createComponent(DraggableInDropZoneWithCustomPreview);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -341,8 +341,6 @@ export class CdkDrag<T = any> implements OnDestroy {
     // while moving the existing elements in all other cases.
     this.element.nativeElement.style.display = '';
 
-    console.log('cleaning up');
-
     if (this._nextSibling) {
       this._nextSibling.parentNode!.insertBefore(this.element.nativeElement, this._nextSibling);
     } else {

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -256,6 +256,11 @@ export class CdkDrag<T = any> implements OnDestroy {
 
     if (this.dropContainer) {
       const element = this.element.nativeElement;
+
+      // Grab the `nextSibling` before the preview and placeholder
+      // have been created so we don't get the preview by accident.
+      this._nextSibling = element.nextSibling;
+
       const preview = this._preview = this._createPreviewElement();
       const placeholder = this._placeholder = this._createPlaceholderElement();
 
@@ -263,7 +268,6 @@ export class CdkDrag<T = any> implements OnDestroy {
       // place will throw off the consumer's `:last-child` selectors. We can't remove the element
       // from the DOM completely, because iOS will stop firing all subsequent events in the chain.
       element.style.display = 'none';
-      this._nextSibling = element.nextSibling;
       this._document.body.appendChild(element.parentNode!.replaceChild(placeholder, element));
       this._document.body.appendChild(preview);
       this.dropContainer.start();
@@ -336,6 +340,8 @@ export class CdkDrag<T = any> implements OnDestroy {
     // can throw off `NgFor` which does smart diffing and re-creates elements only when necessary,
     // while moving the existing elements in all other cases.
     this.element.nativeElement.style.display = '';
+
+    console.log('cleaning up');
 
     if (this._nextSibling) {
       this._nextSibling.parentNode!.insertBefore(this.element.nativeElement, this._nextSibling);

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -94,7 +94,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
     // `Location` from `@angular/common` since we can't tell the difference between whether
     // the consumer is using the hash location strategy or not, because `Location` normalizes
     // both `/#/foo/bar` and `/foo/bar` to the same thing.
-    const path = location ? location.pathname.split('#')[0] : '';
+    const path = location && location.pathname ? location.pathname.split('#')[0] : '';
     this._rectangleFillValue = `url('${path}#${this.progressbarId}')`;
   }
 


### PR DESCRIPTION
When a `cdkDrag` item is picked up, we save its `nextSibling` so we know where to put it once the user has stopped dragging. This logic gets thrown off when we use a custom preview element and it ends up leaving the element in the wrong place in the DOM. These changes ensure that the element is restored to its old position correctly.