### PR TITLE
fix(progress-bar): generate correct url on server

### DIFF
--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -51,8 +51,8 @@ export interface MatProgressBarLocation {
 
 /** @docs-private */
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation {
-  const doc = inject(DOCUMENT);
-  const pathname = (doc && doc.location && doc.location.pathname) || '';
+  const _document = inject(DOCUMENT);
+  const pathname = (_document && _document.location && _document.location.pathname) || '';
   return {pathname};
 }
 

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -13,10 +13,11 @@ import {
   Input,
   Optional,
   ViewEncapsulation,
-  InjectionToken
+  InjectionToken, inject
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {CanColor, mixinColor} from '@angular/material/core';
+import {DOCUMENT} from '@angular/common';
 
 // TODO(josephperrott): Benchpress tests.
 // TODO(josephperrott): Add ARIA attributes for progress bar "for".
@@ -49,7 +50,9 @@ export interface MatProgressBarLocation {
 
 /** @docs-private */
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation {
-  return typeof window !== 'undefined' ? window.location : {pathname: ''};
+  const doc = inject(DOCUMENT);
+  const pathname = (doc && doc.location && doc.location.pathname) || '';
+  return {pathname};
 }
 
 

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -13,7 +13,8 @@ import {
   Input,
   Optional,
   ViewEncapsulation,
-  InjectionToken, inject
+  InjectionToken,
+  inject,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {CanColor, mixinColor} from '@angular/material/core';


### PR DESCRIPTION
* While `window.location` is unavailable on the server, `document.location` is, and can
  be injected in the provider for the progress bar