### PR TITLE
fix(button-toggle): set aria-disabled based on group disabled state

### DIFF
--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -277,6 +277,15 @@ describe('MatButtonToggle without forms', () => {
       expect(buttonToggleInstances[0].checked).toBe(true);
     });
 
+    it('should set aria-disabled based on whether the group is disabled', () => {
+      expect(groupNativeElement.getAttribute('aria-disabled')).toBe('false');
+
+      testComponent.isGroupDisabled = true;
+      fixture.detectChanges();
+
+      expect(groupNativeElement.getAttribute('aria-disabled')).toBe('true');
+    });
+
     it('should update the group value when one of the toggles changes', () => {
       expect(groupInstance.value).toBeFalsy();
       buttonToggleLabelElements[0].click();

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -85,6 +85,7 @@ export class MatButtonToggleChange {
   host: {
     'role': 'group',
     'class': 'mat-button-toggle-group',
+    '[attr.aria-disabled]': 'disabled',
     '[class.mat-button-toggle-vertical]': 'vertical'
   },
   exportAs: 'matButtonToggleGroup',
@@ -98,7 +99,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase impleme
 
   /**
    * Reference to the raw value that the consumer tried to assign. The real
-   * value will exaclude any values from this one that don't correspond to a
+   * value will exclude any values from this one that don't correspond to a
    * toggle. Useful for the cases where the value is assigned before the toggles
    * have been initialized or at the same that they're being swapped out.
    */


### PR DESCRIPTION
Based on the [ARIA spec](https://www.w3.org/TR/wai-aria-1.1/#group) elements with a `group` role can have `aria-disabled`. These changes set the attribute, based on whether the group is disabled.