### PR TITLE
build: prevent publishing from the wrong branch

### DIFF
--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -28,7 +28,8 @@ import './tasks/example-module';
 import './tasks/lint';
 import './tasks/material-release';
 import './tasks/payload';
-import './tasks/publish';
 import './tasks/unit-test';
 import './tasks/universal';
-import './tasks/validate-release';
+
+import './tasks/publish/publish-task';
+import './tasks/publish/validate-release';

--- a/tools/gulp/tasks/publish/branch-check.ts
+++ b/tools/gulp/tasks/publish/branch-check.ts
@@ -1,0 +1,61 @@
+import {bold} from 'chalk';
+import {spawnSync} from 'child_process';
+import {buildConfig} from 'material2-build-tools';
+
+/** Regular expression that matches version names and the individual version segments. */
+export const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d)+)?/;
+
+/** Regular expression that matches publish branch names and their Semver digits. */
+const publishBranchNameRegex = /^([0-9]+)\.([x0-9]+)(?:\.([x0-9]+))?$/;
+
+/** Checks if the specified version can be released from the current Git branch. */
+export function checkPublishBranch(version: string) {
+  const versionType = getSemverVersionType(version);
+  const branchName = spawnSync('git', ['symbolic-ref', '--short', 'HEAD'],
+    {cwd: buildConfig.projectDir}).stdout.toString().trim();
+
+  if (branchName === 'master') {
+    if (versionType === 'major') {
+      return;
+    }
+
+    throw `Publishing of "${versionType}" releases should not happen inside of the ` +
+        `${bold('master')} branch.`;
+  }
+
+  const branchNameMatch = branchName.match(publishBranchNameRegex) || [];
+  const branchDigits = branchNameMatch.slice(1, 4);
+
+  if (branchDigits[2] === 'x' && versionType !== 'patch') {
+    throw `Cannot publish a "${versionType}" release inside of a patch branch (${branchName})`;
+  }
+
+  if (branchDigits[1] === 'x' && versionType !== 'minor') {
+    throw `Cannot publish a "${versionType}" release inside of a minor branch (${branchName})`;
+  }
+
+  throw `Cannot publish a "${versionType}" release from branch: "${branchName}". Releases should `
+  + `be published from "master" or the according publish branch (e.g. "6.x", "6.4.x")`;
+}
+
+/**
+ * Determines the type of the specified semver version. Can be either a major, minor or
+ * patch version.
+ */
+export function getSemverVersionType(version: string): 'major' | 'minor' | 'patch' {
+  const versionNameMatch = version.match(versionNameRegex);
+
+  if (!versionNameMatch) {
+    throw `Could not parse version: ${version}. Cannot properly determine version type.`;
+  }
+
+  const versionDigits = versionNameMatch.slice(1, 4);
+
+  if (versionDigits[1] === '0' && versionDigits[2] === '0') {
+    return 'major';
+  } else if (versionDigits[2] === '0') {
+    return 'minor';
+  } else {
+    return 'patch';
+  }
+}

--- a/tools/gulp/tasks/publish/validate-release.ts
+++ b/tools/gulp/tasks/publish/validate-release.ts
@@ -2,7 +2,7 @@ import {task} from 'gulp';
 import {readFileSync, existsSync} from 'fs';
 import {join} from 'path';
 import {green, red} from 'chalk';
-import {releasePackages} from './publish';
+import {releasePackages} from './publish-task';
 import {sync as glob} from 'glob';
 import {spawnSync} from 'child_process';
 import {buildConfig, sequenceTask} from 'material2-build-tools';
@@ -10,7 +10,7 @@ import {buildConfig, sequenceTask} from 'material2-build-tools';
 const {projectDir, projectVersion, outputDir} = buildConfig;
 
 /** Git repository URL that has been read out from the project package.json file. */
-const repositoryGitUrl = require('../../../package.json').repository.url;
+const repositoryGitUrl = require('../../../../package.json').repository.url;
 
 /** Path to the directory where all releases are created. */
 const releasesDir = join(outputDir, 'releases');


### PR DESCRIPTION
* Patch releases should be published from patch publish branches with the format: `{}.{}.x`
* Minor releases should be published from minor publish branches with the format: `{}.x`
* Major releases should be published from the `master` branch.

Closes #12655