### PR TITLE
fix(chips): improved image scaling in avatar

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -151,6 +151,10 @@ $mat-chip-remove-size: 18px;
   align-items: center;
   display: flex;
   overflow: hidden;
+
+  // Makes `<img>` tags behave like `background-size: cover`. Not supported
+  // in IE, but we're using it as a progressive enhancement.
+  object-fit: cover;
 }
 
 input.mat-chip-input {


### PR DESCRIPTION
Along the same lines as #12660. Uses `object-fit: cover` to better scale the avatar image, where available.

For reference:
![angular_material_-_google_chrome_2018-08-26_19-23-33](https://user-images.githubusercontent.com/4450522/44630973-d11e1200-a965-11e8-8b4b-9e9caae11e4d.png)
![angular_material_-_google_chrome_2018-08-26_19-23-13](https://user-images.githubusercontent.com/4450522/44630974-d4190280-a965-11e8-81ea-652c233749f8.png)
