### PR TITLE
fix(input): do not focus input element twice

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -368,5 +368,12 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  onContainerClick() { this.focus(); }
+  onContainerClick() {
+    // Do not re-focus the input element if the element is already focused. Otherwise it can happen
+    // that someone clicks on a time input and the cursor resets to the "hours" field while the
+    // "minutes" field was actually clicked. See: https://github.com/angular/material2/issues/12849
+    if (!this.focused) {
+      this.focus();
+    }
+  }
 }


### PR DESCRIPTION
* Currently if a user clicks on a input, the element receives focus and the `click` event bubbles up. Once it reaches the `<mat-form-field>`, the click event will cause the `onContainerClick` method to be invoked. This method then manually focused the input element (again). Resulting in unexpected behavior for time inputs in Firefox.

**Note**: There is no good way to test this behavior because we cannot dispatch a click event that sets `focus` and also explicitly selects the `minute` field of a time input. E2E tests don't work either because we run against Chrome headless and not Firefox.

Fixes #12849