### PR TITLE
build: fix radio e2e tests timing out

### DIFF
--- a/e2e/components/radio-e2e.spec.ts
+++ b/e2e/components/radio-e2e.spec.ts
@@ -9,17 +9,12 @@ describe('radio', () => {
       element(by.id('water')).click();
 
       expect(element(by.id('water')).getAttribute('class')).toContain('mat-radio-checked');
-      await browser.wait(ExpectedConditions.not(
-        ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
 
       expect(element(by.css('input[id=water-input]')).getAttribute('checked')).toBeTruthy();
       expect(element(by.css('input[id=leaf-input]')).getAttribute('checked')).toBeFalsy();
 
       element(by.id('leaf')).click();
       expect(element(by.id('leaf')).getAttribute('class')).toContain('mat-radio-checked');
-
-      await browser.wait(ExpectedConditions.not(
-        ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
 
       expect(element(by.css('input[id=leaf-input]')).getAttribute('checked')).toBeTruthy();
       expect(element(by.css('input[id=water-input]')).getAttribute('checked')).toBeFalsy();
@@ -37,9 +32,6 @@ describe('radio', () => {
 
       element(by.id('leaf')).click();
       expect(element(by.id('leaf')).getAttribute('class')).toContain('mat-radio-disabled');
-
-      await browser.wait(ExpectedConditions.not(
-        ExpectedConditions.presenceOf(element(by.css('div.mat-ripple-element')))));
 
       expect(element(by.css('input[id=leaf-input]')).getAttribute('disabled')).toBeTruthy();
     });


### PR DESCRIPTION
Fixes a timeout in the radio button e2e tests, after the new design changes got in. The tests expect there to be no ripples, but the new design introduced a permanent ripple in each button. This is along the same lines as #12699.