### PR TITLE
chore(ripple): fake mousedown test not running

### DIFF
--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -167,7 +167,7 @@ describe('MatRipple', () => {
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(0);
     }));
 
-    it('should ignore fake mouse events from screen readers', () => fakeAsync(() => {
+    it('should ignore fake mouse events from screen readers', fakeAsync(() => {
       const event = createMouseEvent('mousedown');
       Object.defineProperty(event, 'buttons', {get: () => 0});
 


### PR DESCRIPTION
* With 4639a874c7d787d4a47f878b28e680d04ad7da62 a new test has been introduced. Due to a wrong syntax the test does not run properly.