### PR TITLE
chore(drag-drop): import ViewportRuler from cdk/scrolling instead of cdk/overlay

### DIFF
--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Directionality} from '@angular/cdk/bidi';
+import {ViewportRuler} from '@angular/cdk/scrolling';
+import {DOCUMENT} from '@angular/common';
 import {
   ContentChild,
   ContentChildren,
@@ -23,24 +26,22 @@ import {
   SkipSelf,
   ViewContainerRef,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
-import {Directionality} from '@angular/cdk/bidi';
-import {CdkDragHandle} from './drag-handle';
-import {CdkDropContainer, CDK_DROP_CONTAINER} from './drop-container';
-import {
-  CdkDragStart,
-  CdkDragEnd,
-  CdkDragExit,
-  CdkDragEnter,
-  CdkDragDrop,
-  CdkDragMove,
-} from './drag-events';
-import {CdkDragPreview} from './drag-preview';
-import {CdkDragPlaceholder} from './drag-placeholder';
-import {ViewportRuler} from '@angular/cdk/overlay';
-import {DragDropRegistry} from './drag-drop-registry';
-import {Subject, merge, Observable} from 'rxjs';
+import {merge, Observable, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {DragDropRegistry} from './drag-drop-registry';
+import {
+  CdkDragDrop,
+  CdkDragEnd,
+  CdkDragEnter,
+  CdkDragExit,
+  CdkDragMove,
+  CdkDragStart,
+} from './drag-events';
+import {CdkDragHandle} from './drag-handle';
+import {CdkDragPlaceholder} from './drag-placeholder';
+import {CdkDragPreview} from './drag-preview';
+import {CDK_DROP_CONTAINER, CdkDropContainer} from './drop-container';
+
 
 // TODO(crisbeto): add auto-scrolling functionality.
 // TODO(crisbeto): add an API for moving a draggable up/down the

--- a/src/cdk/drag-drop/drop-container.ts
+++ b/src/cdk/drag-drop/drop-container.ts
@@ -9,6 +9,7 @@
 import {InjectionToken, QueryList} from '@angular/core';
 import {CdkDrag} from './drag';
 
+
 export interface CdkDropContainer<T = any> {
   /** Arbitrary data to attach to all events emitted by this container. */
   data: T;

--- a/src/cdk/drag-drop/drop.ts
+++ b/src/cdk/drag-drop/drop.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {coerceArray} from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -20,12 +21,12 @@ import {
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
-import {coerceArray} from '@angular/cdk/coercion';
 import {CdkDrag} from './drag';
-import {CdkDragExit, CdkDragEnter, CdkDragDrop} from './drag-events';
-import {CDK_DROP_CONTAINER} from './drop-container';
 import {DragDropRegistry} from './drag-drop-registry';
+import {CdkDragDrop, CdkDragEnter, CdkDragExit} from './drag-events';
 import {moveItemInArray} from './drag-utils';
+import {CDK_DROP_CONTAINER} from './drop-container';
+
 
 /** Counter used to generate unique ids for drop zones. */
 let _uniqueIdCounter = 0;


### PR DESCRIPTION
I also ran WebStorm's `Optimize imports` on a few files