### PR TITLE
refactor(schematics): add entry point for v7 upgrade

### DIFF
--- a/src/lib/schematics/migration.json
+++ b/src/lib/schematics/migration.json
@@ -1,15 +1,19 @@
 {
   "$schema": "./node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
-    // Update from v5 to v6
     "migration-01": {
-      "version": "6.0.0-rc.12",
-      "description": "Updates Angular Material from v5 to v6",
-      "factory": "./update/update"
+      "version": "6",
+      "description": "Updates Angular Material to v6",
+      "factory": "./update/index#updateToV6"
+    },
+    "migration-02": {
+      "version": "7",
+      "description": "Updates Angular Material to v7",
+      "factory": "./update/index#updateToV7"
     },
     "ng-post-update": {
       "description": "Performs cleanup after ng-update.",
-      "factory": "./update/update#postUpdate",
+      "factory": "./update/index#postUpdate",
       "private": true
     }
   }

--- a/src/lib/schematics/update/index.ts
+++ b/src/lib/schematics/update/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {createUpdateRule} from './update';
+
+/** Possible versions that can be automatically migrated by `ng update`. */
+export enum TargetVersion {
+  V6,
+  V7
+}
+
+/** Entry point for the migration schematics with target of Angular Material 6.0.0 */
+export function updateToV6(): Rule {
+  return createUpdateRule(TargetVersion.V6);
+}
+
+/** Entry point for the migration schematics with target of Angular Material 7.0.0 */
+export function updateToV7(): Rule {
+  return createUpdateRule(TargetVersion.V7);
+}
+
+/** Post-update schematic to be called when update is finished. */
+export function postUpdate(): Rule {
+  return () => console.log(
+    '\nComplete! Please check the output above for any issues that were detected but could not' +
+    ' be automatically fixed.');
+}

--- a/src/lib/schematics/update/tslint-update.ts
+++ b/src/lib/schematics/update/tslint-update.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {join} from 'path';
+import {TargetVersion} from './index';
+
+/** List of rules that need to be enabled when running the TSLint fix task. */
+const upgradeRules = [
+  // Attribute selector update rules.
+  'attribute-selectors-string-literal',
+  'attribute-selectors-stylesheet',
+  'attribute-selectors-template',
+
+  // Class name update rules
+  'class-names-identifier',
+  'class-names-identifier-misc',
+
+  // CSS selectors update rules
+  'css-selectors-string-literal',
+  'css-selectors-stylesheet',
+  'css-selectors-template',
+
+  // Element selector update rules
+  'element-selectors-string-literal',
+  'element-selectors-stylesheet',
+  'element-selectors-template',
+
+  // Input name update rules
+  'input-names-stylesheet',
+  'input-names-template',
+
+  // Output name update rules
+  'output-names-template',
+
+  // Property name update rules
+  'property-names-access',
+  'property-names-misc',
+
+  // Method call checks
+  'method-calls-check',
+
+  // Class inheritance
+  'class-inheritance-check',
+  'class-inheritance-misc',
+
+  // Additional misc rules.
+  'check-import-misc',
+  'check-template-misc'
+];
+
+/** List of absolute paths that refer to directories that contain the upgrade rules. */
+const rulesDirectory = [
+  // TODO(devversion): consider automatically resolving rule directories.
+  join(__dirname, 'rules/'),
+  join(__dirname, 'rules/attribute-selectors'),
+  join(__dirname, 'rules/class-names'),
+  join(__dirname, 'rules/class-inheritance'),
+  join(__dirname, 'rules/input-names'),
+  join(__dirname, 'rules/output-names'),
+  join(__dirname, 'rules/css-selectors'),
+  join(__dirname, 'rules/element-selectors'),
+  join(__dirname, 'rules/property-names'),
+  join(__dirname, 'rules/method-calls'),
+];
+
+/**
+ * Creates a TSLint configuration object that can be passed to the schematic `TSLintFixTask`.
+ * Each rule will have the specified target version as option which can be used to swap out
+ * the upgrade data based on the given target version.
+ */
+export function createTslintConfig(target: TargetVersion) {
+  const rules = upgradeRules.reduce((result, ruleName) => {
+    result[ruleName] = [true, target];
+    return result;
+  }, {});
+
+  return {rulesDirectory, rules};
+}

--- a/src/lib/schematics/update/update.spec.ts
+++ b/src/lib/schematics/update/update.spec.ts
@@ -1,1 +1,0 @@
-describe('Material Update Tool', () => {});


### PR DESCRIPTION
* Refactors the update schematics to support running `ng update` for V7 of Angular Material. Note that the actual upgrade data and general version distinction is not implemented yet. This is an initial commit that should allow the data distinction in future changes.