### PR TITLE
build(docs): fix description comments sometimes empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3969,9 +3969,9 @@
       }
     },
     "dgeni-packages": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.26.2.tgz",
-      "integrity": "sha512-6nVE7xOp1GPPP8vMnhmNVxdarhl0Axn1U3+XidDIrCSGF3J7RoX64A0eOOZRS1t+p1W2nvwSEX6Jjp+N0k9QPw==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.26.7.tgz",
+      "integrity": "sha512-w3skAaCf2dt4siojtgnq7v2WymYqylEw2w4oiMYyzhb+DZ3EPcbzF18QGA3H+dXMdIVqaOa1xNhYS9NDaWsD3g==",
       "dev": true,
       "requires": {
         "canonical-path": "0.0.2",
@@ -4015,7 +4015,7 @@
         },
         "typescript": {
           "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
           "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
           "dev": true
         }
@@ -13472,9 +13472,9 @@
       "dev": true
     },
     "postinstall-build": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
-      "integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.2.tgz",
+      "integrity": "sha512-Rh9azMSTvDWnDhLS8FG155kVVBwVPjLcQZrjZy4crbVPagOpUrr/vGOcBfwaii2A2yGK7jMtK7TBWw9N6amUNw==",
       "dev": true
     },
     "power-assert": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chalk": "^1.1.3",
     "codelyzer": "^4.3.0",
     "dgeni": "^0.4.10",
-    "dgeni-packages": "^0.26.2",
+    "dgeni-packages": "^0.26.7",
     "firebase": "^4.0.0",
     "firebase-admin": "^5.0.0",
     "firebase-tools": "^4.1.0",

--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -1,4 +1,5 @@
 import {Package} from 'dgeni';
+import {Host} from 'dgeni-packages/typescript/services/ts-host/host';
 import {patchLogService} from './patch-log-service';
 import {DocsPrivateFilter} from './processors/docs-private-filter';
 import {Categorizer} from './processors/categorizer';
@@ -122,6 +123,16 @@ apiDocsPackage.config((readTypeScriptModules: ReadTypeScriptModules, tsParser: T
     ...cdkPackages.map(packageName => `./cdk/${packageName}/index.ts`),
     ...materialPackages.map(packageName => `./lib/${packageName}/index.ts`)
   ];
+});
+
+apiDocsPackage.config((tsHost: Host) => {
+  // Disable concatenation of multiple leading comments for a TypeScript node. Since all shipped
+  // source files have a license banner at top, the license banner comment would be incorrectly
+  // considered as "comment" for the first TypeScript node of a given file. Since there are
+  // various files in the Material project where the first node of a source file is exported and
+  // should only use the first leading comment, we need to disable comment concatenation.
+  // See for example: src/cdk/coercion/boolean-property.ts
+  tsHost.concatMultipleLeadingComments = false;
 });
 
 // Configure processor for finding nunjucks templates.


### PR DESCRIPTION
Follow-up commit for 4879dc4720adbcff8eb9abe258b2017b19d775ab since https://github.com/angular/dgeni-packages/pull/270 has been merged and published.

---

Disables concatenation of multiple leading comments for a TypeScript node. Since all shipped source files have a license banner at top, the license banner comment would be incorrectly considered as "comment" for the first TypeScript node of a given file. Since there are various files in the Material project where the first node of a source file is exported and should only use the first leading comment, we need to disable comment concatenation.

See for example: https://github.com/angular/material2/blob/master/src/cdk/coercion/boolean-property.ts