### PR TITLE
feat(drag-drop): add the ability to set an alternate root element

### DIFF
--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -116,3 +116,12 @@ specific axis, you can set `cdkDragLockAxis` on `cdkDrag` or `lockAxis` on `<cdk
 to either `"x"` or `"y"`.
 
 <!-- example(cdk-drag-drop-axis-lock) -->
+
+### Alternate drag root element
+If there's an element that you want to make draggable, but you don't have direct access to it, you
+can use the `cdkDragRootElement` attribute. The attribute works by accepting a selector and looking
+up the DOM until it finds an element that matches the selector. If an element is found, it'll become
+the element that is moved as the user is dragging. This is useful for cases like making a dialog
+draggable.
+
+<!-- example(cdk-drag-drop-root-element) -->

--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -322,6 +322,22 @@ describe('CdkDrag', () => {
       expect(element.classList).not.toContain('cdk-drag-dragging');
     }));
 
+    it('should be able to set an alternate drag root element', fakeAsync(() => {
+      const fixture = createComponent(DraggableWithAlternateRoot);
+      fixture.detectChanges();
+
+      const dragRoot = fixture.componentInstance.dragRoot.nativeElement;
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      expect(dragRoot.style.transform).toBeFalsy();
+      expect(dragElement.style.transform).toBeFalsy();
+
+      dragElementViaMouse(fixture, dragRoot, 50, 100);
+
+      expect(dragRoot.style.transform).toBe('translate3d(50px, 100px, 0px)');
+      expect(dragElement.style.transform).toBeFalsy();
+    }));
+
   });
 
   describe('draggable with a handle', () => {
@@ -1596,6 +1612,23 @@ class ConnectedDropZones implements AfterViewInit {
   }
 }
 
+
+@Component({
+  template: `
+    <div #dragRoot class="alternate-root" style="width: 200px; height: 200px; background: hotpink">
+      <div
+        cdkDrag
+        cdkDragRootElement=".alternate-root"
+        #dragElement
+        style="width: 100px; height: 100px; background: red;"></div>
+    </div>
+  `
+})
+class DraggableWithAlternateRoot {
+  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild('dragRoot') dragRoot: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+}
 
 
 /**

--- a/src/cdk/drag-drop/drop.ts
+++ b/src/cdk/drag-drop/drop.ts
@@ -187,7 +187,7 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
     // Don't use items that are being dragged as a reference, because
     // their element has been moved down to the bottom of the body.
     if (newPositionReference && !this._dragDropRegistry.isDragging(newPositionReference)) {
-      const element = newPositionReference.element.nativeElement;
+      const element = newPositionReference.getRootElement();
       element.parentElement!.insertBefore(placeholder, element);
       this._activeDraggables.splice(newIndex, 0, item);
     } else {
@@ -277,7 +277,7 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
       const isDraggedItem = sibling.drag === item;
       const offset = isDraggedItem ? itemOffset : siblingOffset;
       const elementToOffset = isDraggedItem ? item.getPlaceholderElement() :
-                                              sibling.drag.element.nativeElement;
+                                              sibling.drag.getRootElement();
 
       // Update the offset to reflect the new position.
       sibling.offset += offset;
@@ -320,7 +320,7 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
             // If the element is being dragged, we have to measure the
             // placeholder, because the element is hidden.
             drag.getPlaceholderElement() :
-            drag.element.nativeElement;
+            drag.getRootElement();
         const clientRect = elementToMeasure.getBoundingClientRect();
 
         return {
@@ -355,7 +355,7 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
     this._dragging = false;
 
     // TODO(crisbeto): may have to wait for the animations to finish.
-    this._activeDraggables.forEach(item => item.element.nativeElement.style.transform = '');
+    this._activeDraggables.forEach(item => item.getRootElement().style.transform = '');
     this._activeDraggables = [];
     this._positionCache.items = [];
     this._positionCache.siblings = [];

--- a/src/demo-app/dialog/dialog-demo.ts
+++ b/src/demo-app/dialog/dialog-demo.ts
@@ -90,16 +90,19 @@ export class DialogDemo {
 @Component({
   selector: 'demo-jazz-dialog',
   template: `
-  <p>It's Jazz!</p>
+    <div cdkDrag cdkDragRootElement=".cdk-overlay-pane">
+      <p>It's Jazz!</p>
 
-  <mat-form-field>
-    <mat-label>How much?</mat-label>
-    <input matInput #howMuch>
-  </mat-form-field>
+      <mat-form-field>
+        <mat-label>How much?</mat-label>
+        <input matInput #howMuch>
+      </mat-form-field>
 
-  <p> {{ data.message }} </p>
-  <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>
-  <button (click)="togglePosition()">Change dimensions</button>`
+      <p cdkDragHandle> {{ data.message }} </p>
+      <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>
+      <button (click)="togglePosition()">Change dimensions</button>
+    </div>
+  `
 })
 export class JazzDialog {
   private _dimesionToggle = false;

--- a/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.css
+++ b/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.css
@@ -1,0 +1,21 @@
+.dialog-content {
+  width: 200px;
+  height: 200px;
+  border: solid 1px #ccc;
+  cursor: move;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #fff;
+  border-radius: 4px;
+  transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+              0 2px 2px 0 rgba(0, 0, 0, 0.14),
+              0 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
+
+.dialog-content:active {
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}

--- a/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.html
+++ b/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.html
@@ -1,0 +1,7 @@
+<button (click)="openDialog()">Open a draggable dialog</button>
+
+<ng-template>
+  <div class="dialog-content" cdkDrag cdkDragRootElement=".cdk-overlay-pane">
+    Drag the dialog around!
+  </div>
+</ng-template>

--- a/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.ts
+++ b/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.ts
@@ -1,0 +1,43 @@
+import {
+  Component,
+  ViewChild,
+  TemplateRef,
+  AfterViewInit,
+  ViewContainerRef,
+  OnDestroy,
+} from '@angular/core';
+import {Overlay, OverlayRef} from '@angular/cdk/overlay';
+import {TemplatePortal} from '@angular/cdk/portal';
+
+/**
+ * @title Drag&Drop with alternate root element
+ */
+@Component({
+  selector: 'cdk-drag-drop-root-element-example',
+  templateUrl: 'cdk-drag-drop-root-element-example.html',
+  styleUrls: ['cdk-drag-drop-root-element-example.css'],
+})
+export class CdkDragDropRootElementExample implements AfterViewInit, OnDestroy {
+  @ViewChild(TemplateRef) _dialogTemplate: TemplateRef<any>;
+  private _overlayRef: OverlayRef;
+  private _portal: TemplatePortal;
+
+  constructor(private _overlay: Overlay, private _viewContainerRef: ViewContainerRef) {}
+
+  ngAfterViewInit() {
+    this._portal = new TemplatePortal(this._dialogTemplate, this._viewContainerRef);
+    this._overlayRef = this._overlay.create({
+      positionStrategy: this._overlay.position().global().centerHorizontally().centerVertically(),
+      hasBackdrop: true
+    });
+    this._overlayRef.backdropClick().subscribe(() => this._overlayRef.detach());
+  }
+
+  ngOnDestroy() {
+    this._overlayRef.dispose();
+  }
+
+  openDialog() {
+    this._overlayRef.attach(this._portal);
+  }
+}


### PR DESCRIPTION
Adds the `cdkDragRootElement` input which allows consumers to pass in a selector that will be used to determine which elements is going to become draggable, starting from the `cdkDrag` element and going up the DOM.