### PR TITLE
refactor(schematics): table schematic not inlining style file

### DIFF
--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -8,8 +8,10 @@ import { <%= classify(name) %>DataSource } from './<%= dasherize(name) %>-dataso
     <%= indentTextContent(resolvedFiles.template, 4) %>
   `,<% } else { %>
   templateUrl: './<%= dasherize(name) %>.component.html',<% } if(inlineStyle) { %>
-  styles: []<% } else { %>
-  styleUrls: ['./<%= dasherize(name) %>.component.<%= styleext %>']<% } %><% if(!!viewEncapsulation) { %>,
+  styles: [`
+    <%= indentTextContent(resolvedFiles.stylesheet, 4) %>
+  `],<% } else { %>
+  styleUrls: ['./<%= dasherize(name) %>.component.<%= styleext %>'],<% } %><% if(!!viewEncapsulation) { %>
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })

--- a/src/lib/schematics/table/index.ts
+++ b/src/lib/schematics/table/index.ts
@@ -18,7 +18,8 @@ import {addModuleImportToModule, findModuleFromOptions} from '../utils/ast';
 export default function(options: Schema): Rule {
   return chain([
     buildComponent({...options}, {
-      template: './__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html'
+      template: './__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html',
+      stylesheet: './__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__'
     }),
     options.skipImport ? noop() : addTableModulesToModule(options)
   ]);


### PR DESCRIPTION
* This is not a bug fix because the styleext file is basically empty. But in case we add styles to the styleext template file, we should automatically properly inline the styles if `--inlineStyle` is specified.