### PR TITLE
build: clean up build workaround for ts 2.9

### DIFF
--- a/tools/gulp/tasks/e2e.ts
+++ b/tools/gulp/tasks/e2e.ts
@@ -1,9 +1,8 @@
-import {task, src, dest} from 'gulp';
+import {task} from 'gulp';
 import {join} from 'path';
 import {ngcBuildTask, copyTask, execNodeTask, serverTask} from '../util/task_helpers';
 import {copySync} from 'fs-extra';
 import {buildConfig, sequenceTask, triggerLivereload, watchFiles} from 'material2-build-tools';
-import {sync as globSync} from 'glob';
 
 // There are no type definitions available for these imports.
 const gulpConnect = require('gulp-connect');
@@ -69,7 +68,7 @@ task('e2e-app:build', sequenceTask(
     'material-moment-adapter:build-release',
     'material-examples:build-release'
   ],
-  ['e2e-app:copy-release', 'e2e-app:copy-typings', 'e2e-app:copy-assets'],
+  ['e2e-app:copy-release', 'e2e-app:copy-assets'],
   'e2e-app:build-ts'
 ));
 
@@ -114,18 +113,4 @@ task('e2e-app:copy-release', () => {
   copySync(join(releasesDir, 'material-experimental'), join(outDir, 'material-experimental'));
   copySync(join(releasesDir, 'material-examples'), join(outDir, 'material-examples'));
   copySync(join(releasesDir, 'material-moment-adapter'), join(outDir, 'material-moment-adapter'));
-});
-
-// Copy the core declaration files next to the declarations of each module. This is a workaround
-// for an issue in TypeScript 2.9 where the generated declaration files have wrong import paths.
-// We should be able to remove this task once we update to TypeScript 3.0.
-// See: https://github.com/Microsoft/TypeScript/issues/25511.
-task('e2e-app:copy-typings', () => {
-  const stream = src(join(outDir, 'material/core/typings/*/**'));
-
-  globSync(join(outDir, 'material/!(core)/')).forEach(directory => {
-    stream.pipe(dest(join(directory, 'core')));
-  });
-
-  return stream;
 });


### PR DESCRIPTION
Removes a workaround that was initially introduced to get #12182 through. The root issue has been resolved in #12876.