### PR TITLE
fix(drag-drop): dragging class not being applied on drop container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material2-srcs",
-  "version": "6.4.6",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1766,7 +1766,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -2442,7 +2442,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2664,7 +2664,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true,
           "optional": true
@@ -5324,7 +5324,7 @@
         },
         "firebase": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
           "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
           "dev": true,
           "requires": {
@@ -6864,7 +6864,7 @@
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
@@ -7158,7 +7158,7 @@
     },
     "grpc": {
       "version": "1.10.1",
-      "resolved": "http://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
       "requires": {
@@ -8154,7 +8154,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -11830,7 +11830,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -218,8 +218,12 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
     // their original DOM position and then they get transferred to the portal.
     this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
       const rootElement = this._rootElement = this._getRootElement();
-      rootElement.addEventListener('mousedown', this._startDragging);
-      rootElement.addEventListener('touchstart', this._startDragging);
+
+      // We need to bring the events back into the `NgZone`, because of the `onStable` call.
+      this._ngZone.run(() => {
+        rootElement.addEventListener('mousedown', this._startDragging);
+        rootElement.addEventListener('touchstart', this._startDragging);
+      });
     });
   }
 


### PR DESCRIPTION
Fixes the `cdk-drop-dragging` class not being applied to the drop container after 5d0ec23b1d258504ab786e76f80bd9a1a76cd052. The introduction of the `onStable` call caused the event to be bound outside the `NgZone`.