### PR TITLE
docs(drag-drop): text blending in with card on dark theme

### DIFF
--- a/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
+++ b/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
@@ -2,6 +2,7 @@
   width: 200px;
   height: 200px;
   border: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   cursor: move;
   display: inline-flex;
   justify-content: center;

--- a/src/material-examples/cdk-drag-drop-connected-sorting/cdk-drag-drop-connected-sorting-example.css
+++ b/src/material-examples/cdk-drag-drop-connected-sorting/cdk-drag-drop-connected-sorting-example.css
@@ -18,6 +18,7 @@
 .box {
   padding: 20px 10px;
   border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/material-examples/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.css
+++ b/src/material-examples/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.css
@@ -12,6 +12,7 @@
 .box {
   padding: 20px 10px;
   border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
+++ b/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
@@ -4,6 +4,7 @@
   padding: 10px;
   box-sizing: border-box;
   border: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/material-examples/cdk-drag-drop-horizontal-sorting/cdk-drag-drop-horizontal-sorting-example.css
+++ b/src/material-examples/cdk-drag-drop-horizontal-sorting/cdk-drag-drop-horizontal-sorting-example.css
@@ -13,6 +13,7 @@
 .box {
   padding: 20px 10px;
   border-right: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
+++ b/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
@@ -2,6 +2,7 @@
   width: 200px;
   height: 200px;
   border: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   cursor: move;
   display: flex;
   justify-content: center;

--- a/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.css
+++ b/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.css
@@ -2,6 +2,7 @@
   width: 200px;
   height: 200px;
   border: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   cursor: move;
   display: flex;
   justify-content: center;

--- a/src/material-examples/cdk-drag-drop-sorting/cdk-drag-drop-sorting-example.css
+++ b/src/material-examples/cdk-drag-drop-sorting/cdk-drag-drop-sorting-example.css
@@ -12,6 +12,7 @@
 .box {
   padding: 20px 10px;
   border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
Fixes the text inside the drag&drop boxes blending in on a dark theme.