### PR TITLE
fix(stepper): intl provider not being picked up in lazy-loaded modules

### DIFF
--- a/src/lib/stepper/stepper-intl.ts
+++ b/src/lib/stepper/stepper-intl.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, Optional, SkipSelf} from '@angular/core';
 import {Subject} from 'rxjs';
 
 
@@ -22,3 +22,16 @@ export class MatStepperIntl {
   /** Label that is rendered below optional steps. */
   optionalLabel: string = 'Optional';
 }
+
+
+/** @docs-private */
+export function MAT_STEPPER_INTL_PROVIDER_FACTORY(parentIntl: MatStepperIntl) {
+  return parentIntl || new MatStepperIntl();
+}
+
+/** @docs-private */
+export const MAT_STEPPER_INTL_PROVIDER = {
+  provide: MatStepperIntl,
+  deps: [[new Optional(), new SkipSelf(), MatStepperIntl]],
+  useFactory: MAT_STEPPER_INTL_PROVIDER_FACTORY
+};

--- a/src/lib/stepper/stepper-module.ts
+++ b/src/lib/stepper/stepper-module.ts
@@ -18,7 +18,7 @@ import {MatStepLabel} from './step-label';
 import {MatHorizontalStepper, MatStep, MatStepper, MatVerticalStepper} from './stepper';
 import {MatStepperNext, MatStepperPrevious} from './stepper-button';
 import {MatStepperIcon} from './stepper-icon';
-import {MatStepperIntl} from './stepper-intl';
+import {MAT_STEPPER_INTL_PROVIDER} from './stepper-intl';
 
 
 @NgModule({
@@ -54,6 +54,6 @@ import {MatStepperIntl} from './stepper-intl';
     MatStepHeader,
     MatStepperIcon,
   ],
-  providers: [MatStepperIntl, ErrorStateMatcher],
+  providers: [MAT_STEPPER_INTL_PROVIDER, ErrorStateMatcher],
 })
 export class MatStepperModule {}


### PR DESCRIPTION
Along the same lines as #7988 and #7895. Fixes the consumer-provided `MatStepperIntl` instance not being picked up inside lazy-loaded modules.

Fixes #12904.