### PR TITLE
fix(tree): theming nested notes

### DIFF
--- a/src/lib/tree/_tree-theme.scss
+++ b/src/lib/tree/_tree-theme.scss
@@ -10,7 +10,8 @@
     background: mat-color($background, 'card');
   }
 
-  .mat-tree-node {
+  .mat-tree-node,
+  .mat-nested-tree-node {
     color: mat-color($foreground, text);
   }
 }
@@ -20,7 +21,8 @@
     font-family: mat-font-family($config);
   }
 
-  .mat-tree-node {
+  .mat-tree-node,
+  .mat-nested-tree-node {
     font-weight: mat-font-weight($config, body-1);
     font-size: mat-font-size($config, body-1);
   }


### PR DESCRIPTION
changes nested-tree-nodes to be styled the same as tree-nodes

Currently when using custom font config tree nodes are styled different to nested tree node because the classes used are different between the two