### PR TITLE
fix(tooltip): not showing up on touch devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material2-srcs",
-  "version": "6.4.6",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1766,7 +1766,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -2442,7 +2442,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2664,7 +2664,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true,
           "optional": true
@@ -4001,7 +4001,7 @@
         },
         "typescript": {
           "version": "2.7.2",
-          "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
           "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
           "dev": true
         }
@@ -5324,7 +5324,7 @@
         },
         "firebase": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
           "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
           "dev": true,
           "requires": {
@@ -6864,7 +6864,7 @@
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
@@ -7158,7 +7158,7 @@
     },
     "grpc": {
       "version": "1.10.1",
-      "resolved": "http://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
       "requires": {
@@ -8154,7 +8154,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -11830,7 +11830,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/src/lib/core/gestures/gesture-config.ts
+++ b/src/lib/core/gestures/gesture-config.ts
@@ -100,6 +100,13 @@ export class GestureConfig extends HammerGestureConfig {
     // Overwrite the default `pan` event to use the swipe event.
     pan.recognizeWith(swipe);
 
+    // Since the slide event threshold is set to zero, the slide recognizer can fire and
+    // accidentally reset the longpress recognizer. In order to make sure that the two
+    // recognizers can run simultaneously but don't affect each other, we allow the slide
+    // recognizer to recognize while a longpress is being processed.
+    // See: https://github.com/hammerjs/hammer.js/blob/master/src/manager.js#L123-L124
+    longpress.recognizeWith(slide);
+
     // Add customized gestures to Hammer manager
     mc.add([swipe, press, pan, slide, longpress]);
 


### PR DESCRIPTION
* Currently if someone long presses a tooltip trigger on a touch device, the tooltip will not show up. This is because the `longpress` event does reset immediately and not fire if a `slide` event is being recognized. The `slide` event most likely fires most of the time because of a `threshold = 0` (for smooth sliding)

Fixes #12917