### PR TITLE
fix(tooltip): custom gesture config not set up

### DIFF
--- a/src/lib/tooltip/tooltip-module.ts
+++ b/src/lib/tooltip/tooltip-module.ts
@@ -10,7 +10,8 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {A11yModule} from '@angular/cdk/a11y';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatCommonModule} from '@angular/material/core';
+import {GestureConfig, MatCommonModule} from '@angular/material/core';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {
   MatTooltip,
   TooltipComponent,
@@ -27,6 +28,9 @@ import {
   exports: [MatTooltip, TooltipComponent, MatCommonModule],
   declarations: [MatTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
-  providers: [MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER]
+  providers: [
+    MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER,
+    {provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig},
+  ]
 })
 export class MatTooltipModule {}


### PR DESCRIPTION
* Currently if the `MatTooltip` directive is being used without any other modules that set up our "Material" hammer gesture config, the tooltip will use the default `platform-browser` gesture config and **never** fire the `(longpress)` event.

This could have been probably added to #12940, but I figured that out later and should be fine that way too.

Related to #12917