### PR TITLE
build: update dgeni packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material2-srcs",
-  "version": "6.4.6",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1254,9 +1254,9 @@
       }
     },
     "a-sync-waterfall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
-      "integrity": "sha1-OOgxnXk3niRiiEW1O5ZyKyng5Hw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
       "dev": true
     },
     "abab": {
@@ -1766,7 +1766,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -2442,7 +2442,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2664,7 +2664,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true,
           "optional": true
@@ -3955,9 +3955,9 @@
       }
     },
     "dgeni-packages": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.26.7.tgz",
-      "integrity": "sha512-w3skAaCf2dt4siojtgnq7v2WymYqylEw2w4oiMYyzhb+DZ3EPcbzF18QGA3H+dXMdIVqaOa1xNhYS9NDaWsD3g==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.26.9.tgz",
+      "integrity": "sha512-wvY/74ytYVdX/CMGs4jaP6PJUeUWcYyMjSCuYUVSbgEVU40SdE7lMnAlJuvTr/wTH3Zfx5BV/WTiVmzBwbXvow==",
       "dev": true,
       "requires": {
         "canonical-path": "0.0.2",
@@ -5324,7 +5324,7 @@
         },
         "firebase": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
           "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
           "dev": true,
           "requires": {
@@ -6864,7 +6864,7 @@
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
@@ -7158,7 +7158,7 @@
     },
     "grpc": {
       "version": "1.10.1",
-      "resolved": "http://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
       "requires": {
@@ -8154,7 +8154,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -11830,7 +11830,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chalk": "^1.1.3",
     "codelyzer": "^4.3.0",
     "dgeni": "^0.4.10",
-    "dgeni-packages": "^0.26.7",
+    "dgeni-packages": "^0.26.9",
     "firebase": "^4.0.0",
     "firebase-admin": "^5.0.0",
     "firebase-tools": "^4.1.0",


### PR DESCRIPTION
* Upgrades to the latest Dgeni packages version that includes a fix which ensures that the docs for the `Platform` show up properly.

See: https://github.com/angular/dgeni-packages/commit/ab957d1234b49624fb999e321479a8b7493a114a