### PR TITLE
build: suppress bazel schematic tsconfig warnings

### DIFF
--- a/src/lib/schematics/tsconfig.json
+++ b/src/lib/schematics/tsconfig.json
@@ -22,5 +22,8 @@
     "*/files/**/*",
     // Exclude all test-case files because those should not be included in the schematics output.
     "update/test-cases/**/*"
-  ]
+  ],
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true
+  }
 }


### PR DESCRIPTION
* Since the schematics are also built through Gulp, we need to specify the `exclude` option in the `tsconfig`. Bazel warns because those options will be ignored. Similarly to all other tsconfig files, we should suppress the warnings.