### PR TITLE
fix(drag-drop): incorrectly picking up transitions on non-transform properties

### DIFF
--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -683,6 +683,56 @@ describe('CdkDrag', () => {
           .toBeFalsy('Expected preview to be removed from the DOM if the transition timed out');
     }));
 
+    it('should not wait for transition that are not on the `transform` property', fakeAsync(() => {
+      const fixture = createComponent(DraggableInDropZone);
+      fixture.detectChanges();
+      const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+      dispatchMouseEvent(item, 'mousedown');
+      fixture.detectChanges();
+
+      const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
+      preview.style.transition = 'opacity 500ms ease';
+
+      dispatchTouchEvent(document, 'mousemove', 50, 50);
+      fixture.detectChanges();
+
+      dispatchMouseEvent(document, 'mouseup');
+      fixture.detectChanges();
+      tick(0);
+
+      expect(preview.parentNode)
+          .toBeFalsy('Expected preview to be removed from the DOM immediately');
+    }));
+
+    it('should pick out the `transform` duration if multiple properties are being transitioned',
+      fakeAsync(() => {
+        const fixture = createComponent(DraggableInDropZone);
+        fixture.detectChanges();
+        const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+        dispatchMouseEvent(item, 'mousedown');
+        fixture.detectChanges();
+
+        const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
+        preview.style.transition = 'opacity 500ms ease, transform 1000ms ease';
+
+        dispatchTouchEvent(document, 'mousemove', 50, 50);
+        fixture.detectChanges();
+
+        dispatchMouseEvent(document, 'mouseup');
+        fixture.detectChanges();
+        tick(500);
+
+        expect(preview.parentNode)
+            .toBeTruthy('Expected preview to be in the DOM at the end of the opacity transition');
+
+        tick(1000);
+
+        expect(preview.parentNode).toBeFalsy(
+            'Expected preview to be removed from the DOM at the end of the transform transition');
+      }));
+
     it('should create a placeholder element while the item is dragged', fakeAsync(() => {
       const fixture = createComponent(DraggableInDropZone);
       fixture.detectChanges();


### PR DESCRIPTION
Currently we wait for the transition on a dropped item to end before completing the sequence or timing it out. Our approach works for a single property transition (e.g. `transition: transform 300ms`), but will break down for multi-property ones (`transition: opacity 300ms, transform 600ms`) or ones that don't target `transform` at all. The following changes rework the logic to handle the extra cases.