### PR TITLE
fix(checkbox, slide-toggle): no margin if content is projected

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -271,10 +271,12 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
   /** Method being called whenever the label text changes. */
   _onLabelTextChange() {
-    // This method is getting called whenever the label of the checkbox changes.
-    // Since the checkbox uses the OnPush strategy we need to notify it about the change
-    // that has been recognized by the cdkObserveContent directive.
-    this._changeDetectorRef.markForCheck();
+    // Since the event of the `cdkObserveContent` directive runs outside of the zone, the checkbox
+    // component will be only marked for check, but no actual change detection runs automatically.
+    // Instead of going back into the zone in order to trigger a change detection which causes
+    // *all* components to be checked (if explicitly marked or not using OnPush), we only trigger
+    // an explicit change detection for the checkbox view and it's children.
+    this._changeDetectorRef.detectChanges();
   }
 
   // Implemented as part of ControlValueAccessor.

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -29,7 +29,9 @@ describe('MatSlideToggle without forms', () => {
       declarations: [
         SlideToggleBasic,
         SlideToggleWithTabindexAttr,
-        SlideToggleWithoutLabel
+        SlideToggleWithoutLabel,
+        SlideToggleProjectedLabel,
+        TextBindingComponent,
       ],
       providers: [
         {provide: HAMMER_GESTURE_CONFIG, useFactory: () => gestureConfig = new TestGestureConfig()},
@@ -657,7 +659,6 @@ describe('MatSlideToggle without forms', () => {
   describe('without label', () => {
     let fixture: ComponentFixture<SlideToggleWithoutLabel>;
     let testComponent: SlideToggleWithoutLabel;
-    let slideToggleElement: HTMLElement;
     let slideToggleBarElement: HTMLElement;
 
     beforeEach(() => {
@@ -666,7 +667,6 @@ describe('MatSlideToggle without forms', () => {
       const slideToggleDebugEl = fixture.debugElement.query(By.directive(MatSlideToggle));
 
       testComponent = fixture.componentInstance;
-      slideToggleElement = slideToggleDebugEl.nativeElement;
       slideToggleBarElement = slideToggleDebugEl
           .query(By.css('.mat-slide-toggle-bar')).nativeElement;
     });
@@ -697,9 +697,32 @@ describe('MatSlideToggle without forms', () => {
       flushMutationObserver();
       fixture.detectChanges();
 
-      expect(slideToggleElement.classList)
+      expect(slideToggleBarElement.classList)
         .not.toContain('mat-slide-toggle-bar-no-side-margin');
     }));
+  });
+
+  describe('label margin', () => {
+    let fixture: ComponentFixture<SlideToggleProjectedLabel>;
+    let slideToggleBarElement: HTMLElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SlideToggleProjectedLabel);
+      slideToggleBarElement = fixture.debugElement
+        .query(By.css('.mat-slide-toggle-bar')).nativeElement;
+
+      fixture.detectChanges();
+    });
+
+    it('should properly update margin if label content is projected', () => {
+      // Do not run the change detection for the fixture manually because we want to verify
+      // that the slide-toggle properly toggles the margin class even if the observe content
+      // output fires outside of the zone.
+      flushMutationObserver();
+
+      expect(slideToggleBarElement.classList).not
+        .toContain('mat-slide-toggle-bar-no-side-margin');
+    });
   });
 });
 
@@ -1086,4 +1109,17 @@ class SlideToggleWithoutLabel {
 class SlideToggleWithModelAndChangeEvent {
   checked: boolean;
   onChange: () => void = () => {};
+}
+
+@Component({
+  template: `<mat-slide-toggle><some-text></some-text></mat-slide-toggle>`
+})
+class SlideToggleProjectedLabel {}
+
+@Component({
+  selector: 'some-text',
+  template: `<span>{{text}}</span>`
+})
+class TextBindingComponent {
+  text: string = 'Some text';
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -358,9 +358,11 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
 
   /** Method being called whenever the label text changes. */
   _onLabelTextChange() {
-    // This method is getting called whenever the label of the slide-toggle changes.
-    // Since the slide-toggle uses the OnPush strategy we need to notify it about the change
-    // that has been recognized by the cdkObserveContent directive.
-    this._changeDetectorRef.markForCheck();
+    // Since the event of the `cdkObserveContent` directive runs outside of the zone, the
+    // slide-toggle component will be only marked for check, but no actual change detection runs
+    // automatically. Instead of going back into the zone in order to trigger a change detection
+    // which causes *all* components to be checked (if explicitly marked or not using OnPush),
+    // we only trigger an explicit change detection for the slide-toggle view and it's children.
+    this._changeDetectorRef.detectChanges();
   }
 }


### PR DESCRIPTION
Usually if the label of the checkbox or slide-toggle is empty, we remove the margin between label container and thumb/check because otherwise there would be too much spacing. Currently if developers use a component inside of the checkbox or slide-toggle in order to render the label, the margin is accidentally removed and the label looks misplaced.

This is because the `cdkObserveContent` event runs outside of the `NgZone` and no change detection round _checks_ the checkbox or slide-toggle.

**Simple demo**
* https://stackblitz.com/edit/angular-kh5b4l?file=main.ts

**Why `detectChanges` and not ngZone.run()**?

<details>

* Creating a new zone fork e.g. `ngZone.run(() => {})` causes the `onMicrotaskEmpty` to trigger and dirty check all components which are explicitly "markForCheck`ed or not using `OnPush`.

* Since `cdkObserveContent` emits an @Output() the checkbox will be automatically marked for check, but due to emitting outside of `NgZone`, just no change detection will run because `onMicrotaskEmpty` doesn't fire after callback.

So the best solution for now is:

* Use explicitly `detectChanges` because it would then just check the checkbox and it's children. Since we know that only the margin class binding needs to be updated, this is way better than triggering a global dirty-check.

* If we would use `ngZone.run(() => {}` it would cause Angular to check all components in the application which are marked for check or not using `OnPush` (which is very likely)
</details>

<br/>

Fixes #4720