### PR TITLE
fix(form-field): don't set up mutation observer on non-outline appearances

### DIFF
--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -145,11 +145,7 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
   get disabled() { return this._disabled; }
   set disabled(value: any) {
     this._disabled = coerceBooleanProperty(value);
-    if (this._disabled) {
-      this._unsubscribe();
-    } else {
-      this._subscribe();
-    }
+    this._disabled ? this._unsubscribe() : this._subscribe();
   }
   private _disabled = false;
 

--- a/src/lib/form-field/form-field.html
+++ b/src/lib/form-field/form-field.html
@@ -28,6 +28,7 @@
              read if it comes before the control in the DOM. -->
         <label class="mat-form-field-label"
                (cdkObserveContent)="updateOutlineGap()"
+               [cdkObserveContentDisabled]="appearance != 'outline'"
                [id]="_labelId"
                [attr.for]="_control.id"
                [attr.aria-owns]="_control.id"


### PR DESCRIPTION
Currently we use a `MutationObserver` to update the label gap when the label content changes. This is unnecessary on any appearance aside from `outline`.