### PR TITLE
fix(typings): update typings to support more strict typings in RxJS 6…

### DIFF
--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -191,7 +191,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
       // instead only on the animation that we care about (primary value bar's transitionend)
       this._ngZone.runOutsideAngular((() => {
         this._animationEndSubscription =
-            fromEvent(this._primaryValueBar.nativeElement, 'transitionend')
+            fromEvent<TransitionEvent>(this._primaryValueBar.nativeElement, 'transitionend')
             .pipe(filter(((e: TransitionEvent) =>
               e.target === this._primaryValueBar.nativeElement)))
             .subscribe(_ => this._ngZone.run(() => this.emitAnimationEnd()));

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -200,11 +200,11 @@ export class MatTableDataSource<T> extends DataSource<T> {
     // The `sortChange` and `pageChange` acts as a signal to the combineLatests below so that the
     // pipeline can progress to the next step. Note that the value from these streams are not used,
     // they purely act as a signal to progress in the pipeline.
-    const sortChange: Observable<Sort|null> = this._sort ?
-        merge<Sort>(this._sort.sortChange, this._sort.initialized) :
+    const sortChange: Observable<Sort|null|void> = this._sort ?
+        merge<Sort|void>(this._sort.sortChange, this._sort.initialized) :
         observableOf(null);
-    const pageChange: Observable<PageEvent|null> = this._paginator ?
-        merge<PageEvent>(this._paginator.page, this._paginator.initialized) :
+    const pageChange: Observable<PageEvent|null|void> = this._paginator ?
+        merge<PageEvent|void>(this._paginator.page, this._paginator.initialized) :
         observableOf(null);
 
     const dataStream = this._data;


### PR DESCRIPTION
...3.2

When this project is updated to RxJS 6.3.2, due to stricter typings in RxJS, it uncovers some issues with typings in material. This PR is to remedy that.

Related: https://critique.corp.google.com/#review/211533671