### PR TITLE
refactor(schematics): re-add disabled aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "material2-srcs",
-  "version": "6.4.6",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.1.tgz",
-      "integrity": "sha512-m+j1d+oMZRu0jUN7UyE4C8Kh8YoY9TP6ltjcrO2SzE89mzHg+apY1taf4EzOYKrrCZxw7Q4viPa8EXeF2AJ1cQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.4.tgz",
+      "integrity": "sha512-Blh44vzZVzE8B9xIwjRoo7hXPGSDdlrrax0rntvt3DDGVTjsSGm43qT95aDmXiwJruOCJNC5DsaP3+tTAkAyQQ==",
       "dev": true,
       "requires": {
         "ajv": "~6.4.0",
@@ -25,12 +25,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.7.1.tgz",
-      "integrity": "sha512-8G223dq6RgV1tvp3od6mn5TX3VH57OWCN+v6pz4o27pDOQUhxX94VeuetOrhe2oYu4nmcs8epCateG4CJF7phg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.7.4.tgz",
+      "integrity": "sha512-Gkm2mBMm6a0mNKqZsAcS42VaO7zNSIXhIKbMyZQIcQ1ZMwbsx+Rs0dliQwFVfEVCNGc1pjh0Idc5O5V/g/N5Fw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.7.1",
+        "@angular-devkit/core": "0.7.4",
         "rxjs": "^6.0.0"
       }
     },
@@ -1027,20 +1027,20 @@
       "dev": true
     },
     "@schematics/angular": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.7.1.tgz",
-      "integrity": "sha512-wvP1ofwKVIbu3UCCsLTxdNZ7D0iVl0njoHvFEiMAQEVO+1VnhY3y+xpvnujhmU0pdYfIv17mc/hRNwEH6gQwkQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.7.4.tgz",
+      "integrity": "sha512-/KJH5fPv+40VdadWmVnXR2GlvFZKYH01eYw7XOi77gXM896gk2tGlWmm+6RjUaVyec49ivusmmhRJEjiTyA7NA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.7.1",
-        "@angular-devkit/schematics": "0.7.1",
-        "typescript": ">=2.6.2 <2.8"
+        "@angular-devkit/core": "0.7.4",
+        "@angular-devkit/schematics": "0.7.4",
+        "typescript": ">=2.6.2 <2.10"
       },
       "dependencies": {
         "typescript": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
           "dev": true
         }
       }
@@ -1766,7 +1766,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -2442,7 +2442,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2664,7 +2664,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true,
           "optional": true
@@ -4001,7 +4001,7 @@
         },
         "typescript": {
           "version": "2.7.2",
-          "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
           "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
           "dev": true
         }
@@ -5324,7 +5324,7 @@
         },
         "firebase": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
           "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
           "dev": true,
           "requires": {
@@ -6864,7 +6864,7 @@
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
@@ -7158,7 +7158,7 @@
     },
     "grpc": {
       "version": "1.10.1",
-      "resolved": "http://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
       "requires": {
@@ -8154,7 +8154,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -11830,7 +11830,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "zone.js": "^0.8.26"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^0.7.1",
-    "@angular-devkit/schematics": "^0.7.1",
+    "@angular-devkit/core": "0.7.4",
+    "@angular-devkit/schematics": "0.7.4",
     "@angular/bazel": "7.0.0-beta.4",
     "@angular/compiler-cli": "7.0.0-beta.4",
     "@angular/http": "7.0.0-beta.4",
@@ -55,7 +55,7 @@
     "@bazel/ibazel": "0.3.1",
     "@google-cloud/storage": "^1.1.1",
     "@octokit/rest": "^15.9.4",
-    "@schematics/angular": "^0.7.1",
+    "@schematics/angular": "0.7.4",
     "@types/chalk": "^0.4.31",
     "@types/fs-extra": "^4.0.3",
     "@types/glob": "^5.0.33",

--- a/src/lib/schematics/collection.json
+++ b/src/lib/schematics/collection.json
@@ -7,7 +7,7 @@
       "description": "Adds Angular Material to the application without affecting any templates",
       "factory": "./install",
       "schema": "./install/schema.json",
-      "aliases": ["material-shell"]
+      "aliases": ["material-shell", "install"]
     },
     // Create a dashboard component
     "dashboard": {
@@ -28,22 +28,21 @@
       "description": "Create a component with a responsive sidenav for navigation",
       "factory": "./nav/index",
       "schema": "./nav/schema.json",
-      // TODO(devversion): re-add `materialNav` alias if we have the latest schematics version
-      // that includes https://github.com/angular/angular-cli/pull/11390
-      "aliases": [ "material-nav"]
+      "aliases": ["material-nav", "materialNav"]
     },
     // Create a file tree component
     "tree": {
       "description": "Create a file tree component.",
       "factory": "./tree/index",
-      "schema": "./tree/schema.json"
+      "schema": "./tree/schema.json",
+      "aliases": ["material-tree"]
     },
     // Creates a address form component
     "addressForm": {
       "description": "Create a component with a address form",
       "factory": "./address-form/index",
       "schema": "./address-form/schema.json",
-      "aliases": ["address-form"]
+      "aliases": ["address-form", "material-address-form", "material-addressForm"]
     }
   }
 }


### PR DESCRIPTION
* Due to a devkit issue, we temporarily had to remove the schematic aliases in order to be able to run the tests. Since this issue has been fixed a long time ago, we can re-add the aliases.
* Also adds more aliases to other schematics for consistency.
* Locks the devkit and schematics version because there is a type definition issue within the devkit ([see here](https://unpkg.com/@angular-devkit/core@0.7.5/src/virtual-fs/host/test.d.ts); fixed but not released yet).