### PR TITLE
fix(portal): remove dependency on deprecated parentInjector

### DIFF
--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -48,7 +48,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
       componentRef = portal.viewContainerRef.createComponent(
           componentFactory,
           portal.viewContainerRef.length,
-          portal.injector || portal.viewContainerRef.parentInjector);
+          portal.injector || portal.viewContainerRef.injector);
 
       this.setDisposeFn(() => componentRef.destroy());
     } else {

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -129,7 +129,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
         this._componentFactoryResolver.resolveComponentFactory(portal.component);
     const ref = viewContainerRef.createComponent(
         componentFactory, viewContainerRef.length,
-        portal.injector || viewContainerRef.parentInjector);
+        portal.injector || viewContainerRef.injector);
 
     super.setDisposeFn(() => ref.destroy());
     this._attachedPortal = portal;


### PR DESCRIPTION
The `ViewContainerRef.parentInjector` property is deprecated. These changes remove our dependency on it.