### PR TITLE
fix(button): hover styles taking precedence over focus styling

### DIFF
--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -4,30 +4,35 @@
 @import '../core/style/layout-common';
 @import '../../cdk/a11y/a11y';
 
-.mat-button, .mat-icon-button, .mat-stroked-button, .mat-flat-button {
-  @include mat-button-base;
-}
-
-.mat-button, .mat-icon-button {
-  .mat-button-focus-overlay {
-
-    opacity: 0;
-  }
-}
-
 // Only flat and stroked buttons (not raised, FABs or icon buttons) have a hover style.
 // Use the same visual treatment for hover as for focus.
-.mat-button:hover .mat-button-focus-overlay,
-.mat-stroked-button:hover .mat-button-focus-overlay {
-  opacity: 0.04;
+.mat-button,
+.mat-stroked-button {
+  &:hover .mat-button-focus-overlay {
+    opacity: 0.04;
+  }
 }
 
 // Disable the hover styles on non-hover devices. Since this is more of a progressive
 // enhancement and not all desktop browsers support this kind of media query, we can't
 // use something like `@media (hover)`.
 @media (hover: none) {
-  .mat-button:hover .mat-button-focus-overlay,
-  .mat-stroked-button:hover .mat-button-focus-overlay {
+  .mat-button,
+  .mat-stroked-button {
+    &:hover .mat-button-focus-overlay {
+      opacity: 0;
+    }
+  }
+}
+
+// Should be placed after the `:hover` styles so the focused
+// styling coming in from `mat-button-base` takes precedence.
+.mat-button, .mat-icon-button, .mat-stroked-button, .mat-flat-button {
+  @include mat-button-base;
+}
+
+.mat-button, .mat-icon-button {
+  .mat-button-focus-overlay {
     opacity: 0;
   }
 }


### PR DESCRIPTION
Fixes the `:hover` styles overriding the focused styling, because they have the same specificity, but are positioned lower in the stylesheet.

**Note:** the same could be achieved by adding `:not(.cdk-focused)` to the hover selector, but I opted into this approach, because it doesn't increase the hover specificity further.