### PR TITLE
Observable in MatDateSelection

### DIFF
--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -14,6 +14,10 @@ export abstract class MatDateSelection<D> {
 
   constructor(protected readonly adapter: DateAdapter<D>) {}
 
+  dispose() {
+    this.valueChanges.complete();
+  }
+
   abstract add(date: D): void;
   abstract clone(): MatDateSelection<D>;
   abstract getFirstSelectedDate(): D|null;

--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DateAdapter} from '@angular/material/core';
+
+export abstract class MatDateSelection<D> {
+  abstract add(date: D): void;
+  abstract clone(adaptor: DateAdapter<D>): MatDateSelection<D>;
+  abstract getFirstSelectedDate(): D|null;
+  abstract getLastSelectedDate(): D|null;
+  abstract isComplete(): boolean;
+  abstract isSame(adapter: DateAdapter<D>, other: MatDateSelection<D>): boolean;
+  abstract isValid(adapter: DateAdapter<D>): boolean;
+}
+
+export class MatSingleDateSelection<D> extends MatDateSelection<D> {
+  private date: D | null = null;
+
+  add(date: D) {
+    this.date = date;
+  }
+
+  clone(adapter: DateAdapter<D>): MatDateSelection<D> {
+    const copy = new MatSingleDateSelection<D>();
+
+    if (this.date) {
+      copy.add(adapter.clone(this.date));
+    }
+
+    return copy as MatDateSelection<D>;
+  }
+
+  getFirstSelectedDate() { return this.date; }
+
+  getLastSelectedDate() { return this.date; }
+
+  isComplete() { return !!this.date; }
+
+  isSame(adapter: DateAdapter<D>, other: MatDateSelection<D>): boolean {
+    return other instanceof MatSingleDateSelection &&
+        adapter.sameDate(other.getFirstSelectedDate(), this.getFirstSelectedDate());
+  }
+
+  isValid(adapter: DateAdapter<D>): boolean {
+    return !!(this.date && adapter.isValid(this.date));
+  }
+}
+
+export class MatRangeDateSelection<D> extends MatDateSelection<D> {
+  private start: D | null = null;
+  private end: D | null = null;
+
+  add(date: D): void {
+    if (!this.start) {
+      this.start = date;
+    } else if (!this.end) {
+      this.end = date;
+    } else {
+      this.start = date;
+      this.end = null;
+    }
+  }
+
+
+  clone(adapter: DateAdapter<D>): MatDateSelection<D> {
+    const copy = new MatRangeDateSelection<D>();
+
+    if (this.start) {
+      copy.setFirstSelectedDate(adapter.clone(this.start));
+    }
+
+    if (this.end) {
+      copy.setLastSelectedDate(adapter.clone(this.end));
+    }
+
+    return copy as MatDateSelection<D>;
+  }
+
+  getFirstSelectedDate() { return this.start; }
+
+  getLastSelectedDate() { return this.start; }
+
+  setFirstSelectedDate(value: D | null) { this.start = value; }
+
+  setLastSelectedDate(value: D | null) { this.end = value; }
+
+  isComplete(): boolean {
+    return !!(this.start && this.end);
+  }
+
+  isSame(adapter: DateAdapter<D>, other: MatDateSelection<D>): boolean {
+    return other instanceof MatRangeDateSelection &&
+        adapter.sameDate(this.getFirstSelectedDate(), other.getFirstSelectedDate()) &&
+        adapter.sameDate(this.getLastSelectedDate(), other.getLastSelectedDate());
+  }
+
+  isValid(adapter: DateAdapter<D>): boolean {
+    return !!(this.start && this.end && adapter.isValid(this.start!) && adapter.isValid(this.end!));
+  }
+}

--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -31,6 +31,14 @@ export interface DateRange<D> {
 export class MatSingleDateSelection<D> extends MatDateSelection<D> {
   private date: D | null = null;
 
+  constructor(adapter: DateAdapter<D>, date?: D | null) {
+    super(adapter);
+
+    if (date) {
+      this.date = date;
+    }
+  }
+
   add(date: D) {
     this.date = date;
   }
@@ -72,6 +80,18 @@ export class MatSingleDateSelection<D> extends MatDateSelection<D> {
 export class MatRangeDateSelection<D> extends MatDateSelection<D> {
   private start: D | null = null;
   private end: D | null = null;
+
+  constructor(adapter: DateAdapter<D>, start?: D | null, end?: D | null) {
+    super(adapter);
+
+    if (start) {
+      this.start = start;
+    }
+
+    if (end) {
+      this.end = end;
+    }
+  }
 
   /**
    * Adds an additional date to the range. If no date is set thus far, it will set it to the

--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -7,8 +7,11 @@
  */
 
 import {DateAdapter} from '@angular/material/core';
+import {Subject} from 'rxjs';
 
 export abstract class MatDateSelection<D> {
+  valueChanges = new Subject<void>();
+
   constructor(protected readonly adapter: DateAdapter<D>) {}
 
   abstract add(date: D): void;
@@ -41,16 +44,11 @@ export class MatSingleDateSelection<D> extends MatDateSelection<D> {
 
   add(date: D) {
     this.date = date;
+    this.valueChanges.next();
   }
 
   clone(): MatDateSelection<D> {
-    const copy = new MatSingleDateSelection<D>(this.adapter);
-
-    if (this.date) {
-      copy.add(this.adapter.clone(this.date));
-    }
-
-    return copy as MatDateSelection<D>;
+    return new MatSingleDateSelection<D>(this.adapter, this.date);
   }
 
   getFirstSelectedDate() { return this.date; }
@@ -107,21 +105,13 @@ export class MatRangeDateSelection<D> extends MatDateSelection<D> {
       this.start = date;
       this.end = null;
     }
+
+    this.valueChanges.next();
   }
 
 
   clone(): MatDateSelection<D> {
-    const copy = new MatRangeDateSelection<D>(this.adapter);
-
-    if (this.start) {
-      copy.setFirstSelectedDate(this.adapter.clone(this.start));
-    }
-
-    if (this.end) {
-      copy.setLastSelectedDate(this.adapter.clone(this.end));
-    }
-
-    return copy as MatDateSelection<D>;
+    return new MatRangeDateSelection<D>(this.adapter, this.start, this.end);
   }
 
   getFirstSelectedDate() { return this.start; }

--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -20,6 +20,11 @@ export abstract class MatDateSelection<D> {
   abstract isValid(): boolean;
 }
 
+export interface DateRange<D> {
+  start: D | null;
+  end: D | null;
+}
+
 /**
  * Concrete implementation of a MatDateSelection that holds a single date.
  */
@@ -53,6 +58,10 @@ export class MatSingleDateSelection<D> extends MatDateSelection<D> {
 
   isValid(): boolean {
     return !!(this.date && this.adapter.isValid(this.date));
+  }
+
+  asDate(): D | null {
+    return this.date;
   }
 }
 
@@ -116,5 +125,12 @@ export class MatRangeDateSelection<D> extends MatDateSelection<D> {
   isValid(): boolean {
     return !!(this.start && this.end &&
         this.adapter.isValid(this.start!) && this.adapter.isValid(this.end!));
+  }
+
+  asRange(): DateRange<D> {
+    return {
+      start: this.start,
+      end: this.end,
+    };
   }
 }

--- a/src/lib/core/datetime/index.ts
+++ b/src/lib/core/datetime/index.ts
@@ -17,6 +17,7 @@ export * from './date-adapter';
 export * from './date-formats';
 export * from './native-date-adapter';
 export * from './native-date-formats';
+export * from './date-selection';
 
 
 @NgModule({


### PR DESCRIPTION
This change adds an observable to the date selection. This allows the usage of a single date selection instance instead of creating multiple. 