### PR TITLE
chore(schematics): add missing constructor checks data

### DIFF
--- a/src/lib/schematics/update/material/data/constructor-checks.ts
+++ b/src/lib/schematics/update/material/data/constructor-checks.ts
@@ -27,7 +27,7 @@ export const constructorChecks = [
   // https://github.com/angular/material2/pull/9775
   'MatCalendar',
 
-  // TODO(devversion): The constructor check rule doesn't distinct data based on the target
+  // TODO(devversion): The constructor check rule doesn't distinguish data based on the target
   // TODO(devversion): version. Though it would be more readable to structure the data.
 
   // https://github.com/angular/material2/pull/11706

--- a/src/lib/schematics/update/material/data/constructor-checks.ts
+++ b/src/lib/schematics/update/material/data/constructor-checks.ts
@@ -26,4 +26,13 @@ export const constructorChecks = [
 
   // https://github.com/angular/material2/pull/9775
   'MatCalendar',
+
+  // TODO(devversion): The constructor check rule doesn't distinct data based on the target
+  // TODO(devversion): version. Though it would be more readable to structure the data.
+
+  // https://github.com/angular/material2/pull/11706
+  'MatDrawerContent',
+
+  // https://github.com/angular/material2/pull/11706
+  'MatSidenavContent',
 ];


### PR DESCRIPTION
Adds the constructor signature check data for PR: https://github.com/angular/material2/pull/11706.

 The PR has been already published in `7.0.0-beta.0`.

**Note**: I want to have test cases for V7 upgrade data as well. test cases for this PR will be a follow-up once #13050 has been merged (avoiding conflicts)