### PR TITLE
build(docs): fix directive metadata not showing up in docs

### DIFF
--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -3,19 +3,6 @@ import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/Propert
 import {MemberDoc} from 'dgeni-packages/typescript/api-doc-types/MemberDoc';
 import {CategorizedClassDoc, DeprecationDoc, HasDecoratorsDoc} from './dgeni-definitions';
 
-/**
- * We want to avoid emitting selectors that are deprecated but don't have a way to mark
- * them as such in the source code. Thus, we maintain a separate blacklist of selectors
- * that should not be emitted in the documentation.
- */
-const SELECTOR_BLACKLIST = new Set([
-  '[portal]',
-  '[portalHost]',
-  'textarea[mat-autosize]',
-  '[overlay-origin]',
-  '[connected-overlay]',
-]);
-
 export function isMethod(doc: MemberDoc) {
   return doc.hasOwnProperty('parameters') && !doc.isGetAccessor && !doc.isSetAccessor;
 }
@@ -62,9 +49,7 @@ export function getDirectiveSelectors(classDoc: CategorizedClassDoc) {
   const directiveSelectors: string = classDoc.directiveMetadata.get('selector');
 
   if (directiveSelectors) {
-    // Filter blacklisted selectors and remove line-breaks in resolved selectors.
-    return directiveSelectors.replace(/[\r\n]/g, '').split(/\s*,\s*/)
-      .filter(s => s !== '' && !s.includes('md') && !SELECTOR_BLACKLIST.has(s));
+    return directiveSelectors.replace(/[\r\n]/g, '').split(/\s*,\s*/).filter(s => s !== '');
   }
 }
 

--- a/tools/dgeni/common/directive-metadata.ts
+++ b/tools/dgeni/common/directive-metadata.ts
@@ -1,13 +1,14 @@
-import {CategorizedClassDoc} from './dgeni-definitions';
 import {
   ArrayLiteralExpression,
   CallExpression,
+  isCallExpression,
+  NodeArray,
   ObjectLiteralExpression,
   PropertyAssignment,
   StringLiteral,
   SyntaxKind,
-  NodeArray,
-} from 'typescript';
+} from 'dgeni-packages/node_modules/typescript';
+import {CategorizedClassDoc} from './dgeni-definitions';
 
 /**
  * Determines the component or directive metadata from the specified Dgeni class doc. The resolved
@@ -31,20 +32,15 @@ export function getDirectiveMetadata(classDoc: CategorizedClassDoc): Map<string,
     return null;
   }
 
-  const directiveDecorator = declaration.decorators
-    .filter(decorator => decorator.expression)
-    // TODO(devversion): fix this cast
-    .filter(decorator => (decorator.expression.kind as any) === SyntaxKind.CallExpression)
-    .find(decorator => (decorator.expression as any).expression.getText() === 'Component' ||
-                       (decorator.expression as any).expression.getText() === 'Directive');
+  const expression = declaration.decorators
+    .filter(decorator => decorator.expression && isCallExpression(decorator.expression))
+    .map(decorator => decorator.expression as CallExpression)
+    .find(callExpression => callExpression.expression.getText() === 'Component' ||
+                            callExpression.expression.getText() === 'Directive');
 
-  if (!directiveDecorator) {
+  if (!expression) {
     return null;
   }
-
-  // Since the actual decorator expression is by default a LeftHandSideExpression, and TypeScript
-  // doesn't allow a casting it to a CallExpression, we have to cast it to "any" before.
-  const expression = (directiveDecorator.expression as any) as CallExpression;
 
   // The argument length of the CallExpression needs to be exactly one, because it's the single
   // JSON object in the @Component/@Directive decorator.


### PR DESCRIPTION
* Due to the recent update to TypeScript 3.0.0, the new TS version conflicts with the internal TypeScript version from `dgeni-packages`. This causes the @Input(), @Output(), selector, exported-as to not show up in the docs.

* Removes the selector blacklist and `md-`prefix filter. All of the blacklisted selectors have been removed (except the autosize selector; but the whole class has been deprecated now)