### PR TITLE
build: run publish sanity checks before building

### DIFF
--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -33,4 +33,5 @@ import './tasks/unit-test';
 import './tasks/universal';
 
 import './tasks/publish/publish-task';
+import './tasks/publish/sanity-checks';
 import './tasks/publish/validate-release';

--- a/tools/gulp/tasks/publish/branch-check.ts
+++ b/tools/gulp/tasks/publish/branch-check.ts
@@ -2,7 +2,7 @@ import {spawnSync} from 'child_process';
 import {buildConfig} from 'material2-build-tools';
 
 /** Regular expression that matches version names and the individual version segments. */
-export const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d)+)?/;
+export const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d)+)?$/;
 
 /** Checks if the specified version can be released from the current Git branch. */
 export function checkPublishBranch(version: string) {

--- a/tools/gulp/tasks/publish/sanity-checks.ts
+++ b/tools/gulp/tasks/publish/sanity-checks.ts
@@ -1,0 +1,57 @@
+import {red} from 'chalk';
+import {spawnSync} from 'child_process';
+import {task} from 'gulp';
+import {buildConfig} from 'material2-build-tools';
+import * as minimist from 'minimist';
+import {checkPublishBranch, versionNameRegex} from './branch-check';
+
+const {projectDir, projectVersion} = buildConfig;
+
+/** Git repository URL that has been read out from the project package.json file. */
+const repositoryGitUrl = require('../../../../package.json').repository.url;
+
+/** Parse command-line arguments for release task. */
+const argv = minimist(process.argv.slice(3));
+
+/** Task that runs various sanity checks before publishing. */
+task(':publish:sanity-checks', [
+  ':publish:check-project-version',
+  ':publish:check-remote-tag',
+  ':publish:check-publish-branch',
+]);
+
+/** Task that checks the new project version. */
+task(':publish:check-project-version', () => {
+  const tag = argv['tag'];
+
+  if (!projectVersion.match(versionNameRegex)) {
+    console.error(red(`Error: Cannot publish due to an invalid version name. Version ` +
+        `"${projectVersion}" is not following our semver format.`));
+    console.error(red(`A version should follow this format: X.X.X, X.X.X-beta.X, ` +
+        `X.X.X-alpha.X, X.X.X-rc.X`));
+    process.exit(1);
+  }
+
+  if (projectVersion.match(/(alpha|beta|rc)/) && (!tag || tag === 'latest')) {
+    console.error(red(`Publishing ${projectVersion} to the "latest" tag is not allowed.`));
+    console.error(red(`Alpha, Beta or RC versions shouldn't be published to "latest".`));
+    process.exit(1);
+  }
+});
+
+/** Task that verifies that the new version can be published from the current branch. */
+task(':publish:check-publish-branch', () => checkPublishBranch(projectVersion));
+
+/** Task that ensures that the new release tagged on GitHub before publishing to NPM. */
+task(':publish:check-remote-tag', () => {
+  // Since we cannot assume that every developer uses `origin` as the default name for the upstream
+  // remote, we just pass in the Git URL that refers to angular/material2 repository on Github.
+  const tagCommitSha = spawnSync('git', ['ls-remote', '--tags', repositoryGitUrl, projectVersion],
+      {cwd: projectDir}).stdout.toString().trim();
+
+  if (!tagCommitSha) {
+    console.error(red(`Cannot publish v${projectVersion} because the release is not ` +
+        `tagged on upstream yet. Please tag the release before publishing to NPM.`));
+    process.exit(1);
+  }
+});

--- a/tools/gulp/tasks/publish/validate-release.ts
+++ b/tools/gulp/tasks/publish/validate-release.ts
@@ -1,16 +1,12 @@
-import {task} from 'gulp';
-import {readFileSync, existsSync} from 'fs';
-import {join} from 'path';
 import {green, red} from 'chalk';
-import {releasePackages} from './publish-task';
+import {existsSync, readFileSync} from 'fs';
 import {sync as glob} from 'glob';
-import {spawnSync} from 'child_process';
+import {task} from 'gulp';
 import {buildConfig, sequenceTask} from 'material2-build-tools';
+import {join} from 'path';
+import {releasePackages} from './publish-task';
 
-const {projectDir, projectVersion, outputDir} = buildConfig;
-
-/** Git repository URL that has been read out from the project package.json file. */
-const repositoryGitUrl = require('../../../../package.json').repository.url;
+const {outputDir} = buildConfig;
 
 /** Path to the directory where all releases are created. */
 const releasesDir = join(outputDir, 'releases');
@@ -22,18 +18,6 @@ const inlineStylesSourcemapRegex = /styles: ?\[["'].*sourceMappingURL=.*["']/;
 const externalReferencesRegex = /(templateUrl|styleUrls): *["'[]/;
 
 task('validate-release', sequenceTask(':publish:build-releases', 'validate-release:check-bundles'));
-
-task('validate-release:check-remote-tag', () => {
-  // Since we cannot assume that every developer uses `origin` as the default name for the upstream
-  // remote, we just pass in the Git URL that refers to angular/material2 repository on Github.
-  const tagCommitSha = spawnSync('git', ['ls-remote', '--tags', repositoryGitUrl, projectVersion],
-    {cwd: projectDir}).stdout.toString().trim();
-
-  if (!tagCommitSha) {
-    throw Error(red(`Cannot publish v${projectVersion} because the release is not ` +
-    `tagged on upstream yet. Please tag the release before publishing to NPM.`));
-  }
-});
 
 /** Task that checks the release bundles for any common mistakes before releasing to the public. */
 task('validate-release:check-bundles', () => {


### PR DESCRIPTION
* Runs the publish sanity checks before building the release output of Angular Material. Building the release output is very time consuming, and therefore the sanity checks should run before.

Closes #12918