### PR TITLE
fix(snack-bar): button not centered inside snack bar on IE11

### DIFF
--- a/src/lib/snack-bar/simple-snack-bar.scss
+++ b/src/lib/snack-bar/simple-snack-bar.scss
@@ -20,15 +20,11 @@ $mat-snack-bar-button-vertical-margin:
 }
 
 .mat-simple-snackbar-action {
-  display: flex;
-  flex-direction: column;
   flex-shrink: 0;
-  justify-content: space-around;
   margin: $mat-snack-bar-button-vertical-margin $mat-snack-bar-button-horizontal-margin * -1
           $mat-snack-bar-button-vertical-margin $mat-snack-bar-button-horizontal-margin;
 
   button {
-    flex: 1;
     max-height: $mat-snack-bar-button-height;
     min-width: 0;
   }


### PR DESCRIPTION
Fixes the snack bar's button appearing off-center on IE11. The flex styling that has been removed isn't necessary anymore after the recent design changes.

For reference:

![angular_material_-_internet_explorer_2018-09-10_19-53-06](https://user-images.githubusercontent.com/4450522/45315574-0e24ff80-b535-11e8-8f67-3e558817937c.png)
