### PR TITLE
docs: component-grouper does not always include components

### DIFF
--- a/tools/dgeni/index.ts
+++ b/tools/dgeni/index.ts
@@ -5,7 +5,7 @@ import {DocsPrivateFilter} from './processors/docs-private-filter';
 import {Categorizer} from './processors/categorizer';
 import {FilterDuplicateExports} from './processors/filter-duplicate-exports';
 import {MergeInheritedProperties} from './processors/merge-inherited-properties';
-import {ComponentGrouper} from './processors/component-grouper';
+import {EntryPointGrouper} from './processors/entry-point-grouper';
 import {ReadTypeScriptModules} from 'dgeni-packages/typescript/processors/readTypeScriptModules';
 import {TsParser} from 'dgeni-packages/typescript/services/TsParser';
 import {sync as globSync} from 'glob';
@@ -62,8 +62,8 @@ apiDocsPackage.processor(new DocsPrivateFilter());
 // Processor that appends categorization flags to the docs, e.g. `isDirective`, `isNgModule`, etc.
 apiDocsPackage.processor(new Categorizer());
 
-// Processor to group components into top-level groups such as "Tabs", "Sidenav", etc.
-apiDocsPackage.processor(new ComponentGrouper());
+// Processor to group docs into top-level entry-points such as "tabs", "sidenav", etc.
+apiDocsPackage.processor(new EntryPointGrouper());
 
 // Configure the log level of the API docs dgeni package.
 apiDocsPackage.config((log: any) => log.level = 'info');
@@ -82,7 +82,7 @@ apiDocsPackage.config((log: any) => patchLogService(log));
 // Configure the output path for written files (i.e., file names).
 apiDocsPackage.config((computePathsProcessor: any) => {
   computePathsProcessor.pathTemplates = [{
-    docTypes: ['componentGroup'],
+    docTypes: ['entry-point'],
     pathTemplate: '${name}',
     outputPathTemplate: '${name}.html',
   }];

--- a/tools/dgeni/templates/entry-point.template.html
+++ b/tools/dgeni/templates/entry-point.template.html
@@ -59,32 +59,32 @@
     {% endfor %}
   {%- endif -%}
 
-  {%- if doc.additionalClasses.length -%}
-    <h3 id="additional_classes" class="docs-header-link docs-api-h3">
-      <span header-link="additional_classes"></span>
-      Additional classes
+  {%- if doc.classes.length -%}
+    <h3 id="classes" class="docs-header-link docs-api-h3">
+      <span header-link="classes"></span>
+      Classes
     </h3>
-    {% for other in doc.additionalClasses %}
+    {% for other in doc.classes %}
       {$ class(other) $}
     {% endfor %}
   {%- endif -%}
 
-  {%- if doc.additionalInterfaces.length -%}
-    <h3 id="additional_interfaces" class="docs-header-link docs-api-h3">
-      <span header-link="additional_interfaces"></span>
-      Additional interfaces
+  {%- if doc.interfaces.length -%}
+    <h3 id="interfaces" class="docs-header-link docs-api-h3">
+      <span header-link="interfaces"></span>
+      Interfaces
     </h3>
-    {% for item in doc.additionalInterfaces %}
+    {% for item in doc.interfaces %}
       {$ interface(item) $}
     {% endfor %}
   {%- endif -%}
 
-  {%- if doc.additionalFunctions.length -%}
-    <h3 id="additional_functions" class="docs-header-link docs-api-h3">
-      <span header-link="additional_functions"></span>
-      Additional functions
+  {%- if doc.functions.length -%}
+    <h3 id="functions" class="docs-header-link docs-api-h3">
+      <span header-link="functions"></span>
+      Functions
     </h3>
-    {% for item in doc.additionalFunctions %}
+    {% for item in doc.functions %}
       {#
         Since the function docs have a similar structure as method docs, we use
         the method template.
@@ -93,12 +93,12 @@
     {% endfor %}
   {%- endif -%}
 
-  {%- if doc.additionalTypeAliases.length -%}
-    <h3 id="additional_type_aliases" class="docs-header-link docs-api-h3">
-      <span header-link="additional_type_aliases"></span>
-      Additional type aliases
+  {%- if doc.typeAliases.length -%}
+    <h3 id="type_aliases" class="docs-header-link docs-api-h3">
+      <span header-link="type_aliases"></span>
+      Type aliases
     </h3>
-    {% for item in doc.additionalTypeAliases %}
+    {% for item in doc.typeAliases %}
       {$ typeAlias(item) $}
     {% endfor %}
   {%- endif -%}


### PR DESCRIPTION
* Currently we group the Dgeni docs by entry-points (we just call it *grouping by components*). Technically there are "component groups" that do not even include any component/directive (e.g. `cdk/coercion`, `cdk/platform`). This renames the component grouper to `entry point grouper`.
* No longer displays interfaces, classes, type-aliases etc. as `additional` "parts of an entry-point". (As mentioned above; sometimes classes are the primary export of an entry-point).

---

Also IMO it just looks more explicit and more like an API page if we remove words like `additional`. e.g. Things like the `OverlayRef` are part of an entry-point, and not just something "additional".

![image](https://user-images.githubusercontent.com/4987015/45367881-8695ca00-b5e2-11e8-8595-e6cf833c7a1c.png)

I'm up to discussion. This is more like a proposal.