### PR TITLE
fix(drag-drop): incorrectly calculating index when sorting horizontally

### DIFF
--- a/src/cdk/drag-drop/drop.ts
+++ b/src/cdk/drag-drop/drop.ts
@@ -314,6 +314,7 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
 
   /** Refreshes the position cache of the items and sibling containers. */
   private _cachePositions() {
+    const isHorizontal = this.orientation === 'horizontal';
     this._positionCache.items = this._activeDraggables
       .map(drag => {
         const elementToMeasure = this._dragDropRegistry.isDragging(drag) ?
@@ -340,7 +341,10 @@ export class CdkDrop<T = any> implements OnInit, OnDestroy {
           }
         };
       })
-      .sort((a, b) => a.clientRect.top - b.clientRect.top);
+      .sort((a, b) => {
+        return isHorizontal ? a.clientRect.left - b.clientRect.left :
+                              a.clientRect.top - b.clientRect.top;
+      });
 
     this._positionCache.siblings = coerceArray(this.connectedTo)
       .map(drop => typeof drop === 'string' ? this._dragDropRegistry.getDropContainer(drop)! : drop)


### PR DESCRIPTION
Fixes the list index not being calculated correctly, because the items are being sorted in memory based on their `top` position, even though the dragging is horizontal.

Fixes #13072.

**Note:** we already have some tests capturing this behavior, but they weren't failing, because they don't change the Y axis movement when sending fake events. When an actual user is dragging, they usually make slight movements along both axis.