### PR TITLE
fix(drag-drop): not dropping immediately for failed drag after a successful one

### DIFF
--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -103,7 +103,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
   private _activeTransform: Point = {x: 0, y: 0};
 
   /** Whether the element has moved since the user started dragging it. */
-  private _hasMoved = false;
+  private _hasMoved: boolean;
 
   /** Drop container in which the CdkDrag resided when dragging began. */
   private _initialContainer: CdkDropContainer;
@@ -284,6 +284,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
 
     const endedOrDestroyed = merge(this.ended, this._destroyed);
 
+    this._hasMoved = false;
     this._dragDropRegistry.pointerMove
       .pipe(takeUntil(endedOrDestroyed))
       .subscribe(this._pointerMove);


### PR DESCRIPTION
Fixes the `CdkDrag` having to fall back to waiting for the animation to time out, rather than exiting immediately if the user does a successful dragging sequence, followed by an unsuccessful one. The issue comes from the fact that the `_hasMoved` flag was never being reset.

Fixes #13091.