### PR TITLE
fix(list): action list items clickable area not stretching the full width

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -43,6 +43,10 @@ $mat-list-item-inset-divider-offset: 72px;
   height: $base-height;
   -webkit-tap-highlight-color: transparent;
 
+  // Override the user agent styling if the list item is a button.
+  width: 100%;
+  padding: 0;
+
   .mat-list-item-content {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
* Fixes the items inside an action list not stretching the complete width of the element, making them hard to click.
* Fixes the user agent padding throwing off the alignment for buttons used as items in the action list.