### PR TITLE
fix(grid-list): exception thrown when rowHeight is set before first change detection run

### DIFF
--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -34,6 +34,18 @@ describe('MatGridList', () => {
     expect(() => fixture.detectChanges()).toThrowError(/tile with colspan 5 is wider than grid/);
   });
 
+  it('should not throw when setting the `rowHeight` programmatically before init', () => {
+    const fixture = createComponent(GridListWithUnspecifiedRowHeight);
+    const gridList = fixture.debugElement.query(By.directive(MatGridList));
+
+    expect(() => {
+      // Set the row height twice so the tile styler is initialized.
+      gridList.componentInstance.rowHeight = 12.3;
+      gridList.componentInstance.rowHeight = 32.1;
+      fixture.detectChanges();
+    }).not.toThrow();
+  });
+
   it('should set the columns to zero if a negative number is passed in', () => {
     const fixture = createComponent(GridListWithDynamicCols);
     fixture.detectChanges();

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -178,10 +178,12 @@ export class FixedTileStyler extends TileStyler {
   reset(list: MatGridList) {
     list._setListStyle(['height', null]);
 
-    list._tiles.forEach(tile => {
-      tile._setStyle('top', null);
-      tile._setStyle('height', null);
-    });
+    if (list._tiles) {
+      list._tiles.forEach(tile => {
+        tile._setStyle('top', null);
+        tile._setStyle('height', null);
+      });
+    }
   }
 }
 
@@ -248,7 +250,6 @@ export class RatioTileStyler extends TileStyler {
  * @docs-private
  */
 export class FitTileStyler extends TileStyler {
-
   setRowStyles(tile: MatGridTile, rowIndex: number): void {
     // Percent of the available vertical space that one row takes up.
     let percentHeightPerTile = 100 / this._rowspan;
@@ -264,10 +265,12 @@ export class FitTileStyler extends TileStyler {
   }
 
   reset(list: MatGridList) {
-    list._tiles.forEach(tile => {
-      tile._setStyle('top', null);
-      tile._setStyle('height', null);
-    });
+    if (list._tiles) {
+      list._tiles.forEach(tile => {
+        tile._setStyle('top', null);
+        tile._setStyle('height', null);
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Fixes the grid list throwing an error if the consumer sets the `rowHeight` programmatically before the first change detection run. The issue is that the `QueryList` hasn't been initialized yet.

Fixes #13102.