### PR TITLE
fix(progress-bar): buffer background animation stuttering

### DIFF
--- a/src/lib/progress-bar/progress-bar.scss
+++ b/src/lib/progress-bar/progress-bar.scss
@@ -285,6 +285,7 @@ $mat-progress-bar-secondary-indeterminate-scale-step-3:
 // Animation for buffer mode.
 @keyframes mat-progress-bar-background-scroll {
   to {
-    transform: translateX(-10px);
+    // Needs to be in multiples of the size of the buffer circles.
+    transform: translateX(-$mat-progress-bar-height * 2);
   }
 }


### PR DESCRIPTION
Fixes the animation for the buffer progress bar stuttering, because it didn't align to the dot size.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/45512885-5fd1c200-b7a1-11e8-8342-e6ba164fa3ef.gif)
