### PR TITLE
fix(platform): wrap MSStream property detection as string to prevent Closure property renaming

### DIFF
--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -48,7 +48,7 @@ export class Platform {
 
   /** Whether the current platform is Apple iOS. */
   IOS: boolean = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) &&
-      !(window as any).MSStream;
+      !('MSStream' in window);
 
   /** Whether the current browser is Firefox. */
   // It's difficult to detect the plain Gecko engine, because most of the browsers identify


### PR DESCRIPTION
Prevents potential name collisions on window object, due to Closure compiler property renaming,
that result in incorrect detection of iOS and cause tooltips to show on tap.

Fixes #12223