### PR TITLE
refactor: correct wrong import in date selection

### DIFF
--- a/src/lib/core/datetime/date-selection.ts
+++ b/src/lib/core/datetime/date-selection.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DateAdapter} from '@angular/material/core';
 import {Subject} from 'rxjs';
+import {DateAdapter} from './date-adapter';
 
 export abstract class MatDateSelection<D> {
   valueChanges = new Subject<void>();


### PR DESCRIPTION
Fixes an incorrect import in the `date-selection.ts` that breaks the build.

Fixes #13123.

@jelbourn I'm not too sure whether this is supposed to target the 6.4.x branch.