### PR TITLE
refactor(schematics): add test case for overlay property name change

### DIFF
--- a/src/lib/schematics/update/material/data/property-names.ts
+++ b/src/lib/schematics/update/material/data/property-names.ts
@@ -34,6 +34,19 @@ export const propertyNames: VersionChanges<MaterialPropertyNameData> = {
           }
         }
       ]
+    },
+
+    {
+      pr: 'https://github.com/angular/material2/pull/12927',
+      changes: [
+        {
+          replace: 'flexibleDiemsions',
+          replaceWith: 'flexibleDimensions',
+          whitelist: {
+            classes: ['CdkConnectedOverlay']
+          }
+        }
+      ]
     }
   ],
 
@@ -353,19 +366,5 @@ export const propertyNames: VersionChanges<MaterialPropertyNameData> = {
         }
       ]
     },
-
-    // TODO(devversion): this should be part of the V6 to V7 upgrade
-    {
-      pr: 'https://github.com/angular/material2/pull/12927',
-      changes: [
-        {
-          replace: 'flexibleDiemsions',
-          replaceWith: 'flexibleDimensions',
-          whitelist: {
-            classes: ['CdkConnectedOverlay']
-          }
-        }
-      ]
-    }
   ]
 };

--- a/src/lib/schematics/update/test-cases/v7/property-names_expected_output.ts
+++ b/src/lib/schematics/update/test-cases/v7/property-names_expected_output.ts
@@ -4,15 +4,25 @@ class SelectionModel {
   onChange = new EventEmitter<void>();
 }
 
+class CdkConnectedOverlay {
+  flexibleDiemsions: boolean;
+}
+
 /* Actual test case using the previously defined definitions. */
 
 class A implements OnInit {
   self = {me: this};
 
-  constructor(private a: SelectionModel) {}
+  constructor(private a: SelectionModel, private b: CdkConnectedOverlay) {}
 
   ngOnInit() {
     this.a.changed.subscribe(() => console.log('Changed'));
     this.self.me.a.changed.subscribe(() => console.log('Changed 2'));
+
+    if (this.b.flexibleDimensions) {
+      console.log(this.b.flexibleDimensions ? 'true' : 'false');
+    }
+
+    const _state = this.self.me.b.flexibleDimensions.toString() || 'not-defined';
   }
 }

--- a/src/lib/schematics/update/test-cases/v7/property-names_input.ts
+++ b/src/lib/schematics/update/test-cases/v7/property-names_input.ts
@@ -4,15 +4,25 @@ class SelectionModel {
   onChange = new EventEmitter<void>();
 }
 
+class CdkConnectedOverlay {
+  flexibleDiemsions: boolean;
+}
+
 /* Actual test case using the previously defined definitions. */
 
 class A implements OnInit {
   self = {me: this};
 
-  constructor(private a: SelectionModel) {}
+  constructor(private a: SelectionModel, private b: CdkConnectedOverlay) {}
 
   ngOnInit() {
     this.a.onChange.subscribe(() => console.log('Changed'));
     this.self.me.a.onChange.subscribe(() => console.log('Changed 2'));
+
+    if (this.b.flexibleDiemsions) {
+      console.log(this.b.flexibleDiemsions ? 'true' : 'false');
+    }
+
+    const _state = this.self.me.b.flexibleDiemsions.toString() || 'not-defined';
   }
 }


### PR DESCRIPTION
* Moves the breaking change for `flexibleDimension` into the V7 target data. This is currently in V6 because at the time of the PR, this data distinction didn't exist.
* Adds a test-case for that breaking change