### PR TITLE
docs(collections): wrong property name in docs after property rename

### DIFF
--- a/src/cdk/collections/collections.md
+++ b/src/cdk/collections/collections.md
@@ -30,5 +30,5 @@ console.log(model.isSelected(4)) //-> true
 console.log(model.sort()) //-> [1,2,3,4]
 
 // listen for changes
-model.changes.subscribe(s => console.log(s));
+model.changed.subscribe(s => console.log(s));
 ```


### PR DESCRIPTION
* After the renaming from `onChange` to `changed`, the `collections.md` somehow includes `model.changes` which should be actually `model.changed`.