### PR TITLE
feat(theming): support font-family css variable

### DIFF
--- a/src/lib/badge/_badge-theme.scss
+++ b/src/lib/badge/_badge-theme.scss
@@ -161,7 +161,7 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
   .mat-badge-content {
     font-weight: $mat-badge-font-weight;
     font-size: $mat-badge-font-size;
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-badge-small .mat-badge-content {

--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -31,6 +31,6 @@
 
 @mixin mat-button-toggle-typography($config) {
   .mat-button-toggle {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 }

--- a/src/lib/card/_card-theme.scss
+++ b/src/lib/card/_card-theme.scss
@@ -19,7 +19,7 @@
 
 @mixin mat-card-typography($config) {
   .mat-card {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-card-title {

--- a/src/lib/checkbox/_checkbox-theme.scss
+++ b/src/lib/checkbox/_checkbox-theme.scss
@@ -107,7 +107,7 @@
 
 @mixin mat-checkbox-typography($config) {
   .mat-checkbox {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   // TODO(kara): Remove this style when fixing vertical baseline

--- a/src/lib/core/style/_css-variables.scss
+++ b/src/lib/core/style/_css-variables.scss
@@ -1,0 +1,21 @@
+// Creates a css rule for the property setting it first to the value
+// and then to the provided css variable with the provided value as a fallback
+//
+// @param $property The property to set
+// @param $variable The name of the css variable to use (without the "--mat-" prefix)
+// @param $fallback The value to use when the css variable is not set
+//                  or not supported by the browser
+@mixin mat-css-var($property, $variable, $fallback) {
+  // browsers which do not support css variables will fallback to this value
+  #{$property}: $fallback;
+  #{$property}: var(--mat-#{$variable}, $fallback);
+}
+
+// Wraps the provided fallback value in a css variable declaration
+//
+// @param $variable The name of the css variable to use (without the "--mat-" prefix)
+// @param $fallback The value to use when the css variable is not set
+//                  or not supported by the browser
+@function css-var($variable, $fallback) {
+  @return var(--mat-#{$variable}, $fallback);
+}

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -37,8 +37,8 @@
 }
 
 // Creates a CSS rule for font-family using the --mat-font-family css variable
-@mixin mat-font-family-css-var($config) {
-  @include mat-css-var(font-family, font-family, mat-font-family($config));
+@mixin mat-font-family-css-var($config, $level: null) {
+  @include mat-css-var(font-family, font-family, mat-font-family($config, $level));
 }
 
 // Outputs the shorthand `font` CSS property, based on a set of typography values. Falls back to

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -1,3 +1,5 @@
+@import '../style/css-variables';
+
 // Utility for fetching a nested value from a typography config.
 @function _mat-get-type-value($config, $level, $name) {
   @return map-get(map-get($config, $level), $name);
@@ -24,9 +26,6 @@
 }
 
 // Gets the font-family from a typography config and removes the quotes around it.
-// If the config has $use-css-variables set to true the font-family will be
-// wrapped with the --mat-font-family css variable.
-// Example: var(--mat-font-family, Roboto, "Helvetica Neue", sans-serif)
 @function mat-font-family($config, $level: null) {
   $font-family: map-get($config, font-family);
 
@@ -34,15 +33,12 @@
     $font-family: _mat-get-type-value($config, $level, font-family);
   }
 
-  @return if(
-    $font-family == null,
-    $font-family,
-    if(
-      map-get($config, use-css-variables),
-      var(--mat-font-family, unquote($font-family)),
-      $font-family
-    )
-  );
+  @return if($font-family == null, $font-family, unquote($font-family));
+}
+
+// Creates a CSS rule for font-family using the --mat-font-family css variable
+@mixin mat-font-family-css-var($config) {
+  @include mat-css-var(font-family, font-family, mat-font-family($config));
 }
 
 // Outputs the shorthand `font` CSS property, based on a set of typography values. Falls back to
@@ -63,12 +59,18 @@
     font-weight: $font-weight;
     line-height: $line-height;
     font-family: $font-family;
+
+    // Browsers that do not support CSS variables will fallback to the above css rule
+    font-family: css-var(font-family, $font-family);
   }
   @else {
     // Otherwise use the shorthand `font`, because it's the least amount of bytes. Note
     // that we need to use interpolation for `font-size/line-height` in order to prevent
     // Sass from dividing the two values.
     font: $font-weight #{$font-size}/#{$line-height} $font-family;
+
+    // Browsers that do not support CSS variables will fallback to the above css rule
+    font: $font-weight #{$font-size}/#{$line-height} css-var(font-family, $font-family);
   }
 }
 
@@ -82,3 +84,4 @@
   @include mat-typography-font-shorthand($font-size, $font-weight, $line-height, $font-family);
   letter-spacing: mat-letter-spacing($config, $level);
 }
+

--- a/src/lib/core/typography/_typography-utils.scss
+++ b/src/lib/core/typography/_typography-utils.scss
@@ -24,6 +24,9 @@
 }
 
 // Gets the font-family from a typography config and removes the quotes around it.
+// If the config has $use-css-variables set to true the font-family will be
+// wrapped with the --mat-font-family css variable.
+// Example: var(--mat-font-family, Roboto, "Helvetica Neue", sans-serif)
 @function mat-font-family($config, $level: null) {
   $font-family: map-get($config, font-family);
 
@@ -31,7 +34,15 @@
     $font-family: _mat-get-type-value($config, $level, font-family);
   }
 
-  @return if($font-family == null, $font-family, unquote($font-family));
+  @return if(
+    $font-family == null,
+    $font-family,
+    if(
+      map-get($config, use-css-variables),
+      var(--mat-font-family, unquote($font-family)),
+      $font-family
+    )
+  );
 }
 
 // Outputs the shorthand `font` CSS property, based on a set of typography values. Falls back to

--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -20,21 +20,21 @@
 // Represents a collection of typography levels.
 // Defaults come from https://material.io/guidelines/style/typography.html
 @function mat-typography-config(
-  $font-family:       'Roboto, "Helvetica Neue", sans-serif',
-  $display-4:         mat-typography-level(112px, 112px, 300),
-  $display-3:         mat-typography-level(56px, 56px, 400),
-  $display-2:         mat-typography-level(45px, 48px, 400),
-  $display-1:         mat-typography-level(34px, 40px, 400),
-  $headline:          mat-typography-level(24px, 32px, 400),
-  $title:             mat-typography-level(20px, 32px, 500),
-  $subheading-2:      mat-typography-level(16px, 28px, 400),
-  $subheading-1:      mat-typography-level(15px, 24px, 400),
-  $body-2:            mat-typography-level(14px, 24px, 500),
-  $body-1:            mat-typography-level(14px, 20px, 400),
-  $caption:           mat-typography-level(12px, 20px, 400),
-  $button:            mat-typography-level(14px, 14px, 500),
+  $font-family:   'Roboto, "Helvetica Neue", sans-serif',
+  $display-4:     mat-typography-level(112px, 112px, 300),
+  $display-3:     mat-typography-level(56px, 56px, 400),
+  $display-2:     mat-typography-level(45px, 48px, 400),
+  $display-1:     mat-typography-level(34px, 40px, 400),
+  $headline:      mat-typography-level(24px, 32px, 400),
+  $title:         mat-typography-level(20px, 32px, 500),
+  $subheading-2:  mat-typography-level(16px, 28px, 400),
+  $subheading-1:  mat-typography-level(15px, 24px, 400),
+  $body-2:        mat-typography-level(14px, 24px, 500),
+  $body-1:        mat-typography-level(14px, 20px, 400),
+  $caption:       mat-typography-level(12px, 20px, 400),
+  $button:        mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:             mat-typography-level(inherit, 1.125, 400)
+  $input:         mat-typography-level(inherit, 1.125, 400)
 ) {
 
   // Declare an initial map with all of the levels.
@@ -51,7 +51,7 @@
     body-1:         $body-1,
     caption:        $caption,
     button:         $button,
-    input:          $input
+    input:          $input,
   );
 
   // Loop through the levels and set the `font-family` of the ones that don't have one to the base.

--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -34,8 +34,7 @@
   $caption:           mat-typography-level(12px, 20px, 400),
   $button:            mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:             mat-typography-level(inherit, 1.125, 400),
-  $use-css-variables: false
+  $input:             mat-typography-level(inherit, 1.125, 400)
 ) {
 
   // Declare an initial map with all of the levels.
@@ -65,10 +64,7 @@
   }
 
   // Add the base font family to the config.
-  @return map-merge($config, (
-    font-family: $font-family,
-    use-css-variables: $use-css-variables
-  ));
+  @return map-merge($config, (font-family: $font-family));
 }
 
 // Adds the base typography styles, based on a config.

--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -20,21 +20,22 @@
 // Represents a collection of typography levels.
 // Defaults come from https://material.io/guidelines/style/typography.html
 @function mat-typography-config(
-  $font-family:   'Roboto, "Helvetica Neue", sans-serif',
-  $display-4:     mat-typography-level(112px, 112px, 300),
-  $display-3:     mat-typography-level(56px, 56px, 400),
-  $display-2:     mat-typography-level(45px, 48px, 400),
-  $display-1:     mat-typography-level(34px, 40px, 400),
-  $headline:      mat-typography-level(24px, 32px, 400),
-  $title:         mat-typography-level(20px, 32px, 500),
-  $subheading-2:  mat-typography-level(16px, 28px, 400),
-  $subheading-1:  mat-typography-level(15px, 24px, 400),
-  $body-2:        mat-typography-level(14px, 24px, 500),
-  $body-1:        mat-typography-level(14px, 20px, 400),
-  $caption:       mat-typography-level(12px, 20px, 400),
-  $button:        mat-typography-level(14px, 14px, 500),
+  $font-family:       'Roboto, "Helvetica Neue", sans-serif',
+  $display-4:         mat-typography-level(112px, 112px, 300),
+  $display-3:         mat-typography-level(56px, 56px, 400),
+  $display-2:         mat-typography-level(45px, 48px, 400),
+  $display-1:         mat-typography-level(34px, 40px, 400),
+  $headline:          mat-typography-level(24px, 32px, 400),
+  $title:             mat-typography-level(20px, 32px, 500),
+  $subheading-2:      mat-typography-level(16px, 28px, 400),
+  $subheading-1:      mat-typography-level(15px, 24px, 400),
+  $body-2:            mat-typography-level(14px, 24px, 500),
+  $body-1:            mat-typography-level(14px, 20px, 400),
+  $caption:           mat-typography-level(12px, 20px, 400),
+  $button:            mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:         mat-typography-level(inherit, 1.125, 400)
+  $input:             mat-typography-level(inherit, 1.125, 400),
+  $use-css-variables: false
 ) {
 
   // Declare an initial map with all of the levels.
@@ -51,7 +52,7 @@
     body-1:         $body-1,
     caption:        $caption,
     button:         $button,
-    input:          $input,
+    input:          $input
   );
 
   // Loop through the levels and set the `font-family` of the ones that don't have one to the base.
@@ -64,7 +65,10 @@
   }
 
   // Add the base font family to the config.
-  @return map-merge($config, (font-family: $font-family));
+  @return map-merge($config, (
+    font-family: $font-family,
+    use-css-variables: $use-css-variables
+  ));
 }
 
 // Adds the base typography styles, based on a config.

--- a/src/lib/datepicker/_datepicker-theme.scss
+++ b/src/lib/datepicker/_datepicker-theme.scss
@@ -110,7 +110,7 @@ $mat-calendar-weekday-table-font-size: 11px !default;
 
 @mixin mat-datepicker-typography($config) {
   .mat-calendar {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-calendar-body {

--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -56,7 +56,7 @@
     }
 
     .mat-subheader {
-      font-family: mat-font-family($config, body-2);
+      @include mat-font-family-css-var($config, body-2);
       font-size: mat-font-size($config, body-2);
       font-weight: mat-font-weight($config, body-2);
     }

--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -38,11 +38,11 @@
   $font-family: mat-font-family($config);
 
   .mat-list-item {
-    font-family: $font-family;
+    @include mat-font-family-css-var($config);
   }
 
   .mat-list-option {
-    font-family: $font-family;
+    @include mat-font-family-css-var($config);
   }
 
   // Default list
@@ -77,7 +77,7 @@
     }
 
     .mat-subheader {
-      font-family: $font-family;
+      @include mat-font-family-css-var($config);
       font-size: mat-font-size($config, caption);
       font-weight: mat-font-weight($config, body-2);
     }

--- a/src/lib/list/_list-theme.scss
+++ b/src/lib/list/_list-theme.scss
@@ -35,8 +35,6 @@
 }
 
 @mixin mat-list-typography($config) {
-  $font-family: mat-font-family($config);
-
   .mat-list-item {
     @include mat-font-family-css-var($config);
   }

--- a/src/lib/radio/_radio-theme.scss
+++ b/src/lib/radio/_radio-theme.scss
@@ -68,6 +68,6 @@
 
 @mixin mat-radio-typography($config) {
   .mat-radio-button {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 }

--- a/src/lib/select/_select-theme.scss
+++ b/src/lib/select/_select-theme.scss
@@ -65,7 +65,7 @@
   $line-height: mat-line-height($config, input);
 
   .mat-select {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-select-trigger {

--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -86,6 +86,6 @@
 
 @mixin mat-slide-toggle-typography($config) {
   .mat-slide-toggle-content {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 }

--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -49,7 +49,7 @@
 
 @mixin mat-stepper-typography($config) {
   .mat-stepper-vertical, .mat-stepper-horizontal {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-step-label {

--- a/src/lib/table/_table-theme.scss
+++ b/src/lib/table/_table-theme.scss
@@ -33,7 +33,7 @@
 
 @mixin mat-table-typography($config) {
   .mat-table {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-header-cell {

--- a/src/lib/tabs/_tabs-theme.scss
+++ b/src/lib/tabs/_tabs-theme.scss
@@ -127,7 +127,7 @@
 
 @mixin mat-tabs-typography($config) {
   .mat-tab-group {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-tab-label, .mat-tab-link {

--- a/src/lib/tooltip/_tooltip-theme.scss
+++ b/src/lib/tooltip/_tooltip-theme.scss
@@ -19,7 +19,7 @@ $mat-tooltip-handset-vertical-padding:
 
 @mixin mat-tooltip-typography($config) {
   .mat-tooltip {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
     font-size: $mat-tooltip-font-size;
     padding-top: $mat-tooltip-vertical-padding;
     padding-bottom: $mat-tooltip-vertical-padding;

--- a/src/lib/tree/_tree-theme.scss
+++ b/src/lib/tree/_tree-theme.scss
@@ -18,7 +18,7 @@
 
 @mixin mat-tree-typography($config) {
   .mat-tree {
-    font-family: mat-font-family($config);
+    @include mat-font-family-css-var($config);
   }
 
   .mat-tree-node,


### PR DESCRIPTION
Before, the material font-family could only be set at application build-time. Now, developers can modify the material font-family at runtime by setting the --mat-font-family css variable. This will greatly improve the application's ability to be themed dynamically at runtime and with WYSIWYG material theme editors.

This commit partially addresses this feature request: https://github.com/angular/material2/issues/4352