### PR TITLE
chore(schematics): create update schematic workflow doc

### DIFF
--- a/src/lib/schematics/update/update-schematic.md
+++ b/src/lib/schematics/update/update-schematic.md
@@ -1,0 +1,169 @@
+# Update schematic
+
+The update schematic consists of multiple migration entry-points whereas every entry-point targets a specific Angular Material version.
+
+As of right now, we have two migration entry-points that handle the breaking changes for the given target version:
+
+| Target Version | Description |
+|----------------|-------------|
+| V6 | Upgrade from any version to Angular Material 6.0.0 |
+| V7 | Upgrade from any version to Angular Material 7.0.0 |
+
+Note that the migrations run in order if both versions transitively targeted. For example, consider an application which uses Angular Material 5.0.0. In case the developer runs `ng update`, the  Angular CLI installs V6 and applies the migrations. Then after completion, it will install V7 and apply the associated V7 migrations.
+
+## Update concept
+
+The goal of the update schematic is to automatically migrate code that is affected by breaking changes of the target version. Most of the time, we can apply such automatic migrations, but there are also a few breaking changes that cannot be migrated automatically. 
+
+In that case, our goal should be to notify the developer about the breaking change that needs developer attention.
+
+## Source file transformation
+
+There are various approaches to applying changes to developer's source files:
+
+|Description | Evaluation |
+|------------|------------|
+| TSLint rules| Simple API for walking through nodes; API for applying fixes at nodes; API for reporting non-fixable breaking changes  |
+| Regular Expressions | Too brittle. No type checking possible. Regular Expression _can_ be used in combination with some real AST walking |
+| TypeScript transforms (no emit) | This would be a good solution that avoids using TSLint. No simple API for reporting and visiting specific types of nodes |
+| Plain TypeScript AST | This would be similar to the TypeScript transforms. Extra effort in creating the replacement API; reporting API; walking logic | 
+
+
+**In our case**, we decided to use TSLint rules because those allow us to:
+
+* Easily `visit` specific types of TypeScript nodes (e.g. `visitClassDeclaration`)
+* Structure migrations based on the _upgrade data_ or type of migration (different TSLint rules)
+* Easily apply replacements / fixes for specific TypeScript nodes.
+* Easily report breaking changes at TypeScript nodes that cannot be migrated automatically
+* Double check for rule migrations (TSLint always runs rule again after migrations have been applied)
+
+## Handling external CSS or HTML files
+
+Since `TSLint` allows us to only visit TypeScript nodes, we can technically just apply migrations for inline styles or templates which are part of the TypeScript AST.
+
+But for our update schematic, we also want to apply migrations for external templates or styles. In order to archive this with TSLint, we have a customized implementation of a `TSLint.RuleWalker`. The custom RuleWalker which is called `ComponentWalker` determines external templates and stylesheets from the _component/directive_ metadata. 
+
+The determined resource files will then be wrapped inside of an in-memory TypeScript source file that can be applied to the rule walker. This does not only ensure that only referenced resource files will be migrated, it also allows us to take advantage of the simple replacement and reporting API from TSLint, 
+
+This also makes the rule walker API consistent with the handling of inline resource files.  
+
+```ts
+// PSEUDO CODE
+visitExternalTemplate(node: ts.SourceFile) {
+  const parsed = parse5.parse(node.getFullText());
+  
+  this._findOutdatedInputs()
+    .forEach(offsetStart => this._addExternalFailure(offsetStart, 'Outdated input', _myFix);
+}
+```
+
+### Upgrade data for target versions
+
+The upgrade data for migrations is separated based on the target version. This is necessary in order to allow migrations run sequentially. For example:
+
+* In V6: `onChange` has been renamed to `changed`
+* In V7: `changed` has been renamed to `onValueChange`
+
+If we would not run the migrations in order, or don't separate the upgrade data, we wouldn't be able to properly handle the migrations for each target version. e.g. someone is on 5.0.0 and *only* wants to upgrade to 6.0.0. In that case he would end up with `onValueChange` because the non-separated upgrade data would just include: _`onChange` >`onValueChange`_
+
+Also besides separating the upgrade data based on the target version, we split the upgrade data based on the type of code that is affected by these migrations:
+
+* See here: [src/lib/schematics/update/material/data](https://github.com/angular/material2/tree/master/src/lib/schematics/update/material/data)
+
+### Adding upgrade data
+
+Adding upgrade data is now an essential step before breaking changes should be merged into `upstream`.  For simple and common breaking changes, there should be already an upgrade data file that just needs the new change inserted.
+
+In case there is no upgrade data for a breaking change, we need to evaluate if there should be a single `misc` migration rule that is tied to that specific breaking change, or if we should create a new migration rule in a more generic way.
+
+---
+
+**Example**: Adding upgrade data for a property rename
+**Scenario**: In Angular Material V7.0.0, we rename `MatRipple#color` to `MatRipple#newColor`.
+
+First, look for an existing upgrade data file that covers similar breaking changes. In that case an existing upgrade data file for `property-names` already exists. Insert the new breaking change within the proper `VersionTarget`.
+
+_src/lib/schematics/update/material/data/property-names.ts_
+```ts
+export const propertyNames: VersionChanges<MaterialPropertyNameData> = {  
+  [TargetVersion.V7]: [  
+    {  
+      pr: '{PULL_REQUEST_LINK_FOR_BREAKING_CHANGE}',  
+      changes: [  
+        {  
+          replace: 'color',  
+          replaceWith: 'newColor',  
+          whitelist: {  
+            classes: ['MatRipple']  
+          }  
+        }  
+      ]  
+    }  
+  ],
+  
+  ...
+};
+```
+Once the data is inserted into the upgrade data file, the update schematic will properly migrate `MatRipple#color` to `MatRipple#newColor` if someone upgrades to Angular Material V7.0.0.
+
+But that's not all. It's encouraged to add a test-case for the new migration data. In this case, a test case already exists for the type of migration and we just need to add our breaking change to it. Read more about adding a test case in the next section.
+
+### Adding a breaking change to a test case
+
+Considering we added a breaking change to the update schematic, it's encouraged to add a proper test case for the new change that has been added. 
+
+In the scenario where a property from `MatRipple` has been renamed in V7, we don't need to create a new test-case file because there is already a test case for the `property-names` upgrade data. In that case, we just need to add the breaking change to the existing test case.
+
+_src/lib/schematics/update/test-cases/v7/property-names_input.ts_
+```ts
+...
+/**
+ * Mock definitions. This test case does not have access to @angular/material.
+ */ 
+
+class MatRipple {  
+  color: string;
+}  
+  
+/* 
+ * Actual test cases using the previously defined definitions. 
+ */  
+ 
+class A implements OnInit {   
+
+  constructor(private a: MatRipple) {}  
+  
+  ngOnInit() {  
+    this.a.color = 'primary';
+  }  
+}
+```
+ 
+_src/lib/schematics/update/test-cases/v7/property-names_expected_output.ts_
+```ts
+...
+/**
+ * Mock definitions. This test case does not have access to @angular/material.
+ */ 
+
+class MatRipple {  
+  color: string;
+}  
+  
+/* 
+ * Actual test cases using the previously defined definitions. 
+ */  
+ 
+class A implements OnInit {   
+
+  constructor(private a: MatRipple) {}  
+  
+  ngOnInit() {  
+    this.a.newColor = 'primary';
+  }  
+}
+```
+
+**Note**: The `_input.ts` file will be just transformed by the V7 migrations and compared to the `_expected_output.ts` file. This means that it's necessary to also include the no longer valid mock declarations to the expected output file.
+
+

--- a/src/lib/schematics/update/update-schematic.md
+++ b/src/lib/schematics/update/update-schematic.md
@@ -1,169 +1,148 @@
-# Update schematic
 
-The update schematic consists of multiple migration entry-points whereas every entry-point targets a specific Angular Material version.
-
-As of right now, we have two migration entry-points that handle the breaking changes for the given target version:
-
+# ng-update schematic  
+  
+The `ng-update` schematic consists of multiple migration entry-points where every entry-point targets a specific Angular Material version.  
+  
+As of right now, we have two migration entry-points that handle the breaking changes for the given target version:  
+  
 | Target Version | Description |
 |----------------|-------------|
-| V6 | Upgrade from any version to Angular Material 6.0.0 |
-| V7 | Upgrade from any version to Angular Material 7.0.0 |
+| V6 | Upgrade from any version to Angular Material 6.0.0 |  
+| V7 | Upgrade from any version to Angular Material 7.0.0 |  
+  
+Note that the migrations run in order if multiple versions are transitively targeted. For example, consider an application which uses Angular Material v5.0.0. In case the developer runs `ng update`, the Angular CLI installs V7 and runs the V6 and V7 migrations in order.
+  
+## Update concept  
+  
+The goal of the update schematic is to automatically migrate code that is affected by breaking changes of the target version. Most of the time, we can apply such automatic migrations, but there are also a few breaking changes that cannot be migrated automatically.   
+  
+In that case, our goal should be to notify the developer about the breaking change that needs developer attention.  
+  
+## Transforming TypeScript files  
+  
+In order to automatically migrate TypeScript source files, we take advantage of the `TSLint` toolkit which involves creating custom rules that allow us to: 
+ 
+* Easily `visit` specific types of TypeScript nodes (e.g. `visitClassDeclaration`)  
+* Structure migrations based on the _upgrade data_ or type of migration (different TSLint rules)  
+* Easily apply replacements / fixes for specific TypeScript nodes.  
+* Easily report breaking changes at TypeScript nodes that cannot be migrated automatically  
+* Double check for rule migrations (TSLint always runs rule again after migrations have been applied)  
 
-Note that the migrations run in order if both versions transitively targeted. For example, consider an application which uses Angular Material 5.0.0. In case the developer runs `ng update`, the  Angular CLI installs V6 and applies the migrations. Then after completion, it will install V7 and apply the associated V7 migrations.
-
-## Update concept
-
-The goal of the update schematic is to automatically migrate code that is affected by breaking changes of the target version. Most of the time, we can apply such automatic migrations, but there are also a few breaking changes that cannot be migrated automatically. 
-
-In that case, our goal should be to notify the developer about the breaking change that needs developer attention.
-
-## Source file transformation
-
-There are various approaches to applying changes to developer's source files:
-
-|Description | Evaluation |
-|------------|------------|
-| TSLint rules| Simple API for walking through nodes; API for applying fixes at nodes; API for reporting non-fixable breaking changes  |
-| Regular Expressions | Too brittle. No type checking possible. Regular Expression _can_ be used in combination with some real AST walking |
-| TypeScript transforms (no emit) | This would be a good solution that avoids using TSLint. No simple API for reporting and visiting specific types of nodes |
-| Plain TypeScript AST | This would be similar to the TypeScript transforms. Extra effort in creating the replacement API; reporting API; walking logic | 
-
-
-**In our case**, we decided to use TSLint rules because those allow us to:
-
-* Easily `visit` specific types of TypeScript nodes (e.g. `visitClassDeclaration`)
-* Structure migrations based on the _upgrade data_ or type of migration (different TSLint rules)
-* Easily apply replacements / fixes for specific TypeScript nodes.
-* Easily report breaking changes at TypeScript nodes that cannot be migrated automatically
-* Double check for rule migrations (TSLint always runs rule again after migrations have been applied)
-
-## Handling external CSS or HTML files
-
-Since `TSLint` allows us to only visit TypeScript nodes, we can technically just apply migrations for inline styles or templates which are part of the TypeScript AST.
-
-But for our update schematic, we also want to apply migrations for external templates or styles. In order to archive this with TSLint, we have a customized implementation of a `TSLint.RuleWalker`. The custom RuleWalker which is called `ComponentWalker` determines external templates and stylesheets from the _component/directive_ metadata. 
-
-The determined resource files will then be wrapped inside of an in-memory TypeScript source file that can be applied to the rule walker. This does not only ensure that only referenced resource files will be migrated, it also allows us to take advantage of the simple replacement and reporting API from TSLint, 
-
-This also makes the rule walker API consistent with the handling of inline resource files.  
-
+There also other various concepts for transforming TypeScript source files, but most of them don't provide a simple API for replacements and reporting. Read more about the possible approaches below:
+  
+|Description | Evaluation |  
+|------------|------------|  
+| Regular Expressions | Too brittle. No type checking possible. Regular Expression _can_ be used in combination with some real AST walking |  
+| TypeScript transforms (no emit) | This would be a good solution that avoids using TSLint. No simple API for reporting and visiting specific types of nodes |  
+| Plain TypeScript AST | This would be similar to the TypeScript transforms. Extra effort in creating the replacement API; reporting API; walking logic |
+  
+## ## Transforming CSS and HTML files  
+  
+Since `TSLint` allows us to only visit TypeScript nodes, we can technically just apply migrations for inline styles or templates which are part of the TypeScript AST.  
+  
+But for our update schematic, we also want to apply migrations for external templates or styles. In order to archive this with TSLint, we have a customized implementation of a `TSLint.RuleWalker`. The custom RuleWalker which is called `ComponentWalker` determines external templates and stylesheets from the _component/directive_ metadata.   
+  
+The given resource files will then be wrapped inside of an in-memory TypeScript source file that can be applied to the rule walker. This ensures that only referenced resource files will be migrated and also allows us to take advantage of the simple replacement and reporting API from TSLint,
+  
+This also makes the rule walker API consistent with the handling of inline resource files.    
+  
 ```ts
 // PSEUDO CODE
 visitExternalTemplate(node: ts.SourceFile) {
-  const parsed = parse5.parse(node.getFullText());
-  
-  this._findOutdatedInputs()
-    .forEach(offsetStart => this._addExternalFailure(offsetStart, 'Outdated input', _myFix);
-}
+ const parsed = parse5.parse(node.getFullText());   this._findOutdatedInputs()
+ .forEach(offsetStart => this._addExternalFailure(offsetStart, 'Outdated input', _myFix);}
 ```
 
 ### Upgrade data for target versions
-
-The upgrade data for migrations is separated based on the target version. This is necessary in order to allow migrations run sequentially. For example:
-
+  
+The upgrade data for migrations is separated based on the target version. This is necessary in order to allow migrations run sequentially. For example:  
+  
 * In V6: `onChange` has been renamed to `changed`
 * In V7: `changed` has been renamed to `onValueChange`
-
-If we would not run the migrations in order, or don't separate the upgrade data, we wouldn't be able to properly handle the migrations for each target version. e.g. someone is on 5.0.0 and *only* wants to upgrade to 6.0.0. In that case he would end up with `onValueChange` because the non-separated upgrade data would just include: _`onChange` >`onValueChange`_
-
-Also besides separating the upgrade data based on the target version, we split the upgrade data based on the type of code that is affected by these migrations:
-
-* See here: [src/lib/schematics/update/material/data](https://github.com/angular/material2/tree/master/src/lib/schematics/update/material/data)
-
+  
+If we would not run the migrations in order, or don't separate the upgrade data, we wouldn't be able to properly handle the migrations for each target version. e.g. someone is on 5.0.0 and *only* wants to upgrade to 6.0.0. In that case he would end up with `onValueChange` because the non-separated upgrade data would just include: _`onChange` >`onValueChange`_  
+  
+Also besides separating the upgrade data based on the target version, we split the upgrade data based on the type of code that is affected by these migrations:  
+  
+* See here: [src/lib/schematics/update/material/data](https://github.com/angular/material2/tree/master/src/lib/schematics/update/material/data)  
+  
 ### Adding upgrade data
-
-Adding upgrade data is now an essential step before breaking changes should be merged into `upstream`.  For simple and common breaking changes, there should be already an upgrade data file that just needs the new change inserted.
-
-In case there is no upgrade data for a breaking change, we need to evaluate if there should be a single `misc` migration rule that is tied to that specific breaking change, or if we should create a new migration rule in a more generic way.
+  
+Adding upgrade data is now an essential step before breaking changes should be merged into `upstream`.  For simple and common breaking changes, there should be already an upgrade data file that just needs the new change inserted.  
+  
+In case there is no upgrade data for a breaking change, we need to evaluate if there should be a single `misc` migration rule that is tied to that specific breaking change, or if we should create a new migration rule in a more generic way.  
 
 ---
 
-**Example**: Adding upgrade data for a property rename
+**Example**: Adding upgrade data for a property rename  
 **Scenario**: In Angular Material V7.0.0, we rename `MatRipple#color` to `MatRipple#newColor`.
-
-First, look for an existing upgrade data file that covers similar breaking changes. In that case an existing upgrade data file for `property-names` already exists. Insert the new breaking change within the proper `VersionTarget`.
-
+  
+First, look for an existing upgrade data file that covers similar breaking changes. In that case an existing upgrade data file for `property-names` already exists. Insert the new breaking change within the proper `VersionTarget`.  
+  
 _src/lib/schematics/update/material/data/property-names.ts_
 ```ts
-export const propertyNames: VersionChanges<MaterialPropertyNameData> = {  
-  [TargetVersion.V7]: [  
-    {  
-      pr: '{PULL_REQUEST_LINK_FOR_BREAKING_CHANGE}',  
-      changes: [  
-        {  
-          replace: 'color',  
-          replaceWith: 'newColor',  
-          whitelist: {  
-            classes: ['MatRipple']  
-          }  
-        }  
-      ]  
-    }  
+export const propertyNames: VersionChanges<MaterialPropertyNameData> = {
+  [TargetVersion.V7]: [
+    {
+      pr: '{PULL_REQUEST_LINK_FOR_BREAKING_CHANGE}',
+      changes: [
+        {
+          replace: 'color',
+          replaceWith: 'newColor',
+          whitelist: {
+            classes: ['MatRipple']
+          }
+        }
+      ]
+    }
   ],
-  
-  ...
+   ...
 };
 ```
-Once the data is inserted into the upgrade data file, the update schematic will properly migrate `MatRipple#color` to `MatRipple#newColor` if someone upgrades to Angular Material V7.0.0.
-
-But that's not all. It's encouraged to add a test-case for the new migration data. In this case, a test case already exists for the type of migration and we just need to add our breaking change to it. Read more about adding a test case in the next section.
-
+Once the data is inserted into the upgrade data file, the update schematic will properly migrate `MatRipple#color` to `MatRipple#newColor` if someone upgrades to Angular Material V7.0.0.  
+  
+But that's not all. It's encouraged to add a test-case for the new migration data. In this case, a test case already exists for the type of migration and we just need to add our breaking change to it. Read more about adding a test case in the next section.  
+  
 ### Adding a breaking change to a test case
-
-Considering we added a breaking change to the update schematic, it's encouraged to add a proper test case for the new change that has been added. 
-
-In the scenario where a property from `MatRipple` has been renamed in V7, we don't need to create a new test-case file because there is already a test case for the `property-names` upgrade data. In that case, we just need to add the breaking change to the existing test case.
-
+  
+Considering we added a breaking change to the update schematic, it's encouraged to add a proper test case for the new change that has been added.   
+  
+In the scenario where a property from `MatRipple` has been renamed in V7, we don't need to create a new test-case file because there is already a test case for the `property-names` upgrade data. In that case, we just need to add the breaking change to the existing test case.  
+  
 _src/lib/schematics/update/test-cases/v7/property-names_input.ts_
 ```ts
 ...
 /**
- * Mock definitions. This test case does not have access to @angular/material.
- */ 
-
-class MatRipple {  
+ * Mock definitions. This test case does not have access to @angular/material. */
+class MatRipple {
   color: string;
-}  
-  
-/* 
- * Actual test cases using the previously defined definitions. 
- */  
- 
-class A implements OnInit {   
-
-  constructor(private a: MatRipple) {}  
-  
-  ngOnInit() {  
-    this.a.color = 'primary';
-  }  
 }
+ /*
+ * Actual test cases using the previously defined definitions.
+ */
+ class A implements OnInit {
+ constructor(private a: MatRipple) {}
+  ngOnInit() {
+    this.a.color = 'primary';
+ } }
 ```
- 
-_src/lib/schematics/update/test-cases/v7/property-names_expected_output.ts_
+
+_src/lib/schematics/update/test-cases/v7/property-names_expected_output.ts_  
 ```ts
 ...
 /**
- * Mock definitions. This test case does not have access to @angular/material.
- */ 
-
-class MatRipple {  
+ * Mock definitions. This test case does not have access to @angular/material. */   
+class MatRipple {
   color: string;
-}  
-  
-/* 
- * Actual test cases using the previously defined definitions. 
- */  
- 
-class A implements OnInit {   
-
-  constructor(private a: MatRipple) {}  
-  
-  ngOnInit() {  
-    this.a.newColor = 'primary';
-  }  
 }
+ /*
+ * Actual test cases using the previously defined definitions.   
+ */
+ class A implements OnInit {
+ constructor(private a: MatRipple) {}
+  ngOnInit() {
+    this.a.newColor = 'primary';
+ } }
 ```
 
 **Note**: The `_input.ts` file will be just transformed by the V7 migrations and compared to the `_expected_output.ts` file. This means that it's necessary to also include the no longer valid mock declarations to the expected output file.
-
-


### PR DESCRIPTION
* Adds a new markdown file for the update schematic that explains how everything works, how new schematic upgrade data can be added, how test cases should be created.

**Note**: This is an initial document. We can add more in-depth examples in follow-up PRs. This should be enough for an initial version of the document