### PR TITLE
refactor(schematics): add test cases for method-calls and import checks

### DIFF
--- a/src/lib/schematics/update/test-cases/misc/constructor-checks.spec.ts
+++ b/src/lib/schematics/update/test-cases/misc/constructor-checks.spec.ts
@@ -3,7 +3,7 @@ import {runPostScheduledTasks} from '../../../test-setup/post-scheduled-tasks';
 import {migrationCollection} from '../../../test-setup/test-app';
 import {createTestAppWithTestCase, resolveBazelDataFile} from '../index.spec';
 
-describe('v5 constructor checks', () => {
+describe('constructor checks', () => {
 
   it('should properly report invalid constructor expression signatures', async () => {
     const inputPath = resolveBazelDataFile(`misc/constructor-checks_input.ts`);

--- a/src/lib/schematics/update/test-cases/misc/import-checks.spec.ts
+++ b/src/lib/schematics/update/test-cases/misc/import-checks.spec.ts
@@ -1,0 +1,24 @@
+import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import {runPostScheduledTasks} from '../../../test-setup/post-scheduled-tasks';
+import {migrationCollection} from '../../../test-setup/test-app';
+import {createTestAppWithTestCase, resolveBazelDataFile} from '../index.spec';
+
+describe('v6 import misc checks', () => {
+
+  it('should report imports for deleted animation constants', async () => {
+    const inputPath = resolveBazelDataFile(`misc/import-checks_input.ts`);
+    const runner = new SchematicTestRunner('schematics', migrationCollection);
+
+    runner.runSchematic('migration-01', {}, createTestAppWithTestCase(inputPath));
+
+    let output = '';
+    runner.logger.subscribe(entry => output += entry.message);
+
+    await runPostScheduledTasks(runner, 'tslint-fix').toPromise();
+
+    expect(output).toMatch(/Found deprecated symbol "SHOW_ANIMATION"/);
+    expect(output).toMatch(/Found deprecated symbol "HIDE_ANIMATION"/);
+  });
+});
+
+

--- a/src/lib/schematics/update/test-cases/misc/import-checks_input.ts
+++ b/src/lib/schematics/update/test-cases/misc/import-checks_input.ts
@@ -1,0 +1,3 @@
+import {SHOW_ANIMATION, HIDE_ANIMATION} from '@angular/material';
+
+console.log(SHOW_ANIMATION, HIDE_ANIMATION);

--- a/src/lib/schematics/update/test-cases/misc/method-call-checks.spec.ts
+++ b/src/lib/schematics/update/test-cases/misc/method-call-checks.spec.ts
@@ -1,0 +1,26 @@
+import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import {runPostScheduledTasks} from '../../../test-setup/post-scheduled-tasks';
+import {migrationCollection} from '../../../test-setup/test-app';
+import {createTestAppWithTestCase, resolveBazelDataFile} from '../index.spec';
+
+describe('v6 method call checks', () => {
+
+  it('should properly report invalid method calls', async () => {
+    const inputPath = resolveBazelDataFile(`misc/method-call-checks_input.ts`);
+    const runner = new SchematicTestRunner('schematics', migrationCollection);
+
+    runner.runSchematic('migration-01', {}, createTestAppWithTestCase(inputPath));
+
+    let output = '';
+    runner.logger.subscribe(entry => output += entry.message);
+
+    await runPostScheduledTasks(runner, 'tslint-fix').toPromise();
+
+    expect(output)
+      .toMatch(/\[15,.*Found call to "FocusMonitor\.monitor".*renderer.*has been removed/);
+    expect(output)
+      .toMatch(/\[16,.*Found call to "FocusMonitor\.monitor".*renderer.*has been removed/);
+  });
+});
+
+

--- a/src/lib/schematics/update/test-cases/misc/method-call-checks_input.ts
+++ b/src/lib/schematics/update/test-cases/misc/method-call-checks_input.ts
@@ -1,0 +1,18 @@
+import {AfterViewInit, ElementRef, Renderer2} from '@angular/core';
+
+class FocusMonitor {
+  monitor(_htmlElement: any, _renderer: Renderer2, _checkChildren: boolean) {}
+}
+
+class A implements AfterViewInit {
+  self = {a: this.focusMonitor};
+
+  constructor(private focusMonitor: FocusMonitor,
+              private elementRef: ElementRef,
+              private renderer: Renderer2) {}
+
+  ngAfterViewInit() {
+    this.focusMonitor.monitor(this.elementRef.nativeElement, this.renderer, true);
+    this.self.a.monitor(this.elementRef.nativeElement, this.renderer, true);
+  }
+}


### PR DESCRIPTION
* With the goal of having test cases for each type of source code transformation, this adds test cases for the `method-call checks` and `import-checks`.