### PR TITLE
refactor(schematics): separate constructor checks data

### DIFF
--- a/src/lib/schematics/update/material/data/constructor-checks.ts
+++ b/src/lib/schematics/update/material/data/constructor-checks.ts
@@ -6,33 +6,46 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TargetVersion} from '../../index';
+import {VersionChanges} from '../transform-change-data';
+
 /**
  * List of class names for which the constructor signature has been changed. The new constructor
  * signature types don't need to be stored here because the signature will be determined
  * automatically through type checking.
  */
-export const constructorChecks = [
-  // https://github.com/angular/material2/pull/9190
-  'NativeDateAdapter',
+export const constructorChecks: VersionChanges<string> = {
+  [TargetVersion.V7]: [
+    {
+      pr: 'https://github.com/angular/material2/pull/11706',
+      changes: ['MatDrawerContent'],
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/11706',
+      changes: ['MatSidenavContent']
+    }
+  ],
 
-  // https://github.com/angular/material2/pull/10319
-  'MatAutocomplete',
-
-  // https://github.com/angular/material2/pull/10344
-  'MatTooltip',
-
-  // https://github.com/angular/material2/pull/10389
-  'MatIconRegistry',
-
-  // https://github.com/angular/material2/pull/9775
-  'MatCalendar',
-
-  // TODO(devversion): The constructor check rule doesn't distinguish data based on the target
-  // TODO(devversion): version. Though it would be more readable to structure the data.
-
-  // https://github.com/angular/material2/pull/11706
-  'MatDrawerContent',
-
-  // https://github.com/angular/material2/pull/11706
-  'MatSidenavContent',
-];
+  [TargetVersion.V6]: [
+    {
+      pr: 'https://github.com/angular/material2/pull/9190',
+      changes: ['NativeDateAdapter'],
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/10319',
+      changes: ['MatAutocomplete'],
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/10344',
+      changes: ['MatTooltip'],
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/10389',
+      changes: ['MatIconRegistry'],
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/9775',
+      changes: ['MatCalendar'],
+    },
+  ]
+};

--- a/src/lib/schematics/update/material/transform-change-data.ts
+++ b/src/lib/schematics/update/material/transform-change-data.ts
@@ -35,3 +35,14 @@ export function getChangesForTarget<T>(target: TargetVersion, data: VersionChang
 
   return data[target]!.reduce((result, prData) => result.concat(prData.changes), [] as T[]);
 }
+
+/**
+ * Gets all changes from the specified version changes object. This is helpful in case a migration
+ * rule does not distinguish data based on the target version, but for readability the
+ * upgrade data is separated for each target version.
+ */
+export function getAllChanges<T>(data: VersionChanges<T>): T[] {
+  return Object.keys(data)
+    .map(targetVersion => getChangesForTarget(parseInt(targetVersion), data))
+    .reduce((result, versionData) => result.concat(versionData), []);
+}

--- a/src/lib/schematics/update/rules/signature-check/constructorSignatureCheckRule.ts
+++ b/src/lib/schematics/update/rules/signature-check/constructorSignatureCheckRule.ts
@@ -10,6 +10,7 @@ import {bold, green} from 'chalk';
 import {RuleFailure, Rules, WalkContext} from 'tslint';
 import * as ts from 'typescript';
 import {constructorChecks} from '../../material/data/constructor-checks';
+import {getAllChanges} from '../../material/transform-change-data';
 
 /**
  * List of diagnostic codes that refer to pre-emit diagnostics which indicate invalid
@@ -23,6 +24,9 @@ const signatureErrorDiagnostics = [
   // Constructor argument length invalid diagnostics
   2554, 2555, 2556, 2557,
 ];
+
+/** List of classes of which the constructor signature has changed. */
+const signatureChangedClasses = getAllChanges(constructorChecks);
 
 /**
  * Rule that visits every TypeScript new expression or super call and checks if the parameter
@@ -62,7 +66,7 @@ function visitSourceFile(context: WalkContext<null>, program: ts.Program) {
 
     // TODO(devversion): Consider handling pass-through classes better.
     // TODO(devversion): e.g. `export class CustomCalendar extends MatCalendar {}`
-    if (!constructorChecks.includes(className)) {
+    if (!signatureChangedClasses.includes(className)) {
       continue;
     }
 


### PR DESCRIPTION
* Resolves a `TODO` for the constructor checks data. To be consistent with the other upgrade data, the constructor checks data should be separated based on the target version.