### PR TITLE
refactor(schematics): properly handle inherited constructors for signature checks

### DIFF
--- a/src/lib/schematics/update/test-cases/misc/constructor-checks.spec.ts
+++ b/src/lib/schematics/update/test-cases/misc/constructor-checks.spec.ts
@@ -43,6 +43,9 @@ describe('constructor checks', () => {
 
     expect(output).toMatch(/Found "MatSidenavContent".*super.*: super\((any, ){4}any\)/);
     expect(output).toMatch(/Found "MatSidenavContent".*: new \w+\((any, ){4}any\)/);
+
+    expect(output).toMatch(/Found "ExtendedDateAdapter".*super.*: super\(string, Platform\)/);
+    expect(output).toMatch(/Found "ExtendedDateAdapter".*: new \w+\(string, Platform\)/);
   });
 });
 

--- a/src/lib/schematics/update/test-cases/misc/constructor-checks_input.ts
+++ b/src/lib/schematics/update/test-cases/misc/constructor-checks_input.ts
@@ -64,6 +64,8 @@ class MatSidenavContent {
                _ngZone: any) {}
 }
 
+class ExtendedDateAdapter extends NativeDateAdapter {}
+
 /* Actual test case using the previously defined definitions. */
 
 class A extends NativeDateAdapter {
@@ -127,3 +129,11 @@ class G extends MatSidenavContent {
 }
 
 const _G = new MatSidenavContent({}, 'container');
+
+class H extends ExtendedDateAdapter {
+  constructor() {
+    super('myLocale');
+  }
+}
+
+const _H = new ExtendedDateAdapter('myLocale');


### PR DESCRIPTION
* Currently if someone extends an Angular Material class of which the signature has changed and the constructor is inherited, the constructor signature checks rule won't report the breaking change because the rule does not properly handle the inherited constructor.
