### PR TITLE
build: replace deprecated tslint rule with compiler option

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -10,6 +10,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/cdk-experimental/tsconfig-build.json
+++ b/src/cdk-experimental/tsconfig-build.json
@@ -6,6 +6,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/dev-app/tsconfig-aot.json
+++ b/src/dev-app/tsconfig-aot.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/dev-app/tsconfig-build.json
+++ b/src/dev-app/tsconfig-build.json
@@ -8,6 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -96,8 +96,7 @@ export class MatButton extends _MatButtonMixinBase
                * @deprecated Platform checks for SSR are no longer needed
                * @breaking-change 8.0.0
                */
-              // tslint:disable-next-line:no-unused-variable
-              private _platform: Platform,
+              _platform: Platform,
               private _focusMonitor: FocusMonitor,
               // @breaking-change 8.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {

--- a/src/lib/schematics/tsconfig.json
+++ b/src/lib/schematics/tsconfig.json
@@ -7,6 +7,8 @@
     "noEmitOnError": false,
     "strictNullChecks": true,
     "skipDefaultLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "declaration": true,

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -8,6 +8,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/material-experimental/tsconfig-build.json
+++ b/src/material-experimental/tsconfig-build.json
@@ -6,6 +6,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/material-moment-adapter/tsconfig-build.json
+++ b/src/material-moment-adapter/tsconfig-build.json
@@ -8,6 +8,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -6,6 +6,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -5,6 +5,7 @@
     "stripInternal": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/tools/dgeni/tsconfig.json
+++ b/tools/dgeni/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "lib": ["es2015", "dom", "es2016.array.include"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "lib": ["es2015", "dom", "es2016.array.include"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,6 @@
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
     "no-debugger": true,
-    "no-unused-variable": true,
     "one-line": [
       true,
       "check-catch",


### PR DESCRIPTION
Removes the `no-unused-variable` tslint rule which has been logging out a deprecation warning, with the equivalent compiler option.