### PR TITLE
fix(form-field): blue box inside focused native select on IE

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -152,5 +152,15 @@ select.mat-input-element {
   [dir='rtl'] & {
     background-position: left center;
   }
+
+  // As a part of its user agent styling, IE11 has a blue box inside each focused
+  // `select` element which we have to reset. Note that this needs to be in its own
+  // selector, because having it together with another one will cause other browsers
+  // to ignore it.
+  &::-ms-value {
+    // We need to reset the `color` as well, because IE sets it to white.
+    color: inherit;
+    background: none;
+  }
 }
 


### PR DESCRIPTION
Resets the blue box that the user agent draws inside focused `select` elements in IE11.

For reference:
![angular_material_-_internet_explorer_2018-09-18_22-46-12](https://user-images.githubusercontent.com/4450522/45716700-f6362700-bb97-11e8-9f30-e4fd7d1608b1.png)
