### PR TITLE
fix(form-field): native select options blending in with dropdown background on a dark theme

### DIFF
--- a/src/lib/input/_input-theme.scss
+++ b/src/lib/input/_input-theme.scss
@@ -21,6 +21,21 @@
     @include input-placeholder {
       color: _mat-control-placeholder-color($theme);
     }
+
+    // On dark themes we set the native `select` color to some shade of white,
+    // however the color propagates to all of the `option` elements, which are
+    // always on a white background inside the dropdown, causing them to blend in.
+    // Since we can't change background of the dropdown, we need to explicitly
+    // reset the color of the options to something dark.
+    @if (map-get($theme, is-dark)) {
+      option {
+        color: $dark-primary-text;
+      }
+
+      option:disabled {
+        color: $dark-disabled-text;
+      }
+    }
   }
 
   .mat-accent .mat-input-element {


### PR DESCRIPTION
When we have a dark theme, we set the color of `select` to white which ends up propagating to the `option` elements, causing them to blend in with the background which is always white. These changes set the options explicitly to a dark color for dark themes.

For reference:
![angular_material_-_google_chrome_2018-09-19_22-24-13](https://user-images.githubusercontent.com/4450522/45780200-4dea9600-bc5d-11e8-9469-88d7e02c0e00.png)
