### PR TITLE
chore: fix checkbox lint warning

### DIFF
--- a/e2e/components/checkbox-e2e.spec.ts
+++ b/e2e/components/checkbox-e2e.spec.ts
@@ -1,4 +1,4 @@
-import {browser, by, element, Key, ExpectedConditions} from 'protractor';
+import {browser, by, element, Key} from 'protractor';
 
 describe('checkbox', () => {
 


### PR DESCRIPTION
Fixes an unused import that got into master.

**Note:** targeting major, because I think that it got introduced in the PR for the checkbox design changes.