### PR TITLE
fix(tabs): paginated header offset incorrect on IE

### DIFF
--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -328,6 +328,11 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     // and ripples will exceed the boundaries of the visible tab bar.
     // See: https://github.com/angular/material2/issues/10276
     this._tabList.nativeElement.style.transform = `translateX(${translateX}px)`;
+
+    // Setting the `transform` on IE will change the scroll offset of the parent, causing the
+    // position to be thrown off in some cases. We have to reset it ourselves to ensure that
+    // it doesn't get thrown off.
+    this._tabListContainer.nativeElement.scrollLeft = 0;
   }
 
   /** Sets the distance in pixels that the tab header should be transformed in the X-axis. */


### PR DESCRIPTION
Currently we position the paginated tab header items using a `transform` in order to be able to animate them. On IE setting the transform also ends up changing the scroll position of the parent element, causing the tab offset to be thrown off. These changes reset the scroll after setting the transform.

Fixes #13217.