### PR TITLE
fix(autocomplete): dividers in list throwing off keyboard navigation

### DIFF
--- a/src/lib/autocomplete/autocomplete.scss
+++ b/src/lib/autocomplete/autocomplete.scss
@@ -32,6 +32,12 @@ $mat-autocomplete-panel-border-radius: 4px !default;
     border-top-right-radius: $mat-autocomplete-panel-border-radius;
   }
 
+  // We need to offset horizontal dividers by their height, because
+  // they throw off the keyboard navigation inside the panel.
+  .mat-divider-horizontal {
+    margin-top: -1px;
+  }
+
   @include cdk-high-contrast {
     outline: solid 1px;
   }


### PR DESCRIPTION
Since we count on the options being a particular height, having 1px dividers between them ends up throwing off the keyboard navigation. These changes add an offset to the dividers to avoid the issue.

Fixes #13200.