### PR TITLE
fix(select): give native select a bigger clickable area

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -138,6 +138,9 @@ select.mat-input-element {
   background-color: transparent;
   display: inline-flex;
   box-sizing: border-box;
+  padding-top: 1em;
+  top: -1em;
+  margin-bottom: -1em;
 
   &::-ms-expand {
     display: none;


### PR DESCRIPTION
Add padding to let select catch the click in bigger area; move the select up to let the padding overlap with the existing label so they look the same. Give it a negative margin so the item below can move up.