### PR TITLE
fix(schematics): table schematic not expanding full width

### DIFF
--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
@@ -1,0 +1,3 @@
+.my-table {
+  width: 100%;
+}

--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
@@ -1,3 +1,3 @@
-.my-table {
+.full-width-table {
   width: 100%;
 }

--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -1,5 +1,5 @@
 <div class="mat-elevation-z8">
-  <table mat-table #table [dataSource]="dataSource" matSort aria-label="Elements">
+  <table mat-table [dataSource]="dataSource" matSort aria-label="Elements" class="my-table">
     <!-- Id Column -->
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Id</th>

--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -1,5 +1,5 @@
 <div class="mat-elevation-z8">
-  <table mat-table [dataSource]="dataSource" matSort aria-label="Elements" class="my-table">
+  <table mat-table class="full-width-table" [dataSource]="dataSource" matSort aria-label="Elements">
     <!-- Id Column -->
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Id</th>


### PR DESCRIPTION
Currently the `table` schematic generates a `<table>` element that does not expand to the available width. By default, we should expand to the full width. Similarly to every table example on our docs. This makes it easier to play with the table and also gives people a better first glance of a table.

Also currently it doesn't look that good (in perspective of layout) because the paginator expands to full width, but the table not.