### PR TITLE
Fix missing selector

### DIFF
--- a/src/material-examples/autocomplete-optgroup/autocomplete-optgroup-example.ts
+++ b/src/material-examples/autocomplete-optgroup/autocomplete-optgroup-example.ts
@@ -18,6 +18,7 @@ export const _filter = (opt: string[], value: string): string[] => {
  * @title Option groups autocomplete
  */
 @Component({
+  selector: 'autocomplete-optgroup-example',
   templateUrl: './autocomplete-optgroup-example.html',
   styleUrls: ['./autocomplete-optgroup-example.css'],
 })


### PR DESCRIPTION
Option groups autocomplete example here(https://material.angular.io/components/autocomplete/overview) on stackblitz (https://stackblitz.com/angular/dkblpjpqklq?file=app%2Fautocomplete-optgroup-example.ts) is missing a selector
selector: 'autocomplete-optgroup-example',

```
@Component({ 
  selector: 'autocomplete-optgroup-example', 
  templateUrl: './autocomplete-optgroup-example.html', 
  styleUrls: ['./autocomplete-optgroup-example.css'], })
```