### PR TITLE
fix(checkbox): no focus indicator in high contrast

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -240,6 +240,14 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   ._mat-animation-noopable & {
     transition: none;
   }
+
+  @include cdk-high-contrast {
+    // Note that we change the border style of the checkbox frame to dotted because this
+    // is how IE/Edge similarly treats native checkboxes in high contrast mode.
+    .mat-checkbox.cdk-keyboard-focused & {
+      border-style: dotted;
+    }
+  }
 }
 
 .mat-checkbox-background {


### PR DESCRIPTION
* Fixes that the checkbox does not have a focus indicator in high-contrast. Similarly to native checkboxes, the Material checkbox should have a dotted border/outline on keyboard focus.

Fixes #13227