### PR TITLE
chore(examples): disable user select in ripple-overview example

### DIFF
--- a/src/material-examples/ripple-overview/ripple-overview-example.css
+++ b/src/material-examples/ripple-overview/ripple-overview-example.css
@@ -5,6 +5,12 @@
   width: 300px;
   height: 300px;
   line-height: 300px;
+
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+
   -webkit-user-drag: none;
   -webkit-tap-highlight-color: transparent;
 }

--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -8,7 +8,10 @@
     "./tools/stylelint/no-top-level-ampersand-in-mixin/index.js"
   ],
   "rules": {
-    "material/no-prefixes": [["last 2 versions", "not ie <= 10", "not ie_mob <= 10"]],
+    "material/no-prefixes": [true, {
+      "browsers": ["last 2 versions", "not ie <= 10", "not ie_mob <= 10"],
+      "filePattern": "**/!(*-example.css)"
+    }],
     "material/selector-no-deep": true,
     "material/no-nested-mixin": true,
     "material/no-ampersand-beyond-selector-start": [true, {

--- a/tools/stylelint/no-prefixes/no-prefixes.js
+++ b/tools/stylelint/no-prefixes/no-prefixes.js
@@ -1,6 +1,7 @@
 const stylelint = require('stylelint');
 const NeedsPrefix = require('./needs-prefix');
 const parseSelector = require('stylelint/lib/utils/parseSelector');
+const minimatch = require('minimatch');
 
 const ruleName = 'material/no-prefixes';
 const messages =  stylelint.utils.ruleMessages(ruleName, {
@@ -14,9 +15,17 @@ const messages =  stylelint.utils.ruleMessages(ruleName, {
 /**
  * Stylelint plugin that warns for unprefixed CSS.
  */
-const plugin = stylelint.createPlugin(ruleName, browsers => {
+const plugin = stylelint.createPlugin(ruleName, (isEnabled, options) => {
   return (root, result) => {
-    if (!stylelint.utils.validateOptions(result, ruleName, {})) return;
+    if (!isEnabled || !stylelint.utils.validateOptions(result, ruleName, {})) {
+      return;
+    }
+
+    const {browsers, filePattern} = options;
+
+    if (filePattern && !minimatch(root.source.input.file, filePattern)) {
+      return;
+    }
 
     const needsPrefix = new NeedsPrefix(browsers);
 


### PR DESCRIPTION
* Since people often click on the ripple container of the example, we need to disable the user selection because otherwise the text will be accidentally selected.

* Disables the `no-prefixes` rule for example style files. The examples are not auto-prefixed and we don't want to show the `/** stylelint-disable` comments in the examples.
