### PR TITLE
build: stylelint should not check node_modules

### DIFF
--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -5,8 +5,11 @@ import {IMinimatch, Minimatch} from 'minimatch';
 import {join} from 'path';
 import {execNodeTask} from '../util/task_helpers';
 
-/** Glob that matches all SCSS or CSS files that should be linted. */
-const stylesGlob = '+(tools|src)/**/!(*.bundle).+(css|scss)';
+/** Globs that matchall SCSS or CSS files that should be linted. */
+const styleGlobs = [
+  'src/**/*.+(css|scss)',
+  'tools/dashboard/src/*.+(css|scss)',
+];
 
 /** List of flags that will passed to the different TSLint tasks. */
 const tsLintBaseFlags = ['-c', 'tslint.json', '--project', './tsconfig.json'];
@@ -21,7 +24,7 @@ task('lint', ['tslint', 'stylelint', 'ownerslint']);
 
 /** Task to lint Angular Material's scss stylesheets. */
 task('stylelint', execNodeTask(
-  'stylelint', [stylesGlob, '--config', 'stylelint-config.json', '--syntax', 'scss']
+  'stylelint', [...styleGlobs, '--config', 'stylelint-config.json', '--syntax', 'scss']
 ));
 
 /** Task to run TSLint against the e2e/ and src/ directories. */


### PR DESCRIPTION
* Currently, if someone runs `gulp stylelint` and has the dashboard node modules installed, stylelint will lint the `tools/dashboard/node_modules/`. This causes stylelint to report thousands of failures due to some minified CSS files in the `node_modules/`.