### PR TITLE
fix(chips): content not centered vertically on IE in some cases

### DIFF
--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -40,6 +40,11 @@ $mat-chip-remove-size: 18px;
   cursor: default;
   min-height: $mat-chip-min-height;
 
+  // Centering the content using flexbox won't work on IE, if we have
+  // a `min-height` without setting a `height`. This height won't do
+  // anything since it's less than the minimum set above.
+  height: 1px;
+
   .mat-chip-remove.mat-icon {
     width: $mat-chip-remove-size;
     height: $mat-chip-remove-size;


### PR DESCRIPTION
Fixes the chip content not being centered on IE when using a chip avatar. The issue comes from the fact that IE's centering doesn't work if the element has a `min-height`, but not a `height`.

For reference:
![angular_material_-_internet_explorer_2018-09-22_15-53-46](https://user-images.githubusercontent.com/4450522/45918350-eb281300-be85-11e8-9667-f2a122c65f7b.png)
