### PR TITLE
fix(stepper): vertical step header labels not centered on IE

### DIFF
--- a/src/lib/stepper/stepper.scss
+++ b/src/lib/stepper/stepper.scss
@@ -107,7 +107,9 @@ $mat-stepper-line-gap: 8px !default;
   display: flex;
   align-items: center;
   padding: $mat-stepper-side-gap;
-  max-height: $mat-stepper-label-header-height;
+
+  // We can't use `max-height` here, because it breaks the flexbox centering in IE.
+  height: $mat-stepper-label-header-height;
 
   .mat-step-icon {
     margin-right: $mat-vertical-stepper-content-margin - $mat-stepper-side-gap;


### PR DESCRIPTION
Fixes the step header circle labels not being completely centered in IE, because the step header only uses `max-height`.

For reference:
![angular_material_-_internet_explorer_2018-09-22_17-13-48](https://user-images.githubusercontent.com/4450522/45918903-b61fbe80-be8d-11e8-8734-58dcfc7a0105.png)
