### PR TITLE
fix(chips): invalid ripple color for selected chips

### DIFF
--- a/src/lib/chips/_chips-theme.scss
+++ b/src/lib/chips/_chips-theme.scss
@@ -5,10 +5,6 @@
 
 $mat-chip-remove-font-size: 18px;
 
-@mixin mat-chips-theme-color($color) {
-  @include mat-chips-color(mat-color($color, default-contrast), mat-color($color));
-}
-
 @mixin mat-chips-color($foreground, $background) {
   background-color: $background;
   color: $foreground;
@@ -20,6 +16,14 @@ $mat-chip-remove-font-size: 18px;
 
   .mat-chip-remove:hover {
     opacity: 0.54;
+  }
+}
+
+@mixin mat-chips-theme-color($palette) {
+  @include mat-chips-color(mat-color($palette, default-contrast), mat-color($palette));
+
+  .mat-ripple-element {
+    background: mat-color($palette, default-contrast, 0.1);
   }
 }
 


### PR DESCRIPTION
* In case a chip is selected and is solid colored, we need to make sure that the ripples have the proper color (similar to raised, flat and fab buttons)