### PR TITLE
fix(chips): disabled state not matching specs

### DIFF
--- a/src/demo-app/chips/chips-demo.html
+++ b/src/demo-app/chips/chips-demo.html
@@ -36,7 +36,7 @@
 
 
       <mat-chip-list>
-        <mat-chip>
+        <mat-chip disabled>
           <mat-icon matChipAvatar>home</mat-icon>
           Home
           <mat-icon matChipRemove>cancel</mat-icon>

--- a/src/lib/chips/_chips-theme.scss
+++ b/src/lib/chips/_chips-theme.scss
@@ -13,10 +13,6 @@ $mat-chip-remove-font-size: 18px;
     color: $foreground;
     opacity: 0.4;
   }
-
-  .mat-chip-remove:hover {
-    opacity: 0.54;
-  }
 }
 
 @mixin mat-chips-theme-color($palette) {
@@ -38,12 +34,21 @@ $mat-chip-remove-font-size: 18px;
   $unselected-background: mat-color($background, unselected-chip);
   $unselected-foreground: mat-color($foreground, text);
 
-
   .mat-chip.mat-standard-chip {
     @include mat-chips-color($unselected-foreground, $unselected-background);
 
-    &:focus {
-      @include _mat-theme-elevation(3, $theme);
+    &:not(.mat-chip-disabled) {
+      &:active {
+        @include _mat-theme-elevation(3, $theme);
+      }
+
+      .mat-chip-remove:hover {
+        opacity: 0.54;
+      }
+    }
+
+    &.mat-chip-disabled {
+      opacity: 0.4;
     }
   }
 

--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -76,16 +76,23 @@ $mat-chip-remove-size: 18px;
     }
   }
 
-  &:active {
-    @include mat-elevation(3);
-  }
-
   @include cdk-high-contrast {
     outline: solid 1px;
 
     &:focus {
       // Use 2px here since the dotted outline is a little thinner.
       outline: dotted 2px;
+    }
+  }
+
+  &.mat-chip-disabled {
+    &::after {
+      opacity: 0;
+    }
+
+    .mat-chip-remove,
+    .mat-chip-trailing-icon {
+      cursor: default;
     }
   }
 


### PR DESCRIPTION
* Currently if chips are disabled with the spec 2018 alignment, it's not clear whether a chip is disabled or not. The chip still has a focus effect, hover effect and pointer cursor for the `mat-chip-remove`.
* Also moves the `@include mat-elevation` to the theme (probably introduced before: https://github.com/angular/material2/pull/11344 has been merged)

