### PR TITLE
fix(snackbar): move elevation style to snackbar theme

### DIFF
--- a/src/lib/snack-bar/_snack-bar-theme.scss
+++ b/src/lib/snack-bar/_snack-bar-theme.scss
@@ -1,5 +1,6 @@
 @import '../core/typography/typography-utils';
 @import '../core/theming/palette';
+@import '../core/style/elevation';
 
 @mixin mat-snack-bar-theme($theme) {
   $is-dark-theme: map-get($theme, is-dark);
@@ -10,6 +11,8 @@
     // a secondary, because the contrast on the light primary text is poor.
     color: if($is-dark-theme, $dark-primary-text, $light-secondary-text);
     background: if($is-dark-theme, map-get($mat-grey, 50), #323232);
+
+    @include _mat-theme-elevation(6, $theme);
   }
 
   .mat-simple-snackbar-action {

--- a/src/lib/snack-bar/snack-bar-container.scss
+++ b/src/lib/snack-bar/snack-bar-container.scss
@@ -1,5 +1,4 @@
 @import '../../cdk/a11y/a11y';
-@import '../core/style/elevation';
 
 $mat-snack-bar-padding: 14px 16px !default;
 $mat-snack-bar-min-height: 48px !default;
@@ -10,7 +9,6 @@ $mat-snack-bar-spacing-margin-handset: 8px !default;
 
 
 .mat-snack-bar-container {
-  @include mat-elevation(6);
   border-radius: 4px;
   box-sizing: border-box;
   display: block;


### PR DESCRIPTION
* Fixes a remaining elevation style which is not created inside of the theme. (related to: https://github.com/angular/material2/pull/11344)