### PR TITLE
build: livereload not working for core/theming files

### DIFF
--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -133,9 +133,15 @@ task(':watch:devapp', () => {
   // CDK package watchers.
   watchFiles(join(cdkPackage.sourceDir, '**/*'), ['cdk:build-no-bundles']);
 
+  const materialCoreThemingGlob = join(materialPackage.sourceDir, '**/core/theming/**/*.scss');
+
   // Material package watchers.
-  watchFiles(join(materialPackage.sourceDir, '**/!(*-theme.scss)'), ['material:build-no-bundles']);
-  watchFiles(join(materialPackage.sourceDir, '**/*-theme.scss'), [':build:devapp:scss']);
+  watchFiles([
+    join(materialPackage.sourceDir, '**/!(*-theme.scss)'), `!${materialCoreThemingGlob}`
+  ], ['material:build-no-bundles']);
+  watchFiles([
+    join(materialPackage.sourceDir, '**/*-theme.scss'), materialCoreThemingGlob
+  ], [':build:devapp:scss']);
 
   // Moment adapter package watchers
   watchFiles(join(momentAdapterPackage.sourceDir, '**/*'),


### PR DESCRIPTION
* Since most of the SCSS files inside of `core/theming` are not suffixed with `-theme.scss`, the livereload will rebuild the Material bundles, but not the theme SCSS files. This causes undesired slow-down and a non-working livereload.