### PR TITLE
fix(drag-drop): error on IE when customizing root element

### DIFF
--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -670,10 +670,13 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
   /** Gets the root draggable element, based on the `rootElementSelector`. */
   private _getRootElement(): HTMLElement {
     if (this.rootElementSelector) {
+      const selector = this.rootElementSelector;
       let currentElement = this.element.nativeElement.parentElement as HTMLElement | null;
 
       while (currentElement) {
-        if (currentElement.matches(this.rootElementSelector)) {
+        // IE doesn't support `matches` so we have to fall back to `msMatchesSelector`.
+        if (currentElement.matches ? currentElement.matches(selector) :
+            currentElement.msMatchesSelector(selector)) {
           return currentElement;
         }
 


### PR DESCRIPTION
Fixes an error being thrown on IE when the root element is customized. The error comes from the fact that IE doesn't support `Element.prototype.matches`, but it does support `msMatchesSelector`.