### PR TITLE
fix(schematics): sidenav toolbar should use default background

### DIFF
--- a/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
+++ b/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
@@ -6,6 +6,10 @@
   width: 200px;
 }
 
+.sidenav .mat-toolbar {
+  background: inherit;
+}
+
 .mat-toolbar.mat-primary {
   position: sticky;
   top: 0;

--- a/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -6,7 +6,7 @@
     [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
     [mode]="(isHandset$ | async) ? 'over' : 'side'"
     [opened]="!(isHandset$ | async)">
-    <mat-toolbar color="primary">Menu</mat-toolbar>
+    <mat-toolbar>Menu</mat-toolbar>
     <mat-nav-list>
       <a mat-list-item href="#">Link 1</a>
       <a mat-list-item href="#">Link 2</a>


### PR DESCRIPTION
it should also have a bottom border rather than elevation

Spec:
![mio-design_assets_11lvr4y0v_yjj1pqoggxwfx0rius2irmu_standard-behavior-visibility-permanent](https://user-images.githubusercontent.com/3506071/45931515-0ace4280-bf3d-11e8-96d1-0cae2dda33e4.png)

Before:
![screen shot 2018-09-22 at 9 15 05 pm](https://user-images.githubusercontent.com/3506071/45931464-85e32900-bf3c-11e8-8698-01f50f859e95.png)

After:
![screen shot 2018-09-23 at 2 27 50 pm](https://user-images.githubusercontent.com/3506071/45931505-f5f1af00-bf3c-11e8-81c5-62c2f5c9d0b7.png)
