### PR TITLE
fix(slide-toggle): no focus indication in high-contrast mode

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -240,6 +240,14 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
 
   .mat-slide-toggle-bar {
     background: #fff;
+
+    // As a focus indication in high contrast mode, we add a dotted outline to the slide-toggle
+    // bar. Since the bar element does not have any padding, we need to specify an outline offset
+    // because otherwise the opaque thumb element will hide the outline.
+    .mat-slide-toggle.cdk-keyboard-focused & {
+      outline: 1px dotted;
+      outline-offset: ($mat-slide-toggle-height - $mat-slide-toggle-bar-height) / 2;
+    }
   }
 }
 


### PR DESCRIPTION
* Fixes that the slide-toggle does not have any visible focus indication in high contrast mode.