### PR TITLE
fix(checkbox): ripple not hiding after click/touch

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -266,7 +266,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     opacity: 0.04;
   }
 
-  .mat-checkbox.cdk-focused & {
+  .mat-checkbox.cdk-keyboard-focused & {
     opacity: 0.12;
   }
 


### PR DESCRIPTION
* Currently if someone toggles the slide-toggle through mouse interaction, the persistent ripple will show up besides one transient ripple. The persistent ripple should only show up if the native checkbox element was focused through keyboard.

https://storage.googleapis.com/spec-host-backup/mio-design%2Fassets%2F1hEITxP1I5Tw8pjtU4ALuto7EzjFoZJwl%2Fslidercontrols-parent-child-v03.mp4

Fixes #13291