### PR TITLE
fix(form-field): always use native input value to determine whether control is empty

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -332,7 +332,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
 
   /** Does some manual dirty checking on the native input `value` property. */
   protected _dirtyCheckNativeValue() {
-    const newValue = this.value;
+    const newValue = this._elementRef.nativeElement.value;
 
     if (this._previousNativeValue !== newValue) {
       this._previousNativeValue = newValue;


### PR DESCRIPTION
Currently we use the input value accessor to figure out whether an input has a value. This doesn't handle the case with `matDatepicker` where we have a custom accessor whose model value may not change, even though the value in the input has changed. These changes switch to always using the value from the input element.

Fixes #13305.