### PR TITLE
build: fix schematics TS errors

### DIFF
--- a/src/lib/schematics/tsconfig.json
+++ b/src/lib/schematics/tsconfig.json
@@ -16,7 +16,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@angular/cdk/schematics": ["../../../dist/packages/cdk/schematics/"]
+      "@angular/cdk/schematics": ["../../cdk/schematics/"]
     }
   },
   "exclude": [
@@ -26,7 +26,7 @@
     // Exclude template files that will be copied by the schematics. Those are not valid TS.
     "*/files/**/*",
     // Exclude all test-case files because those should not be included in the schematics output.
-    "update/test-cases/**/*"
+    "ng-update/test-cases/**/*"
   ],
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true


### PR DESCRIPTION
Fixes some TS errors being logged out when building the schematics due to an outdated path in the `exclude` and an incorrect mapping in the `paths`.