### PR TITLE
build: ts compilation not reporting failures

### DIFF
--- a/tools/package-tools/ts-compile.ts
+++ b/tools/package-tools/ts-compile.ts
@@ -16,6 +16,8 @@ export function tsCompile(binary: 'tsc' | 'ngc', flags: string[]) {
     // Pipe stdout and stderr from the child process.
     childProcess.stdout.on('data', (data: string|Buffer) => console.log(`${data}`));
     childProcess.stderr.on('data', (data: string|Buffer) => console.error(red(`${data}`)));
-    childProcess.on('exit', (exitCode: number) => exitCode === 0 ? resolve() : reject());
+    childProcess.on('exit', (exitCode: number) => {
+      exitCode === 0 ? resolve() : reject(`${binary} compilation failure`);
+    });
   });
 }


### PR DESCRIPTION
* Currently if the TS compilation (either through `ngc` or `tsc`) fails, the gulp tasks won't report the error properly because the `reject()` call of the Promise does not have any error message. This causes compilation failures to be ignored. See: #13310 

**Note**: Should be merged after #13310 has been merged.