### PR TITLE
fix(form-field): native date/time input taller than text input

### DIFF
--- a/src/lib/input/input.scss
+++ b/src/lib/input/input.scss
@@ -76,6 +76,14 @@
     }
   }
 
+  // Reduce the size of the native buttons in a date/time input,
+  // because they can increase the height of the input (see #13317).
+  &::-webkit-inner-spin-button,
+  &::-webkit-calendar-picker-indicator,
+  &::-webkit-clear-button {
+    font-size: 0.75em;
+  }
+
   @include input-placeholder {
     // Delay the transition until the label has animated about a third of the way through, in
     // order to prevent the placeholder from overlapping for a split second.


### PR DESCRIPTION
Fixes the `type="date"` and `type="time"` inputs inside a form field making the field taller than a `type="input"`.

Fixes #13317.