### PR TITLE
fix(list): set aria-multiselectable on selection list

### DIFF
--- a/src/lib/list/selection-list.spec.ts
+++ b/src/lib/list/selection-list.spec.ts
@@ -431,6 +431,11 @@ describe('MatSelectionList without forms', () => {
 
       expect(item.selected).toBe(true);
     });
+
+    it('should set aria-multiselectable to true on the selection list element', () => {
+      expect(selectionList.nativeElement.getAttribute('aria-multiselectable')).toBe('true');
+    });
+
   });
 
   describe('with list option selected', () => {

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -264,6 +264,7 @@ export class MatListOption extends _MatListOptionMixinBase
     '(focus)': 'focus()',
     '(blur)': '_onTouched()',
     '(keydown)': '_keydown($event)',
+    'aria-multiselectable': 'true',
     '[attr.aria-disabled]': 'disabled.toString()',
   },
   template: '<ng-content></ng-content>',


### PR DESCRIPTION
The `mat-selection-list` is set up as a listbox, however we never set `aria-multiselectable`, which means that the element is assumed to be single selection. These changes add `aria-multiselectable="true"` since selection lists are always multi-selection.