### PR TITLE
refactor(schematics): rename migration entry-points

### DIFF
--- a/src/lib/schematics/migration.json
+++ b/src/lib/schematics/migration.json
@@ -1,12 +1,12 @@
 {
   "$schema": "./node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
-    "migration-01": {
+    "migration-v6": {
       "version": "6",
       "description": "Updates Angular Material to v6",
       "factory": "./ng-update/index#updateToV6"
     },
-    "migration-02": {
+    "migration-v7": {
       "version": "7",
       "description": "Updates Angular Material to v7",
       "factory": "./ng-update/index#updateToV7"

--- a/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
@@ -3,7 +3,7 @@ import {resolveBazelDataFile, runTestCases} from '../index.spec';
 describe('constructor checks', () => {
 
   it('should properly report invalid constructor expression signatures', async () => {
-    const {logOutput} = await runTestCases('migration-01', {
+    const {logOutput} = await runTestCases('migration-v6', {
       'constructor-checks': resolveBazelDataFile(`misc/constructor-checks_input.ts`)
     });
 

--- a/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
@@ -3,7 +3,7 @@ import {resolveBazelDataFile, runTestCases} from '../index.spec';
 describe('v6 import misc checks', () => {
 
   it('should report imports for deleted animation constants', async () => {
-    const {logOutput} = await runTestCases('migration-01', {
+    const {logOutput} = await runTestCases('migration-v6', {
       'import-checks': resolveBazelDataFile(`misc/import-checks_input.ts`)
     });
 

--- a/src/lib/schematics/ng-update/test-cases/misc/method-call-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/method-call-checks.spec.ts
@@ -3,7 +3,7 @@ import {resolveBazelDataFile, runTestCases} from '../index.spec';
 describe('v6 method call checks', () => {
 
   it('should properly report invalid method calls', async () => {
-    const {logOutput} = await runTestCases('migration-01', {
+    const {logOutput} = await runTestCases('migration-v6', {
       'method-call-checks': resolveBazelDataFile(`misc/method-call-checks_input.ts`)
     });
 

--- a/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
@@ -25,7 +25,7 @@ describe('v6 upgrade test cases', () => {
       return inputs;
     }, {});
 
-    const {tempPath} = await runTestCases('migration-01', testCaseInputs);
+    const {tempPath} = await runTestCases('migration-v6', testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/material/src/test-cases/');
   });

--- a/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
@@ -20,7 +20,7 @@ describe('v7 upgrade test cases', () => {
       return inputs;
     }, {});
 
-    const {tempPath} = await runTestCases('migration-02', testCaseInputs);
+    const {tempPath} = await runTestCases('migration-v7', testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/material/src/test-cases/');
   });


### PR DESCRIPTION
* In favor of consistency, we should rename the migration entry-points for Material similarly to the CDK migration entry-points. Also `migration-01` and `migration-01` is pretty much saying nothing about what it does.