### PR TITLE
build: cache bazel managed node modules

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -1,0 +1,7 @@
+# Bazel configuration that will be copied to /etc/bazel.bazelrc in CircleCI containers.
+# This allows us adding specific configuration flags for builds within CircleCI.
+# See more: https://docs.bazel.build/versions/master/user-manual.html#where-are-the-bazelrc-files
+
+# Save downloaded repositories in a location that can be cached by CircleCI. This helps us
+# speeding up the analysis time with Bazel managed node dependencies significantly on the CI.
+build --experimental_repository_cache=/home/circleci/bazel_repository_cache

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -3,5 +3,5 @@
 # See more: https://docs.bazel.build/versions/master/user-manual.html#where-are-the-bazelrc-files
 
 # Save downloaded repositories in a location that can be cached by CircleCI. This helps us
-# speeding up the analysis time with Bazel managed node dependencies significantly on the CI.
+# speeding up the analysis time significantly with Bazel managed node dependencies on the CI.
 build --experimental_repository_cache=/home/circleci/bazel_repository_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
           <<: *post_checkout
       - restore_cache:
           key: *cache_key
+      # Set up the CircleCI specific bazel configuration.
+      - run: sudo cp ./.circleci/bazel.rc /etc/bazel.bazelrc
 
       # TODO(jelbourn): Update this command to run all tests if the Bazel issues have been fixed.
       - run: bazel test src/{cdk,lib}/schematics:unit_tests
@@ -52,6 +54,7 @@ jobs:
           key: *cache_key
           paths:
             - "node_modules"
+            - "~/bazel_repository_cache"
 
 workflows:
   version: 2


### PR DESCRIPTION
* Since we recently switched to Bazel managed dependencies, we need to cache the repository cache of our workspace because otherwise CircleCI will analyze the Bazel managed dependencies for each run (which takes multiple minutes)