### PR TITLE
docs(drag-drop): fix cross-browser inconsistencies in demos

### DIFF
--- a/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
+++ b/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
@@ -7,6 +7,7 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
   background: #fff;
   border-radius: 4px;
   margin-right: 25px;

--- a/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
+++ b/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
@@ -30,4 +30,6 @@
   right: 10px;
   color: #ccc;
   cursor: move;
+  width: 24px;
+  height: 24px;
 }

--- a/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
+++ b/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
@@ -7,6 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
   background: #fff;
   border-radius: 4px;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);


### PR DESCRIPTION
Fixes the text in the drag&drop demos not being centered horizontally on some browsers, as well as the handle being too tall on IE11.