### PR TITLE
fix(chips): start focus from first selected chip

### DIFF
--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -127,6 +127,29 @@ describe('MatChipList', () => {
         expect(manager.activeItemIndex).toBe(0);
       });
 
+      it('should focus the first selected chip, if any', () => {
+        chips.toArray()[2].selected = true;
+        fixture.detectChanges();
+
+        chipListInstance.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(2);
+      });
+
+      it('should not focus the selected chip, if it is disabled', () => {
+        const thirdChip = chips.toArray()[2];
+
+        thirdChip.disabled = true;
+        thirdChip.selected = true;
+        fixture.detectChanges();
+
+        chipListInstance.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(0);
+      });
+
       it('should watch for chip focus', () => {
         let array = chips.toArray();
         let lastIndex = array.length - 1;

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -448,16 +448,16 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
    * are no eligible chips.
    */
   focus(): void {
-    if (this.disabled) {
+    if (this.disabled || (this._chipInput && this._chipInput.focused)) {
       return;
     }
 
-    // TODO: ARIA says this should focus the first `selected` chip if any are selected.
-    // Focus on first element if there's no chipInput inside chip-list
-    if (this._chipInput && this._chipInput.focused) {
-      // do nothing
-    } else if (this.chips.length > 0) {
-      this._keyManager.setFirstItemActive();
+    // Focus the first selected and enabled chip, otherwise fall back to focusing the first chip.
+    if (this.chips.length > 0) {
+      const manager = this._keyManager;
+      const selectedChip = this.chips.find(chip => chip.selected && !chip.disabled);
+
+      selectedChip ? manager.setActiveItem(selectedChip) : manager.setFirstItemActive();
       this.stateChanges.next();
     } else {
       this._focusInput();


### PR DESCRIPTION
Currently when focus lands on a chip list, it always gets forwarded to the first chip. These changes switch to starting focus from the first selected chip instead and falling back to the first chip if there are no selected ones.