### PR TITLE
fix(button-toggle): remove extra focus indication added by firefox

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -151,4 +151,9 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   .mat-button-toggle-disabled & {
     cursor: default;
   }
+
+  // Remove the extra focus outline that is added by Firefox on native buttons.
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }


### PR DESCRIPTION
Resets the extra focus indication that Firefox adds on top of our custom indication.

For reference:
![angular_material_-_mozilla_firefox_2018-09-30_18-31-05](https://user-images.githubusercontent.com/4450522/46259905-aa607780-c4df-11e8-9d11-97ed47cc28f2.png)
