### PR TITLE
fix(schematics): proper error if name is not specified

### DIFF
--- a/src/lib/schematics/address-form/index.spec.ts
+++ b/src/lib/schematics/address-form/index.spec.ts
@@ -40,6 +40,12 @@ describe('Material address-form schematic', () => {
     expect(moduleContent).toContain('ReactiveFormsModule');
   });
 
+  it('should throw if no name has been specified', () => {
+    expect(() => {
+      runner.runSchematic('address-form', {project: 'material'}, createTestApp(runner));
+    }).toThrowError(/required property 'name'/);
+  });
+
   describe('styleext option', () => {
     it('should respect the option value', () => {
       const tree = runner.runSchematic(
@@ -48,7 +54,7 @@ describe('Material address-form schematic', () => {
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'address-form', baseOptions, createTestApp(runner, {style: 'less'}));
 
@@ -64,7 +70,7 @@ describe('Material address-form schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'address-form', baseOptions, createTestApp(runner, {inlineStyle: true}));
 
@@ -80,7 +86,7 @@ describe('Material address-form schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'address-form', baseOptions, createTestApp(runner, {inlineTemplate: true}));
 
@@ -96,7 +102,7 @@ describe('Material address-form schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'address-form', baseOptions, createTestApp(runner, {skipTests: true}));
 

--- a/src/lib/schematics/address-form/schema.json
+++ b/src/lib/schematics/address-form/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }

--- a/src/lib/schematics/dashboard/index.spec.ts
+++ b/src/lib/schematics/dashboard/index.spec.ts
@@ -44,6 +44,12 @@ describe('material-dashboard-schematic', () => {
       `import { MatGridListModule, MatCardModule, MatMenuModule, MatIconModule, MatButtonModule } from '@angular/material';`);
   });
 
+  it('should throw if no name has been specified', () => {
+    expect(() => {
+      runner.runSchematic('dashboard', {project: 'material'}, createTestApp(runner));
+    }).toThrowError(/required property 'name'/);
+  });
+
   describe('styleext option', () => {
     it('should respect the option value', () => {
       const tree = runner.runSchematic(
@@ -52,7 +58,7 @@ describe('material-dashboard-schematic', () => {
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'dashboard', baseOptions, createTestApp(runner, {style: 'less'}));
 
@@ -68,7 +74,7 @@ describe('material-dashboard-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'dashboard', baseOptions, createTestApp(runner, {inlineStyle: true}));
 
@@ -84,7 +90,7 @@ describe('material-dashboard-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'dashboard', baseOptions, createTestApp(runner, {inlineTemplate: true}));
 
@@ -100,7 +106,7 @@ describe('material-dashboard-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'dashboard', baseOptions, createTestApp(runner, {skipTests: true}));
 

--- a/src/lib/schematics/dashboard/schema.json
+++ b/src/lib/schematics/dashboard/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }

--- a/src/lib/schematics/nav/index.spec.ts
+++ b/src/lib/schematics/nav/index.spec.ts
@@ -46,6 +46,12 @@ describe('material-nav-schematic', () => {
       `MatListModule } from '@angular/material';`);
   });
 
+  it('should throw if no name has been specified', () => {
+    expect(() => {
+      runner.runSchematic('nav', {project: 'material'}, createTestApp(runner));
+    }).toThrowError(/required property 'name'/);
+  });
+
   describe('styleext option', () => {
     it('should respect the option value', () => {
       const tree = runner.runSchematic(
@@ -54,7 +60,7 @@ describe('material-nav-schematic', () => {
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'nav', baseOptions, createTestApp(runner, {style: 'less'}));
 
@@ -70,7 +76,7 @@ describe('material-nav-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'nav', baseOptions, createTestApp(runner, {inlineStyle: true}));
 
@@ -86,7 +92,7 @@ describe('material-nav-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'nav', baseOptions, createTestApp(runner, {inlineTemplate: true}));
 
@@ -102,7 +108,7 @@ describe('material-nav-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'nav', baseOptions, createTestApp(runner, {skipTests: true}));
 

--- a/src/lib/schematics/nav/schema.json
+++ b/src/lib/schematics/nav/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }

--- a/src/lib/schematics/table/index.spec.ts
+++ b/src/lib/schematics/table/index.spec.ts
@@ -53,6 +53,12 @@ describe('material-table-schematic', () => {
       `import { MatTableModule, MatPaginatorModule, MatSortModule } from '@angular/material';`);
   });
 
+  it('should throw if no name has been specified', () => {
+    expect(() => {
+      runner.runSchematic('table', {project: 'material'}, createTestApp(runner));
+    }).toThrowError(/required property 'name'/);
+  });
+
   describe('styleext option', () => {
     it('should respect the option value', () => {
       const tree = runner.runSchematic(
@@ -61,7 +67,7 @@ describe('material-table-schematic', () => {
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'table', baseOptions, createTestApp(runner, {style: 'less'}));
 
@@ -77,7 +83,7 @@ describe('material-table-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'table', baseOptions, createTestApp(runner, {inlineStyle: true}));
 
@@ -93,7 +99,7 @@ describe('material-table-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'table', baseOptions, createTestApp(runner, {inlineTemplate: true}));
 
@@ -109,7 +115,7 @@ describe('material-table-schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'table', baseOptions, createTestApp(runner, {skipTests: true}));
 

--- a/src/lib/schematics/table/schema.json
+++ b/src/lib/schematics/table/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }

--- a/src/lib/schematics/tree/index.spec.ts
+++ b/src/lib/schematics/tree/index.spec.ts
@@ -38,6 +38,12 @@ describe('Material tree schematic', () => {
     expect(moduleContent).toContain('MatButtonModule');
   });
 
+  it('should throw if no name has been specified', () => {
+    expect(() => {
+      runner.runSchematic('tree', {project: 'material'}, createTestApp(runner));
+    }).toThrowError(/required property 'name'/);
+  });
+
   describe('styleext option', () => {
     it('should respect the option value', () => {
       const tree = runner.runSchematic(
@@ -46,7 +52,7 @@ describe('Material tree schematic', () => {
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'tree', baseOptions, createTestApp(runner, {style: 'less'}));
 
@@ -62,7 +68,7 @@ describe('Material tree schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'tree', baseOptions, createTestApp(runner, {inlineStyle: true}));
 
@@ -78,7 +84,7 @@ describe('Material tree schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'tree', baseOptions, createTestApp(runner, {inlineTemplate: true}));
 
@@ -94,7 +100,7 @@ describe('Material tree schematic', () => {
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
-    it('should fallback to the @schematics/angular:component option value', () => {
+    it('should fall back to the @schematics/angular:component option value', () => {
       const tree = runner.runSchematic(
           'tree', baseOptions, createTestApp(runner, {skipTests: true}));
 

--- a/src/lib/schematics/tree/schema.json
+++ b/src/lib/schematics/tree/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }


### PR DESCRIPTION
Currently if someone doesn't specify a name when running ´ng generate`, a bad runtime exception shows up.

This makes the `name` required. Similar to the `@schematics/angular:component` schematic.