### PR TITLE
refactor: add support for noImplicitAny

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1546,6 +1546,55 @@
         "@types/vinyl": "*"
       }
     },
+    "@types/gulp-util": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@types/gulp-util/-/gulp-util-3.0.34.tgz",
+      "integrity": "sha512-E06WN1OfqL5UsMwJ1T7ClgnaXgaPipb7Ee8euMc3KRHLNqxdvWrDir9KA6uevgzBgT7XbjgmzZA2pkzDqBBX7A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/through2": "*",
+        "@types/vinyl": "*",
+        "chalk": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@types/hammerjs": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
@@ -1649,6 +1698,15 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.10.tgz",
       "integrity": "sha512-ikB0JHv6vCR1KYUQAzTO4gi/lXLElT4Tx+6De2pc/OZwizE9LRNiTa+U8TBFKBD/nntPnr/MPSHSnOTybjhqNA==",
       "dev": true
+    },
+    "@types/through2": {
+      "version": "2.0.34",
+      "resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.34.tgz",
+      "integrity": "sha512-nhRG8+RuG/L+0fAZBQYaRflXKjTrHOKH8MFTChnf+dNVMxA3wHYYrfj0tztK0W51ABXjGfRCDc0vRkecCOrsow==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "2.3.3",
@@ -5496,7 +5554,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "optional": true,
@@ -7510,25 +7568,25 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "resolved": false,
               "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "resolved": false,
               "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "requires": {
@@ -7538,13 +7596,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "requires": {
@@ -7554,37 +7612,37 @@
             },
             "chownr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "resolved": false,
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
               "requires": {
@@ -7593,25 +7651,25 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "resolved": false,
               "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "resolved": false,
               "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "dev": true,
               "requires": {
@@ -7620,13 +7678,13 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "resolved": false,
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "requires": {
@@ -7642,7 +7700,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "resolved": false,
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "requires": {
@@ -7656,13 +7714,13 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "resolved": false,
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "requires": {
@@ -7671,7 +7729,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "requires": {
@@ -7680,7 +7738,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": false,
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
@@ -7690,19 +7748,19 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "resolved": false,
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
@@ -7711,13 +7769,13 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
@@ -7726,13 +7784,13 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             },
             "minipass": {
               "version": "2.3.4",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+              "resolved": false,
               "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
               "dev": true,
               "requires": {
@@ -7742,7 +7800,7 @@
             },
             "minizlib": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
               "dev": true,
               "requires": {
@@ -7751,7 +7809,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
@@ -7760,7 +7818,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": false,
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
@@ -7768,13 +7826,13 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             },
             "needle": {
               "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.3.tgz",
+              "resolved": false,
               "integrity": "sha512-GPL22d/U9cai87FcCPO6e+MT3vyHS2j+zwotakDc7kE2DtUAqFKMXLJCTtRp+5S75vXIwQPvIxkvlctxf9q4gQ==",
               "dev": true,
               "requires": {
@@ -7785,7 +7843,7 @@
             },
             "node-pre-gyp": {
               "version": "0.10.3",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+              "resolved": false,
               "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
               "dev": true,
               "requires": {
@@ -7803,7 +7861,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "requires": {
@@ -7813,13 +7871,13 @@
             },
             "npm-bundled": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+              "resolved": false,
               "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
               "dev": true
             },
             "npm-packlist": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
+              "resolved": false,
               "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
               "dev": true,
               "requires": {
@@ -7829,7 +7887,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "requires": {
@@ -7841,19 +7899,19 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
@@ -7862,19 +7920,19 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "resolved": false,
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "requires": {
@@ -7884,13 +7942,13 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "dev": true
             },
@@ -7908,7 +7966,7 @@
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "resolved": false,
               "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "requires": {
@@ -7920,7 +7978,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": false,
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -7935,7 +7993,7 @@
             },
             "rimraf": {
               "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "resolved": false,
               "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
               "dev": true,
               "requires": {
@@ -7944,43 +8002,43 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "resolved": false,
               "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true
             },
             "semver": {
               "version": "5.5.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+              "resolved": false,
               "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
               "dev": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true
             },
             "signal-exit": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -7991,7 +8049,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": false,
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -8000,7 +8058,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
@@ -8009,13 +8067,13 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true
             },
             "tar": {
               "version": "4.4.6",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+              "resolved": false,
               "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
               "dev": true,
               "requires": {
@@ -8030,13 +8088,13 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "resolved": false,
               "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "requires": {
@@ -8045,13 +8103,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "yallist": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
               "dev": true
             }
@@ -8265,13 +8323,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "resolved": false,
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
@@ -8283,19 +8341,19 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
@@ -8305,43 +8363,43 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "resolved": false,
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "resolved": false,
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "resolved": false,
           "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
@@ -8351,7 +8409,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "resolved": false,
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
@@ -8360,7 +8418,7 @@
         },
         "boom": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "resolved": false,
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
@@ -8369,7 +8427,7 @@
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "resolved": false,
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
@@ -8379,25 +8437,25 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "resolved": false,
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "resolved": false,
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
@@ -8406,25 +8464,25 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "resolved": false,
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
@@ -8433,7 +8491,7 @@
           "dependencies": {
             "boom": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
@@ -8444,7 +8502,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "resolved": false,
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
@@ -8453,7 +8511,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -8462,31 +8520,31 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "resolved": false,
           "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
@@ -8496,37 +8554,37 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "resolved": false,
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "resolved": false,
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "resolved": false,
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
@@ -8537,13 +8595,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "resolved": false,
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
@@ -8555,7 +8613,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "resolved": false,
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "requires": {
@@ -8566,7 +8624,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
@@ -8582,7 +8640,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "resolved": false,
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
@@ -8591,7 +8649,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -8605,19 +8663,19 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": false,
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "dev": true
         },
         "har-validator": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
@@ -8627,13 +8685,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hawk": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "resolved": false,
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
@@ -8645,13 +8703,13 @@
         },
         "hoek": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
           "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
@@ -8662,7 +8720,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -8672,19 +8730,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -8693,50 +8751,50 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "resolved": false,
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "resolved": false,
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "resolved": false,
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
@@ -8748,13 +8806,13 @@
         },
         "mime-db": {
           "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "resolved": false,
           "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "resolved": false,
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
@@ -8763,7 +8821,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -8772,13 +8830,13 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -8787,7 +8845,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
@@ -8795,13 +8853,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "node-pre-gyp": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.7.0.tgz",
+          "resolved": false,
           "integrity": "sha1-Va7/uu2TtQ0KRlfUaRmM2ArJ3zY=",
           "dev": true,
           "requires": {
@@ -8819,7 +8877,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
@@ -8829,7 +8887,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
@@ -8841,25 +8899,25 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "resolved": false,
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -8868,19 +8926,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
@@ -8890,37 +8948,37 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qs": {
           "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "resolved": false,
           "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         },
         "rc": {
           "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+          "resolved": false,
           "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
           "dev": true,
           "requires": {
@@ -8932,7 +8990,7 @@
         },
         "readable-stream": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
@@ -8947,7 +9005,7 @@
         },
         "request": {
           "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "resolved": false,
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
@@ -8977,7 +9035,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
@@ -8986,31 +9044,31 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "sntp": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
@@ -9019,7 +9077,7 @@
         },
         "sshpk": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+          "resolved": false,
           "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
           "dev": true,
           "requires": {
@@ -9035,7 +9093,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -9046,7 +9104,7 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
@@ -9055,13 +9113,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "resolved": false,
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -9070,13 +9128,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "resolved": false,
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
@@ -9087,7 +9145,7 @@
         },
         "tar-pack": {
           "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
           "dev": true,
           "requires": {
@@ -9103,7 +9161,7 @@
         },
         "tough-cookie": {
           "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "resolved": false,
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
@@ -9112,7 +9170,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -9121,32 +9179,32 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "resolved": false,
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
           "dev": true
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "resolved": false,
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
@@ -9157,7 +9215,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
@@ -9166,7 +9224,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
@@ -11567,7 +11625,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/fs-extra": "^4.0.3",
     "@types/glob": "^5.0.33",
     "@types/gulp": "3.8.32",
+    "@types/gulp-util": "^3.0.34",
     "@types/hammerjs": "^2.0.35",
     "@types/jasmine": "^2.8.8",
     "@types/merge2": "^0.3.30",

--- a/src/cdk-experimental/dialog/dialog-injectors.ts
+++ b/src/cdk-experimental/dialog/dialog-injectors.ts
@@ -7,7 +7,11 @@
  */
 
 import {InjectionToken} from '@angular/core';
-import {ComponentType, Overlay, ScrollStrategy, BlockScrollStrategy} from '@angular/cdk/overlay';
+import {
+  ComponentType,
+  Overlay,
+  ScrollStrategy,
+} from '@angular/cdk/overlay';
 import {DialogRef} from './dialog-ref';
 import {CdkDialogContainer} from './dialog-container';
 import {DialogConfig} from './dialog-config';
@@ -31,7 +35,7 @@ export const DIALOG_CONTAINER =
 
 /** @docs-private */
 export function MAT_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => BlockScrollStrategy {
+    () => ScrollStrategy {
   return () => overlay.scrollStrategies.block();
 }
 

--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -14,7 +14,8 @@ import {
   Injector,
   Inject,
   ComponentRef,
-  OnDestroy
+  OnDestroy,
+  Type
 } from '@angular/core';
 import {ComponentPortal, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
 import {of as observableOf, Observable, Subject, defer} from 'rxjs';
@@ -28,6 +29,7 @@ import {
   Overlay,
   OverlayRef,
   OverlayConfig,
+  ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {startWith} from 'rxjs/operators';
 
@@ -45,6 +47,8 @@ import {
  */
 @Injectable()
 export class Dialog implements OnDestroy {
+  private _scrollStrategy: () => ScrollStrategy;
+
   /** Stream that emits when all dialogs are closed. */
   get _afterAllClosed(): Observable<void> {
     return this._parentDialog ? this._parentDialog.afterAllClosed : this._afterAllClosedBase;
@@ -68,8 +72,10 @@ export class Dialog implements OnDestroy {
   constructor(
       private overlay: Overlay,
       private injector: Injector,
-      @Inject(DIALOG_REF) private dialogRefConstructor,
-      @Inject(DIALOG_SCROLL_STRATEGY) private _scrollStrategy,
+      @Inject(DIALOG_REF) private dialogRefConstructor: Type<DialogRef<any>>,
+      // TODO(crisbeto): the `any` here can be replaced
+      // with the proper type once we start using Ivy.
+      @Inject(DIALOG_SCROLL_STRATEGY) scrollStrategy: any,
       @Optional() @SkipSelf() private _parentDialog: Dialog,
       @Optional() location: Location) {
 
@@ -79,6 +85,8 @@ export class Dialog implements OnDestroy {
     if (!_parentDialog && location) {
       location.subscribe(() => this.closeAll());
     }
+
+    this._scrollStrategy = scrollStrategy;
   }
 
   /** Gets an open dialog by id. */

--- a/src/cdk-experimental/tsconfig-build.json
+++ b/src/cdk-experimental/tsconfig-build.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "newLine": "lf",
     "module": "es2015",

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -66,12 +66,10 @@ describe('CdkAccordion', () => {
 
 @Component({template: `
   <cdk-accordion [multi]="multi">
-    <cdk-accordion-item #item1></cdk-accordion-item>
-    <cdk-accordion-item #item2></cdk-accordion-item>
+    <cdk-accordion-item></cdk-accordion-item>
+    <cdk-accordion-item></cdk-accordion-item>
   </cdk-accordion>`})
 class SetOfItems {
-  @ViewChild('item1') item1;
-  @ViewChild('item2') item2;
   multi: boolean = false;
 }
 

--- a/src/cdk/collections/tree-adapter.ts
+++ b/src/cdk/collections/tree-adapter.ts
@@ -27,5 +27,5 @@ export interface TreeDataNodeFlattener<T> {
    * Put node descendants of node in array.
    * If `onlyExpandable` is true, then only process expandable descendants.
    */
-  nodeDescendents(node: T, nodes: T[], onlyExpandable: boolean);
+  nodeDescendents(node: T, nodes: T[], onlyExpandable: boolean): void;
 }

--- a/src/cdk/drag-drop/drag-utils.spec.ts
+++ b/src/cdk/drag-drop/drag-utils.spec.ts
@@ -57,7 +57,7 @@ describe('dragging utilities', () => {
     });
 
     it('should not do anything if the source array is empty', () => {
-      const a = [];
+      const a: number[] = [];
       const b = [3, 4, 5];
 
       transferArrayItem(a, b, 0, 0);

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -28,7 +28,7 @@ import {
   SkipSelf,
   ViewContainerRef,
 } from '@angular/core';
-import {Observable, Subject, Subscription} from 'rxjs';
+import {Observable, Subject, Subscription, Observer} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {DragDropRegistry} from './drag-drop-registry';
 import {
@@ -206,15 +206,16 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
    * Emits as the user is dragging the item. Use with caution,
    * because this event will fire for every pixel that the user has dragged.
    */
-  @Output('cdkDragMoved') moved: Observable<CdkDragMove<T>> = Observable.create(observer => {
-    const subscription = this._moveEvents.subscribe(observer);
-    this._moveEventSubscriptions++;
+  @Output('cdkDragMoved') moved: Observable<CdkDragMove<T>> =
+      Observable.create((observer: Observer<CdkDragMove<T>>) => {
+        const subscription = this._moveEvents.subscribe(observer);
+        this._moveEventSubscriptions++;
 
-    return () => {
-      subscription.unsubscribe();
-      this._moveEventSubscriptions--;
-    };
-  });
+        return () => {
+          subscription.unsubscribe();
+          this._moveEventSubscriptions--;
+        };
+      });
 
   constructor(
     /** Element that the draggable is attached to. */
@@ -470,7 +471,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
    * Updates the item's position in its drop container, or moves it
    * into a new one, depending on its current drag position.
    */
-  private _updateActiveDropContainer({x, y}) {
+  private _updateActiveDropContainer({x, y}: Point) {
     // Drop container that draggable has been moved into.
     let newContainer = this.dropContainer._getSiblingContainerFromPosition(this, x, y);
 

--- a/src/cdk/layout/breakpoints-observer.spec.ts
+++ b/src/cdk/layout/breakpoints-observer.spec.ts
@@ -137,7 +137,7 @@ export class FakeMediaQueryList {
   /** The callback for change events. */
   addListenerCallback?: (mql: MediaQueryListEvent) => void;
 
-  constructor(public matches, public media) {}
+  constructor(public matches: boolean, public media: string) {}
 
   /** Toggles the matches state and "emits" a change event. */
   setMatches(matches: boolean) {

--- a/src/cdk/layout/breakpoints-observer.ts
+++ b/src/cdk/layout/breakpoints-observer.ts
@@ -98,7 +98,10 @@ export class BreakpointObserver implements OnDestroy {
     }
 
     const mql: MediaQueryList = this.mediaMatcher.matchMedia(query);
-    let queryListener;
+
+    // TODO(jelbourn): change this `any` to `MediaQueryListEvent` once Google has upgraded to
+    // TypeScript 3.1 (the type is unavailable before then).
+    let queryListener: any;
 
     // Create callback for match changes and add it is as a listener.
     const queryObservable = fromEventPattern<MediaQueryList>(
@@ -108,8 +111,6 @@ export class BreakpointObserver implements OnDestroy {
       // have MediaQueryList inherit from EventTarget, which causes inconsistencies in how Zone.js
       // patches it.
       (listener: Function) => {
-        // TODO(jelbourn): change this `any` to `MediaQueryListEvent` once Google has upgraded to
-        // TypeScript 3.1 (the type is unavailable before then).
         queryListener = (e: any) => this.zone.run(() => listener(e));
         mql.addListener(queryListener);
       },

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -19,7 +19,7 @@ import {
   OnDestroy,
   Output,
 } from '@angular/core';
-import {Observable, Subject, Subscription} from 'rxjs';
+import {Observable, Subject, Subscription, Observer} from 'rxjs';
 import {debounceTime} from 'rxjs/operators';
 
 /**
@@ -65,7 +65,7 @@ export class ContentObserver implements OnDestroy {
   observe(elementOrRef: Element | ElementRef<Element>): Observable<MutationRecord[]> {
     const element = elementOrRef instanceof ElementRef ? elementOrRef.nativeElement : elementOrRef;
 
-    return Observable.create(observer => {
+    return Observable.create((observer: Observer<MutationRecord[]>) => {
       const stream = this._observeElement(element);
       const subscription = stream.subscribe(observer);
 

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -8,8 +8,7 @@
 
 import {PositionStrategy} from './position/position-strategy';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {ScrollStrategy} from './scroll/scroll-strategy';
-import {NoopScrollStrategy} from './scroll/noop-scroll-strategy';
+import {ScrollStrategy, NoopScrollStrategy} from './scroll/index';
 
 
 /** Initial configuration used when creating an overlay. */
@@ -62,9 +61,13 @@ export class OverlayConfig {
 
   constructor(config?: OverlayConfig) {
     if (config) {
-      Object.keys(config)
-        .filter(key => typeof config[key] !== 'undefined')
-        .forEach(key => this[key] = config[key]);
+      Object.keys(config).forEach(k => {
+        const key = k as keyof OverlayConfig;
+
+        if (typeof config[key] !== 'undefined') {
+          this[key] = config[key];
+        }
+      });
     }
   }
 }

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -114,6 +114,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   private _offsetX: number;
   private _offsetY: number;
   private _position: FlexibleConnectedPositionStrategy;
+  private _scrollStrategyFactory: () => ScrollStrategy;
 
   /** Origin for the connected overlay. */
   @Input('cdkConnectedOverlayOrigin') origin: CdkOverlayOrigin;
@@ -165,8 +166,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   @Input('cdkConnectedOverlayViewportMargin') viewportMargin: number = 0;
 
   /** Strategy to be used when handling scroll events while the overlay is open. */
-  @Input('cdkConnectedOverlayScrollStrategy') scrollStrategy: ScrollStrategy =
-      this._scrollStrategy();
+  @Input('cdkConnectedOverlayScrollStrategy') scrollStrategy: ScrollStrategy;
 
   /** Whether the overlay is open. */
   @Input('cdkConnectedOverlayOpen') open: boolean = false;
@@ -219,9 +219,11 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       private _overlay: Overlay,
       templateRef: TemplateRef<any>,
       viewContainerRef: ViewContainerRef,
-      @Inject(CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY) private _scrollStrategy,
+      @Inject(CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY) scrollStrategyFactory: any,
       @Optional() private _dir: Directionality) {
     this._templatePortal = new TemplatePortal(templateRef, viewContainerRef);
+    this._scrollStrategyFactory = scrollStrategyFactory;
+    this.scrollStrategy = this._scrollStrategyFactory();
   }
 
   /** The associated overlay reference. */

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -10,7 +10,7 @@ import {Direction, Directionality} from '@angular/cdk/bidi';
 import {ComponentPortal, Portal, PortalOutlet, TemplatePortal} from '@angular/cdk/portal';
 import {ComponentRef, EmbeddedViewRef, NgZone} from '@angular/core';
 import {Location} from '@angular/common';
-import {Observable, Subject, merge, SubscriptionLike, Subscription} from 'rxjs';
+import {Observable, Subject, merge, SubscriptionLike, Subscription, Observer} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 import {OverlayKeyboardDispatcher} from './keyboard/overlay-keyboard-dispatcher';
 import {OverlayConfig} from './overlay-config';
@@ -42,15 +42,16 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
    */
   private _previousHostParent: HTMLElement;
 
-  private _keydownEventsObservable: Observable<KeyboardEvent> = Observable.create(observer => {
-    const subscription = this._keydownEvents.subscribe(observer);
-    this._keydownEventSubscriptions++;
+  private _keydownEventsObservable: Observable<KeyboardEvent> =
+      Observable.create((observer: Observer<KeyboardEvent>) => {
+        const subscription = this._keydownEvents.subscribe(observer);
+        this._keydownEventSubscriptions++;
 
-    return () => {
-      subscription.unsubscribe();
-      this._keydownEventSubscriptions--;
-    };
-  });
+        return () => {
+          subscription.unsubscribe();
+          this._keydownEventSubscriptions--;
+        };
+      });
 
   /** Stream of keydown events dispatched to this overlay. */
   _keydownEvents = new Subject<KeyboardEvent>();

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -16,7 +16,7 @@ import {
   validateHorizontalPosition,
   validateVerticalPosition,
 } from './connected-position';
-import {Observable, Subscription, Subject} from 'rxjs';
+import {Observable, Subscription, Subject, Observer} from 'rxjs';
 import {OverlayReference} from '../overlay-reference';
 import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';
 import {coerceCssPixelValue, coerceArray} from '@angular/cdk/coercion';
@@ -122,15 +122,16 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _previousPushAmount: {x: number, y: number} | null;
 
   /** Observable sequence of position changes. */
-  positionChanges: Observable<ConnectedOverlayPositionChange> = Observable.create(observer => {
-    const subscription = this._positionChanges.subscribe(observer);
-    this._positionChangeSubscriptions++;
+  positionChanges: Observable<ConnectedOverlayPositionChange> =
+      Observable.create((observer: Observer<ConnectedOverlayPositionChange>) => {
+        const subscription = this._positionChanges.subscribe(observer);
+        this._positionChangeSubscriptions++;
 
-    return () => {
-      subscription.unsubscribe();
-      this._positionChangeSubscriptions--;
-    };
-  });
+        return () => {
+          subscription.unsubscribe();
+          this._positionChangeSubscriptions--;
+        };
+      });
 
   /** Ordered list of preferred positions, from most to least desirable. */
   get positions() {
@@ -705,7 +706,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _calculateBoundingBoxRect(origin: Point, position: ConnectedPosition): BoundingBoxRect {
     const viewport = this._viewportRect;
     const isRtl = this._isRtl();
-    let height, top, bottom;
+    let height: number, top: number, bottom: number;
 
     if (position.overlayY === 'top') {
       // Overlay is opening "downward" and thus is bound by the bottom viewport edge.
@@ -745,7 +746,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
         (position.overlayX === 'end' && !isRtl) ||
         (position.overlayX === 'start' && isRtl);
 
-    let width, left, right;
+    let width: number, left: number, right: number;
 
     if (isBoundedByLeftViewportEdge) {
       right = viewport.right - origin.x + this._viewportMargin;
@@ -770,7 +771,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       }
     }
 
-    return {top, left, bottom, right, width, height};
+    return {top: top!, left: left!, bottom: bottom!, right: right!, width, height};
   }
 
   /**

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -144,22 +144,24 @@ describe('BlockScrollStrategy', () => {
   it('should not clobber user-defined scroll-behavior', skipIOS(() => {
     const root = documentElement;
     const body = document.body;
+    const rootStyle = root.style as CSSStyleDeclaration & {scrollBehavior: string};
+    const bodyStyle = body.style as CSSStyleDeclaration & {scrollBehavior: string};
 
-    root.style['scrollBehavior'] = body.style['scrollBehavior'] = 'smooth';
+    rootStyle.scrollBehavior = bodyStyle.scrollBehavior = 'smooth';
 
     // Get the value via the style declaration in order to
     // handle browsers that don't support the property yet.
-    const initialRootValue = root.style['scrollBehavior'];
-    const initialBodyValue = root.style['scrollBehavior'];
+    const initialRootValue = rootStyle.scrollBehavior;
+    const initialBodyValue = rootStyle.scrollBehavior;
 
     overlayRef.attach(componentPortal);
     overlayRef.detach();
 
-    expect(root.style['scrollBehavior']).toBe(initialRootValue);
-    expect(body.style['scrollBehavior']).toBe(initialBodyValue);
+    expect(rootStyle.scrollBehavior).toBe(initialRootValue);
+    expect(bodyStyle.scrollBehavior).toBe(initialBodyValue);
 
     // Avoid bleeding styles into other tests.
-    root.style['scrollBehavior'] = body.style['scrollBehavior'] = '';
+    rootStyle.scrollBehavior = bodyStyle.scrollBehavior = '';
   }));
 
   /**

--- a/src/cdk/overlay/scroll/block-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.ts
@@ -11,10 +11,17 @@ import {ViewportRuler} from '@angular/cdk/scrolling';
 import {coerceCssPixelValue} from '@angular/cdk/coercion';
 
 /**
+ * Extended `CSSStyleDeclaration` that includes `scrollBehavior` which isn't part of the
+ * built-in TS typings. Once it is, this declaration can be removed safely.
+ * @docs-private
+ */
+type ScrollBehaviorCSSStyleDeclaration = CSSStyleDeclaration & {scrollBehavior: string};
+
+/**
  * Strategy that will prevent the user from scrolling while the overlay is visible.
  */
 export class BlockScrollStrategy implements ScrollStrategy {
-  private _previousHTMLStyles = { top: '', left: '' };
+  private _previousHTMLStyles = {top: '', left: ''};
   private _previousScrollPosition: { top: number, left: number };
   private _isEnabled = false;
   private _document: Document;
@@ -51,23 +58,25 @@ export class BlockScrollStrategy implements ScrollStrategy {
     if (this._isEnabled) {
       const html = this._document.documentElement!;
       const body = this._document.body!;
-      const previousHtmlScrollBehavior = html.style['scrollBehavior'] || '';
-      const previousBodyScrollBehavior = body.style['scrollBehavior'] || '';
+      const htmlStyle = html.style as ScrollBehaviorCSSStyleDeclaration;
+      const bodyStyle = body.style as ScrollBehaviorCSSStyleDeclaration;
+      const previousHtmlScrollBehavior = htmlStyle.scrollBehavior || '';
+      const previousBodyScrollBehavior = bodyStyle.scrollBehavior || '';
 
       this._isEnabled = false;
 
-      html.style.left = this._previousHTMLStyles.left;
-      html.style.top = this._previousHTMLStyles.top;
+      htmlStyle.left = this._previousHTMLStyles.left;
+      htmlStyle.top = this._previousHTMLStyles.top;
       html.classList.remove('cdk-global-scrollblock');
 
       // Disable user-defined smooth scrolling temporarily while we restore the scroll position.
       // See https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
-      html.style['scrollBehavior'] = body.style['scrollBehavior'] = 'auto';
+      htmlStyle.scrollBehavior = bodyStyle.scrollBehavior = 'auto';
 
       window.scroll(this._previousScrollPosition.left, this._previousScrollPosition.top);
 
-      html.style['scrollBehavior'] = previousHtmlScrollBehavior;
-      body.style['scrollBehavior'] = previousBodyScrollBehavior;
+      htmlStyle.scrollBehavior = previousHtmlScrollBehavior;
+      bodyStyle.scrollBehavior = previousBodyScrollBehavior;
     }
   }
 

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -15,7 +15,7 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core';
-import {fromEvent, of as observableOf, Subject, Subscription, Observable} from 'rxjs';
+import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
 import {CdkScrollable} from './scrollable';
 
@@ -82,7 +82,11 @@ export class ScrollDispatcher implements OnDestroy {
    * to run the callback using `NgZone.run`.
    */
   scrolled(auditTimeInMs: number = DEFAULT_SCROLL_TIME): Observable<CdkScrollable|void> {
-    return this._platform.isBrowser ? Observable.create(observer => {
+    if (!this._platform.isBrowser) {
+      return observableOf<void>();
+    }
+
+    return Observable.create((observer: Observer<CdkScrollable|void>) => {
       if (!this._globalSubscription) {
         this._addGlobalListener();
       }
@@ -103,7 +107,7 @@ export class ScrollDispatcher implements OnDestroy {
           this._removeGlobalListener();
         }
       };
-    }) : observableOf<void>();
+    });
   }
 
   ngOnDestroy() {

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -13,7 +13,7 @@ import {
   supportsScrollBehavior
 } from '@angular/cdk/platform';
 import {Directive, ElementRef, NgZone, OnDestroy, OnInit, Optional} from '@angular/core';
-import {fromEvent, Observable, Subject} from 'rxjs';
+import {fromEvent, Observable, Subject, Observer} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
 
@@ -47,7 +47,7 @@ export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
 export class CdkScrollable implements OnInit, OnDestroy {
   private _destroyed = new Subject();
 
-  private _elementScrolled: Observable<Event> = Observable.create(observer =>
+  private _elementScrolled: Observable<Event> = Observable.create((observer: Observer<Event>) =>
       this.ngZone.runOutsideAngular(() =>
           fromEvent(this.elementRef.nativeElement, 'scroll').pipe(takeUntil(this._destroyed))
               .subscribe(observer)));

--- a/src/cdk/scrolling/virtual-scroll-strategy.ts
+++ b/src/cdk/scrolling/virtual-scroll-strategy.ts
@@ -31,16 +31,16 @@ export interface VirtualScrollStrategy {
   detach(): void;
 
   /** Called when the viewport is scrolled (debounced using requestAnimationFrame). */
-  onContentScrolled();
+  onContentScrolled(): void;
 
   /** Called when the length of the data changes. */
-  onDataLengthChanged();
+  onDataLengthChanged(): void;
 
   /** Called when the range of items rendered in the DOM has changed. */
-  onContentRendered();
+  onContentRendered(): void;
 
   /** Called when the offset of the rendered items changed. */
-  onRenderedOffsetChanged();
+  onRenderedOffsetChanged(): void;
 
   /**
    * Scroll to the offset for the given index.

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -23,7 +23,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {animationFrameScheduler, Observable, Subject} from 'rxjs';
+import {animationFrameScheduler, Observable, Subject, Observer} from 'rxjs';
 import {auditTime, startWith, takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkScrollable, ExtendedScrollToOptions} from './scrollable';
@@ -66,9 +66,10 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   // depending on how the strategy calculates the scrolled index, it may come at a cost to
   // performance.
   /** Emits when the index of the first element visible in the viewport changes. */
-  @Output() scrolledIndexChange: Observable<number> = Observable.create(observer =>
-      this._scrollStrategy.scrolledIndexChange.subscribe(index =>
-          Promise.resolve().then(() => this.ngZone.run(() => observer.next(index)))));
+  @Output() scrolledIndexChange: Observable<number> =
+      Observable.create((observer: Observer<number>) =>
+        this._scrollStrategy.scrolledIndexChange.subscribe(index =>
+            Promise.resolve().then(() => this.ngZone.run(() => observer.next(index)))));
 
   /** The element that wraps the rendered content. */
   @ViewChild('contentWrapper') _contentWrapper: ElementRef<HTMLElement>;

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -708,6 +708,7 @@ describe('CdkTable', () => {
 
   describe('with sticky positioning', () => {
     interface PositionDirections {
+      [key: string]: string | undefined;
       top?: string;
       bottom?: string;
       left?: string;
@@ -731,21 +732,23 @@ describe('CdkTable', () => {
       expect(element.style.zIndex).toBe(zIndex, `Expected zIndex to be ${zIndex}`);
 
       ['top', 'bottom', 'left', 'right'].forEach(d => {
-        if (!directions[d]) {
+        const directionValue = directions[d];
+
+        if (!directionValue) {
           // If no expected position for this direction, must either be unset or empty string
           expect(element.style[d] || 'unset').toBe('unset', `Expected ${d} to be unset`);
           return;
         }
 
-        const expectationMessage = `Expected direction ${d} to be ${directions[d]}`;
+        const expectationMessage = `Expected direction ${d} to be ${directionValue}`;
 
         // If the direction contains `px`, we parse the number to be able to avoid deviations
         // caused by individual browsers.
-        if (directions[d].includes('px')) {
+        if (directionValue.includes('px')) {
           expect(Math.round(parseInt(element.style[d])))
-            .toBe(Math.round(parseInt(directions[d])), expectationMessage);
+            .toBe(Math.round(parseInt(directionValue)), expectationMessage);
         } else {
-          expect(element.style[d]).toBe(directions[d], expectationMessage);
+          expect(element.style[d]).toBe(directionValue, expectationMessage);
         }
       });
     }
@@ -1095,7 +1098,7 @@ describe('CdkTable', () => {
   });
 
   describe('with trackBy', () => {
-    function createTestComponentWithTrackyByTable(trackByStrategy) {
+    function createTestComponentWithTrackyByTable(trackByStrategy: string) {
       fixture = createComponent(TrackByCdkTableApp);
 
       component = fixture.componentInstance;
@@ -1150,7 +1153,7 @@ describe('CdkTable', () => {
 
       // Change each item reference to show that the trackby is not checking the item properties.
       component.dataSource.data = component.dataSource.data
-          .map(item => { return {a: item.a, b: item.b, c: item.c}; });
+          .map((item: TestData) => ({a: item.a, b: item.b, c: item.c}));
 
       // Expect that all the rows are considered new since their references are all different
       const changedRows = getRows(tableElement);
@@ -1167,7 +1170,7 @@ describe('CdkTable', () => {
       // Change each item reference to show that the trackby is checking the item properties.
       // Otherwise this would cause them all to be removed/added.
       component.dataSource.data = component.dataSource.data
-          .map(item => { return {a: item.a, b: item.b, c: item.c}; });
+          .map((item: TestData) => ({a: item.a, b: item.b, c: item.c}));
 
       // Expect that the first and second rows were swapped and that the last row is new
       const changedRows = getRows(tableElement);
@@ -1184,7 +1187,7 @@ describe('CdkTable', () => {
       // Change each item reference to show that the trackby is checking the index.
       // Otherwise this would cause them all to be removed/added.
       component.dataSource.data = component.dataSource.data
-          .map(item => { return {a: item.a, b: item.b, c: item.c}; });
+          .map((item: TestData) => ({a: item.a, b: item.b, c: item.c}));
 
       // Expect first two to be the same since they were swapped but indicies are consistent.
       // The third element was removed and caught by the table so it was removed before another
@@ -1206,7 +1209,7 @@ describe('CdkTable', () => {
       // Change each item reference to show that the trackby is checking the index.
       // Otherwise this would cause them all to be removed/added.
       component.dataSource.data = component.dataSource.data
-          .map(item => ({a: item.a, b: item.b, c: item.c}));
+          .map((item: TestData) => ({a: item.a, b: item.b, c: item.c}));
 
       // Expect the rows were given the right implicit data even though the rows were not moved.
       fixture.detectChanges();
@@ -2043,7 +2046,7 @@ class MissingFooterRowDefCdkTableApp {
   `
 })
 class UndefinedColumnsCdkTableApp {
-  undefinedColumns;
+  undefinedColumns: string[];
   dataSource: FakeDataSource = new FakeDataSource();
 }
 
@@ -2146,7 +2149,7 @@ class OuterTableApp {
   columnsToRender =
       ['content_column_a', 'content_column_b', 'injected_column_a', 'injected_column_b'];
 
-  firstRow = i => i === 0;
+  firstRow = (i: number) => i === 0;
 }
 
 @Component({

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -99,7 +99,7 @@ describe('AutofillMonitor', () => {
     const inputEl = testComponent.input1.nativeElement;
     let animationStartCallback: Function = () => {};
     let autofillStreamEvent: AutofillEvent | null = null;
-    inputEl.addEventListener.and.callFake((_, cb) => animationStartCallback = cb);
+    inputEl.addEventListener.and.callFake((_: string, cb: Function) => animationStartCallback = cb);
     const autofillStream = autofillMonitor.monitor(inputEl);
     autofillStream.subscribe(event => autofillStreamEvent = event);
     expect(autofillStreamEvent).toBeNull();
@@ -114,7 +114,7 @@ describe('AutofillMonitor', () => {
     const inputEl = testComponent.input1.nativeElement;
     let animationStartCallback: Function = () => {};
     let autofillStreamEvent: AutofillEvent | null = null;
-    inputEl.addEventListener.and.callFake((_, cb) => animationStartCallback = cb);
+    inputEl.addEventListener.and.callFake((_: string, cb: Function) => animationStartCallback = cb);
     const autofillStream = autofillMonitor.monitor(inputEl);
     autofillStream.subscribe(event => autofillStreamEvent = event);
     animationStartCallback({animationName: 'cdk-text-field-autofill-start', target: inputEl});
@@ -129,7 +129,7 @@ describe('AutofillMonitor', () => {
   it('should cleanup filled class if monitoring stopped in autofilled state', () => {
     const inputEl = testComponent.input1.nativeElement;
     let animationStartCallback: Function = () => {};
-    inputEl.addEventListener.and.callFake((_, cb) => animationStartCallback = cb);
+    inputEl.addEventListener.and.callFake((_: string, cb: Function) => animationStartCallback = cb);
     autofillMonitor.monitor(inputEl);
     animationStartCallback({animationName: 'cdk-text-field-autofill-start', target: inputEl});
     expect(inputEl.classList).toContain('cdk-text-field-autofilled');
@@ -153,7 +153,7 @@ describe('AutofillMonitor', () => {
   it('should emit on stream inside the NgZone', () => {
     const inputEl = testComponent.input1.nativeElement;
     let animationStartCallback: Function = () => {};
-    inputEl.addEventListener.and.callFake((_, cb) => animationStartCallback = cb);
+    inputEl.addEventListener.and.callFake((_: string, cb: Function) => animationStartCallback = cb);
     const autofillStream = autofillMonitor.monitor(inputEl);
     const spy = jasmine.createSpy('autofill spy');
 
@@ -167,7 +167,7 @@ describe('AutofillMonitor', () => {
   it('should not emit on init if input is unfilled', () => {
     const inputEl = testComponent.input1.nativeElement;
     let animationStartCallback: Function = () => {};
-    inputEl.addEventListener.and.callFake((_, cb) => animationStartCallback = cb);
+    inputEl.addEventListener.and.callFake((_: string, cb: Function) => animationStartCallback = cb);
     const autofillStream = autofillMonitor.monitor(inputEl);
     const spy = jasmine.createSpy('autofill spy');
     autofillStream.subscribe(() => spy());

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -113,15 +113,15 @@ export class AutofillMonitor implements OnDestroy {
    * Stop monitoring the autofill state of the given input element.
    * @param element The element to stop monitoring.
    */
-  stopMonitoring(element: Element);
+  stopMonitoring(element: Element): void;
 
   /**
    * Stop monitoring the autofill state of the given input element.
    * @param element The element to stop monitoring.
    */
-  stopMonitoring(element: ElementRef<Element>);
+  stopMonitoring(element: ElementRef<Element>): void;
 
-  stopMonitoring(elementOrRef: Element | ElementRef<Element>) {
+  stopMonitoring(elementOrRef: Element | ElementRef<Element>): void {
     const element = elementOrRef instanceof ElementRef ? elementOrRef.nativeElement : elementOrRef;
     const info = this._monitoredElements.get(element);
 

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -90,7 +90,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
         `${this.minRows * this._cachedLineHeight}px` : null;
 
     if (minHeight)  {
-      this._setTextareaStyle('minHeight', minHeight);
+      this._textareaElement.style.minHeight = minHeight;
     }
   }
 
@@ -100,7 +100,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
         `${this.maxRows * this._cachedLineHeight}px` : null;
 
     if (maxHeight) {
-      this._setTextareaStyle('maxHeight', maxHeight);
+      this._textareaElement.style.maxHeight = maxHeight;
     }
   }
 
@@ -122,11 +122,6 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
-  }
-
-  /** Sets a style property on the textarea element. */
-  private _setTextareaStyle(property: string, value: string): void {
-    this._textareaElement.style[property] = value;
   }
 
   /**

--- a/src/cdk/tree/control/flat-tree-control.spec.ts
+++ b/src/cdk/tree/control/flat-tree-control.spec.ts
@@ -93,8 +93,7 @@ describe('CdkFlatTreeControl', () => {
       const numChildren = 4;
       const numGrandChildren = 2;
       const nodes = generateData(numNodes, numChildren, numGrandChildren);
-
-      let data = [];
+      const data: TestData[] = [];
       flatten(nodes, data);
       treeControl.dataNodes = data;
 
@@ -122,7 +121,7 @@ describe('CdkFlatTreeControl', () => {
       const numChildren = 4;
       const numGrandChildren = 2;
       const nodes = generateData(numNodes, numChildren, numGrandChildren);
-      let data = [];
+      const data: TestData[] = [];
       flatten(nodes, data);
       treeControl.dataNodes = data;
 

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -32,7 +32,8 @@ export class NestedTreeControl<T> extends BaseTreeControl<T> {
 
   /** Gets a list of descendant dataNodes of a subtree rooted at given data node recursively. */
   getDescendants(dataNode: T): T[] {
-    const descendants = [];
+    const descendants: T[] = [];
+
     this._getDescendants(descendants, dataNode);
     // Remove the node itself
     return descendants.splice(1);

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
-import {Component, ViewChild, TrackByFunction} from '@angular/core';
+import {Component, ViewChild, TrackByFunction, Type} from '@angular/core';
 
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {combineLatest, BehaviorSubject, Observable} from 'rxjs';
@@ -28,7 +28,7 @@ describe('CdkTree', () => {
   let treeElement: HTMLElement;
   let tree: CdkTree<TestData>;
 
-  function configureCdkTreeTestingModule(declarations) {
+  function configureCdkTreeTestingModule(declarations: Type<any>[]) {
     TestBed.configureTestingModule({
       imports: [CdkTreeModule],
       declarations: declarations,

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "newLine": "lf",
     "module": "es2015",

--- a/src/demo-app/tsconfig-aot.json
+++ b/src/demo-app/tsconfig-aot.json
@@ -9,6 +9,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "outDir": "../../dist/packages/demo-app",
     "rootDirs": [
       ".",

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -120,6 +120,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
   private _portal: TemplatePortal;
   private _componentDestroyed = false;
   private _autocompleteDisabled = false;
+  private _scrollStrategy: () => ScrollStrategy;
 
   /** Old value of the native input. Used to work around issues with the `input` event on IE. */
   private _previousValue: string | number | null;
@@ -193,7 +194,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
               private _viewContainerRef: ViewContainerRef,
               private _zone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef,
-              @Inject(MAT_AUTOCOMPLETE_SCROLL_STRATEGY) private _scrollStrategy,
+              @Inject(MAT_AUTOCOMPLETE_SCROLL_STRATEGY) scrollStrategy: any,
               @Optional() private _dir: Directionality,
               @Optional() @Host() private _formField: MatFormField,
               @Optional() @Inject(DOCUMENT) private _document: any,
@@ -205,6 +206,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
         window.addEventListener('blur', this._windowBlurHandler);
       });
     }
+
+    this._scrollStrategy = scrollStrategy;
   }
 
   ngOnDestroy() {

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -1206,7 +1206,7 @@ class CheckboxWithTabIndex {
     <mat-checkbox></mat-checkbox>`,
 })
 class CheckboxUsingViewChild {
-  @ViewChild(MatCheckbox) checkbox;
+  @ViewChild(MatCheckbox) checkbox: MatCheckbox;
 
   set isDisabled(value: boolean) {
     this.checkbox.disabled = value;

--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -63,7 +63,8 @@ export class MatCommonModule {
 
   /** Whether the code is running in tests. */
   private _isTestEnv() {
-    return this._window && (this._window['__karma__'] || this._window['jasmine']);
+    const window = this._window as any;
+    return window && (window.__karma__ || window.jasmine);
   }
 
   private _checkDoctypeIsDefined(): void {
@@ -109,7 +110,7 @@ export class MatCommonModule {
       return;
     }
 
-    if (this._areChecksEnabled() && !this._window['Hammer'] && !this._hammerLoader) {
+    if (this._areChecksEnabled() && !(this._window as any)['Hammer'] && !this._hammerLoader) {
       console.warn(
         'Could not find HammerJS. Certain Angular Material components may not work correctly.');
     }

--- a/src/lib/core/common-behaviors/error-state.ts
+++ b/src/lib/core/common-behaviors/error-state.ts
@@ -14,7 +14,7 @@ import {Constructor} from './constructor';
 
 /** @docs-private */
 export interface CanUpdateErrorState {
-  updateErrorState();
+  updateErrorState(): void;
   readonly stateChanges: Subject<void>;
   errorState: boolean;
   errorStateMatcher: ErrorStateMatcher;

--- a/src/lib/core/gestures/gesture-config.spec.ts
+++ b/src/lib/core/gestures/gesture-config.spec.ts
@@ -17,7 +17,7 @@ describe('GestureConfig', () => {
     const fixture = TestBed.createComponent(ButtonWithLongpressHander);
     fixture.detectChanges();
 
-    expect(window['Hammer']).toHaveBeenCalled();
+    expect((window as any).Hammer).toHaveBeenCalled();
   });
 
   it('should be able to pass options to HammerJS', () => {
@@ -38,7 +38,7 @@ describe('GestureConfig', () => {
     fixture.detectChanges();
 
     const button = fixture.debugElement.nativeElement.querySelector('button');
-    const firstCallArgs = window['Hammer'].calls.first().args;
+    const firstCallArgs = (window as any).Hammer.calls.first().args;
 
     expect(firstCallArgs[0]).toBe(button);
     expect(firstCallArgs[1].cssProps.touchAction).toBe('auto');

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -24,7 +24,7 @@ describe('MatRipple', () => {
   let platform: Platform;
 
   /** Extracts the numeric value of a pixel size string like '123px'. */
-  const pxStringToFloat = s => parseFloat(s) || 0;
+  const pxStringToFloat = (s: string | null) => s ? parseFloat(s) : 0;
   const startingWindowWidth = window.innerWidth;
   const startingWindowHeight = window.innerHeight;
 

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -139,6 +139,8 @@ export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
   encapsulation: ViewEncapsulation.None,
 })
 export class MatDatepicker<D> implements OnDestroy, CanColor {
+  private _scrollStrategy: () => ScrollStrategy;
+
   /** An input indicating the type of the custom header component for the calendar, if set. */
   @Input() calendarHeaderComponent: ComponentType<any>;
 
@@ -276,13 +278,15 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
               private _overlay: Overlay,
               private _ngZone: NgZone,
               private _viewContainerRef: ViewContainerRef,
-              @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) private _scrollStrategy,
+              @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) scrollStrategy: any,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,
               @Optional() @Inject(DOCUMENT) private _document: any) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }
+
+    this._scrollStrategy = scrollStrategy;
   }
 
   ngOnDestroy() {

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -45,13 +45,13 @@ export const MAT_DIALOG_SCROLL_STRATEGY =
     new InjectionToken<() => ScrollStrategy>('mat-dialog-scroll-strategy');
 
 /** @docs-private */
-export function MAT_DIALOG_SCROLL_STRATEGY_FACTORY(overlay: Overlay): ()  => ScrollStrategy {
+export function MAT_DIALOG_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.block();
 }
 
 /** @docs-private */
 export function MAT_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => ScrollStrategy {
+  () => ScrollStrategy {
   return () => overlay.scrollStrategies.block();
 }
 
@@ -72,6 +72,7 @@ export class MatDialog implements OnDestroy {
   private readonly _afterAllClosedAtThisLevel = new Subject<void>();
   private readonly _afterOpenedAtThisLevel = new Subject<MatDialogRef<any>>();
   private _ariaHiddenElements = new Map<Element, string|null>();
+  private _scrollStrategy: () => ScrollStrategy;
 
   /** Keeps track of the currently-open dialogs. */
   get openDialogs(): MatDialogRef<any>[] {
@@ -92,7 +93,7 @@ export class MatDialog implements OnDestroy {
     return this.afterOpened;
   }
 
-  get _afterAllClosed() {
+  get _afterAllClosed(): Subject<void> {
     const parent = this._parentDialog;
     return parent ? parent._afterAllClosed : this._afterAllClosedAtThisLevel;
   }
@@ -109,10 +110,12 @@ export class MatDialog implements OnDestroy {
       private _overlay: Overlay,
       private _injector: Injector,
       @Optional() private _location: Location,
-      @Optional() @Inject(MAT_DIALOG_DEFAULT_OPTIONS) private _defaultOptions,
-      @Inject(MAT_DIALOG_SCROLL_STRATEGY) private _scrollStrategy,
+      @Optional() @Inject(MAT_DIALOG_DEFAULT_OPTIONS) private _defaultOptions: MatDialogConfig,
+      @Inject(MAT_DIALOG_SCROLL_STRATEGY) scrollStrategy: any,
       @Optional() @SkipSelf() private _parentDialog: MatDialog,
-      private _overlayContainer: OverlayContainer) {}
+      private _overlayContainer: OverlayContainer) {
+    this._scrollStrategy = scrollStrategy;
+  }
 
   /**
    * Opens a modal dialog containing the given component.

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -50,6 +50,7 @@ import {MatPlaceholder} from './placeholder';
 import {MatPrefix} from './prefix';
 import {MatSuffix} from './suffix';
 import {Platform} from '@angular/cdk/platform';
+import {NgControl} from '@angular/forms';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
@@ -317,7 +318,7 @@ export class MatFormField extends _MatFormFieldMixinBase
   }
 
   /** Determines whether a class from the NgControl should be forwarded to the host element. */
-  _shouldForward(prop: string): boolean {
+  _shouldForward(prop: keyof NgControl): boolean {
     const ngControl = this._control ? this._control.ngControl : null;
     return ngControl && ngControl[prop];
   }

--- a/src/lib/grid-list/grid-list.ts
+++ b/src/lib/grid-list/grid-list.ts
@@ -166,7 +166,7 @@ export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked
   /** Sets style on the main grid-list element, given the style name and value. */
   _setListStyle(style: [string, string | null] | null): void {
     if (style) {
-      this._element.nativeElement.style[style[0]] = style[1];
+      (this._element.nativeElement.style as any)[style[0]] = style[1];
     }
   }
 }

--- a/src/lib/grid-list/grid-tile.ts
+++ b/src/lib/grid-list/grid-tile.ts
@@ -58,7 +58,7 @@ export class MatGridTile {
    * "Changed after checked" errors that would occur with HostBinding.
    */
   _setStyle(property: string, value: any): void {
-    this._element.nativeElement.style[property] = value;
+    (this._element.nativeElement.style as any)[property] = value;
   }
 }
 

--- a/src/lib/grid-list/tile-styler.ts
+++ b/src/lib/grid-list/tile-styler.ts
@@ -138,7 +138,7 @@ export abstract class TileStyler {
    * @docs-private
    */
   abstract setRowStyles(tile: MatGridTile, rowIndex: number, percentWidth: number,
-                        gutterWidth: number);
+                        gutterWidth: number): void;
 
   /**
    * Calculates the computed height and returns the correct style property to set.
@@ -152,7 +152,7 @@ export abstract class TileStyler {
    * @param list Grid list that the styler was attached to.
    * @docs-private
    */
-  abstract reset(list: MatGridList);
+  abstract reset(list: MatGridList): void;
 }
 
 

--- a/src/lib/list/selection-list.spec.ts
+++ b/src/lib/list/selection-list.spec.ts
@@ -975,7 +975,7 @@ describe('MatSelectionList with forms', () => {
       const fixture = TestBed.createComponent(SelectionListWithCustomComparator);
       const testComponent = fixture.componentInstance;
 
-      testComponent.compareWith = jasmine.createSpy('comparator', (o1, o2) => {
+      testComponent.compareWith = jasmine.createSpy('comparator', (o1: any, o2: any) => {
         return o1 && o2 && o1.id === o2.id;
       }).and.callThrough();
 

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -15,8 +15,8 @@ import {
   Overlay,
   OverlayConfig,
   OverlayRef,
-  ScrollStrategy,
   VerticalConnectionPos,
+  ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {
@@ -83,6 +83,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _menuOpen: boolean = false;
   private _closeSubscription = Subscription.EMPTY;
   private _hoverSubscription = Subscription.EMPTY;
+  private _scrollStrategy: () => ScrollStrategy;
 
   // Tracking input type is necessary so it's possible to only auto-focus
   // the first item of the list when the menu is opened via the keyboard
@@ -132,7 +133,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   constructor(private _overlay: Overlay,
               private _element: ElementRef<HTMLElement>,
               private _viewContainerRef: ViewContainerRef,
-              @Inject(MAT_MENU_SCROLL_STRATEGY) private _scrollStrategy,
+              @Inject(MAT_MENU_SCROLL_STRATEGY) scrollStrategy: any,
               @Optional() private _parentMenu: MatMenu,
               @Optional() @Self() private _menuItemInstance: MatMenuItem,
               @Optional() private _dir: Directionality,
@@ -143,12 +144,14 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     if (_menuItemInstance) {
       _menuItemInstance._triggersSubmenu = this.triggersSubmenu();
     }
+
+    this._scrollStrategy = scrollStrategy;
   }
 
   ngAfterContentInit() {
     this._checkMenu();
 
-    this.menu.close.subscribe(reason => {
+    this.menu.close.asObservable().subscribe(reason => {
       this._destroyMenu();
 
       // If a click closed the menu, we should close the entire chain of nested menus.

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -800,7 +800,8 @@ describe('MatMenu', () => {
 
       constructor(ctor: {new(): T; }, inputs: {[key: string]: any} = {}) {
         this.fixture = createComponent(ctor);
-        Object.keys(inputs).forEach(key => this.fixture.componentInstance[key] = inputs[key]);
+        Object.keys(inputs)
+            .forEach(key => (this.fixture.componentInstance as any)[key] = inputs[key]);
         this.fixture.detectChanges();
         this.trigger = this.fixture.componentInstance.triggerEl.nativeElement;
       }

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -835,7 +835,7 @@ class RadioGroupWithNgModel {
   template: `<mat-radio-button>One</mat-radio-button>`
 })
 class DisableableRadioButton {
-  @ViewChild(MatRadioButton) matRadioButton;
+  @ViewChild(MatRadioButton) matRadioButton: MatRadioButton;
 
   set disabled(value: boolean) {
     this.matRadioButton.disabled = value;

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2926,7 +2926,7 @@ describe('MatSelect', () => {
       const overlayTop = overlayPane.getBoundingClientRect().top;
       const options = overlayPane.querySelectorAll('mat-option');
       const optionTop = options[index].getBoundingClientRect().top;
-      const triggerFontSize = parseInt(window.getComputedStyle(trigger)['font-size']);
+      const triggerFontSize = parseInt(window.getComputedStyle(trigger).fontSize || '0');
       const triggerLineHeightEm = 1.125;
 
       // Extra trigger height beyond the font size caused by the fact that the line-height is

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -21,12 +21,7 @@ import {
   SPACE,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {
-  CdkConnectedOverlay,
-  Overlay,
-  RepositionScrollStrategy,
-  ScrollStrategy,
-} from '@angular/cdk/overlay';
+import {CdkConnectedOverlay, Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {
   AfterContentInit,
@@ -141,7 +136,7 @@ export const MAT_SELECT_SCROLL_STRATEGY =
 
 /** @docs-private */
 export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay):
-    () => RepositionScrollStrategy {
+    () => ScrollStrategy {
   return () => overlay.scrollStrategies.reposition();
 }
 
@@ -230,6 +225,8 @@ export class MatSelectTrigger {}
 export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges,
     OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable, HasTabIndex,
     MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
+  private _scrollStrategyFactory: () => ScrollStrategy;
+
   /** Whether or not the overlay panel is open. */
   private _panelOpen = false;
 
@@ -285,7 +282,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   _panelDoneAnimatingStream = new Subject<string>();
 
   /** Strategy that will be used to handle scrolling while the select panel is open. */
-  _scrollStrategy = this._scrollStrategyFactory();
+  _scrollStrategy: ScrollStrategy;
 
   /**
    * The y-offset of the overlay panel in relation to the trigger's top start corner.
@@ -487,7 +484,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     @Optional() private _parentFormField: MatFormField,
     @Self() @Optional() public ngControl: NgControl,
     @Attribute('tabindex') tabIndex: string,
-    @Inject(MAT_SELECT_SCROLL_STRATEGY) private _scrollStrategyFactory) {
+    @Inject(MAT_SELECT_SCROLL_STRATEGY) scrollStrategyFactory: any) {
     super(elementRef, _defaultErrorStateMatcher, _parentForm,
           _parentFormGroup, ngControl);
 
@@ -497,6 +494,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       this.ngControl.valueAccessor = this;
     }
 
+    this._scrollStrategyFactory = scrollStrategyFactory;
+    this._scrollStrategy = this._scrollStrategyFactory();
     this.tabIndex = parseInt(tabIndex) || 0;
 
     // Force setter to be called in case id was not specified.
@@ -572,7 +571,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     this._triggerRect = this.trigger.nativeElement.getBoundingClientRect();
     // Note: The computed font-size will be a string pixel value (e.g. "16px").
     // `parseInt` ignores the trailing 'px' and converts this to a number.
-    this._triggerFontSize = parseInt(getComputedStyle(this.trigger.nativeElement)['font-size']);
+    this._triggerFontSize = parseInt(getComputedStyle(this.trigger.nativeElement).fontSize || '0');
 
     this._panelOpen = true;
     this._keyManager.withHorizontalOrientation(null);

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -99,9 +99,10 @@ describe('MatDrawer', () => {
     it('should resolve the open method promise with the new state of the drawer', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
-      const drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      const drawer: MatDrawer =
+          fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
 
-      drawer.componentInstance.open().then(result => expect(result).toBe('open'));
+      drawer.open().then(result => expect(result).toBe('open'));
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -111,13 +112,14 @@ describe('MatDrawer', () => {
       const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
       const drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      const drawerInstance: MatDrawer = drawer.componentInstance;
 
-      drawer.componentInstance.open();
+      drawerInstance.open();
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
 
-      drawer.componentInstance.close().then(result => expect(result).toBe('close'));
+      drawerInstance.close().then(result => expect(result).toBe('close'));
       fixture.detectChanges();
       flush();
       fixture.detectChanges();

--- a/src/lib/stepper/stepper.spec.ts
+++ b/src/lib/stepper/stepper.spec.ts
@@ -369,7 +369,7 @@ describe('MatStepper', () => {
   });
 
   describe('basic stepper with i18n label change', () => {
-    let i18nFixture;
+    let i18nFixture: ComponentFixture<SimpleMatHorizontalStepperApp>;
 
     beforeEach(() => {
       i18nFixture = createComponent(SimpleMatHorizontalStepperApp);
@@ -688,7 +688,7 @@ describe('MatStepper', () => {
   });
 
   describe('linear stepper with a pre-defined selectedIndex', () => {
-    let preselectedFixture;
+    let preselectedFixture: ComponentFixture<SimplePreselectedMatHorizontalStepperApp>;
     beforeEach(() => {
       preselectedFixture = createComponent(SimplePreselectedMatHorizontalStepperApp);
     });
@@ -699,7 +699,7 @@ describe('MatStepper', () => {
   });
 
   describe('linear stepper with no `stepControl`', () => {
-    let noStepControlFixture;
+    let noStepControlFixture: ComponentFixture<SimpleStepperWithoutStepControl>;
     beforeEach(() => {
       noStepControlFixture = createComponent(SimpleStepperWithoutStepControl);
       noStepControlFixture.detectChanges();
@@ -721,7 +721,7 @@ describe('MatStepper', () => {
   });
 
   describe('linear stepper with `stepControl`', () => {
-    let controlAndBindingFixture;
+    let controlAndBindingFixture: ComponentFixture<SimpleStepperWithStepControlAndCompletedBinding>;
     beforeEach(() => {
       controlAndBindingFixture =
       createComponent(SimpleStepperWithStepControlAndCompletedBinding);
@@ -1326,7 +1326,7 @@ class SimpleStepperWithStepControlAndCompletedBinding {
 })
 class IconOverridesStepper {
   getRomanNumeral(value: number) {
-    return {
+    const numberMap: {[key: number]: string} = {
       1: 'I',
       2: 'II',
       3: 'III',
@@ -1336,7 +1336,9 @@ class IconOverridesStepper {
       7: 'VII',
       8: 'VIII',
       9: 'IX'
-    }[value];
+    };
+
+    return numberMap[value];
   }
 }
 

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -108,7 +108,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
    */
   sortingDataAccessor: ((data: T, sortHeaderId: string) => string|number) =
       (data: T, sortHeaderId: string): string|number => {
-    const value: any = data[sortHeaderId];
+    const value = (data as {[key: string]: any})[sortHeaderId];
 
     if (_isNumberValue(value)) {
       const numberValue = Number(value);
@@ -173,7 +173,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
    */
   filterPredicate: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
     // Transform the data into a lowercase string of all property values.
-    const accumulator = (currentTerm, key) => currentTerm + data[key];
+    const accumulator =
+        (currentTerm: string, key: string) => currentTerm + (data as {[key: string]: any})[key];
     const dataStr = Object.keys(data).reduce(accumulator, '').toLowerCase();
 
     // Transform the filter by converting it to lowercase and removing whitespace.

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -161,7 +161,7 @@ export class MatTabBody implements OnInit, OnDestroy {
               changeDetectorRef?: ChangeDetectorRef) {
 
     if (this._dir && changeDetectorRef) {
-      this._dirChangeSubscription = this._dir.change.subscribe(dir => {
+      this._dirChangeSubscription = this._dir.change.subscribe((dir: Direction) => {
         this._computePositionAnimationState(dir);
         changeDetectorRef.markForCheck();
       });

--- a/src/lib/toolbar/toolbar.ts
+++ b/src/lib/toolbar/toolbar.ts
@@ -88,10 +88,10 @@ export class MatToolbar extends _MatToolbarMixinBase implements CanColor, AfterV
 
     // Check if there are any other DOM nodes that can display content but aren't inside of
     // a <mat-toolbar-row> element.
-    const isCombinedUsage = [].slice.call(this._elementRef.nativeElement.childNodes)
+    const isCombinedUsage = Array.from<HTMLElement>(this._elementRef.nativeElement.childNodes)
       .filter(node => !(node.classList && node.classList.contains('mat-toolbar-row')))
       .filter(node => node.nodeType !== (this._document ? this._document.COMMENT_NODE : 8))
-      .some(node => node.textContent.trim());
+      .some(node => !!(node.textContent && node.textContent.trim()));
 
     if (isCombinedUsage) {
       throwToolbarMixedModesError();

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -18,8 +18,8 @@ import {
   Overlay,
   OverlayConnectionPosition,
   OverlayRef,
-  ScrollStrategy,
   VerticalConnectionPos,
+  ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
@@ -122,6 +122,7 @@ export class MatTooltip implements OnDestroy {
   private _position: TooltipPosition = 'below';
   private _disabled: boolean = false;
   private _tooltipClass: string|string[]|Set<string>|{[key: string]: any};
+  private _scrollStrategy: () => ScrollStrategy;
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   @Input('matTooltipPosition')
@@ -203,12 +204,14 @@ export class MatTooltip implements OnDestroy {
     private _platform: Platform,
     private _ariaDescriber: AriaDescriber,
     private _focusMonitor: FocusMonitor,
-    @Inject(MAT_TOOLTIP_SCROLL_STRATEGY) private _scrollStrategy,
+    @Inject(MAT_TOOLTIP_SCROLL_STRATEGY) scrollStrategy: any,
     @Optional() private _dir: Directionality,
     @Optional() @Inject(MAT_TOOLTIP_DEFAULT_OPTIONS)
       private _defaultOptions: MatTooltipDefaultOptions) {
 
+    this._scrollStrategy = scrollStrategy;
     const element: HTMLElement = _elementRef.nativeElement;
+    const elementStyle = element.style as CSSStyleDeclaration & {webkitUserDrag: string};
 
     // The mouse events shouldn't be bound on mobile devices, because they can prevent the
     // first tap from firing its click event or can cause the tooltip to open for clicks.
@@ -225,14 +228,14 @@ export class MatTooltip implements OnDestroy {
       // problematic on iOS and in Safari, because it will prevent users from typing in inputs.
       // Since `user-select: none` is not needed for the `longpress` event and can cause unexpected
       // behavior for text fields, we always clear the `user-select` to avoid such issues.
-      element.style.webkitUserSelect = element.style.userSelect = element.style.msUserSelect = '';
+      elementStyle.webkitUserSelect = elementStyle.userSelect = elementStyle.msUserSelect = '';
     }
 
     // Hammer applies `-webkit-user-drag: none` on all elements by default,
     // which breaks the native drag&drop. If the consumer explicitly made
     // the element draggable, clear the `-webkit-user-drag`.
-    if (element.draggable && element.style['webkitUserDrag'] === 'none') {
-      element.style['webkitUserDrag'] = '';
+    if (element.draggable && elementStyle.webkitUserDrag === 'none') {
+      elementStyle.webkitUserDrag = '';
     }
 
     _focusMonitor.monitor(_elementRef).pipe(takeUntil(this._destroyed)).subscribe(origin => {

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {FlatTreeControl, NestedTreeControl, TreeControl} from '@angular/cdk/tree';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {
@@ -25,7 +25,7 @@ describe('MatTree', () => {
   let treeElement: HTMLElement;
   let underlyingDataSource: FakeDataSource;
 
-  function configureMatTreeTestingModule(declarations) {
+  function configureMatTreeTestingModule(declarations: Type<any>[]) {
     TestBed.configureTestingModule({
       imports: [MatTreeModule],
       declarations: declarations,

--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -7,6 +7,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "newLine": "lf",
     "module": "es2015",

--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -91,7 +91,7 @@ export class FileDatabase {
    * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
    * The return value is the list of `FileNode`.
    */
-  buildFileTree(obj: object, level: number): FileNode[] {
+  buildFileTree(obj: {[key: string]: any}, level: number): FileNode[] {
     return Object.keys(obj).reduce<FileNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new FileNode();

--- a/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
+++ b/src/material-examples/cdk-tree-nested/cdk-tree-nested-example.ts
@@ -84,7 +84,7 @@ export class FileDatabase {
    * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
    * The return value is the list of `FileNode`.
    */
-  buildFileTree(obj: object, level: number): FileNode[] {
+  buildFileTree(obj: {[key: string]: any}, level: number): FileNode[] {
     return Object.keys(obj).reduce<FileNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new FileNode();

--- a/src/material-examples/sort-overview/sort-overview-example.ts
+++ b/src/material-examples/sort-overview/sort-overview-example.ts
@@ -53,6 +53,6 @@ export class SortOverviewExample {
   }
 }
 
-function compare(a, b, isAsc) {
+function compare(a: number | string, b: number | string, isAsc: boolean) {
   return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
 }

--- a/src/material-examples/tree-checklist/tree-checklist-example.ts
+++ b/src/material-examples/tree-checklist/tree-checklist-example.ts
@@ -68,7 +68,7 @@ export class ChecklistDatabase {
    * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
    * The return value is the list of `TodoItemNode`.
    */
-  buildFileTree(obj: object, level: number): TodoItemNode[] {
+  buildFileTree(obj: {[key: string]: any}, level: number): TodoItemNode[] {
     return Object.keys(obj).reduce<TodoItemNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new TodoItemNode();

--- a/src/material-examples/tree-flat-overview/tree-flat-overview-example.ts
+++ b/src/material-examples/tree-flat-overview/tree-flat-overview-example.ts
@@ -91,7 +91,7 @@ export class FileDatabase {
    * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
    * The return value is the list of `FileNode`.
    */
-  buildFileTree(obj: object, level: number): FileNode[] {
+  buildFileTree(obj: {[key: string]: any}, level: number): FileNode[] {
     return Object.keys(obj).reduce<FileNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new FileNode();

--- a/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
+++ b/src/material-examples/tree-nested-overview/tree-nested-overview-example.ts
@@ -84,7 +84,7 @@ export class FileDatabase {
    * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
    * The return value is the list of `FileNode`.
    */
-  buildFileTree(obj: object, level: number): FileNode[] {
+  buildFileTree(obj: {[key: string]: any}, level: number): FileNode[] {
     return Object.keys(obj).reduce<FileNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new FileNode();

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "module": "es2015",
     "moduleResolution": "node",

--- a/src/material-experimental/tsconfig-build.json
+++ b/src/material-experimental/tsconfig-build.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "newLine": "lf",
     "module": "es2015",

--- a/src/material-moment-adapter/tsconfig-build.json
+++ b/src/material-moment-adapter/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "importHelpers": true,
     "newLine": "lf",
     "module": "es2015",

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": ".",

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -7,6 +7,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "skipLibCheck": true,
     "target": "es2015",
     "lib": ["es5", "es2015", "dom"],


### PR DESCRIPTION
Enables the `noImplicitAny` compiler option and fixes all of the resulting compiler errors.

Fixes #13330.