### PR TITLE
build: fix bazel schematic setup on windows

### DIFF
--- a/src/cdk/schematics/#bazel_workaround.txt
+++ b/src/cdk/schematics/#bazel_workaround.txt
@@ -1,0 +1,3 @@
+WORKAROUND
+
+https://github.com/bazelbuild/rules_nodejs/issues/352

--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -4,6 +4,9 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "jasmine_node_test")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
 
+# TODO(devversion): remove when https://github.com/bazelbuild/rules_nodejs/issues/352 is fixed
+exports_files(["#bazel_workaround.txt"])
+
 filegroup(
   name = "schematics_assets",
   srcs = glob(["**/*.json"]) + ["README.md"],

--- a/src/lib/schematics/BUILD.bazel
+++ b/src/lib/schematics/BUILD.bazel
@@ -13,9 +13,8 @@ ts_library(
   name = "schematics",
   module_name = "@angular/material/schematics",
   srcs = glob(["**/*.ts"], exclude=[
+    "**/files/**/*.ts",
     "**/*.spec.ts",
-    "**/files/**/*",
-    "test-setup/**/*",
     "ng-update/test-cases/**/*",
   ]),
   deps = [
@@ -45,13 +44,13 @@ npm_package(
 jasmine_node_test(
   name = "unit_tests",
   srcs = [":schematics_test_sources"],
-  data = [":schematics_assets", ":schematics_test_cases"],
+  data = [":node_loader_workaround", ":schematics_assets", ":schematics_test_cases"],
   deps = ["@npm//:jasmine"]
 )
 
 ts_library(
   name = "schematics_test_sources",
-  srcs = glob(["**/*.spec.ts", "test-setup/**/*.ts"], exclude=["**/files/**/*"]),
+  srcs = glob(["**/*.spec.ts"], exclude=["**/files/**/*.spec.ts"]),
   deps = [
     ":schematics",
     "//src/cdk/schematics",
@@ -71,5 +70,18 @@ filegroup(
     "ng-update/test-cases/**/*_input.ts",
     "ng-update/test-cases/**/*_expected_output.ts"
   ]),
+  testonly = True,
+)
+
+# Filegroup that references a text file which comes alphabetically before the
+# "cdk/schematics/index.js" file. This is necessary because on Windows in order to support absolute
+# paths, the NodeJS rules resolve the actual workspace root by looking for the first entry that
+# refers to the Bazel "USER_WORKSPACE" in the MANIFEST file. Since it's alphabetically ordered, and
+# the CDK comes always before the Material schematics, we need to make sure that it doesn't resolve
+# to the CDK bazel output which has been built as dependency.
+# See more: https://github.com/bazelbuild/rules_nodejs/issues/352
+filegroup(
+  name = "node_loader_workaround",
+  srcs = ["//src/cdk/schematics:#bazel_workaround.txt"],
   testonly = True,
 )


### PR DESCRIPTION
* Currently running tests of the schematic is not working on Windows because there is a bug within the `rules_nodejs`. See: https://github.com/bazelbuild/rules_nodejs/issues/352

@jelbourn This is pretty important for myself as developer on Windows, because otherwise I need to run the tests on the CI (which takes long) or I need to switch to MacOS/Linux.