### PR TITLE
chore(changelog): remove superfluous breaking change note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,6 @@
 
 * **ripple:** deprecated `[matRippleSpeedFactor]` and `baseSpeedFactor` for the ripples have been removed. Use the new animation config instead.
 
-* Add test case; fix NodeJS version target circular dependency; Support for rule version constraints
-
 
 
 <a name="7.0.0-beta.2"></a>


### PR DESCRIPTION
* Removes the superfluous breaking change text that appears because the PR has been squashed and merged (while concatenating the commit descriptions).

I've had it mentioned in https://github.com/angular/material2/pull/13342, but this one is outdated now. We should be able to close that.