### PR TITLE
fix(select): allow extra content to be projected after label in mat-optgroup

### DIFF
--- a/src/lib/core/option/optgroup.html
+++ b/src/lib/core/option/optgroup.html
@@ -1,2 +1,2 @@
-<label class="mat-optgroup-label" [id]="_labelId">{{ label }}</label>
+<label class="mat-optgroup-label" [id]="_labelId">{{ label }} <ng-content></ng-content></label>
 <ng-content select="mat-option, ng-container"></ng-content>


### PR DESCRIPTION
Allows for consumers to project extra content into the label of `mat-optgroup`. Currently any content that isn't a `mat-option` won't be rendered.

Fixes #11489.