### PR TITLE
fix(button-toggle): not setting proper border in vertical mode

### DIFF
--- a/src/lib/button-toggle/_button-toggle-theme.scss
+++ b/src/lib/button-toggle/_button-toggle-theme.scss
@@ -44,10 +44,12 @@
     border-right: solid 1px $divider-color;
   }
 
-  .mat-button-toggle-vertical-appearance-standard .mat-button-toggle + .mat-button-toggle {
-    border-left: none;
-    border-right: none;
-    border-top: solid 1px $divider-color;
+  .mat-button-toggle-group-appearance-standard.mat-button-toggle-vertical {
+    .mat-button-toggle + .mat-button-toggle {
+      border-left: none;
+      border-right: none;
+      border-top: solid 1px $divider-color;
+    }
   }
 
   .mat-button-toggle-checked {


### PR DESCRIPTION
Looks like something that slipped through when refactoring the previous PR to support multiple appearances. The selector that was supposed to set the proper borders in vertical mode was incorrect.