### PR TITLE
chore: fix drag-drop test failure

### DIFF
--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -1622,7 +1622,7 @@ describe('CdkDrag', () => {
         dropInstances[0].connectedTo = dropInstances[1];
         dropInstances[1].connectedTo = [];
 
-        dispatchMouseEvent(item.element.nativeElement, 'mousedown');
+        startDraggingViaMouse(fixture, item.element.nativeElement);
         fixture.detectChanges();
 
         const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;


### PR DESCRIPTION
Fixes a failure in `cdk/drag-drop` that was due to a couple of conflicting PRs getting in close to each other.