### PR TITLE
fix(schematics): @angular/material schematics not working

### DIFF
--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "composite": true,
+    "declaration": true,
     "lib": ["es2017"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/src/lib/schematics/ng-update/upgrade-data.ts
+++ b/src/lib/schematics/ng-update/upgrade-data.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuleUpgradeData} from '@angular/cdk/schematics';
 import {
   attributeSelectors,
   classNames,
@@ -19,7 +20,7 @@ import {
 } from './data';
 
 /** Upgrade data that will be used for the Angular Material ng-update schematic. */
-export const materialUpgradeData = {
+export const materialUpgradeData: RuleUpgradeData = {
   attributeSelectors,
   classNames,
   constructorChecks,

--- a/src/lib/schematics/tsconfig.json
+++ b/src/lib/schematics/tsconfig.json
@@ -9,6 +9,7 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    "declaration": true,
     "target": "es6",
     "types": [
       "jasmine",
@@ -16,9 +17,12 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@angular/cdk/schematics": ["../../cdk/schematics/"]
+      "@angular/cdk/schematics": ["../../cdk/schematics"]
     }
   },
+  "references": [
+    {"path": "../../cdk/schematics"}
+  ],
   "exclude": [
     "**/*.spec.ts",
     // Exclude the test-setup utility files. Those should not be part of the output.


### PR DESCRIPTION
Due to the fact that the Material schematics depend on the CDK schematics, we need to use TypeScript path mappings. For some reason, TypeScript no longer flattens the output properly and also generates the output of the CDK. This happens if we refer to the actual sources or to the `dist/packages/cdk` output. 

In all cases, the output will have an incorrect directory structure. Not sure whether this now happens due to TypeScript 3.1. In order to fix this, we need to use the new "Project References" feature.

---

https://github.com/angular/material2-builds/tree/master/schematics/

_Notice_ the additional `lib/schematics` folder in the `@angular/material/schematics` folder.