### PR TITLE
fix(virtual-scroll): don't set both `right` and `left` on the content wrapper

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.scss
+++ b/src/cdk/scrolling/virtual-scroll-viewport.scss
@@ -56,12 +56,10 @@ cdk-virtual-scroll-viewport {
 }
 
 .cdk-virtual-scroll-orientation-horizontal .cdk-virtual-scroll-content-wrapper {
-  bottom: 0;
   @include _cdk-virtual-scroll-clear-container-space(horizontal);
 }
 
 .cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
-  right: 0;
   @include _cdk-virtual-scroll-clear-container-space(vertical);
 }
 


### PR DESCRIPTION
Otherwise it prevents the horizontal scrollbar from showing when
`contain: content` is used. Fixes #13231