### PR TITLE
fix(form-field): updated form-field-prefix-suffix password icon

### DIFF
--- a/src/material-examples/form-field-prefix-suffix/form-field-prefix-suffix-example.html
+++ b/src/material-examples/form-field-prefix-suffix/form-field-prefix-suffix-example.html
@@ -1,7 +1,7 @@
 <div class="example-container">
   <mat-form-field>
     <input matInput placeholder="Enter your password" [type]="hide ? 'password' : 'text'">
-    <mat-icon matSuffix (click)="hide = !hide">{{hide ? 'visibility' : 'visibility_off'}}</mat-icon>
+    <mat-icon matSuffix (click)="hide = !hide">{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
   </mat-form-field>
 
   <mat-form-field>


### PR DESCRIPTION
The password icon must represents the current input state:
* When the input is in __hidden state__ _(i.e. the password input is a password input and the chars are hidden)_, the password icon must be *__visibility_off__*;
* When the input is in __visible text state__ _(i.e. the password input is a text input and the chars are shown)_, the password icon must be *__visibility__*.

This is according to the Material rules (see https://material.io/design/components/text-fields.html#outlined-text-field)