### PR TITLE
fix(experimental/dialog): clean up open dialogs on destroy

### DIFF
--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -618,6 +618,20 @@ describe('Dialog', () => {
     expect(spy).toHaveBeenCalled();
   }));
 
+  it('should close all open dialogs on destroy', fakeAsync(() => {
+    dialog.openFromComponent(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    dialog.openFromComponent(PizzaMsg, { viewContainerRef: testViewContainerRef });
+
+    viewContainerFixture.detectChanges();
+    expect(overlayContainerElement.querySelectorAll('cdk-dialog-container').length).toBe(2);
+
+    dialog.ngOnDestroy();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.querySelectorAll('cdk-dialog-container').length).toBe(0);
+  }));
+
   describe('passing in data', () => {
     it('should be able to pass in data', () => {
       let config = {
@@ -990,6 +1004,22 @@ describe('Dialog with a parent Dialog', () => {
       expect(overlayContainerElement.textContent!.trim())
           .toBe('', 'Expected closeAll on parent Dialog to close dialog opened by child');
     }));
+
+  it('should not close the parent dialogs, when a child is destroyed', fakeAsync(() => {
+    parentDialog.openFromComponent(PizzaMsg);
+    fixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.textContent)
+        .toContain('Pizza', 'Expected a dialog to be opened');
+
+    childDialog.ngOnDestroy();
+    fixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.textContent)
+        .toContain('Pizza', 'Expected a dialog to remain opened');
+  }));
 
   it('should close the top dialog via the escape key', fakeAsync(() => {
     childDialog.openFromComponent(PizzaMsg);

--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -13,7 +13,8 @@ import {
   Injectable,
   Injector,
   Inject,
-  ComponentRef
+  ComponentRef,
+  OnDestroy
 } from '@angular/core';
 import {ComponentPortal, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
 import {of as observableOf, Observable, Subject, defer} from 'rxjs';
@@ -43,7 +44,7 @@ import {
  * Service to open modal dialogs.
  */
 @Injectable()
-export class Dialog {
+export class Dialog implements OnDestroy {
   /** Stream that emits when all dialogs are closed. */
   get _afterAllClosed(): Observable<void> {
     return this._parentDialog ? this._parentDialog.afterAllClosed : this._afterAllClosedBase;
@@ -122,6 +123,11 @@ export class Dialog {
 
     this.registerDialogRef(dialogRef);
     return dialogRef;
+  }
+
+  ngOnDestroy() {
+    // Only close all the dialogs at this level.
+    this._openDialogs.forEach(ref => ref.close());
   }
 
   /**


### PR DESCRIPTION
Cleans up all of the open dialogs when a dialog from `cdk-experimental/dialog` is destroyed.