### PR TITLE
fix(ng-add): allow using noop animations

### DIFF
--- a/src/cdk/schematics/utils/ast/ng-module-imports.ts
+++ b/src/cdk/schematics/utils/ast/ng-module-imports.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Tree} from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+
+/**
+ * Whether the Angular module in the given path imports the specifed module class name.
+ */
+export function hasNgModuleImport(tree: Tree, modulePath: string, className: string): boolean {
+  const moduleFileContent = tree.read(modulePath);
+
+  if (!moduleFileContent) {
+    throw new Error(`Could not read Angular module file: ${modulePath}`);
+  }
+
+  const parsedFile = ts.createSourceFile(modulePath, moduleFileContent.toString(),
+      ts.ScriptTarget.Latest, true);
+  let ngModuleMetadata: ts.ObjectLiteralExpression | null = null;
+
+  const findModuleDecorator = (node: ts.Node) => {
+    if (ts.isDecorator(node) && ts.isCallExpression(node.expression) &&
+        isNgModuleCallExpression(node.expression)) {
+      ngModuleMetadata = node.expression.arguments[0] as ts.ObjectLiteralExpression;
+      return;
+    }
+
+    ts.forEachChild(node, findModuleDecorator);
+  };
+
+  ts.forEachChild(parsedFile, findModuleDecorator);
+
+  if (!ngModuleMetadata) {
+    throw new Error(`Could not find NgModule declaration inside: "${modulePath}"`);
+  }
+
+  for (let property of ngModuleMetadata!.properties) {
+    if (!ts.isPropertyAssignment(property) || property.name.getText() !== 'imports' ||
+        !ts.isArrayLiteralExpression(property.initializer)) {
+      continue;
+    }
+
+    if (property.initializer.elements.some(element => element.getText() === className)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Resolves the last identifier that is part of the given expression. This helps resolving
+ * identifiers of nested property access expressions (e.g. myNamespace.core.NgModule).
+ */
+function resolveIdentifierOfExpression(expression: ts.Expression): ts.Identifier | null {
+  if (ts.isIdentifier(expression)) {
+    return expression;
+  } else if (ts.isPropertyAccessExpression(expression)) {
+    return resolveIdentifierOfExpression(expression.expression);
+  }
+  return null;
+}
+
+/** Whether the specified call expression is referring to a NgModule definition. */
+function isNgModuleCallExpression(callExpression: ts.CallExpression): boolean {
+  if (!callExpression.arguments.length ||
+      !ts.isObjectLiteralExpression(callExpression.arguments[0])) {
+    return false;
+  }
+
+  const decoratorIdentifier = resolveIdentifierOfExpression(callExpression.expression);
+  return decoratorIdentifier ? decoratorIdentifier.text === 'NgModule' : false;
+}

--- a/src/cdk/schematics/utils/index.ts
+++ b/src/cdk/schematics/utils/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './ast';
+export * from './ast/ng-module-imports';
 export * from './build-component';
 export * from './get-project';
 export * from './parse5-element';

--- a/src/lib/schematics/ng-add/schema.json
+++ b/src/lib/schematics/ng-add/schema.json
@@ -22,6 +22,12 @@
       "default": true,
       "description": "Whether gesture support should be set up or not.",
       "x-prompt": "Set up HammerJS for gesture recognition?"
+    },
+    "animations": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Angular browser animations should be set up or not.",
+      "x-prompt": "Set up browser animations for Angular Material?"
     }
   },
   "required": []

--- a/src/lib/schematics/ng-add/schema.ts
+++ b/src/lib/schematics/ng-add/schema.ts
@@ -14,6 +14,9 @@ export interface Schema {
   /** Whether gesture support should be set up or not. */
   gestures: boolean;
 
+  /** Whether Angular browser animations should be set up or not. */
+  animations: boolean;
+
   /** Name of pre-built theme to install. */
   theme: 'indigo-pink' | 'deeppurple-amber' | 'pink-bluegrey' | 'purple-green' | 'custom';
 }


### PR DESCRIPTION
* Currently we always install `@angular/animations` and add the `BrowserAnimationsModule` to the project module. There should be a prompt/option that allows developers to use the `NoopAnimationsModule`.

* No longer adds the `BrowserAnimationsModule` if the project already uses the `NoopAnimationsModule` (avoiding magic). Same applies for the `NoopAnimationsModule`. We won't add the noop animations module if the browser animations module is configured.