### PR TITLE
refactor(schematics): better margin for drag-drop schematic

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
@@ -1,7 +1,7 @@
 .container {
   width: 400px;
   max-width: 100%;
-  margin: 0 25px 25px 0;
+  margin: 0 20px;
   display: inline-block;
   vertical-align: top;
 }

--- a/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/lib/schematics/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -1,11 +1,8 @@
 <mat-sidenav-container class="sidenav-container">
-  <mat-sidenav
-    #drawer
-    class="sidenav"
-    fixedInViewport="true"
-    [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
-    [mode]="(isHandset$ | async) ? 'over' : 'side'"
-    [opened]="!(isHandset$ | async)">
+  <mat-sidenav #drawer class="sidenav" fixedInViewport="true"
+      [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
+      [mode]="(isHandset$ | async) ? 'over' : 'side'"
+      [opened]="!(isHandset$ | async)">
     <mat-toolbar>Menu</mat-toolbar>
     <mat-nav-list>
       <a mat-list-item href="#">Link 1</a>

--- a/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/lib/schematics/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -17,9 +17,9 @@
   </table>
 
   <mat-paginator #paginator
-    [length]="dataSource.data.length"
-    [pageIndex]="0"
-    [pageSize]="50"
-    [pageSizeOptions]="[25, 50, 100, 250]">
+      [length]="dataSource.data.length"
+      [pageIndex]="0"
+      [pageSize]="50"
+      [pageSizeOptions]="[25, 50, 100, 250]">
   </mat-paginator>
 </div>


### PR DESCRIPTION
* Improves the margin of the drag-drop schematic containers. Since the component does not have any inner padding, the containers would show up at the edge of the page. This happens if someone just runs `ng add @angular/cdk` and `ng g @angular/cdk:drag-drop myComponent`.
* Indents wrapped attributes in HTML template files. The goal of the schematics should be also to generate resources that can be used for learning. Right now it's not 100% clear where the child element starts (see: https://google.github.io/styleguide/htmlcssguide.html#HTML_Line-Wrapping)