### PR TITLE
build(docs): deprecated state of type alias not showing up

### DIFF
--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -3,6 +3,7 @@ import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExpor
 import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {ConstExportDoc} from 'dgeni-packages/typescript/api-doc-types/ConstExportDoc';
 import {PropertyMemberDoc} from 'dgeni-packages/typescript/api-doc-types/PropertyMemberDoc';
+import {TypeAliasExportDoc} from 'dgeni-packages/typescript/api-doc-types/TypeAliasExportDoc';
 import {ParsedDecorator} from 'dgeni-packages/typescript/services/TsParser/getDecorators';
 import {FunctionExportDoc} from 'dgeni-packages/typescript/api-doc-types/FunctionExportDoc';
 import {MethodMemberDoc} from 'dgeni-packages/typescript/api-doc-types/MethodMemberDoc';
@@ -55,3 +56,6 @@ export interface CategorizedFunctionExportDoc
 
 /** Extended Dgeni const export document that simplifies logic for the Dgeni template. */
 export interface CategorizedConstExportDoc extends ConstExportDoc, DeprecationDoc {}
+
+/** Extended Dgeni type alias document that includes more information when rendering. */
+export interface CategorizedTypeAliasExportDoc extends TypeAliasExportDoc, DeprecationDoc {}

--- a/tools/dgeni/processors/categorizer.ts
+++ b/tools/dgeni/processors/categorizer.ts
@@ -16,6 +16,7 @@ import {
   CategorizedFunctionExportDoc,
   CategorizedMethodMemberDoc,
   CategorizedPropertyMemberDoc,
+  CategorizedTypeAliasExportDoc,
 } from '../common/dgeni-definitions';
 import {getDirectiveMetadata} from '../common/directive-metadata';
 import {normalizeFunctionParameters} from '../common/normalize-function-parameters';
@@ -47,6 +48,10 @@ export class Categorizer implements Processor {
     docs
       .filter(doc => doc.docType === 'const')
       .forEach(doc => this.decorateConstExportDoc(doc));
+
+    docs
+      .filter(doc => doc.docType === 'type-alias')
+      .forEach(doc => this.decorateTypeAliasExportDoc(doc));
   }
 
   /**
@@ -127,6 +132,14 @@ export class Categorizer implements Processor {
    * documents with a property that states whether the constant is deprecated or not.
    */
   private decorateConstExportDoc(doc: CategorizedConstExportDoc) {
+    decorateDeprecatedDoc(doc);
+  }
+
+  /**
+   * Method that will be called for each type-alias export document. We decorate the type-alias
+   * documents with a property that states whether the type-alias is deprecated or not.
+   */
+  private decorateTypeAliasExportDoc(doc: CategorizedTypeAliasExportDoc) {
     decorateDeprecatedDoc(doc);
   }
 

--- a/tools/dgeni/templates/constant.template.html
+++ b/tools/dgeni/templates/constant.template.html
@@ -18,7 +18,7 @@
 <pre class="docs-markdown-pre">
 <code class="docs-markdown-code">
 {%- highlight "typescript" -%}
-  const {$ constant.name | safe $}: {$ constant.type | safe $}
+  const {$ constant.name | safe $}: {$ constant.type | safe $};
 {%- end_highlight -%}
 </code>
 </pre>

--- a/tools/dgeni/templates/type-alias.template.html
+++ b/tools/dgeni/templates/type-alias.template.html
@@ -5,11 +5,20 @@
   <code>{$ alias.name $}</code>
 </h4>
 
+{%- if alias.isDeprecated -%}
+<div class="docs-api-type-alias-deprecated-marker" {$ macros.deprecationTitle(alias) $}>
+  Deprecated
+</div>
+{%- endif -%}
+
 {%- if alias.description -%}
   <p class="docs-api-type-alias-description">{$ alias.description | marked | safe $}</p>
 {%- endif -%}
 
-<p class="docs-api-type-alias-value">
-  <span class="docs-api-type-alias-value-label">Type:</span>
-  <code class="docs-api-type-alias-value">{$ alias.typeDefinition $}</code>
-</p>
+<pre class="docs-markdown-pre">
+<code class="docs-markdown-code">
+{%- highlight "typescript" -%}
+  type {$ alias.name | safe $} = {$ alias.typeDefinition | safe $};
+{%- end_highlight -%}
+</code>
+</pre>


### PR DESCRIPTION
* Currently if a type alias is marked as `@deprecated`, we don't add an indication as for the constants. Now a similar indication will be added if a type alias is deprecated.

---

* Similarly to the constants and `angular.io`, we will display the actual type of the `type-alias` in a better-looking & more clear way.
* Also fixes that the constant code "overview" does not include the trailing semicolon (Angular.io also adds a trailing semicolon)

![image](https://user-images.githubusercontent.com/4987015/46545203-f6d3fa80-c8c5-11e8-9f19-06f62285f63d.png)

