### PR TITLE
fix(schematics): name is required when generating the drag-drop schematic

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/schema.json
+++ b/src/cdk/schematics/ng-generate/drag-drop/schema.json
@@ -93,5 +93,5 @@
       "description": "Specifies if the component is an entry component of declaring module."
     }
   },
-  "required": []
+  "required": ["name"]
 }


### PR DESCRIPTION
* Similar to the other component generation schematics in `@angular/material`, the drag-drop schematic in `@angular/cdk` requires a name to be specified. If we don't mark this as required, a runtime exception will be thrown (`Cannot read property 'replace' of undefined`)