### PR TITLE
fix(schematics): tree folder icons do not have enough contrast

### DIFF
--- a/src/lib/schematics/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
+++ b/src/lib/schematics/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.__styleext__
@@ -1,4 +1,4 @@
 .type-icon {
-  color: #999;
+  color: #757575;
   margin-right: 5px;
 }


### PR DESCRIPTION
addresses [aXe](https://dequeuniversity.com/rules/axe/2.2/color-contrast?application=lighthouse)/Lighthouse a11y audit failures

This raises the Lighthouse a11y score for all schematics combined from `88` to `94`. The other 6 missing points are from https://github.com/angular/material2/issues/11083 and https://github.com/angular/material2/issues/11083#issuecomment-427507968.