### PR TITLE
build: fix firebase peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@angular/upgrade": "7.0.0-rc.0",
     "@bazel/ibazel": "0.3.1",
     "@bazel/typescript": "^0.19.1",
+    "@firebase/app-types": "^0.3.2",
     "@google-cloud/storage": "^1.1.1",
     "@octokit/rest": "^15.9.4",
     "@schematics/angular": "7.0.0-rc.1",

--- a/tools/gulp/util/firebase.ts
+++ b/tools/gulp/util/firebase.ts
@@ -1,5 +1,7 @@
+import {initializeApp} from 'firebase';
+
+// This import lacks type definitions.
 const firebaseAdmin = require('firebase-admin');
-const firebase = require('firebase');
 
 /** Database URL of the dashboard firebase project. */
 const dashboardDatabaseUrl = 'https://material2-board.firebaseio.com';
@@ -22,7 +24,7 @@ export function openFirebaseDashboardApp() {
 
 /** Opens a connection to the Firebase dashboard app with no authentication. */
 export function openFirebaseDashboardAppAsGuest() {
-  return firebase.initializeApp({ databaseURL: dashboardDatabaseUrl });
+  return initializeApp({ databaseURL: dashboardDatabaseUrl });
 }
 
 /** Decodes a Travis CI variable that is public in favor for PRs. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,7 +273,7 @@
     tsickle "0.28.0"
     tsutils "2.27.2"
 
-"@firebase/app-types@0.3.2":
+"@firebase/app-types@0.3.2", "@firebase/app-types@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
   integrity sha512-ZD8lTgW07NGgo75bTyBJA8Lt9+NweNzot7lrsBtIvfciwUzaFJLsv2EShqjBeuhF7RpG6YFucJ6m67w5buCtzw==


### PR DESCRIPTION
* The `firebase` packages comes by default without typings. Firebase defines the app types as peer dependencies, so we should fix those.

_Marking as major_, since the Yarn PR was also marked as "major".