### PR TITLE
build: enable sourcemaps for bazel

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "scss-bundle": "^2.0.1-beta.7",
     "selenium-webdriver": "^3.6.0",
     "sorcery": "^0.10.0",
+    "source-map-support": "^0.5.9",
     "stylelint": "^9.5.0",
     "ts-node": "^3.0.4",
     "tsconfig-paths": "^2.3.0",

--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -1,8 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "jasmine_node_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
+load("//tools:defaults.bzl", "jasmine_node_test")
 
 # TODO(devversion): remove when https://github.com/bazelbuild/rules_nodejs/issues/352 is fixed
 exports_files(["#bazel_workaround.txt"])
@@ -20,11 +21,10 @@ ts_library(
   deps = [
     "@npm//:@schematics/angular",
     "@npm//:@angular-devkit/schematics",
-     # TODO(devversion): Only include jasmine for test sources.
+     # TODO(devversion): Only include jasmine for test sources (See: tsconfig types).
     "@npm//:@types/jasmine",
     "@npm//:@types/node",
     "@npm//:glob",
-    "@npm//:jasmine",
     "@npm//:parse5",
     "@npm//:rxjs",
     "@npm//:tslint",
@@ -46,7 +46,6 @@ jasmine_node_test(
   name = "unit_tests",
   srcs = [":schematics_test_sources"],
   data = [":schematics_assets"],
-  deps = ["@npm//:jasmine"],
 )
 
 ts_library(

--- a/src/lib/schematics/BUILD.bazel
+++ b/src/lib/schematics/BUILD.bazel
@@ -1,8 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "jasmine_node_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
+load("//tools:defaults.bzl", "jasmine_node_test")
 
 filegroup(
   name = "schematics_assets",
@@ -21,7 +22,7 @@ ts_library(
     "//src/cdk/schematics",
     "@npm//:@angular-devkit/schematics",
     "@npm//:@schematics/angular",
-    # TODO(devversion): Only include jasmine for test sources.
+    # TODO(devversion): Only include jasmine for test sources (See: tsconfig types).
     "@npm//:@types/jasmine",
     "@npm//:@types/node",
     "@npm//:parse5",
@@ -45,7 +46,6 @@ jasmine_node_test(
   name = "unit_tests",
   srcs = [":schematics_test_sources"],
   data = [":node_loader_workaround", ":schematics_assets", ":schematics_test_cases"],
-  deps = ["@npm//:jasmine"]
 )
 
 ts_library(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,0 +1,15 @@
+# Re-export of Bazel rules with repository-wide defaults
+
+load("@build_bazel_rules_nodejs//:defs.bzl", _jasmine_node_test = "jasmine_node_test")
+
+def jasmine_node_test(deps = [], **kwargs):
+  local_deps = [
+    # Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/344
+    "@npm//:jasmine",
+    "@npm//:source-map-support",
+  ] + deps
+
+  _jasmine_node_test(
+    deps = local_deps,
+    **kwargs
+  )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9720,7 +9720,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@0.5.9, source-map-support@^0.5.0:
+source-map-support@0.5.9, source-map-support@^0.5.0, source-map-support@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==


### PR DESCRIPTION
* Since the NodeJS rules execute built code in a sandbox, we need to enable source map support. This is recommended by the `Bazel NodeJS` rules.
* Also introduces support for repository-wide defaults. This will be helpful when fully switching to Bazel.