### PR TITLE
chore: clean up unused catch clause parameters

### DIFF
--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
@@ -150,7 +150,7 @@ export class InteractivityChecker {
 function getFrameElement(window: Window) {
   try {
     return window.frameElement as HTMLElement;
-  } catch (e) {
+  } catch {
     return null;
   }
 }

--- a/src/lib/toolbar/toolbar.spec.ts
+++ b/src/lib/toolbar/toolbar.spec.ts
@@ -79,7 +79,7 @@ describe('MatToolbar', () => {
           fixture.componentInstance.showToolbarRow = true;
           fixture.detectChanges();
           flush();
-        } catch (e) {
+        } catch {
           flush();
         }
       }).toThrowError(/attempting to combine different/i);

--- a/tools/dashboard/functions/jwt/verify-token.ts
+++ b/tools/dashboard/functions/jwt/verify-token.ts
@@ -18,7 +18,7 @@ export function verifyToken(token: string): boolean {
     }
 
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -16,15 +16,14 @@ const {projectDir} = buildConfig;
 
 /** If the string passed in is a glob, returns it, otherwise append '**\/*' to it. */
 function _globify(maybeGlob: string, suffix = '**/*') {
-  if (maybeGlob.indexOf('*') != -1) {
+  if (maybeGlob.indexOf('*') > -1) {
     return maybeGlob;
   }
   try {
-    const stat = fs.statSync(maybeGlob);
-    if (stat.isFile()) {
+    if (fs.statSync(maybeGlob).isFile()) {
       return maybeGlob;
     }
-  } catch (e) {}
+  } catch {}
   return path.join(maybeGlob, suffix);
 }
 


### PR DESCRIPTION
For a few TS versions now the parameter of a `catch` clause hasn't been required. These changes clean them up in the places where they weren't being used.