### PR TITLE
fix(button-toggle): content shifting in IE11

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -86,6 +86,9 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   line-height: $mat-button-toggle-legacy-height;
   padding: $mat-button-toggle-legacy-padding;
 
+  // Prevents IE from shifting the content on click.
+  position: relative;
+
   .mat-button-toggle-appearance-standard & {
     line-height: $mat-button-toggle-standard-height;
     padding: $mat-button-toggle-standard-padding;


### PR DESCRIPTION
Prevents IE from shifting the button toggle's content when clicked.

For reference:
![demo2](https://user-images.githubusercontent.com/4450522/46617482-84f9ec00-cb25-11e8-939b-7c36118c3195.gif)
