### PR TITLE
chore: fix z-index on drag-drop demos and button width on tooltip demo

### DIFF
--- a/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
+++ b/src/material-examples/cdk-drag-drop-axis-lock/cdk-drag-drop-axis-lock-example.css
@@ -11,6 +11,8 @@
   background: #fff;
   border-radius: 4px;
   margin-right: 25px;
+  position: relative;
+  z-index: 1;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
+++ b/src/material-examples/cdk-drag-drop-handle/cdk-drag-drop-handle-example.css
@@ -12,6 +12,7 @@
   background: #fff;
   border-radius: 4px;
   position: relative;
+  z-index: 1;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
+++ b/src/material-examples/cdk-drag-drop-overview/cdk-drag-drop-overview-example.css
@@ -10,6 +10,8 @@
   text-align: center;
   background: #fff;
   border-radius: 4px;
+  position: relative;
+  z-index: 1;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/src/material-examples/tooltip-auto-hide/tooltip-auto-hide-example.css
+++ b/src/material-examples/tooltip-auto-hide/tooltip-auto-hide-example.css
@@ -1,6 +1,5 @@
 .example-button {
   display: block;
-  width: 48px;
   margin: 80px auto 400px;
 }
 


### PR DESCRIPTION
* Fixes the free-dragging example in the docs site going under other UI elements if they're dragged too far.
* Fixes one of the buttons on the tooltip demo being uneven.

Fixes #13510.