### PR TITLE
feat(schematics): prompt for name when generating component

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/schema.json
+++ b/src/cdk/schematics/ng-generate/drag-drop/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/src/lib/schematics/address-form/schema.json
+++ b/src/lib/schematics/address-form/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/src/lib/schematics/dashboard/schema.json
+++ b/src/lib/schematics/dashboard/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/src/lib/schematics/nav/schema.json
+++ b/src/lib/schematics/nav/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/src/lib/schematics/table/schema.json
+++ b/src/lib/schematics/table/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",

--- a/src/lib/schematics/tree/schema.json
+++ b/src/lib/schematics/tree/schema.json
@@ -23,7 +23,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What should be the name of the component?"
     },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",


### PR DESCRIPTION
* Since the CLI is able to prompt for required schema properties, we should automatically prompt for a name (if none has been specified explicitly) when a developer wants to generate a CDK or Material component.