### PR TITLE
fix(schematics): template content exceeds max line length

### DIFF
--- a/src/lib/schematics/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/src/lib/schematics/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -23,7 +23,9 @@ export class <%= classify(name) %>Component {
     address2: null,
     city: [null, Validators.required],
     state: [null, Validators.required],
-    postalCode: [null, Validators.compose([Validators.required, Validators.minLength(5), Validators.maxLength(5)])],
+    postalCode: [null, Validators.compose([
+      Validators.required, Validators.minLength(5), Validators.maxLength(5)])
+    ],
     shipping: ['free', Validators.required]
   });
 


### PR DESCRIPTION
* Assuming most of the CLI projects have the line limit at around `100`, one line within the `address-form` TS template file exceeds this average max-line-length boundary by `17`.