### PR TITLE
docs(tree-checklist-example): root tree node correct selected state

### DIFF
--- a/src/material-examples/tree-checklist/tree-checklist-example.html
+++ b/src/material-examples/tree-checklist/tree-checklist-example.html
@@ -3,7 +3,7 @@
     <button mat-icon-button disabled></button>
     <mat-checkbox class="checklist-leaf-node"
                   [checked]="checklistSelection.isSelected(node)"
-                  (change)="checklistSelection.toggle(node);">{{node.item}}</mat-checkbox>
+                  (change)="todoLeafItemSelectionToggle(node)">{{node.item}}</mat-checkbox>
   </mat-tree-node>
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>

--- a/src/material-examples/tree-checklist/tree-checklist-example.ts
+++ b/src/material-examples/tree-checklist/tree-checklist-example.ts
@@ -168,20 +168,13 @@ export class TreeChecklistExample {
     return flatNode;
   }
 
-  /**
-   * Whether all the descendants of the node are selected.
-   * And remove the node from this.checklistSelection if it isn't selected.
-   */
+  /** Whether all the descendants of the node are selected. */
   descendantsAllSelected(node: TodoItemFlatNode): boolean {
     const descendants = this.treeControl.getDescendants(node);
     const descAllSelected = descendants.every(child =>
       this.checklistSelection.isSelected(child)
     );
-    if (this.checklistSelection.isSelected(node) && !descAllSelected) {
-      this.checklistSelection.deselect(node);
-    } else if(!this.checklistSelection.isSelected(node) && descAllSelected) {
-      this.checklistSelection.select(node);
-    }
+    this.checkRootNodeSelection(node, descAllSelected);
     return descAllSelected;
   }
 
@@ -199,6 +192,16 @@ export class TreeChecklistExample {
     this.checklistSelection.isSelected(node)
       ? this.checklistSelection.select(...descendants)
       : this.checklistSelection.deselect(...descendants);
+  }
+
+  /** Check root node checked state and change it accordingly */
+  checkRootNodeSelection(node: TodoItemFlatNode, descAllSelected: boolean): void {
+    const nodeSelected = this.checklistSelection.isSelected(node);
+    if (nodeSelected && !descAllSelected) {
+      this.checklistSelection.deselect(node);
+    } else if (!nodeSelected && descAllSelected) {
+      this.checklistSelection.select(node);
+    }
   }
 
   /** Select the category so we can insert the new item. */

--- a/src/material-examples/tree-checklist/tree-checklist-example.ts
+++ b/src/material-examples/tree-checklist/tree-checklist-example.ts
@@ -168,10 +168,19 @@ export class TreeChecklistExample {
     return flatNode;
   }
 
-  /** Whether all the descendants of the node are selected */
+  /**
+   * Whether all the descendants of the node are selected.
+   * And remove the node from this.checklistSelection if it isn't selected.
+   */
   descendantsAllSelected(node: TodoItemFlatNode): boolean {
     const descendants = this.treeControl.getDescendants(node);
-    return descendants.every(child => this.checklistSelection.isSelected(child));
+    const descAllSelected = descendants.every(child =>
+      this.checklistSelection.isSelected(child)
+    );
+    if (this.checklistSelection.isSelected(node) && !descAllSelected) {
+      this.checklistSelection.deselect(node);
+    }
+    return descAllSelected;
   }
 
   /** Whether part of the descendants are selected */

--- a/src/material-examples/tree-checklist/tree-checklist-example.ts
+++ b/src/material-examples/tree-checklist/tree-checklist-example.ts
@@ -179,6 +179,8 @@ export class TreeChecklistExample {
     );
     if (this.checklistSelection.isSelected(node) && !descAllSelected) {
       this.checklistSelection.deselect(node);
+    } else if(!this.checklistSelection.isSelected(node) && descAllSelected) {
+      this.checklistSelection.select(node);
     }
     return descAllSelected;
   }

--- a/src/material-examples/tree-checklist/tree-checklist-example.ts
+++ b/src/material-examples/tree-checklist/tree-checklist-example.ts
@@ -174,7 +174,6 @@ export class TreeChecklistExample {
     const descAllSelected = descendants.every(child =>
       this.checklistSelection.isSelected(child)
     );
-    this.checkRootNodeSelection(node, descAllSelected);
     return descAllSelected;
   }
 
@@ -192,16 +191,61 @@ export class TreeChecklistExample {
     this.checklistSelection.isSelected(node)
       ? this.checklistSelection.select(...descendants)
       : this.checklistSelection.deselect(...descendants);
+
+    // Force update for the parent
+    descendants.every(child =>
+      this.checklistSelection.isSelected(child)
+    );
+    this.checkAllParentsSelection(node);
+  }
+
+  /** Toggle a leaf to-do item selection. Check all the parents to see if they changed */
+  todoLeafItemSelectionToggle(node: TodoItemFlatNode): void {
+    this.checklistSelection.toggle(node);
+    this.checkAllParentsSelection(node);
+  }
+
+  /* Checks all the parents when a leaf node is selected/unselected */
+  checkAllParentsSelection(node: TodoItemFlatNode): void {
+    let parent: TodoItemFlatNode | null = this.getParentNode(node);
+    while (parent) {
+      this.checkRootNodeSelection(parent);
+      parent = this.getParentNode(parent);
+    }
   }
 
   /** Check root node checked state and change it accordingly */
-  checkRootNodeSelection(node: TodoItemFlatNode, descAllSelected: boolean): void {
+  checkRootNodeSelection(node: TodoItemFlatNode): void {
     const nodeSelected = this.checklistSelection.isSelected(node);
+    const descendants = this.treeControl.getDescendants(node);
+    const descAllSelected = descendants.every(child =>
+      this.checklistSelection.isSelected(child)
+    );
     if (nodeSelected && !descAllSelected) {
       this.checklistSelection.deselect(node);
     } else if (!nodeSelected && descAllSelected) {
       this.checklistSelection.select(node);
     }
+  }
+
+  /* Get the parent node of a node */
+  getParentNode(node: TodoItemFlatNode): TodoItemFlatNode | null {
+    const currentLevel = this.getLevel(node);
+
+    if (currentLevel < 1) {
+      return null;
+    }
+
+    const startIndex = this.treeControl.dataNodes.indexOf(node) - 1;
+
+    for (let i = startIndex; i >= 0; i--) {
+      const currentNode = this.treeControl.dataNodes[i];
+
+      if (this.getLevel(currentNode) < currentLevel) {
+        return currentNode;
+      }
+    }
+    return null;
   }
 
   /** Select the category so we can insert the new item. */


### PR DESCRIPTION
Fixed the checked state of the root node in the tree when the initial root state was checked, but then children were deselected, causing the root node to not update correctly.

Fixes #13314