### PR TITLE
perf(focus-monitor): mark event listeners as passive

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -241,21 +241,22 @@ export class FocusMonitor implements OnDestroy {
       this._windowFocusTimeoutId = setTimeout(() => this._windowFocused = false);
     };
 
+    const eventListenerOptions = supportsPassiveEventListeners() ?
+      {passive: true, capture: true} : true;
+
     // Note: we listen to events in the capture phase so we can detect them even if the user stops
     // propagation.
     this._ngZone.runOutsideAngular(() => {
-      document.addEventListener('keydown', documentKeydownListener, true);
-      document.addEventListener('mousedown', documentMousedownListener, true);
-      document.addEventListener('touchstart', documentTouchstartListener,
-          supportsPassiveEventListeners() ? ({passive: true, capture: true} as any) : true);
+      document.addEventListener('keydown', documentKeydownListener, eventListenerOptions);
+      document.addEventListener('mousedown', documentMousedownListener, eventListenerOptions);
+      document.addEventListener('touchstart', documentTouchstartListener, eventListenerOptions);
       window.addEventListener('focus', windowFocusListener);
     });
 
     this._unregisterGlobalListeners = () => {
-      document.removeEventListener('keydown', documentKeydownListener, true);
-      document.removeEventListener('mousedown', documentMousedownListener, true);
-      document.removeEventListener('touchstart', documentTouchstartListener,
-          supportsPassiveEventListeners() ? ({passive: true, capture: true} as any) : true);
+      document.removeEventListener('keydown', documentKeydownListener, eventListenerOptions);
+      document.removeEventListener('mousedown', documentMousedownListener, eventListenerOptions);
+      document.removeEventListener('touchstart', documentTouchstartListener, eventListenerOptions);
       window.removeEventListener('focus', windowFocusListener);
 
       // Clear timeouts for all potentially pending timeouts to prevent the leaks.

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -241,22 +241,28 @@ export class FocusMonitor implements OnDestroy {
       this._windowFocusTimeoutId = setTimeout(() => this._windowFocused = false);
     };
 
-    const eventListenerOptions = supportsPassiveEventListeners() ?
+    // Event listener options that enable capturing and also mark the the listener as passive
+    // if the browser supports it.
+    const captureEventListenerOptions = supportsPassiveEventListeners() ?
       {passive: true, capture: true} : true;
 
     // Note: we listen to events in the capture phase so we can detect them even if the user stops
     // propagation.
     this._ngZone.runOutsideAngular(() => {
-      document.addEventListener('keydown', documentKeydownListener, eventListenerOptions);
-      document.addEventListener('mousedown', documentMousedownListener, eventListenerOptions);
-      document.addEventListener('touchstart', documentTouchstartListener, eventListenerOptions);
+      document.addEventListener('keydown', documentKeydownListener, captureEventListenerOptions);
+      document.addEventListener('mousedown', documentMousedownListener,
+        captureEventListenerOptions);
+      document.addEventListener('touchstart', documentTouchstartListener,
+        captureEventListenerOptions);
       window.addEventListener('focus', windowFocusListener);
     });
 
     this._unregisterGlobalListeners = () => {
-      document.removeEventListener('keydown', documentKeydownListener, eventListenerOptions);
-      document.removeEventListener('mousedown', documentMousedownListener, eventListenerOptions);
-      document.removeEventListener('touchstart', documentTouchstartListener, eventListenerOptions);
+      document.removeEventListener('keydown', documentKeydownListener, captureEventListenerOptions);
+      document.removeEventListener('mousedown', documentMousedownListener,
+        captureEventListenerOptions);
+      document.removeEventListener('touchstart', documentTouchstartListener,
+        captureEventListenerOptions);
       window.removeEventListener('focus', windowFocusListener);
 
       // Clear timeouts for all potentially pending timeouts to prevent the leaks.


### PR DESCRIPTION
* If a browser supports passive events, we should also mark the `FocusMonitor` global event listeners as passive, because browsers could technically make optimizations by knowing that _these_ event listeners won't prevented and therefore can run non-blocking.