### PR TITLE
chore(schematics): re-enable linting for ignored file

### DIFF
--- a/src/cdk/schematics/utils/build-component.ts
+++ b/src/cdk/schematics/utils/build-component.ts
@@ -1,5 +1,3 @@
-/* tslint:disable */
-
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.
@@ -58,7 +56,7 @@ function addDeclarationToNgModule(options: ComponentOptions): Rule {
     }
 
     const modulePath = options.module;
-    const source = readIntoSourceFile(host, modulePath);
+    let source = readIntoSourceFile(host, modulePath);
 
     const componentPath = `/${options.path}/`
       + (options.flat ? '' : strings.dasherize(options.name) + '/')
@@ -83,9 +81,9 @@ function addDeclarationToNgModule(options: ComponentOptions): Rule {
 
     if (options.export) {
       // Need to refresh the AST because we overwrote the file in the host.
-      const source = readIntoSourceFile(host, modulePath);
-      const exportRecorder = host.beginUpdate(modulePath);
+      source = readIntoSourceFile(host, modulePath);
 
+      const exportRecorder = host.beginUpdate(modulePath);
       const exportChanges = addExportToModule(
         source,
         modulePath,
@@ -102,9 +100,9 @@ function addDeclarationToNgModule(options: ComponentOptions): Rule {
 
     if (options.entryComponent) {
       // Need to refresh the AST because we overwrote the file in the host.
-      const source = readIntoSourceFile(host, modulePath);
-      const entryComponentRecorder = host.beginUpdate(modulePath);
+      source = readIntoSourceFile(host, modulePath);
 
+      const entryComponentRecorder = host.beginUpdate(modulePath);
       const entryComponentChanges = addEntryComponentToModule(
         source,
         modulePath,


### PR DESCRIPTION
Re-enables linting for the `build-component` file which has been originally copied from `@schematics/angular` but partially modified by us. For some reason, linting has been disabled explicitly for this file. This re-enables TSLint.


Also fixes a few shadowed variable failures (this logic comes from the `@schematics/angular:component` schematic and **should** be kept as similar as possible)