### PR TITLE
fix(radio): only show focus ripple for keyboard focus

### DIFF
--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -142,7 +142,7 @@ $mat-radio-ripple-radius: 20px;
     opacity: 0.04;
   }
 
-  .mat-radio-button:not(.mat-radio-disabled).cdk-focused & {
+  .mat-radio-button:not(.mat-radio-disabled).cdk-keyboard-focused & {
     opacity: 0.12;
   }
 


### PR DESCRIPTION
After the switch to the latest Material Design spec, we started showing the focus ripple for all kinds of focus, however it's only supposed to be for keyboard focus.

Fixes #13544.