### PR TITLE
fix(radio): improved alignment for native validation messages

### DIFF
--- a/src/lib/radio/radio.html
+++ b/src/lib/radio/radio.html
@@ -14,20 +14,20 @@
 
       <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
     </div>
-  </div>
 
-  <input #input class="mat-radio-input cdk-visually-hidden" type="radio"
-         [id]="inputId"
-         [checked]="checked"
-         [disabled]="disabled"
-         [tabIndex]="tabIndex"
-         [attr.name]="name"
-         [required]="required"
-         [attr.aria-label]="ariaLabel"
-         [attr.aria-labelledby]="ariaLabelledby"
-         [attr.aria-describedby]="ariaDescribedby"
-         (change)="_onInputChange($event)"
-         (click)="_onInputClick($event)">
+    <input #input class="mat-radio-input cdk-visually-hidden" type="radio"
+        [id]="inputId"
+        [checked]="checked"
+        [disabled]="disabled"
+        [tabIndex]="tabIndex"
+        [attr.name]="name"
+        [required]="required"
+        [attr.aria-label]="ariaLabel"
+        [attr.aria-labelledby]="ariaLabelledby"
+        [attr.aria-describedby]="ariaDescribedby"
+        (change)="_onInputChange($event)"
+        (click)="_onInputClick($event)">
+  </div>
 
   <!-- The label content for radio control. -->
   <div class="mat-radio-label-content" [class.mat-radio-label-before]="labelPosition == 'before'">

--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -152,3 +152,10 @@ $mat-radio-ripple-radius: 20px;
     opacity: 0;
   }
 }
+
+.mat-radio-input {
+  // Move the input in the middle and towards the bottom so
+  // the native validation messages are aligned correctly.
+  bottom: 0;
+  left: 50%;
+}


### PR DESCRIPTION
Centers the underlying native `input` element in order to align the native validation messages properly.

For reference:
![angular_material_-_google_chrome_2018-10-11_16-35-05](https://user-images.githubusercontent.com/4450522/46809896-2d06f380-cd78-11e8-9199-fcfeaf975f2f.png)
![angular_material_-_google_chrome_2018-10-11_17-03-37](https://user-images.githubusercontent.com/4450522/46809908-3001e400-cd78-11e8-931b-73c12c9a3228.png)
