### PR TITLE
Update datepicker-toggle to correct toggle position in Edge

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.scss
+++ b/src/lib/datepicker/datepicker-toggle.scss
@@ -11,9 +11,11 @@
   .mat-form-field-prefix,
   .mat-form-field-suffix {
     .mat-datepicker-toggle-default-icon {
-      display: block;
+      display: inline-block ;
+      top: 5px;
       width: 1.5em;
       height: 1.5em;
+      
     }
 
     .mat-icon-button .mat-datepicker-toggle-default-icon {


### PR DESCRIPTION
Hi in Edge the datepicker toggle go down out of its rigth position. I had in this scss these line
      `display: inline-block ;
      top: 4px;`
to give its right position .