### PR TITLE
build: fix cronjob snapshot jobs failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ env:
 before_install:
   - source ./scripts/ci/travis-env.sh
   - source ./scripts/ci/install-yarn.sh
-  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then ./scripts/install-angular-snapshot.sh --only-save; fi
 
 install:
   - ./scripts/ci/travis-install.sh
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then ./scripts/install-angular-snapshot.sh --only-save; fi
 
 before_script:
   - mkdir -p $LOGS_DIR

--- a/scripts/install-angular-snapshot.sh
+++ b/scripts/install-angular-snapshot.sh
@@ -1,21 +1,12 @@
 #!/bin/bash
 
-# Script that modifies the project `package.json` by setting the version for all Angular
-# dependencies to the Github snapshot builds. Afterwards, if the `--only-save` flag is not set,
-# the script will also run NPM to install the new versions.
-
+# Script that re-installs all Angular dependencies using the GitHub build snapshots. We need to
+# this after the locked node modules have been installed because otherwise `--frozen-lockfile`
+# would complain about outdated lock files.
 set -e
 
 # Go to the project root directory
 cd $(dirname $0)/../
 
-searchRegex='(@angular\/(.*))":\s+".*"'
-searchReplace='\1": "github:angular\/\2-builds"'
-
-# Replace the Angular versions in `package.json` with their corresponding
-# build snapshots so that we only have to run `npm install` once.
-sed -i -r "s/${searchRegex}/${searchReplace}/g" package.json
-
-if [[ ${*} != *--only-save* ]]; then
-  npm install
-fi
+yarn add \
+  $(awk 'match($0, "@angular/(.*)\":", m){print "github:angular/"m[1]"-builds"}' package.json)


### PR DESCRIPTION
* Due to the fact that we modify the `package.json` in cronjobs without updating the actual lock-file, the `--frozen-lockfile` installation fails. In order to fix this, we should just re-install the dependencies after the general `yarn` installation.