### PR TITLE
fix(expansion-panel): emitting events twice on some browsers

### DIFF
--- a/src/lib/expansion/expansion-panel.html
+++ b/src/lib/expansion/expansion-panel.html
@@ -2,7 +2,7 @@
 <div class="mat-expansion-panel-content"
      role="region"
      [@bodyExpansion]="_getExpandedState()"
-     (@bodyExpansion.done)="_bodyAnimation($event)"
+     (@bodyExpansion.done)="_bodyAnimationDone.next($event)"
      [attr.aria-labelledby]="_headerId"
      [id]="id"
      #body>


### PR DESCRIPTION
Fixes the expansion panel emitting the `afterExpand` and `afterCollapse` events twice on IE and Edge due to a bug in `@angular/animations`.