### PR TITLE
chore(drag-drop): fix leftover cdkDrop references

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -23,8 +23,8 @@ type PointerEventHandler = (event: TouchEvent | MouseEvent) => void;
  * instances, and manages global event listeners on the `document`.
  * @docs-private
  */
-// Note: this class is generic, rather than referencing CdkDrag and CdkDrop directly, in order to
-// avoid circular imports. If we were to reference them here, importing the registry into the
+// Note: this class is generic, rather than referencing CdkDrag and CdkDropList directly, in order
+// to avoid circular imports. If we were to reference them here, importing the registry into the
 // classes that are registering themselves will introduce a circular import.
 @Injectable({providedIn: 'root'})
 export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {

--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -57,7 +57,7 @@ by the directives:
 
 | Selector            | Description                                                              |
 |---------------------|--------------------------------------------------------------------------|
-| `.cdk-drop-list`         | Corresponds to the `cdkDropList` container.                                  |
+| `.cdk-drop-list`    | Corresponds to the `cdkDropList` container.                                  |
 | `.cdk-drag`         | Corresponds to a `cdkDrag` instance.                                     |
 | `.cdk-drag-preview` | This is the element that will be rendered next to the user's cursor as they're dragging an item in a sortable list. By default the element looks exactly like the element that is being dragged. |
 | `.cdk-drag-placeholder` | This is element that will be shown instead of the real element as it's being dragged inside a `cdkDropList`. By default this will look exactly like the element that is being sorted. |

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -77,7 +77,7 @@ export function CDK_DRAG_CONFIG_FACTORY(): CdkDragConfig {
   return {dragStartThreshold: 5, pointerDirectionChangeThreshold: 5};
 }
 
-/** Element that can be moved inside a CdkDrop container. */
+/** Element that can be moved inside a CdkDropList container. */
 @Directive({
   selector: '[cdkDrag]',
   exportAs: 'cdkDrag',

--- a/src/cdk/drag-drop/drop-list-container.ts
+++ b/src/cdk/drag-drop/drop-list-container.ts
@@ -64,7 +64,7 @@ export interface CdkDropListContainer<T = any> {
 }
 
 /**
- * Injection token that is used to provide a CdkDrop instance to CdkDrag.
+ * Injection token that is used to provide a CdkDropList instance to CdkDrag.
  * Used for avoiding circular imports.
  */
 export const CDK_DROP_LIST_CONTAINER =

--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html
@@ -1,8 +1,8 @@
 <div class="container">
   <h2>To do</h2>
 
-  <div cdkDrop #todoList="cdkDrop" [cdkDropData]="todo" [cdkDropConnectedTo]="doneList" class="list"
-      (cdkDropDropped)="drop($event)">
+  <div cdkDropList #todoList="cdkDropList" [cdkDropListData]="todo"
+      [cdkDropListConnectedTo]="doneList" class="list" (cdkDropListDropped)="drop($event)">
     <div class="list-item" *ngFor="let item of todo" cdkDrag>{{item}}</div>
   </div>
 </div>
@@ -10,8 +10,8 @@
 <div class="container">
   <h2>Done</h2>
 
-  <div cdkDrop #doneList="cdkDrop" [cdkDropData]="done" [cdkDropConnectedTo]="todoList" class="list"
-      (cdkDropDropped)="drop($event)">
+  <div cdkDropList #doneList="cdkDropList" [cdkDropListData]="done"
+      [cdkDropListConnectedTo]="todoList" class="list" (cdkDropListDropped)="drop($event)">
     <div class="list-item" *ngFor="let item of done" cdkDrag>{{item}}</div>
   </div>
 </div>

--- a/src/material-examples/cdk-drag-drop-horizontal-sorting/cdk-drag-drop-horizontal-sorting-example.html
+++ b/src/material-examples/cdk-drag-drop-horizontal-sorting/cdk-drag-drop-horizontal-sorting-example.html
@@ -1,3 +1,3 @@
-<div cdkDropList cdkDropOrientation="horizontal" class="example-list" (cdkDropListDropped)="drop($event)">
+<div cdkDropList cdkDropListOrientation="horizontal" class="example-list" (cdkDropListDropped)="drop($event)">
   <div class="example-box" *ngFor="let timePeriod of timePeriods" cdkDrag>{{timePeriod}}</div>
 </div>


### PR DESCRIPTION
Fixes some invalid leftover references to `cdkDrop` after #13619.