### PR TITLE
fix(schematics): do not publish testing utilities to npm

### DIFF
--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -19,7 +19,8 @@ ts_library(
   srcs = glob(["**/*.ts"], exclude=[
     "**/files/**/*.ts",
     "**/*.spec.ts",
-    "ng-update/test-cases/**/*",
+    "ng-update/test-cases/**/*.ts",
+    "testing/**/*.ts"
   ]),
   tsconfig = ":tsconfig.json",
   deps = [
@@ -28,11 +29,8 @@ ts_library(
     # TODO(devversion): Only include jasmine for test sources (See: tsconfig types).
     "@npm//@types/jasmine",
     "@npm//@types/node",
-    # TODO(devversion): Similarly to "jasmine", we need to extract these into testing only.
-    "@npm//fs-extra",
     "@npm//glob",
     "@npm//parse5",
-    "@npm//rxjs",
     "@npm//tslint",
     "@npm//typescript"
   ],
@@ -58,7 +56,7 @@ ts_library(
   name = "schematics_test_sources",
   srcs = glob(["**/*.spec.ts"], exclude = ["**/files/**/*.spec.ts"]),
   deps = [
-    ":schematics",
+    "//src/cdk/schematics/testing",
     "@npm//@schematics/angular",
     "@npm//@angular-devkit/schematics",
     "@npm//@types/jasmine",
@@ -66,6 +64,7 @@ ts_library(
     "@npm//mock-fs",
     "@npm//tslint",
     "@npm//typescript",
+    ":schematics",
   ],
   tsconfig = ":tsconfig.json",
   testonly = True,

--- a/src/cdk/schematics/index.ts
+++ b/src/cdk/schematics/index.ts
@@ -7,5 +7,4 @@
  */
 
 export * from './utils';
-export * from './testing';
 export * from './ng-update/public-api';

--- a/src/cdk/schematics/testing/BUILD.bazel
+++ b/src/cdk/schematics/testing/BUILD.bazel
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+  name = "testing",
+  module_name = "@angular/cdk/schematics/testing",
+  srcs = glob(["**/*.ts"]),
+  deps = [
+    "@npm//@angular-devkit/core",
+    "@npm//@angular-devkit/schematics",
+    "@npm//@schematics/angular",
+    "@npm//@types/node",
+    "@npm//@types/fs-extra",
+    "@npm//fs-extra",
+    "@npm//rxjs",
+  ],
+)

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -20,7 +20,8 @@
   "exclude": [
     "**/files/**/*",
     "**/*.spec.ts",
-    "ng-update/test-cases/**/*"
+    "ng-update/test-cases/**/*",
+    "testing/**/*.ts"
   ],
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true

--- a/src/lib/schematics/BUILD.bazel
+++ b/src/lib/schematics/BUILD.bazel
@@ -53,6 +53,7 @@ ts_library(
   deps = [
     ":schematics",
     "//src/cdk/schematics",
+    "//src/cdk/schematics/testing",
     "@npm//@schematics/angular",
     "@npm//@angular-devkit/schematics",
     "@npm//@types/jasmine",

--- a/src/lib/schematics/address-form/index.spec.ts
+++ b/src/lib/schematics/address-form/index.spec.ts
@@ -1,5 +1,5 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
-import {createTestApp} from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {Schema} from './schema';
 

--- a/src/lib/schematics/dashboard/index.spec.ts
+++ b/src/lib/schematics/dashboard/index.spec.ts
@@ -1,5 +1,5 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
-import {createTestApp} from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {Schema} from './schema';
 

--- a/src/lib/schematics/nav/index.spec.ts
+++ b/src/lib/schematics/nav/index.spec.ts
@@ -1,7 +1,7 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {Schema} from './schema';
 import {getFileContent} from '@schematics/angular/utility/test';
-import {createTestApp} from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 
 describe('material-nav-schematic', () => {
   let runner: SchematicTestRunner;

--- a/src/lib/schematics/ng-add/index.spec.ts
+++ b/src/lib/schematics/ng-add/index.spec.ts
@@ -4,11 +4,11 @@ import {Tree} from '@angular-devkit/schematics';
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {
   addModuleImportToRootModule,
-  createTestApp,
   getProjectFromWorkspace,
   getProjectStyleFile,
   getProjectTargetOptions,
 } from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 import {getWorkspace} from '@schematics/angular/utility/config';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {getIndexHtmlPath} from './fonts/project-index-html';

--- a/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
@@ -1,5 +1,5 @@
 import {migrationCollection} from '../index.spec';
-import {runTestCases} from '@angular/cdk/schematics';
+import {runTestCases} from '@angular/cdk/schematics/testing';
 
 describe('constructor checks', () => {
 

--- a/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
@@ -1,4 +1,4 @@
-import {runTestCases} from '@angular/cdk/schematics';
+import {runTestCases} from '@angular/cdk/schematics/testing';
 import {migrationCollection} from '../index.spec';
 
 describe('v6 import misc checks', () => {

--- a/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {readFileContent, runTestCases} from '@angular/cdk/schematics';
+import {readFileContent, runTestCases} from '@angular/cdk/schematics/testing';
 import {migrationCollection} from './index.spec';
 
 describe('v6 upgrade test cases', () => {

--- a/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {readFileContent, runTestCases} from '@angular/cdk/schematics';
+import {readFileContent, runTestCases} from '@angular/cdk/schematics/testing';
 import {migrationCollection} from './index.spec';
 
 describe('v7 upgrade test cases', () => {

--- a/src/lib/schematics/table/index.spec.ts
+++ b/src/lib/schematics/table/index.spec.ts
@@ -1,5 +1,5 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
-import {createTestApp} from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {Schema} from './schema';
 

--- a/src/lib/schematics/tree/index.spec.ts
+++ b/src/lib/schematics/tree/index.spec.ts
@@ -1,5 +1,5 @@
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
-import {createTestApp} from '@angular/cdk/schematics';
+import {createTestApp} from '@angular/cdk/schematics/testing';
 import {getFileContent} from '@schematics/angular/utility/test';
 import {Schema} from './schema';
 


### PR DESCRIPTION
* No longer publishes the CDK schematic testing utilities to NPM. We just re-exported them because the Angular Material schematic tests share logic with the CDK schematics. This now moves the CDK schematic testing utilities into a secondary entry-point that is just accessable for testing.

This is the error that shows up someone just runs any CDK or Material schematic

![image](https://user-images.githubusercontent.com/4987015/47038853-ccfebb80-d182-11e8-86da-ca267ec37d26.png)
