### PR TITLE
fix(autocomplete): not propagating same model value when reset while open

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -532,6 +532,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     } else {
       this._element.nativeElement.value = inputValue;
     }
+
+    this._previousValue = inputValue;
   }
 
   /**

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -2194,6 +2194,33 @@ describe('MatAutocomplete', () => {
     expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom),
         'Expected autocomplete panel to align with the bottom of the new origin.');
   });
+
+  it('should be able to re-type the same value when it is reset while open', fakeAsync(() => {
+    const fixture = createComponent(SimpleAutocomplete);
+    fixture.detectChanges();
+    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const formControl = fixture.componentInstance.stateCtrl;
+
+    typeInElement('Cal', input);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(formControl.value).toBe('Cal', 'Expected initial value to be propagated to model');
+
+    formControl.setValue('');
+    fixture.detectChanges();
+
+    expect(input.value).toBe('', 'Expected input value to reset when model is reset');
+
+    typeInElement('Cal', input);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(formControl.value).toBe('Cal', 'Expected new value to be propagated to model');
+  }));
+
 });
 
 @Component({


### PR DESCRIPTION
Fixes the autocomplete trigger not propagating the model value if the user typed something, it got reset while the input is open and then they typed the same thing again.

Fixes #13632.