### PR TITLE
build: run overlay and text-field tests with Bazel

### DIFF
--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
@@ -32,6 +32,12 @@ sass_library(
   srcs = [":overlay_scss_partials"],
 )
 
+sass_binary(
+  name = "overlay_prebuilt_scss",
+  src = "overlay-prebuilt.scss",
+  deps = [":overlay_scss_lib"]
+)
+
 ng_test_library(
   name = "overlay_test_sources",
   srcs = glob(["**/*.spec.ts"]),
@@ -54,7 +60,5 @@ ng_test_library(
 ng_web_test_suite(
   name = "unit_tests",
   deps = [":overlay_test_sources"],
-  # TODO(devversion): Disabling this test until we found a way to set the screen resolution
-  # of the web test instance. Currently all positioning tests are not passing.
-  tags = ["manual"]
+  static_css = ["overlay_prebuilt_scss"],
 )

--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -50,7 +50,5 @@ ng_test_library(
 ng_web_test_suite(
   name = "unit_tests",
   deps = [":text-field_test_sources"],
-  # TODO(devversion): Disabling this test until we found a way to set the screen resolution
-  # of the web test instance. Currently all positioning tests are not passing.
-  tags = ["manual"],
+  static_css = [":text_field_prebuilt_scss"]
 )


### PR DESCRIPTION
* Implements a small and simple workaround that allows us to run the overlay and text-field unit tests through Bazel. Works around issue: https://github.com/bazelbuild/rules_typescript/issues/301