### PR TITLE
chore: clean up internal usages of deprecated signatures

### DIFF
--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -28,7 +28,7 @@ describe('CdkAccordionItem', () => {
       fixture = TestBed.createComponent(SingleItem);
       item = fixture.debugElement
         .query(By.directive(CdkAccordionItem))
-        .injector.get(CdkAccordionItem);
+        .injector.get<CdkAccordionItem>(CdkAccordionItem);
     });
 
     describe('that is not disabled', () => {
@@ -182,9 +182,7 @@ describe('CdkAccordionItem', () => {
       fixture = TestBed.createComponent(ItemGroupWithoutAccordion);
       [firstItem, secondItem] = fixture.debugElement
         .queryAll(By.directive(CdkAccordionItem))
-        .map(el => {
-          return el.injector.get(CdkAccordionItem) as CdkAccordionItem;
-        });
+        .map(el => el.injector.get<CdkAccordionItem>(CdkAccordionItem));
     });
 
     it('should not change expanded state based on unrelated items', () => {
@@ -225,9 +223,7 @@ describe('CdkAccordionItem', () => {
       fixture = TestBed.createComponent(ItemGroupWithAccordion);
       [firstItem, secondItem] = fixture.debugElement
         .queryAll(By.directive(CdkAccordionItem))
-        .map(el => {
-          return el.injector.get(CdkAccordionItem) as CdkAccordionItem;
-        });
+        .map(el => el.injector.get<CdkAccordionItem>(CdkAccordionItem));
     });
 
     it('should change expanded state based on related items', () => {

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -23,9 +23,7 @@ describe('CdkAccordion', () => {
     const fixture = TestBed.createComponent(SetOfItems);
     const [firstPanel, secondPanel] = fixture.debugElement
       .queryAll(By.directive(CdkAccordionItem))
-      .map(el => {
-        return el.injector.get(CdkAccordionItem) as CdkAccordionItem;
-      });
+      .map(el => el.injector.get<CdkAccordionItem>(CdkAccordionItem));
 
     firstPanel.open();
     fixture.detectChanges();
@@ -42,9 +40,7 @@ describe('CdkAccordion', () => {
     const fixture = TestBed.createComponent(SetOfItems);
     const [firstPanel, secondPanel] = fixture.debugElement
       .queryAll(By.directive(CdkAccordionItem))
-      .map(el => {
-        return el.injector.get(CdkAccordionItem) as CdkAccordionItem;
-      });
+      .map(el => el.injector.get<CdkAccordionItem>(CdkAccordionItem));
 
     fixture.componentInstance.multi = true;
     fixture.detectChanges();

--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -41,28 +41,28 @@ describe('SelectionModel', () => {
     beforeEach(() => model = new SelectionModel(true));
 
     it('should be able to select multiple options', () => {
-      const onChangeSpy = jasmine.createSpy('onChange spy');
+      const changedSpy = jasmine.createSpy('changed spy');
 
-      model.changed.subscribe(onChangeSpy);
+      model.changed.subscribe(changedSpy);
       model.select(1);
       model.select(2);
 
       expect(model.selected.length).toBe(2);
       expect(model.isSelected(1)).toBe(true);
       expect(model.isSelected(2)).toBe(true);
-      expect(onChangeSpy).toHaveBeenCalledTimes(2);
+      expect(changedSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should be able to select multiple options at the same time', () => {
-      const onChangeSpy = jasmine.createSpy('onChange spy');
+      const changedSpy = jasmine.createSpy('changed spy');
 
-      model.changed.subscribe(onChangeSpy);
+      model.changed.subscribe(changedSpy);
       model.select(1, 2);
 
       expect(model.selected.length).toBe(2);
       expect(model.isSelected(1)).toBe(true);
       expect(model.isSelected(2)).toBe(true);
-      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+      expect(changedSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should be able to preselect multiple options', () => {
@@ -92,12 +92,12 @@ describe('SelectionModel', () => {
     });
   });
 
-  describe('onChange event', () => {
+  describe('changed event', () => {
     it('should return the model that dispatched the event', () => {
       let model = new SelectionModel();
       let spy = jasmine.createSpy('SelectionModel change event');
 
-      model.onChange.subscribe(spy);
+      model.changed.subscribe(spy);
       model.select(1);
 
       let event = spy.calls.mostRecent().args[0];
@@ -130,7 +130,7 @@ describe('SelectionModel', () => {
       // Note: this assertion is only here to run the getter.
       expect(model.selected).toEqual([]);
 
-      model.onChange.subscribe(() => spy(model.selected));
+      model.changed.subscribe(() => spy(model.selected));
       model.select(1);
 
       expect(spy).toHaveBeenCalledWith([1]);

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -157,7 +157,8 @@ describe('CdkTextareaAutosize', () => {
     // detection should be triggered after a multiline content is set.
     fixture = TestBed.createComponent(AutosizeTextAreaWithContent);
     textarea = fixture.nativeElement.querySelector('textarea');
-    autosize = fixture.debugElement.query(By.css('textarea')).injector.get(CdkTextareaAutosize);
+    autosize = fixture.debugElement.query(By.css('textarea'))
+        .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
 
     fixture.componentInstance.content = `
       Line
@@ -223,7 +224,7 @@ describe('CdkTextareaAutosize', () => {
     const fixtureWithoutAutosize = TestBed.createComponent(AutosizeTextareaWithoutAutosize);
     textarea = fixtureWithoutAutosize.nativeElement.querySelector('textarea');
     autosize = fixtureWithoutAutosize.debugElement.query(By.css('textarea'))
-        .injector.get(CdkTextareaAutosize);
+        .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
 
     fixtureWithoutAutosize.detectChanges();
 

--- a/src/lib/chips/chip-input.spec.ts
+++ b/src/lib/chips/chip-input.spec.ts
@@ -41,7 +41,7 @@ describe('MatChipInput', () => {
     fixture.detectChanges();
 
     inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
-    chipInputDirective = inputDebugElement.injector.get(MatChipInput) as MatChipInput;
+    chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
     inputNativeElement = inputDebugElement.nativeElement;
   }));
 
@@ -172,7 +172,7 @@ describe('MatChipInput', () => {
       fixture.detectChanges();
 
       inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
-      chipInputDirective = inputDebugElement.injector.get(MatChipInput) as MatChipInput;
+      chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
       inputNativeElement = inputDebugElement.nativeElement;
 
       spyOn(testChipInput, 'add');

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -35,7 +35,7 @@ describe('Chips', () => {
 
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
       chipNativeElement = chipDebugElement.nativeElement;
-      chipInstance = chipDebugElement.injector.get(MatChip);
+      chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
 
       document.body.appendChild(chipNativeElement);
     });
@@ -59,7 +59,7 @@ describe('Chips', () => {
 
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
       chipNativeElement = chipDebugElement.nativeElement;
-      chipInstance = chipDebugElement.injector.get(MatChip);
+      chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
       testComponent = fixture.debugElement.componentInstance;
 
       document.body.appendChild(chipNativeElement);

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -773,7 +773,8 @@ describe('MatInput without forms', () => {
       const fixture = createComponent(MatInputTextTestController);
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.directive(MatInput)).injector.get(MatInput);
+      const input = fixture.debugElement.query(By.directive(MatInput))
+          .injector.get<MatInput>(MatInput);
       const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
 
       // Call the focus handler directly to avoid flakyness where

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -174,7 +174,7 @@ describe('MatTabNavBar', () => {
     it('should be able to disable ripples on a tab link', () => {
       const tabLinkDebug = fixture.debugElement.query(By.css('a'));
       const tabLinkElement = tabLinkDebug.nativeElement;
-      const tabLinkInstance = tabLinkDebug.injector.get(MatTabLink);
+      const tabLinkInstance = tabLinkDebug.injector.get<MatTabLink>(MatTabLink);
 
       tabLinkInstance.disableRipple = true;
 
@@ -264,7 +264,8 @@ describe('MatTabNavBar', () => {
       const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
     fixture.detectChanges();
 
-    const tabLink = fixture.debugElement.query(By.directive(MatTabLink)).injector.get(MatTabLink);
+    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))
+        .injector.get<MatTabLink>(MatTabLink);
 
     expect(tabLink.tabIndex)
       .toBe(5, 'Expected the tabIndex to be set from the native tabindex attribute.');
@@ -274,7 +275,8 @@ describe('MatTabNavBar', () => {
     const fixture = TestBed.createComponent(TabLinkWithTabIndexBinding);
     fixture.detectChanges();
 
-    const tabLink = fixture.debugElement.query(By.directive(MatTabLink)).injector.get(MatTabLink);
+    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))
+        .injector.get<MatTabLink>(MatTabLink);
 
     expect(tabLink.tabIndex).toBe(0, 'Expected the tabIndex to be set to 0 by default.');
 

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -184,7 +184,8 @@ describe('MatTooltip', () => {
 
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
-      tooltipDirective = fixture.debugElement.query(By.css('button')).injector.get(MatTooltip);
+      tooltipDirective = fixture.debugElement.query(By.css('button'))
+          .injector.get<MatTooltip>(MatTooltip);
 
       tooltipDirective.show();
       fixture.detectChanges();


### PR DESCRIPTION
Cleans up usages of some signatures that have been deprecated in core. Also cleans up a couple of usages of our own deprecated APIs. This also fixes some cases where the type was resolving to `any`.