### PR TITLE
chore: update required statuses for github robot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ jobs:
 # ----------------------------------------------------------------------------------------
 # Workflow definitions. A workflow usually groups multiple jobs together. This is useful if
 # one job depends on another.
+#
+# NOTE: When updating this configuration section, make sure to update GitHub robot
+#       config to match the new workflow jobs.
 # ----------------------------------------------------------------------------------------
 workflows:
   version: 2

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -52,7 +52,9 @@ merge:
     requiredStatuses:
       # TODO(josephperrott): reenable once CI flakiness is addressed
       # - "continuous-integration/travis-ci/pr"
-      - "ci/circleci: build"
+      - "ci/circleci: lint"
+      - "ci/circleci: bazel_build_test"
+      - "ci/circleci: tests_local_browsers"
 
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option


### PR DESCRIPTION
* Currently the merge status is always pending because the CircleCI job workflows have been changed.