### PR TITLE
build: move bazel config to workspace root

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,31 +1,24 @@
 ###############################
-# Directory structure         #
+# Filesystem interactions     #
 ###############################
 
 # Don't create bazel-* symlinks in the WORKSPACE directory.
-# These require .gitignore and may scare users.
-# Also, it's a workaround for https://github.com/bazelbuild/rules_typescript/issues/12
-# which affects the common case of having `tsconfig.json` in the WORKSPACE directory.
-#
-# Instead, you should run `bazel info bazel-bin` to find out where the outputs went.
+# These require .gitignore and may scare users. Also, it's a workaround for
+# https://github.com/bazelbuild/rules_typescript/issues/12 which affects the common case of
+# having `tsconfig.json` in the WORKSPACE directory. Instead, you should run
+# `bazel info output_base` to find out where the outputs went.
 build --symlink_prefix=/
 
-# Another good choice is to create a dist/ directory. Then you can use
-# build --symlink_prefix=dist/
-# to get folders like dist/bin
-# But be aware, this will still create a bazel-out symlink in your project directory.
-# You may still need to exclude that, eg. from the editor's search path.
+# Performance: avoid stat'ing input files
+build --watchfs
 
 ###############################
-# Output                      #
+# Output control              #
 ###############################
 
 # A more useful default output mode for bazel query
 # Prints eg. "ng_module rule //foo:bar" rather than just "//foo:bar"
 query --output=label_kind
-
-# Don't print every dependency in :node_modules, for example
-query --noimplicit_deps
 
 # By default, failing tests don't print any output, it goes to the log file
 test --test_output=errors
@@ -43,9 +36,15 @@ build --workspace_status_command=./tools/bazel-stamp-vars.sh
 ###############################
 # Typescript / Angular / Sass #
 ###############################
-# Make TypeScript and Angular compilation fast, by keeping a few copies of the compiler
+
+# Make compilation fast, by keeping a few copies of the compilers
 # running as daemons, and cache SourceFile AST's to reduce parse time.
-build --strategy=TypeScriptCompile=worker --strategy=AngularTemplateCompile=worker
+build --strategy=TypeScriptCompile=worker
+build --strategy=AngularTemplateCompile=worker
+
+################################
+# Temporary Settings for Ivy   #
+################################
 
 # Use the legacy AOT compiler strategy. We don't want to compile with Ivy nor with "ngtsc" which
 # does not generate factory files which are needed for AOT.


### PR DESCRIPTION
* In order to prepare for the next bazel releases, we need to move the `tools/bazel.rc` to `%workspace_root%/.bazelrc`. The new location is already supported by 0.17.1+, but `tools/.bazel.rc` has been just left for backwards compatibility.
* Also updates the bazel config to be more in sync with the bazelrc from `angular/angular`.