### PR TITLE
fix(sidenav): opened and closed events emitting twice on IE and Edge

### DIFF
--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -60,8 +60,8 @@ export class MatSidenavContent extends MatDrawerContent {
     'class': 'mat-drawer mat-sidenav',
     'tabIndex': '-1',
     '[@transform]': '_animationState',
-    '(@transform.start)': '_onAnimationStart($event)',
-    '(@transform.done)': '_onAnimationEnd($event)',
+    '(@transform.start)': '_animationStarted.next($event)',
+    '(@transform.done)': '_animationEnd.next($event)',
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',
     '[class.mat-drawer-end]': 'position === "end"',


### PR DESCRIPTION
Fixes the `opened` and `closed` events emitting twice on IE and Edge. The issue is that our events are bound to Angular's `.done` events which have a bug that causes them to emit twice on some browsers.