### PR TITLE
refactor(schematics): better ng-update success message

### DIFF
--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -7,6 +7,7 @@
  */
 
 import {Rule} from '@angular-devkit/schematics';
+import {green, yellow} from 'chalk';
 import {TargetVersion} from './target-version';
 import {cdkUpgradeData} from './upgrade-data';
 import {createUpgradeRule} from './upgrade-rules';
@@ -36,7 +37,11 @@ export function updateToV7(): Rule {
 
 /** Post-update schematic to be called when update is finished. */
 export function postUpdate(): Rule {
-  return () => console.log(
-    '\nComplete! Please check the output above for any issues that were detected but could not' +
-    ' be automatically fixed.');
+  return () => {
+    console.log();
+    console.log(green('  ✓  Angular CDK update complete'));
+    console.log();
+    console.log(yellow('  ⚠  Please check the output above for any issues that were detected ' +
+      'but could not be automatically fixed.'));
+  };
 }

--- a/src/lib/schematics/ng-update/index.ts
+++ b/src/lib/schematics/ng-update/index.ts
@@ -8,6 +8,7 @@
 
 import {Rule} from '@angular-devkit/schematics';
 import {TargetVersion, createUpgradeRule, UpgradeTSLintConfig} from '@angular/cdk/schematics';
+import {green, yellow} from 'chalk';
 import {sync as globSync} from 'glob';
 import {materialUpgradeData} from './upgrade-data';
 
@@ -47,7 +48,11 @@ export function updateToV7(): Rule {
 
 /** Post-update schematic to be called when update is finished. */
 export function postUpdate(): Rule {
-  return () => console.log(
-    '\nComplete! Please check the output above for any issues that were detected but could not' +
-    ' be automatically fixed.');
+  return () => {
+    console.log();
+    console.log(green('  ✓  Angular Material update complete'));
+    console.log();
+    console.log(yellow('  ⚠  Please check the output above for any issues that were detected ' +
+      'but could not be automatically fixed.'));
+  };
 }


### PR DESCRIPTION
* Instead of just saying "Complete..." we should make clear which `ng-update` schematic ran. This is necessary because the CDK and Material update runs independently.