### PR TITLE
build(schematics): version placeholders not replaced

### DIFF
--- a/tools/package-tools/build-release.ts
+++ b/tools/package-tools/build-release.ts
@@ -48,15 +48,15 @@ export function composeRelease(buildPackage: BuildPackage) {
   copyFiles(packagesDir, 'README.md', releasePath);
   copyFiles(sourceDir, 'package.json', releasePath);
 
+  if (buildPackage.hasSchematics) {
+    copyFiles(join(packageOut, 'schematics'), '**/*', join(releasePath, 'schematics'));
+  }
+
   replaceVersionPlaceholders(releasePath);
   insertPackageJsonVersionStamp(join(releasePath, 'package.json'));
 
   createTypingsReexportFile(releasePath, './typings/index', name);
   createMetadataReexportFile(releasePath, './typings/index', name, importAsName);
-
-  if (buildPackage.hasSchematics) {
-    copyFiles(join(packageOut, 'schematics'), '**/*', join(releasePath, 'schematics'));
-  }
 
   if (buildPackage.secondaryEntryPoints.length) {
     createFilesForSecondaryEntryPoint(buildPackage, releasePath);

--- a/tools/package-tools/build-release.ts
+++ b/tools/package-tools/build-release.ts
@@ -48,6 +48,8 @@ export function composeRelease(buildPackage: BuildPackage) {
   copyFiles(packagesDir, 'README.md', releasePath);
   copyFiles(sourceDir, 'package.json', releasePath);
 
+  // This must happen before replacing the version placeholders because the schematics
+  // could use the version placeholders for setting up specific dependencies within `ng-add`.
   if (buildPackage.hasSchematics) {
     copyFiles(join(packageOut, 'schematics'), '**/*', join(releasePath, 'schematics'));
   }


### PR DESCRIPTION
* Since we copy the schematics after the version placeholders have been inlined, the version range that uses the NG version placeholder is not replaced properly.

This is an _issue_ right now, because by default we determine the NG version based on the installed `@angular/core` version.

```ts
 addPackageToPackageJson(host, '@angular/animations',
        ngCoreVersionTag || requiredAngularVersionRange);
```
