### PR TITLE
fix(slide-toggle): don't show hover ripples on touch devices

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -214,6 +214,16 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   &, .mat-slide-toggle.mat-disabled .mat-slide-toggle-bar:hover & {
     opacity: 0;
   }
+
+  // Hover styles will be displayed after tapping on touch devices.
+  // Disable the hover styling if the user's device doesn't support hovering.
+  @media (hover: none) {
+    // Note that we only negate the `:hover` rather than setting it to always be `display: none`,
+    // in order to maintain the focus indication for hybrid touch + keyboard devices.
+    .mat-slide-toggle-bar:hover & {
+      display: none;
+    }
+  }
 }
 
 /** Custom styling to make the slide-toggle usable in high contrast mode. */


### PR DESCRIPTION
On touch devices `:hover` styling persists after the user has tapped. These changes hide the persistent ripple if the user isn't able to hover, in order to avoid confusion with the other ripples.

Related to #13675.

**Note:** this is the same issue that is fixed in #13700. I'm splitting into separate PRs, because we're blocked on merging style changes for some components, for now.