### PR TITLE
fix(drag-drop): drop list not toggling dragging class inside component with OnPush change detection

### DIFF
--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -28,7 +28,7 @@ import {
   SkipSelf,
   ViewContainerRef,
 } from '@angular/core';
-import {supportsPassiveEventListeners} from '@angular/cdk/platform';
+import {normalizePassiveListenerOptions} from '@angular/cdk/platform';
 import {Observable, Subject, Subscription, Observer} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {DragDropRegistry} from './drag-drop-registry';
@@ -80,8 +80,7 @@ export function CDK_DRAG_CONFIG_FACTORY(): CdkDragConfig {
 }
 
 /** Options that can be used to bind a passive event listener. */
-const passiveEventListenerOptions = supportsPassiveEventListeners() ?
-    {passive: true} as EventListenerOptions : false;
+const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: true});
 
 /** Element that can be moved inside a CdkDropList container. */
 @Directive({

--- a/src/cdk/drag-drop/drop-list.ts
+++ b/src/cdk/drag-drop/drop-list.ts
@@ -19,6 +19,7 @@ import {
   QueryList,
   Optional,
   Directive,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {CdkDrag} from './drag';
@@ -141,6 +142,7 @@ export class CdkDropList<T = any> implements OnInit, OnDestroy {
   constructor(
     public element: ElementRef<HTMLElement>,
     private _dragDropRegistry: DragDropRegistry<CdkDrag, CdkDropList<T>>,
+    private _changeDetectorRef: ChangeDetectorRef,
     @Optional() private _dir?: Directionality) {}
 
   ngOnInit() {
@@ -175,6 +177,7 @@ export class CdkDropList<T = any> implements OnInit, OnDestroy {
     this._dragging = true;
     this._activeDraggables = this._draggables.toArray();
     this._cachePositions();
+    this._changeDetectorRef.markForCheck();
   }
 
   /**


### PR DESCRIPTION
Fixes the `CdkDropList` not toggling its `cdk-drop-list-dragging` class if it's placed inside a component with `OnPush` change detection.

Fixes #13680.