### PR TITLE
build: bazel and gulp tsconfigs need to be in sync

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -24,8 +24,5 @@
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
     "types": ["tslib"]
-  },
-  "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true
   }
 }

--- a/src/cdk/tsconfig-build.json
+++ b/src/cdk/tsconfig-build.json
@@ -1,6 +1,6 @@
 // TypeScript config file that is used to compile the cdk's ES2015 package through Gulp. As the
 // long term goal is to switch to Bazel, and we already want to run tests with Bazel, we need to
-// ensure the TypeScript build options are the same for Gulp and Bazel. We archive this by
+// ensure the TypeScript build options are the same for Gulp and Bazel. We achieve this by
 // extending the generic Bazel build tsconfig which will be used for each entry-point.
 {
   "extends": "../bazel-tsconfig-build.json",

--- a/src/lib/tsconfig-build.json
+++ b/src/lib/tsconfig-build.json
@@ -1,31 +1,17 @@
-// TypeScript config file that is used to compile the library into ES2015.
+// TypeScript config file that is used to compile the Material package through Gulp. As the
+// long term goal is to switch to Bazel, and we already want to run tests with Bazel, we need to
+// ensure the TypeScript build options are the same for Gulp and Bazel. We achieve this by
+// extending the generic Bazel build tsconfig which will be used for each entry-point.
 {
+  "extends": "../bazel-tsconfig-build.json",
   "compilerOptions": {
-    "declaration": true,
-    "stripInternal": false,
-    "experimentalDecorators": true,
-    "noUnusedParameters": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "importHelpers": true,
-    "newLine": "lf",
-    "module": "es2015",
-    "moduleResolution": "node",
+    "baseUrl": ".",
     "outDir": "../../dist/packages/material",
     "rootDir": ".",
     "rootDirs": [
       ".",
       "../../dist/packages/material"
     ],
-    "sourceMap": true,
-    "inlineSources": true,
-    "target": "es2015",
-    "lib": ["es2015", "dom"],
-    "skipLibCheck": true,
-    "types": [],
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../../dist/packages/cdk/*"],
       "@angular/material/*": ["../../dist/packages/material/*"]
@@ -42,8 +28,5 @@
     "flatModuleId": "@angular/material",
     "skipTemplateCodegen": true,
     "fullTemplateTypeCheck": true
-  },
-  "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true
   }
 }

--- a/src/lib/tsconfig-tests.json
+++ b/src/lib/tsconfig-tests.json
@@ -22,7 +22,7 @@
     // Unset options inherited from tsconfig-build
     "annotateForClosureCompiler": false,
     "flatModuleOutFile": null,
-    "flatModuleId": null,
+    "flatModuleId": null
   },
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
* Similar to how we did it for the CDK, the ts compilations through Bazel and Gulp should be as similar as possible in order to make the tests w/ Bazel creditable.