### PR TITLE
fix(button-toggle): webkit tap highlight conflicting with ripples

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -15,7 +15,6 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   position: relative;
   display: inline-flex;
   flex-direction: row;
-  cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
   border-radius: $mat-button-toggle-legacy-border-radius;


### PR DESCRIPTION
Due to the fact that the `<mat-button-toggle-group>` still has `cursor: pointer`, the webkit tap highlight overlay will show up on touch devices.

This causes a bad UX because the overlay covers the whole group while only an individual option has been touched. Additionally a ripple already shows up and now conflicts with the tap highlight overlay.