### PR TITLE
fix(button-toggle): remove hover state on touch devices

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -19,6 +19,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   white-space: nowrap;
   overflow: hidden;
   border-radius: $mat-button-toggle-legacy-border-radius;
+  -webkit-tap-highlight-color: transparent;
 
   @include cdk-high-contrast {
     outline: solid 1px;
@@ -47,7 +48,6 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
 .mat-button-toggle {
   white-space: nowrap;
   position: relative;
-  -webkit-tap-highlight-color: transparent;
 
   &.cdk-keyboard-focused {
     .mat-button-toggle-focus-overlay {
@@ -76,6 +76,16 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
 
     @include cdk-high-contrast {
       opacity: 0.5;
+    }
+  }
+
+  // On touch devices the hover state will linger on the element after the user has tapped.
+  // Disable it, because it can be confused with focus. We target the :hover state explicitly,
+  // because we still want to preserve the keyboard focus state for hybrid devices that have
+  // a keyboard and a touchscreen.
+  @media (hover: none) {
+    &:not(.mat-button-toggle-disabled):hover .mat-button-toggle-focus-overlay {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Negates the `:hover` state on touch devices, in order to prevent it from lingering after the user taps on a button toggle. Also fixes the native tap highlight showing up if the user taps on a disabled toggle group.