### PR TITLE
fix(checkbox): disabled property not being coerced

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -245,8 +245,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   @Input()
   get disabled() { return this._disabled; }
   set disabled(value: any) {
-    if (value != this.disabled) {
-      this._disabled = value;
+    const newValue = coerceBooleanProperty(value);
+
+    if (newValue !== this.disabled) {
+      this._disabled = newValue;
       this._changeDetectorRef.markForCheck();
     }
   }


### PR DESCRIPTION
Fixes the `disabled` property not being coerced like all the other components.

Fixes #13739.