### PR TITLE
fix(stepper): incorrect border color in dark theme for header with label position

### DIFF
--- a/src/lib/stepper/_stepper-theme.scss
+++ b/src/lib/stepper/_stepper-theme.scss
@@ -54,6 +54,8 @@
     border-left-color: mat-color($foreground, divider);
   }
 
+  .mat-horizontal-stepper-header::before,
+  .mat-horizontal-stepper-header::after,
   .mat-stepper-horizontal-line {
     border-top-color: mat-color($foreground, divider);
   }

--- a/src/lib/stepper/stepper.scss
+++ b/src/lib/stepper/stepper.scss
@@ -40,7 +40,6 @@ $mat-stepper-line-gap: 8px !default;
 }
 
 %mat-header-horizontal-line-label-position-bottom {
-  border-top-color: rgba(0, 0, 0, 0.12);
   border-top-width: $mat-stepper-line-width;
   border-top-style: solid;
   content: '';


### PR DESCRIPTION
Fixes the extra border that gets added in `labelPosition="bottom"` not being colored based on the theme.

For reference:
<img width="311" alt="screenshot at oct 24 17-25-40" src="https://user-images.githubusercontent.com/4450522/47442157-2a61c080-d7b2-11e8-8fce-25bbc1f24982.png">
