### PR TITLE
build: suppress warnings when building tests with bazel

### DIFF
--- a/src/bazel-tsconfig-test.json
+++ b/src/bazel-tsconfig-test.json
@@ -6,5 +6,8 @@
   "compilerOptions": {
     "importHelpers": false,
     "types": ["jasmine"]
+  },
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true
   }
 }


### PR DESCRIPTION
* Suppress Bazel warnings when compiling the unit tests. This is necessary for the test tsconfig because TypeScript does not inherit third-party `tsconfig` options.