### PR TITLE
fix(tabs): mat-align-tabs not working on mat-tab-nav-bar

### DIFF
--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -9,6 +9,14 @@
 .mat-tab-links {
   position: relative;
   display: flex;
+
+  [mat-align-tabs='center'] & {
+    justify-content: center;
+  }
+
+  [mat-align-tabs='end'] & {
+    justify-content: flex-end;
+  }
 }
 
 // Wraps each link in the header


### PR DESCRIPTION
For consistency with `mat-tab-group`, adds support for `mat-align-tabs` to `mat-tab-nav-bar`.

Fixes #13798.