### PR TITLE
Update to Angular 7.0.1 http_archive & @angular/bazel package

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,10 @@ build --symlink_prefix=/
 # Performance: avoid stat'ing input files
 build --watchfs
 
+# Turn off legacy external runfiles
+run --nolegacy_external_runfiles
+test --nolegacy_external_runfiles
+
 ###############################
 # Output control              #
 ###############################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@
 # To validate changes, use an online parser, eg.
 # http://yaml-online-parser.appspot.com/
 
-var_1: &docker_image angular/ngcontainer:0.6.0
-var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.6.0
+var_1: &docker_image angular/ngcontainer:0.7.0
+var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.7.0
 
 # Settings common to each job
 var_3: &job_defaults

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,6 @@ http_archive(
   name = "io_bazel_rules_sass",
   url = "https://github.com/bazelbuild/rules_sass/archive/1.14.1.zip",
   strip_prefix = "rules_sass-1.14.1",
-  sha256 = "d8b89e47b05092a6eed3fa199f2de7cf671a4b9165d0bf38f12a0363dda928d3",
 )
 
 # Since we are explitly fetching @build_bazel_rules_typescript, we should explicly

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,42 +5,20 @@ http_archive(
   name = "build_bazel_rules_nodejs",
   url = "https://github.com/bazelbuild/rules_nodejs/archive/0.15.3.zip",
   strip_prefix = "rules_nodejs-0.15.3",
-  sha256 = "05afbbc13b0b7d5056e412d66c98853978bd46a94bc8e7b71c7fba4349b77eef",
 )
 
 # Add TypeScript rules
 http_archive(
   name = "build_bazel_rules_typescript",
-  url = "https://github.com/bazelbuild/rules_typescript/archive/0.20.3.zip",
-  strip_prefix = "rules_typescript-0.20.3",
-  sha256 = "2a03b23c30c5109ab0863cfa60acce73ceb56337d41efc2dd67f8455a1c1d5f3",
+  url = "https://github.com/bazelbuild/rules_typescript/archive/8ea1a55cf5cf8be84ddfeefc0940769b80da792f.zip",
+  strip_prefix = "rules_typescript-8ea1a55cf5cf8be84ddfeefc0940769b80da792f",
 )
-
-# Fetch transient dependencies of the TypeScript bazel rules.
-load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
-rules_typescript_dependencies()
-
-# Add sass rules
-http_archive(
-  name = "io_bazel_rules_sass",
-  url = "https://github.com/bazelbuild/rules_sass/archive/1.14.1.zip",
-  strip_prefix = "rules_sass-1.14.1",
-  sha256 = "d8b89e47b05092a6eed3fa199f2de7cf671a4b9165d0bf38f12a0363dda928d3",
-)
-
-load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
-sass_repositories()
 
 # Add Angular source and Bazel rules.
 http_archive(
   name = "angular",
-  # Locked to commit "07b89902d5178afefeedeb18d316f4a1c77c6025" that has been merged after v7.0.0
-  # has been released. This explicitly used version of angular/angular includes the latest changes
-  # to @angular/bazel that have been merged from the `bazel` branch into `master.`
-  # TODO(devversion): start using release archives once 7.0.1 is available w/ the Bazel changes.
-  url = "https://github.com/angular/angular/archive/07b89902d5178afefeedeb18d316f4a1c77c6025.zip",
-  strip_prefix = "angular-07b89902d5178afefeedeb18d316f4a1c77c6025",
-  sha256 = "6439dcd01afa5ef3456f9f454ba546a385f7fc56bbc8b6e4ec990dbd9773ba8f",
+  url = "https://github.com/angular/angular/archive/7.0.1.zip",
+  strip_prefix = "angular-7.0.1",
 )
 
 # Add RxJS as repository because those are needed in order to build Angular from source.
@@ -53,10 +31,41 @@ http_archive(
   sha256 = "72b0b4e517f43358f554c125e40e39f67688cd2738a8998b4a266981ed32f403",
 )
 
+# Add sass rules
+http_archive(
+  name = "io_bazel_rules_sass",
+  url = "https://github.com/bazelbuild/rules_sass/archive/1.14.1.zip",
+  strip_prefix = "rules_sass-1.14.1",
+  sha256 = "d8b89e47b05092a6eed3fa199f2de7cf671a4b9165d0bf38f12a0363dda928d3",
+)
+
+# Since we are explitly fetching @build_bazel_rules_typescript, we should explicly
+# ask for its transitive deps from the version we fetched since
+# rules_angular_dependencies() will load transitive deps for the version
+# it would fetch transitively
+load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
+rules_typescript_dependencies()
+
+# Since we are explitly fetching @build_bazel_rules_nodejs, we should explicly
+# ask for its transitive deps from the version we fetched since
+# rules_angular_dependencies() will load transitive deps for the version
+# it would fetch transitively
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+rules_nodejs_dependencies()
+
+# Fetch @angular repo transitive deps that are not already fetched above
+load("@angular//packages/bazel:package.bzl", "rules_angular_dependencies")
+rules_angular_dependencies()
+
+load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
+sass_repositories()
+
 # NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
 # your npm dependencies. You must still run the package manager.
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
+load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
+# The minimum bazel version to use with this repo is 0.18.0
+check_bazel_version("0.18.0")
 node_repositories(
   # For deterministic builds, specify explicit NodeJS and Yarn versions. Keep the Yarn version
   # in sync with the version of Travis.
@@ -76,10 +85,6 @@ yarn_install(
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 
-# Setup Angular bazel rules
-load("@angular//packages/bazel:package.bzl", "rules_angular_dependencies")
-rules_angular_dependencies()
-
 # Setup Angular workspace for building (Bazel managed node modules)
 load("@angular//:index.bzl", "ng_setup_workspace")
 ng_setup_workspace()
@@ -91,8 +96,7 @@ go_register_toolchains()
 
 # Setup web testing. We need to setup a browser because the web testing rules for TypeScript need
 # a reference to a registered browser (ideally that's a hermetic version of a browser)
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories",
-  "web_test_repositories")
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 
 web_test_repositories()
 browser_repositories(

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "zone.js": "^0.8.26"
   },
   "devDependencies": {
+    "@angular/bazel": "7.0.1",
     "@angular-devkit/core": "^7.0.1",
     "@angular-devkit/schematics": "^7.0.1",
     "@angular/compiler-cli": "^7.0.0",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -8,12 +8,6 @@ load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library",
 DEFAULT_TSCONFIG_BUILD = "//src:bazel-tsconfig-build.json"
 DEFAULT_TSCONFIG_TEST = "//src:bazel-tsconfig-test.json"
 
-# By default, the Angular bazel rules assume that the `@angular/bazel` package has been
-# installed through NPM. Therefore it expects ngc-wrapped binaries to be available in the "@npm"
-# workspace. Since we build from source, the Bazel rules are not part of the NPM workspace.
-_SOURCE_NG_MODULE_COMPILER = "@angular//packages/bazel/src/ngc-wrapped"
-_SOURCE_NG_MODULE_XI18N = "@angular//packages/bazel/src/ngc-wrapped:xi18n"
-
 def _getDefaultTsConfig(testonly):
   if testonly:
     return DEFAULT_TSCONFIG_TEST
@@ -48,8 +42,6 @@ def ng_module(deps = [], tsconfig = None, testonly = False, **kwargs):
     deps = local_deps,
     tsconfig = tsconfig,
     testonly = testonly,
-    compiler = _SOURCE_NG_MODULE_COMPILER,
-    ng_xi18n = _SOURCE_NG_MODULE_XI18N,
     **kwargs
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,16 @@
   dependencies:
     tslib "^1.9.0"
 
+"@angular/bazel@7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-7.0.1.tgz#42e1a114a20643ea53cff1bb8091e1ba08637885"
+  integrity sha512-DEv1QiccMglqPyXqxtl3Onm4j1aIJzvWx/4Tyy6gEK/r7wOqwffkPrmQGGJC3QAhsXxXMRK0mQ3jkKoAXLbunA==
+  dependencies:
+    "@bazel/typescript" "^0.20.3"
+    "@types/node" "6.0.84"
+    shelljs "0.8.2"
+    tsickle "0.32.1"
+
 "@angular/common@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@angular/common/-/common-7.0.0.tgz#29206614d2b8dc79e5207b7dc6f9fc559e9a24f2"
@@ -261,7 +271,7 @@
     requirejs "2.3.5"
     tmp "0.0.33"
 
-"@bazel/typescript@0.20.3":
+"@bazel/typescript@0.20.3", "@bazel/typescript@^0.20.3":
   version "0.20.3"
   resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.20.3.tgz#51dcc369c2af0d7f2311d6e692d07776492060f4"
   integrity sha512-BZmfzaNkgS++53CGEUk5p9FXOG+k8FNWCDbxzYljoIGP60aIkw4UgRQ24ReBwhCMg6M6KW609yje7AvDZkA6bg==
@@ -766,6 +776,11 @@
   version "10.11.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
   integrity sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==
+
+"@types/node@6.0.84":
+  version "6.0.84"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.84.tgz#193ffe5a9f42864d425ffd9739d95b753c6a1eab"
+  integrity sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg==
 
 "@types/node@^6.0.46":
   version "6.0.118"
@@ -10295,19 +10310,19 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.7.0:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@0.8.2, shelljs@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
+  integrity sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
-  integrity sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==
+shelljs@^0.7.0:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -11459,7 +11474,7 @@ tsickle@0.28.0:
     source-map "^0.6.0"
     source-map-support "^0.5.0"
 
-tsickle@^0.32.0:
+tsickle@0.32.1, tsickle@^0.32.0:
   version "0.32.1"
   resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.32.1.tgz#f16e94ba80b32fc9ebe320dc94fbc2ca7f3521a5"
   integrity sha512-JW9j+W0SaMSZGejIFZBk0AiPfnhljK3oLx5SaqxrJhjlvzFyPml5zqG1/PuScUj6yTe1muEqwk5CnDK0cOZmKw==


### PR DESCRIPTION
Updates to idiomatic install of @angular/bazel package v7.0.1 which should match the version of the angular http_archive() in WORKSPACE. Also removes the compiler override in ng_module. Not necessary when @angular/bazel is installed from npm.

Some cleanup as well:

* checks for minimum Bazel version of 0.18.0
* adds .bazelignore
* removes rules_typescript_dependencies() from WORKSPACE (these deps are installed by by rules_angular_dependencies())
