### PR TITLE
fix(button-toggle): svg icon not align inside toggle

### DIFF
--- a/src/lib/button-toggle/button-toggle.scss
+++ b/src/lib/button-toggle/button-toggle.scss
@@ -48,6 +48,11 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   position: relative;
   -webkit-tap-highlight-color: transparent;
 
+  // Fixes SVG icons that get thrown off because of the `vertical-align` on the parent.
+  .mat-icon svg {
+    vertical-align: top;
+  }
+
   &.cdk-keyboard-focused {
     .mat-button-toggle-focus-overlay {
       opacity: 1;


### PR DESCRIPTION
Fixes the `svg` node inside the icon being shifted down inside a button toggle.

Fixes #13726.

For reference:
![angular_material_-_google_chrome_2018-10-27_12-01-27](https://user-images.githubusercontent.com/4450522/47602634-ebb24d00-d9e1-11e8-93b7-72ff2370ce7d.png)
