### PR TITLE
fix(list): remove disabled selection list hover feedback on mobile

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -300,7 +300,7 @@ mat-action-list {
 @media (hover: none) {
   .mat-list-option,
   .mat-nav-list .mat-list-item {
-    &:hover {
+    &:not(.mat-list-item-disabled):hover {
       background: none;
     }
   }


### PR DESCRIPTION
Currently on mobile devices we counteract the `:hover` styling by removing the background, however this ends up removing the disabled styling.

For reference:
![angular_material_-_google_chrome_2018-10-28_20-15-12](https://user-images.githubusercontent.com/4450522/47620806-d7a84180-daee-11e8-907b-c1fef9f1ccb9.png)
