### PR TITLE
build: do not run browserstack in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,6 @@ jobs:
     environment:
       BROWSER_STACK_USERNAME: "angularteam1"
       BROWSER_STACK_ACCESS_KEY: "CaXMeMHD9pr5PHg8N7Jq"
-    parallelism: 2
     steps:
       - *checkout_code
       - *restore_cache


### PR DESCRIPTION
* No longer runs BrowserStack in parallel because it causes rate limit exceptions that didn't show up if we just had one tunnel per job.

**Note**: I've kept the array split logic because it's made to respect the `parallelism` option from Circle, so it should be fine to keep this function in our code base. It might be useful if we revisit with a new BS license or if we want to run multiple instances of the local browsers etc.