### PR TITLE
build: update dgeni-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "zone.js": "^0.8.26"
   },
   "devDependencies": {
-    "@angular/bazel": "7.0.1",
     "@angular-devkit/core": "^7.0.1",
     "@angular-devkit/schematics": "^7.0.1",
+    "@angular/bazel": "7.0.1",
     "@angular/compiler-cli": "^7.0.0",
     "@angular/http": "^7.0.0",
     "@angular/platform-browser-dynamic": "^7.0.0",
@@ -80,7 +80,7 @@
     "chalk": "^1.1.3",
     "codelyzer": "^4.3.0",
     "dgeni": "^0.4.10",
-    "dgeni-packages": "^0.26.11",
+    "dgeni-packages": "^0.26.12",
     "firebase": "^5.5.2",
     "firebase-admin": "^5.0.0",
     "firebase-tools": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3288,10 +3288,10 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-dgeni-packages@^0.26.11:
-  version "0.26.11"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.11.tgz#88659a36d99d1ac69e33e7d09eaab5df2028b0e9"
-  integrity sha512-9b8WBQLX3szU7PFOnefbIBG2JRCwaysTK0xpR/zJWXnI+t41roQn2923q/fmnFFQ014d4AK/X482ihVnZ/VWJQ==
+dgeni-packages@^0.26.12:
+  version "0.26.12"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.12.tgz#6b8329b59a17213d30137b53a689d579cd6a9fb1"
+  integrity sha512-dYuRYnw+sURD82F6JJ+2erOKOlaReBymR9g2bjpws3GSIpBbX1p1kE9VYwmAaBoZRE2h+woK8RyDktZvkzETfg==
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
* Updates `dgeni-packages` to the most recent version that includes an improvement for parameter types in the docs (https://github.com/angular/dgeni-packages/commit/148bc949e5880357817b21f1da09ac056ca9c0b0)
* Fixes that the `@angular/bazel` dependency is not being inserted at the proper position (alphabetically)