### PR TITLE
build: move snapshot publish job to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,28 @@ jobs:
 
       - *save_cache
 
+  # ----------------------------------------
+  # Job that publishes the build snapshots
+  # ----------------------------------------
+  publish_snapshots:
+    <<: *job_defaults
+    steps:
+      # Since CircleCI currently does not have any way to easily restrict jobs to only run
+      # for push builds, we need to manually skip publishing if the jobs runs for a PR.
+      # https://discuss.circleci.com/t/workflows-pull-request-filter/14396/11
+      - run:
+          name: Check whether this job should be skipped.
+          command: '[[ -n ${CIRCLE_PR_NUMBER} ]] && circleci step halt || true'
+
+      - *checkout_code
+      - *restore_cache
+      - *yarn_install
+      - *attach_release_output
+
+      - run: ./scripts/circleci/publish-snapshots.sh
+
+      - *save_cache
+
 # ----------------------------------------------------------------------------------------
 # Workflow definitions. A workflow usually groups multiple jobs together. This is useful if
 # one job depends on another.
@@ -232,6 +254,9 @@ workflows:
     jobs:
       - build_release_packages
       - build_demoapp_aot:
+          requires:
+            - build_release_packages
+      - publish_snapshots:
           requires:
             - build_release_packages
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ jobs:
   include:
     - env: "MODE=payload"
     - env: "MODE=saucelabs_required"
-    - env: "DEPLOY_MODE=build-artifacts"
-      if: type = push
-    - env: "DEPLOY_MODE=docs-content"
-      if: type = push
     - env: "DEPLOY_MODE=dashboard"
       if: type = cron
 env:

--- a/scripts/circleci/publish-snapshots.sh
+++ b/scripts/circleci/publish-snapshots.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script should fail if one of the individual publish scripts fails.
+set -e
+
+# Go to project directory.
+cd $(dirname ${0})/../..
+
+# Deploy build artifacts to the GitHub build repositories. The release output is already
+# fetched from the CircleCI workspace storage.
+./scripts/deploy/publish-build-artifacts.sh --no-build
+
+# Build the docs output before publishing the docs content.
+yarn gulp docs
+
+# Deploy the docs content to the Github repository. We don't want to build the examples
+# package here again because it's already fetched from the CircleCI workspace storage.
+./scripts/deploy/publish-docs-content.sh --no-build
+

--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -31,7 +31,7 @@ publishPackage() {
 
   buildDir="$(pwd)/dist/releases/${packageName}"
   buildVersion=$(node -pe "require('./package.json').version")
-  branchName=${TRAVIS_BRANCH:-'master'}
+  branchName=${CIRCLE_BRANCH:-'master'}
 
   commitSha=$(git rev-parse --short HEAD)
   commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -8,9 +8,9 @@ set -e
 
 cd "$(dirname $0)/../../"
 
-if [ -z ${MATERIAL2_DOCS_CONTENT_TOKEN} ]; then
+if [ -z ${MATERIAL2_BUILDS_TOKEN} ]; then
   echo "Error: No access token for GitHub could be found." \
-       "Please set the environment variable 'MATERIAL2_DOCS_CONTENT_TOKEN'."
+       "Please set the environment variable 'MATERIAL2_BUILDS_TOKEN'."
   exit 1
 fi
 
@@ -117,7 +117,7 @@ git config user.name "$commitAuthorName"
 git config user.email "$commitAuthorEmail"
 git config credential.helper "store --file=.git/credentials"
 
-echo "https://${MATERIAL2_DOCS_CONTENT_TOKEN}:@github.com" > .git/credentials
+echo "https://${MATERIAL2_BUILDS_TOKEN}:@github.com" > .git/credentials
 
 echo "Credentials for docs-content repository are now set up. Publishing.."
 

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -38,7 +38,7 @@ docsContentRepoUrl="https://github.com/angular/material2-docs-content"
 buildVersion=$(node -pe "require('./package.json').version")
 
 # Name of the branch that is currently being deployed.
-branchName=${TRAVIS_BRANCH:-'master'}
+branchName=${CIRCLE_BRANCH:-'master'}
 
 # Additional information about the last commit for docs-content commits.
 commitSha=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Needs the following tokens to be available within CircleCI:

- `MATERIAL2_BUILDS_TOKEN`
- `MATERIAL2_DOCS_CONTENT_TOKEN`

I'd vote for combining this tokens into a single one at some point.