### PR TITLE
chore: add yarn logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ node_modules
 /coverage/*
 /libpeerconnection.log
 npm-debug.log
+yarn-debug.log
+yarn-error.log
 testem.log
 /.chrome
 /.git


### PR DESCRIPTION
Adds the yarn-related logs to a gitignore so people don't try to commit them accidentally. See #13814.