### PR TITLE
fix(portal): use portal's ComponentFactoryResolver in portal outlet directive

### DIFF
--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -92,6 +92,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
     this._attachedPortal = portal;
   }
 
+  /** Emits when a portal is attached to the outlet. */
   @Output() attached: EventEmitter<CdkPortalOutletAttachedRef> =
       new EventEmitter<CdkPortalOutletAttachedRef>();
 
@@ -125,8 +126,8 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
         portal.viewContainerRef :
         this._viewContainerRef;
 
-    const componentFactory =
-        this._componentFactoryResolver.resolveComponentFactory(portal.component);
+    const resolver = portal.componentFactoryResolver || this._componentFactoryResolver;
+    const componentFactory = resolver.resolveComponentFactory(portal.component);
     const ref = viewContainerRef.createComponent(
         componentFactory, viewContainerRef.length,
         portal.injector || viewContainerRef.injector);

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -29,9 +29,14 @@ describe('Portals', () => {
 
   describe('CdkPortalOutlet', () => {
     let fixture: ComponentFixture<PortalTestApp>;
+    let componentFactoryResolver: ComponentFactoryResolver;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(PortalTestApp);
+
+      inject([ComponentFactoryResolver], (cfr: ComponentFactoryResolver) => {
+        componentFactoryResolver = cfr;
+      })();
     });
 
     it('should load a component into the portal', () => {
@@ -311,6 +316,20 @@ describe('Portals', () => {
       expect(instance.portalOutlet.hasAttached()).toBe(true);
     });
 
+    it('should use the `ComponentFactoryResolver` from the portal, if available', () => {
+      const spy = jasmine.createSpy('resolveComponentFactorySpy');
+      const portal = new ComponentPortal(PizzaMsg, undefined, undefined, {
+        resolveComponentFactory: (...args: any[]) => {
+          spy();
+          return componentFactoryResolver.resolveComponentFactory
+              .apply(componentFactoryResolver, args);
+        }
+      });
+
+      fixture.componentInstance.portalOutlet.attachComponentPortal(portal);
+      expect(spy).toHaveBeenCalled();
+    });
+
   });
 
   describe('DomPortalOutlet', () => {
@@ -324,8 +343,8 @@ describe('Portals', () => {
     let appRef: ApplicationRef;
     let deps = [ComponentFactoryResolver, Injector, ApplicationRef];
 
-    beforeEach(inject(deps, (dcl: ComponentFactoryResolver, i: Injector, ar: ApplicationRef) => {
-      componentFactoryResolver = dcl;
+    beforeEach(inject(deps, (cfr: ComponentFactoryResolver, i: Injector, ar: ApplicationRef) => {
+      componentFactoryResolver = cfr;
       injector = i;
       appRef = ar;
     }));


### PR DESCRIPTION
Follow-up from #12677 where we missed to add the new functionality to the `CdkPortalOutlet` directive.

Fixes #9712.