### PR TITLE
docs: add ability to close current expanded row in table expandable rows example

### DIFF
--- a/src/material-examples/table-expandable-rows/table-expandable-rows-example.html
+++ b/src/material-examples/table-expandable-rows/table-expandable-rows-example.html
@@ -29,7 +29,7 @@
   <tr mat-row *matRowDef="let element; columns: columnsToDisplay;"
       class="example-element-row"
       [class.example-expanded-row]="expandedElement === element"
-      (click)="expandedElement = element">
+      (click)="expandedElement === element ? expandedElement = null : expandedElement = element;">
   </tr>
   <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="example-detail-row"></tr>
 </table>

--- a/src/material-examples/table-expandable-rows/table-expandable-rows-example.html
+++ b/src/material-examples/table-expandable-rows/table-expandable-rows-example.html
@@ -29,7 +29,7 @@
   <tr mat-row *matRowDef="let element; columns: columnsToDisplay;"
       class="example-element-row"
       [class.example-expanded-row]="expandedElement === element"
-      (click)="expandedElement === element ? expandedElement = null : expandedElement = element;">
+      (click)="expandedElement = expandedElement === element ? null : element">
   </tr>
   <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="example-detail-row"></tr>
 </table>

--- a/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
+++ b/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
@@ -19,7 +19,7 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
 export class TableExpandableRowsExample {
   dataSource = ELEMENT_DATA;
   columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
-  expandedElement: PeriodicElement;
+  expandedElement: PeriodicElement|null;
 }
 
 export interface PeriodicElement {

--- a/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
+++ b/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
@@ -19,7 +19,7 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
 export class TableExpandableRowsExample {
   dataSource = ELEMENT_DATA;
   columnsToDisplay = ['name', 'weight', 'symbol', 'position'];
-  expandedElement: PeriodicElement|null;
+  expandedElement: PeriodicElement | null;
 }
 
 export interface PeriodicElement {


### PR DESCRIPTION
Like this if you click on a row which is already expanded it will be closed.