### PR TITLE
docs: pointing out breaking change for MatSidenav and MatDrawer in 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ ng update @angular/material
 * **ripple:** deprecated `[matRippleSpeedFactor]` and `baseSpeedFactor` for the ripples have been removed. Use the new animation config instead.
 * **overlay:** The `flexibleDiemsions` property on `CdkConnectedOverlay` has been renamed to `flexibleDimensions`
 * **sidenav:** the constructor signature of the `MatDrawerContent` and `MatSidenavContent` has changed.
+* **sidenav:** the template for `MatSidenav` and `MatDrawer` have changed.
 * **elevation:** Because `mat-elevation` usages have been moved out of component stylesheets, users who have
 not invoked a theme mixin will not see any elevation shadows on Material components.
 However, users that have created a custom theme which lacks the `elevation` property will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ ng update @angular/material
 * **ripple:** deprecated `[matRippleSpeedFactor]` and `baseSpeedFactor` for the ripples have been removed. Use the new animation config instead.
 * **overlay:** The `flexibleDiemsions` property on `CdkConnectedOverlay` has been renamed to `flexibleDimensions`
 * **sidenav:** the constructor signature of the `MatDrawerContent` and `MatSidenavContent` has changed.
-* **sidenav:** the template for `MatSidenav` and `MatDrawer` have changed.
+* **sidenav:** the templates for `MatSidenav` and `MatDrawer` have changed.
 * **elevation:** Because `mat-elevation` usages have been moved out of component stylesheets, users who have
 not invoked a theme mixin will not see any elevation shadows on Material components.
 However, users that have created a custom theme which lacks the `elevation` property will


### PR DESCRIPTION
Added description to Breaking changes that the template for MatSidenav and MatDrawer have changed. Was done in this https://github.com/angular/material2/pull/12741/commits/0f83c1807f138be2924b36c7725936cbb2d1a258 commit.