### PR TITLE
Removing ~ from @import command

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -35,7 +35,7 @@ Available pre-built themes:
 If you're using Angular CLI, this is as simple as including one line
 in your `styles.css`  file:
 ```css
-@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
+@import '@angular/material/prebuilt-themes/deeppurple-amber.css';
 ```
 
 Alternatively, you can just reference the file directly. This would look something like:


### PR DESCRIPTION
Under the current build of Angular CLI ( with Angular Material v.7.0.2), adding the ~ in the @import command will cause a compilation error.  I am proposing to remove the tilde on line 38 to reflect this change for this version.