### PR TITLE
fix(icon): account for query params when prefixing external references

### DIFF
--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -59,11 +59,12 @@ export interface MatIconLocation {
 /** @docs-private */
 export function MAT_ICON_LOCATION_FACTORY(): MatIconLocation {
   const _document = inject(DOCUMENT);
+  const _location = _document ? _document.location : null;
 
   return {
     // Note that this needs to be a function, rather than a property, because Angular
     // will only resolve it once, but we want the current path on each call.
-    getPathname: () => (_document && _document.location && _document.location.pathname) || ''
+    getPathname: () => _location ? (_location.pathname + _location.search) : ''
   };
 }
 


### PR DESCRIPTION
Fixes `mat-icon` ignoring query params when prefixing external references inside the SVG.

Fixes #13924.