### PR TITLE
build: moment-adapter package should not depend on all material entry-points

### DIFF
--- a/src/material-moment-adapter/BUILD.bazel
+++ b/src/material-moment-adapter/BUILD.bazel
@@ -9,8 +9,9 @@ ng_module(
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/material-moment-adapter",
   deps = [
+    "@angular//packages/core",
     "@npm//moment",
-    "//src/lib:material"
+    "//src/lib/core"
   ],
   # Explicitly specify the tsconfig that is also used by Gulp. We need to explicitly use this
   # tsconfig because in order to import Moment with TypeScript, we need some special options

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material';
+import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import {MAT_MOMENT_DATE_ADAPTER_OPTIONS, MomentDateAdapter} from './moment-date-adapter';
 import {MAT_MOMENT_DATE_FORMATS} from './moment-date-formats';
 

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -7,7 +7,7 @@
  */
 
 import {Inject, Injectable, Optional, InjectionToken} from '@angular/core';
-import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 // Depending on whether rollup is used, moment needs to be imported differently.
 // Since Moment.js doesn't have a default export, we normally need to import using the `* as`
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using

--- a/src/material-moment-adapter/adapter/moment-date-formats.ts
+++ b/src/material-moment-adapter/adapter/moment-date-formats.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MatDateFormats} from '@angular/material';
+import {MatDateFormats} from '@angular/material/core';
 
 
 export const MAT_MOMENT_DATE_FORMATS: MatDateFormats = {


### PR DESCRIPTION
Since we have the ability to only build specific parts of Material with Bazel, the `material-moment-adapter` should just depend on it's *actual*  dependencies and not on the _whole set_ of Material entry-points.