### PR TITLE
build: fix publish snapshot job not working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,11 @@ jobs:
           name: Check whether this job should be skipped.
           command: '[[ -n ${CIRCLE_PR_NUMBER} ]] && circleci step halt || true'
 
+      # CircleCI has a config setting to enforce SSH for all github connections.
+      # This is not compatible with our mechanism of using a Personal Access Token
+      # to publish the build snapshots. In order to fix this, we unset the global option.
+      - run: git config --global --unset "url.ssh://git@github.com.insteadof"
+
       - *checkout_code
       - *restore_cache
       - *yarn_install


### PR DESCRIPTION
* Fixes that the publish snapshot job is not able to push the artifacts to Github.