### PR TITLE
build: circleci git config being updated too early

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,15 +215,15 @@ jobs:
           name: Check whether this job should be skipped.
           command: '[[ -n ${CIRCLE_PR_NUMBER} ]] && circleci step halt || true'
 
-      # CircleCI has a config setting to enforce SSH for all github connections.
-      # This is not compatible with our mechanism of using a Personal Access Token
-      # to publish the build snapshots. In order to fix this, we unset the global option.
-      - run: git config --global --unset "url.ssh://git@github.com.insteadof"
-
       - *checkout_code
       - *restore_cache
       - *yarn_install
       - *attach_release_output
+
+      # CircleCI has a config setting to enforce SSH for all github connections.
+      # This is not compatible with our mechanism of using a Personal Access Token
+      # to publish the build snapshots. In order to fix this, we unset the global option.
+      - run: git config --global --unset "url.ssh://git@github.com.insteadof"
 
       - run: ./scripts/circleci/publish-snapshots.sh
 


### PR DESCRIPTION
* Due to the fact that we try to run `git config --global` before CircleCI set up the global Git configuration, the publish task is still broken. This _should_ fix it.