### PR TITLE
build: do not throw if example module is created through gulp

### DIFF
--- a/src/material-examples/BUILD.bazel
+++ b/src/material-examples/BUILD.bazel
@@ -33,7 +33,10 @@ ng_package(
 
 genrule(
   name = "example-module",
-  srcs = glob(["**/*.ts"]),
+  # In case the example-module.ts file is present as an actual source file (e.g. generated
+  # through Gulp), we need to exclude it because otherwise the genrule would fail.
+  # TODO(devversion): remove this once gulp has been replaced with bazel.
+  srcs = glob(["**/*.ts"], exclude = ["example-module.ts"]),
   outs = ["example-module.ts"],
   cmd = """
     # As a workaround for https://github.com/bazelbuild/rules_nodejs/issues/404, we pass the


### PR DESCRIPTION
In case someone uses both Gulp and Bazel to build Angular Material, there will be an error because our gulp process generates the `example-module` as an actual source file. 

This is problematic because the `genrule` cannot have the `example-module` as an `input` and an `output` at the same time.