### PR TITLE
fix(chips): remove circular dependency between chip-list and chip-input

### DIFF
--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -7,9 +7,10 @@
  */
 
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Directive, ElementRef, EventEmitter, Input, Output, Inject, OnChanges} from '@angular/core';
-import {MatChipList} from './chip-list';
+import {Directive, ElementRef, EventEmitter, Inject, Input, OnChanges, Output} from '@angular/core';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
+import {MatChipList} from './chip-list';
+import {MatChipTextControl} from './chip-text-control';
 
 
 /** Represents an input event on a `matChipInput`. */
@@ -43,7 +44,7 @@ let nextUniqueId = 0;
     '[attr.aria-invalid]': '_chipList && _chipList.ngControl ? _chipList.ngControl.invalid : null',
   }
 })
-export class MatChipInput implements OnChanges {
+export class MatChipInput implements MatChipTextControl, OnChanges {
   /** Whether the control is focused. */
   focused: boolean = false;
   _chipList: MatChipList;

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -40,7 +40,7 @@ import {MatFormFieldControl} from '@angular/material/form-field';
 import {merge, Observable, Subject, Subscription} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 import {MatChip, MatChipEvent, MatChipSelectionChange} from './chip';
-import {MatChipInput} from './chip-input';
+import {MatChipTextControl} from './chip-text-control';
 
 
 // Boilerplate for applying mixins to MatChipList.
@@ -131,7 +131,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   private _chipRemoveSubscription: Subscription | null;
 
   /** The chip input to add more chips */
-  protected _chipInput: MatChipInput;
+  protected _chipInput: MatChipTextControl;
 
   /** Uid of the chip list */
   _uid: string = `mat-chip-list-${nextUniqueId++}`;
@@ -400,7 +400,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
 
   /** Associates an HTML input element with this chip list. */
-  registerInput(inputElement: MatChipInput): void {
+  registerInput(inputElement: MatChipTextControl): void {
     this._chipInput = inputElement;
   }
 

--- a/src/lib/chips/chip-text-control.ts
+++ b/src/lib/chips/chip-text-control.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+/** Interface for a text control that is used to drive interaction with a mat-chip-list. */
+export interface MatChipTextControl {
+  /** Unique identifier for the text control. */
+  id: string;
+
+  /** The text control's placeholder text. */
+  placeholder: string;
+
+  /** Whether the text control has browser focus. */
+  focused: boolean;
+
+  /** Whether the text control is empty. */
+  empty: boolean;
+
+  /** Focuses the text control. */
+  focus(): void;
+}


### PR DESCRIPTION
This change is necessary because some Google-internal infrastructure has
started encountering errors because of this particular circular dep.