### PR TITLE
fix(datepicker): unable to disable ripple on datepicker toggle

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.html
+++ b/src/lib/datepicker/datepicker-toggle.html
@@ -5,6 +5,7 @@
   [attr.aria-label]="_intl.openCalendarLabel"
   [attr.tabindex]="disabled ? -1 : tabIndex"
   [disabled]="disabled"
+  [disableRipple]="disableRipple"
   (click)="_open($event)">
 
   <svg

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -69,6 +69,9 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   }
   private _disabled: boolean;
 
+  /** Whether ripples on the toggle should be disabled. */
+  @Input() disableRipple: boolean;
+
   /** Custom icon set by the consumer. */
   @ContentChild(MatDatepickerToggleIcon) _customIcon: MatDatepickerToggleIcon;
 


### PR DESCRIPTION
Allows for the ripple on the datepicker toggle to be disabled.

Fixes #13986.

Note that these changes don't use the mixin for disabling ripples, because it isn't necessary since it is implemented by the underlying `mat-button` already.