### PR TITLE
build: add check when running npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "api": "gulp api-docs",
     "breaking-changes": "gulp breaking-changes",
     "gulp": "gulp",
-    "stage-release": "bash ./tools/release/stage-release-bin.sh"
+    "stage-release": "bash ./tools/release/stage-release-bin.sh",
+    "preinstall": "node ./tools/npm/check-npm.js"
   },
   "version": "7.0.2",
   "requiredAngularVersion": ">=7.0.0",

--- a/tools/angular_material_setup_workspace.bzl
+++ b/tools/angular_material_setup_workspace.bzl
@@ -13,7 +13,7 @@ def angular_material_setup_workspace():
     It creates some additional Bazel external repositories that are used internally
     to build Angular Material
   """
-  # Use Bazel managed node modules. See more below: 
+  # Use Bazel managed node modules. See more below:
   # https://github.com/bazelbuild/rules_nodejs#bazel-managed-vs-self-managed-dependencies
   # Note: The repository_rule name is `@matdeps` so it does not conflict with the `@npm` repository
   # name downstream when building Angular Material from source. In the future when Angular + Bazel
@@ -22,5 +22,7 @@ def angular_material_setup_workspace():
   yarn_install(
     name = "matdeps",
     package_json = "@angular_material//:package.json",
+    # Ensure that the script is available when running `postinstall` in the Bazel sandbox.
+    data = ["@angular_material//:tools/npm/check-npm.js"],
     yarn_lock = "@angular_material//:yarn.lock",
   )

--- a/tools/npm/check-npm.js
+++ b/tools/npm/check-npm.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+if (process.env.npm_execpath.indexOf('yarn') === -1) {
+    console.error('Please use Yarn instead of NPM to install dependencies. ' +
+                  'See: https://yarnpkg.com/lang/en/docs/install/');
+    process.exit(1);
+}


### PR DESCRIPTION
Even though we're using `yarn` for everything, it's still easy to fall into the old habit of running `npm i` which could mess up the `node_modules` and generate a new lock file. These changes add a script that throws an error when trying to `npm install`, similar to angular/angular.