### PR TITLE
build: enable size plugin from angular robot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,9 @@ jobs:
             mkdir -p  /tmp/cdk-umd-artifacts
             cp dist/releases/cdk/bundles/*.umd.js /tmp/cdk-umd-artifacts
 
-      # Publish artifacts in favor of the CircleCI size calculations.
-      # Make sure that the size plugin from the Angular robot fetches the
-      # artifacts from this CircleCI job.
+      # Publish bundle artifacts which will be used to calculate the size change.
+      # Note: Make sure that the size plugin from the Angular robot fetches the artifacts
+      # from this CircleCI job (see .github/angular-robot.yml)
       - store_artifacts:
           path: dist/releases/material/bundles/material.umd.js
           destination: material.umd.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ var_9: &docker-firefox-image
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 var_10: &attach_release_output
   attach_workspace:
-      at: dist/releases
+    at: dist/releases
 
 # -----------------------------
 # Container version of CircleCI
@@ -199,6 +199,25 @@ jobs:
           root: dist/releases
           paths:
             - "**/*"
+
+      # Since there is no UMD bundle that includes everything from the CDK, we need to move
+      # all bundles into a directory. This allows us to store all CDK UMD bundles as job
+      # artifacts that can be picked up by the Angular Github bot.
+      - run:
+          name: Prepare CDK artifacts for publish.
+          command: |
+            mkdir -p  /tmp/cdk-umd-artifacts
+            cp dist/releases/cdk/bundles/*.umd.js /tmp/cdk-umd-artifacts
+
+      # Publish artifacts in favor of the CircleCI size calculations.
+      # Make sure that the size plugin from the Angular robot fetches the
+      # artifacts from this CircleCI job.
+      - store_artifacts:
+          path: dist/releases/material/bundles/material.umd.js
+          destination: material.umd.js
+      - store_artifacts:
+          path: /tmp/cdk-umd-artifacts
+          destination: /
 
       - *save_cache
 

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -2,7 +2,12 @@
 
 #options for the size plugin
 size:
-  disabled: true
+  disabled: false
+  # Name of the status that will be responsible for providing
+  # artifacts that will be measured by the robot.
+  circleCiStatusName: "ci/circleci: build_release_packages"
+  # Byte value of maximum allowed change in size
+  maxSizeIncrease: 1500
 
 # options for the merge plugin
 merge:
@@ -55,6 +60,8 @@ merge:
       - "ci/circleci: lint"
       - "ci/circleci: bazel_build_test"
       - "ci/circleci: tests_local_browsers"
+      - "ci/circleci: tests_browserstack"
+      - "ci/circleci: build_release_packages"
 
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option


### PR DESCRIPTION
We only measure the CDK and Material for now. We can revisit checking other packages as well in the future. First, we should figure out whether the size plugin works for us.