### PR TITLE
fix(menu): use passive touch listener

### DIFF
--- a/src/lib/menu/BUILD.bazel
+++ b/src/lib/menu/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
     "//src/cdk/keycodes",
     "//src/cdk/overlay",
     "//src/cdk/portal",
+    "//src/cdk/platform",
     "//src/lib/core",
   ],
 )


### PR DESCRIPTION
Fixes a warning from Chrome that the `mat-menu-trigger` is using a blocking `touchstart` listener.