### PR TITLE
fix(checkbox): poor color contrast for disabled checkbox

### DIFF
--- a/src/lib/checkbox/_checkbox-theme.scss
+++ b/src/lib/checkbox/_checkbox-theme.scss
@@ -9,6 +9,7 @@
   $accent: map-get($theme, accent);
   $warn: map-get($theme, warn);
   $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
 
 
   // The color of the checkbox's checkmark / mixedmark.
@@ -22,7 +23,7 @@
   $disabled-color: if($is-dark-theme, $white-30pct-opacity-on-dark, $black-26pct-opacity-on-light);
 
   .mat-checkbox-frame {
-    border-color: mat-color(map-get($theme, foreground), secondary-text);
+    border-color: mat-color($foreground, secondary-text);
   }
 
   .mat-checkbox-checkmark {
@@ -73,7 +74,7 @@
     }
 
     .mat-checkbox-label {
-      color: $disabled-color;
+      color: mat-color($foreground, secondary-text);
     }
 
     @include cdk-high-contrast {


### PR DESCRIPTION
Fixes some poor color contrast on the text of a disabled checkbox. The issue comes from the fact that it was using a custom color rather than the one from theme.

For reference (top one is what we have in master):
<img width="440" alt="before" src="https://user-images.githubusercontent.com/4450522/48200180-42ab1100-e356-11e8-9e5b-e163cbfe53ab.png">
<img width="441" alt="after" src="https://user-images.githubusercontent.com/4450522/48200192-46d72e80-e356-11e8-8303-5ee6c392b0a0.png">
