### PR TITLE
fix(slide-toggle): showing focus ripple when clicking disabled control

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -204,7 +204,7 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
     opacity: 0.04;
   }
 
-  .mat-slide-toggle.cdk-focused & {
+  .mat-slide-toggle:not(.mat-disabled).cdk-focused & {
     opacity: 0.12;
   }
 


### PR DESCRIPTION
Seems to be a regression from #13957. Since the focus monitor still tracks focus, even though the element is disabled, the focus ripple will show up when clicking on a disabled toggle.

*Note:* a similar issue is probably on #13959 and #13956 as well. I've applied the same fix there since the other PRs haven't been merged yet.