### PR TITLE
fix(chips): not updating keyboard controls if direction changes

### DIFF
--- a/src/lib/chips/BUILD.bazel
+++ b/src/lib/chips/BUILD.bazel
@@ -45,6 +45,7 @@ ng_test_library(
   name = "chips_test_sources",
   srcs = glob(["**/*.spec.ts"]),
   deps = [
+    "@rxjs",
     "@angular//packages/animations",
     "@angular//packages/forms",
     "@angular//packages/platform-browser",

--- a/src/lib/chips/chip-input.spec.ts
+++ b/src/lib/chips/chip-input.spec.ts
@@ -7,6 +7,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatFormFieldModule} from '@angular/material/form-field';
+import {Subject} from 'rxjs';
 import {MatChipInput, MatChipInputEvent} from './chip-input';
 import {MatChipsModule} from './index';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
@@ -27,7 +28,10 @@ describe('MatChipInput', () => {
       declarations: [TestChipInput],
       providers: [{
         provide: Directionality, useFactory: () => {
-          return {value: dir.toLowerCase()};
+          return {
+            value: dir.toLowerCase(),
+            change: new Subject()
+          };
         }
       }]
     });

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -352,6 +352,12 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
       .withVerticalOrientation()
       .withHorizontalOrientation(this._dir ? this._dir.value : 'ltr');
 
+    if (this._dir) {
+      this._dir.change
+        .pipe(takeUntil(this._destroyed))
+        .subscribe(dir => this._keyManager.withHorizontalOrientation(dir));
+    }
+
     // Prevents the chip list from capturing focus and redirecting
     // it back to the first chip when the user tabs out.
     this._keyManager.tabOut.pipe(takeUntil(this._destroyed)).subscribe(() => {

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -4,6 +4,7 @@ import {createKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
 import {Component, DebugElement} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
 import {MatChip, MatChipEvent, MatChipSelectionChange, MatChipsModule} from './index';
 
 
@@ -20,7 +21,10 @@ describe('Chips', () => {
       imports: [MatChipsModule],
       declarations: [BasicChip, SingleChip],
       providers: [{
-        provide: Directionality, useFactory: () => ({value: dir})
+        provide: Directionality, useFactory: () => ({
+          value: dir,
+          change: new Subject()
+        })
       }]
     });
 


### PR DESCRIPTION
Fixes the chip list not updating the direction of its keyboard controls, if the direction changes after the component has been initialized.