### PR TITLE
build: increase max size limit of angular robot

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -7,7 +7,7 @@ size:
   # artifacts that will be measured by the robot.
   circleCiStatusName: "ci/circleci: build_release_packages"
   # Byte value of maximum allowed change in size
-  maxSizeIncrease: 1500
+  maxSizeIncrease: 10000
 
 # options for the merge plugin
 merge:


### PR DESCRIPTION
Increases the max size limit because 1KB limit is currently **way** too less. Causing all simple PRs with small changes to exceed the limit.