### PR TITLE
refactor(datepicker): reduce repetitive calculations in calendar view

### DIFF
--- a/src/lib/datepicker/calendar-body.html
+++ b/src/lib/datepicker/calendar-body.html
@@ -5,8 +5,8 @@
 <tr *ngIf="_firstRowOffset < labelMinRequiredCells" aria-hidden="true">
   <td class="mat-calendar-body-label"
       [attr.colspan]="numCols"
-      [style.paddingTop.%]="50 * cellAspectRatio / numCols"
-      [style.paddingBottom.%]="50 * cellAspectRatio / numCols">
+      [style.paddingTop]="_cellPadding"
+      [style.paddingBottom]="_cellPadding">
     {{label}}
   </td>
 </tr>
@@ -23,8 +23,8 @@
       aria-hidden="true"
       class="mat-calendar-body-label"
       [attr.colspan]="_firstRowOffset"
-      [style.paddingTop.%]="50 * cellAspectRatio / numCols"
-      [style.paddingBottom.%]="50 * cellAspectRatio / numCols">
+      [style.paddingTop]="_cellPadding"
+      [style.paddingBottom]="_cellPadding">
     {{_firstRowOffset >= labelMinRequiredCells ? label : ''}}
   </td>
   <td *ngFor="let item of row; let colIndex = index"
@@ -38,9 +38,9 @@
       [attr.aria-disabled]="!item.enabled || null"
       [attr.aria-selected]="selectedValue === item.value"
       (click)="_cellClicked(item)"
-      [style.width.%]="100 / numCols"
-      [style.paddingTop.%]="50 * cellAspectRatio / numCols"
-      [style.paddingBottom.%]="50 * cellAspectRatio / numCols">
+      [style.width]="_cellWidth"
+      [style.paddingTop]="_cellPadding"
+      [style.paddingBottom]="_cellPadding">
     <div class="mat-calendar-body-cell-content"
          [class.mat-calendar-body-selected]="selectedValue === item.value"
          [class.mat-calendar-body-today]="todayValue === item.value">

--- a/src/lib/datepicker/calendar-body.ts
+++ b/src/lib/datepicker/calendar-body.ts
@@ -15,6 +15,8 @@ import {
   Output,
   ViewEncapsulation,
   NgZone,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {take} from 'rxjs/operators';
 
@@ -54,7 +56,7 @@ export class MatCalendarCell {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatCalendarBody {
+export class MatCalendarBody implements OnChanges {
   /** The label for the table. (e.g. "Jan 2017"). */
   @Input() label: string;
 
@@ -85,6 +87,15 @@ export class MatCalendarBody {
   /** Emits when a new value is selected. */
   @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
+  /** The number of blank cells to put at the beginning for the first row. */
+  _firstRowOffset: number;
+
+  /** Padding for the individual date cells. */
+  _cellPadding: string;
+
+  /** Width of an individual cell. */
+  _cellWidth: string;
+
   constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) { }
 
   _cellClicked(cell: MatCalendarCell): void {
@@ -93,10 +104,21 @@ export class MatCalendarBody {
     }
   }
 
-  /** The number of blank cells to put at the beginning for the first row. */
-  get _firstRowOffset(): number {
-    return this.rows && this.rows.length && this.rows[0].length ?
-        this.numCols - this.rows[0].length : 0;
+  ngOnChanges(changes: SimpleChanges) {
+    const columnChanges = changes.numCols;
+    const {rows, numCols} = this;
+
+    if (changes.rows || columnChanges) {
+      this._firstRowOffset = rows && rows.length && rows[0].length ? numCols - rows[0].length : 0;
+    }
+
+    if (changes.cellAspectRatio || columnChanges || !this._cellPadding) {
+      this._cellPadding = `${50 * this.cellAspectRatio / numCols}%`;
+    }
+
+    if (columnChanges || !this._cellWidth) {
+      this._cellWidth = `${100 / numCols}%`;
+    }
   }
 
   _isActiveCell(rowIndex: number, colIndex: number): boolean {


### PR DESCRIPTION
Currently in the calendar we have a few cheap calculations that are being run multiple times per cell, for each change detection run. Even though these calculations are cheap, their result usually doesn't change after the initial render and it ends up stacking up since we have a lot of cells and we're applying them multiple times per cell. These changes rework calendar body to only do them once if something has changed.