### PR TITLE
fix(menu): not unsubscribing from close stream if trigger is destroyed

### DIFF
--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -85,7 +85,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _portal: TemplatePortal;
   private _overlayRef: OverlayRef | null = null;
   private _menuOpen: boolean = false;
-  private _closeSubscription = Subscription.EMPTY;
+  private _closingActionsSubscription = Subscription.EMPTY;
   private _hoverSubscription = Subscription.EMPTY;
   private _menuCloseSubscription = Subscription.EMPTY;
   private _scrollStrategy: () => ScrollStrategy;
@@ -195,6 +195,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         passiveEventListenerOptions);
 
     this._cleanUpSubscriptions();
+    this._closingActionsSubscription.unsubscribe();
   }
 
   /** Whether the menu is open. */
@@ -233,7 +234,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       this.menu.lazyContent.attach(this.menuData);
     }
 
-    this._closeSubscription = this._menuClosingActions().subscribe(() => this.closeMenu());
+    this._closingActionsSubscription = this._menuClosingActions().subscribe(() => this.closeMenu());
     this._initMenu();
 
     if (this.menu instanceof MatMenu) {
@@ -266,7 +267,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
     const menu = this.menu;
 
-    this._closeSubscription.unsubscribe();
+    this._closingActionsSubscription.unsubscribe();
     this._overlayRef.detach();
 
     if (menu instanceof MatMenu) {
@@ -466,7 +467,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
   /** Cleans up the active subscriptions. */
   private _cleanUpSubscriptions(): void {
-    this._closeSubscription.unsubscribe();
+    this._closingActionsSubscription.unsubscribe();
     this._hoverSubscription.unsubscribe();
   }
 


### PR DESCRIPTION
Fixes the menu trigger not unsubscribing from the menu panel's `close` stream. In most cases it isn't an issue, because `close` gets completed when the panel is destroyed, however the user can still run into it if the trigger is destroyed, but the panel stays in place.