### PR TITLE
build: ensure tunnel identifiers are unique

### DIFF
--- a/scripts/browserstack/start-tunnel.sh
+++ b/scripts/browserstack/start-tunnel.sh
@@ -31,7 +31,7 @@ rm ${tunnelFileName}
 ARGS=""
 
 if [ ! -z "${CIRCLE_BUILD_NUM}" ]; then
-  ARGS="${ARGS} --local-identifier ${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
+  ARGS="${ARGS} --local-identifier angular-material-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
 fi
 
 echo "Starting Browserstack Local in the background, logging into: ${tunnelLogFile}"

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -31,7 +31,7 @@ rm ${tunnelFileName}
 sauceArgs="--readyfile ${tunnelReadyFile} --pidfile ${tunnelPidFile}"
 
 if [ ! -z "${CIRCLE_BUILD_NUM}" ]; then
-  sauceArgs="${sauceArgs} --tunnel-identifier ${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
+  sauceArgs="${sauceArgs} --tunnel-identifier angular-material-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
 fi
 
 echo "Starting Sauce Connect in the background, logging into: ${tunnelLogFile}"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -96,8 +96,9 @@ module.exports = (config) => {
   if (process.env['CIRCLECI']) {
     const instanceIndex = Number(process.env['CIRCLE_NODE_INDEX']);
     const maxParallelInstances = Number(process.env['CIRCLE_NODE_TOTAL']);
-    const tunnelIdentifier = `${process.env['CIRCLE_BUILD_NUM']}-${instanceIndex}`;
-    const buildIdentifier = `angular-material-${tunnelIdentifier}`;
+    const tunnelIdentifier =
+        `angular-material-${process.env['CIRCLE_BUILD_NUM']}-${instanceIndex}`;
+    const buildIdentifier = `circleci-${tunnelIdentifier}`;
     const testPlatform = process.env['TEST_PLATFORM'];
 
     if (testPlatform === 'browserstack') {


### PR DESCRIPTION
* Currently it can happen that our tunnel identifier conflicts with other tunnel identifiers from other Angular projects. A few PRs reported that their tunnel couldn't be re-opened because it was already used and closed successfully.