### PR TITLE
chore: run circleci for 7.0.x branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,6 +318,7 @@ general:
   branches:
     only:
       - master
+      - 7.0.x
       # 5.2.x, 6.0.x, etc
       - /\d+\.\d+\.x/
       # 5.x, 6.x, etc


### PR DESCRIPTION
Seeing if this works because it appears that CircleCI is not currently running tasks for this branch