### PR TITLE
build: remove duplicate branches filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,8 +318,7 @@ general:
   branches:
     only:
       - master
-      - 7.0.x
-      # 5.2.x, 6.0.x, etc
+      # 6.2.x, 7.0.x etc.
       - /\d+\.\d+\.x/
-      # 5.x, 6.x, etc
+      # 6.x, 7.x, etc.
       - /\d+\.x/


### PR DESCRIPTION
* The `7.0.x` branch is already covered by one of the regular expressions in the `config.yml` for CircleCI.