### PR TITLE
build: throw when running build tasks inside of a directory with spaces

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,8 +6,15 @@
 
 const path = require('path');
 
-const tsconfigPath = path.join(__dirname, 'tools/gulp/tsconfig.json');
+const projectDir = __dirname;
+const tsconfigPath = path.join(projectDir, 'tools/gulp/tsconfig.json');
 const tsconfig = require(tsconfigPath);
+
+if (projectDir.includes(' ')) {
+  console.error('Error: Cannot run the Angular Material build tasks if the project is ' +
+    'located in a directory with spaces in between. Please rename your project directory.');
+  process.exit(1);
+}
 
 // Register TS compilation.
 require('ts-node').register({


### PR DESCRIPTION
Currently building Angular Material with gulp inside of directories that include spaces, does not work because `child_process.spawnSync` does not properly treat the whole path as binary and just considers everything after the first space as command line argument.

We can fix these issues by ensuring that the binary is always located in the working directory. Also we would need to make sure that we wrap all `child_process` arguments with explict quotes because otherwise NodeJS would treat them as individual arguments (e.g. `path/to/my project/ -> ["path/to/my", "project"])

--

**TL;DR**: As this is just too much work for something we will eventually replace with Bazel, we are just printing an error message.

Closes #13871