### PR TITLE
build: add tslib to ts_library rules by default

### DIFF
--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -6,7 +6,6 @@ ts_library(
   name = "coercion",
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/cdk/coercion",
-  deps = ["@matdeps//tslib"],
 )
 
 ts_library(

--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -6,7 +6,6 @@ ts_library(
   name = "keycodes",
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/cdk/keycodes",
-  deps = ["@matdeps//tslib"],
 )
 
 ts_library(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -15,13 +15,17 @@ def _getDefaultTsConfig(testonly):
   else:
     return _DEFAULT_TSCONFIG_BUILD
 
-def ts_library(tsconfig = None, testonly = False, **kwargs):
+def ts_library(tsconfig = None, deps = [], testonly = False, **kwargs):
+  # Add tslib because we use import helpers for all public packages.
+  local_deps = ["@matdeps//tslib"] + deps
+
   if not tsconfig:
     tsconfig = _getDefaultTsConfig(testonly)
 
   _ts_library(
     tsconfig = tsconfig,
     testonly = testonly,
+    deps = local_deps,
     node_modules = _DEFAULT_TS_TYPINGS,
     **kwargs
   )
@@ -31,8 +35,7 @@ def ng_module(deps = [], tsconfig = None, testonly = False, **kwargs):
     tsconfig = _getDefaultTsConfig(testonly)
 
   local_deps = [
-    # Since we use the TypeScript import helpers (tslib) for each TypeScript configuration,
-    # we declare TSLib as default dependency
+    # Add tslib because we use import helpers for all public packages.
     "@matdeps//tslib",
 
     # Depend on the module typings for each `ng_module`. Since all components within the project


### PR DESCRIPTION
* Similar to how `angular/angular` provides defaults for the `ts_library` macro, we should also add `tslib` as default dependency. This spares us some duplications and makes it easier to use the default `bazel-tsconfig` files.