### PR TITLE
feat(drag-drop): add the ability to set an alternate drop-list element

### DIFF
--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -181,6 +181,9 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
   /** Root element that will be dragged by the user. */
   private _rootElement: HTMLElement;
 
+  /** Root element parent in which the `_rootElement` resided when dragging began */
+  private _initialRootElementParent: HTMLElement;
+
   /** Subscription to pointer movement events. */
   private _pointerMoveSubscription = Subscription.EMPTY;
 
@@ -411,6 +414,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
 
     this._hasStartedDragging = this._hasMoved = false;
     this._initialContainer = this.dropContainer;
+    this._initialRootElementParent = this._rootElement.parentNode as HTMLElement;
     this._pointerMoveSubscription = this._dragDropRegistry.pointerMove.subscribe(this._pointerMove);
     this._pointerUpSubscription = this._dragDropRegistry.pointerUp.subscribe(this._pointerUp);
     this._scrollPosition = this._viewportRuler.getViewportScrollPosition();
@@ -549,7 +553,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
     if (this._nextSibling) {
       this._nextSibling.parentNode!.insertBefore(this._rootElement, this._nextSibling);
     } else {
-      this._initialContainer.element.nativeElement.appendChild(this._rootElement);
+      this._initialRootElementParent.appendChild(this._rootElement);
     }
 
     this._destroyPreview();

--- a/src/cdk/drag-drop/drop-list.ts
+++ b/src/cdk/drag-drop/drop-list.ts
@@ -116,6 +116,14 @@ export class CdkDropList<T = any> implements OnInit, OnDestroy {
   /** Locks the position of the draggable elements inside the container along the specified axis. */
   @Input('cdkDropListLockAxis') lockAxis: 'x' | 'y';
 
+  /**
+   * Selector that will be used to determine the direct container element, starting from
+   * the `cdkDropList` element and going down the DOM. Passing an alternate direct container element
+   * is useful when the `cdkDropList` is not the direct parent (i.e. ancestor but not father)
+   * of the draggable elements.
+   */
+  @Input('cdkDropListDirectContainerElement') directContainerElement: string;
+
   /** Whether starting a dragging sequence from this container is disabled. */
   @Input('cdkDropListDisabled')
   get disabled(): boolean { return this._disabled; }
@@ -250,7 +258,11 @@ export class CdkDropList<T = any> implements OnInit, OnDestroy {
       element.parentElement!.insertBefore(placeholder, element);
       this._activeDraggables.splice(newIndex, 0, item);
     } else {
-      this.element.nativeElement.appendChild(placeholder);
+      let element = this.element.nativeElement;
+      if (this.directContainerElement) {
+        element = element.querySelector(this.directContainerElement) || element;
+      }
+      element.appendChild(placeholder);
       this._activeDraggables.push(item);
     }
 


### PR DESCRIPTION
Adds the `cdkDropListDirectContainerElement` input which allows consumers to pass in a selector that will be used to determine which elements is going to be the direct parent (father) of the draggable items, starting from the `cdkDropList` element and going down the DOM.

This will also fix #14148, propely handling cleanup in `cdkDrag`.

closes #14148