### PR TITLE
fix(menu): unable to set icon color dynamically

### DIFF
--- a/src/lib/menu/_menu-theme.scss
+++ b/src/lib/menu/_menu-theme.scss
@@ -24,7 +24,7 @@
     }
   }
 
-  .mat-menu-item .mat-icon:not([color]),
+  .mat-menu-item .mat-icon:not(.mat-primary):not(.mat-accent):not(.mat-warn),
   .mat-menu-item-submenu-trigger::after {
     color: mat-color($foreground, 'icon');
   }


### PR DESCRIPTION
Fixes not being able to set the color of a `mat-icon` inside a `mat-menu-item` dynamically.

Fixes #14151.