### PR TITLE
fix(scrolling): provide virtual scroll viewport as scrollable

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -50,6 +50,10 @@ function rangesEqual(r1: ListRange, r2: ListRange): boolean {
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [{
+    provide: CdkScrollable,
+    useExisting: CdkVirtualScrollViewport,
+  }]
 })
 export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
   /** Emits when the viewport is detached from a CdkVirtualForOf. */


### PR DESCRIPTION
Since the `CdkVirtualScrollViewport` extends `CdkScrollable`, it should also provide itself as a `CdkScrollable` to DI.