### PR TITLE
feat(paginator): add optional page numbers

### DIFF
--- a/src/dev-app/paginator/paginator-demo.html
+++ b/src/dev-app/paginator/paginator-demo.html
@@ -17,10 +17,15 @@
       <input matInput placeholder="Page Index" type="number" [(ngModel)]="pageIndex">
     </mat-form-field>
 
+    <mat-form-field *ngIf="showPageNumbers">
+      <input matInput placeholder="Count of page numbers" type="number" [(ngModel)]="pageNumberCount">
+    </mat-form-field>
+
     <mat-slide-toggle [(ngModel)]="hidePageSize">Hide page size</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="showPageSizeOptions">Show multiple page size options</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="showFirstLastButtons">Show first/last buttons</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="disabled">Disabled</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="showPageNumbers">Show Page Numbers</mat-slide-toggle>
   </div>
 
   <mat-paginator #paginator
@@ -31,7 +36,9 @@
                  [showFirstLastButtons]="showFirstLastButtons"
                  [pageSizeOptions]="showPageSizeOptions ? pageSizeOptions : []"
                  [hidePageSize]="hidePageSize"
-                 [pageIndex]="pageIndex">
+                 [pageIndex]="pageIndex"
+                 [showPageNumbers]="showPageNumbers"
+                 [pageNumberCount]="pageNumberCount">
   </mat-paginator>
 
   <div> Output event: {{pageEvent | json}} </div>

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -26,6 +26,8 @@ export class PaginatorDemo {
   showPageSizeOptions = true;
   showFirstLastButtons = true;
   disabled = false;
+  showPageNumbers = false;
+  pageNumberCount = 3;
 
   pageEvent: PageEvent;
 

--- a/src/lib/paginator/_paginator-theme.scss
+++ b/src/lib/paginator/_paginator-theme.scss
@@ -27,6 +27,10 @@
     border-top: 2px solid mat-color($foreground, 'icon');
   }
 
+  .mat-paginator-current-page {
+    color: mat-color($foreground, 'text')
+  }
+
   .mat-icon-button[disabled] {
     .mat-paginator-decrement,
     .mat-paginator-increment,

--- a/src/lib/paginator/_paginator-theme.scss
+++ b/src/lib/paginator/_paginator-theme.scss
@@ -28,7 +28,7 @@
   }
 
   .mat-paginator-current-page {
-    color: mat-color($foreground, 'text')
+    color: mat-color($foreground, 'text');
   }
 
   .mat-icon-button[disabled] {

--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -53,6 +53,29 @@
           <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
         </svg>
       </button>
+      <div *ngIf="showPageNumbers">
+        <button mat-icon-button type="button"
+                class="mat-paginator-page-button-{{previousPage}} mat-icon-button"
+                *ngFor="let previousPage of previousPageNumbers()"
+                (click)="clickPageNumber(previousPage)"
+                [attr.aria-label]="'Skip to page ' + previousPage">
+                {{ previousPage }}
+        </button>
+        <button mat-icon-button type="button"
+                class="mat-paginator-current-page"
+                aria-disabled="true"
+                attr.aria-label="Current Page">
+                {{ currentPageNumber() }}
+        </button>
+      
+        <button mat-icon-button type="button"
+                class="mat-paginator-page-button-{{nextPage}} mat-icon-button"
+                *ngFor="let nextPage of nextPageNumbers()"
+                (click)="clickPageNumber(nextPage)"
+                [attr.aria-label]="'Skip to page ' + nextPage">
+                {{ nextPage }}
+        </button>
+      </div>
       <button mat-icon-button type="button"
               class="mat-paginator-navigation-next"
               (click)="nextPage()"

--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -99,3 +99,7 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
     transform: rotate(180deg);
   }
 }
+
+.mat-paginator-current-page {
+  font-weight: bold;
+}

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -414,6 +414,55 @@ describe('MatPaginator', () => {
     expect(getLastButton(fixture).hasAttribute('disabled')).toBe(true);
   });
 
+  it('should be able to go to the clicked page', () => {
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(paginator.pageIndex).toBe(0);
+
+    dispatchMouseEvent(getPageNumberButton(fixture), 'click');
+
+    expect(paginator.pageIndex).toBe(2);
+    expect(component.pageEvent).toHaveBeenCalledWith(jasmine.objectContaining({
+      previousPageIndex: 0,
+      pageIndex: 2
+    }));
+  });
+
+  it('should be able to show page numbers', () => {
+    expect(getPageNumberButton(fixture, 2))
+        .toBeNull('Expected page number 2 button to not exist.');
+
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 2))
+        .toBeTruthy('Expected page number 2 button to exist.');
+
+    expect(getPageNumberButton(fixture))
+        .toBeTruthy('Expected page number 3 button to exist.');
+  });
+
+  it('should know how many page numbers to show', () => {
+    expect(getPageNumberButton(fixture, 2))
+        .toBeNull('Expected page number 2 button to not exist.');
+
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 5))
+        .toBeFalsy('Should not have 5 page numbers by default');
+
+    fixture.componentInstance.pageNumberCount = 5;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 5))
+        .toBeTruthy('Should have 5 pages');
+
+    expect(getPageNumberButton(fixture, 6))
+        .toBeFalsy('Should not have 6 pages');
+  });
+
 });
 
 function getPreviousButton(fixture: ComponentFixture<any>) {
@@ -432,6 +481,10 @@ function getLastButton(fixture: ComponentFixture<any>) {
     return fixture.nativeElement.querySelector('.mat-paginator-navigation-last');
 }
 
+function getPageNumberButton(fixture: ComponentFixture<any>, pageNumber: number = 3) {
+    return fixture.nativeElement.querySelector(`.mat-paginator-page-button-${pageNumber}`);
+}
+
 @Component({
   template: `
     <mat-paginator [pageIndex]="pageIndex"
@@ -439,6 +492,8 @@ function getLastButton(fixture: ComponentFixture<any>) {
                    [pageSizeOptions]="pageSizeOptions"
                    [hidePageSize]="hidePageSize"
                    [showFirstLastButtons]="showFirstLastButtons"
+                   [showPageNumbers]="showPageNumbers"
+                   [pageNumberCount]="pageNumberCount"
                    [length]="length"
                    [color]="color"
                    [disabled]="disabled"
@@ -452,6 +507,8 @@ class MatPaginatorApp {
   pageSizeOptions = [5, 10, 25, 100];
   hidePageSize = false;
   showFirstLastButtons = false;
+  showPageNumbers = false;
+  pageNumberCount = 3;
   length = 100;
   disabled: boolean;
   pageEvent = jasmine.createSpy('page event');

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -58,7 +58,7 @@ export class PageEvent {
 /** @docs-private */
 export class MatPaginatorBase {}
 export const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorBase =
-  mixinDisabled(mixinInitialized(MatPaginatorBase));
+    mixinDisabled(mixinInitialized(MatPaginatorBase));
 
 /**
  * Component to provide navigation between paged information. Displays the size of the current
@@ -166,7 +166,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   _displayedPageSizeOptions: number[];
 
   constructor(public _intl: MatPaginatorIntl,
-    private _changeDetectorRef: ChangeDetectorRef) {
+              private _changeDetectorRef: ChangeDetectorRef) {
     super();
     this._intlChanges = _intl.changes.subscribe(() => this._changeDetectorRef.markForCheck());
   }
@@ -323,8 +323,8 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     // If no page size is provided, use the first page size option or the default page size.
     if (!this.pageSize) {
       this._pageSize = this.pageSizeOptions.length != 0 ?
-        this.pageSizeOptions[0] :
-        DEFAULT_PAGE_SIZE;
+          this.pageSizeOptions[0] :
+          DEFAULT_PAGE_SIZE;
     }
 
     this._displayedPageSizeOptions = this.pageSizeOptions.slice();

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -58,7 +58,7 @@ export class PageEvent {
 /** @docs-private */
 export class MatPaginatorBase {}
 export const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorBase =
-    mixinDisabled(mixinInitialized(MatPaginatorBase));
+  mixinDisabled(mixinInitialized(MatPaginatorBase));
 
 /**
  * Component to provide navigation between paged information. Displays the size of the current
@@ -139,6 +139,26 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   }
   private _showFirstLastButtons = false;
 
+  /** Whether to show the page number UI to the user. */
+  @Input()
+  get showPageNumbers(): boolean { return this._showPageNumbers; }
+  set showPageNumbers(value: boolean) {
+    this._showPageNumbers = coerceBooleanProperty(value);
+  }
+  private _showPageNumbers = false;
+
+  /**
+   * Total count of page numbers to display, if shown.  Default to 3.
+   * Even numbers are incremented to allow for equal previous and next sections, plus current page
+   */
+  @Input()
+  get pageNumberCount(): number { return this._pageNumberCount; }
+  set pageNumberCount(value: number) {
+    this._pageNumberCount = Math.max(coerceNumberProperty(value), 0);
+    this._updateDisplayedPageSizeOptions();
+  }
+  private _pageNumberCount: number = 3;
+
   /** Event emitted when the paginator changes the page size or page index. */
   @Output() readonly page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
 
@@ -146,7 +166,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   _displayedPageSizeOptions: number[];
 
   constructor(public _intl: MatPaginatorIntl,
-              private _changeDetectorRef: ChangeDetectorRef) {
+    private _changeDetectorRef: ChangeDetectorRef) {
     super();
     this._intlChanges = _intl.changes.subscribe(() => this._changeDetectorRef.markForCheck());
   }
@@ -210,6 +230,50 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     return this.pageIndex < maxPageIndex && this.pageSize != 0;
   }
 
+  /** Determines currently selected page number to display */
+  currentPageNumber() {
+    return this.pageIndex + 1;
+  }
+
+  /** Navigate to selected page number, if it exists. */
+  clickPageNumber(nextPage: number) {
+    if (nextPage > (this.getNumberOfPages()) || nextPage < 1) {
+      return;
+    }
+    const previousPageIndex = this.pageIndex;
+    this.pageIndex = nextPage - 1;
+    this._emitPageEvent(previousPageIndex);
+  }
+
+  /** Determines list of 'previous' page numbers to display */
+  previousPageNumbers() {
+    const previousPageNumbers = [];
+    const previousPageCount = Math.floor(this._pageNumberCount / 2)
+                            + Math.floor(this._pageNumberCount / 2) - this.nextPageNumbers().length;
+    for (let i = 1; i <= previousPageCount; i++) {
+      const prev = this.currentPageNumber() - i;
+      if (prev > 0) {
+        previousPageNumbers.push(prev);
+      }
+    }
+    previousPageNumbers.reverse();
+    return previousPageNumbers;
+  }
+
+  /** Determines list of 'next' page numbers to display */
+  nextPageNumbers() {
+    const nextPageNumbers = [];
+    const nextPageCount = Math.floor(this._pageNumberCount / 2) <= this.pageIndex
+      ? Math.floor(this._pageNumberCount / 2) + 1 : this._pageNumberCount - this.pageIndex;
+    for (let i = 1; i < nextPageCount; i++) {
+      const next = this.currentPageNumber() + i;
+      if (next <= Math.ceil(this.length / this.pageSize)) {
+        nextPageNumbers.push(next);
+      }
+    }
+    return nextPageNumbers;
+  }
+
   /** Calculate the number of pages */
   getNumberOfPages(): number {
     if (!this.pageSize) {
@@ -259,8 +323,8 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     // If no page size is provided, use the first page size option or the default page size.
     if (!this.pageSize) {
       this._pageSize = this.pageSizeOptions.length != 0 ?
-          this.pageSizeOptions[0] :
-          DEFAULT_PAGE_SIZE;
+        this.pageSizeOptions[0] :
+        DEFAULT_PAGE_SIZE;
     }
 
     this._displayedPageSizeOptions = this.pageSizeOptions.slice();


### PR DESCRIPTION
Add optional page numbers for displaying navigation on paginator.
Number of visible pages defaults to 3, and is configurable.
Even numbers are rounded up to odd numbers to display equal number
of pages on each side of the current selected page.