### PR TITLE
Update to angular 7.0.4 and latest rules_nodejs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,25 @@
+# Notes for releasing
+
+## Angular version
+
+For Bazel support downstream, the version of the @angular/bazel npm package
+in `package.json` and `tools/npm/package.json` must match the version of the
+`@angular` `http_archive` in `WORKSPACE`. For this reason, `@angular/bazel`
+should be pinned to a specific version in both `package.json` files. If updating
+the version of the angular http_archive, ensure sure that all 3 versions line up.
+
+For example:
+
+```
+http_archive(
+  name = "angular",
+  url = "https://github.com/angular/angular/archive/7.0.4.zip",
+  strip_prefix = "angular-7.0.4",
+)
+```
+
+in `WORKSPACE` must match the version in in `package.json` and `tools/npm/package.json`:
+
+```
+"@angular/bazel": "7.0.4",
+```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,10 +3,11 @@ workspace(name = "angular_material")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Add NodeJS rules (explicitly used for sass bundle rules)
+# TODO(gmagolan): update to rules_nodejs 0.16.2 when it is released
 http_archive(
   name = "build_bazel_rules_nodejs",
-  url = "https://github.com/bazelbuild/rules_nodejs/archive/0.15.3.zip",
-  strip_prefix = "rules_nodejs-0.15.3",
+  url = "https://github.com/bazelbuild/rules_nodejs/archive/e373001c571fe879884395f3b8492c9043962eeb.zip",
+  strip_prefix = "rules_nodejs-e373001c571fe879884395f3b8492c9043962eeb",
 )
 
 # Add TypeScript rules
@@ -19,8 +20,8 @@ http_archive(
 # Add Angular source and Bazel rules.
 http_archive(
   name = "angular",
-  url = "https://github.com/angular/angular/archive/2ec05415e24137d44f24b07202c34c5054c968ed.zip",
-  strip_prefix = "angular-2ec05415e24137d44f24b07202c34c5054c968ed",
+  url = "https://github.com/angular/angular/archive/7.0.4.zip",
+  strip_prefix = "angular-7.0.4",
 )
 
 # Add RxJS as repository because those are needed in order to build Angular from source.
@@ -38,10 +39,8 @@ http_archive(
 # Add sass rules
 http_archive(
   name = "io_bazel_rules_sass",
-  # Explicitly depend on SHA c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe because this one includes
-  # the major API overhaul and fix for the NodeJS source map warnings.
-  url = "https://github.com/bazelbuild/rules_sass/archive/c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe.zip",
-  strip_prefix = "rules_sass-c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe",
+  url = "https://github.com/bazelbuild/rules_sass/archive/1.15.0.zip",
+  strip_prefix = "rules_sass-1.15.0",
 )
 
 # Since we are explitly fetching @build_bazel_rules_typescript, we should explicitly ask for
@@ -66,12 +65,14 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_reposi
     "yarn_install")
 
 # The minimum bazel version to use with this repo is 0.18.0
+# 0.18.0: support for .bazelignore
 check_bazel_version("0.18.0")
 
 node_repositories(
   # For deterministic builds, specify explicit NodeJS and Yarn versions.
-  node_version = "10.10.0",
-  yarn_version = "1.9.4",
+  node_version = "10.13.0",
+  # Use latest yarn version to support integrity field (added in yarn 1.10)
+  yarn_version = "1.12.1",
 )
 
 # @npm is temporarily needed to build @rxjs from source since its ts_library
@@ -89,7 +90,7 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 
 # Setup the Sass rule repositories.
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
 sass_repositories()
 
 # Setup Angular workspace for building (Bazel managed node modules)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@angular-devkit/core": "^7.0.4",
     "@angular-devkit/schematics": "^7.0.4",
-    "@angular/bazel": "^7.0.3",
+    "@angular/bazel": "7.0.4",
     "@angular/compiler-cli": "^7.0.3",
     "@angular/http": "^7.0.3",
     "@angular/platform-browser-dynamic": "^7.0.3",

--- a/src/cdk-experimental/dialog/BUILD.bazel
+++ b/src/cdk-experimental/dialog/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/cdk/scrolling/BUILD.bazel
+++ b/src/cdk/scrolling/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/autocomplete/BUILD.bazel
+++ b/src/lib/autocomplete/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/badge/BUILD.bazel
+++ b/src/lib/badge/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/bottom-sheet/BUILD.bazel
+++ b/src/lib/bottom-sheet/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/button-toggle/BUILD.bazel
+++ b/src/lib/button-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/button/BUILD.bazel
+++ b/src/lib/button/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/card/BUILD.bazel
+++ b/src/lib/card/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/src/lib/checkbox/BUILD.bazel
+++ b/src/lib/checkbox/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/chips/BUILD.bazel
+++ b/src/lib/chips/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/core/BUILD.bazel
+++ b/src/lib/core/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//:packages.bzl", "MATERIAL_PACKAGES")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 

--- a/src/lib/datepicker/BUILD.bazel
+++ b/src/lib/datepicker/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/dialog/BUILD.bazel
+++ b/src/lib/dialog/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/divider/BUILD.bazel
+++ b/src/lib/divider/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/expansion/BUILD.bazel
+++ b/src/lib/expansion/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/form-field/BUILD.bazel
+++ b/src/lib/form-field/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/src/lib/grid-list/BUILD.bazel
+++ b/src/lib/grid-list/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/icon/BUILD.bazel
+++ b/src/lib/icon/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/input/BUILD.bazel
+++ b/src/lib/input/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/list/BUILD.bazel
+++ b/src/lib/list/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/menu/BUILD.bazel
+++ b/src/lib/menu/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/paginator/BUILD.bazel
+++ b/src/lib/paginator/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/progress-bar/BUILD.bazel
+++ b/src/lib/progress-bar/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/progress-spinner/BUILD.bazel
+++ b/src/lib/progress-spinner/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/radio/BUILD.bazel
+++ b/src/lib/radio/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/select/BUILD.bazel
+++ b/src/lib/select/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/sidenav/BUILD.bazel
+++ b/src/lib/sidenav/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/slide-toggle/BUILD.bazel
+++ b/src/lib/slide-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/slider/BUILD.bazel
+++ b/src/lib/slider/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/snack-bar/BUILD.bazel
+++ b/src/lib/snack-bar/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/sort/BUILD.bazel
+++ b/src/lib/sort/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/stepper/BUILD.bazel
+++ b/src/lib/stepper/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/table/BUILD.bazel
+++ b/src/lib/table/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/tabs/BUILD.bazel
+++ b/src/lib/tabs/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/toolbar/BUILD.bazel
+++ b/src/lib/toolbar/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/tooltip/BUILD.bazel
+++ b/src/lib/tooltip/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/src/lib/tree/BUILD.bazel
+++ b/src/lib/tree/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(

--- a/tools/npm/package.json
+++ b/tools/npm/package.json
@@ -1,9 +1,9 @@
 {
   "description": "minimal @npm repo required to build @rxjs from source and so that @npm//@angular/bazel is a valid target",
   "dependencies": {
-    "@angular/bazel": "7.0.3",
-    "@angular/compiler": "7.0.3",
-    "@angular/compiler-cli": "7.0.3",
+    "@angular/bazel": "7.0.4",
+    "@angular/compiler": "7.0.4",
+    "@angular/compiler-cli": "7.0.4",
     "@bazel/karma": "0.20.3",
     "@bazel/typescript": "0.20.3",
     "typescript": "^3.1.1"

--- a/tools/npm/yarn.lock
+++ b/tools/npm/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@angular/bazel@7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-7.0.3.tgz#6ea2c98957f83db5902a2df0e5fed0e36574411c"
-  integrity sha512-IX6HtSht2etmC7IR6DnFpMt0eIedcElYCHu3ghqfIqQo8ZDZQAMbsBo02sYY5qkqRKYyrhzeWxtUoi7uFx9kHA==
+"@angular/bazel@7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-7.0.4.tgz#e653db2202cfc2b41d592bb70e241bfd56bb99ab"
+  integrity sha512-QukWwQbZlcgzjGWYOwUBpCNlSe0pRrl1gJUOfpHks2mRCL7Nyr/75asMFmpvLCJDbcDGRx/UNQEY/sqUrNWNWw==
   dependencies:
     "@bazel/typescript" "^0.20.3"
     "@types/node" "6.0.84"
     shelljs "0.8.2"
     tsickle "0.32.1"
 
-"@angular/compiler-cli@7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-7.0.3.tgz#5d2567056251a8417ad0154de5d6757fa502f837"
-  integrity sha512-8/SNgyce0Eqhfn8N/XkwSDSxTJryA+/EVLA68D2IopOSg/95u6GgYv3mVNNQnclSzC4g1FuK0zt4z0zRIWZ6JA==
+"@angular/compiler-cli@7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-7.0.4.tgz#f96fc1c0aec27ee97ec5f13a8eb72bc8b964db97"
+  integrity sha512-kvhWt6OTb1Uduns9Vm+Dwd/UUBNSEU6Jgu+QOPeHr7lg+4NTyr9uQLU0DtfBP0ljOlds8esmfii5IIFTeUQw1Q==
   dependencies:
     canonical-path "1.0.0"
     chokidar "^1.4.2"
@@ -26,12 +26,13 @@
     reflect-metadata "^0.1.2"
     shelljs "^0.8.1"
     source-map "^0.6.1"
+    tslib "^1.9.0"
     yargs "9.0.1"
 
-"@angular/compiler@7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-7.0.3.tgz#c9bf049b92d37f9fec932698f52743c3be8ad6e7"
-  integrity sha512-1eF4PzWej9eoEQhHwuMxujx9B4oSjP70vORIs9pgXF8O4nWDWTKtfPQyNCPxc8mY+Fwb0+nSOEvvA+Ou8Hnreg==
+"@angular/compiler@7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-7.0.4.tgz#df91dab990c46b464705b0901d70d1cfdfd190e1"
+  integrity sha512-ExDhH1cJkuJkUsgNRZyZBse0a7wWkQyG5O8HONi3Rzig9dalFEuve9jD04zfA1Jx1GTXhovqtGnF72x4kw0V8Q==
   dependencies:
     tslib "^1.9.0"
 
@@ -2058,7 +2059,7 @@ karma-sourcemap-loader@0.3.7:
   dependencies:
     graceful-fs "^4.1.2"
 
-karma@alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a:
+"karma@github:alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a":
   version "1.7.1"
   resolved "https://codeload.github.com/alexeagle/karma/tar.gz/fa1a84ac881485b5657cb669e9b4e5da77b79f0a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/bazel@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-7.0.3.tgz#6ea2c98957f83db5902a2df0e5fed0e36574411c"
-  integrity sha512-IX6HtSht2etmC7IR6DnFpMt0eIedcElYCHu3ghqfIqQo8ZDZQAMbsBo02sYY5qkqRKYyrhzeWxtUoi7uFx9kHA==
+"@angular/bazel@7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-7.0.4.tgz#e653db2202cfc2b41d592bb70e241bfd56bb99ab"
+  integrity sha512-QukWwQbZlcgzjGWYOwUBpCNlSe0pRrl1gJUOfpHks2mRCL7Nyr/75asMFmpvLCJDbcDGRx/UNQEY/sqUrNWNWw==
   dependencies:
     "@bazel/typescript" "^0.20.3"
     "@types/node" "6.0.84"
@@ -6707,7 +6707,7 @@ karma@^3.0.0:
     tmp "0.0.33"
     useragent "2.2.1"
 
-karma@alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a:
+"karma@github:alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a":
   version "1.7.1"
   resolved "https://codeload.github.com/alexeagle/karma/tar.gz/fa1a84ac881485b5657cb669e9b4e5da77b79f0a"
   dependencies:


### PR DESCRIPTION
A few issues in the downstream Bazel build that this fixes.

* rules_sass was on an older version that was using `load` paths that are no longer valid in the newest version. Update to latest version and updated load paths.

* the version of `@angular/bazel` in package.json (`^7.0.3` but pinned to `7.0.3` in the lock file) causes a version skew issue downstream in angular-bazel-example when updating to angular 7.0.4. For the time being, this version needs to be pinned to a specific version that matches the angular http_archive version in WORKSPACE. the exact version match requirement will be relaxed to a range in the future and with Ivy this will no longer be an issue since the downstream Bazel build will use the material bundles

I added a `RELEASING.md` file to remind the caretaker to match up these versions when releasing

Other updates:

* latest rules_nodejs supports yarn 1.12.1 which is preferred as it support the `integrity` lock field which is removed from the lock file when `yarn_install` runs with a pre-1.10 version of yarn

