### PR TITLE
build: make sass bazel targets consistent

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -71,6 +71,12 @@ MATERIAL_PACKAGES = [
 
 MATERIAL_TARGETS = ["//src/lib:material"] + ["//src/lib/%s" % p for p in MATERIAL_PACKAGES]
 
+# List that references the sass libraries for each Material package. This can be used to create
+# the theming scss-bundle or to specify dependencies for the all-theme.scss file.
+MATERIAL_SCSS_LIBS = [
+  "//src/lib/%s:%s_scss_lib" % (p, p.replace('-', '_')) for p in MATERIAL_PACKAGES
+]
+
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.

--- a/src/cdk-experimental/dialog/BUILD.bazel
+++ b/src/cdk-experimental/dialog/BUILD.bazel
@@ -22,12 +22,6 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "dialog_container_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_binary(
   name = "dialog_container_scss",
   src = "dialog-container.scss",

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
@@ -19,15 +19,15 @@ ng_module(
   ]
 )
 
-# TODO(jelbourn): remove this when sass_library acts like a filegroup
-filegroup(
-  name = "a11y_scss_partials",
+sass_library(
+  name = "a11y_scss_lib",
   srcs = glob(["**/_*.scss"]),
 )
 
-sass_library(
-  name = "a11y_scss_lib",
-  srcs = [":a11y_scss_partials"],
+sass_binary(
+  name = "a11y_prebuilt_scss",
+  src = "a11y-prebuilt.scss",
+  deps = [":a11y_scss_lib"]
 )
 
 ng_test_library(

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -21,15 +21,9 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "overlay_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_library(
   name = "overlay_scss_lib",
-  srcs = [":overlay_scss_partials"],
+  srcs = glob(["**/_*.scss"]),
 )
 
 sass_binary(

--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -16,15 +16,9 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "text_field_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_library(
   name = "text_field_scss_lib",
-  srcs = [":text_field_scss_partials"],
+  srcs = glob(["**/_*.scss"]),
 )
 
 sass_binary(

--- a/src/lib/BUILD.bazel
+++ b/src/lib/BUILD.bazel
@@ -2,9 +2,9 @@ package(default_visibility=["//visibility:public"])
 
 load("@angular//:index.bzl", "ng_package")
 load("//tools:sass_bundle.bzl", "sass_bundle")
-load("//:packages.bzl", "MATERIAL_PACKAGES", "MATERIAL_TARGETS", "ROLLUP_GLOBALS",
-    "VERSION_PLACEHOLDER_REPLACEMENTS")
 load("//tools:defaults.bzl", "ng_module")
+load("//:packages.bzl", "MATERIAL_PACKAGES", "MATERIAL_TARGETS", "MATERIAL_SCSS_LIBS",
+    "ROLLUP_GLOBALS", "VERSION_PLACEHOLDER_REPLACEMENTS")
 
 # Root "@angular/material" entry-point.
 ng_module(
@@ -16,15 +16,11 @@ ng_module(
 
 sass_bundle(
   name = "theming_bundle",
-  # Use the filegroup rules for these sass partials directly because sass_library doesn't
-  # act like a filegroup.
   srcs = [
-    "//src/cdk/a11y:a11y_scss_partials",
-    "//src/cdk/overlay:overlay_scss_partials",
-    "//src/cdk/text-field:text_field_scss_partials",
-  ] + [
-    "//src/lib/%s:%s_scss_partials" % (p, p.replace('-', '_')) for p in MATERIAL_PACKAGES
-  ],
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/cdk/overlay:overlay_scss_lib",
+    "//src/cdk/text-field:text_field_scss_lib",
+  ] + MATERIAL_SCSS_LIBS,
   entry_point = '//src/lib/core:theming/_all-theme.scss',
   output_name = "_theming.scss",
 )

--- a/src/lib/autocomplete/BUILD.bazel
+++ b/src/lib/autocomplete/BUILD.bazel
@@ -26,21 +26,19 @@ ng_module(
   ]
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "autocomplete_scss_partials",
+sass_library(
+  name = "autocomplete_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "autocomplete_scss",
   src = "autocomplete.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/badge/BUILD.bazel
+++ b/src/lib/badge/BUILD.bazel
@@ -16,15 +16,13 @@ ng_module(
   ] + glob(["**/*.html"]),
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "badge_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  name = "badge_scss_lib",
+  srcs = glob(["**/_*.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ]
 )
 
 ng_test_library(

--- a/src/lib/bottom-sheet/BUILD.bazel
+++ b/src/lib/bottom-sheet/BUILD.bazel
@@ -26,21 +26,16 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "bottom_sheet_scss_partials",
+sass_library(
+  name = "bottom_sheet_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "bottom_sheet_container_scss",
   src = "bottom-sheet-container.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 ng_test_library(

--- a/src/lib/button-toggle/BUILD.bazel
+++ b/src/lib/button-toggle/BUILD.bazel
@@ -18,21 +18,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "button_toggle_scss_partials",
+sass_library(
+  name = "button_toggle_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"]
 )
 
 sass_binary(
   name = "button_toggle_scss",
   src = "button-toggle.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/button/BUILD.bazel
+++ b/src/lib/button/BUILD.bazel
@@ -18,28 +18,20 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): remove this when sass_library acts like a filegroup
-filegroup(
-  name = "button_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
-# Library of all button scss partials.
 sass_library(
   name = "button_scss_lib",
-  srcs = [":button_scss_partials"],
+  srcs = glob(["**/_*.scss"]),
   deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "button_scss",
   src = "button.scss",
-  deps = [":button_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+    ":button_scss_lib"
+  ],
 )
 
 ng_test_library(

--- a/src/lib/card/BUILD.bazel
+++ b/src/lib/card/BUILD.bazel
@@ -14,19 +14,17 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "card_scss_partials",
+sass_library(
+  name = "card_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "card_scss",
   src = "card.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )

--- a/src/lib/checkbox/BUILD.bazel
+++ b/src/lib/checkbox/BUILD.bazel
@@ -20,21 +20,22 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "checkbox_scss_partials",
+sass_library(
+  name = "checkbox_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ]
 )
 
 sass_binary(
   name = "checkbox_scss",
   src = "checkbox.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/chips/BUILD.bazel
+++ b/src/lib/chips/BUILD.bazel
@@ -24,21 +24,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "chips_scss_partials",
+sass_library(
+  name = "chips_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "chips_scss",
   src = "chips.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/core/BUILD.bazel
+++ b/src/lib/core/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
-load("//:packages.bzl", "MATERIAL_PACKAGES")
+load("//:packages.bzl", "MATERIAL_SCSS_LIBS")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 exports_files(["theming/_theming.scss"])
@@ -30,18 +30,9 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): remove this when sass_library acts like a filegroup
-filegroup(
-  name = "core_scss_partials",
-  srcs = glob([
-    "**/_*.scss"
-  ], exclude = ["theming/_all-theme.scss"]),
-)
-
-# Library of all core scss partials.
 sass_library(
   name = "core_scss_lib",
-  srcs = [":core_scss_partials"],
+  srcs = glob(["**/_*.scss"], exclude = ["theming/_all-theme.scss"]),
   deps = [
     "//src/cdk/a11y:a11y_scss_lib",
     "//src/cdk/overlay:overlay_scss_lib",
@@ -73,7 +64,7 @@ sass_library(
     "theming/_all-theme.scss",
     "typography/_all-typography.scss",
   ],
-  deps = [":core_scss_lib"] + ["//src/lib/%s:theme" % p for p in MATERIAL_PACKAGES],
+  deps = MATERIAL_SCSS_LIBS,
 )
 
 sass_binary(
@@ -100,11 +91,6 @@ sass_binary(
   deps = [":all_themes"],
 )
 
-# This rule exists so that we can use MATERIAL_PACKAGES to enumerate all themes.
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
 
 #################
 #  Test targets

--- a/src/lib/datepicker/BUILD.bazel
+++ b/src/lib/datepicker/BUILD.bazel
@@ -34,22 +34,20 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "datepicker_scss_partials",
+sass_library(
+  name = "datepicker_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "datepicker_content_scss",
   src = "datepicker-content.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "datepicker_toggle_scss",
   src = "datepicker-toggle.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
@@ -61,12 +59,7 @@ sass_binary(
 sass_binary(
   name = "calendar_body_scss",
   src = "calendar-body.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 ng_test_library(

--- a/src/lib/dialog/BUILD.bazel
+++ b/src/lib/dialog/BUILD.bazel
@@ -23,21 +23,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "dialog_scss_partials",
+sass_library(
+  name = "dialog_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "dialog_scss",
   src = "dialog.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/divider/BUILD.bazel
+++ b/src/lib/divider/BUILD.bazel
@@ -16,30 +16,16 @@ ng_module(
   ],
 )
 
-
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "divider_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_library(
   name = "divider_scss_lib",
-  srcs = ["divider.scss"],
+  srcs = glob(["**/_*.scss"]),
   deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "divider_scss",
   src = "divider.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
 )
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
-
 
 ng_test_library(
   name = "divider_test_sources",

--- a/src/lib/divider/_divider-offset.scss
+++ b/src/lib/divider/_divider-offset.scss
@@ -1,0 +1,12 @@
+// This mixin provides the correct offset for an inset divider based on the
+// size of the parent class (e.g. avatar vs icon)
+@mixin mat-inset-divider-offset($offset, $padding) {
+  $mat-inset-divider-offset: #{(2 * $padding) + $offset};
+  margin-left: $mat-inset-divider-offset;
+  width: calc(100% - #{$mat-inset-divider-offset});
+
+  [dir='rtl'] & {
+    margin-left: auto;
+    margin-right: $mat-inset-divider-offset;
+  }
+}

--- a/src/lib/divider/divider.scss
+++ b/src/lib/divider/divider.scss
@@ -1,19 +1,6 @@
 $mat-divider-width: 1px;
 $mat-divider-inset-margin: 80px;
 
-// This mixin provides the correct offset for an inset divider based on the
-// size of the parent class (e.g. avatar vs icon)
-@mixin mat-inset-divider-offset($offset, $padding) {
-  $mat-inset-divider-offset: #{(2 * $padding) + $offset};
-  margin-left: $mat-inset-divider-offset;
-  width: calc(100% - #{$mat-inset-divider-offset});
-
-  [dir='rtl'] & {
-    margin-left: auto;
-    margin-right: $mat-inset-divider-offset;
-  }
-}
-
 .mat-divider {
   display: block;
   margin: 0;

--- a/src/lib/expansion/BUILD.bazel
+++ b/src/lib/expansion/BUILD.bazel
@@ -7,10 +7,10 @@ ng_module(
   name = "expansion",
   srcs = glob(["**/*.ts"], exclude=["**/*.spec.ts"]),
   module_name = "@angular/material/expansion",
-  assets = [
+  assets = glob(["**/*.html"]) + [
     ":expansion-panel.css",
     ":expansion-panel-header.css",
-  ] + glob(["**/*.html"]),
+  ],
   deps = [
     "@angular//packages/animations",
     "@angular//packages/common",
@@ -27,27 +27,24 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "expansion_scss_partials",
+sass_library(
+  name = "expansion_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "expansion_panel_scss",
   src = "expansion-panel.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 sass_binary(
   name = "expansion_panel_header_scss",
   src = "expansion-panel-header.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/expansion/expansion-panel-header.scss
+++ b/src/lib/expansion/expansion-panel-header.scss
@@ -1,4 +1,3 @@
-
 .mat-expansion-panel-header {
   display: flex;
   flex-direction: row;
@@ -12,7 +11,7 @@
   }
 
   &.mat-expanded:focus,
-  &.mat-expanded:hover, {
+  &.mat-expanded:hover {
     background: inherit;
   }
 

--- a/src/lib/form-field/BUILD.bazel
+++ b/src/lib/form-field/BUILD.bazel
@@ -31,22 +31,28 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "form_field_scss_partials",
+sass_library(
+  name = "form_field_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "form_field_scss",
   src = "form-field.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 sass_binary(
   name = "form_field_fill_scss",
   src = "form-field-fill.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 sass_binary(
@@ -58,7 +64,10 @@ sass_binary(
 sass_binary(
   name = "form_field_legacy_scss",
   src = "form-field-legacy.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 sass_binary(
@@ -70,10 +79,8 @@ sass_binary(
 sass_binary(
   name = "form_field_standard_scss",
   src = "form-field-standard.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )

--- a/src/lib/form-field/_form-field-theme.scss
+++ b/src/lib/form-field/_form-field-theme.scss
@@ -2,14 +2,13 @@
 @import '../core/theming/theming';
 @import '../core/style/form-common';
 @import '../core/typography/typography-utils';
-@import 'form-field-fill-theme.scss';
-@import 'form-field-legacy-theme.scss';
-@import 'form-field-outline-theme.scss';
-@import 'form-field-standard-theme.scss';
 
+@import './form-field-fill-theme.scss';
+@import './form-field-legacy-theme.scss';
+@import './form-field-outline-theme.scss';
+@import './form-field-standard-theme.scss';
 
 // Theme styles that apply to all appearances of the form-field.
-
 @mixin mat-form-field-theme($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);

--- a/src/lib/grid-list/BUILD.bazel
+++ b/src/lib/grid-list/BUILD.bazel
@@ -16,10 +16,10 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "grid_list_scss_partials",
+sass_library(
+  name = "grid_list_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
@@ -27,12 +27,6 @@ sass_binary(
   src = "grid-list.scss",
   deps = ["//src/lib/core:core_scss_lib"],
 )
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
-
 
 ng_test_library(
   name = "grid_list_test_sources",

--- a/src/lib/icon/BUILD.bazel
+++ b/src/lib/icon/BUILD.bazel
@@ -20,21 +20,16 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "icon_scss_partials",
+sass_library(
+  name = "icon_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "icon_scss",
   src = "icon.scss",
   deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/input/BUILD.bazel
+++ b/src/lib/input/BUILD.bazel
@@ -21,15 +21,10 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "input_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
 sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  name = "input_scss_lib",
+  srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 ng_test_library(

--- a/src/lib/list/BUILD.bazel
+++ b/src/lib/list/BUILD.bazel
@@ -22,21 +22,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "list_scss_partials",
+sass_library(
+  name = "list_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "list_scss",
   src = "list.scss",
-  deps = ["//src/lib/core:core_scss_lib", "//src/lib/divider:divider_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/lib/core:core_scss_lib",
+    "//src/lib/divider:divider_scss_lib"
+  ],
 )
 
 ng_test_library(

--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -1,7 +1,7 @@
 @import '../core/style/variables';
 @import '../core/style/list-common';
 @import '../core/style/layout-common';
-@import '../divider/divider';
+@import '../divider/divider-offset';
 
 
 $mat-list-side-padding: 16px;

--- a/src/lib/menu/BUILD.bazel
+++ b/src/lib/menu/BUILD.bazel
@@ -25,22 +25,21 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "menu_scss_partials",
+sass_library(
+  name = "menu_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "menu_scss",
   src = "menu.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
 ng_test_library(
   name = "menu_test_sources",
   srcs = glob(["**/*.spec.ts"]),

--- a/src/lib/paginator/BUILD.bazel
+++ b/src/lib/paginator/BUILD.bazel
@@ -20,21 +20,15 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "paginator_scss_partials",
+sass_library(
+  name = "paginator_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "paginator_scss",
   src = "paginator.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/progress-bar/BUILD.bazel
+++ b/src/lib/progress-bar/BUILD.bazel
@@ -18,21 +18,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "progress_bar_scss_partials",
+sass_library(
+  name = "progress_bar_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "progress_bar_scss",
   src = "progress-bar.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/progress-spinner/BUILD.bazel
+++ b/src/lib/progress-spinner/BUILD.bazel
@@ -18,10 +18,10 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "progress_spinner_scss_partials",
+sass_library(
+  name = "progress_spinner_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
@@ -30,10 +30,6 @@ sass_binary(
   deps = ["//src/lib/core:core_scss_lib"],
 )
 
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
 ng_test_library(
   name = "progress_spinner_test_sources",
   srcs = glob(["**/*.spec.ts"]),

--- a/src/lib/radio/BUILD.bazel
+++ b/src/lib/radio/BUILD.bazel
@@ -20,21 +20,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "radio_scss_partials",
+sass_library(
+  name = "radio_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "radio_scss",
   src = "radio.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/select/BUILD.bazel
+++ b/src/lib/select/BUILD.bazel
@@ -27,21 +27,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "select_scss_partials",
+sass_library(
+  name = "select_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "select_scss",
   src = "select.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib"
+  ],
 )
 
 ng_test_library(

--- a/src/lib/sidenav/BUILD.bazel
+++ b/src/lib/sidenav/BUILD.bazel
@@ -25,21 +25,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "sidenav_scss_partials",
+sass_library(
+  name = "sidenav_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "drawer_scss",
   src = "drawer.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/slide-toggle/BUILD.bazel
+++ b/src/lib/slide-toggle/BUILD.bazel
@@ -22,21 +22,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "slide_toggle_scss_partials",
+sass_library(
+  name = "slide_toggle_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "slide_toggle_scss",
   src = "slide-toggle.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/slider/BUILD.bazel
+++ b/src/lib/slider/BUILD.bazel
@@ -23,21 +23,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "slider_scss_partials",
+sass_library(
+  name = "slider_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "slider_scss",
   src = "slider.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/snack-bar/BUILD.bazel
+++ b/src/lib/snack-bar/BUILD.bazel
@@ -27,27 +27,22 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "snack_bar_scss_partials",
+sass_library(
+  name = "snack_bar_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "snack_bar_container_scss",
   src = "snack-bar-container.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 sass_binary(
   name = "simple_snack_bar_scss",
   src = "simple-snack-bar.scss",
   deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/sort/BUILD.bazel
+++ b/src/lib/sort/BUILD.bazel
@@ -18,21 +18,15 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "sort_scss_partials",
+sass_library(
+  name = "sort_scss_lib",
   srcs = glob(["**/_*.scss"]),
 )
 
 sass_binary(
   name = "sort_header_scss",
   src = "sort-header.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 ng_test_library(

--- a/src/lib/stepper/BUILD.bazel
+++ b/src/lib/stepper/BUILD.bazel
@@ -28,10 +28,10 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "stepper_scss_partials",
+sass_library(
+  name = "stepper_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
@@ -44,12 +44,6 @@ sass_binary(
   name = "step_header_scss",
   src = "step-header.scss",
   deps = ["//src/lib/core:core_scss_lib"],
-)
-
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/table/BUILD.bazel
+++ b/src/lib/table/BUILD.bazel
@@ -21,21 +21,15 @@ ng_module(
   ] + glob(["**/*.html"]),
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "table_scss_partials",
+sass_library(
+  name = "table_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "table_scss",
   src = "table.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/tabs/BUILD.bazel
+++ b/src/lib/tabs/BUILD.bazel
@@ -31,27 +31,19 @@ ng_module(
   ],
 )
 
-
-# TODO(jelbourn): remove this when sass_library acts like a filegroup
-filegroup(
-  name = "tabs_scss_partials",
-  srcs = glob(["**/_*.scss"]),
-)
-
-# Library of all tabs scss partials.
 sass_library(
   name = "tabs_scss_lib",
-  srcs = [":tabs_scss_partials"],
-  deps = ["//src/lib/core:core_scss_lib"],
+  srcs = glob(["**/_*.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 sass_binary(
   name = "tab_body_scss",
   src = "tab-body.scss",
-  deps = [
-    "//src/lib/core:core_scss_lib",
-    "tabs_scss_lib",
-  ],
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
@@ -59,7 +51,7 @@ sass_binary(
   src = "tab-header.scss",
   deps = [
     "//src/lib/core:core_scss_lib",
-    "tabs_scss_lib",
+    ":tabs_scss_lib",
   ],
 )
 
@@ -68,7 +60,7 @@ sass_binary(
   src = "tab-group.scss",
   deps = [
     "//src/lib/core:core_scss_lib",
-    "tabs_scss_lib",
+    ":tabs_scss_lib",
   ],
 )
 
@@ -77,13 +69,8 @@ sass_binary(
   src = "tab-nav-bar/tab-nav-bar.scss",
   deps = [
     "//src/lib/core:core_scss_lib",
-    "tabs_scss_lib",
+    ":tabs_scss_lib",
   ],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(

--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -1,6 +1,6 @@
 @import '../core/style/variables';
 @import '../core/style/layout-common';
-@import 'tabs-common';
+@import './tabs-common';
 
 .mat-tab-group {
   display: flex;

--- a/src/lib/tabs/tab-header.scss
+++ b/src/lib/tabs/tab-header.scss
@@ -1,6 +1,6 @@
 @import '../core/style/variables';
 @import '../core/style/layout-common';
-@import 'tabs-common';
+@import './tabs-common';
 
 .mat-tab-header {
   display: flex;

--- a/src/lib/toolbar/BUILD.bazel
+++ b/src/lib/toolbar/BUILD.bazel
@@ -16,22 +16,21 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "toolbar_scss_partials",
+sass_library(
+  name = "toolbar_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "toolbar_scss",
   src = "toolbar.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
-)
 ng_test_library(
   name = "toolbar_test_sources",
   srcs = glob(["**/*.spec.ts"]),

--- a/src/lib/tooltip/BUILD.bazel
+++ b/src/lib/tooltip/BUILD.bazel
@@ -28,21 +28,19 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "tooltip_scss_partials",
+sass_library(
+  name = "tooltip_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "tooltip_scss",
   src = "tooltip.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
+  deps = [
+    "//src/cdk/a11y:a11y_scss_lib",
+    "//src/lib/core:core_scss_lib",
+  ],
 )
 
 ng_test_library(

--- a/src/lib/tree/BUILD.bazel
+++ b/src/lib/tree/BUILD.bazel
@@ -19,21 +19,15 @@ ng_module(
   ],
 )
 
-# TODO(jelbourn): replace this w/ sass_library when it supports acting like a filegroup
-filegroup(
-  name = "tree_scss_partials",
+sass_library(
+  name = "tree_scss_lib",
   srcs = glob(["**/_*.scss"]),
+  deps = ["//src/lib/core:core_scss_lib"],
 )
 
 sass_binary(
   name = "tree_scss",
   src = "tree.scss",
-  deps = ["//src/lib/core:core_scss_lib"],
-)
-
-sass_library(
-  name = "theme",
-  srcs = glob(["**/*-theme.scss"]),
 )
 
 ng_test_library(


### PR DESCRIPTION
* Fixes that the `list.scss` accidentally imports the `divider.scss` (while it just wants an actual mixin)
* Fixes that the `cdk/a11y` package does not expose the `a11y-prebuilt.css` as Bazel target
* Makes all `BUILD` files consistent in regards to Sass targets.
* Ensures that each `sass_binary` or `sass_library` has it's **explicit** dependencies. Currently it's not possible to depend on a single target (depending on transitive build outputs/targets)
* Removes the `_partials` filegroups because those can be replaced with a `sass_library` now. Also removes the `theme` sass_library in favor of the `_scss_lib`. Note that this does not change anything for the `theming_bundle` or `core:all_themes` target.