### PR TITLE
build: update to latest sass_rules version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,10 +38,8 @@ http_archive(
 # Add sass rules
 http_archive(
   name = "io_bazel_rules_sass",
-  # Explicitly depend on SHA c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe because this one includes
-  # the major API overhaul and fix for the NodeJS source map warnings.
-  url = "https://github.com/bazelbuild/rules_sass/archive/c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe.zip",
-  strip_prefix = "rules_sass-c93cadb20753f4e4d4eabe83f8ea882bfb8f2efe",
+  url = "https://github.com/bazelbuild/rules_sass/archive/1.15.1.zip",
+  strip_prefix = "rules_sass-1.15.1",
 )
 
 # Since we are explitly fetching @build_bazel_rules_typescript, we should explicitly ask for

--- a/tools/sass_bundle.bzl
+++ b/tools/sass_bundle.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_sass//sass:sass.bzl", "SassInfo")
+load("@io_bazel_rules_sass//:defs.bzl", "SassInfo")
 
 # Implementation of sass_bundle that performs an action
 def _sass_bundle(ctx):


### PR DESCRIPTION
* Updates to the latest version of the Bazel sass rules because the release now includes: https://github.com/bazelbuild/rules_sass/commit/1c7b293c4cdf401b1aeb3189181ee599e2d6e8d6