### PR TITLE
fix(chips): invert focus overlay on dark theme

### DIFF
--- a/src/lib/chips/_chips-theme.scss
+++ b/src/lib/chips/_chips-theme.scss
@@ -50,10 +50,13 @@ $mat-chip-remove-font-size: 18px;
     &.mat-chip-disabled {
       opacity: 0.4;
     }
+
+    &::after {
+      background: map_get($foreground, base);
+    }
   }
 
   .mat-chip.mat-standard-chip.mat-chip-selected {
-
     &.mat-primary {
       @include mat-chips-theme-color($primary);
     }

--- a/src/lib/chips/chips.scss
+++ b/src/lib/chips/chips.scss
@@ -57,7 +57,6 @@ $mat-chip-remove-size: 18px;
   &::after {
     @include mat-fill;
     border-radius: inherit;
-    background-color: black;
     opacity: 0;
     content: '';
     pointer-events: none;


### PR DESCRIPTION
Similarly to `mat-button`, inverts the focus overlay color on a dark theme. Currently we always use an opaque black which can be mistaken for the disabled color on dark themes.

For reference:
![angular_material_-_google_chrome_2018-11-19_19-43-49](https://user-images.githubusercontent.com/4450522/48728401-28661280-ec35-11e8-9534-e898ba2fb42b.png)
