### PR TITLE
fix(drag-drop): add support for dragging svg elements in IE11

### DIFF
--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -2243,8 +2243,6 @@ class StandaloneDraggable {
   template: `
     <svg><g
       cdkDrag
-      (cdkDragStarted)="startedSpy($event)"
-      (cdkDragEnded)="endedSpy($event)"
       #dragElement>
       <circle fill="red" r="50" cx="50" cy="50"/>
     </g></svg>
@@ -2252,9 +2250,6 @@ class StandaloneDraggable {
 })
 class StandaloneDraggableSvg {
   @ViewChild('dragElement') dragElement: ElementRef<SVGElement>;
-  @ViewChild(CdkDrag) dragInstance: CdkDrag;
-  startedSpy = jasmine.createSpy('started spy');
-  endedSpy = jasmine.createSpy('ended spy');
 }
 
 @Component({

--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -66,14 +66,14 @@ describe('CdkDrag', () => {
         expect(dragElement.style.transform).toBe('translate3d(50px, 100px, 0px)');
       }));
 
-      it('should drag an svg element freely to a particular position', fakeAsync(() => {
+      it('should drag an SVG element freely to a particular position', fakeAsync(() => {
         const fixture = createComponent(StandaloneDraggableSvg);
         fixture.detectChanges();
         const dragElement = fixture.componentInstance.dragElement.nativeElement;
 
         expect(dragElement.getAttribute('transform')).toBeFalsy();
         dragElementViaMouse(fixture, dragElement, 50, 100);
-        expect(dragElement.getAttribute('transform')).toBe('matrix(1, 0, 0, 1, 50, 100)');
+        expect(dragElement.getAttribute('transform')).toBe('translate(50, 100)');
       }));
 
       it('should drag an element freely to a particular position when the page is scrolled',

--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -73,7 +73,7 @@ describe('CdkDrag', () => {
 
         expect(dragElement.getAttribute('transform')).toBeFalsy();
         dragElementViaMouse(fixture, dragElement, 50, 100);
-        expect(dragElement.getAttribute('transform')).toBe('translate(50, 100)');
+        expect(dragElement.getAttribute('transform')).toBe('translate(50 100)');
       }));
 
       it('should drag an element freely to a particular position when the page is scrolled',

--- a/src/cdk/drag-drop/drag.spec.ts
+++ b/src/cdk/drag-drop/drag.spec.ts
@@ -66,6 +66,16 @@ describe('CdkDrag', () => {
         expect(dragElement.style.transform).toBe('translate3d(50px, 100px, 0px)');
       }));
 
+      it('should drag an svg element freely to a particular position', fakeAsync(() => {
+        const fixture = createComponent(StandaloneDraggableSvg);
+        fixture.detectChanges();
+        const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+        expect(dragElement.getAttribute('transform')).toBeFalsy();
+        dragElementViaMouse(fixture, dragElement, 50, 100);
+        expect(dragElement.getAttribute('transform')).toBe('matrix(1, 0, 0, 1, 50, 100)');
+      }));
+
       it('should drag an element freely to a particular position when the page is scrolled',
         fakeAsync(() => {
           const fixture = createComponent(StandaloneDraggable);
@@ -2224,6 +2234,24 @@ describe('CdkDrag', () => {
 })
 class StandaloneDraggable {
   @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+  startedSpy = jasmine.createSpy('started spy');
+  endedSpy = jasmine.createSpy('ended spy');
+}
+
+@Component({
+  template: `
+    <svg><g
+      cdkDrag
+      (cdkDragStarted)="startedSpy($event)"
+      (cdkDragEnded)="endedSpy($event)"
+      #dragElement>
+      <circle fill="red" r="50" cx="50" cy="50"/>
+    </g></svg>
+  `
+})
+class StandaloneDraggableSvg {
+  @ViewChild('dragElement') dragElement: ElementRef<SVGElement>;
   @ViewChild(CdkDrag) dragInstance: CdkDrag;
   startedSpy = jasmine.createSpy('started spy');
   endedSpy = jasmine.createSpy('ended spy');

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -493,7 +493,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
           this._initialTransform + ' ' + transform : transform;
 
       // Apply transform as attribute if dragging and svg element to work for IE
-      if (this._rootElement instanceof SVGElement) {
+      if (typeof SVGElement !== 'undefined' && this._rootElement instanceof SVGElement) {
         const appliedTransform = `translate(${activeTransform.x} ${activeTransform.y})`;
         this._rootElement.setAttribute('transform', appliedTransform);
       }

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -491,6 +491,19 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
       // Preserve the previous `transform` value, if there was one.
       this._rootElement.style.transform = this._initialTransform ?
           this._initialTransform + ' ' + transform : transform;
+
+      // Apply transform as attribute if dragging and svg element to work for IE
+      if (this._rootElement instanceof SVGElement) {
+        let appliedTransform = getComputedStyle(this._rootElement).getPropertyValue('transform');
+        // Check if the value is a matrix3d(), and convert to matrix() for IE compatibility
+        const match = appliedTransform.match(/^matrix3d\((.+)\)$/);
+        if (match) {
+          const transformX = match[1].split(', ')[12];
+          const transformY = match[1].split(', ')[13];
+          appliedTransform = 'matrix(1, 0, 0, 1, ' + transformX + ', ' + transformY + ')';
+        }
+        this._rootElement.setAttribute('transform', appliedTransform);
+      }
     }
 
     // Since this event gets fired for every pixel while dragging, we only

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -494,7 +494,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
 
       // Apply transform as attribute if dragging and svg element to work for IE
       if (this._rootElement instanceof SVGElement) {
-        const appliedTransform = `translate(${activeTransform.x}, ${activeTransform.y})`;
+        const appliedTransform = `translate(${activeTransform.x} ${activeTransform.y})`;
         this._rootElement.setAttribute('transform', appliedTransform);
       }
     }

--- a/src/cdk/drag-drop/drag.ts
+++ b/src/cdk/drag-drop/drag.ts
@@ -494,14 +494,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
 
       // Apply transform as attribute if dragging and svg element to work for IE
       if (this._rootElement instanceof SVGElement) {
-        let appliedTransform = getComputedStyle(this._rootElement).getPropertyValue('transform');
-        // Check if the value is a matrix3d(), and convert to matrix() for IE compatibility
-        const match = appliedTransform.match(/^matrix3d\((.+)\)$/);
-        if (match) {
-          const transformX = match[1].split(', ')[12];
-          const transformY = match[1].split(', ')[13];
-          appliedTransform = 'matrix(1, 0, 0, 1, ' + transformX + ', ' + transformY + ')';
-        }
+        const appliedTransform = `translate(${activeTransform.x}, ${activeTransform.y})`;
         this._rootElement.setAttribute('transform', appliedTransform);
       }
     }


### PR DESCRIPTION
Added check for when _rootElement is an SVGElement and set the transform attribute as well.
- IE11 does not acknowledge the style.transform property, but does allow the attribute
- IE11's getComputedStyle returns a matrix3d(), but doesn't allow that to be passed via setAttribute

Closes #14214