### PR TITLE
docs: remove internal build fixes from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 * **tabs:** add the ability to customize the animation duration ([#13505](https://github.com/angular/material2/issues/13505)) ([0cd7536](https://github.com/angular/material2/commit/0cd7536)), closes [#13428](https://github.com/angular/material2/issues/13428)
 * **tabs:** make the updatePagination method public ([#13935](https://github.com/angular/material2/issues/13935)) ([1e4ee0c](https://github.com/angular/material2/commit/1e4ee0c))
 
+
 ### Performance Improvements
 
 * **focus-monitor:** mark event listeners as passive ([#13532](https://github.com/angular/material2/issues/13532)) ([bfc00a0](https://github.com/angular/material2/commit/bfc00a0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,11 +96,6 @@
 * **text-field:** autosize textarea not resizing on minRows decrease ([#13437](https://github.com/angular/material2/issues/13437)) ([cfeab79](https://github.com/angular/material2/commit/cfeab79))
 * **tooltip:** add fallback for touch devices if Hammer isn't loaded ([#13580](https://github.com/angular/material2/issues/13580)) ([5d54920](https://github.com/angular/material2/commit/5d54920)), closes [#13536](https://github.com/angular/material2/issues/13536)
 * **virtual-scroll:** not removing view from container if it's outside the template cache ([#13916](https://github.com/angular/material2/issues/13916)) ([8922100](https://github.com/angular/material2/commit/8922100)), closes [#13901](https://github.com/angular/material2/issues/13901)
-* bazel support for downstream apps ([#13836](https://github.com/angular/material2/issues/13836)) ([150c964](https://github.com/angular/material2/commit/150c964))
-* material not working with ES2015 ([#13709](https://github.com/angular/material2/issues/13709)) ([985774a](https://github.com/angular/material2/commit/985774a)), closes [#12760](https://github.com/angular/material2/issues/12760) [#13695](https://github.com/angular/material2/issues/13695)
-* reference symbols for example components rather than providing a string of the component name ([#13992](https://github.com/angular/material2/issues/13992)) ([d0d97c3](https://github.com/angular/material2/commit/d0d97c3))
-* workaround for es2015 inheritance not always working ([#13834](https://github.com/angular/material2/issues/13834)) ([a22a9fa](https://github.com/angular/material2/commit/a22a9fa))
-
 
 ### Features
 
@@ -116,7 +111,6 @@
 * **stepper:** add CdkStepHeader directive and fix CdkStepper error on init ([#10614](https://github.com/angular/material2/issues/10614)) ([fbbe463](https://github.com/angular/material2/commit/fbbe463)), closes [#10611](https://github.com/angular/material2/issues/10611)
 * **tabs:** add the ability to customize the animation duration ([#13505](https://github.com/angular/material2/issues/13505)) ([0cd7536](https://github.com/angular/material2/commit/0cd7536)), closes [#13428](https://github.com/angular/material2/issues/13428)
 * **tabs:** make the updatePagination method public ([#13935](https://github.com/angular/material2/issues/13935)) ([1e4ee0c](https://github.com/angular/material2/commit/1e4ee0c))
-
 
 ### Performance Improvements
 


### PR DESCRIPTION
* https://github.com/angular/material2/commit/d0d97c3 has been accidentally marked as `fix` while it should be `build`.
* https://github.com/angular/material2/commit/a22a9fa has been re-added because we removed it manually from the changelog version (see [deduping logic](https://github.com/angular/material2/blob/master/tools/gulp/tasks/changelog.ts#L90))
* https://github.com/angular/material2/commit/985774a Same as for the commit above
* https://github.com/angular/material2/commit/150c964 Is _not_ a fix, and actually still internal because we miss documentation etc.