### PR TITLE
chore(datepicker): remove unused svg element

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.html
+++ b/src/lib/datepicker/datepicker-toggle.html
@@ -17,7 +17,6 @@
     height="24px"
     fill="currentColor"
     focusable="false">
-    <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
   </svg>
 


### PR DESCRIPTION
Some of the Material design icons include a blank `path` element which doesn't really do anything. These changes remove it from our default datepicker icon.