### PR TITLE
docs(form-field): native select reset values not working in examples

### DIFF
--- a/src/material-examples/select-disabled/select-disabled-example.html
+++ b/src/material-examples/select-disabled/select-disabled-example.html
@@ -14,7 +14,7 @@
 <h4>native html select</h4>
 <mat-form-field>
   <select matNativeControl placeholder="Choose an option" [disabled]="disableSelect.value">
-    <option value="" disabled selected></option>
+    <option value="" selected></option>
     <option value="volvo">Volvo</option>
     <option value="saab" disabled>Saab</option>
     <option value="mercedes">Mercedes</option>

--- a/src/material-examples/select-form/select-form-example.html
+++ b/src/material-examples/select-form/select-form-example.html
@@ -11,7 +11,7 @@
   <h4>native html select</h4>
   <mat-form-field>
     <select matNativeControl placeholder="Favorite car" [(ngModel)]="selectedCar" name="car">
-      <option value="" disabled selected></option>
+      <option value="" selected></option>
       <option *ngFor="let car of cars" [value]="car.value">
         {{car.viewValue}}
       </option>


### PR DESCRIPTION
On a couple of the examples the reset option was marked as `disabled` which means that people aren't able to reset the value.

Fixes #14030.