### PR TITLE
feat(drag-drop): add the ability to constrain dragging to an element

### DIFF
--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -10,6 +10,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
     _placeholderTemplate: CdkDragPlaceholder;
     _pointerDown: (event: TouchEvent | MouseEvent) => void;
     _previewTemplate: CdkDragPreview;
+    boundaryElementSelector: string;
     data: T;
     disabled: boolean;
     dropContainer: CdkDropListContainer;


### PR DESCRIPTION
Adds the `cdkDragBoundary` input that allows for people to constrain the dragging of an element to another element.

Fixes #14211.