### PR TITLE
fix(dialog): complete injectable streams on destroy

### DIFF
--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -651,6 +651,23 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelectorAll('mat-dialog-container').length).toBe(0);
   }));
 
+  it('should complete open and close streams when the injectable is destroyed', fakeAsync(() => {
+    const afterOpenedSpy = jasmine.createSpy('after opened spy');
+    const afterAllClosedSpy = jasmine.createSpy('after all closed spy');
+    const afterOpenedSubscription = dialog.afterOpened.subscribe({complete: afterOpenedSpy});
+    const afterAllClosedSubscription = dialog.afterAllClosed.subscribe({
+      complete: afterAllClosedSpy
+    });
+
+    dialog.ngOnDestroy();
+
+    expect(afterOpenedSpy).toHaveBeenCalled();
+    expect(afterAllClosedSpy).toHaveBeenCalled();
+
+    afterOpenedSubscription.unsubscribe();
+    afterAllClosedSubscription.unsubscribe();
+  }));
+
   it('should allow the consumer to disable closing a dialog on navigation', fakeAsync(() => {
     dialog.open(PizzaMsg);
     dialog.open(PizzaMsg, {closeOnNavigation: false});

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -171,6 +171,8 @@ export class MatDialog implements OnDestroy {
     // Only close the dialogs at this level on destroy
     // since the parent service may still be active.
     this._closeDialogs(this._openDialogsAtThisLevel);
+    this._afterAllClosedAtThisLevel.complete();
+    this._afterOpenedAtThisLevel.complete();
   }
 
   /**


### PR DESCRIPTION
Fixes a couple of the streams on `MatDialog` not being completed when the provider is destroyed.