### PR TITLE
fix(badge): badge instances not being cleaned up on destroy

### DIFF
--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -137,8 +137,19 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, CanDisabl
   }
 
   ngOnDestroy() {
-    if (this.description && this._badgeElement) {
-      this._ariaDescriber.removeDescription(this._badgeElement, this.description);
+    const badgeElement = this._badgeElement;
+
+    if (badgeElement) {
+      if (this.description) {
+        this._ariaDescriber.removeDescription(badgeElement, this.description);
+      }
+
+      // When creating a badge through the Renderer, Angular will keep it in an index.
+      // We have to destroy it ourselves, otherwise it'll be retained in memory.
+      // @breaking-change 8.0.0 remove _renderer from null.
+      if (this._renderer && this._renderer.destroyNode) {
+        this._renderer.destroyNode(badgeElement);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the `MatBadge` instances not being collected once the view is destroyed. The issue comes from the fact that when an element is created through the `Renderer2`, Angular adds it to an index (see `DebugRenderer2`), however we never tell it that it should be removed.