### PR TITLE
docs(ripple): fix typo in comments

### DIFF
--- a/src/lib/core/ripple/ripple-renderer.ts
+++ b/src/lib/core/ripple/ripple-renderer.ts
@@ -201,7 +201,7 @@ export class RippleRenderer {
       this._containerRect = null;
     }
 
-    // For ripples that are not active anymore, don't re-un the fade-out animation.
+    // For ripples that are not active anymore, don't re-run the fade-out animation.
     if (!wasActive) {
       return;
     }


### PR DESCRIPTION
fix typo in ripple-renderer.ts:204 from re-un to re-run