### PR TITLE
build: provide better defaults for browser-sync

### DIFF
--- a/tools/gulp/util/task_helpers.ts
+++ b/tools/gulp/util/task_helpers.ts
@@ -153,6 +153,14 @@ export function serverTask(packagePath: string, rewrites?: {from: string, to: st
       server: projectDir,
       port: 4200,
       middleware: httpRewrite.getMiddleware(rewrites || defaultHttpRewrites),
+      notify: false,
+
+      // Options which are disabled by default. We don't want to enable ghostMode by default
+      // because it can throw-off change detection due to the event listeners syncing events
+      // between browsers. Also opening the browser is not always desired because in some cases
+      // developers just want to serve the app, and open the browser on a different device.
+      ghostMode: process.argv.includes('--ghostMode'),
+      open: process.argv.includes('--open'),
     });
   };
 }


### PR DESCRIPTION
* No longer opens the browser by default
* No longer enables ghost mode by default
* No longer shows the `Connected to Browsersync` notification. This might throw off e2e test results.