### PR TITLE
fix(slide-toggle): label not being read out by JAWS

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.html
+++ b/src/lib/slide-toggle/slide-toggle.html
@@ -38,6 +38,8 @@
   </div>
 
   <span class="mat-slide-toggle-content" #labelContent (cdkObserveContent)="_onLabelTextChange()">
+    <!-- Add an invisible span so JAWS can read the label -->
+    <span style="display:none">&nbsp;</span>
     <ng-content></ng-content>
   </span>
 </label>


### PR DESCRIPTION
Along the same lines as #4610. Adds an extra element to allow for JAWS to pick up the label.