### PR TITLE
docs(tree): fix nested tree node example markup

### DIFF
--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -28,10 +28,10 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
  * be added in the `cdkTreeNodeOutlet` in tree node template.
  * For example:
  *   ```html
- *   <cdk-mested-tree-node>
+ *   <cdk-nested-tree-node>
  *     {{node.name}}
  *     <ng-template cdkTreeNodeOutlet></ng-template>
- *   </cdk-tree-node>
+ *   </cdk-nested-tree-node>
  *   ```
  * The children of node will be automatically added to `cdkTreeNodeOutlet`, the result dom will be
  * like this:
@@ -40,7 +40,7 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
  *     {{node.name}}
  *      <cdk-nested-tree-node>{{child1.name}}</cdk-tree-node>
  *      <cdk-nested-tree-node>{{child2.name}}</cdk-tree-node>
- *   </cdk-tree-node>
+ *   </cdk-nested-tree-node>
  *   ```
  */
 @Directive({

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -38,8 +38,8 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
  *   ```html
  *   <cdk-nested-tree-node>
  *     {{node.name}}
- *      <cdk-nested-tree-node>{{child1.name}}</cdk-tree-node>
- *      <cdk-nested-tree-node>{{child2.name}}</cdk-tree-node>
+ *      <cdk-nested-tree-node>{{child1.name}}</cdk-nested-tree-node>
+ *      <cdk-nested-tree-node>{{child2.name}}</cdk-nested-tree-node>
  *   </cdk-nested-tree-node>
  *   ```
  */


### PR DESCRIPTION
Correct typos in example markup for nested tree node.

Should this part
```
<ng-template cdkTreeNodeOutlet></ng-template>
```
be changed to
```
<ng-container cdkTreeNodeOutlet></ng-container>
```
as seen in [Docs: Tree overview](https://material.angular.io/cdk/tree/overview)?