### PR TITLE
fix(form-field): multiple projected block-level prefix/suffix stacking on top of each other

### DIFF
--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -45,6 +45,9 @@ $mat-form-field-default-infix-width: 180px !default;
   white-space: nowrap;
   flex: none;
   position: relative;
+
+  // Allow for projected block-level elements not stand next to each other, rather than stack.
+  display: flex;
 }
 
 .mat-form-field-infix {


### PR DESCRIPTION
Fixes multiple block elements that are projected inside a prefix or a suffix stacking on top of each other, rather than going sideways.