### PR TITLE
chore(schematics): use devkit SchematicException for schematic errors

### DIFF
--- a/src/cdk/schematics/ng-update/upgrade-data.ts
+++ b/src/cdk/schematics/ng-update/upgrade-data.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {SchematicsException} from '@angular-devkit/schematics';
 import {RuleWalker} from 'tslint';
 import {
   attributeSelectors,
@@ -81,7 +82,8 @@ export const cdkUpgradeData: RuleUpgradeData = {
  */
 export function getChangesForTarget<T>(target: TargetVersion, data: VersionChanges<T>): T[] {
   if (!data) {
-    throw new Error(`No data could be found for target version: ${TargetVersion[target]}`);
+    throw new SchematicsException(
+      `No data could be found for target version: ${TargetVersion[target]}`);
   }
 
   if (!data[target]) {

--- a/src/cdk/schematics/ng-update/upgrade-rules/index.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/index.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Rule, SchematicContext, TaskId, Tree} from '@angular-devkit/schematics';
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  TaskId,
+  Tree
+} from '@angular-devkit/schematics';
 import {RunSchematicTask, TslintFixTask} from '@angular-devkit/schematics/tasks';
 import {sync as globSync} from 'glob';
 import {getProjectTsConfigPaths} from './project-tsconfig-paths';
@@ -22,8 +28,8 @@ export function createUpgradeRule(targetVersion: TargetVersion,
     const tslintFixTasks: TaskId[] = [];
 
     if (!projectTsConfigPaths.length) {
-      throw new Error('Could not find any tsconfig file. Please submit an issue on the Angular ' +
-        'Material repository that includes the name of your TypeScript configuration.');
+      throw new SchematicsException('Could not find any tsconfig file. Please submit an issue ' +
+        'on the Angular Material repository that includes the path to your "tsconfig" file.');
     }
     // In some applications, developers will have global stylesheets which are not specified in any
     // Angular component. Therefore we glob up all CSS and SCSS files outside of node_modules and

--- a/src/cdk/schematics/utils/ast/ng-module-imports.ts
+++ b/src/cdk/schematics/utils/ast/ng-module-imports.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Tree} from '@angular-devkit/schematics';
+import {SchematicsException, Tree} from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 
 /**
- * Whether the Angular module in the given path imports the specifed module class name.
+ * Whether the Angular module in the given path imports the specified module class name.
  */
 export function hasNgModuleImport(tree: Tree, modulePath: string, className: string): boolean {
   const moduleFileContent = tree.read(modulePath);
 
   if (!moduleFileContent) {
-    throw new Error(`Could not read Angular module file: ${modulePath}`);
+    throw new SchematicsException(`Could not read Angular module file: ${modulePath}`);
   }
 
   const parsedFile = ts.createSourceFile(modulePath, moduleFileContent.toString(),
@@ -36,7 +36,7 @@ export function hasNgModuleImport(tree: Tree, modulePath: string, className: str
   ts.forEachChild(parsedFile, findModuleDecorator);
 
   if (!ngModuleMetadata) {
-    throw new Error(`Could not find NgModule declaration inside: "${modulePath}"`);
+    throw new SchematicsException(`Could not find NgModule declaration inside: "${modulePath}"`);
   }
 
   for (let property of ngModuleMetadata!.properties) {

--- a/src/cdk/schematics/utils/get-project.ts
+++ b/src/cdk/schematics/utils/get-project.ts
@@ -7,6 +7,7 @@
  */
 
 import {WorkspaceSchema, WorkspaceProject} from '@angular-devkit/core/src/workspace';
+import {SchematicsException} from '@angular-devkit/schematics';
 
 /**
  * Finds the specified project configuration in the workspace. Throws an error if the project
@@ -19,7 +20,7 @@ export function getProjectFromWorkspace(
   const project = workspace.projects[projectName || workspace.defaultProject!];
 
   if (!project) {
-    throw new Error(`Could not find project in workspace: ${projectName}`);
+    throw new SchematicsException(`Could not find project in workspace: ${projectName}`);
   }
 
   return project;

--- a/src/cdk/schematics/utils/parse5-element.ts
+++ b/src/cdk/schematics/utils/parse5-element.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {SchematicsException} from '@angular-devkit/schematics';
 import {DefaultTreeElement} from 'parse5';
 
 /** Determines the indentation of child elements for the given Parse5 element. */
@@ -14,8 +15,8 @@ export function getChildElementIndentation(element: DefaultTreeElement) {
     .find(node => node['tagName']) as DefaultTreeElement | null;
 
   if ((childElement && !childElement.sourceCodeLocation) || !element.sourceCodeLocation) {
-    throw new Error('Cannot determine child element indentation because the specified Parse5 ' +
-        'element does not have any source code location metadata.');
+    throw new SchematicsException('Cannot determine child element indentation because the ' +
+      'specified Parse5 element does not have any source code location metadata.');
   }
 
   const startColumns = childElement ?

--- a/src/cdk/schematics/utils/project-targets.ts
+++ b/src/cdk/schematics/utils/project-targets.ts
@@ -7,6 +7,7 @@
  */
 
 import {WorkspaceProject} from '@angular-devkit/core/src/workspace';
+import {SchematicsException} from '@angular-devkit/schematics';
 
 /** Resolves the architect options for the build target of the given project. */
 export function getProjectTargetOptions(project: WorkspaceProject, buildTarget: string) {
@@ -27,5 +28,6 @@ export function getProjectTargetOptions(project: WorkspaceProject, buildTarget: 
     return project.architect[buildTarget].options;
   }
 
-  throw new Error(`Cannot determine project target configuration for: ${buildTarget}.`);
+  throw new SchematicsException(
+    `Cannot determine project target configuration for: ${buildTarget}.`);
 }

--- a/src/cdk/schematics/utils/version-agnostic-typescript.ts
+++ b/src/cdk/schematics/utils/version-agnostic-typescript.ts
@@ -13,6 +13,7 @@
  * dependency that will be shipped with `@schematics/angular`.
  */
 import typescript = require('typescript');
+import {SchematicsException} from '@angular-devkit/schematics';
 
 /**
  * This is an agnostic re-export of TypeScript. Depending on the context, this module file will
@@ -30,8 +31,8 @@ try {
   try {
     ts = require('typescript');
   } catch {
-    throw new Error('Error: Could not find a TypeScript version for the schematics. ' +
-      'Please report an issue on the Angular Material repository.');
+    throw new SchematicsException('Error: Could not find a TypeScript version for the ' +
+      'schematics. Please report an issue on the Angular Material repository.');
   }
 }
 

--- a/src/lib/schematics/ng-add/theming/theming.ts
+++ b/src/lib/schematics/ng-add/theming/theming.ts
@@ -8,7 +8,7 @@
 
 import {normalize} from '@angular-devkit/core';
 import {WorkspaceProject, WorkspaceSchema} from '@angular-devkit/core/src/workspace';
-import {Tree} from '@angular-devkit/schematics';
+import {SchematicsException, Tree} from '@angular-devkit/schematics';
 import {
   getProjectFromWorkspace,
   getProjectStyleFile,
@@ -62,8 +62,8 @@ function insertCustomTheme(project: WorkspaceProject, projectName: string, host:
 
   if (!stylesPath) {
     if (!project.sourceRoot) {
-      throw new Error(`Could not find source root for project: "${projectName}". Please make ` +
-        `sure that the "sourceRoot" property is set in the workspace config.`);
+      throw new SchematicsException(`Could not find source root for project: "${projectName}". ` +
+        `Please make sure that the "sourceRoot" property is set in the workspace config.`);
     }
 
     // Normalize the path through the devkit utilities because we want to avoid having
@@ -159,9 +159,9 @@ function validateDefaultTargetBuilder(project: WorkspaceProject, targetName: 'bu
   // builder has been changed, we warn because a theme is not mandatory for running tests
   // with Material. See: https://github.com/angular/material2/issues/14176
   if (!isDefaultBuilder && targetName === 'build') {
-    throw new Error(`Your project is not using the default builders for "${targetName}". The ` +
-      `Angular Material schematics cannot add a theme to the workspace configuration if the ` +
-      `builder has been changed. Exiting..`);
+    throw new SchematicsException(`Your project is not using the default builders for ` +
+      `"${targetName}". The Angular Material schematics cannot add a theme to the workspace ` +
+      `configuration if the builder has been changed.`);
   } else if (!isDefaultBuilder) {
     console.warn(`Your project is not using the default builders for "${targetName}". This ` +
       `means that we cannot add the configured theme to the "${targetName}" target.`);


### PR DESCRIPTION
* Makes all error throwings in the `cdk/schematics` and `lib/schematics` consistent by using `SchematicsException`. This is recommended by the CLI team so that the CLI can show different error-codes in the future (still planned AFAIK; but we want this change for consistency anyway)