### PR TITLE
fix(drag-drop): prevent text selection while dragging on Safari

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -190,6 +190,16 @@ describe('DragDropRegistry', () => {
     expect(dispatchFakeEvent(document, 'wheel').defaultPrevented).toBe(true);
   });
 
+  it('should not prevent the default `selectstart` actions when nothing is being dragged', () => {
+    expect(dispatchFakeEvent(document, 'selectstart').defaultPrevented).toBe(false);
+  });
+
+  it('should prevent the default `selectstart` action when an item is being dragged', () => {
+    registry.startDragging(testComponent.dragItems.first, createMouseEvent('mousedown'));
+    expect(dispatchFakeEvent(document, 'selectstart').defaultPrevented).toBe(true);
+  });
+
+
 });
 
 @Component({

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -720,6 +720,8 @@ export class DragRef<T = any> {
       zIndex: '1000'
     });
 
+    toggleNativeDragInteractions(preview, false);
+
     preview.classList.add('cdk-drag-preview');
     preview.setAttribute('dir', this._dir ? this._dir.value : 'ltr');
 


### PR DESCRIPTION
Fixes being able to select text while dragging an item on Safari.

Fixes #14403.