### PR TITLE
fix(autocomplete): auto-highlighted first option not display correctly if the floating label is disabled

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -493,6 +493,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
         switchMap(() => {
           this._resetActiveItem();
           this.autocomplete._setVisibility();
+          this._changeDetectorRef.detectChanges();
 
           if (this.panelOpen) {
             this._overlayRef!.updatePosition();

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1632,6 +1632,22 @@ describe('MatAutocomplete', () => {
           .toContain('mat-active', 'Expected first option to be highlighted.');
     }));
 
+    it('should be able to preselect the first option when the floating label is disabled',
+      fakeAsync(() => {
+        fixture.componentInstance.floatLabel = 'never';
+        fixture.componentInstance.trigger.autocomplete.autoActiveFirstOption = true;
+        fixture.detectChanges();
+
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        // Note: should not have a detectChanges call here
+        // in order for the test to fail when it's supposed to.
+
+        expect(overlayContainerElement.querySelectorAll('mat-option')[0].classList)
+            .toContain('mat-active', 'Expected first option to be highlighted.');
+      }));
+
     it('should be able to configure preselecting the first option globally', fakeAsync(() => {
       overlayContainer.ngOnDestroy();
       fixture.destroy();


### PR DESCRIPTION
Fixes the first option not appearing as highlighted if the consumer has set `floatLabel="never"` and `autoActiveFirstOption`. It looks like we were depending on the `transitioned` event from the label to kick off the change detection that shows the highlight.

Fixes #13734.