### PR TITLE
fix(drag-drop): update root element if selector changes

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -475,6 +475,27 @@ describe('CdkDrag', () => {
 
     it('should be able to set an alternate drag root element', fakeAsync(() => {
       const fixture = createComponent(DraggableWithAlternateRoot);
+      fixture.componentInstance.rootElementSelector = '.alternate-root';
+      fixture.detectChanges();
+
+      const dragRoot = fixture.componentInstance.dragRoot.nativeElement;
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      expect(dragRoot.style.transform).toBeFalsy();
+      expect(dragElement.style.transform).toBeFalsy();
+
+      dragElementViaMouse(fixture, dragRoot, 50, 100);
+
+      expect(dragRoot.style.transform).toBe('translate3d(50px, 100px, 0px)');
+      expect(dragElement.style.transform).toBeFalsy();
+    }));
+
+    it('should handle the root element selector changing after init', fakeAsync(() => {
+      const fixture = createComponent(DraggableWithAlternateRoot);
+      fixture.detectChanges();
+      tick();
+
+      fixture.componentInstance.rootElementSelector = '.alternate-root';
       fixture.detectChanges();
 
       const dragRoot = fixture.componentInstance.dragRoot.nativeElement;
@@ -2999,7 +3020,7 @@ class ConnectedDropZonesViaGroupDirective extends ConnectedDropZones {
     <div #dragRoot class="alternate-root" style="width: 200px; height: 200px; background: hotpink">
       <div
         cdkDrag
-        cdkDragRootElement=".alternate-root"
+        [cdkDragRootElement]="rootElementSelector"
         #dragElement
         style="width: 100px; height: 100px; background: red;"></div>
     </div>
@@ -3009,6 +3030,7 @@ class DraggableWithAlternateRoot {
   @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
   @ViewChild('dragRoot') dragRoot: ElementRef<HTMLElement>;
   @ViewChild(CdkDrag) dragInstance: CdkDrag;
+  rootElementSelector: string;
 }
 
 

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -6,7 +6,7 @@ export declare const CDK_DROP_LIST: InjectionToken<CdkDropListContainer<any>>;
 
 export declare const CDK_DROP_LIST_CONTAINER: InjectionToken<CdkDropListContainer<any>>;
 
-export declare class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
+export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     _dragRef: DragRef<CdkDrag<T>>;
     _handles: QueryList<CdkDragHandle>;
     _placeholderTemplate: CdkDragPlaceholder;
@@ -31,6 +31,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnDestroy {
     getPlaceholderElement(): HTMLElement;
     getRootElement(): HTMLElement;
     ngAfterViewInit(): void;
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     reset(): void;
 }


### PR DESCRIPTION
Currently the root element is only resolved once on init, however since it's an input, it could change. These changes add some logic to keep the element up to date.