### PR TITLE
build: only stamp build builds in release mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,9 +33,14 @@ test --test_output=errors
 build --experimental_ui
 test --experimental_ui
 
+#################################
+# Release configuration.        #
+# Run with "--config=release"   #
+#################################
+
 # Configures script to do version stamping.
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--workspace_status_command
-build --workspace_status_command=./tools/bazel-stamp-vars.sh
+build:release --workspace_status_command=./tools/bazel-stamp-vars.sh
 
 ###############################
 # Typescript / Angular / Sass #


### PR DESCRIPTION
* No longer runs the `workspace_status_command` for normal Bazel builds. This should speed up builds by about ~8 seconds init phase.