### PR TITLE
feat(drag-drop): add service for attaching drag&drop to arbitrary DOM nodes

### DIFF
--- a/src/cdk/drag-drop/BUILD.bazel
+++ b/src/cdk/drag-drop/BUILD.bazel
@@ -23,6 +23,7 @@ ng_test_library(
   name = "drag-drop_test_sources",
   srcs = glob(["**/*.spec.ts"]),
   deps = [
+    "@rxjs",
     "//src/cdk/testing",
     "//src/cdk/bidi",
     ":drag-drop",

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -21,6 +21,7 @@ import {
   createTouchEvent,
 } from '@angular/cdk/testing';
 import {Directionality} from '@angular/cdk/bidi';
+import {of as observableOf} from 'rxjs';
 import {CdkDrag, CDK_DRAG_CONFIG} from './drag';
 import {CdkDragDrop} from '../drag-events';
 import {moveItemInArray} from '../drag-utils';
@@ -1140,7 +1141,7 @@ describe('CdkDrag', () => {
     it('should dispatch the correct `dropped` event in RTL horizontal drop zone', fakeAsync(() => {
       const fixture = createComponent(DraggableInHorizontalDropZone, [{
         provide: Directionality,
-        useValue: ({value: 'rtl'})
+        useValue: ({value: 'rtl', change: observableOf()})
       }]);
 
       fixture.nativeElement.setAttribute('dir', 'rtl');
@@ -1296,7 +1297,7 @@ describe('CdkDrag', () => {
     it('should pass the proper direction to the preview in rtl', fakeAsync(() => {
       const fixture = createComponent(DraggableInDropZone, [{
         provide: Directionality,
-        useValue: ({value: 'rtl'})
+        useValue: ({value: 'rtl', change: observableOf()})
       }]);
 
       fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-drop-module.ts
+++ b/src/cdk/drag-drop/drag-drop-module.ts
@@ -13,6 +13,7 @@ import {CdkDrag} from './directives/drag';
 import {CdkDragHandle} from './directives/drag-handle';
 import {CdkDragPreview} from './directives/drag-preview';
 import {CdkDragPlaceholder} from './directives/drag-placeholder';
+import {DragDrop} from './drag-drop';
 
 @NgModule({
   declarations: [
@@ -31,5 +32,8 @@ import {CdkDragPlaceholder} from './directives/drag-placeholder';
     CdkDragPreview,
     CdkDragPlaceholder,
   ],
+  providers: [
+    DragDrop,
+  ]
 })
 export class DragDropModule {}

--- a/src/cdk/drag-drop/drag-drop.spec.ts
+++ b/src/cdk/drag-drop/drag-drop.spec.ts
@@ -1,0 +1,47 @@
+import {Component, ElementRef} from '@angular/core';
+import {fakeAsync, TestBed, inject} from '@angular/core/testing';
+import {DragDropModule} from './drag-drop-module';
+import {DragDrop} from './drag-drop';
+import {DragRef} from './drag-ref';
+import {DropListRef} from './drop-list-ref';
+
+describe('DragDrop', () => {
+  let service: DragDrop;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [DragDropModule],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(inject([DragDrop], (d: DragDrop) => {
+    service = d;
+  }));
+
+  it('should be able to attach a DragRef to a DOM node', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    const ref = service.createDrag(fixture.componentInstance.elementRef);
+
+    expect(ref instanceof DragRef).toBe(true);
+  });
+
+  it('should be able to attach a DropListRef to a DOM node', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    const ref = service.createDropList(fixture.componentInstance.elementRef);
+
+    expect(ref instanceof DropListRef).toBe(true);
+  });
+});
+
+
+@Component({
+  template: '<div></div>'
+})
+class TestComponent {
+  constructor(public elementRef: ElementRef<HTMLElement>) {}
+}

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, Inject, NgZone, ElementRef} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {ViewportRuler} from '@angular/cdk/scrolling';
+import {DragRef, DragRefConfig} from './drag-ref';
+import {DropListRef} from './drop-list-ref';
+import {DragDropRegistry} from './drag-drop-registry';
+
+/** Default configuration to be used when creating a `DragRef`. */
+const DEFAULT_CONFIG = {
+  dragStartThreshold: 5,
+  pointerDirectionChangeThreshold: 5
+};
+
+/**
+ * Service that allows for drag-and-drop functionality to be attached to DOM elements.
+ */
+@Injectable({providedIn: 'root'})
+export class DragDrop {
+  constructor(
+    @Inject(DOCUMENT) private _document: any,
+    private _ngZone: NgZone,
+    private _viewportRuler: ViewportRuler,
+    private _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>) {}
+
+  /**
+   * Turns an element into a draggable item.
+   * @param element Element to which to attach the dragging functionality.
+   * @param config Object used to configure the dragging behavior.
+   */
+  createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement,
+                config: DragRefConfig = DEFAULT_CONFIG): DragRef<T> {
+
+    return new DragRef<T>(element, config, this._document, this._ngZone, this._viewportRuler,
+        this._dragDropRegistry);
+  }
+
+  /**
+   * Turns an element into a drop list.
+   * @param element Element to which to attach the drop list functionality.
+   */
+  createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T> {
+    return new DropListRef<T>(element, this._dragDropRegistry, this._document);
+  }
+}

--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// TODO(crisbeto): export once API is finalized
-// export * from './drag-ref';
-// export * from './drop-list-ref';
+export {DragDrop} from './drag-drop';
+export {DragRef, DragRefConfig} from './drag-ref';
+export {DropListRef} from './drop-list-ref';
 
 export * from './drop-list-container';
 export * from './drag-events';
@@ -16,7 +16,7 @@ export * from './drag-utils';
 export * from './drag-drop-module';
 export * from './drag-drop-registry';
 
-export * from './directives/drop-list';
+export {CdkDropList} from './directives/drop-list';
 export * from './directives/drop-list-group';
 export * from './directives/drag';
 export * from './directives/drag-handle';

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -27,7 +27,8 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     started: EventEmitter<CdkDragStart>;
     constructor(
     element: ElementRef<HTMLElement>,
-    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _config: DragRefConfig, _dir: Directionality);
+    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, viewportRuler: ViewportRuler, dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, config: DragRefConfig, _dir: Directionality,
+    dragDrop?: DragDrop);
     getPlaceholderElement(): HTMLElement;
     getRootElement(): HTMLElement;
     ngAfterViewInit(): void;
@@ -111,7 +112,7 @@ export interface CdkDragStart<T = any> {
     source: CdkDrag<T>;
 }
 
-export declare class CdkDropList<T = any> implements CdkDropListContainer, OnDestroy {
+export declare class CdkDropList<T = any> implements CdkDropListContainer, AfterContentInit, OnDestroy {
     _draggables: QueryList<CdkDrag>;
     _dropListRef: DropListRef<CdkDropList<T>>;
     connectedTo: (CdkDropList | string)[] | CdkDropList | string;
@@ -126,7 +127,9 @@ export declare class CdkDropList<T = any> implements CdkDropListContainer, OnDes
     lockAxis: 'x' | 'y';
     orientation: 'horizontal' | 'vertical';
     sorted: EventEmitter<CdkDragSortEvent<T>>;
-    constructor(element: ElementRef<HTMLElement>, dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _changeDetectorRef: ChangeDetectorRef, dir?: Directionality, _group?: CdkDropListGroup<CdkDropList<any>> | undefined, _document?: any);
+    constructor(
+    element: ElementRef<HTMLElement>, dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined, _document?: any,
+    dragDrop?: DragDrop);
     _getSiblingContainerFromPosition(item: CdkDrag, x: number, y: number): CdkDropListContainer | null;
     _isOverContainer(x: number, y: number): boolean;
     _sortItem(item: CdkDrag, pointerX: number, pointerY: number, pointerDelta: {
@@ -137,6 +140,7 @@ export declare class CdkDropList<T = any> implements CdkDropListContainer, OnDes
     enter(item: CdkDrag, pointerX: number, pointerY: number): void;
     exit(item: CdkDrag): void;
     getItemIndex(item: CdkDrag): number;
+    ngAfterContentInit(): void;
     ngOnDestroy(): void;
     start(): void;
 }
@@ -168,10 +172,13 @@ export declare class CdkDropListGroup<T> implements OnDestroy {
     ngOnDestroy(): void;
 }
 
-export interface CdkDropListInternal extends CdkDropList {
-}
-
 export declare function copyArrayItem<T = any>(currentArray: T[], targetArray: T[], currentIndex: number, targetIndex: number): void;
+
+export declare class DragDrop {
+    constructor(_document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
+    createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement, config?: DragRefConfig): DragRef<T>;
+    createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T>;
+}
 
 export declare class DragDropModule {
 }
@@ -191,6 +198,124 @@ export declare class DragDropRegistry<I, C extends {
     removeDropContainer(drop: C): void;
     startDragging(drag: I, event: TouchEvent | MouseEvent): void;
     stopDragging(drag: I): void;
+}
+
+export declare class DragRef<T = any> {
+    beforeStarted: Subject<void>;
+    data: T;
+    disabled: boolean;
+    dropped: Subject<{
+        previousIndex: number;
+        currentIndex: number;
+        item: DragRef<any>;
+        container: DropListRef;
+        previousContainer: DropListRef;
+        isPointerOverContainer: boolean;
+    }>;
+    ended: Subject<{
+        source: DragRef<any>;
+    }>;
+    entered: Subject<{
+        container: DropListRef;
+        item: DragRef<any>;
+    }>;
+    exited: Subject<{
+        container: DropListRef;
+        item: DragRef<any>;
+    }>;
+    lockAxis: 'x' | 'y';
+    moved: Observable<{
+        source: DragRef;
+        pointerPosition: {
+            x: number;
+            y: number;
+        };
+        event: MouseEvent | TouchEvent;
+        delta: {
+            x: -1 | 0 | 1;
+            y: -1 | 0 | 1;
+        };
+    }>;
+    released: Subject<{
+        source: DragRef<any>;
+    }>;
+    started: Subject<{
+        source: DragRef<any>;
+    }>;
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
+    _withDropContainer(container: DropListRef): void;
+    disableHandle(handle: HTMLElement): void;
+    dispose(): void;
+    enableHandle(handle: HTMLElement): void;
+    getPlaceholderElement(): HTMLElement;
+    getRootElement(): HTMLElement;
+    isDragging(): boolean;
+    reset(): void;
+    withBoundaryElement(boundaryElement: ElementRef<HTMLElement> | HTMLElement | null): this;
+    withDirection(direction: Direction): this;
+    withHandles(handles: (HTMLElement | ElementRef<HTMLElement>)[]): this;
+    withPlaceholderTemplate(template: DragHelperTemplate | null): this;
+    withPreviewTemplate(template: DragHelperTemplate | null): this;
+    withRootElement(rootElement: ElementRef<HTMLElement> | HTMLElement): this;
+}
+
+export interface DragRefConfig {
+    dragStartThreshold: number;
+    pointerDirectionChangeThreshold: number;
+}
+
+export declare class DropListRef<T = any> {
+    beforeStarted: Subject<void>;
+    data: T;
+    disabled: boolean;
+    dropped: Subject<{
+        item: DragRef;
+        currentIndex: number;
+        previousIndex: number;
+        container: DropListRef<any>;
+        previousContainer: DropListRef<any>;
+        isPointerOverContainer: boolean;
+    }>;
+    readonly element: HTMLElement;
+    enterPredicate: (drag: DragRef, drop: DropListRef) => boolean;
+    entered: Subject<{
+        item: DragRef;
+        container: DropListRef<any>;
+    }>;
+    exited: Subject<{
+        item: DragRef;
+        container: DropListRef<any>;
+    }>;
+    id: string;
+    lockAxis: 'x' | 'y';
+    sorted: Subject<{
+        previousIndex: number;
+        currentIndex: number;
+        container: DropListRef<any>;
+        item: DragRef;
+    }>;
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _document: any);
+    _canReceive(item: DragRef, x: number, y: number): boolean;
+    _getSiblingContainerFromPosition(item: DragRef, x: number, y: number): DropListRef | undefined;
+    _isOverContainer(x: number, y: number): boolean;
+    _sortItem(item: DragRef, pointerX: number, pointerY: number, pointerDelta: {
+        x: number;
+        y: number;
+    }): void;
+    _startReceiving(sibling: DropListRef): void;
+    _stopReceiving(sibling: DropListRef): void;
+    connectedTo(connectedTo: DropListRef[]): this;
+    dispose(): void;
+    drop(item: DragRef, currentIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean): void;
+    enter(item: DragRef, pointerX: number, pointerY: number): void;
+    exit(item: DragRef): void;
+    getItemIndex(item: DragRef): number;
+    isDragging(): boolean;
+    isReceiving(): boolean;
+    start(): void;
+    withDirection(direction: Direction): this;
+    withItems(items: DragRef[]): this;
+    withOrientation(orientation: 'vertical' | 'horizontal'): this;
 }
 
 export declare function moveItemInArray<T = any>(array: T[], fromIndex: number, toIndex: number): void;


### PR DESCRIPTION
* Adds the  `DragDrop` service that simplifies the construction logic for `DragRef` and `DropListRef` and allows consumers to attach drag&drop functionality to arbitrary DOM nodes, rather than having to go through the directives.
* Reworks `DragRef` and `DragDropRef` to make them easier to construct.
* Normalizes some of the instances where some parameters only accept an `ElementRef`, whereas others accept `ElementRef | HTMLElement`.