### PR TITLE
fix(schematics): drag-drop schematic two consecutive commas

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -11,8 +11,8 @@ import { CdkDragDrop, moveItemInArray, transferArrayItem } from '@angular/cdk/dr
     <%= indentTextContent(resolvedFiles.stylesheet, 4) %>
   `],<% } else { %>
   styleUrls: ['./<%= dasherize(name) %>.component.<%= styleext %>'],<% } %><% if(!!viewEncapsulation) { %>
-  encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
-  changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
+  encapsulation: ViewEncapsulation.<%= viewEncapsulation %>,<% } if (changeDetection !== 'Default') { %>
+  changeDetection: ChangeDetectionStrategy.<%= changeDetection %>,<% } %>
 })
 export class <%= classify(name) %>Component {
   todo = [


### PR DESCRIPTION
Similar to https://github.com/angular/material2/commit/dd6065cec47647980291bd2c24067cdc71966f33, we should also fix the issue for the drag-drop schematic.