### PR TITLE
chore(schematics): cleanup temporary directory after test case run

### DIFF
--- a/src/cdk/schematics/ng-update/test-cases/misc/method-call-checks.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/method-call-checks.spec.ts
@@ -4,7 +4,7 @@ import {runTestCases} from '../../../testing';
 describe('v6 method call checks', () => {
 
   it('should properly report invalid method calls', async () => {
-    const {logOutput} = await runTestCases('migration-v6', migrationCollection, {
+    const {logOutput, removeTempDir} = await runTestCases('migration-v6', migrationCollection, {
       'method-call-checks': require.resolve('./method-call-checks_input.ts')
     });
 
@@ -12,5 +12,7 @@ describe('v6 method call checks', () => {
       .toMatch(/\[15,.*Found call to "FocusMonitor\.monitor".*renderer.*has been removed/);
     expect(logOutput)
       .toMatch(/\[16,.*Found call to "FocusMonitor\.monitor".*renderer.*has been removed/);
+
+    removeTempDir();
   });
 });

--- a/src/cdk/schematics/ng-update/test-cases/v6-test-cases.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/v6-test-cases.spec.ts
@@ -16,6 +16,7 @@ describe('v6 upgrade test cases', () => {
   ];
 
   let testCasesOutputPath: string;
+  let cleanupTestApp: () => void;
 
   beforeAll(async () => {
     const testCaseInputs = testCases.reduce((inputs, testCaseName) => {
@@ -23,10 +24,14 @@ describe('v6 upgrade test cases', () => {
       return inputs;
     }, {} as {[name: string]: string});
 
-    const {tempPath} = await runTestCases('migration-v6', migrationCollection, testCaseInputs);
+    const {tempPath, removeTempDir} =
+      await runTestCases('migration-v6', migrationCollection, testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/cdk-testing/src/test-cases/');
+    cleanupTestApp = removeTempDir;
   });
+
+  afterAll(() => cleanupTestApp());
 
   // Iterates through every test case directory and generates a jasmine test block that will
   // verify that the update schematics properly updated the test input to the expected output.

--- a/src/cdk/schematics/ng-update/test-cases/v7-test-cases.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/v7-test-cases.spec.ts
@@ -13,6 +13,7 @@ describe('v7 upgrade test cases', () => {
   ];
 
   let testCasesOutputPath: string;
+  let cleanupTestApp: () => void;
 
   beforeAll(async () => {
     const testCaseInputs = testCases.reduce((inputs, testCaseName) => {
@@ -20,10 +21,14 @@ describe('v7 upgrade test cases', () => {
       return inputs;
     }, {} as {[name: string]: string});
 
-    const {tempPath} = await runTestCases('migration-v7', migrationCollection, testCaseInputs);
+    const {tempPath, removeTempDir} =
+      await runTestCases('migration-v7', migrationCollection, testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/cdk-testing/src/test-cases/');
+    cleanupTestApp = removeTempDir;
   });
+
+  afterAll(() => cleanupTestApp());
 
   // Iterates through every test case directory and generates a jasmine test block that will
   // verify that the update schematics properly updated the test input to the expected output.

--- a/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/constructor-checks.spec.ts
@@ -4,7 +4,7 @@ import {runTestCases} from '@angular/cdk/schematics/testing';
 describe('constructor checks', () => {
 
   it('should properly report invalid constructor expression signatures', async () => {
-    const {logOutput} = await runTestCases('migration-v6', migrationCollection, {
+    const {logOutput, removeTempDir} = await runTestCases('migration-v6', migrationCollection, {
       'constructor-checks': require.resolve('./constructor-checks_input.ts')
     });
 
@@ -38,6 +38,8 @@ describe('constructor checks', () => {
 
     expect(logOutput).toMatch(/Found "ExtendedDateAdapter".*super.*: super\(string, Platform\)/);
     expect(logOutput).toMatch(/Found "ExtendedDateAdapter".*: new \w+\(string, Platform\)/);
+
+    removeTempDir();
   });
 });
 

--- a/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/misc/import-checks.spec.ts
@@ -4,12 +4,14 @@ import {migrationCollection} from '../index.spec';
 describe('v6 import misc checks', () => {
 
   it('should report imports for deleted animation constants', async () => {
-    const {logOutput} = await runTestCases('migration-v6', migrationCollection, {
+    const {logOutput, removeTempDir} = await runTestCases('migration-v6', migrationCollection, {
       'import-checks': require.resolve('./import-checks_input.ts')
     });
 
     expect(logOutput).toMatch(/Found deprecated symbol "SHOW_ANIMATION"/);
     expect(logOutput).toMatch(/Found deprecated symbol "HIDE_ANIMATION"/);
+
+    removeTempDir();
   });
 });
 

--- a/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v6-test-cases.spec.ts
@@ -19,6 +19,7 @@ describe('v6 upgrade test cases', () => {
   ];
 
   let testCasesOutputPath: string;
+  let cleanupTestApp: () => void;
 
   beforeAll(async () => {
     const testCaseInputs = testCases.reduce((inputs, testCaseName) => {
@@ -26,10 +27,14 @@ describe('v6 upgrade test cases', () => {
       return inputs;
     }, {} as {[name: string]: string});
 
-    const {tempPath} = await runTestCases('migration-v6', migrationCollection, testCaseInputs);
+    const {tempPath, removeTempDir} =
+      await runTestCases('migration-v6', migrationCollection, testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/cdk-testing/src/test-cases/');
+    cleanupTestApp = removeTempDir;
   });
+
+  afterAll(() => cleanupTestApp());
 
   // Iterates through every test case directory and generates a jasmine test block that will
   // verify that the update schematics properly updated the test input to the expected output.

--- a/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
+++ b/src/lib/schematics/ng-update/test-cases/v7-test-cases.spec.ts
@@ -14,6 +14,7 @@ describe('v7 upgrade test cases', () => {
   ];
 
   let testCasesOutputPath: string;
+  let cleanupTestApp: () => void;
 
   beforeAll(async () => {
     const testCaseInputs = testCases.reduce((inputs, testCaseName) => {
@@ -21,10 +22,14 @@ describe('v7 upgrade test cases', () => {
       return inputs;
     }, {} as {[name: string]: string});
 
-    const {tempPath} = await runTestCases('migration-v7', migrationCollection, testCaseInputs);
+    const {tempPath, removeTempDir} =
+      await runTestCases('migration-v7', migrationCollection, testCaseInputs);
 
     testCasesOutputPath = join(tempPath, 'projects/cdk-testing/src/test-cases/');
+    cleanupTestApp = removeTempDir;
   });
+
+  afterAll(() => cleanupTestApp());
 
   // Iterates through every test case directory and generates a jasmine test block that will
   // verify that the update schematics properly updated the test input to the expected output.


### PR DESCRIPTION
* Currently we run _multiple_ test cases for the schematics and create temporary directories in order to test them with TSLint. This pollutes the temporary directory because we don't remove the temporary directory afterwards.