### PR TITLE
build: staging script should switch to publish branch

### DIFF
--- a/tools/release/git/git-client.ts
+++ b/tools/release/git/git-client.ts
@@ -33,6 +33,11 @@ export class GitClient {
     return spawnSync('git', ['diff-index', '--quiet', 'HEAD'], {cwd: this.projectDir}).status !== 0;
   }
 
+  /** Checks out an existing branch with the specified name. */
+  checkoutBranch(branchName: string): boolean {
+    return spawnSync('git', ['checkout', branchName], {cwd: this.projectDir}).status === 0;
+  }
+
   /** Creates a new branch which is based on the previous active branch. */
   checkoutNewBranch(branchName: string): boolean {
     return spawnSync('git', ['checkout', '-b', branchName], {cwd: this.projectDir}).status === 0;


### PR DESCRIPTION
* Rather than throwing an exception if an unexpected branch is currently checked out, we should just try switching to the expected publish branch.