### PR TITLE
build: saucelabs verbose logging

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -6,7 +6,6 @@ tunnelFileName="sc-4.5.2-linux.tar.gz"
 tunnelUrl="https://saucelabs.com/downloads/${tunnelFileName}"
 
 tunnelTmpDir="/tmp/material-saucelabs"
-tunnelLogFile="${tunnelTmpDir}/saucelabs-connect.log"
 tunnelReadyFile="${tunnelTmpDir}/readyfile"
 tunnelPidFile="${tunnelTmpDir}/pidfile"
 
@@ -28,7 +27,7 @@ tar --extract --file=${tunnelFileName} --strip-components=1 --directory=sauce-co
 rm ${tunnelFileName}
 
 # Command arguments that will be passed to sauce-connect.
-sauceArgs="--readyfile ${tunnelReadyFile} --pidfile ${tunnelPidFile}"
+sauceArgs="--readyfile ${tunnelReadyFile} --pidfile ${tunnelPidFile} --verbose"
 
 if [ ! -z "${CIRCLE_BUILD_NUM}" ]; then
   sauceArgs="${sauceArgs} --tunnel-identifier angular-material-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
@@ -36,5 +35,4 @@ fi
 
 echo "Starting Sauce Connect in the background, logging into: ${tunnelLogFile}"
 
-sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs} 2>&1 >> \
-  ${tunnelLogFile} &
+sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs} &

--- a/scripts/saucelabs/stop-tunnel.sh
+++ b/scripts/saucelabs/stop-tunnel.sh
@@ -19,7 +19,7 @@ tunnelProcessId=$(cat ${tunnelPidFile})
 # we cannot use killall because CircleCI base container images don't have it installed.
 kill ${tunnelProcessId}
 
-while (ps -p ${tunnelProcessId} &> /dev/null); do
+while (ps -p ${tunnelProcessId}); do
   printf "."
   sleep .5
 done

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
 tunnelTmpDir="/tmp/material-saucelabs"
-tunnelLogFile="${tunnelTmpDir}/saucelabs-connect.log"
 tunnelReadyFile="${tunnelTmpDir}/readyfile"
 
 WAIT_DELAY=30
-
-# Method that prints the logfile output of the saucelabs tunnel.
-printLog() {
-  echo "Logfile output of Saucelabs tunnel (${tunnelLogFile}):"
-  echo ""
-  cat ${tunnelLogFile}
-}
 
 # Wait for Saucelabs Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
@@ -25,7 +17,6 @@ while [ ! -f ${tunnelReadyFile} ]; do
   if [ $counter -gt $[${WAIT_DELAY} * 2] ]; then
     echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
-    printLog
     exit 5
   fi
 


### PR DESCRIPTION
* In order to be able to observe stability of Saucelabs, I want to see the verbose output immediately instead of deferred.

**Note**: Currently looking why the API rate limit even fails while being authenticated. Not to mix up with the actual browser rate limit ([read more](https://wiki.saucelabs.com/display/DOCS/Rate+Limits+for+the+Sauce+Labs+REST+API))