### PR TITLE
Revert "fix(checkbox): redirect focus to underlying input element"

### DIFF
--- a/src/lib/checkbox/checkbox.scss
+++ b/src/lib/checkbox/checkbox.scss
@@ -182,7 +182,6 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
 
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  outline: 0;
 
   .mat-ripple-element:not(.mat-checkbox-persistent-ripple) {
     opacity: 0.16;

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -370,15 +370,6 @@ describe('MatCheckbox', () => {
       expect(document.activeElement).toBe(inputElement);
     });
 
-    it('should focus on underlying input element when the host is focused', () => {
-      expect(document.activeElement).not.toBe(inputElement);
-
-      checkboxNativeElement.focus();
-      fixture.detectChanges();
-
-      expect(document.activeElement).toBe(inputElement);
-    });
-
     it('should forward the value to input element', () => {
       testComponent.checkboxValue = 'basic_checkbox';
       fixture.detectChanges();
@@ -799,7 +790,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
 
       const checkbox = fixture.debugElement.query(By.directive(MatCheckbox)).nativeElement;
-      expect(checkbox.getAttribute('tabindex')).toBe('-1');
+      expect(checkbox.getAttribute('tabindex')).toBeFalsy();
     });
   });
 

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -119,13 +119,12 @@ export const _MatCheckboxMixinBase:
   host: {
     'class': 'mat-checkbox',
     '[id]': 'id',
-    '[attr.tabindex]': '-1', // Reset back to -1 so that the `focus` event still works.
+    '[attr.tabindex]': 'null',
     '[class.mat-checkbox-indeterminate]': 'indeterminate',
     '[class.mat-checkbox-checked]': 'checked',
     '[class.mat-checkbox-disabled]': 'disabled',
     '[class.mat-checkbox-label-before]': 'labelPosition == "before"',
     '[class._mat-animation-noopable]': `_animationMode === 'NoopAnimations'`,
-    '(focus)': '_inputElement.nativeElement.focus()',
   },
   providers: [MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR],
   inputs: ['disableRipple', 'color', 'tabIndex'],


### PR DESCRIPTION
Reverts angular/material2#13959

Causes test failures in g3