### PR TITLE
build: increase saucelabs connect timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^2.0.1",
     "karma-parallel": "^0.3.0",
-    "karma-sauce-launcher": "^2.0.0",
+    "karma-sauce-launcher": "^2.0.2",
     "karma-sourcemap-loader": "^0.3.7",
     "magic-string": "^0.22.4",
     "marked": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^2.0.1",
     "karma-parallel": "^0.3.0",
-    "karma-sauce-launcher": "^1.2.0",
+    "karma-sauce-launcher": "^2.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "magic-string": "^0.22.4",
     "marked": "^0.5.1",

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -6,7 +6,6 @@ tunnelFileName="sc-4.5.2-linux.tar.gz"
 tunnelUrl="https://saucelabs.com/downloads/${tunnelFileName}"
 
 tunnelTmpDir="/tmp/material-saucelabs"
-tunnelLogFile="${tunnelTmpDir}/saucelabs-connect.log"
 tunnelReadyFile="${tunnelTmpDir}/readyfile"
 tunnelPidFile="${tunnelTmpDir}/pidfile"
 
@@ -34,7 +33,6 @@ if [ ! -z "${CIRCLE_BUILD_NUM}" ]; then
   sauceArgs="${sauceArgs} --tunnel-identifier angular-material-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
 fi
 
-echo "Starting Sauce Connect in the background, logging into: ${tunnelLogFile}"
+echo "Starting Sauce Connect in the background. Passed arguments: ${sauceArgs}"
 
-sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs} 2>&1 >> \
-  ${tunnelLogFile} &
+sauce-connect/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs} &

--- a/scripts/saucelabs/wait-tunnel.sh
+++ b/scripts/saucelabs/wait-tunnel.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
 tunnelTmpDir="/tmp/material-saucelabs"
-tunnelLogFile="${tunnelTmpDir}/saucelabs-connect.log"
 tunnelReadyFile="${tunnelTmpDir}/readyfile"
 
-WAIT_DELAY=30
-
-# Method that prints the logfile output of the saucelabs tunnel.
-printLog() {
-  echo "Logfile output of Saucelabs tunnel (${tunnelLogFile}):"
-  echo ""
-  cat ${tunnelLogFile}
-}
+WAIT_DELAY=120
 
 # Wait for Saucelabs Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
@@ -25,7 +17,6 @@ while [ ! -f ${tunnelReadyFile} ]; do
   if [ $counter -gt $[${WAIT_DELAY} * 2] ]; then
     echo ""
     echo "Timed out after 2 minutes waiting for tunnel ready file"
-    printLog
     exit 5
   fi
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -121,6 +121,9 @@ module.exports = config => {
     } else if (testPlatform === 'saucelabs') {
       config.sauceLabs.build = buildIdentifier;
       config.sauceLabs.tunnelIdentifier = tunnelIdentifier;
+      // Setup the saucelabs reporter so that we report back to Saucelabs once
+      // our tests finished.
+      config.reporters.push('saucelabs');
     }
 
     const platformBrowsers = platformMap[testPlatform];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6361,10 +6361,10 @@ karma-sauce-launcher@1.2.0:
     saucelabs "^1.4.0"
     wd "^1.4.0"
 
-karma-sauce-launcher@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/karma-sauce-launcher/-/karma-sauce-launcher-2.0.0.tgz#f2d39013eb34e148bafb83172b744fa96ce90e5d"
-  integrity sha512-WIlCHnolf5R5Tye8v4LjUE+JAlO+uPZtw574gg+mfsXNjbZ4KO000A36Pm/iqzGYpgjZ59rHm5jlWwG43GNaYw==
+karma-sauce-launcher@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/karma-sauce-launcher/-/karma-sauce-launcher-2.0.2.tgz#dbf98e70d86bf287b03a537cf637eb7aefa975c3"
+  integrity sha512-jLUFaJhHMcKpxFWUesyWYihzM5FvQiJsDwGcCtKeOy2lsWhkVw0V0Byqb1d+wU6myU1mribBtsIcub23HS4kWA==
   dependencies:
     sauce-connect-launcher "^1.2.4"
     saucelabs "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6351,7 +6351,7 @@ karma-requirejs@1.1.0:
   resolved "https://registry.yarnpkg.com/karma-requirejs/-/karma-requirejs-1.1.0.tgz#fddae2cb87d7ebc16fb0222893564d7fee578798"
   integrity sha1-/driy4fX68FvsCIok1ZNf+5Xh5g=
 
-karma-sauce-launcher@1.2.0, karma-sauce-launcher@^1.2.0:
+karma-sauce-launcher@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz#6f2558ddef3cf56879fa27540c8ae9f8bfd16bca"
   integrity sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==
@@ -6360,6 +6360,15 @@ karma-sauce-launcher@1.2.0, karma-sauce-launcher@^1.2.0:
     sauce-connect-launcher "^1.2.2"
     saucelabs "^1.4.0"
     wd "^1.4.0"
+
+karma-sauce-launcher@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/karma-sauce-launcher/-/karma-sauce-launcher-2.0.0.tgz#f2d39013eb34e148bafb83172b744fa96ce90e5d"
+  integrity sha512-WIlCHnolf5R5Tye8v4LjUE+JAlO+uPZtw574gg+mfsXNjbZ4KO000A36Pm/iqzGYpgjZ59rHm5jlWwG43GNaYw==
+  dependencies:
+    sauce-connect-launcher "^1.2.4"
+    saucelabs "^1.5.0"
+    selenium-webdriver "^4.0.0-alpha.1"
 
 karma-sourcemap-loader@0.3.7, karma-sourcemap-loader@^0.3.7:
   version "0.3.7"
@@ -9518,7 +9527,7 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sauce-connect-launcher@^1.2.2:
+sauce-connect-launcher@^1.2.2, sauce-connect-launcher@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sauce-connect-launcher/-/sauce-connect-launcher-1.2.4.tgz#8d38f85242a9fbede1b2303b559f7e20c5609a1c"
   integrity sha512-X2vfwulR6brUGiicXKxPm1GJ7dBEeP1II450Uv4bHGrcGOapZNgzJvn9aioea5IC5BPp/7qjKdE3xbbTBIVXMA==
@@ -9566,6 +9575,16 @@ selenium-webdriver@3.6.0, "selenium-webdriver@>= 2.53.1", selenium-webdriver@^3.
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz#2ba87a1662c020b8988c981ae62cb2a01298eafc"
   integrity sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==
+  dependencies:
+    jszip "^3.1.3"
+    rimraf "^2.5.4"
+    tmp "0.0.30"
+    xml2js "^0.4.17"
+
+selenium-webdriver@^4.0.0-alpha.1:
+  version "4.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.1.tgz#cc93415e21d2dc1dfd85dfc5f6b55f3ac53933b1"
+  integrity sha512-z88rdjHAv3jmTZ7KSGUkTvo4rGzcDGMq0oXWHNIDK96Gs31JKVdu9+FMtT4KBrVoibg8dUicJDok6GnqqttO5Q==
   dependencies:
     jszip "^3.1.3"
     rimraf "^2.5.4"


### PR DESCRIPTION
At some point we went down from a 2min wait timeout to 30seconds because we re-ran the startup script if something failed. Since re-running didn't really help and we removed it, we should move the timeout back to a longer period.

```
11 Dec 17:38:29 - Sauce Connect 4.5.2, build 4485 4a87b52 
11 Dec 17:38:29 - Using CA certificate bundle /etc/ssl/certs/ca-certificates.crt.
11 Dec 17:38:29 - Using CA certificate verify path /etc/ssl/certs.
11 Dec 17:38:29 - Starting up; pid 414
11 Dec 17:38:29 - Command line arguments: sauce-connect/bin/sc -u angular-ci -k **** --readyfile /tmp/material-saucelabs/readyfile --pidfile /tmp/material-saucelabs/pidfile --tunnel-identifier angular-material-25254-0 
11 Dec 17:38:29 - Log file: /tmp/sc-angular-material-25254-0.log
11 Dec 17:38:29 - Pid file: /tmp/material-saucelabs/pidfile
11 Dec 17:38:29 - Timezone: UTC GMT offset: 0h
11 Dec 17:38:29 - Using no proxy for connecting to Sauce Labs REST API.
11 Dec 17:38:31 - Started scproxy on port 40078.
11 Dec 17:38:31 - Please wait for 'you may start your tests' to start your tests.

// EXIT Timeout (30 seconds)

```

e.g. see: https://circleci.com/gh/angular/material2/25254 where it successfully acquired a tunnel, but just didn't have enough time to actually establish it.