### PR TITLE
build: re-add firebase app types

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@bazel/ibazel": "^0.9.0",
     "@bazel/karma": "0.21.0",
     "@bazel/typescript": "0.21.0",
+    "@firebase/app-types": "^0.3.2",
     "@octokit/rest": "^15.9.4",
     "@schematics/angular": "^7.1.2",
     "@types/browser-sync": "^0.0.42",

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,6 +316,11 @@
     source-map-support "0.5.9"
     tsutils "2.27.2"
 
+"@firebase/app-types@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
+  integrity sha512-ZD8lTgW07NGgo75bTyBJA8Lt9+NweNzot7lrsBtIvfciwUzaFJLsv2EShqjBeuhF7RpG6YFucJ6m67w5buCtzw==
+
 "@google-cloud/common@^0.17.0":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.17.0.tgz#8ef558750db481fc10a13757a49479ab9a1c8c07"


### PR DESCRIPTION
Re-adds the firebase app types which have been removed but are still an optional dependency of `firebase-tools`.