### PR TITLE
build: force push publish artifacts script

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -106,7 +106,7 @@ publishPackage() {
   git add -A
   git commit --allow-empty -m "${buildCommitMessage}"
   git tag "${buildTagName}"
-  git push origin ${branchName} --tags
+  git push origin ${branchName} --tags --force
 
   echo "Published package artifacts for ${packageName}#${buildVersionName} into ${branchName}"
 }

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -124,6 +124,6 @@ echo "Credentials for docs-content repository are now set up. Publishing.."
 git add -A
 git commit --allow-empty -m "${buildCommitMessage}"
 git tag "${buildTagName}"
-git push origin ${branchName} --tags
+git push origin ${branchName} --tags --force
 
 echo "Published docs-content for ${buildVersionName} into ${branchName} successfully"


### PR DESCRIPTION
* Similarly to `angular/angular`, we should publish our artifacts using `git push --force`. This avoids the race condition where another CI job pushes to the builds repository before we try to push with our outdated `HEAD`.