### PR TITLE
Revert "fix(menu): allow text wrapping in menu items"

### DIFF
--- a/src/dev-app/menu/menu-demo.ts
+++ b/src/dev-app/menu/menu-demo.ts
@@ -19,13 +19,13 @@ export class MenuDemo {
   selected = '';
   items = [
     {text: 'Refresh'},
-    {text: 'Settings with a longer name so we can test text wrapping'},
+    {text: 'Settings'},
     {text: 'Help', disabled: true},
     {text: 'Sign Out'}
   ];
 
   iconItems = [
-    {text: 'Redial with a longer name so we can test text wrapping', icon: 'dialpad'},
+    {text: 'Redial', icon: 'dialpad'},
     {text: 'Check voicemail', icon: 'voicemail', disabled: true},
     {text: 'Disable alerts', icon: 'notifications_off'}
   ];

--- a/src/lib/core/option/option.scss
+++ b/src/lib/core/option/option.scss
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: row;
   max-width: 100%;
+  box-sizing: border-box;
   align-items: center;
   -webkit-tap-highlight-color: transparent;
 

--- a/src/lib/core/style/_menu-common.scss
+++ b/src/lib/core/style/_menu-common.scss
@@ -28,7 +28,6 @@ $mat-menu-icon-margin: 16px !default;
   line-height: $mat-menu-item-height;
   height: $mat-menu-item-height;
   padding: 0 $mat-menu-side-padding;
-  box-sizing: border-box;
 
   text-align: left;
   text-decoration: none;   // necessary to reset anchor tags

--- a/src/lib/menu/menu.scss
+++ b/src/lib/menu/menu.scss
@@ -5,7 +5,6 @@
 @import '../../cdk/a11y/a11y';
 
 $mat-menu-vertical-padding: 8px !default;
-$mat-menu-item-vertical-padding: 8px !default;
 $mat-menu-border-radius: 4px !default;
 $mat-menu-submenu-indicator-size: 10px !default;
 
@@ -30,17 +29,6 @@ $mat-menu-submenu-indicator-size: 10px !default;
   @include mat-button-reset();
   @include mat-menu-item-base();
   position: relative;
-
-  // TODO(crisbeto): most of these can be moved into the `mat-menu-item-base`
-  // once we start allowing text wrapping in mat-select and mat-autocomplete.
-  display: flex;
-  align-items: center;
-  white-space: normal;
-  line-height: normal;
-  height: auto;
-  min-height: $mat-menu-item-height;
-  padding-top: $mat-menu-item-vertical-padding;
-  padding-bottom: $mat-menu-item-vertical-padding;
 
   @include cdk-high-contrast {
     &.cdk-program-focused,


### PR DESCRIPTION
Reverts angular/material2#11430

menu.scss has duplicated height definition that breaks google.