### PR TITLE
Revert "fix(snack-bar): announcing same message twice to screen readers"

### DIFF
--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -186,16 +186,18 @@ describe('MatSnackBar', () => {
   }));
 
 
-  it('should clear the announcement message if it is the same as main message', fakeAsync(() => {
+  it('should default to the passed message for the announcement message', fakeAsync(() => {
     spyOn(liveAnnouncer, 'announce');
 
-    snackBar.open(simpleMessage, undefined, {announcementMessage: simpleMessage});
+    snackBar.open(simpleMessage);
     viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.childElementCount)
       .toBe(1, 'Expected the overlay with the default announcement message to be added');
 
-    expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+    // Expect the live announcer to have been called with the display message and some
+    // string for the politeness. We do not want to test for the default politeness here.
+    expect(liveAnnouncer.announce).toHaveBeenCalledWith(simpleMessage, jasmine.any(String));
   }));
 
   it('should be able to specify a custom announcement message', fakeAsync(() => {

--- a/src/lib/snack-bar/snack-bar.ts
+++ b/src/lib/snack-bar/snack-bar.ts
@@ -114,10 +114,8 @@ export class MatSnackBar implements OnDestroy {
     // override the data to pass in our own message and action.
     _config.data = {message, action};
 
-    // Since the snack bar has `role="alert"`, we don't
-    // want to announce the same message twice.
-    if (_config.announcementMessage === message) {
-      _config.announcementMessage = undefined;
+    if (!_config.announcementMessage) {
+      _config.announcementMessage = message;
     }
 
     return this.openFromComponent(SimpleSnackBar, _config);


### PR DESCRIPTION
Reverts angular/material2#13298

The syncing into google has failures for this PR, revert it to get to a clean statge.