### PR TITLE
build: print url to commits if staging script fails due to failing status

### DIFF
--- a/tools/release/git/github-urls.ts
+++ b/tools/release/git/github-urls.ts
@@ -1,0 +1,4 @@
+/** Gets a Github URL that refers to a lists of recent commits within a specified branch. */
+export function getGithubBranchCommitsUrl(owner: string, repository: string, branchName: string) {
+  return `https://github.com/${owner}/${repository}/commits/${branchName}`;
+}

--- a/tools/release/prompt/new-version-prompt.ts
+++ b/tools/release/prompt/new-version-prompt.ts
@@ -50,6 +50,7 @@ export async function promptForNewVersion(currentVersion: Version): Promise<Vers
     message: 'Should this be a pre-release?',
     // Prompt whether this should a pre-release if the current release is not a pre-release
     when: !currentVersion.prereleaseLabel,
+    default: false,
   }, {
     type: 'list',
     name: 'prereleaseLabel',


### PR DESCRIPTION
Based on a recent chat with Miles, it would be good if we default the `Is pre-release?` question to `false` and also print an URL if the status checks for a given branch fail (this should be just more convenient to see what failed)