### PR TITLE
test: remove duplicate words

### DIFF
--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -335,7 +335,7 @@ describe('Dialog', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should should override the width of the overlay pane', () => {
+  it('should override the width of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       width: '500px'
     });
@@ -347,7 +347,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.width).toBe('500px');
   });
 
-  it('should should override the height of the overlay pane', () => {
+  it('should override the height of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       height: '100px'
     });
@@ -359,7 +359,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.height).toBe('100px');
   });
 
-  it('should should override the min-width of the overlay pane', () => {
+  it('should override the min-width of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       minWidth: '500px'
     });
@@ -371,7 +371,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.minWidth).toBe('500px');
   });
 
-  it('should should override the max-width of the overlay pane', fakeAsync(() => {
+  it('should override the max-width of the overlay pane', fakeAsync(() => {
     let dialogRef = dialog.openFromComponent(PizzaMsg);
 
     viewContainerFixture.detectChanges();
@@ -399,7 +399,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.maxWidth).toBe('100px');
   }));
 
-  it('should should override the min-height of the overlay pane', () => {
+  it('should override the min-height of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       minHeight: '300px'
     });
@@ -411,7 +411,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.minHeight).toBe('300px');
   });
 
-  it('should should override the max-height of the overlay pane', () => {
+  it('should override the max-height of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       maxHeight: '100px'
     });
@@ -423,7 +423,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.maxHeight).toBe('100px');
   });
 
-  it('should should override the top offset of the overlay pane', () => {
+  it('should override the top offset of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       position: {
         top: '100px'
@@ -437,7 +437,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.marginTop).toBe('100px');
   });
 
-  it('should should override the bottom offset of the overlay pane', () => {
+  it('should override the bottom offset of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       position: {
         bottom: '200px'
@@ -451,7 +451,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.marginBottom).toBe('200px');
   });
 
-  it('should should override the left offset of the overlay pane', () => {
+  it('should override the left offset of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       position: {
         left: '250px'
@@ -465,7 +465,7 @@ describe('Dialog', () => {
     expect(overlayPane.style.marginLeft).toBe('250px');
   });
 
-  it('should should override the right offset of the overlay pane', () => {
+  it('should override the right offset of the overlay pane', () => {
     dialog.openFromComponent(PizzaMsg, {
       position: {
         right: '125px'

--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -48,7 +48,7 @@ describe('MatButton', () => {
     expect(button.ripple).toBeTruthy();
   });
 
-  it('should should not clear previous defined classes', () => {
+  it('should not clear previous defined classes', () => {
     let fixture = TestBed.createComponent(TestApp);
     let testComponent = fixture.debugElement.componentInstance;
     let buttonDebugElement = fixture.debugElement.query(By.css('button'));

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -444,7 +444,7 @@ describe('MatCheckbox', () => {
         expect(checkboxNativeElement.classList.contains('mat-accent')).toBe(true);
       });
 
-      it('should should not clear previous defined classes', () => {
+      it('should not clear previous defined classes', () => {
         checkboxNativeElement.classList.add('custom-class');
 
         testComponent.checkboxColor = 'primary';

--- a/src/lib/core/gestures/gesture-config.spec.ts
+++ b/src/lib/core/gestures/gesture-config.spec.ts
@@ -44,7 +44,7 @@ describe('GestureConfig', () => {
     expect(firstCallArgs[1].cssProps.touchAction).toBe('auto');
   });
 
-  it('should should not error when HammerJS is not loaded', () => {
+  it('should not error when HammerJS is not loaded', () => {
     // Remove the Hammer global from the environment, storing it to restore at the end of the test.
     const hammerGlobal = (window as any).Hammer;
     (window as any).Hammer = undefined;

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -363,7 +363,7 @@ describe('MatDialog', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should should override the width of the overlay pane', () => {
+  it('should override the width of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       width: '500px'
     });
@@ -375,7 +375,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.width).toBe('500px');
   });
 
-  it('should should override the height of the overlay pane', () => {
+  it('should override the height of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       height: '100px'
     });
@@ -387,7 +387,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.height).toBe('100px');
   });
 
-  it('should should override the min-width of the overlay pane', () => {
+  it('should override the min-width of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       minWidth: '500px'
     });
@@ -399,7 +399,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.minWidth).toBe('500px');
   });
 
-  it('should should override the max-width of the overlay pane', fakeAsync(() => {
+  it('should override the max-width of the overlay pane', fakeAsync(() => {
     let dialogRef = dialog.open(PizzaMsg);
 
     viewContainerFixture.detectChanges();
@@ -426,7 +426,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.maxWidth).toBe('100px');
   }));
 
-  it('should should override the min-height of the overlay pane', () => {
+  it('should override the min-height of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       minHeight: '300px'
     });
@@ -438,7 +438,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.minHeight).toBe('300px');
   });
 
-  it('should should override the max-height of the overlay pane', () => {
+  it('should override the max-height of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       maxHeight: '100px'
     });
@@ -450,7 +450,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.maxHeight).toBe('100px');
   });
 
-  it('should should override the top offset of the overlay pane', () => {
+  it('should override the top offset of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       position: {
         top: '100px'
@@ -464,7 +464,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.marginTop).toBe('100px');
   });
 
-  it('should should override the bottom offset of the overlay pane', () => {
+  it('should override the bottom offset of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       position: {
         bottom: '200px'
@@ -478,7 +478,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.marginBottom).toBe('200px');
   });
 
-  it('should should override the left offset of the overlay pane', () => {
+  it('should override the left offset of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       position: {
         left: '250px'
@@ -492,7 +492,7 @@ describe('MatDialog', () => {
     expect(overlayPane.style.marginLeft).toBe('250px');
   });
 
-  it('should should override the right offset of the overlay pane', () => {
+  it('should override the right offset of the overlay pane', () => {
     dialog.open(PizzaMsg, {
       position: {
         right: '125px'

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -395,7 +395,7 @@ describe('MatSelect', () => {
           expect(formControl.value).toBeFalsy('Expected value not to have changed.');
         }));
 
-        it('should should close when pressing ALT + DOWN_ARROW', fakeAsync(() => {
+        it('should close when pressing ALT + DOWN_ARROW', fakeAsync(() => {
           const {select: selectInstance} = fixture.componentInstance;
 
           selectInstance.open();
@@ -412,7 +412,7 @@ describe('MatSelect', () => {
           expect(event.defaultPrevented).toBe(true, 'Expected default action to be prevented.');
         }));
 
-        it('should should close when pressing ALT + UP_ARROW', fakeAsync(() => {
+        it('should close when pressing ALT + UP_ARROW', fakeAsync(() => {
           const {select: selectInstance} = fixture.componentInstance;
 
           selectInstance.open();

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -597,7 +597,7 @@ describe('MatSlideToggle without forms', () => {
       expect(slideThumbContainer.classList).not.toContain('mat-dragging');
     }));
 
-    it('should should emit a change event after drag', fakeAsync(() => {
+    it('should emit a change event after drag', fakeAsync(() => {
       expect(slideToggle.checked).toBe(false);
 
       gestureConfig.emitEventForElement('slidestart', slideThumbContainer);


### PR DESCRIPTION
* Replace all instances of "should should" with "should" in unit tests