### PR TITLE
fix(tree): handle null children in nested tree

### DIFF
--- a/src/cdk/tree/control/nested-tree-control.spec.ts
+++ b/src/cdk/tree/control/nested-tree-control.spec.ts
@@ -1,3 +1,4 @@
+import {fakeAsync, flush} from '@angular/core/testing';
 import {of as observableOf} from 'rxjs';
 import {NestedTreeControl} from './nested-tree-control';
 
@@ -91,6 +92,20 @@ describe('CdkNestedTreeControl', () => {
       expect(treeControl.expansionModel.selected.length)
         .toBe(totalNumber, `Expect ${totalNumber} expanded nodes`);
     });
+
+    // Note that this needs to be `fakeAsync` in order to
+    // catch the error inside an observable correctly.
+    it('should handle null children', fakeAsync(() => {
+      const nodes = generateData(3, 2);
+
+      nodes[1].children = null!;
+      treeControl.dataNodes = nodes;
+
+      expect(() => {
+        treeControl.expandAll();
+        flush();
+      }).not.toThrow();
+    }));
 
     describe('with children array', () => {
       let getStaticChildren = (node: TestData) => node.children;
@@ -201,12 +216,12 @@ export class TestData {
 
 function generateData(dataLength: number, childLength: number, grandChildLength: number = 0)
     : TestData[] {
-  let data = <any>[];
+  let data: TestData[] = [];
   let nextIndex = 0;
   for (let i = 0; i < dataLength; i++) {
-    let children = <any>[];
+    let children: TestData[] = [];
     for (let j = 0; j < childLength; j++) {
-      let grandChildren = <any>[];
+      let grandChildren: TestData[] = [];
       for (let k = 0; k < grandChildLength; k++) {
         grandChildren.push(new TestData(`a_${nextIndex}`, `b_${nextIndex}`, `c_${nextIndex++}`, 3));
       }

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Observable} from 'rxjs';
-import {take} from 'rxjs/operators';
+import {take, filter} from 'rxjs/operators';
 import {BaseTreeControl} from './base-tree-control';
 
 /** Nested tree control. Able to expand/collapse a subtree recursively for NestedNode type. */
@@ -46,7 +46,7 @@ export class NestedTreeControl<T> extends BaseTreeControl<T> {
     if (Array.isArray(childrenNodes)) {
       childrenNodes.forEach((child: T) => this._getDescendants(descendants, child));
     } else if (childrenNodes instanceof Observable) {
-      childrenNodes.pipe(take(1)).subscribe(children => {
+      childrenNodes.pipe(take(1), filter(Boolean)).subscribe(children => {
         children.forEach((child: T) => this._getDescendants(descendants, child));
       });
     }


### PR DESCRIPTION
Gracefully handles nodes whose children are set to null. This seems to be something that we used to handle until a regression from #10886.

Fixes #14545.