### PR TITLE
docs(drag-drop): add missing example

### DIFF
--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -41,7 +41,7 @@ by referencing the `id` of another drop container:
 
 If you have an unknown number of connected drop lists, you can use the `cdkDropListGroup` directive
 to set up the connection automatically. Note that any new `cdkDropList` that is added under a group
-will be connected to all other automatically.
+will be connected to all other lists automatically.
 
 ```html
 <div cdkDropListGroup>

--- a/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.css
+++ b/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.css
@@ -1,0 +1,54 @@
+.example-container {
+  width: 400px;
+  max-width: 100%;
+  margin: 0 25px 25px 0;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.example-list {
+  border: solid 1px #ccc;
+  min-height: 60px;
+  background: white;
+  border-radius: 4px;
+  overflow: hidden;
+  display: block;
+}
+
+.example-box {
+  padding: 20px 10px;
+  border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  cursor: move;
+  background: white;
+  font-size: 14px;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-box:last-child {
+  border: none;
+}
+
+.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.html
+++ b/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.html
@@ -1,0 +1,25 @@
+<div cdkDropListGroup>
+  <div class="example-container">
+    <h2>To do</h2>
+
+    <div
+      cdkDropList
+      [cdkDropListData]="todo"
+      class="example-list"
+      (cdkDropListDropped)="drop($event)">
+      <div class="example-box" *ngFor="let item of todo" cdkDrag>{{item}}</div>
+    </div>
+  </div>
+
+  <div class="example-container">
+    <h2>Done</h2>
+
+    <div
+      cdkDropList
+      [cdkDropListData]="done"
+      class="example-list"
+      (cdkDropListDropped)="drop($event)">
+      <div class="example-box" *ngFor="let item of done" cdkDrag>{{item}}</div>
+    </div>
+  </div>
+</div>

--- a/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.ts
+++ b/src/material-examples/cdk-drag-drop-connected-sorting-group/cdk-drag-drop-connected-sorting-group-example.ts
@@ -1,0 +1,38 @@
+import {Component} from '@angular/core';
+import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag-drop';
+
+/**
+ * @title Drag&Drop connected sorting group
+ */
+@Component({
+  selector: 'cdk-drag-drop-connected-sorting-group-example',
+  templateUrl: 'cdk-drag-drop-connected-sorting-group-example.html',
+  styleUrls: ['cdk-drag-drop-connected-sorting-group-example.css'],
+})
+export class CdkDragDropConnectedSortingGroupExample {
+  todo = [
+    'Get to work',
+    'Pick up groceries',
+    'Go home',
+    'Fall asleep'
+  ];
+
+  done = [
+    'Get up',
+    'Brush teeth',
+    'Take a shower',
+    'Check e-mail',
+    'Walk dog'
+  ];
+
+  drop(event: CdkDragDrop<string[]>) {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(event.previousContainer.data,
+                        event.container.data,
+                        event.previousIndex,
+                        event.currentIndex);
+    }
+  }
+}


### PR DESCRIPTION
Adds an example that was being embedded in the readme, but isn't in the docs. It seems like it was missed in #13754 where a reference to it was introduced.