### PR TITLE
fix(drag-drop): showing touch device tap highlight when using a handle

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -684,6 +684,58 @@ describe('CdkDrag', () => {
           .toBe('translate3d(50px, 100px, 0px)', 'Expected to drag the element by its handle.');
     }));
 
+    it('should disable the tap highlight while dragging via the handle', fakeAsync(() => {
+      // This test is irrelevant if the browser doesn't support styling the tap highlight color.
+      if (!('webkitTapHighlightColor' in document.body.style)) {
+        return;
+      }
+
+      const fixture = createComponent(StandaloneDraggableWithHandle);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const handle = fixture.componentInstance.handleElement.nativeElement;
+
+      expect(dragElement.style.webkitTapHighlightColor).toBeFalsy();
+
+      startDraggingViaMouse(fixture, handle);
+
+      expect(dragElement.style.webkitTapHighlightColor).toBe('transparent');
+
+      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      fixture.detectChanges();
+
+      dispatchMouseEvent(document, 'mouseup', 50, 100);
+      fixture.detectChanges();
+
+      expect(dragElement.style.webkitTapHighlightColor).toBeFalsy();
+    }));
+
+    it('should preserve any existing `webkitTapHighlightColor`', fakeAsync(() => {
+      // This test is irrelevant if the browser doesn't support styling the tap highlight color.
+      if (!('webkitTapHighlightColor' in document.body.style)) {
+        return;
+      }
+
+      const fixture = createComponent(StandaloneDraggableWithHandle);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const handle = fixture.componentInstance.handleElement.nativeElement;
+
+      dragElement.style.webkitTapHighlightColor = 'purple';
+
+      startDraggingViaMouse(fixture, handle);
+
+      expect(dragElement.style.webkitTapHighlightColor).toBe('transparent');
+
+      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      fixture.detectChanges();
+
+      dispatchMouseEvent(document, 'mouseup', 50, 100);
+      fixture.detectChanges();
+
+      expect(dragElement.style.webkitTapHighlightColor).toBe('purple');
+    }));
+
   });
 
   describe('in a drop container', () => {


### PR DESCRIPTION
Currently we disable all native drag interactions on the elements that we bind events to. Since when a `cdkDrag` has a handle, we don't remove its tap highlight which means that iOS will show a dark overlay over it. These changes disable the tap highlight while dragging.

For reference:

<img width="265" alt="screenshot at dec 17 17-21-34" src="https://user-images.githubusercontent.com/4450522/50112237-09ac6900-023f-11e9-9fc6-9a929d8c5e34.png">
