### PR TITLE
fix(overlay): not updating hasBackdrop after first open

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -1,6 +1,6 @@
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {ComponentFixture, TestBed, async, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed, async, inject, fakeAsync, tick} from '@angular/core/testing';
 import {Directionality} from '@angular/cdk/bidi';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {ESCAPE, A} from '@angular/cdk/keycodes';
@@ -210,17 +210,36 @@ describe('Overlay directives', () => {
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
 
-      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
-      expect(backdrop).toBeTruthy();
+      expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeTruthy();
     });
 
     it('should not create the backdrop by default', () => {
       fixture.componentInstance.isOpen = true;
       fixture.detectChanges();
 
-      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
-      expect(backdrop).toBeNull();
+      expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeNull();
     });
+
+    it('should be able to change hasBackdrop after the overlay has been initialized',
+      fakeAsync(() => {
+        // Open once with a backdrop
+        fixture.componentInstance.hasBackdrop = true;
+        fixture.componentInstance.isOpen = true;
+        fixture.detectChanges();
+
+        expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeTruthy();
+
+        fixture.componentInstance.isOpen = false;
+        fixture.detectChanges();
+        tick(500);
+
+        // Open again without a backdrop.
+        fixture.componentInstance.hasBackdrop = false;
+        fixture.componentInstance.isOpen = true;
+        fixture.detectChanges();
+
+        expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeFalsy();
+      }));
 
     it('should set the custom backdrop class', () => {
       fixture.componentInstance.hasBackdrop = true;

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -237,7 +237,11 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
-    this._destroyOverlay();
+    if (this._overlayRef) {
+      this._overlayRef.dispose();
+    }
+
+    this._backdropSubscription.unsubscribe();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -351,6 +355,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
         height: this.height,
         minHeight: this.minHeight,
       });
+
+      this._overlayRef.getConfig().hasBackdrop = this.hasBackdrop;
     }
 
     if (!this._overlayRef.hasAttached()) {
@@ -362,6 +368,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       this._backdropSubscription = this._overlayRef.backdropClick().subscribe(event => {
         this.backdropClick.emit(event);
       });
+    } else {
+      this._backdropSubscription.unsubscribe();
     }
   }
 
@@ -370,15 +378,6 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     if (this._overlayRef) {
       this._overlayRef.detach();
       this.detach.emit();
-    }
-
-    this._backdropSubscription.unsubscribe();
-  }
-
-  /** Destroys the overlay created by this directive. */
-  private _destroyOverlay() {
-    if (this._overlayRef) {
-      this._overlayRef.dispose();
     }
 
     this._backdropSubscription.unsubscribe();


### PR DESCRIPTION
Along the same lines as #14561. The connected overlay directive has an input on whether it should have a backdrop, however we only use it the first time we create the backdrop.