### PR TITLE
build: update to latest karma version

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "http-rewrite-middleware": "^0.1.6",
     "inquirer": "^6.2.0",
     "jasmine-core": "^3.3.0",
-    "karma": "^3.1.3",
+    "karma": "^3.1.4",
     "karma-browserstack-launcher": "^1.3.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6379,10 +6379,10 @@ karma-sourcemap-loader@0.3.7, karma-sourcemap-loader@^0.3.7:
   dependencies:
     graceful-fs "^4.1.2"
 
-karma@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.3.tgz#6e251648e3aff900927bc1126dbcbcb92d3edd61"
-  integrity sha512-JU4FYUtFEGsLZd6ZJzLrivcPj0TkteBiIRDcXWFsltPMGgZMDtby/MIzNOzgyZv/9dahs9vHpSxerC/ZfeX9Qw==
+karma@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.4.tgz#3890ca9722b10d1d14b726e1335931455788499e"
+  integrity sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==
   dependencies:
     bluebird "^3.3.0"
     body-parser "^1.16.1"


### PR DESCRIPTION
Updates to the latest Karma version that includes https://github.com/karma-runner/karma/commit/cc2eff27deb680f789afb34577fd337d2ad5dcac and should be able to properly restart disconnected browsers. This was a long-term Karma bug and affected CI flakiness significantly.