### PR TITLE
chore: update a11y golden

### DIFF
--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -70,8 +70,8 @@ export declare class FocusKeyManager<T> extends ListKeyManager<FocusableOption &
 export declare class FocusMonitor implements OnDestroy {
     constructor(_ngZone: NgZone, _platform: Platform);
     _onBlur(event: FocusEvent, element: HTMLElement): void;
-    focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void;
     focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions): void;
+    focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void;
     monitor(element: ElementRef<HTMLElement>, checkChildren?: boolean): Observable<FocusOrigin>;
     monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin>;
     ngOnDestroy(): void;


### PR DESCRIPTION
It seems like a change made it in that moves something around in the a11y golden file that fails the build.