### PR TITLE
build: update branch manager config

### DIFF
--- a/.github/branch-manager.yml
+++ b/.github/branch-manager.yml
@@ -1,7 +1,7 @@
 enabled: true
 
 branches:
-  - branchName: 7.1.x
+  - branchName: 7.2.x
     label: "target: patch"
   - branchName: 7.x
     label: "target: minor"


### PR DESCRIPTION
Currently `7.1.x` is not really in sync with the build tooling from `master`. This was because some PRs couldn't be cherry-picked cleanly into the `7.1.x` branch, and were just left out.

Now that we have `7.2.0`, we should use a new patch branch and base it on `master`, so that the branch-manager will not mark a lot of PRs as failing.