### PR TITLE
build: add readme that marks schematics sources as internal

### DIFF
--- a/src/cdk/schematics/README.md
+++ b/src/cdk/schematics/README.md
@@ -1,0 +1,4 @@
+## CDK schematics
+
+The sources of this directory are only used internally and should not be considered
+as part of the public API


### PR DESCRIPTION
In order to make clear that the sources/exports of the `cdk/schematics` directory are only intended for internal use, we should add a readme that makes this clear.