### PR TITLE
fix(progress-bar): set appropriate aria-busy based on the current mode

### DIFF
--- a/src/lib/progress-bar/progress-bar.spec.ts
+++ b/src/lib/progress-bar/progress-bar.spec.ts
@@ -141,6 +141,35 @@ describe('MatProgressBar', () => {
 
         expect(rect.getAttribute('fill')).toMatch(/^url\(['"]?\/another-fake-path#.*['"]?\)$/);
       });
+
+      it('should set the correct `aria-busy` based on the mode', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+        const progressDebugElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressInstance: MatProgressBar = progressDebugElement.componentInstance;
+        const progressElement: HTMLElement = progressDebugElement.nativeElement;
+
+        progressInstance.mode = 'determinate';
+        fixture.detectChanges();
+        expect(progressElement.getAttribute('aria-busy'))
+            .toBe('false', 'Expected not to be busy in determinate mode.');
+
+        progressInstance.mode = 'indeterminate';
+        fixture.detectChanges();
+        expect(progressElement.getAttribute('aria-busy'))
+            .toBe('true', 'Expected to be busy in indeterminate mode.');
+
+        progressInstance.mode = 'buffer';
+        fixture.detectChanges();
+        expect(progressElement.getAttribute('aria-busy'))
+            .toBe('false', 'Expected not to be busy in buffer mode.');
+
+        progressInstance.mode = 'query';
+        fixture.detectChanges();
+        expect(progressElement.getAttribute('aria-busy'))
+            .toBe('true', 'Expected to be busy in query mode.');
+      });
+
     });
 
     describe('animation trigger on determinate setting', () => {

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -92,6 +92,7 @@ let progressbarId = 0;
     'aria-valuemax': '100',
     '[attr.aria-valuenow]': 'value',
     '[attr.mode]': 'mode',
+    '[attr.aria-busy]': 'mode === "indeterminate" || mode === "query"',
     'class': 'mat-progress-bar',
     '[class._mat-animation-noopable]': `_isNoopAnimation`,
   },


### PR DESCRIPTION
Based on [the following example of an accessible progress bar](https://dequeuniversity.com/library/aria/custom-controls/sf-progress-bar-unbounded), these changes set the correct `aria-busy` value based on mode of the progress bar.