### PR TITLE
fix(overlay): update size if dimensions change in overlay directives

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -427,6 +427,24 @@ describe('Overlay directives', () => {
       expect(fixture.componentInstance.connectedOverlayDirective.push).toBe(true);
     });
 
+    it('should update the element size if it changes while open', () => {
+      fixture.componentInstance.width = 250;
+      fixture.componentInstance.height = 250;
+      fixture.componentInstance.isOpen = true;
+      fixture.detectChanges();
+
+      const pane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+      expect(pane.style.width).toBe('250px');
+      expect(pane.style.height).toBe('250px');
+
+      fixture.componentInstance.width = 100;
+      fixture.componentInstance.height = 100;
+      fixture.detectChanges();
+
+      expect(pane.style.width).toBe('100px');
+      expect(pane.style.height).toBe('100px');
+    });
+
   });
 
   describe('outputs', () => {

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -247,6 +247,12 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (this._position) {
       this._updatePositionStrategy(this._position);
+      this._overlayRef.updateSize({
+        width: this.width,
+        minWidth: this.minWidth,
+        height: this.height,
+        minHeight: this.minHeight,
+      });
 
       if (changes['origin'] && this.open) {
         this._position.apply();
@@ -349,13 +355,6 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       this._createOverlay();
     } else {
       // Update the overlay size, in case the directive's inputs have changed
-      this._overlayRef.updateSize({
-        width: this.width,
-        minWidth: this.minWidth,
-        height: this.height,
-        minHeight: this.minHeight,
-      });
-
       this._overlayRef.getConfig().hasBackdrop = this.hasBackdrop;
     }
 


### PR DESCRIPTION
Fixes the size of the overlay not being updated by the connected overlay directive, if it changes while open. This is required in order to handle cases like #7811.