### PR TITLE
build: dev app not picking up typography changes

### DIFF
--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -138,7 +138,10 @@ task(':watch:devapp', () => {
   // CDK package watchers.
   watchFilesAndReload(join(cdkPackage.sourceDir, '**/*'), ['cdk:build-no-bundles']);
 
-  const materialCoreThemingGlob = join(materialPackage.sourceDir, '**/core/theming/**/*.scss');
+  const materialCoreThemingGlob = join(
+    materialPackage.sourceDir,
+    '**/core/+(theming|typography)/**/*.scss'
+  );
 
   // Material package watchers.
   watchFilesAndReload([


### PR DESCRIPTION
Fixes the dev app CSS not being rebuilt when the typography styles change.