### PR TITLE
build: switch to docs-content from examples package

### DIFF
--- a/src/material-examples/example-data.ts
+++ b/src/material-examples/example-data.ts
@@ -11,9 +11,6 @@ export class ExampleData {
   /** Description of the example. */
   description: string;
 
-  /** Path to the example. This is based on the structure of the material.angular.io repo. */
-  examplePath: string;
-
   /** List of files that are part of this example. */
   exampleFiles: string[];
 
@@ -38,7 +35,6 @@ export class ExampleData {
 
     // TODO(tinayuangao): Do not hard-code extensions
     this.exampleFiles = ['html', 'ts', 'css'].map(extension => `${example}-example.${extension}`);
-    this.examplePath = `/assets/stackblitz/examples/${example}/`;
     this.selectorName = this.indexFilename = `${example}-example`;
 
     if (exampleConfig.additionalFiles) {

--- a/tools/dgeni/templates/constant.template.html
+++ b/tools/dgeni/templates/constant.template.html
@@ -15,6 +15,7 @@
   <p class="docs-api-constant-description">{$ constant.description | marked | safe $}</p>
 {%- endif -%}
 
+<div class="docs-markdown">
 <pre class="docs-markdown-pre">
 <code class="docs-markdown-code">
 {%- highlight "typescript" -%}
@@ -22,3 +23,4 @@
 {%- end_highlight -%}
 </code>
 </pre>
+</div>

--- a/tools/dgeni/templates/type-alias.template.html
+++ b/tools/dgeni/templates/type-alias.template.html
@@ -15,6 +15,7 @@
   <p class="docs-api-type-alias-description">{$ alias.description | marked | safe $}</p>
 {%- endif -%}
 
+<div class="docs-markdown">
 <pre class="docs-markdown-pre">
 <code class="docs-markdown-code">
 {%- highlight "typescript" -%}
@@ -22,3 +23,4 @@
 {%- end_highlight -%}
 </code>
 </pre>
+</div>

--- a/tools/package-docs-content/package-docs-content.ts
+++ b/tools/package-docs-content/package-docs-content.ts
@@ -26,8 +26,8 @@ function getBazelActionArguments() {
 }
 
 if (require.main === module) {
-  // The script expects the output path as first argument. All remaining arguments will be
-  // considered as markdown input files that need to be transformed.
+  // Process all file pairs that have been passed to this executable. Each argument will
+  // consist of the input file path and the desired output location.
   getBazelActionArguments().forEach(argument => {
     // Each argument that has been passed consists of an input file path and the expected
     // output path. e.g. {path_to_input_file},{expected_output_path}


### PR DESCRIPTION
With https://github.com/angular/material.angular.io/pull/565 the docs-content will be pulled from the `@angular/material-examples` package. Changes needed on this repository:

* Since we update some styles and logic in favor of simplicity, we need to update the Dgeni templates to conform with these changes.
* Remove the unnecessary `examplesPath` property member because we now compute the `docs-content/` asset paths in a consistent way and don't want to mix up the source locations.