### PR TITLE
build: ensure that there are no invalid dynamic imports

### DIFF
--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -1,6 +1,6 @@
 import {existsSync, readFileSync} from 'fs';
 import {sync as glob} from 'glob';
-import {join} from 'path';
+import {dirname, isAbsolute, join} from 'path';
 
 /** RegExp that matches Angular component inline styles that contain a sourcemap reference. */
 const inlineStylesSourcemapRegex = /styles: ?\[["'].*sourceMappingURL=.*["']/;
@@ -8,13 +8,16 @@ const inlineStylesSourcemapRegex = /styles: ?\[["'].*sourceMappingURL=.*["']/;
 /** RegExp that matches Angular component metadata properties that refer to external resources. */
 const externalReferencesRegex = /(templateUrl|styleUrls): *["'[]/;
 
+/** RegExp that matches TypeScript dynamic import statements. */
+const dynamicImportStatement = /import\(["'](.*)["']\)/g;
+
 /**
  * Checks the specified release bundle and ensures that it does not contain
  * any external resource URLs.
  */
 export function checkReleaseBundle(bundlePath: string): string[] {
   const bundleContent = readFileSync(bundlePath, 'utf8');
-  let failures: string[] = [];
+  const failures: string[] = [];
 
   if (inlineStylesSourcemapRegex.exec(bundleContent) !== null) {
     failures.push('Found sourcemap references in component styles.');
@@ -22,6 +25,41 @@ export function checkReleaseBundle(bundlePath: string): string[] {
 
   if (externalReferencesRegex.exec(bundleContent) !== null) {
     failures.push('Found external component resource references');
+  }
+
+  return failures;
+}
+
+/**
+ * Checks the specified TypeScript definition file by ensuring it does not contain invalid
+ * dynamic import statements. There can be invalid dynamic imports paths because we compose the
+ * release package by moving things in a desired output structure. See Angular package format
+ * specification and https://github.com/angular/material2/pull/12876
+ */
+export function checkTypeDefinitionFile(filePath: string): string[] {
+  const baseDir = dirname(filePath);
+  const fileContent = readFileSync(filePath, 'utf8');
+  const failures = [];
+
+  let match: RegExpMatchArray;
+
+  // Walk through each dynamic import and ensure that the import path is valid within the release
+  // output. Note that we don't want to enforce that there are no dynamic imports because type
+  // inference is heavily used within the schematics and is useful in some situations.
+  while ((match = dynamicImportStatement.exec(fileContent)) !== null) {
+    const importPath = match[1];
+
+    if (isAbsolute(importPath)) {
+      failures.push('Found absolute dynamic imports in definition file.');
+      continue;
+    }
+
+    // In case the dynamic import path starts with a dot, we know that this is a relative path
+    // and can ensure that the target path exists. Note that we cannot completely rely on
+    // "isAbsolute" because dynamic imports can also import from modules (e.g. "my-npm-module")
+    if (importPath.startsWith('.') && !existsSync(join(baseDir, `${importPath}.d.ts`))) {
+      failures.push('Found relative dynamic imports which do not exist.');
+    }
   }
 
   return failures;

--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -1,15 +1,13 @@
 import {existsSync, readFileSync} from 'fs';
 import {sync as glob} from 'glob';
 import {dirname, isAbsolute, join} from 'path';
+import * as ts from 'typescript';
 
 /** RegExp that matches Angular component inline styles that contain a sourcemap reference. */
 const inlineStylesSourcemapRegex = /styles: ?\[["'].*sourceMappingURL=.*["']/;
 
 /** RegExp that matches Angular component metadata properties that refer to external resources. */
 const externalReferencesRegex = /(templateUrl|styleUrls): *["'[]/;
-
-/** RegExp that matches TypeScript dynamic import statements. */
-const dynamicImportStatement = /import\(["'](.*)["']\)/g;
 
 /**
  * Checks the specified release bundle and ensures that it does not contain
@@ -32,7 +30,7 @@ export function checkReleaseBundle(bundlePath: string): string[] {
 
 /**
  * Checks the specified TypeScript definition file by ensuring it does not contain invalid
- * dynamic import statements. There can be invalid dynamic imports paths because we compose the
+ * dynamic import statements. There can be invalid type imports paths because we compose the
  * release package by moving things in a desired output structure. See Angular package format
  * specification and https://github.com/angular/material2/pull/12876
  */
@@ -41,25 +39,30 @@ export function checkTypeDefinitionFile(filePath: string): string[] {
   const fileContent = readFileSync(filePath, 'utf8');
   const failures = [];
 
-  let match: RegExpMatchArray;
+  const sourceFile = ts.createSourceFile(filePath, fileContent, ts.ScriptTarget.Latest, true);
+  const nodeQueue = [...sourceFile.getChildren()];
 
-  // Walk through each dynamic import and ensure that the import path is valid within the release
-  // output. Note that we don't want to enforce that there are no dynamic imports because type
-  // inference is heavily used within the schematics and is useful in some situations.
-  while ((match = dynamicImportStatement.exec(fileContent)) !== null) {
-    const importPath = match[1];
+  while (nodeQueue.length) {
+    const node = nodeQueue.shift()!;
 
-    if (isAbsolute(importPath)) {
-      failures.push('Found absolute dynamic imports in definition file.');
-      continue;
+    // Check all dynamic type imports and ensure that the import path is valid within the release
+    // output. Note that we don't want to enforce that there are no dynamic type imports because
+    // type inference is heavily used within the schematics and is useful in some situations.
+    if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) &&
+        ts.isStringLiteral(node.argument.literal)) {
+      const importPath = node.argument.literal.text;
+
+      // In case the type import path starts with a dot, we know that this is a relative path
+      // and can ensure that the target path exists. Note that we cannot completely rely on
+      // "isAbsolute" because dynamic imports can also import from modules (e.g. "my-npm-module")
+      if (importPath.startsWith('.') && !existsSync(join(baseDir, `${importPath}.d.ts`))) {
+        failures.push('Found relative type imports which do not exist.');
+      } else if (isAbsolute(importPath)) {
+        failures.push('Found absolute type imports in definition file.');
+      }
     }
 
-    // In case the dynamic import path starts with a dot, we know that this is a relative path
-    // and can ensure that the target path exists. Note that we cannot completely rely on
-    // "isAbsolute" because dynamic imports can also import from modules (e.g. "my-npm-module")
-    if (importPath.startsWith('.') && !existsSync(join(baseDir, `${importPath}.d.ts`))) {
-      failures.push('Found relative dynamic imports which do not exist.');
-    }
+    nodeQueue.push(...node.getChildren());
   }
 
   return failures;


### PR DESCRIPTION
**Note**: In a follow-up I want to wire up the release output validations as part of a CircleCI job. It just makes sense to keep all of these release output validations in the same place.

References https://github.com/angular/material2/issues/12877