### PR TITLE
fix(tooltip): afterHidden stream not being completed

### DIFF
--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -453,6 +453,24 @@ describe('MatTooltip', () => {
       } as AnimationEvent);
     }));
 
+    it('should complete the afterHidden stream when tooltip is destroyed', fakeAsync(() => {
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick(150);
+
+      const spy = jasmine.createSpy('complete spy');
+      const subscription = tooltipDirective._tooltipInstance!.afterHidden()
+          .subscribe(undefined, undefined, spy);
+
+      tooltipDirective.hide(0);
+      tick(0);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    }));
+
     it('should consistently position before and after overlay origin in ltr and rtl dir', () => {
       tooltipDirective.position = 'left';
       const leftOrigin = tooltipDirective._getOrigin().main;

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -528,7 +528,7 @@ export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
     'aria-hidden': 'true',
   }
 })
-export class TooltipComponent {
+export class TooltipComponent implements OnDestroy {
   /** Message to display in the tooltip */
   message: string;
 
@@ -609,6 +609,10 @@ export class TooltipComponent {
   /** Whether the tooltip is being displayed. */
   isVisible(): boolean {
     return this._visibility === 'visible';
+  }
+
+  ngOnDestroy() {
+    this._onHide.complete();
   }
 
   _animationStart() {


### PR DESCRIPTION
Fixes the `afterHidden` stream not being completed, which causes the host tooltip directive to accumulate subscriptions for every time it is opened, until the entire view is destroyed.