### PR TITLE
build: bazel repository changes not cached on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 # http://yaml-online-parser.appspot.com/
 
 var_1: &docker_image angular/ngcontainer:0.7.0
-var_2: &cache_key v2-ng-mat-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.7.0
+var_2: &cache_key v2-ng-mat-{{ checksum "WORKSPACE" }}-{{ checksum "yarn.lock" }}-0.7.0
 
 # Settings common to each job
 var_3: &job_defaults


### PR DESCRIPTION
Currently if we update the Bazel `WORKSPACE` and some external repositories have changed, CircleCI won't be able to cache the bazel repositories because the cache-key has not changed and saving will be skipped. We should make sure that the Bazel repositories will be cached properly because otherwise this can cause a significant slow-down with Bazel managed deps.

Additionally we no longer store the cache based on the current `branch` because that means that caching does not always work for pull requests. Since the caching only depends on two inputs (yarn.lock and WORKSPACE), it's safe to just remove the branch from the cache key.