### PR TITLE
fix(focus-trap): apply aria-hidden to focus trap tab anchors

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -101,6 +101,7 @@ describe('FocusTrap', () => {
       ) as HTMLElement[];
 
       expect(anchors.every(current => current.getAttribute('tabindex') === '0')).toBe(true);
+      expect(anchors.every(current => current.getAttribute('aria-hidden') === 'true')).toBe(true);
 
       fixture.componentInstance._isFocusTrapEnabled = false;
       fixture.detectChanges();

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -289,6 +289,7 @@ export class FocusTrap {
     this._toggleAnchorTabIndex(this._enabled, anchor);
     anchor.classList.add('cdk-visually-hidden');
     anchor.classList.add('cdk-focus-trap-anchor');
+    anchor.setAttribute('aria-hidden', 'true');
     return anchor;
   }
 


### PR DESCRIPTION
These anchors at the book ends of a FocusTrap'ed element have focus listeners that redirect focus
back to the element. However, some screen readers may access these focus traps without moving
programmatic focus, leaving the SR user wondering why an empty control lives on the page.  Android
TalkBack currently treats this as a stop with no announcement (because it has no content). Adding
the aria-hidden should prevent these from being accessed in SR contexts while preserving the core
functionality of redirecting focus when it's moved linearly (e.g., with tab).

cdk FocusTrap adds focus trap divs with tabindex=0 at the beginning and end of the trapped container to prevent focus from leaving when pressing tab or linearly navigating. When these elements are focused, a focus handler redirects the browser focus as to effectively cycle focus within an element. This works fine for e.g., OS X VoiceOver, which generally moves focus when navigating the page. However some screenreaders may routinely browse elements without moving focus. A notable example is TalkBack, which is one of Angular Material's supported environments https://github.com/angular/material2#browser-and-screen-reader-support. This is also true in some popular configurations of JAWS/NVDA.

Settings these to have aria-hidden=true will typically cause for SRs to ignore these when linearly navigating the page, if they're not already ignored.

I've tested a primitive version of this fix on TalkBack and it works well.

https://stackblitz.com/edit/angular-e9gqbr?file=app%2Fdialog-content-example.ts
https://www.youtube.com/watch?v=SN1chzTfvTs

I can imagine some rare edge cases where this could cause a regression in functionality. In cases where cdk FocusTrap is used but were relying on SRs to "see" the focus trap anchors and shift focus to them, so that the active focus handler would redirect focus, this may break things, and SRs may wrongly shift focus to a bad spot. However, doing it this way would have been extremely finicky in the first place. If you wanted SRs not to be able to escape the focus trap, you should have set aria-hidden on the rest of the page in the first place (MatDialog does this https://github.com/angular/material2/blob/d22f48c742c0bbdc971f79ea1261ec5c20d15a69/src/lib/dialog/dialog.ts#L345, and individual application code may wrap cdk Overlay to do this; it's a bit of a mystery to me why cdk Overlay or cdk FocusTrap doesn't do this itself, but that's a separate concern). Such a page would have been a pain for SRs in the first place since heading and landmark navigation, common SR navigation techniques, could easily have shifted focus to the underlying page anyway. These users should be encouraged to apply aria-hidden appropriately. That said, we have tested this on the following SRs on the latest versions and things appear to be no worse:

Android TalkBack - my fix should address the hidden SR stop
NVDA/JAWS with virtual cursor - similar fix, but virtual cursor configuration varies greatly among users; generally, the hidden tab stops aren't problematic
OS X VO - always ignored the empty tabindex=0 anchors anyway

Internal bug reference b/122041252.