### PR TITLE
refactor(drag-drop): clean up DragRef public API

### DIFF
--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Optional, Input} from '@angular/core';
+import {Directive, ElementRef, Inject, Optional, Input, OnDestroy} from '@angular/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Subject} from 'rxjs';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {toggleNativeDragInteractions} from '../drag-styling';
 
@@ -18,15 +19,19 @@ import {toggleNativeDragInteractions} from '../drag-styling';
     'class': 'cdk-drag-handle'
   }
 })
-export class CdkDragHandle {
+export class CdkDragHandle implements OnDestroy {
   /** Closest parent draggable instance. */
   _parentDrag: {} | undefined;
+
+  /** Emits when the state of the handle has changed. */
+  _stateChanges = new Subject<CdkDragHandle>();
 
   /** Whether starting to drag through this handle is disabled. */
   @Input('cdkDragHandleDisabled')
   get disabled(): boolean { return this._disabled; }
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
+    this._stateChanges.next(this);
   }
   private _disabled = false;
 
@@ -36,5 +41,9 @@ export class CdkDragHandle {
 
     this._parentDrag = parentDrag;
     toggleNativeDragInteractions(element.nativeElement, false);
+  }
+
+  ngOnDestroy() {
+    this._stateChanges.complete();
   }
 }

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -147,10 +147,7 @@ export class DropListRef<T = any> {
    */
   private _previousSwap = {drag: null as DragRef | null, delta: 0};
 
-  /**
-   * Draggable items in the container.
-   * TODO(crisbeto): support arrays.
-   */
+  /** Draggable items in the container. */
   private _draggables: DragRef[];
 
   private _siblings: DropListRef[] = [];

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -62,11 +62,13 @@ export interface CdkDragExit<T = any, I = T> {
     item: CdkDrag<I>;
 }
 
-export declare class CdkDragHandle {
+export declare class CdkDragHandle implements OnDestroy {
     _parentDrag: {} | undefined;
+    _stateChanges: Subject<CdkDragHandle>;
     disabled: boolean;
     element: ElementRef<HTMLElement>;
     constructor(element: ElementRef<HTMLElement>, parentDrag?: any);
+    ngOnDestroy(): void;
 }
 
 export interface CdkDragMove<T = any> {


### PR DESCRIPTION
Cleans up the API of the DragRef before we can expose it through the public API by making the handle, custom placeholder and custom preview easier to configure.

**Note:** marking as merge safe, because all of the public API signature changes are to classes that haven't been exposed yet.