### PR TITLE
fix(overlay): reset transform when disposing of position strategy

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -158,7 +158,9 @@ describe('FlexibleConnectedPositionStrategy', () => {
           overlayX: 'start',
           overlayY: 'top',
           originX: 'start',
-          originY: 'bottom'
+          originY: 'bottom',
+          offsetX: 10,
+          offsetY: 20
         }]);
 
     // Needs to be in the DOM for IE not to throw an "Unspecified error".
@@ -185,6 +187,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     expect(pane.style.left).toBeFalsy();
     expect(pane.style.right).toBeFalsy();
     expect(pane.style.position).toBeFalsy();
+    expect(pane.style.transform).toBeFalsy();
 
     overlayRef.dispose();
     document.body.removeChild(origin);

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -857,6 +857,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       bottom: '',
       right: '',
       position: '',
+      transform: '',
     } as CSSStyleDeclaration);
   }
 


### PR DESCRIPTION
Fixes the `transform` value not being reset when a flexible position strategy is disposed.

Fixes #14657.