### PR TITLE
perf(scrolling): avoid hitting change detection of virtual scroll size changes

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.html
+++ b/src/cdk/scrolling/virtual-scroll-viewport.html
@@ -9,4 +9,4 @@
   Spacer used to force the scrolling container to the correct size for the *total* number of items
   so that the scrollbar captures the size of the entire data set.
 -->
-<div class="cdk-virtual-scroll-spacer" [style.transform]="_totalContentSizeTransform"></div>
+<div #scrollSpacer class="cdk-virtual-scroll-spacer"></div>

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -78,14 +78,11 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** The element that wraps the rendered content. */
   @ViewChild('contentWrapper') _contentWrapper: ElementRef<HTMLElement>;
 
+  /** Spacer used to force the scrolling container to the correct size. */
+  @ViewChild('scrollSpacer') _scrollSpacer: ElementRef<HTMLElement>;
+
   /** A stream that emits whenever the rendered range changes. */
   renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();
-
-  /**
-   * The transform used to scale the spacer to the same size as all content, including content that
-   * is not currently rendered.
-   */
-  _totalContentSizeTransform = '';
 
   /**
    * The total size of all content (in pixels), including content that is not currently rendered.
@@ -231,8 +228,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     if (this._totalContentSize !== size) {
       this._totalContentSize = size;
       const axis = this.orientation == 'horizontal' ? 'X' : 'Y';
-      this._totalContentSizeTransform = `scale${axis}(${this._totalContentSize})`;
-      this._markChangeDetectionNeeded();
+      this._scrollSpacer.nativeElement.style.transform = `scale${axis}(${this._totalContentSize})`;
     }
   }
 

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -90,7 +90,7 @@ export declare type CdkVirtualForOfContext<T> = {
 
 export declare class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
     _contentWrapper: ElementRef<HTMLElement>;
-    _totalContentSizeTransform: string;
+    _scrollSpacer: ElementRef<HTMLElement>;
     elementRef: ElementRef<HTMLElement>;
     orientation: 'horizontal' | 'vertical';
     renderedRangeStream: Observable<ListRange>;


### PR DESCRIPTION
Avoids having to go through change detection to set the total content size of the virtual scroll viewport. Since we always have a hold of the element and we already do our own change detection internally, there isn't much benefit to having this expression go through Angular's change detection.