### PR TITLE
fix(overlay): not sizing flexible overlay correctly when opening downwards on a scrollable page

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1777,6 +1777,47 @@ describe('FlexibleConnectedPositionStrategy', () => {
       document.body.removeChild(veryLargeElement);
     });
 
+    it('should size the bounding box correctly when opening downwards on a scrolled page', () => {
+      const viewportMargin = 10;
+      const veryLargeElement: HTMLElement = document.createElement('div');
+      veryLargeElement.style.width = '4000px';
+      veryLargeElement.style.height = '4000px';
+      document.body.appendChild(veryLargeElement);
+      window.scroll(2100, 2100);
+
+      originElement.style.position = 'fixed';
+      originElement.style.top = '100px';
+      originElement.style.left = '200px';
+
+      positionStrategy
+        .withFlexibleDimensions()
+        .withPush(false)
+        .withViewportMargin(viewportMargin)
+        .withPositions([{
+          overlayY: 'top',
+          overlayX: 'start',
+          originY: 'bottom',
+          originX: 'start'
+        }]);
+
+      attachOverlay({positionStrategy});
+
+      const boundingBox = overlayContainer
+        .getContainerElement()
+        .querySelector('.cdk-overlay-connected-position-bounding-box') as HTMLElement;
+
+      // Use the `documentElement` here to determine the viewport
+      // height since it's what is used by the overlay.
+      const viewportHeight = document.documentElement!.clientHeight - (2 * viewportMargin);
+      const originRect = originElement.getBoundingClientRect();
+      const boundingBoxRect = boundingBox.getBoundingClientRect();
+
+      expect(Math.floor(boundingBoxRect.height))
+          .toBe(Math.floor(viewportHeight - originRect.bottom + viewportMargin));
+
+      window.scroll(0, 0);
+      document.body.removeChild(veryLargeElement);
+    });
 
   });
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -711,7 +711,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     if (position.overlayY === 'top') {
       // Overlay is opening "downward" and thus is bound by the bottom viewport edge.
       top = origin.y;
-      height = viewport.bottom - origin.y;
+      height = viewport.height - top + this._viewportMargin;
     } else if (position.overlayY === 'bottom') {
       // Overlay is opening "upward" and thus is bound by the top viewport edge. We need to add
       // the viewport margin back in, because the viewport rect is narrowed down to remove the


### PR DESCRIPTION
Fixes the height of the bounding box being incorrect, if the overlay is flexible, is opening downwards and the page is scrollable.

For reference, note the red bounding box from the demo app:
![angular_material_-_google_chrome_2018-12-29_11-09-13](https://user-images.githubusercontent.com/4450522/50537024-97535700-0b63-11e9-80ab-ca75d4937ed0.png)
