### PR TITLE
docs(snack-bar): fix 404 for CSS files in examples

### DIFF
--- a/src/material-examples/snack-bar-component/snack-bar-component-example.css
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/material-examples/snack-bar-component/snack-bar-component-example.ts
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example.ts
@@ -7,9 +7,10 @@ import {MatSnackBar} from '@angular/material';
 @Component({
   selector: 'snack-bar-component-example',
   templateUrl: 'snack-bar-component-example.html',
+  styleUrls: ['snack-bar-component-example.css'],
 })
 export class SnackBarComponentExample {
-  constructor(public snackBar: MatSnackBar) {}
+  constructor(private snackBar: MatSnackBar) {}
 
   openSnackBar() {
     this.snackBar.openFromComponent(PizzaPartyComponent, {

--- a/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
+++ b/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
@@ -10,7 +10,7 @@ import {MatSnackBar} from '@angular/material';
   styleUrls: ['snack-bar-overview-example.css'],
 })
 export class SnackBarOverviewExample {
-  constructor(public snackBar: MatSnackBar) {}
+  constructor(private snackBar: MatSnackBar) {}
 
   openSnackBar(message: string, action: string) {
     this.snackBar.open(message, action, {

--- a/src/material-examples/snack-bar-position/snack-bar-position-example.css
+++ b/src/material-examples/snack-bar-position/snack-bar-position-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/material-examples/snack-bar-position/snack-bar-position-example.ts
+++ b/src/material-examples/snack-bar-position/snack-bar-position-example.ts
@@ -11,13 +11,14 @@ import {
 @Component({
   selector: 'snack-bar-position-example',
   templateUrl: 'snack-bar-position-example.html',
+  styleUrls: ['snack-bar-position-example.css'],
 })
 export class SnackBarPositionExample {
 
   horizontalPosition: MatSnackBarHorizontalPosition = 'start';
   verticalPosition: MatSnackBarVerticalPosition = 'bottom';
 
-  constructor(public snackBar: MatSnackBar) {}
+  constructor(private snackBar: MatSnackBar) {}
 
   openSnackBar() {
     this.snackBar.open('Canonball!!', 'End now', {


### PR DESCRIPTION
Fixes a couple of the live examples causing a 404 if the user goes to look at their CSS.

Fixes #14682.