### PR TITLE
fix(datepicker): native date adapter not preserving time when cloning

### DIFF
--- a/src/lib/core/datetime/native-date-adapter.spec.ts
+++ b/src/lib/core/datetime/native-date-adapter.spec.ts
@@ -290,6 +290,12 @@ describe('NativeDateAdapter', () => {
     expect(adapter.clone(date)).not.toBe(date);
   });
 
+  it('should preserve time when cloning', () => {
+    let date = new Date(2017, JAN, 1, 4, 5, 6);
+    expect(adapter.clone(date)).toEqual(date);
+    expect(adapter.clone(date)).not.toBe(date);
+  });
+
   it('should compare dates', () => {
     expect(adapter.compareDate(new Date(2017, JAN, 1), new Date(2017, JAN, 2))).toBeLessThan(0);
     expect(adapter.compareDate(new Date(2017, JAN, 1), new Date(2017, FEB, 1))).toBeLessThan(0);

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -146,7 +146,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   }
 
   clone(date: Date): Date {
-    return this.createDate(this.getYear(date), this.getMonth(date), this.getDate(date));
+    return new Date(date.getTime());
   }
 
   createDate(year: number, month: number, date: number): Date {


### PR DESCRIPTION
When the `NativeDateAdapter` clones a date, it creates the clone only from the year, month and day which means that the clone's time will be different from the source.