### PR TITLE
fix(list): action list button outline not being reset on firefox

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -269,13 +269,18 @@ $mat-list-item-inset-divider-offset: 72px;
 }
 
 mat-action-list {
-  //remove the native button look and make it look like a list item
+  // Remove the native button look and make it look like a list item
   button {
     background: none;
     color: inherit;
     border: none;
     font: inherit;
     outline: inherit;
+    -webkit-tap-highlight-color: transparent;
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
   }
 
   .mat-list-item {


### PR DESCRIPTION
Fixes the extra focus outline that Firefox adds to buttons not being reset for the action list items.

For reference:
![angular_material_-_mozilla_firefox_2019-01-01_21-38-37](https://user-images.githubusercontent.com/4450522/50575828-f4723580-0e0d-11e9-8401-6a20faa77ee8.png)
