### PR TITLE
fix(drag-drop): incorrectly preserving transform if root element changes

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -490,6 +490,26 @@ describe('CdkDrag', () => {
       expect(dragElement.style.transform).toBeFalsy();
     }));
 
+    it('should preserve the initial transform if the root element changes', fakeAsync(() => {
+      const fixture = createComponent(DraggableWithAlternateRoot);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const alternateRoot = fixture.componentInstance.dragRoot.nativeElement;
+
+      dragElement.style.transform = 'translateX(-50%)';
+      dragElementViaMouse(fixture, dragElement, 50, 100);
+      expect(dragElement.style.transform).toContain('translateX(-50%)');
+
+      alternateRoot.style.transform = 'scale(2)';
+      fixture.componentInstance.rootElementSelector = '.alternate-root';
+      fixture.detectChanges();
+
+      dragElementViaMouse(fixture, alternateRoot, 50, 100);
+
+      expect(alternateRoot.style.transform).not.toContain('translateX(-50%)');
+      expect(alternateRoot.style.transform).toContain('scale(2)');
+    }));
+
     it('should handle the root element selector changing after init', fakeAsync(() => {
       const fixture = createComponent(DraggableWithAlternateRoot);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -330,6 +330,7 @@ export class DragRef<T = any> {
 
       element.addEventListener('mousedown', this._pointerDown, activeEventListenerOptions);
       element.addEventListener('touchstart', this._pointerDown, passiveEventListenerOptions);
+      this._initialTransform = undefined;
       this._rootElement = element;
     }
 


### PR DESCRIPTION
Currently we cache the element's initial transform so that we can preserve it after the user has dragged it, however if the root element changes, the cached value will be incorrect. These changes reset the cached value if the root element changes.