### PR TITLE
fix(drag-drop): restore initial transform when resetting

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -578,6 +578,20 @@ describe('CdkDrag', () => {
       expect(dragElement.style.transform).toBeFalsy();
     }));
 
+    it('should preserve initial transform after resetting', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      dragElement.style.transform = 'scale(2)';
+
+      dragElementViaMouse(fixture, dragElement, 50, 100);
+      expect(dragElement.style.transform).toBe('scale(2) translate3d(50px, 100px, 0px)');
+
+      fixture.componentInstance.dragInstance.reset();
+      expect(dragElement.style.transform).toBe('scale(2)');
+    }));
+
     it('should start dragging an item from its initial position after a reset', fakeAsync(() => {
       const fixture = createComponent(StandaloneDraggable);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -381,7 +381,7 @@ export class DragRef<T = any> {
 
   /** Resets a standalone drag item to its initial position. */
   reset(): void {
-    this._rootElement.style.transform = '';
+    this._rootElement.style.transform = this._initialTransform || '';
     this._activeTransform = {x: 0, y: 0};
     this._passiveTransform = {x: 0, y: 0};
   }


### PR DESCRIPTION
Currently we preserve the any `transform` that an element might have had before the user started dragging it, however that `transform` is lost if it's position is reset via the `DragRef.reset` method. These changes reset the `transform` back to its initial value.