### PR TITLE
build: do not run docs-package targets on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - *restore_cache
       - *copy_bazel_config
 
-      - run: bazel build src/...
+      - run: bazel build src/... --build_tag_filters=-docs-package
       - run: bazel test src/...
 
       # Note: We want to save the cache in this job because the workspace cache also

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -31,4 +31,5 @@ dgeni_api_docs(
     "cdk": CDK_PACKAGES,
     "material": MATERIAL_PACKAGES,
   },
+  tags = ["docs-package"],
 )

--- a/src/material-examples/BUILD.bazel
+++ b/src/material-examples/BUILD.bazel
@@ -24,12 +24,13 @@ ng_module(
 
 filegroup(
   name = "example-source-files",
-  srcs = glob(["*/*.html", "*/*.css", "*/*.ts"])
+  srcs = glob(["*/*.html", "*/*.css", "*/*.ts"]),
 )
 
 highlight_files(
   name = "highlighted-source-files",
-  srcs = [":example-source-files"]
+  srcs = [":example-source-files"],
+  tags = ["docs-package"],
 )
 
 package_docs_content(
@@ -53,7 +54,8 @@ package_docs_content(
 
     # Package the API docs for the Material and CDK package into the docs-content
     "//src:api-docs": "api-docs",
-  }
+  },
+  tags = ["docs-package"],
 )
 
 ng_package(
@@ -63,8 +65,7 @@ ng_package(
   globals = ROLLUP_GLOBALS,
   deps = [":examples"],
   data = [":docs-content"],
-  # TODO(devversion): re-enable once we have set up the proper compiler for the ng_package
-  tags = ["manual"],
+  tags = ["docs-package"],
 )
 
 genrule(


### PR DESCRIPTION
* No longer runs expensive `docs-package` Bazel targets as part of the `bazel_build_test` job. These docs-package targets will be built as part of the `publish_snapshots` job where we build the docs-package and push it to the Github `material2-docs-content` repository.