### PR TITLE
build: do not load tslib and moment twice in tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = config => {
     ],
     files: [
       {pattern: 'node_modules/core-js/client/core.min.js', included: true, watched: false},
-      {pattern: 'node_modules/tslib/tslib.js', included: true, watched: false},
+      {pattern: 'node_modules/tslib/tslib.js', included: false, watched: false},
       {pattern: 'node_modules/systemjs/dist/system.js', included: true, watched: false},
       {pattern: 'node_modules/zone.js/dist/zone.min.js', included: true, watched: false},
       {pattern: 'node_modules/zone.js/dist/proxy.min.js', included: true, watched: false},
@@ -24,7 +24,7 @@ module.exports = config => {
       {pattern: 'node_modules/zone.js/dist/async-test.js', included: true, watched: false},
       {pattern: 'node_modules/zone.js/dist/fake-async-test.js', included: true, watched: false},
       {pattern: 'node_modules/hammerjs/hammer.min.js', included: true, watched: false},
-      {pattern: 'node_modules/moment/min/moment-with-locales.min.js', included: true, watched: false},
+      {pattern: 'node_modules/moment/min/moment-with-locales.min.js', included: false, watched: false},
 
       // Include all Angular dependencies
       {pattern: 'node_modules/@angular/**/*', included: false, watched: false},


### PR DESCRIPTION
SystemJS is responsible for loading `tslib` and `moment` as registered AMD modules. This means that we don't need to include them in Karma as well.

Currently the browsers fetches Moment and tslib twice and also runs it without having any necessary effect.