### PR TITLE
fix(sort): extra Firefox focus outline not being reset

### DIFF
--- a/src/lib/sort/sort-header.scss
+++ b/src/lib/sort/sort-header.scss
@@ -31,6 +31,13 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
   outline: 0;
   font: inherit;
   color: currentColor;
+
+  // The `outline: 0` from above works on all browsers, however Firefox also
+  // adds a special `focus-inner` which we have to disable explicitly. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Firefox
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
 .mat-sort-header-arrow {


### PR DESCRIPTION
Fixes the extra outline that Firefox adds to focusable buttons not being reset for the sort header buttons.

For reference:
![angular_material_-_mozilla_firefox_2019-01-05_16-09-00](https://user-images.githubusercontent.com/4450522/50725357-0a7d4000-1105-11e9-8661-6688e0ce5bff.png)
