### PR TITLE
Adding a forgotten markForCheck in mat-chip-list

### DIFF
--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -362,7 +362,10 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     // it back to the first chip when the user tabs out.
     this._keyManager.tabOut.pipe(takeUntil(this._destroyed)).subscribe(() => {
       this._tabIndex = -1;
-      setTimeout(() => this._tabIndex = this._userTabIndex || 0);
+      setTimeout(() => {
+        this._tabIndex = this._userTabIndex || 0;
+        this._changeDetectorRef.markForCheck();
+      });
     });
 
     // When the list changes, re-subscribe


### PR DESCRIPTION
This issue causes forward tab navigation to be not the same as backward navigation.

In our use case, component sets tabIndex=-1, and goes into the setTimeout, and sets the tabIndex=0. But the update to 0 doesn't get reflected. This is an OnPush component, and the view would not be updated in this case since _tabIndex is not @Input()

@jelbourn has some context into this issue