### PR TITLE
fix(table): data can be sorted by the value of objects in properties.

### DIFF
--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -98,6 +98,19 @@ export class MatTableDataSource<T> extends DataSource<T> {
   private _paginator: MatPaginator|null;
 
   /**
+   * This function can match the data not only value in properties. 
+   * Moreover, the value of objects in properties can aslo be used.
+   * (e.g. column Abc.Xyz represents data['Abc']['Xyz'])
+   * @param data Data object that is being accessed.
+   * @param path The property of the nestedObj.
+   */
+  getNestedObject: ((nestedObj: any, path: string) => string | number) =
+    (nestedObj: any, path: string): string | number => {
+      return path.split('.').reduce((obj, key) =>
+        (obj && obj[key] !== 'undefined') ? obj[key] : undefined, nestedObj);
+  }
+  
+  /**
    * Data accessor function that is used for accessing data properties for sorting through
    * the default sortData function.
    * This default function assumes that the sort header IDs (which defaults to the column name)
@@ -108,7 +121,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
    */
   sortingDataAccessor: ((data: T, sortHeaderId: string) => string|number) =
       (data: T, sortHeaderId: string): string|number => {
-    const value = (data as {[key: string]: any})[sortHeaderId];
+    const value = this.getNestedObject(data as { [key: string]: any }, sortHeaderId);
 
     if (_isNumberValue(value)) {
       const numberValue = Number(value);

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -121,7 +121,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
    */
   sortingDataAccessor: ((data: T, sortHeaderId: string) => string|number) =
       (data: T, sortHeaderId: string): string|number => {
-    const value = this.getNestedObject(data as { [key: string]: any }, sortHeaderId);
+    const value = this.getNestedObject(data as {[key: string]: any}, sortHeaderId);
 
     if (_isNumberValue(value)) {
       const numberValue = Number(value);

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -98,7 +98,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
   private _paginator: MatPaginator|null;
 
   /**
-   * This function can match the data not only value in properties. 
+   * This function can match the data not only value in properties.
    * Moreover, the value of objects in properties can aslo be used.
    * (e.g. column Abc.Xyz represents data['Abc']['Xyz'])
    * @param data Data object that is being accessed.
@@ -109,7 +109,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
       return path.split('.').reduce((obj, key) =>
         (obj && obj[key] !== 'undefined') ? obj[key] : undefined, nestedObj);
   }
-  
+
   /**
    * Data accessor function that is used for accessing data properties for sorting through
    * the default sortData function.


### PR DESCRIPTION
fixes the column sort when the column is used the value in objects in the data.
In general, column 'Xyz' represents data['Xyz'].
I want to make column 'Xyz.Abc' represents data['Xyz'][Abc], that is more flexible, but "sortingDataAccessor" is not work!!
After adding codes above, it work pretty good~

![image](https://user-images.githubusercontent.com/35286773/50900470-3f183100-1450-11e9-9541-71121edf193f.png)
