### PR TITLE
test(overlay): block scroll strategy testing styles leaking into other tests

### DIFF
--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -122,6 +122,9 @@ describe('BlockScrollStrategy', () => {
 
     expect(root.style.top).toBe('13px');
     expect(root.style.left).toBe('37px');
+
+    root.style.top = '';
+    root.style.left = '';
   }));
 
   it(`should't do anything if the page isn't scrollable`, skipIOS(() => {


### PR DESCRIPTION
Fixes some styles that are assigned to the `html` node not being reset after the test is done.