### PR TITLE
fix(tabs): better handling of animationDuration without units

### DIFF
--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -622,7 +622,7 @@ describe('nested MatTabGroup with enabled animations', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTabsModule, BrowserAnimationsModule],
-      declarations: [NestedTabs]
+      declarations: [NestedTabs, TabsWithCustomAnimationDuration]
     });
 
     TestBed.compileComponents();
@@ -631,6 +631,14 @@ describe('nested MatTabGroup with enabled animations', () => {
   it('should not throw when creating a component with nested tab groups', fakeAsync(() => {
     expect(() => {
       let fixture = TestBed.createComponent(NestedTabs);
+      fixture.detectChanges();
+      tick();
+    }).not.toThrow();
+  }));
+
+  it('should not throw when setting an animationDuration without units', fakeAsync(() => {
+    expect(() => {
+      let fixture = TestBed.createComponent(TabsWithCustomAnimationDuration);
       fixture.detectChanges();
       tick();
     }).not.toThrow();
@@ -861,3 +869,14 @@ class TabGroupWithAriaInputs {
 })
 class TabGroupWithIsActiveBinding {
 }
+
+
+@Component({
+  template: `
+    <mat-tab-group animationDuration="500">
+      <mat-tab label="One">Tab one content</mat-tab>
+      <mat-tab label="Two">Tab two content</mat-tab>
+    </mat-tab-group>
+  `,
+})
+class TabsWithCustomAnimationDuration {}

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -129,8 +129,13 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   /** Position of the tab header. */
   @Input() headerPosition: MatTabHeaderPosition = 'above';
 
-  /** Duration for the tab animation. Must be a valid CSS value (e.g. 600ms). */
-  @Input() animationDuration: string;
+  /** Duration for the tab animation. Will be normalized to milliseconds if no units are set. */
+  @Input()
+  get animationDuration(): string { return this._animationDuration; }
+  set animationDuration(value: string) {
+    this._animationDuration = /^\d+$/.test(value) ? value + 'ms' : value;
+  }
+  private _animationDuration: string;
 
   /** Background color of the tab group. */
   @Input()


### PR DESCRIPTION
Based off of the discussions on #13428. Handles values passed to `animationDuration` that don't have units, rather than allowing them to continue through to  the `BrowserAnimationsModule` and to throw an error.