### PR TITLE
Build/filter docs package targets for bazel test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - *copy_bazel_config
 
       - run: bazel build src/... --build_tag_filters=-docs-package
-      - run: bazel test src/...
+      - run: bazel test src/... --build_tag_filters=-docs-package
 
       # Note: We want to save the cache in this job because the workspace cache also
       # includes the Bazel repository cache that will be updated in this job.


### PR DESCRIPTION
* https://github.com/angular/material2/commit/74c7681957c47d285e945e83ffb86602ee07cfa1 should have already disabled all `docs-package` targets on the CI, but apparently `bazel test` also builds targets which aren't even tests, so we need to filter `bazel test` as well.