### PR TITLE
fix(icon): clean up cached references in icon registry on destroy

### DIFF
--- a/src/lib/icon/icon-registry.ts
+++ b/src/lib/icon/icon-registry.ts
@@ -15,6 +15,7 @@ import {
   Optional,
   SecurityContext,
   SkipSelf,
+  OnDestroy,
 } from '@angular/core';
 import {DomSanitizer, SafeResourceUrl, SafeHtml} from '@angular/platform-browser';
 import {forkJoin, Observable, of as observableOf, throwError as observableThrow} from 'rxjs';
@@ -93,7 +94,7 @@ class SvgIconConfig {
  * - Loads icons from URLs and extracts individual icons from icon sets.
  */
 @Injectable({providedIn: 'root'})
-export class MatIconRegistry {
+export class MatIconRegistry implements OnDestroy {
   private _document: Document;
 
   /**
@@ -308,6 +309,12 @@ export class MatIconRegistry {
     }
 
     return observableThrow(getMatIconNameNotFoundError(key));
+  }
+
+  ngOnDestroy() {
+   this._svgIconConfigs.clear();
+   this._iconSetConfigs.clear();
+   this._cachedIconsByUrl.clear();
   }
 
   /**

--- a/tools/public_api_guard/lib/icon.d.ts
+++ b/tools/public_api_guard/lib/icon.d.ts
@@ -45,7 +45,7 @@ export interface MatIconLocation {
 export declare class MatIconModule {
 }
 
-export declare class MatIconRegistry {
+export declare class MatIconRegistry implements OnDestroy {
     constructor(_httpClient: HttpClient, _sanitizer: DomSanitizer, document: any);
     addSvgIcon(iconName: string, url: SafeResourceUrl): this;
     addSvgIconInNamespace(namespace: string, iconName: string, url: SafeResourceUrl): this;
@@ -59,6 +59,7 @@ export declare class MatIconRegistry {
     getDefaultFontSetClass(): string;
     getNamedSvgIcon(name: string, namespace?: string): Observable<SVGElement>;
     getSvgIconFromUrl(safeUrl: SafeResourceUrl): Observable<SVGElement>;
+    ngOnDestroy(): void;
     registerFontClassAlias(alias: string, className?: string): this;
     setDefaultFontSetClass(className: string): this;
 }


### PR DESCRIPTION
The icon registry can end up caching some fairly large SVG elements which may end up being retained, because we're using a regular `Map`. These changes clear out all the references if the registry is destroyed.