### PR TITLE
refactor(list): refactor component inputs

### DIFF
--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -272,7 +272,7 @@ export class MatListOption extends _MatListOptionMixinBase
   moduleId: module.id,
   selector: 'mat-selection-list',
   exportAs: 'matSelectionList',
-  inputs: ['disabled', 'disableRipple', 'tabIndex'],
+  inputs: ['disableRipple'],
   host: {
     'role': 'listbox',
     '[tabIndex]': 'tabIndex',


### PR DESCRIPTION
* remove `disabled` and `tabIndex` from `MatSelectionList` array
  of inputs. `disabled` and `tabIndex` properties of the component
  are already decorated with `@Input()` decorator