### PR TITLE
refactor(paginator): remove extra exposed properties

### DIFF
--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -93,7 +93,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     this._pageIndex = Math.max(coerceNumberProperty(value), 0);
     this._changeDetectorRef.markForCheck();
   }
-  _pageIndex: number = 0;
+  private _pageIndex = 0;
 
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
   @Input()
@@ -102,7 +102,7 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     this._length = coerceNumberProperty(value);
     this._changeDetectorRef.markForCheck();
   }
-  _length: number = 0;
+  private _length = 0;
 
   /** Number of items to display on a page. By default set to 50. */
   @Input()

--- a/tools/public_api_guard/lib/paginator.d.ts
+++ b/tools/public_api_guard/lib/paginator.d.ts
@@ -11,8 +11,6 @@ export declare function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPagin
 export declare class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
     _displayedPageSizeOptions: number[];
     _intl: MatPaginatorIntl;
-    _length: number;
-    _pageIndex: number;
     color: ThemePalette;
     hidePageSize: boolean;
     length: number;


### PR DESCRIPTION
Makes the `_pageIndex` and `_length` properties private so they don't pollute the public API and because they already have public getters.