### PR TITLE
feat(dialog): Add an option to provide a default dialog result

### DIFF
--- a/src/dev-app/dialog/dialog-demo.html
+++ b/src/dev-app/dialog/dialog-demo.html
@@ -103,6 +103,13 @@
     </p>
 
     <p>
+      <mat-form-field>
+        <mat-label>Default result</mat-label>
+        <input matInput [(ngModel)]="config.data.defaultResult">
+      </mat-form-field>
+    </p>
+
+    <p>
       <mat-checkbox [(ngModel)]="config.disableClose">Disable close</mat-checkbox>
     </p>
   </mat-card-content>

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -42,7 +42,8 @@ export class DialogDemo {
       right: ''
     },
     data: {
-      message: 'Jazzy jazz jazz'
+      message: 'Jazzy jazz jazz',
+      defaultResult: undefined
     }
   };
   numTemplateOpens = 0;
@@ -112,7 +113,9 @@ export class JazzDialog {
 
   constructor(
     public dialogRef: MatDialogRef<JazzDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: any) { }
+    @Inject(MAT_DIALOG_DATA) public data: any) {
+    this.dialogRef.setDefaultResult(data.defaultResult);
+  }
 
   togglePosition(): void {
     this._dimesionToggle = !this._dimesionToggle;

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -31,7 +31,7 @@ export interface DialogPosition {
 /**
  * Configuration for opening a modal dialog with the MatDialog service.
  */
-export class MatDialogConfig<D = any> {
+export class MatDialogConfig<D = any, R = any> {
 
   /**
    * Where the attached component should live in Angular's *logical* component tree.
@@ -82,6 +82,9 @@ export class MatDialogConfig<D = any> {
 
   /** Data being injected into the child component. */
   data?: D | null = null;
+
+  /** A default result to be returned by the dialog if it gets closed without an explicit result. */
+  defaultResult?: R;
 
   /** Layout direction for the dialog's content. */
   direction?: Direction;

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -247,6 +247,53 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should return the default result set in the dialog ref', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {
+      viewContainerRef: testViewContainerRef
+    }).setDefaultResult('default');
+
+    const afterClosedHandler = jasmine.createSpy('afterClosed callback');
+    dialogRef.afterClosed().subscribe(afterClosedHandler);
+
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(afterClosedHandler).toHaveBeenCalledWith('default');
+  }));
+
+  it('should return the default result set in the dialog config', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {
+      viewContainerRef: testViewContainerRef,
+      defaultResult: 'default'
+    });
+
+    const afterClosedHandler = jasmine.createSpy('afterClosed callback');
+    dialogRef.afterClosed().subscribe(afterClosedHandler);
+
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(afterClosedHandler).toHaveBeenCalledWith('default');
+  }));
+
+  it('should return the correct default result when both are set', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {
+      viewContainerRef: testViewContainerRef,
+      defaultResult: 'defaultInConfig'
+    }).setDefaultResult('defaultInDialog');
+
+    const afterClosedHandler = jasmine.createSpy('afterClosed callback');
+    dialogRef.afterClosed().subscribe(afterClosedHandler);
+
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(afterClosedHandler).toHaveBeenCalledWith('defaultInConfig');
+  }));
+
   it('should close from a ViewContainerRef with OnPush change detection', fakeAsync(() => {
     const onPushFixture = TestBed.createComponent(ComponentWithOnPushViewContainer);
 

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -125,7 +125,7 @@ export class MatDialog implements OnDestroy {
    * @returns Reference to the newly-opened dialog.
    */
   open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig<D>): MatDialogRef<T, R> {
+          config?: MatDialogConfig<D, R>): MatDialogRef<T, R> {
 
     config = _applyConfigDefaults(config, this._defaultOptions || new MatDialogConfig());
 

--- a/tools/public_api_guard/lib/dialog.d.ts
+++ b/tools/public_api_guard/lib/dialog.d.ts
@@ -9,7 +9,7 @@ export declare type DialogRole = 'dialog' | 'alertdialog';
 
 export declare const MAT_DIALOG_DATA: InjectionToken<any>;
 
-export declare const MAT_DIALOG_DEFAULT_OPTIONS: InjectionToken<MatDialogConfig<any>>;
+export declare const MAT_DIALOG_DEFAULT_OPTIONS: InjectionToken<MatDialogConfig<any, any>>;
 
 export declare const MAT_DIALOG_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
@@ -33,7 +33,7 @@ export declare class MatDialog implements OnDestroy {
     closeAll(): void;
     getDialogById(id: string): MatDialogRef<any> | undefined;
     ngOnDestroy(): void;
-    open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+    open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>, config?: MatDialogConfig<D, R>): MatDialogRef<T, R>;
 }
 
 export declare class MatDialogActions {
@@ -54,13 +54,14 @@ export declare class MatDialogClose implements OnInit, OnChanges {
     ngOnInit(): void;
 }
 
-export declare class MatDialogConfig<D = any> {
+export declare class MatDialogConfig<D = any, R = any> {
     ariaDescribedBy?: string | null;
     ariaLabel?: string | null;
     autoFocus?: boolean;
     backdropClass?: string;
     closeOnNavigation?: boolean;
     data?: D | null;
+    defaultResult?: R;
     direction?: Direction;
     disableClose?: boolean;
     hasBackdrop?: boolean;
@@ -117,6 +118,7 @@ export declare class MatDialogRef<T, R = any> {
     close(dialogResult?: R): void;
     keydownEvents(): Observable<KeyboardEvent>;
     removePanelClass(classes: string | string[]): this;
+    setDefaultResult(defaultResult: R): this;
     updatePosition(position?: DialogPosition): this;
     updateSize(width?: string, height?: string): this;
 }


### PR DESCRIPTION
Provide the option to use a default value as the dialog result when close() gets called without parameters. This can be useful when a dialog is expected to return a result when it gets closed via escape or a backdrop click.

Closes #14780.