### PR TITLE
refactor(tabs): fix incorrect types for outputs

### DIFF
--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -132,10 +132,10 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
   private _selectedIndex: number = 0;
 
   /** Event emitted when the option is selected. */
-  @Output() readonly selectFocusedIndex = new EventEmitter();
+  @Output() readonly selectFocusedIndex: EventEmitter<number> = new EventEmitter<number>();
 
   /** Event emitted when a label is focused. */
-  @Output() readonly indexFocused = new EventEmitter();
+  @Output() readonly indexFocused: EventEmitter<number> = new EventEmitter<number>();
 
   constructor(private _elementRef: ElementRef,
               private _changeDetectorRef: ChangeDetectorRef,

--- a/tools/public_api_guard/lib/tabs.d.ts
+++ b/tools/public_api_guard/lib/tabs.d.ts
@@ -118,9 +118,9 @@ export declare class MatTabHeader extends _MatTabHeaderMixinBase implements Afte
     _tabList: ElementRef;
     _tabListContainer: ElementRef;
     focusIndex: number;
-    readonly indexFocused: EventEmitter<{}>;
+    readonly indexFocused: EventEmitter<number>;
     scrollDistance: number;
-    readonly selectFocusedIndex: EventEmitter<{}>;
+    readonly selectFocusedIndex: EventEmitter<number>;
     selectedIndex: number;
     constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _viewportRuler: ViewportRuler, _dir: Directionality, _ngZone?: NgZone | undefined);
     _alignInkBarToSelectedTab(): void;


### PR DESCRIPTION
Corrects some inaccurate types on a couple of the outputs of the `MatTabHeader`.