### PR TITLE
build: fix api goldens for dialog changes

### DIFF
--- a/tools/public_api_guard/lib/dialog.d.ts
+++ b/tools/public_api_guard/lib/dialog.d.ts
@@ -107,6 +107,7 @@ export declare class MatDialogRef<T, R = any> {
     disableClose: boolean | undefined;
     readonly id: string;
     constructor(_overlayRef: OverlayRef, _containerInstance: MatDialogContainer, _location?: Location, id?: string);
+    addPanelClass(classes: string | string[]): this;
     afterClosed(): Observable<R | undefined>;
     afterOpen(): Observable<void>;
     afterOpened(): Observable<void>;
@@ -115,6 +116,7 @@ export declare class MatDialogRef<T, R = any> {
     beforeClosed(): Observable<R | undefined>;
     close(dialogResult?: R): void;
     keydownEvents(): Observable<KeyboardEvent>;
+    removePanelClass(classes: string | string[]): this;
     updatePosition(position?: DialogPosition): this;
     updateSize(width?: string, height?: string): this;
 }


### PR DESCRIPTION
* Fixes the API goldens which haven't been updated for https://github.com/angular/material2/commit/b62f3f3b4a0fe5713aeef459d56ff1adcea853bb properly due to not being rebased on ec9f9c836c0cf60a3d8b7f730c425e8e5796ddb9