### PR TITLE
refactor: Prepare for TypeScript v3.2.2

### DIFF
--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -95,13 +95,15 @@ export class CdkScrollable implements OnInit, OnDestroy {
 
     // Rewrite the bottom offset as a top offset.
     if (options.bottom != null) {
-      options.top = el.scrollHeight - el.clientHeight - options.bottom;
+      (options as _Without<_Bottom> & _Top).top =
+          el.scrollHeight - el.clientHeight - options.bottom;
     }
 
     // Rewrite the right offset as a left offset.
     if (isRtl && getRtlScrollAxisType() != RtlScrollAxisType.NORMAL) {
       if (options.left != null) {
-        options.right = el.scrollWidth - el.clientWidth - options.left;
+        (options as _Without<_Left> & _Right).right =
+            el.scrollWidth - el.clientWidth - options.left;
       }
 
       if (getRtlScrollAxisType() == RtlScrollAxisType.INVERTED) {
@@ -111,7 +113,8 @@ export class CdkScrollable implements OnInit, OnDestroy {
       }
     } else {
       if (options.right != null) {
-        options.left = el.scrollWidth - el.clientWidth - options.right;
+        (options as _Without<_Right> & _Left).left =
+            el.scrollWidth - el.clientWidth - options.right;
       }
     }
 


### PR DESCRIPTION
We're upgrading TypeScript to v3.2.2 in google3. This PR suppresses the
compilation errors without actually upgrading the version of TypeScript.

[According to the comments](https://github.com/angular/material2/blob/f66302d44301c936d5647c6d6cfd326b118808fb/src/cdk/scrolling/scrollable.ts#L31-L37), the `top` and `bottom` properties in
`ExtendedScrollToOptions` are mutually exclusive. However when rewriting
the bottom offset as a top offset both properties are defined. With the
improved type inference in TypeScript 3.2 this is now a compilation
error.