### PR TITLE
build: fix bazel running out of memory for "publish_snapshots"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
   # ----------------------------------------
   publish_snapshots:
     <<: *job_defaults
+    resource_class: xlarge
     steps:
       - *checkout_code
       - *restore_cache


### PR DESCRIPTION
Due to a bug within Bazel, we need to increase the resource class for the CircleCI jobs that use Bazel. This can be lowered once we run everything with RBE; but for now we need it to get our CI green. 

https://github.com/bazelbuild/bazel/issues/3645. Not adding a comment because the RBE PR is ready for merge, and this is generally good to have since it speeds up the overall Bazel building. So the resource class is not only specific to this bug.