### PR TITLE
build: run e2e tests with bazel rbe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,13 @@ jobs:
   e2e_tests:
     <<: *job_defaults
     resource_class: xlarge
+    environment:
+      GCP_DECRYPT_TOKEN: *gcp_decrypt_token
     steps:
       - *checkout_code
       - *restore_cache
+      - *copy_bazel_config
+      - *setup_bazel_remote_execution
 
       - run: bazel test e2e/...
 
@@ -305,6 +309,7 @@ jobs:
       - *checkout_code
       - *restore_cache
       - *attach_release_output
+      - *copy_bazel_config
       - *setup_bazel_remote_execution
 
       # CircleCI has a config setting to enforce SSH for all github connections.


### PR DESCRIPTION
* Similar to other Bazel jobs, we should enable remote execution for the e2e tests. These currently build Angular Material in order to serve the e2e-app, so this could slow-down CI. Ideally remote caching would be also accepted, but this will be discussed soon.

Pretty similar to #14867, but decided to make a new PR because the commit message would be off.