### PR TITLE
docs(radio): fix typo in intro section

### DIFF
--- a/src/lib/radio/radio.md
+++ b/src/lib/radio/radio.md
@@ -1,4 +1,4 @@
-`<mat-radio>` provides the same functionality as a native `<input type="radio">` enhanced with
+`<mat-radio-button>` provides the same functionality as a native `<input type="radio">` enhanced with
 Material Design styling and animations.
 
 <!-- example(radio-overview) -->


### PR DESCRIPTION
docs (radio.md): simple typographical error fix

Renamed <mat-radio> to <mat-radio-button> because only <mat-radio-button> exists.