### PR TITLE
[mat-icon] preventing content from translation

### DIFF
--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -97,7 +97,7 @@ describe('MatIcon', () => {
     fixture.detectChanges();
 
     expect(sortedClassNames(matIconElement))
-        .toEqual(['mat-icon', 'mat-icon-no-color', 'material-icons']);
+        .toEqual(['mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
   });
 
   it('should mark mat-icon as aria-hidden by default', () => {

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -84,7 +84,7 @@ describe('MatIcon', () => {
     testComponent.iconName = 'home';
     testComponent.iconColor = 'primary';
     fixture.detectChanges();
-    expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-primary', 'material-icons']);
+    expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-primary', 'material-icons', 'notranslate']);
   });
 
   it('should apply a class if there is no color', () => {
@@ -135,7 +135,7 @@ describe('MatIcon', () => {
       testComponent.iconName = 'home';
       fixture.detectChanges();
       expect(sortedClassNames(matIconElement))
-          .toEqual(['mat-icon', 'mat-icon-no-color', 'material-icons']);
+          .toEqual(['mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
     });
 
     it('should use alternate icon font if set', () => {
@@ -147,7 +147,7 @@ describe('MatIcon', () => {
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       fixture.detectChanges();
-      expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-icon-no-color', 'myfont']);
+      expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-icon-no-color', 'myfont', 'notranslate']);
     });
   });
 
@@ -697,19 +697,19 @@ describe('MatIcon', () => {
       testComponent.fontIcon = 'house';
       fixture.detectChanges();
       expect(sortedClassNames(matIconElement))
-          .toEqual(['font1', 'house', 'mat-icon', 'mat-icon-no-color']);
+          .toEqual(['font1', 'house', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
 
       testComponent.fontSet = 'f2';
       testComponent.fontIcon = 'igloo';
       fixture.detectChanges();
       expect(sortedClassNames(matIconElement))
-          .toEqual(['f2', 'igloo', 'mat-icon', 'mat-icon-no-color']);
+          .toEqual(['f2', 'igloo', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
 
       testComponent.fontSet = 'f3';
       testComponent.fontIcon = 'tent';
       fixture.detectChanges();
       expect(sortedClassNames(matIconElement))
-          .toEqual(['f3', 'mat-icon', 'mat-icon-no-color', 'tent']);
+          .toEqual(['f3', 'mat-icon', 'mat-icon-no-color', 'notranslate', 'tent']);
     });
 
     it('should handle values with extraneous spaces being passed in to `fontSet`', () => {
@@ -721,7 +721,7 @@ describe('MatIcon', () => {
         fixture.detectChanges();
       }).not.toThrow();
 
-      expect(sortedClassNames(matIconElement)).toEqual(['font', 'mat-icon', 'mat-icon-no-color']);
+      expect(sortedClassNames(matIconElement)).toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
 
       expect(() => {
         fixture.componentInstance.fontSet = ' changed';
@@ -729,7 +729,7 @@ describe('MatIcon', () => {
       }).not.toThrow();
 
       expect(sortedClassNames(matIconElement))
-          .toEqual(['changed', 'mat-icon', 'mat-icon-no-color']);
+          .toEqual(['changed', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
     });
 
     it('should handle values with extraneous spaces being passed in to `fontIcon`', () => {
@@ -742,7 +742,7 @@ describe('MatIcon', () => {
       }).not.toThrow();
 
       expect(sortedClassNames(matIconElement))
-          .toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'material-icons']);
+          .toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
 
       expect(() => {
         fixture.componentInstance.fontIcon = ' changed';
@@ -750,7 +750,7 @@ describe('MatIcon', () => {
       }).not.toThrow();
 
       expect(sortedClassNames(matIconElement))
-          .toEqual(['changed', 'mat-icon', 'mat-icon-no-color', 'material-icons']);
+          .toEqual(['changed', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
     });
 
   });

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -84,7 +84,8 @@ describe('MatIcon', () => {
     testComponent.iconName = 'home';
     testComponent.iconColor = 'primary';
     fixture.detectChanges();
-    expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-primary', 'material-icons', 'notranslate']);
+    expect(sortedClassNames(matIconElement))
+        .toEqual(['mat-icon', 'mat-primary', 'material-icons', 'notranslate']);
   });
 
   it('should apply a class if there is no color', () => {
@@ -147,7 +148,8 @@ describe('MatIcon', () => {
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
       testComponent.iconName = 'home';
       fixture.detectChanges();
-      expect(sortedClassNames(matIconElement)).toEqual(['mat-icon', 'mat-icon-no-color', 'myfont', 'notranslate']);
+      expect(sortedClassNames(matIconElement))
+          .toEqual(['mat-icon', 'mat-icon-no-color', 'myfont', 'notranslate']);
     });
   });
 
@@ -721,7 +723,8 @@ describe('MatIcon', () => {
         fixture.detectChanges();
       }).not.toThrow();
 
-      expect(sortedClassNames(matIconElement)).toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
+      expect(sortedClassNames(matIconElement))
+          .toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'notranslate']);
 
       expect(() => {
         fixture.componentInstance.fontSet = ' changed';
@@ -742,7 +745,7 @@ describe('MatIcon', () => {
       }).not.toThrow();
 
       expect(sortedClassNames(matIconElement))
-          .toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
+        .toEqual(['font', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
 
       expect(() => {
         fixture.componentInstance.fontIcon = ' changed';
@@ -750,7 +753,7 @@ describe('MatIcon', () => {
       }).not.toThrow();
 
       expect(sortedClassNames(matIconElement))
-          .toEqual(['changed', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
+        .toEqual(['changed', 'mat-icon', 'mat-icon-no-color', 'material-icons', 'notranslate']);
     });
 
   });

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -75,11 +75,10 @@ describe('MatIcon', () => {
       http = h;
       sanitizer = ds;
     }));
-  
+
   it('should include notranslate class by default', () => {
     let fixture = TestBed.createComponent(IconWithColor);
 
-    const testComponent = fixture.componentInstance;
     const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
     expect(matIconElement.classList.contains('notranslate'))
       .toBeTruthy('Expected the mat-icon element to include the notranslate class');

--- a/src/lib/icon/icon.spec.ts
+++ b/src/lib/icon/icon.spec.ts
@@ -75,6 +75,15 @@ describe('MatIcon', () => {
       http = h;
       sanitizer = ds;
     }));
+  
+  it('should include notranslate class by default', () => {
+    let fixture = TestBed.createComponent(IconWithColor);
+
+    const testComponent = fixture.componentInstance;
+    const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
+    expect(matIconElement.classList.contains('notranslate'))
+      .toBeTruthy('Expected the mat-icon element to include the notranslate class');
+  });
 
   it('should apply class based on color attribute', () => {
     let fixture = TestBed.createComponent(IconWithColor);

--- a/src/lib/icon/icon.ts
+++ b/src/lib/icon/icon.ts
@@ -127,7 +127,7 @@ const funcIriPattern = /^url\(['"]?#(.*?)['"]?\)$/;
   inputs: ['color'],
   host: {
     'role': 'img',
-    'class': 'mat-icon',
+    'class': 'mat-icon notranslate',
     '[class.mat-icon-inline]': 'inline',
     '[class.mat-icon-no-color]': 'color !== "primary" && color !== "accent" && color !== "warn"',
   },


### PR DESCRIPTION
Current behavior: 

before translation | after translation
:---:|:---:
![image](https://user-images.githubusercontent.com/24639631/51412407-8bfcb580-1b7c-11e9-8d4c-9f1204b556b7.png) | ![image](https://user-images.githubusercontent.com/24639631/51412741-aaaf7c00-1b7d-11e9-9921-060f8e28a337.png)

to prevent `mat-icon` content from translation by automated tools I'm adding `notranslate` class to `mat-icon` by default.

PS: I think it makes sense to use this class all the time and not only for font icons since even for svg icons there are only the following use cases:

1.  There is no text inside svg icon - so class will do no harm
2.  There is some text (e.g. one big letter as an icon) and it most likely shouldn't be translated
3.  It is highly unlikely to have a long text inside svg icon and to want it to be translated

This why I decided to have less conditions and add class to all icons by default.

From [Google Translate FAQ](https://cloud.google.com/translate/faq):
![image](https://user-images.githubusercontent.com/24639631/51423871-50430980-1bd7-11e9-9705-42ea24307b0f.png)