### PR TITLE
fix(radio): underlying label not expanding to width of radio button

### DIFF
--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -21,6 +21,9 @@ $mat-radio-ripple-radius: 20px;
   align-items: center;
   white-space: nowrap;
   vertical-align: middle;
+
+  // Have the label span the rest of the radio button for maximum clickable area.
+  width: 100%;
 }
 
 // Container for radio circles and ripple.


### PR DESCRIPTION
Fixes the `label` inside a `mat-radio-button` not expanding to the width of the radio button, reducing the clickable area.

Fixes #14894.