### PR TITLE
fix(cdk-experimental/dialog): re-export portal module

### DIFF
--- a/src/cdk-experimental/dialog/dialog-module.ts
+++ b/src/cdk-experimental/dialog/dialog-module.ts
@@ -31,6 +31,9 @@ import {
     A11yModule,
   ],
   exports: [
+    // Re-export the PortalModule so that people extending the `CdkDialogContainer`
+    // don't have to remember to import it or be faced with an unhelpful error.
+    PortalModule,
     CdkDialogContainer,
   ],
   declarations: [


### PR DESCRIPTION
Re-exports the `PortalModule` from the `DialogModule` in `cdk-experimental/dialog`. This makes it easier to extend the existing `CdkDialogContainer`.

Fixes #14900.