### PR TITLE
build: remove unused dgeni package configurations

### DIFF
--- a/tools/dgeni/BUILD.bazel
+++ b/tools/dgeni/BUILD.bazel
@@ -19,7 +19,6 @@ ts_library(
   srcs = glob(["**/*.ts"]),
   deps = [
     "@matdeps//@types/node",
-    "@matdeps//@types/glob",
     "@matdeps//dgeni",
     "@matdeps//dgeni-packages",
     "//tools/highlight-files:sources",

--- a/tools/dgeni/bazel-bin.ts
+++ b/tools/dgeni/bazel-bin.ts
@@ -3,7 +3,7 @@ import {ReadTypeScriptModules} from 'dgeni-packages/typescript/processors/readTy
 import {TsParser} from 'dgeni-packages/typescript/services/TsParser';
 import {readFileSync} from 'fs';
 import {join, relative} from 'path';
-import {apiDocsPackage} from './index';
+import {apiDocsPackage} from './docs-package';
 
 /**
  * Determines the command line arguments for the current Bazel action. Since this action can
@@ -51,6 +51,10 @@ if (require.main === module) {
     // all sources (also known as the path to the current Bazel target). This makes it easier for
     // custom processors (such as the `entry-point-grouper) to compute entry-point paths.
     readTypeScriptModules.basePath = packagePath;
+
+    // Initialize the "tsParser" path mappings. These will be passed to the TypeScript program
+    // and therefore use the same syntax as the "paths" option in a tsconfig.
+    tsParser.options.paths = {};
 
     // For each package we want to setup all entry points in Dgeni so that their API
     // will be generated. Packages and their associated entry points are passed in pairs.

--- a/tools/dgeni/tsconfig.json
+++ b/tools/dgeni/tsconfig.json
@@ -1,26 +1,15 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "lib": ["es2015", "dom", "es2016.array.include"],
-    "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "../../dist/tools/dgeni",
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
-    "noEmitOnError": true,
     "noImplicitAny": true,
-    "target": "es5",
     "types": [
       "node"
     ]
-  },
-  "files": [
-    "index.ts"
-  ],
-  "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true
   }
 }


### PR DESCRIPTION
* Removes some configuration parts of the Dgeni docs package which are overwritten by Bazel using the `apiDocsPackage`. Globs do not work within Bazel.