### PR TITLE
build: add missing bazel action names

### DIFF
--- a/tools/dgeni/index.bzl
+++ b/tools/dgeni/index.bzl
@@ -60,6 +60,7 @@ def _dgeni_api_docs(ctx):
     executable = ctx.executable._dgeni_bin,
     outputs = expected_outputs,
     arguments = [args],
+    progress_message = "Dgeni (%s)" % (output_dir_path),
   )
 
   return DefaultInfo(files = depset(expected_outputs))

--- a/tools/highlight-files/index.bzl
+++ b/tools/highlight-files/index.bzl
@@ -59,6 +59,7 @@ def _highlight_files(ctx):
     executable = ctx.executable._highlight_files,
     outputs = expected_outputs,
     arguments = [args],
+    progress_message = "HighlightFiles",
   )
 
   return DefaultInfo(files = depset(expected_outputs))

--- a/tools/markdown-to-html/index.bzl
+++ b/tools/markdown-to-html/index.bzl
@@ -47,6 +47,7 @@ def _markdown_to_html(ctx):
     executable = ctx.executable._transform_markdown,
     outputs = expected_outputs,
     arguments = [args],
+    progress_message = "MarkdownToHtml",
   )
 
   return DefaultInfo(files = depset(expected_outputs))

--- a/tools/package-docs-content/index.bzl
+++ b/tools/package-docs-content/index.bzl
@@ -53,6 +53,7 @@ def _package_docs_content(ctx):
     executable = ctx.executable._packager,
     outputs = expected_outputs,
     arguments = [args],
+    progress_message = "PackageDocsContent",
   )
 
   return DefaultInfo(files = depset(expected_outputs))

--- a/tools/sass_bundle.bzl
+++ b/tools/sass_bundle.bzl
@@ -24,6 +24,7 @@ def _sass_bundle(ctx):
     executable = ctx.executable._sass_bundle,
     outputs = [ctx.outputs.output_name],
     arguments = [args],
+    progress_message = "SassBundle (%s)" % ctx.attr.output_name,
   )
 
   output_depset = depset([ctx.outputs.output_name])


### PR DESCRIPTION
In order to have proper action names when running bazel, we should add progress messages for all custom rules. Currently Bazel always uses the first input as action name, but this is *very* confusing since failures lead to the input file, instead of the associated Bazel action.

Note that this is not really a progress_message, but it is consistent with native bazel actions (e.g. `StarlarkAction`)