### PR TITLE
fix(overlay): flexible position strategy throwing error for empty strings

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -2168,6 +2168,19 @@ describe('FlexibleConnectedPositionStrategy', () => {
       expect(overlayRef.overlayElement.classList).toContain('is-under');
     });
 
+    it('should not throw if an empty string is passed in as a panel class', () => {
+      positionStrategy.withPositions([{
+        originX: 'start',
+        originY: 'bottom',
+        overlayX: 'start',
+        overlayY: 'top',
+        panelClass: ['is-below', '']
+      }]);
+
+      expect(() => attachOverlay({positionStrategy})).not.toThrow();
+      expect(overlayRef.overlayElement.classList).toContain('is-below');
+    });
+
     it('should remove the panel class when detaching', () => {
       positionStrategy.withPositions([{
         originX: 'start',

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -1081,7 +1081,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _addPanelClasses(cssClasses: string | string[]) {
     if (this._pane) {
       coerceArray(cssClasses).forEach(cssClass => {
-        if (this._appliedPanelClasses.indexOf(cssClass) === -1) {
+        if (cssClass !== '' && this._appliedPanelClasses.indexOf(cssClass) === -1) {
           this._appliedPanelClasses.push(cssClass);
           this._pane.classList.add(cssClass);
         }
@@ -1092,7 +1092,9 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   /** Clears the classes that the position strategy has applied from the overlay panel. */
   private _clearPanelClasses() {
     if (this._pane) {
-      this._appliedPanelClasses.forEach(cssClass => this._pane.classList.remove(cssClass));
+      this._appliedPanelClasses.forEach(cssClass => {
+        this._pane.classList.remove(cssClass);
+      });
       this._appliedPanelClasses = [];
     }
   }


### PR DESCRIPTION
Fixes the `FlexibleConnectedPositionStrategy` throwing an error if one of its panel classes is an empty string.