### PR TITLE
fix(examples): fix form-field custom control `disabled` input

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -307,21 +307,13 @@ make up our component.
 
 ```ts
 @Input()
-get disabled() {
-  return this._disabled;
-}
-set disabled(dis) {
-  this._disabled = coerceBooleanProperty(dis);
+get disabled(): boolean { return this._disabled; }
+set disabled(value: boolean) {
+  this._disabled = coerceBooleanProperty(value);
+  this._disabled ? this.parts.disable() : this.parts.enable();
   this.stateChanges.next();
 }
 private _disabled = false;
-```
-```html
-<input class="area" formControlName="area" size="3" [disabled]="disabled">
-<span>&ndash;</span>
-<input class="exchange" formControlName="exchange" size="3" [disabled]="disabled">
-<span>&ndash;</span>
-<input class="subscriber" formControlName="subscriber" size="4" [disabled]="disabled">
 ```
 
 #### `errorState`

--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
@@ -70,6 +70,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel>, OnDestroy {
   get disabled(): boolean { return this._disabled; }
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
+    this._disabled ? this.parts.disable() : this.parts.enable();
     this.stateChanges.next();
   }
   private _disabled = false;


### PR DESCRIPTION
* fixes form-field custom control example and guide so as not to attempt
  to use the `disabled` attribute on an input element that has a reactive
  form directive. see: https://github.com/angular/angular/blob/e2c98fbe11272295c3827b0e54f859d283cd32bf/packages/forms/src/directives/reactive_errors.ts#L64