### PR TITLE
chore: fix dead link in docs

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -93,7 +93,7 @@ details.
 
 ## LiveAnnouncer
 `LiveAnnouncer` is used to announce messages for screen-reader users using an `aria-live` region.
-See [the W3C's WAI-ARIA](https://www.w3.org/TR/wai-aria/states_and_properties#aria-live)
+See [the W3C's WAI-ARIA](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-live)
 for more information on aria-live regions.
 
 ### Example


### PR DESCRIPTION
Fixes a dead link in the a11y docs.

Fixes #14955.