### PR TITLE
fix(MatPseudoCheckbox): fix checkmark pseudo-element box-sizing

### DIFF
--- a/src/lib/core/selection/pseudo-checkbox/pseudo-checkbox.scss
+++ b/src/lib/core/selection/pseudo-checkbox/pseudo-checkbox.scss
@@ -64,4 +64,5 @@ $_mat-pseudo-checkmark-size: $mat-checkbox-size - (2 * $_mat-pseudo-checkbox-pad
   border-left: $mat-checkbox-border-width solid currentColor;
   transform: rotate(-45deg);
   opacity: 1;
+  box-sizing: content-box;
 }


### PR DESCRIPTION
Some CSS reset libraries use the default `box-sizing: border-box` on all elements and also on all the pseudo-element, which creates a regression on `checkmark` of `MatPseudoCheckbox`.

here is an example of regression using Bootstrap Reboot:
https://stackblitz.com/edit/angular-pseudo-checkbox-with-css-reset