### PR TITLE
build: simplify api golden target names

### DIFF
--- a/tools/public_api_guard/generate-guard-tests.bzl
+++ b/tools/public_api_guard/generate-guard-tests.bzl
@@ -24,7 +24,7 @@ def generate_test_targets(golden_files):
 
     # Create the test rule that compares the build output with the golden file.
     ts_api_guardian_test(
-      name = "%s_%s_api" % (package_name, entry_point),
+      name = "%s_api" % golden_file,
       actual = "angular_material/src/%s/index.d.ts" % entry_point_path,
       data = [golden_file] + [
         "//src/%s" % (entry_point_path),


### PR DESCRIPTION
In order to make it easier to test/update goldens, the Bazel targets are updated to the match the actual golden file paths.

This is useful because developers can then use terminal autocompletion to go to the desired golden file, and just need to add the `_api` suffix. This easier than manually constructing the Bazel API target name which is not intuitive and takes up time.