### PR TITLE
fix(layout): breakpoint observer completing unrelated subscribers when preceding subscriber unsubscribes

### DIFF
--- a/src/cdk/layout/BUILD.bazel
+++ b/src/cdk/layout/BUILD.bazel
@@ -20,6 +20,8 @@ ng_test_library(
   name = "layout_test_sources",
   srcs = glob(["**/*.spec.ts"]),
   deps = [
+    "@rxjs",
+    "@rxjs//operators",
     "//src/cdk/platform",
     ":layout",
   ],


### PR DESCRIPTION
Fixes the `BreakpointObserver` completing subscribers that come after the current one, if one of the preceding subscribers unsubscribes. The issue seems to come from the way we store the listener in order to remove it later on. These changes switch to creating the `Observable` ourselves, rather than going through `fromEventPattern` so that we have more control over the event handler.

Fixes #14983.