### PR TITLE
fix(checkbox): not marked as touched immediately on blur with OnPush change detection

### DIFF
--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -212,7 +212,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
         // (such as a form control's 'ng-touched') will cause a changed-after-checked error.
         // See https://github.com/angular/angular/issues/17793. To work around this, we defer
         // telling the form control it has been touched until the next tick.
-        Promise.resolve().then(() => this._onTouched());
+        Promise.resolve().then(() => {
+          this._onTouched();
+          _changeDetectorRef.markForCheck();
+        });
       }
     });
   }


### PR DESCRIPTION
Fixes a checkbox which is blurred inside a component with `OnPush` change detection not being marked as touched.

Fixes #14980.