### PR TITLE
build: fix syntax error within codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -197,7 +197,7 @@
 /.circleci/**                                      @jelbourn
 /scripts/**                                        @devversion @jelbourn
 /test/**                                           @devversion @jelbourn
-/tools/**/!(*.d.ts)                                @devversion @jelbourn
+/tools/**                                          @devversion @jelbourn
 
 # Public API golden files
 /tools/public_api_guard/cdk/a11y.d.ts              @jelbourn @devversion


### PR DESCRIPTION
Since https://github.com/angular/material2/commit/88601fa51d581f538468a9b63890b0e285e519cb landed, it seems that the Github codeowner's are no longer working. This is because globs with such negations are not supported within the `CODEOWNERS` file

The exclusion of `.d.ts` files shouldn't be necessary anyway since the last match in the `CODEOWNERS` file takes precedence over previous matches.