### PR TITLE
build: fix dev app fullscreen styles

### DIFF
--- a/src/dev-app/dev-app.html
+++ b/src/dev-app/dev-app.html
@@ -45,7 +45,7 @@
       </div>
     </mat-toolbar>
 
-    <div #root="dir" dir="ltr" class="demo-content">
+    <div #root="dir" dir="ltr" class="demo-content mat-app-background">
       <router-outlet></router-outlet>
     </div>
   </main>

--- a/src/dev-app/dev-app.scss
+++ b/src/dev-app/dev-app.scss
@@ -54,6 +54,7 @@ body {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+  overflow: auto;
 }
 
 .demo-container {


### PR DESCRIPTION
Fixes not being able to debug fullscreen behavior properly in the dev app, because the fullscreen element uses a black background and isn't scrolling.