### PR TITLE
fix(drag-drop): disabled value not being synced to drop list ref

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -839,6 +839,25 @@ describe('CdkDrag', () => {
       expect(fixture.componentInstance.dropInstance.data).toBe(fixture.componentInstance.items);
     });
 
+    it('should sync the drop list inputs with the drop list ref', () => {
+      const fixture = createComponent(DraggableInDropZone);
+      fixture.detectChanges();
+
+      const dropInstance = fixture.componentInstance.dropInstance;
+      const dropListRef = dropInstance._dropListRef;
+
+      expect(dropListRef.lockAxis).toBeFalsy();
+      expect(dropListRef.disabled).toBe(false);
+
+      dropInstance.lockAxis = 'x';
+      dropInstance.disabled = true;
+
+      dropListRef.beforeStarted.next();
+
+      expect(dropListRef.lockAxis).toBe('x');
+      expect(dropListRef.disabled).toBe(true);
+    });
+
     it('should be able to attach data to a drag item', () => {
       const fixture = createComponent(DraggableInDropZone);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -306,6 +306,7 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
         });
       }
 
+      ref.disabled = this.disabled;
       ref.lockAxis = this.lockAxis;
       ref
         .connectedTo(siblings.filter(drop => drop && drop !== this).map(list => list._dropListRef))


### PR DESCRIPTION
Fixes the input value from the `CdkDropList` directive not being synced to the `DropListRef`.

**Note:** this didn't really break anything, because we have some logic for syncing the disabled value in `CdkDrag` as well, hence why all the tests are passing. These changes are here primarily to ensure that things are consistent and so that we don't run into weird issues in the future.