### PR TITLE
feat(overlay): allow for scroll strategy to be swapped out

### DIFF
--- a/src/cdk/overlay/scroll/close-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.ts
@@ -75,6 +75,11 @@ export class CloseScrollStrategy implements ScrollStrategy {
     }
   }
 
+  detach() {
+    this.disable();
+    this._overlayRef = null!;
+  }
+
   /** Detaches the overlay ref and disables the scroll strategy. */
   private _detach = () => {
     this.disable();

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
@@ -79,4 +79,9 @@ export class RepositionScrollStrategy implements ScrollStrategy {
       this._scrollSubscription = null;
     }
   }
+
+  detach() {
+    this.disable();
+    this._overlayRef = null!;
+  }
 }

--- a/src/cdk/overlay/scroll/scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy.ts
@@ -20,6 +20,9 @@ export interface ScrollStrategy {
 
   /** Attaches this `ScrollStrategy` to an overlay. */
   attach: (overlayRef: OverlayReference) => void;
+
+  /** Detaches the scroll strategy from the current overlay. */
+  detach?: () => void;
 }
 
 /**

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -45,6 +45,7 @@ export declare class CdkOverlayOrigin {
 export declare class CloseScrollStrategy implements ScrollStrategy {
     constructor(_scrollDispatcher: ScrollDispatcher, _ngZone: NgZone, _viewportRuler: ViewportRuler, _config?: CloseScrollStrategyConfig | undefined);
     attach(overlayRef: OverlayReference): void;
+    detach(): void;
     disable(): void;
     enable(): void;
 }
@@ -228,9 +229,9 @@ export declare class OverlayRef implements PortalOutlet, OverlayReference {
     readonly overlayElement: HTMLElement;
     constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location?: Location | undefined);
     addPanelClass(classes: string | string[]): void;
-    attach(portal: any): any;
     attach<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attach<T>(portal: TemplatePortal<T>): EmbeddedViewRef<T>;
+    attach(portal: any): any;
     attachments(): Observable<void>;
     backdropClick(): Observable<MouseEvent>;
     detach(): any;
@@ -245,6 +246,7 @@ export declare class OverlayRef implements PortalOutlet, OverlayReference {
     setDirection(dir: Direction | Directionality): void;
     updatePosition(): void;
     updatePositionStrategy(strategy: PositionStrategy): void;
+    updateScrollStrategy(strategy: ScrollStrategy): void;
     updateSize(sizeConfig: OverlaySizeConfig): void;
 }
 
@@ -267,6 +269,7 @@ export interface PositionStrategy {
 export declare class RepositionScrollStrategy implements ScrollStrategy {
     constructor(_scrollDispatcher: ScrollDispatcher, _viewportRuler: ViewportRuler, _ngZone: NgZone, _config?: RepositionScrollStrategyConfig | undefined);
     attach(overlayRef: OverlayReference): void;
+    detach(): void;
     disable(): void;
     enable(): void;
 }
@@ -285,6 +288,7 @@ export declare class ScrollingVisibility {
 
 export interface ScrollStrategy {
     attach: (overlayRef: OverlayReference) => void;
+    detach?: () => void;
     disable: () => void;
     enable: () => void;
 }


### PR DESCRIPTION
With #12306 we added the ability to swap out position strategies, however that won't be enough to handle all use cases since the consumer is still locked into the scroll strategy that they chose at the start. E.g. when switching an overlay from a dialog to a dropdown, it might not make sense to block scrolling anymore. These changes add an API to allow for the scroll strategy to be swapped.