### PR TITLE
docs(table): note that viewchange is not yet implemented

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -351,6 +351,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   /**
    * Stream containing the latest information on what rows are being displayed on screen.
    * Can be used by the data source to as a heuristic of what data should be provided.
+   *
+   * @docs-private
    */
   viewChange: BehaviorSubject<{start: number, end: number}> =
       new BehaviorSubject<{start: number, end: number}>({start: 0, end: Number.MAX_VALUE});


### PR DESCRIPTION
It can be frustrating to discover that a feature is documented but not yet implemented. Someone shouldn't have to dig into the code to realize that there's a "TODO".

This should help with that.