### PR TITLE
build: publish script should not print error if tag does not exist 

### DIFF
--- a/tools/release/extract-release-notes.ts
+++ b/tools/release/extract-release-notes.ts
@@ -10,8 +10,12 @@ export function extractReleaseNotes(changelogPath: string, versionName: string) 
   // section of a version by starting with the release header which can either use the markdown
   // "h1" or "h2" syntax. The end of the section will be matched by just looking for the first
   // subsequent release header.
-  const releaseNotesRegex = new RegExp(`(##? ${escapedVersion}.*?)##? 7\\.`, 's');
+  const releaseNotesRegex = new RegExp(
+      `(##? ${escapedVersion} "(.*?)" \\(.*?)##? \\d+\\.\\d+`, 's');
   const matches = releaseNotesRegex.exec(changelogContent);
 
-  return matches ? matches[1].trim() : null;
+  return matches ? {
+    releaseTitle: matches[2],
+    releaseNotes: matches[1].trim(),
+  } : null;
 }

--- a/tools/release/git/git-client.ts
+++ b/tools/release/git/git-client.ts
@@ -14,10 +14,10 @@ export class GitClient {
    * Spawns a child process running Git. The "stderr" output is inherited and will be printed
    * in case of errors. This makes it easier to debug failed commands.
    */
-  private _spawnGitProcess(args: string[]): SpawnSyncReturns<string> {
+  private _spawnGitProcess(args: string[], printStderr = true): SpawnSyncReturns<string> {
     return spawnSync('git', args, {
       cwd: this.projectDir,
-      stdio: ['pipe', 'pipe', 'inherit'],
+      stdio: ['pipe', 'pipe', printStderr ? 'inherit' : 'pipe'],
       encoding: 'utf8',
     });
   }
@@ -76,7 +76,7 @@ export class GitClient {
 
   /** Checks whether the specified tag exists locally. */
   hasLocalTag(tagName: string) {
-    return this._spawnGitProcess(['rev-parse', `refs/tags/${tagName}`]).status === 0;
+    return this._spawnGitProcess(['rev-parse', `refs/tags/${tagName}`], false).status === 0;
   }
 
   /** Gets the Git SHA of the specified local tag. */

--- a/tools/release/git/github-urls.ts
+++ b/tools/release/git/github-urls.ts
@@ -3,7 +3,11 @@ export function getGithubBranchCommitsUrl(owner: string, repository: string, bra
   return `https://github.com/${owner}/${repository}/commits/${branchName}`;
 }
 
-/** Gets a Github URL that refers list of releases within the specified repository. */
-export function getGithubReleasesUrl(owner: string, repository: string) {
-  return `https://github.com/${owner}/${repository}/releases`;
+/** Gets a Github URL that can be used to create a new release from a given tag. */
+export function getGithubNewReleaseUrl(options: {owner: string, repository: string,
+    tagName: string, releaseTitle: string}) {
+
+  return `https://github.com/${options.owner}/${options.repository}/releases/new?` +
+    `tag=${encodeURIComponent(options.tagName)}&` +
+    `title=${encodeURIComponent(options.releaseTitle)}&`;
 }

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -6,7 +6,7 @@ import {BaseReleaseTask} from './base-release-task';
 import {checkReleaseOutput} from './check-release-output';
 import {extractReleaseNotes} from './extract-release-notes';
 import {GitClient} from './git/git-client';
-import {getGithubReleasesUrl} from './git/github-urls';
+import {getGithubNewReleaseUrl} from './git/github-urls';
 import {isNpmAuthenticated, runInteractiveNpmLogin, runNpmPublish} from './npm/npm-client';
 import {promptForNpmDistTag} from './prompt/npm-dist-tag-prompt';
 import {releasePackages} from './release-output/release-packages';
@@ -91,7 +91,7 @@ class PublishReleaseTask extends BaseReleaseTask {
     checkReleaseOutput(this.releaseOutputPath);
 
     // Extract the release notes for the new version from the changelog file.
-    const releaseNotes = extractReleaseNotes(
+    const {releaseNotes, releaseTitle} = extractReleaseNotes(
       join(this.projectDir, CHANGELOG_FILE_NAME), newVersionName);
 
     if (!releaseNotes) {
@@ -114,11 +114,17 @@ class PublishReleaseTask extends BaseReleaseTask {
       this.publishPackageToNpm(packageName, npmDistTag);
     }
 
+    const newReleaseUrl = getGithubNewReleaseUrl({
+      owner: this.repositoryOwner,
+      repository: this.repositoryName,
+      tagName: newVersionName,
+      releaseTitle: releaseTitle,
+    });
+
     console.log();
     console.info(green(bold(`  ✓   Published all packages successfully`)));
     console.info(yellow(`  ⚠   Please draft a new release of the version on Github.`));
-    console.info(yellow(
-      `      ${getGithubReleasesUrl(this.repositoryOwner, this.repositoryName)}`));
+    console.info(yellow(`      ${newReleaseUrl}`));
   }
 
   /**


### PR DESCRIPTION
Currently the publish script prints an error if the release tag does not exist locally yet. This is not expected since the function that calls `git` to check if a given tag exists, returns a boolean and should not additionally print the git `stderr`.