### PR TITLE
build: branch manager should use "7.3.x" as patch branch

### DIFF
--- a/.github/branch-manager.yml
+++ b/.github/branch-manager.yml
@@ -1,7 +1,7 @@
 enabled: true
 
 branches:
-  - branchName: 7.2.x
+  - branchName: 7.3.x
     label: "target: patch"
   - branchName: 7.x
     label: "target: minor"


### PR DESCRIPTION
Updates the branch manager to validate patch PRs against the `7.3.x` branch. This is necessary because currently some PRs are marked as failing because they no longer apply to the outdated `7.2.x` branch.

cc. @josephperrott should we somehow add this to the release instructions? or should the branch manager automatically pick up the proper branch somehow (e.g. by checking the "package.json")