### PR TITLE
refactor(drag-drop): don't clone items array inside withItems

### DIFF
--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -130,10 +130,10 @@ export class DropListRef<T = any> {
   private _previousSwap = {drag: null as DragRef | null, delta: 0};
 
   /** Draggable items in the container. */
-  private _draggables: DragRef[];
+  private _draggables: ReadonlyArray<DragRef>;
 
   /** Drop lists that are connected to the current one. */
-  private _siblings: DropListRef[] = [];
+  private _siblings: ReadonlyArray<DropListRef> = [];
 
   /** Direction in which the list is oriented. */
   private _orientation: 'horizontal' | 'vertical' = 'vertical';
@@ -256,7 +256,7 @@ export class DropListRef<T = any> {
    * @param items Items that are a part of this list.
    */
   withItems(items: DragRef[]): this {
-    this._draggables = items.slice();
+    this._draggables = items;
     items.forEach(item => item._withDropContainer(this));
     return this;
   }


### PR DESCRIPTION
Currently when the consumer passes in an array of items to `withItems`, we clone the array which means that the indices won't update if the consumer shuffles them around. The original rationale behind it was to avoid accidentally mutating the array, however this makes it less convenient to use since the consumer would have to remember to move the item in the array __and__ call `withItems` in order to keep everything in sync when an item is dropped.

These changes remove the cloning and use `ReadonlyArray` to prevent us from accidentally making changes.

Fixes #15089.