### PR TITLE
fix(tooltip): tooltip sample not working with keyboard navigation.

### DIFF
--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -1,20 +1,20 @@
 <div>
-  <span> Mouse over to </span>
+  <span> Click the following buttons to... </span>
   <button mat-button
-          (mouseenter)="tooltip.show()"
-          aria-label="Button that progamatically shows a tooltip on another button"
+          (click)="tooltip.show()"
+          aria-label="Show tooltip on the button at the end of this section"
           class="example-action-button">
     show
   </button>
   <button mat-button
-          (mouseenter)="tooltip.hide()"
-          aria-label="Button that progamatically hides a tooltip on another button"
+          (click)="tooltip.hide()"
+          aria-label="Hide tooltip on the button at the end of this section"
           class="example-action-button">
     hide
   </button>
   <button mat-button
-          (mouseenter)="tooltip.toggle()"
-          aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
+          (click)="tooltip.toggle()"
+          aria-label="Show/Hide tooltip on the button at the end of this section"
           class="example-action-button">
     toggle show/hide
   </button>


### PR DESCRIPTION
Tooltip showing/hiding in sample when buttons are focused.
Fixes: #15044