### PR TITLE
fix: add dependency on @angular/forms

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -25,7 +25,8 @@
     "@angular/animations": "0.0.0-NG",
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "@angular/common": "0.0.0-NG"
+    "@angular/common": "0.0.0-NG",
+    "@angular/forms": "0.0.0-NG"
   },
   "dependencies": {
     "tslib": "^1.7.1"

--- a/src/lib/schematics/ng-add/index.spec.ts
+++ b/src/lib/schematics/ng-add/index.spec.ts
@@ -48,6 +48,8 @@ describe('ng-add schematic', () => {
     expect(dependencies['@angular/material']).toBeDefined();
     expect(dependencies['@angular/cdk']).toBeDefined();
     expect(dependencies['hammerjs']).toBeDefined();
+    expect(dependencies['@angular/forms']).toBe(angularCoreVersion,
+      'Expected the @angular/forms package to have the same version as @angular/core.');
     expect(dependencies['@angular/animations']).toBe(angularCoreVersion,
       'Expected the @angular/animations package to have the same version as @angular/core.');
 

--- a/src/lib/schematics/ng-add/index.ts
+++ b/src/lib/schematics/ng-add/index.ts
@@ -25,13 +25,14 @@ export default function(options: Schema): Rule {
     // of the CLI project. This tag should be preferred because all Angular dependencies should
     // have the same version tag if possible.
     const ngCoreVersionTag = getPackageVersionFromPackageJson(host, '@angular/core');
+    const angularDependencyVersion =  ngCoreVersionTag || requiredAngularVersionRange;
 
     // In order to align the Material and CDK version with the other Angular dependencies,
     // we use tilde instead of caret. This is default for Angular dependencies in new CLI projects.
     addPackageToPackageJson(host, '@angular/cdk', `~${materialVersion}`);
     addPackageToPackageJson(host, '@angular/material', `~${materialVersion}`);
-    addPackageToPackageJson(host, '@angular/animations',
-        ngCoreVersionTag || requiredAngularVersionRange);
+    addPackageToPackageJson(host, '@angular/forms', angularDependencyVersion);
+    addPackageToPackageJson(host, '@angular/animations', angularDependencyVersion);
 
     if (options.gestures) {
       addPackageToPackageJson(host, 'hammerjs', hammerjsVersion);


### PR DESCRIPTION
Adds `@angular/forms` to the list of dependencies, because there are around 10 Material components that are importing symbols from it.

Fixes #15085.