### PR TITLE
refactor(stepper): remove dependency on @angular/forms

### DIFF
--- a/src/cdk/stepper/BUILD.bazel
+++ b/src/cdk/stepper/BUILD.bazel
@@ -9,7 +9,6 @@ ng_module(
   deps = [
     "@angular//packages/common",
     "@angular//packages/core",
-    "@angular//packages/forms",
     "@rxjs",
     "@rxjs//operators",
     "//src/cdk/a11y",

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -34,7 +34,6 @@ import {
   InjectionToken,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {AbstractControl} from '@angular/forms';
 import {CdkStepLabel} from './step-label';
 import {Observable, Subject, of as obaservableOf} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
@@ -125,7 +124,12 @@ export class CdkStep implements OnChanges {
   @ViewChild(TemplateRef) content: TemplateRef<any>;
 
   /** The top level abstract control of the step. */
-  @Input() stepControl: AbstractControl;
+  @Input() stepControl: {
+    valid: boolean;
+    invalid: boolean;
+    pending: boolean;
+    reset: () => void;
+  };
 
   /** Whether user has seen the expanded step content or not. */
   interacted = false;

--- a/tools/public_api_guard/cdk/stepper.d.ts
+++ b/tools/public_api_guard/cdk/stepper.d.ts
@@ -12,7 +12,12 @@ export declare class CdkStep implements OnChanges {
     label: string;
     optional: boolean;
     state: StepState;
-    stepControl: AbstractControl;
+    stepControl: {
+        valid: boolean;
+        invalid: boolean;
+        pending: boolean;
+        reset: () => void;
+    };
     stepLabel: CdkStepLabel;
     constructor(_stepper: CdkStepper, stepperOptions?: StepperOptions);
     ngOnChanges(): void;


### PR DESCRIPTION
While looking at #15085, I noticed that the only place in the CDK where we use `@angular/forms` is to type an optional input in the stepper. These changes replace the typing with a partial representation of the `AbstractControl` so that we can drop the dependency.