### PR TITLE
feat(drag-drop): add the ability to customize how the position is constrained

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -48,7 +48,7 @@ import {CdkDragPlaceholder} from './drag-placeholder';
 import {CdkDragPreview} from './drag-preview';
 import {CDK_DROP_LIST} from '../drop-list-container';
 import {CDK_DRAG_PARENT} from '../drag-parent';
-import {DragRef, DragRefConfig} from '../drag-ref';
+import {DragRef, DragRefConfig, Point} from '../drag-ref';
 import {DropListRef} from '../drop-list-ref';
 import {CdkDropListInternal as CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
@@ -126,6 +126,14 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     this._dragRef.disabled = this._disabled;
   }
   private _disabled = false;
+
+  /**
+   * Function that can be used to customize the logic of how the position of the drag item
+   * is limited while it's being dragged. Gets called with a point containing the current position
+   * of the user's pointer on the page and should return a point describing where the item should
+   * be rendered.
+   */
+  @Input('cdkDragConstrainPosition') constrainPosition?: (point: Point) => Point;
 
   /** Emits when the user starts dragging the item. */
   @Output('cdkDragStarted') started: EventEmitter<CdkDragStart> = new EventEmitter<CdkDragStart>();
@@ -310,6 +318,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         ref.disabled = this.disabled;
         ref.lockAxis = this.lockAxis;
         ref.dragStartDelay = this.dragStartDelay;
+        ref.constrainPosition = this.constrainPosition;
         ref
           .withBoundaryElement(this._getBoundaryElement())
           .withPlaceholderTemplate(placeholder)

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -273,6 +273,14 @@ export class DragRef<T = any> {
   /** Arbitrary data that can be attached to the drag item. */
   data: T;
 
+  /**
+   * Function that can be used to customize the logic of how the position of the drag item
+   * is limited while it's being dragged. Gets called with a point containing the current position
+   * of the user's pointer on the page and should return a point describing where the item should
+   * be rendered.
+   */
+  constrainPosition?: (point: Point) => Point;
+
   constructor(
     element: ElementRef<HTMLElement> | HTMLElement,
     private _config: DragRefConfig,
@@ -909,12 +917,13 @@ export class DragRef<T = any> {
   /** Gets the pointer position on the page, accounting for any position constraints. */
   private _getConstrainedPointerPosition(event: MouseEvent | TouchEvent): Point {
     const point = this._getPointerPositionOnPage(event);
+    const constrainedPoint = this.constrainPosition ? this.constrainPosition(point) : point;
     const dropContainerLock = this._dropContainer ? this._dropContainer.lockAxis : null;
 
     if (this.lockAxis === 'x' || dropContainerLock === 'x') {
-      point.y = this._pickupPositionOnPage.y;
+      constrainedPoint.y = this._pickupPositionOnPage.y;
     } else if (this.lockAxis === 'y' || dropContainerLock === 'y') {
-      point.x = this._pickupPositionOnPage.x;
+      constrainedPoint.x = this._pickupPositionOnPage.x;
     }
 
     if (this._boundaryRect) {
@@ -926,11 +935,11 @@ export class DragRef<T = any> {
       const minX = boundaryRect.left + pickupX;
       const maxX = boundaryRect.right - (previewRect.width - pickupX);
 
-      point.x = clamp(point.x, minX, maxX);
-      point.y = clamp(point.y, minY, maxY);
+      constrainedPoint.x = clamp(constrainedPoint.x, minX, maxX);
+      constrainedPoint.y = clamp(constrainedPoint.y, minY, maxY);
     }
 
-    return point;
+    return constrainedPoint;
   }
 
 
@@ -984,7 +993,7 @@ export class DragRef<T = any> {
 }
 
 /** Point on the page or within an element. */
-interface Point {
+export interface Point {
   x: number;
   y: number;
 }

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -12,6 +12,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     _placeholderTemplate: CdkDragPlaceholder;
     _previewTemplate: CdkDragPreview;
     boundaryElementSelector: string;
+    constrainPosition?: (point: Point) => Point;
     data: T;
     disabled: boolean;
     dragStartDelay: number;
@@ -204,6 +205,7 @@ export declare class DragDropRegistry<I, C extends {
 
 export declare class DragRef<T = any> {
     beforeStarted: Subject<void>;
+    constrainPosition?: (point: Point) => Point;
     data: T;
     disabled: boolean;
     dragStartDelay: number;


### PR DESCRIPTION
Adds the `constrainPosition` function that allows people to hook into the logic that constrains the position of the element as it's being dragged and to customize it.

Fixes #15055.