### PR TITLE
Fixing a typo in a 'select' test

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1821,7 +1821,7 @@ describe('MatSelect', () => {
         expect(panel.scrollTop).toBe(320, 'Expected scroll to be at the 9th option.');
       }));
 
-      it('should scroll top the top when pressing HOME', fakeAsync(() => {
+      it('should scroll to the top when pressing HOME', fakeAsync(() => {
         for (let i = 0; i < 20; i++) {
           dispatchKeyboardEvent(host, 'keydown', DOWN_ARROW);
           fixture.detectChanges();

--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -2,21 +2,23 @@
   <span> Mouse over to </span>
   <button mat-button
           (mouseenter)="tooltip.show()"
-          (keyup.enter)="tooltip.show()"
+          (focus)="tooltip.show()"
+          (focusout)="tooltip.hide()"
           aria-label="Button that progamatically shows a tooltip on another button"
           class="example-action-button">
     show
   </button>
   <button mat-button
           (mouseenter)="tooltip.hide()"
-          (keyup.enter)="tooltip.hide()"
+          (focus)="tooltip.hide()"
           aria-label="Button that progamatically hides a tooltip on another button"
           class="example-action-button">
     hide
   </button>
   <button mat-button
           (mouseenter)="tooltip.toggle()"
-          (keyup.enter)="tooltip.toggle()"
+          (focus)="tooltip.toggle()"
+          (focusout)="tooltip.hide()"
           aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
           class="example-action-button">
     toggle show/hide

--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -2,18 +2,21 @@
   <span> Mouse over to </span>
   <button mat-button
           (mouseenter)="tooltip.show()"
+          (keyup.enter)="tooltip.show()"
           aria-label="Button that progamatically shows a tooltip on another button"
           class="example-action-button">
     show
   </button>
   <button mat-button
           (mouseenter)="tooltip.hide()"
+          (keyup.enter)="tooltip.hide()"
           aria-label="Button that progamatically hides a tooltip on another button"
           class="example-action-button">
     hide
   </button>
   <button mat-button
           (mouseenter)="tooltip.toggle()"
+          (keyup.enter)="tooltip.toggle()"
           aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
           class="example-action-button">
     toggle show/hide


### PR DESCRIPTION
it('should scroll **top** the top when pressing HOME',
is changed to
it('should scroll **to** the top when pressing HOME',