### PR TITLE
fix(docs): Menu button in example is missing an accessible name #15039

### DIFF
--- a/src/material-examples/menu-icons/menu-icons-example.html
+++ b/src/material-examples/menu-icons/menu-icons-example.html
@@ -1,4 +1,4 @@
-<button mat-icon-button [matMenuTriggerFor]="menu">
+<button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon">
   <mat-icon>more_vert</mat-icon>
 </button>
 <mat-menu #menu="matMenu">

--- a/src/material-examples/menu-icons/menu-icons-example.html
+++ b/src/material-examples/menu-icons/menu-icons-example.html
@@ -8,7 +8,7 @@
   </button>
   <button mat-menu-item disabled>
     <mat-icon>voicemail</mat-icon>
-    <span>Check voicemail</span>
+    <span>Check voice mail</span>
   </button>
   <button mat-menu-item>
     <mat-icon>notifications_off</mat-icon>

--- a/src/material-examples/menu-icons/menu-icons-example.html
+++ b/src/material-examples/menu-icons/menu-icons-example.html
@@ -1,4 +1,4 @@
-<button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon">
+<button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
   <mat-icon>more_vert</mat-icon>
 </button>
 <mat-menu #menu="matMenu">


### PR DESCRIPTION
Fixes #15039