### PR TITLE
docs(radio): add aria labelling to examples

### DIFF
--- a/src/material-examples/radio-ng-model/radio-ng-model-example.css
+++ b/src/material-examples/radio-ng-model/radio-ng-model-example.css
@@ -1,12 +1,9 @@
 .example-radio-group {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
+  margin: 15px 0;
 }
 
 .example-radio-button {
   margin: 5px;
-}
-
-.example-selected-value {
-  margin: 15px 0;
 }

--- a/src/material-examples/radio-ng-model/radio-ng-model-example.html
+++ b/src/material-examples/radio-ng-model/radio-ng-model-example.html
@@ -1,6 +1,10 @@
-<mat-radio-group class="example-radio-group" [(ngModel)]="favoriteSeason">
+<label id="example-radio-group-label">Pick your favorite season</label>
+<mat-radio-group
+  aria-labelledby="example-radio-group-label"
+  class="example-radio-group"
+  [(ngModel)]="favoriteSeason">
   <mat-radio-button class="example-radio-button" *ngFor="let season of seasons" [value]="season">
     {{season}}
   </mat-radio-button>
 </mat-radio-group>
-<div class="example-selected-value">Your favorite season is: {{favoriteSeason}}</div>
+<div>Your favorite season is: {{favoriteSeason}}</div>

--- a/src/material-examples/radio-overview/radio-overview-example.html
+++ b/src/material-examples/radio-overview/radio-overview-example.html
@@ -1,4 +1,4 @@
-<mat-radio-group>
+<mat-radio-group aria-label="Select an option">
   <mat-radio-button value="1">Option 1</mat-radio-button>
   <mat-radio-button value="2">Option 2</mat-radio-button>
 </mat-radio-group>


### PR DESCRIPTION
Adds the missing labels to a couple of the radio button live examples.

Fixes #15026.