### PR TITLE
fix(docs): add aria label to checkboxes in selection example, #15021

### DIFF
--- a/src/material-examples/table-selection/table-selection-example.html
+++ b/src/material-examples/table-selection/table-selection-example.html
@@ -5,13 +5,15 @@
     <th mat-header-cell *matHeaderCellDef>
       <mat-checkbox (change)="$event ? masterToggle() : null"
                     [checked]="selection.hasValue() && isAllSelected()"
-                    [indeterminate]="selection.hasValue() && !isAllSelected()">
+                    [indeterminate]="selection.hasValue() && !isAllSelected()"
+                    [aria-label]='checkboxLabel()'>
       </mat-checkbox>
     </th>
     <td mat-cell *matCellDef="let row">
       <mat-checkbox (click)="$event.stopPropagation()"
                     (change)="$event ? selection.toggle(row) : null"
-                    [checked]="selection.isSelected(row)">
+                    [checked]="selection.isSelected(row)"
+                    [aria-label]="checkboxLabel(row)">
       </mat-checkbox>
     </td>
   </ng-container>

--- a/src/material-examples/table-selection/table-selection-example.html
+++ b/src/material-examples/table-selection/table-selection-example.html
@@ -6,7 +6,7 @@
       <mat-checkbox (change)="$event ? masterToggle() : null"
                     [checked]="selection.hasValue() && isAllSelected()"
                     [indeterminate]="selection.hasValue() && !isAllSelected()"
-                    [aria-label]='checkboxLabel()'>
+                    [aria-label]="checkboxLabel()">
       </mat-checkbox>
     </th>
     <td mat-cell *matCellDef="let row">

--- a/src/material-examples/table-selection/table-selection-example.ts
+++ b/src/material-examples/table-selection/table-selection-example.ts
@@ -48,4 +48,12 @@ export class TableSelectionExample {
         this.selection.clear() :
         this.dataSource.data.forEach(row => this.selection.select(row));
   }
+
+  /** The label for the checkbox on the passed row */
+  checkboxLabel(row?: PeriodicElement): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.position + 1}`;
+  }
 }


### PR DESCRIPTION
Fixes #15021

PR adds aria-labels to the check-boxes in the [table selection example](https://material.angular.io/components/table/examples) so they can be read by accessibility tools