### PR TITLE
fix(select): error when navigating via keyboard to reset option on a closed select

### DIFF
--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -383,6 +383,21 @@ describe('MatSelect', () => {
           flush();
         })));
 
+        it('should not throw when reaching a reset option using the arrow keys on a closed select',
+           fakeAsync(() => {
+             fixture.componentInstance.foods =
+                 [{value: 'steak-0', viewValue: 'Steak'}, {value: null, viewValue: 'None'}];
+             fixture.detectChanges();
+             fixture.componentInstance.control.setValue('steak-0');
+
+             expect(() => {
+               dispatchKeyboardEvent(select, 'keydown', DOWN_ARROW);
+               fixture.detectChanges();
+             }).not.toThrow();
+
+             flush();
+           }));
+
         it('should open a single-selection select using ALT + DOWN_ARROW', fakeAsync(() => {
           const {control: formControl, select: selectInstance} = fixture.componentInstance;
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -705,7 +705,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       event.preventDefault(); // prevents the page from scrolling down when pressing space
       this.open();
     } else if (!this.multiple) {
-      const selectedOption = this.selected;
+      const previouslySelectedOption = this.selected;
 
       if (keyCode === HOME || keyCode === END) {
         keyCode === HOME ? manager.setFirstItemActive() : manager.setLastItemActive();
@@ -714,10 +714,12 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
         manager.onKeydown(event);
       }
 
+      const selectedOption = this.selected;
+
       // Since the value has changed, we need to announce it ourselves.
       // @breaking-change 8.0.0 remove null check for _liveAnnouncer.
-      if (this._liveAnnouncer && selectedOption !== this.selected) {
-        this._liveAnnouncer.announce((this.selected as MatOption).viewValue);
+      if (this._liveAnnouncer && selectedOption && previouslySelectedOption !== selectedOption) {
+        this._liveAnnouncer.announce((selectedOption as MatOption).viewValue);
       }
     }
   }


### PR DESCRIPTION
Fixes `mat-select` throwing an error when the user reaches a reset option using the arrow keys on a closed select. Seems to be due to a missing null check in the changes from #14540.

Fixes #15159.