### PR TITLE
docs(stepper): update non-default boolean for editable prop

### DIFF
--- a/src/cdk/stepper/stepper.md
+++ b/src/cdk/stepper/stepper.md
@@ -33,7 +33,7 @@ on `CdkStep` in a `linear` stepper.
 
 #### Editable step
 By default, steps are editable, which means users can return to previously completed steps and
-edit their responses. `editable="true"` can be set on `CdkStep` to change the default.
+edit their responses. `editable="false"` can be set on `CdkStep` to change the default.
 
 #### Completed step
 By default, the `completed` attribute of a step returns `true` if the step is valid (in case of

--- a/src/lib/stepper/stepper.md
+++ b/src/lib/stepper/stepper.md
@@ -127,7 +127,7 @@ on `mat-step`.
 
 #### Editable step
 By default, steps are editable, which means users can return to previously completed steps and
-edit their responses. `editable="true"` can be set on `mat-step` to change the default.
+edit their responses. `editable="false"` can be set on `mat-step` to change the default.
 
 <!-- example(stepper-editable) -->
 


### PR DESCRIPTION
Previously, the docs said `editable` can be set to `true`, but that is the default, so it makes more sense to say they can be set to `false` to change the default behavior.