### PR TITLE
fix:(tabs) add call for rechecking tab scroll distance

### DIFF
--- a/src/lib/tabs/tab-header.spec.ts
+++ b/src/lib/tabs/tab-header.spec.ts
@@ -604,6 +604,26 @@ describe('MatTabHeader', () => {
       expect(tabHeaderElement.classList).toContain(enabledClass);
     });
 
+    it('scroll to last tab', () => {
+      fixture = TestBed.createComponent(SimpleTabHeaderApp);
+      appComponent = fixture.componentInstance;
+      appComponent.tabs = [
+        {label: 'tab one'},
+        {label: 'tab two'},
+        {label: 'tab three'},
+        {label: 'tab four'},
+        {label: 'tab five'},
+        {label: 'tab six'},
+        {label: 'tab seven'},
+        {label: 'tab eight'},
+      ];
+      appComponent.tabHeader.selectedIndex = 8;
+
+      fixture.componentRef.changeDetectorRef.markForCheck();
+
+      expect(appComponent.tabHeader.scrollDistance)
+          .toBe(appComponent.tabHeader._getMaxScrollDistance());
+    });
   });
 });
 

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -247,6 +247,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     const dirChange = this._dir ? this._dir.change : observableOf(null);
     const resize = this._viewportRuler.change(150);
     const realign = () => {
+      this._scrollToLabel(this._selectedIndex);
       this.updatePagination();
       this._alignInkBarToSelectedTab();
     };


### PR DESCRIPTION
Add call to scroll the tabs header after initialising header pagination, to accurately calculate the scroll distance.

Fixes #12889