### PR TITLE
build: downgrade to sauce-connect v4.5.1

### DIFF
--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-tunnelFileName="sc-4.5.3-linux.tar.gz"
+tunnelFileName="sc-4.5.1-linux.tar.gz"
 tunnelUrl="https://saucelabs.com/downloads/${tunnelFileName}"
 
 tunnelTmpDir="/tmp/material-saucelabs"


### PR DESCRIPTION
We currently face some flakiness with our Saucelabs job. These randomly exceed the 2min establish timeout because something throws off `sauce-connect` in a long-lasting loop where it tries to connect to some of their Saucelabs servers.

The initial assumption from the Saucelabs team was that we might have some invalid firewall rules, but this does not answer why this happens _randomly_, so the **latest update from the support** is that there have been some changes in the latest version of `sauce-connect` version that cause this flakiness.

Note that is commit is based on my investigations over at `angular/angular`. See: https://github.com/angular/angular/commit/6050cd0c1bc27bc8daf67c58836297b503ebb0e1

e.g. https://github.com/angular/material2/pull/15173