### PR TITLE
fix(mat-button): text-decoration removed from anchors on hover

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -43,9 +43,11 @@ $mat-mini-fab-padding: 8px !default;
   // Make anchors render like buttons.
   display: inline-block;
   white-space: nowrap;
-  text-decoration: none;
   vertical-align: baseline;
   text-align: center;
+  &:hover {
+    text-decoration: none;
+  }
 
   // Sizing.
   margin: $mat-button-margin;


### PR DESCRIPTION
When hovering over an anchor element that has mat-button styling, the text is not underlined.