### PR TITLE
fix(docs): CDK bidi overview

### DIFF
--- a/src/cdk/bidi/bidi.md
+++ b/src/cdk/bidi/bidi.md
@@ -20,7 +20,7 @@ export class MyWidget implements OnDestroy {
   constructor(dir: Directionality) {
     this.isRtl = dir.value === 'rtl';
     
-    _dirChangeSubscription = dir.change.subscribe(() => {
+    this._dirChangeSubscription = dir.change.subscribe(() => {
       this.flipDirection();
     });
   }


### PR DESCRIPTION
a `this.` is missing in the example
