### PR TITLE
build: publish script should should note where to paste changelog

### DIFF
--- a/tools/release/git/github-urls.ts
+++ b/tools/release/git/github-urls.ts
@@ -5,9 +5,10 @@ export function getGithubBranchCommitsUrl(owner: string, repository: string, bra
 
 /** Gets a Github URL that can be used to create a new release from a given tag. */
 export function getGithubNewReleaseUrl(options: {owner: string, repository: string,
-    tagName: string, releaseTitle: string}) {
+    tagName: string, releaseTitle: string, body: string}) {
 
   return `https://github.com/${options.owner}/${options.repository}/releases/new?` +
     `tag=${encodeURIComponent(options.tagName)}&` +
-    `title=${encodeURIComponent(options.releaseTitle)}&`;
+    `title=${encodeURIComponent(options.releaseTitle)}&` +
+    `body=${encodeURIComponent(options.body)}`;
 }

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -126,6 +126,9 @@ class PublishReleaseTask extends BaseReleaseTask {
       repository: this.repositoryName,
       tagName: newVersionName,
       releaseTitle: releaseTitle,
+      // TODO: we cannot insert the real changelog here since the URL would become
+      // way too large and Github would consider this as a malformed page request.
+      body: 'Copy-paste changelog in here!'
     });
 
     console.log();
@@ -133,8 +136,11 @@ class PublishReleaseTask extends BaseReleaseTask {
 
     // Always log out of npm after releasing to prevent unintentional changes to
     // any packages.
-    npmLogout();
-    console.info(green(bold(`  ✓   Logged out of npm`)));
+    if (npmLogout()) {
+      console.info(green(`  ✓   Logged out of npm`));
+    } else {
+      console.error(red(`  ✘   Could not log out of NPM. Please manually log out!`));
+    }
 
     console.info(yellow(`  ⚠   Please draft a new release of the version on Github.`));
     console.info(yellow(`      ${newReleaseUrl}`));


### PR DESCRIPTION
Currently we still cannot cut the Github release automatically because
the publish script does not have API access. Though it's sometimes
not quite clear for the caretaker what he needs to do manually. In
the meanwhile we make this _slighty_ more clear by adding a
note that indicates where the release notes should be copy-pasted
to.