### PR TITLE
feat(dialog): extend config with custom dialog container (#8857)

### DIFF
--- a/src/dev-app/dev-app-module.ts
+++ b/src/dev-app/dev-app-module.ts
@@ -29,7 +29,7 @@ import {ChipsDemo} from './chips/chips-demo';
 import {ConnectedOverlayDemo} from './connected-overlay/connected-overlay-demo';
 import {CustomHeader, CustomHeaderNgContent, DatepickerDemo} from './datepicker/datepicker-demo';
 import {DevAppComponent, DevAppHome, DevApp404} from './dev-app';
-import {ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog} from './dialog/dialog-demo';
+import {ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog, CustomDialogContainer} from './dialog/dialog-demo';
 import {DragAndDropDemo} from './drag-drop/drag-drop-demo';
 import {DrawerDemo} from './drawer/drawer-demo';
 import {ExamplePageModule} from './example/example-module';
@@ -139,6 +139,7 @@ import {VirtualScrollDemo} from './virtual-scroll/virtual-scroll-demo';
     TooltipDemo,
     TypographyDemo,
     VirtualScrollDemo,
+    CustomDialogContainer
   ],
   providers: [
     {provide: OverlayContainer, useClass: FullscreenOverlayContainer},
@@ -152,6 +153,7 @@ import {VirtualScrollDemo} from './virtual-scroll/virtual-scroll-demo';
     IFrameDialog,
     JazzDialog,
     ScienceJoke,
+    CustomDialogContainer
   ],
   bootstrap: [DevAppComponent],
 })

--- a/src/dev-app/dialog/dialog-demo.html
+++ b/src/dev-app/dialog/dialog-demo.html
@@ -9,6 +9,9 @@
 <button mat-raised-button color="accent" (click)="openTemplate()">
   Open dialog with template content
 </button>
+<button mat-raised-button color="accent" (click)="openCustomContainer()">
+  Open dialog custom container
+</button>
 
 <mat-card class="demo-dialog-card">
   <mat-card-content>

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -8,7 +8,14 @@
 
 import {DOCUMENT} from '@angular/common';
 import {Component, Inject, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialog, MatDialogConfig, MatDialogRef} from '@angular/material';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog, MatDialogConfig,
+  MatDialogRef,
+  MatDialogContainer,
+  MatDialogHostConfig
+} from '@angular/material';
+import { trigger, state, style, transition, animate } from '@angular/animations';
 
 
 const defaultDialogConfig = new MatDialogConfig();
@@ -83,6 +90,21 @@ export class DialogDemo {
   openTemplate() {
     this.numTemplateOpens++;
     this.dialog.open(this.template, this.config);
+  }
+
+  openCustomContainer() {
+    this.dialogRef = this.dialog.open(JazzDialog, {
+      ...this.config,
+      container: CustomDialogContainer
+    });
+
+    this.dialogRef.beforeClosed().subscribe((result: string) => {
+      this.lastBeforeCloseResult = result;
+    });
+    this.dialogRef.afterClosed().subscribe((result: string) => {
+      this.lastAfterClosedResult = result;
+      this.dialogRef = null;
+    });
   }
 }
 
@@ -214,3 +236,22 @@ export class ContentElementDialog {
   `
 })
 export class IFrameDialog {}
+
+
+const slideUpAnimation = trigger('dialogContainer', [
+  state('void, exit', style({transform: 'translateY(100vh)'})),
+  state('enter', style({transform: 'none'})),
+  transition('* => enter', animate('300ms cubic-bezier(0, 0, 0.2, 1)',
+      style({transform: 'none'}))),
+  transition('* => void, * => exit',
+      animate('300ms cubic-bezier(0, 0, 0.2, 1)', style({transform: 'translateY(100vh)'}))),
+]);
+
+@Component({
+  selector: 'custom-dialog-container',
+  template: `<ng-template cdkPortalOutlet></ng-template>`,
+  animations: [slideUpAnimation],
+  host: MatDialogHostConfig,
+  encapsulation: ViewEncapsulation.None
+})
+export class CustomDialogContainer extends MatDialogContainer {}

--- a/src/lib/dialog/dialog-config.ts
+++ b/src/lib/dialog/dialog-config.ts
@@ -8,7 +8,8 @@
 
 import {ViewContainerRef} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
-import {ScrollStrategy} from '@angular/cdk/overlay';
+import {ScrollStrategy, ComponentType} from '@angular/cdk/overlay';
+import {MatDialogContainer} from './dialog-container';
 
 /** Valid ARIA roles for a dialog element. */
 export type DialogRole = 'dialog' | 'alertdialog';
@@ -113,6 +114,9 @@ export class MatDialogConfig<D = any> {
    * the `HashLocationStrategy`).
    */
   closeOnNavigation?: boolean = true;
+
+  /** Container for the dialog. */
+  container?: ComponentType<MatDialogContainer>;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -41,6 +41,20 @@ export function throwMatDialogContentAlreadyAttachedError() {
   throw Error('Attempting to attach dialog content after content is already attached');
 }
 
+export const MatDialogHostConfig: { [key: string]: string } = {
+    'class': 'mat-dialog-container',
+    'tabindex': '-1',
+    'aria-modal': 'true',
+    '[attr.id]': '_id',
+    '[attr.role]': '_config.role',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
+    '[attr.aria-label]': '_config.ariaLabel',
+    '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
+    '[@dialogContainer]': '_state',
+    '(@dialogContainer.start)': '_onAnimationStart($event)',
+    '(@dialogContainer.done)': '_onAnimationDone($event)'
+};
+
 /**
  * Internal component that wraps user-provided dialog content.
  * Animation is based on https://material.io/guidelines/motion/choreography.html.
@@ -56,19 +70,7 @@ export function throwMatDialogContentAlreadyAttachedError() {
   // tslint:disable-next-line:validate-decorators
   changeDetection: ChangeDetectionStrategy.Default,
   animations: [matDialogAnimations.dialogContainer],
-  host: {
-    'class': 'mat-dialog-container',
-    'tabindex': '-1',
-    'aria-modal': 'true',
-    '[attr.id]': '_id',
-    '[attr.role]': '_config.role',
-    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
-    '[attr.aria-label]': '_config.ariaLabel',
-    '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
-    '[@dialogContainer]': '_state',
-    '(@dialogContainer.start)': '_onAnimationStart($event)',
-    '(@dialogContainer.done)': '_onAnimationDone($event)',
-  },
+  host: MatDialogHostConfig
 })
 export class MatDialogContainer extends BasePortalOutlet {
   /** The portal outlet inside of this container into which the dialog content will be loaded. */

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -223,7 +223,8 @@ export class MatDialog implements OnDestroy {
       [MatDialogConfig, config]
     ]));
     const containerPortal =
-        new ComponentPortal(MatDialogContainer, config.viewContainerRef, injector);
+        new ComponentPortal(config.container || MatDialogContainer,
+          config.viewContainerRef, injector);
     const containerRef = overlay.attach<MatDialogContainer>(containerPortal);
 
     return containerRef.instance;


### PR DESCRIPTION
This PR is for solving this Issue: #8857

The PR is still in progress. I just created it to start a conversation about how to open dialogs with custom animation.

I have the following open questions:

1. How to use the style from the default MatDialogContainer
2. How to use the html from the default MatDialogContainer

@crisbeto What do you think about this PR?
Could you share your opinion, thoughts and concerns?