### PR TITLE
fix(slide-toggle): thumb animation not working on mobile

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.scss
+++ b/src/lib/slide-toggle/slide-toggle.scss
@@ -113,9 +113,12 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
 
   // Once the thumb container is being dragged around, we remove the transition duration to
   // make the drag feeling fast and not delayed.
-  &.mat-dragging, &:active {
-    @include cursor-grabbing;
+  &.mat-dragging {
     transition-duration: 0ms;
+  }
+
+  &:active {
+    @include cursor-grabbing;
   }
 
   ._mat-animation-noopable & {


### PR DESCRIPTION
With https://github.com/angular/material2/commit/cc8f871e8d3978cca95bffb3c0ab0d79961a8ddd, we enabled the `grabbing` cursor if the thumb container is pressed.

This accidentally broke animation for the thumb sometimes because the
`:active` pseudo class is added on tap/touch and sometimes remains set until
the user clicks away. This now accidentally causes the thumb transition duration
to be set to `0ms`,  while it should be only set to `0ms` if the user started dragging
the thumb (with a small threshold to avoid such issues)

Fixes #15232