### PR TITLE
fix(datepicker): toggle throwing an error if datepicker is not defined on init

### DIFF
--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -66,7 +66,11 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   /** Whether the toggle button is disabled. */
   @Input()
   get disabled(): boolean {
-    return this._disabled === undefined ? this.datepicker.disabled : !!this._disabled;
+    if (this._disabled === undefined && this.datepicker) {
+      return this.datepicker.disabled;
+    }
+
+    return !!this._disabled;
   }
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1538,6 +1538,15 @@ describe('MatDatepicker', () => {
     });
   });
 
+  describe('datepicker toggle without a datepicker', () => {
+    it('should not throw on init if toggle does not have a datepicker', () => {
+      expect(() => {
+        const fixture = createComponent(DatepickerToggleWithNoDatepicker, [MatNativeDateModule]);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+  });
+
   describe('popup positioning', () => {
     let fixture: ComponentFixture<StandardDatepicker>;
     let testComponent: StandardDatepicker;
@@ -1963,7 +1972,6 @@ class DelayedDatepicker {
 }
 
 
-
 @Component({
   template: `
     <input [matDatepicker]="d">
@@ -1974,3 +1982,11 @@ class DelayedDatepicker {
   `,
 })
 class DatepickerWithTabindexOnToggle {}
+
+
+@Component({
+  template: `
+    <mat-datepicker-toggle></mat-datepicker-toggle>
+  `,
+})
+class DatepickerToggleWithNoDatepicker {}


### PR DESCRIPTION
Fixes the `mat-datepicker-toggle` throwing an error if the `datepicker` undefined on init. We already have guards for this in all of the other cases, but it was missing in this one.