### PR TITLE
fix(drag-drop): dragged styling not being removed when exiting component with OnPush

### DIFF
--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -342,6 +342,7 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
         container: this,
         item: event.item.data
       });
+      this._changeDetectorRef.markForCheck();
     });
 
     ref.sorted.subscribe(event => {


### PR DESCRIPTION
Fixes the dragged styling not being removed from a drop container, which is wrapped inside a component with `OnPush` change detection, when an item is dragged into a connected container.

Fixes #15233.