### PR TITLE
fix(badge): increase font size of small badge

### DIFF
--- a/src/lib/badge/_badge-theme.scss
+++ b/src/lib/badge/_badge-theme.scss
@@ -189,7 +189,8 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
   }
 
   .mat-badge-small .mat-badge-content {
-    font-size: $mat-badge-font-size / 2;
+    // Set the font size to 75% of the original.
+    font-size: $mat-badge-font-size * 0.75;
   }
 
   .mat-badge-large .mat-badge-content {


### PR DESCRIPTION
Bumps the font size of the small badge, because the current one is too small.

Fixes #15251.

**Note:** setting this for `major`, because it could cause screenshot differences. For reference:

Before: 
<img width="48" alt="screenshot at feb 22 15-34-34" src="https://user-images.githubusercontent.com/4450522/53249227-e7f4b580-36b7-11e9-8372-a36628387069.png">

After:
<img width="42" alt="screenshot at feb 22 15-36-02" src="https://user-images.githubusercontent.com/4450522/53249236-ecb96980-36b7-11e9-9351-9af7d6dc09a3.png">

