### PR TITLE
fix(schematics): incorrectly throws if NgModule uses namespaced decorator

### DIFF
--- a/src/cdk/schematics/utils/ast/ng-module-imports.spec.ts
+++ b/src/cdk/schematics/utils/ast/ng-module-imports.spec.ts
@@ -1,0 +1,38 @@
+import {HostTree} from '@angular-devkit/schematics';
+import {UnitTestTree} from '@angular-devkit/schematics/testing';
+import {hasNgModuleImport} from './ng-module-imports';
+
+describe('NgModule import utils', () => {
+
+  let host: UnitTestTree;
+
+  beforeEach(() => {
+    host = new UnitTestTree(new HostTree());
+  });
+
+  describe('hasNgModuleImport', () => {
+    it('should properly detect imports', () => {
+      host.create('/test.ts', `
+      @NgModule({
+        imports: [TestModule],
+      })
+      export class MyModule {}
+    `);
+
+      expect(hasNgModuleImport(host, '/test.ts', 'TestModule')).toBe(true);
+      expect(hasNgModuleImport(host, '/test.ts', 'NotExistent')).toBe(false);
+    });
+
+    it(`should detect imports for NgModule's using a namespaced identifier`, () => {
+      host.create('/test.ts', `
+      @myImport.NgModule({
+        imports: [TestModule],
+      })
+      export class MyModule {}
+    `);
+
+      expect(hasNgModuleImport(host, '/test.ts', 'TestModule')).toBe(true);
+      expect(hasNgModuleImport(host, '/test.ts', 'NotExistent')).toBe(false);
+    });
+  });
+});

--- a/src/cdk/schematics/utils/ast/ng-module-imports.ts
+++ b/src/cdk/schematics/utils/ast/ng-module-imports.ts
@@ -49,7 +49,7 @@ function resolveIdentifierOfExpression(expression: ts.Expression): ts.Identifier
   if (ts.isIdentifier(expression)) {
     return expression;
   } else if (ts.isPropertyAccessExpression(expression)) {
-    return resolveIdentifierOfExpression(expression.expression);
+    return expression.name;
   }
   return null;
 }


### PR DESCRIPTION
Currently if the developer defines the primary app `NgModule` using a namespaced
import (e.g. `@ngCore.NgModule`), the Material schematics will incorrectly not detect
that module as the logic that resolves the decorator name of a class declaration
is flawed.

This is because it incorrectly traverses a `PropertyAccessExpression`, while the
accessed property name is exposed at the root level `PropertyAccessExpression`.

This PR fixes this and also adds additional unit tests for the `hasNgModuleImport`
utility function. (We have integration tests for this; but we don't test that special case)