### PR TITLE
test(grid-list): make error expectation less brittle

### DIFF
--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -23,9 +23,10 @@ describe('MatGridList', () => {
   });
 
   it('should throw error if rowHeight ratio is invalid', () => {
-    const fixture = createComponent(GridListWithInvalidRowHeightRatio);
-
-    expect(() => fixture.detectChanges()).toThrowError(/invalid ratio given for row-height/);
+    expect(() => {
+      const fixture = createComponent(GridListWithInvalidRowHeightRatio);
+      fixture.detectChanges();
+    }).toThrowError(/invalid ratio given for row-height/);
   });
 
   it('should throw error if tile colspan is wider than total cols', () => {


### PR DESCRIPTION
This makes the test pass in ivy (as well as ViewEngine) since attribute
bindings are set during creating mode in ivy.