### PR TITLE
refactor(button): use [attr.disabled] host binding in MatButton

### DIFF
--- a/src/lib/button/button.spec.ts
+++ b/src/lib/button/button.spec.ts
@@ -43,8 +43,9 @@ describe('MatButton', () => {
 
   it('should expose the ripple instance', () => {
     const fixture = TestBed.createComponent(TestApp);
-    const button = fixture.debugElement.query(By.css('button')).componentInstance as MatButton;
+    fixture.detectChanges();
 
+    const button = fixture.debugElement.query(By.directive(MatButton)).componentInstance;
     expect(button.ripple).toBeTruthy();
   });
 

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -70,7 +70,7 @@ export const _MatButtonMixinBase:
              button[mat-flat-button]`,
   exportAs: 'matButton',
   host: {
-    '[disabled]': 'disabled || null',
+    '[attr.disabled]': 'disabled || null',
     '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
   },
   templateUrl: 'button.html',


### PR DESCRIPTION
With ivy, MatAnchor will inherit the host bindings of MatButton. The
`[disabled]` binding would then be an error since HTMLAnchorElement does
not have a `disabled` property. To work around this, we can simply use
the `disabled` attribute instead, which will always be reflected back
into the property when it exists.

Also add a missing `fixture.detectChanges()` to a test.