### PR TITLE
test(slide-toggle): adding missing detectChanges() and tick()

### DIFF
--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -435,6 +435,8 @@ describe('MatSlideToggle without forms', () => {
           ]
         });
       const fixture = TestBed.createComponent(SlideToggleBasic);
+      fixture.detectChanges();
+
       const testComponent = fixture.debugElement.componentInstance;
       const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
       const thumbContainerDebug = slideToggleDebug
@@ -448,6 +450,7 @@ describe('MatSlideToggle without forms', () => {
       expect(slideToggle.checked).toBe(false);
 
       gestureConfig.emitEventForElement('slidestart', slideThumbContainer);
+      tick();
 
       expect(slideThumbContainer.classList).toContain('mat-dragging');
 


### PR DESCRIPTION
This makes a test pass both with ivy and ViewEngine