### PR TITLE
fix(form-field): allow user to click through arrow on native select

### DIFF
--- a/src/lib/form-field/form-field-input.scss
+++ b/src/lib/form-field/form-field-input.scss
@@ -193,6 +193,9 @@ select.mat-input-element {
     right: 0;
     margin-top: -$arrow-size / 2;
 
+    // Make the arrow non-clickable so the user can click on the form control under it.
+    pointer-events: none;
+
     [dir='rtl'] & {
       right: auto;
       left: 0;


### PR DESCRIPTION
Currently the user's click could be blocked by clicking on the arrow directly. These changes allow the user to click through it.

Fixes #15318.