### PR TITLE
test(expansion): rework tests that depend on static queries

### DIFF
--- a/src/lib/expansion/accordion.spec.ts
+++ b/src/lib/expansion/accordion.spec.ts
@@ -113,6 +113,8 @@ describe('MatAccordion', () => {
 
   it('should not register nested panels to the same accordion', () => {
     const fixture = TestBed.createComponent(NestedPanel);
+    fixture.detectChanges();
+
     const innerPanel = fixture.componentInstance.innerPanel;
     const outerPanel = fixture.componentInstance.outerPanel;
 

--- a/src/lib/expansion/expansion.spec.ts
+++ b/src/lib/expansion/expansion.spec.ts
@@ -118,6 +118,7 @@ describe('MatExpansionPanel', () => {
 
   it('should toggle the panel when pressing SPACE on the header', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
+    fixture.detectChanges();
     const headerEl = fixture.nativeElement.querySelector('.mat-expansion-panel-header');
 
     spyOn(fixture.componentInstance.panel, 'toggle');
@@ -132,6 +133,7 @@ describe('MatExpansionPanel', () => {
 
   it('should toggle the panel when pressing ENTER on the header', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
+    fixture.detectChanges();
     const headerEl = fixture.nativeElement.querySelector('.mat-expansion-panel-header');
 
     spyOn(fixture.componentInstance.panel, 'toggle');
@@ -146,6 +148,7 @@ describe('MatExpansionPanel', () => {
 
   it('should not toggle if a modifier key is pressed', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
+    fixture.detectChanges();
     const headerEl = fixture.nativeElement.querySelector('.mat-expansion-panel-header');
 
     spyOn(fixture.componentInstance.panel, 'toggle');


### PR DESCRIPTION
Fixes some tests that fail under Ivy, because they depend on static queries.