### PR TITLE
refactor(selection-list): avoid deprecated method

### DIFF
--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -433,7 +433,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
 
   /** Sets the focused option of the selection-list. */
   _setFocusedOption(option: MatListOption) {
-    this._keyManager.updateActiveItemIndex(this._getOptionIndex(option));
+    this._keyManager.updateActiveItem(option);
   }
 
   /**


### PR DESCRIPTION
* use `ListKeyManager`'s `updateActiveItem` instead of deprecated `updateActiveItemIndex`