### PR TITLE
fix(radio): unable to distinguish disabled radio button in high contrast mode

### DIFF
--- a/src/lib/radio/radio.scss
+++ b/src/lib/radio/radio.scss
@@ -181,3 +181,9 @@ $mat-radio-ripple-radius: 20px;
   bottom: 0;
   left: 50%;
 }
+
+@include cdk-high-contrast {
+  .mat-radio-disabled {
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
Fixes not being to tell apart an enabled and a disabled radio button in high contrast mode.