### PR TITLE
build: fix missing badge dependency

### DIFF
--- a/src/lib/badge/BUILD.bazel
+++ b/src/lib/badge/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
   deps = [
     "@angular//packages/common",
     "@angular//packages/core",
+    "@angular//packages/platform-browser/animations",
     "//src/cdk/a11y",
     "//src/cdk/coercion",
     "//src/lib/core",


### PR DESCRIPTION
Fixes the release build errors which were due to a missing dependency in the badge module.