### PR TITLE
fix(list): override native button text align in action list

### DIFF
--- a/src/lib/list/list.scss
+++ b/src/lib/list/list.scss
@@ -279,6 +279,11 @@ mat-action-list {
     outline: inherit;
     -webkit-tap-highlight-color: transparent;
 
+    text-align: left;
+    [dir='rtl'] & {
+      text-align: right;
+    }
+
     &::-moz-focus-inner {
       border: 0;
     }


### PR DESCRIPTION
This happens to work when the content is just text; however, content gets center
aligned when there are matLine elements nested in a `<button mat-list-item>`.