### PR TITLE
fix: add disabled styling for unchecked pseudo checkbox

### DIFF
--- a/src/lib/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/lib/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -23,6 +23,10 @@
     }
   }
 
+  .mat-pseudo-checkbox-disabled {
+    color: $disabled-color;
+  }
+
   // Default to the accent color. Note that the pseudo checkboxes are meant to inherit the
   // theme from their parent, rather than implementing their own theming, which is why we
   // don't attach to the `mat-*` classes.


### PR DESCRIPTION
Currently we have some disabled styling for the pseudo checkbox, but it only applies to checked checkboxes. These changes add some styling to distinguish unchecked disabled checkboxes.