### PR TITLE
Mark static queries as static

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -97,7 +97,7 @@ export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
   // tslint:disable:no-host-decorator-in-concrete
 
   /** The portal host inside of this container into which the dialog content will be loaded. */
-  @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
+  @ViewChild(PortalHostDirective, {static: true}) _portalHost: PortalHostDirective;
 
   /** A subject emitting before the dialog enters the view. */
   _beforeEnter: Subject<void> = new Subject();

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -20,6 +20,7 @@ describe('AriaDescriber', () => {
     fixture = TestBed.createComponent(TestApp);
     component = fixture.componentInstance;
     ariaDescriber = component.ariaDescriber;
+    fixture.detectChanges();
   });
 
   afterEach(() => {

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -77,6 +77,6 @@ class SetOfItems {
     </cdk-accordion-item>
   </cdk-accordion>`})
 class NestedItems {
-  @ViewChild('outerItem') outerItem: CdkAccordionItem;
-  @ViewChild('innerItem') innerItem: CdkAccordionItem;
+  @ViewChild('outerItem', {static: true}) outerItem: CdkAccordionItem;
+  @ViewChild('innerItem', {static: true}) innerItem: CdkAccordionItem;
 }

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -111,7 +111,7 @@ describe('FullscreenOverlayContainer', () => {
   providers: [Overlay],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  @ViewChild(CdkPortal, {static: true}) templatePortal: CdkPortal;
 
   constructor(public viewContainerRef: ViewContainerRef) { }
 }

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -60,7 +60,7 @@ describe('OverlayContainer', () => {
   providers: [Overlay],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  @ViewChild(CdkPortal, {static: true}) templatePortal: CdkPortal;
 
   constructor(public viewContainerRef: ViewContainerRef) { }
 }

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -563,8 +563,8 @@ class ArbitraryViewContainerRefComponent {
 })
 class PortalTestApp {
   @ViewChildren(CdkPortal) portals: QueryList<CdkPortal>;
-  @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
-  @ViewChild('templateRef', { read: TemplateRef }) templateRef: TemplateRef<any>;
+  @ViewChild(CdkPortalOutlet, {static: true}) portalOutlet: CdkPortalOutlet;
+  @ViewChild('templateRef', { read: TemplateRef , static: true}) templateRef: TemplateRef<any>;
 
   selectedPortal: Portal<any>|undefined;
   fruit: string = 'Banana';
@@ -600,7 +600,7 @@ class PortalTestApp {
   `,
 })
 class UnboundPortalTestApp {
-  @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
+  @ViewChild(CdkPortalOutlet, {static: true}) portalOutlet: CdkPortalOutlet;
 }
 
 // Create a real (non-test) NgModule as a workaround for

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -836,9 +836,9 @@ function triggerScroll(viewport: CdkVirtualScrollViewport, offset?: number) {
   encapsulation: ViewEncapsulation.None,
 })
 class FixedSizeVirtualScroll {
-  @ViewChild(CdkVirtualScrollViewport) viewport: CdkVirtualScrollViewport;
+  @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
   // Casting virtualForOf as any so we can spy on private methods
-  @ViewChild(CdkVirtualForOf) virtualForOf: any;
+  @ViewChild(CdkVirtualForOf, {static: true}) virtualForOf: any;
 
   @Input() orientation = 'vertical';
   @Input() viewportSize = 200;
@@ -888,7 +888,7 @@ class FixedSizeVirtualScroll {
   encapsulation: ViewEncapsulation.None,
 })
 class FixedSizeVirtualScrollWithRtlDirection {
-  @ViewChild(CdkVirtualScrollViewport) viewport: CdkVirtualScrollViewport;
+  @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
 
   @Input() orientation = 'vertical';
   @Input() viewportSize = 200;

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -84,7 +84,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
             Promise.resolve().then(() => this.ngZone.run(() => observer.next(index)))));
 
   /** The element that wraps the rendered content. */
-  @ViewChild('contentWrapper') _contentWrapper: ElementRef<HTMLElement>;
+  @ViewChild('contentWrapper', {static: true}) _contentWrapper: ElementRef<HTMLElement>;
 
   /** A stream that emits whenever the rendered range changes. */
   renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -2137,7 +2137,7 @@ class WrapperCdkTableApp<T> implements AfterContentInit {
   @ContentChild(CdkHeaderRowDef) headerRowDef: CdkHeaderRowDef;
   @ContentChildren(CdkRowDef) rowDefs: QueryList<CdkRowDef<T>>;
 
-  @ViewChild(CdkTable) table: CdkTable<T>;
+  @ViewChild(CdkTable, {static: true}) table: CdkTable<T>;
 
   @Input() columns: string[];
   @Input() dataSource: DataSource<T>;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -356,9 +356,9 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       new BehaviorSubject<{start: number, end: number}>({start: 0, end: Number.MAX_VALUE});
 
   // Outlets in the table's template where the header, data rows, and footer will be inserted.
-  @ViewChild(DataRowOutlet) _rowOutlet: DataRowOutlet;
-  @ViewChild(HeaderRowOutlet) _headerRowOutlet: HeaderRowOutlet;
-  @ViewChild(FooterRowOutlet) _footerRowOutlet: FooterRowOutlet;
+  @ViewChild(DataRowOutlet, {static: true}) _rowOutlet: DataRowOutlet;
+  @ViewChild(HeaderRowOutlet, {static: true}) _headerRowOutlet: HeaderRowOutlet;
+  @ViewChild(FooterRowOutlet, {static: true}) _footerRowOutlet: FooterRowOutlet;
 
   /**
    * The column definitions provided by the user that contain what the header, data, and footer

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -217,9 +217,9 @@ describe('cdkAutofill', () => {
 })
 class Inputs {
   // Cast to `any` so we can stub out some methods in the tests.
-  @ViewChild('input1') input1: ElementRef<any>;
-  @ViewChild('input2') input2: ElementRef<any>;
-  @ViewChild('input3') input3: ElementRef<any>;
+  @ViewChild('input1', {static: true}) input1: ElementRef<any>;
+  @ViewChild('input2', {static: true}) input2: ElementRef<any>;
+  @ViewChild('input3', {static: true}) input3: ElementRef<any>;
 }
 
 @Component({

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -64,12 +64,12 @@ describe('CdkTree', () => {
         configureCdkTreeTestingModule([SimpleCdkTreeApp]);
         fixture = TestBed.createComponent(SimpleCdkTreeApp);
 
+        fixture.detectChanges();
+
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with a connected data source', () => {
@@ -164,12 +164,12 @@ describe('CdkTree', () => {
         configureCdkTreeTestingModule([CdkTreeAppWithToggle]);
         fixture = TestBed.createComponent(CdkTreeAppWithToggle);
 
+        fixture.detectChanges();
+
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('should expand/collapse the node', () => {
@@ -250,12 +250,12 @@ describe('CdkTree', () => {
         configureCdkTreeTestingModule([WhenNodeCdkTreeApp]);
         fixture = TestBed.createComponent(WhenNodeCdkTreeApp);
 
+        fixture.detectChanges();
+
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -288,13 +288,13 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([ArrayDataSourceCdkTreeApp]);
         fixture = TestBed.createComponent(ArrayDataSourceCdkTreeApp);
+        fixture.detectChanges();
+
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -328,12 +328,12 @@ describe('CdkTree', () => {
         configureCdkTreeTestingModule([ObservableDataSourceCdkTreeApp]);
         fixture = TestBed.createComponent(ObservableDataSourceCdkTreeApp);
 
+        fixture.detectChanges();
+
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -368,18 +368,18 @@ describe('CdkTree', () => {
         fixture = TestBed.createComponent(CdkTreeAppWithTrackBy);
         component = fixture.componentInstance;
         component.trackByStrategy = trackByStrategy;
+        fixture.detectChanges();
+
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
 
         // Each node receives an attribute 'initialIndex' the element's original place
         getNodes(treeElement).forEach((node: Element, index: number) => {
           node.setAttribute('initialIndex', index.toString());
         });
 
-        // Prove that the attributes match their indicies
+        // Prove that the attributes match their indices
         const initialNodes = getNodes(treeElement);
         expect(initialNodes[0].getAttribute('initialIndex')).toBe('0');
         expect(initialNodes[1].getAttribute('initialIndex')).toBe('1');
@@ -459,13 +459,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([NestedCdkTreeApp]);
         fixture = TestBed.createComponent(NestedCdkTreeApp);
+        fixture.detectChanges();
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with a connected data source', () => {
@@ -547,13 +546,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
       configureCdkTreeTestingModule([StaticNestedCdkTreeApp]);
       fixture = TestBed.createComponent(StaticNestedCdkTreeApp);
+      fixture.detectChanges();
 
       component = fixture.componentInstance;
       dataSource = component.dataSource as FakeDataSource;
       tree = component.tree;
       treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-      fixture.detectChanges();
     });
 
     it('with the right data', () => {
@@ -574,13 +572,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([WhenNodeNestedCdkTreeApp]);
         fixture = TestBed.createComponent(WhenNodeNestedCdkTreeApp);
+        fixture.detectChanges();
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -613,13 +610,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([NestedCdkTreeAppWithToggle]);
         fixture = TestBed.createComponent(NestedCdkTreeAppWithToggle);
+        fixture.detectChanges();
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('should expand/collapse the node multiple times', () => {
@@ -712,13 +708,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([ArrayDataSourceNestedCdkTreeApp]);
         fixture = TestBed.createComponent(ArrayDataSourceNestedCdkTreeApp);
+        fixture.detectChanges();
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -749,13 +744,12 @@ describe('CdkTree', () => {
       beforeEach(() => {
         configureCdkTreeTestingModule([ObservableDataSourceNestedCdkTreeApp]);
         fixture = TestBed.createComponent(ObservableDataSourceNestedCdkTreeApp);
+        fixture.detectChanges();
 
         component = fixture.componentInstance;
         dataSource = component.dataSource as FakeDataSource;
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
       });
 
       it('with the right data', () => {
@@ -789,11 +783,10 @@ describe('CdkTree', () => {
         component = fixture.componentInstance;
         component.trackByStrategy = trackByStrategy;
         dataSource = component.dataSource as FakeDataSource;
+        fixture.detectChanges();
 
         tree = component.tree;
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-        fixture.detectChanges();
 
         // Each node receives an attribute 'initialIndex' the element's original place
         getNodes(treeElement).forEach((node: Element, index: number) => {
@@ -935,13 +928,12 @@ describe('CdkTree', () => {
     beforeEach(() => {
       configureCdkTreeTestingModule([DepthNestedCdkTreeApp]);
       fixture = TestBed.createComponent(DepthNestedCdkTreeApp);
+      fixture.detectChanges();
 
       component = fixture.componentInstance;
       dataSource = component.dataSource as FakeDataSource;
       tree = component.tree;
       treeElement = fixture.nativeElement.querySelector('cdk-tree');
-
-      fixture.detectChanges();
     });
 
     it('should have correct depth for nested tree', () => {

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -99,7 +99,7 @@ export class CdkTree<T>
   @Input() trackBy: TrackByFunction<T>;
 
   // Outlets within the tree's template where the dataNodes will be inserted.
-  @ViewChild(CdkTreeNodeOutlet) _nodeOutlet: CdkTreeNodeOutlet;
+  @ViewChild(CdkTreeNodeOutlet, {static: true}) _nodeOutlet: CdkTreeNodeOutlet;
 
   /** The tree node template for the tree */
   @ContentChildren(CdkTreeNodeDef) _nodeDefs: QueryList<CdkTreeNodeDef<T>>;

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -2352,7 +2352,7 @@ class SimpleAutocomplete implements OnDestroy {
   openedSpy = jasmine.createSpy('autocomplete opened spy');
   closedSpy = jasmine.createSpy('autocomplete closed spy');
 
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
   @ViewChild(MatAutocomplete) panel: MatAutocomplete;
   @ViewChild(MatFormField) formField: MatFormField;
   @ViewChildren(MatOption) options: QueryList<MatOption>;

--- a/src/lib/bottom-sheet/bottom-sheet-container.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-container.ts
@@ -63,7 +63,7 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   private _breakpointSubscription: Subscription;
 
   /** The portal outlet inside of this container into which the content will be loaded. */
-  @ViewChild(CdkPortalOutlet) _portalOutlet: CdkPortalOutlet;
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
 
   /** The state of the bottom sheet animations. */
   _animationState: 'void' | 'visible' | 'hidden' = 'void';

--- a/src/lib/dialog/dialog-container.ts
+++ b/src/lib/dialog/dialog-container.ts
@@ -72,7 +72,7 @@ export function throwMatDialogContentAlreadyAttachedError() {
 })
 export class MatDialogContainer extends BasePortalOutlet {
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
-  @ViewChild(CdkPortalOutlet) _portalOutlet: CdkPortalOutlet;
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
 
   /** The class that traps and manages focus within the dialog. */
   private _focusTrap: FocusTrap;

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -537,9 +537,9 @@ describe('MatMenu', () => {
         useFactory: (overlay: Overlay) => () => overlay.scrollStrategies.close()
       }
     ], [FakeIcon]);
+    fixture.detectChanges();
     const trigger = fixture.componentInstance.trigger;
 
-    fixture.detectChanges();
     trigger.openMenu();
     fixture.detectChanges();
 

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -32,10 +32,10 @@ describe('MatPaginator', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MatPaginatorApp);
+    fixture.detectChanges();
+
     component = fixture.componentInstance;
     paginator = component.paginator;
-
-    fixture.detectChanges();
   });
 
   describe('with the default internationalization provider', () => {
@@ -368,10 +368,9 @@ describe('MatPaginator', () => {
 
   it('should handle the number inputs being passed in as strings', () => {
     const withStringFixture = TestBed.createComponent(MatPaginatorWithStringValues);
-    const withStringPaginator = withStringFixture.componentInstance.paginator;
-
     withStringFixture.detectChanges();
 
+    const withStringPaginator = withStringFixture.componentInstance.paginator;
     expect(withStringPaginator.pageIndex).toEqual(0);
     expect(withStringPaginator.length).toEqual(100);
     expect(withStringPaginator.pageSize).toEqual(10);

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -1818,6 +1818,7 @@ describe('MatSelect', () => {
         fixture.componentInstance.select.open();
         fixture.detectChanges();
         flush();
+        fixture.detectChanges();
 
         host = fixture.debugElement.query(By.css('mat-select')).nativeElement;
         panel = overlayContainerElement.querySelector('.mat-select-panel')! as HTMLElement;
@@ -4232,7 +4233,7 @@ class BasicSelect {
   panelClass = ['custom-one', 'custom-two'];
   disableRipple: boolean;
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: true}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 }
 
@@ -4386,7 +4387,7 @@ class CustomSelectAccessor implements ControlValueAccessor {
 })
 class CompWithCustomSelect {
   ctrl = new FormControl('initial value');
-  @ViewChild(CustomSelectAccessor) customAccessor: CustomSelectAccessor;
+  @ViewChild(CustomSelectAccessor, {static: true}) customAccessor: CustomSelectAccessor;
 }
 
 @Component({

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -282,6 +282,8 @@ describe('MatDrawer', () => {
       let fixture = TestBed.createComponent(BasicTestApp);
       let drawer: MatDrawer = fixture.debugElement
           .query(By.directive(MatDrawer)).componentInstance;
+      fixture.detectChanges();
+
       let openButton = fixture.componentInstance.openButton.nativeElement;
       let closeButton = fixture.componentInstance.closeButton.nativeElement;
 

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -699,6 +699,7 @@ describe('MatDrawerContainer', () => {
     it('should be able to explicitly enable the backdrop in `side` mode', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicTestApp);
       const root = fixture.nativeElement;
+      fixture.detectChanges();
 
       fixture.componentInstance.drawer.mode = 'side';
       fixture.detectChanges();

--- a/src/lib/slide-toggle/slide-toggle.spec.ts
+++ b/src/lib/slide-toggle/slide-toggle.spec.ts
@@ -394,6 +394,8 @@ describe('MatSlideToggle without forms', () => {
           ]
         });
       const fixture = TestBed.createComponent(SlideToggleBasic);
+      fixture.detectChanges();
+
       const testComponent = fixture.debugElement.componentInstance;
       const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
 

--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -55,7 +55,7 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   private _destroyed = false;
 
   /** The portal outlet inside of this container into which the snack bar content will be loaded. */
-  @ViewChild(CdkPortalOutlet) _portalOutlet: CdkPortalOutlet;
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
 
   /** Subject for notifying that the snack bar has exited from view. */
   readonly _onExit: Subject<any> = new Subject();

--- a/src/lib/tabs/tab-header.spec.ts
+++ b/src/lib/tabs/tab-header.spec.ts
@@ -641,7 +641,7 @@ class SimpleTabHeaderApp {
   tabs: Tab[] = [{label: 'tab one'}, {label: 'tab one'}, {label: 'tab one'}, {label: 'tab one'}];
   dir: Direction = 'ltr';
 
-  @ViewChild(MatTabHeader) tabHeader: MatTabHeader;
+  @ViewChild(MatTabHeader, {static: true}) tabHeader: MatTabHeader;
 
   constructor() {
     this.tabs[this.disabledTabIndex].disabled = true;

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -98,9 +98,9 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     implements AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy, CanDisableRipple {
 
   @ContentChildren(MatTabLabelWrapper) _labelWrappers: QueryList<MatTabLabelWrapper>;
-  @ViewChild(MatInkBar) _inkBar: MatInkBar;
-  @ViewChild('tabListContainer') _tabListContainer: ElementRef;
-  @ViewChild('tabList') _tabList: ElementRef;
+  @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
+  @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
+  @ViewChild('tabList', {static: true}) _tabList: ElementRef;
   @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
   @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
 

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -81,7 +81,7 @@ export class MatTabNav extends _MatTabNavMixinBase
   private _activeLinkChanged: boolean;
   private _activeLinkElement: ElementRef<HTMLElement> | null;
 
-  @ViewChild(MatInkBar) _inkBar: MatInkBar;
+  @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
 
   /** Query list of all tab links of the tab navigation. */
   @ContentChildren(forwardRef(() => MatTabLink), {descendants: true})

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -49,10 +49,11 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
    */
-  @ContentChild(MatTabContent, {read: TemplateRef}) _explicitContent: TemplateRef<any>;
+  @ContentChild(MatTabContent, {read: TemplateRef, static: true})
+  _explicitContent: TemplateRef<any>;
 
   /** Template inside the MatTab view that contains an `<ng-content>`. */
-  @ViewChild(TemplateRef) _implicitContent: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: true}) _implicitContent: TemplateRef<any>;
 
   /** Plain text label for the tab, used when there is no template label. */
   @Input('label') textLabel: string = '';

--- a/src/lib/tree/tree.ts
+++ b/src/lib/tree/tree.ts
@@ -29,5 +29,5 @@ import {MatTreeNodeOutlet} from './outlet';
 })
 export class MatTree<T> extends CdkTree<T> {
   // Outlets within the tree's template where the dataNodes will be inserted.
-  @ViewChild(MatTreeNodeOutlet) _nodeOutlet: MatTreeNodeOutlet;
+  @ViewChild(MatTreeNodeOutlet, {static: true}) _nodeOutlet: MatTreeNodeOutlet;
 }


### PR DESCRIPTION
This PR moves a bunch of commits from ivy-2019 branch to master. These are mostly fixes to add the `static: true` flag to queries that need to be static, but it also contains some trivial test refactors that weren't yet on master.