### PR TITLE
fix(schematics): do not run migrations multiple times

### DIFF
--- a/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.spec.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.spec.ts
@@ -3,7 +3,6 @@ import {UnitTestTree} from '@angular-devkit/schematics/testing';
 import {getProjectTsConfigPaths} from './project-tsconfig-paths';
 
 describe('ng-update project-tsconfig-paths', () => {
-
   let testTree: UnitTestTree;
 
   beforeEach(() => {
@@ -13,39 +12,19 @@ describe('ng-update project-tsconfig-paths', () => {
   it('should detect build tsconfig path inside of angular.json file', () => {
     testTree.create('/my-custom-config.json', '');
     testTree.create('/angular.json', JSON.stringify({
-      projects: {
-        my_name: {
-          architect: {
-            build: {
-              options: {
-                tsConfig: './my-custom-config.json'
-              }
-            }
-          }
-        }
-      }
+      projects: {my_name: {architect: {build: {options: {tsConfig: './my-custom-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree)).toEqual(['./my-custom-config.json']);
+    expect(getProjectTsConfigPaths(testTree)).toEqual(['my-custom-config.json']);
   });
 
   it('should detect test tsconfig path inside of .angular.json file', () => {
     testTree.create('/my-test-config.json', '');
     testTree.create('/.angular.json', JSON.stringify({
-      projects: {
-        with_tests: {
-          architect: {
-            test: {
-              options: {
-                tsConfig: './my-test-config.json'
-              }
-            }
-          }
-        }
-      }
+      projects: {with_tests: {architect: {test: {options: {tsConfig: './my-test-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree)).toEqual(['./my-test-config.json']);
+    expect(getProjectTsConfigPaths(testTree)).toEqual(['my-test-config.json']);
   });
 
   it('should detect common tsconfigs if no workspace config could be found', () => {
@@ -53,7 +32,17 @@ describe('ng-update project-tsconfig-paths', () => {
     testTree.create('/src/tsconfig.json', '');
     testTree.create('/src/tsconfig.app.json', '');
 
-    expect(getProjectTsConfigPaths(testTree))
-      .toEqual(['./tsconfig.json', './src/tsconfig.json', './src/tsconfig.app.json']);
+    expect(getProjectTsConfigPaths(testTree)).toEqual([
+      'tsconfig.json', 'src/tsconfig.json', 'src/tsconfig.app.json'
+    ]);
+  });
+
+  it('should not return duplicate tsconfig files', () => {
+    testTree.create('/tsconfig.json', '');
+    testTree.create('/.angular.json', JSON.stringify({
+      projects: {app: {architect: {test: {options: {tsConfig: 'tsconfig.json'}}}}}
+    }));
+
+    expect(getProjectTsConfigPaths(testTree)).toEqual(['tsconfig.json']);
   });
 });


### PR DESCRIPTION
Currently when someone runs the update schematic within a CLI project,
the migration could be executed multiple times for the same `tsconfig` path
This can happen because the `getProjectTsConfigPaths` function _can_
incorrectly return the same tsconfig multiple times. The paths are not properly
deduped as we don't normalize the determined project tsconfig paths.

e.g. `/tsconfig.json` exists and the common tsconfig path is detected. At the same time the
workspace configuration specifies `tsconfig.json` in the project options. Both paths refer
to the same tsconfig project, but are different strings and therefore aren't filtered out
by the `Set` which contains all possible tsconfig locations --> migrations are executed
for both paths.