### PR TITLE
refactor: remove explicit generics in rxjs usages

### DIFF
--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -56,8 +56,8 @@ export class Dialog implements OnDestroy {
   _afterAllClosedBase = new Subject<void>();
 
   // TODO(jelbourn): tighten the type on the right-hand side of this expression.
-  afterAllClosed: Observable<void> = defer<any>(() => this.openDialogs.length ?
-      this._afterAllClosed : this._afterAllClosed.pipe(startWith<void>(undefined))) as any;
+  afterAllClosed: Observable<void> = defer(() => this.openDialogs.length ?
+      this._afterAllClosed : this._afterAllClosed.pipe(startWith(undefined)));
 
   /** Stream that emits when a dialog is opened. */
   get afterOpened(): Subject<DialogRef<any>> {

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -38,7 +38,7 @@ export class ViewportRuler implements OnDestroy {
   constructor(private _platform: Platform, ngZone: NgZone) {
     ngZone.runOutsideAngular(() => {
       this._change = _platform.isBrowser ?
-          merge<Event>(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')) :
+          merge(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')) :
           observableOf();
 
       // Note that we need to do the subscription inside `runOutsideAngular`

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -131,7 +131,7 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   dataStream: Observable<T[] | ReadonlyArray<T>> = this._dataSourceChanges
       .pipe(
           // Start off with null `DataSource`.
-          startWith<DataSource<T>>(null!),
+          startWith(null!),
           // Bundle up the previous and current data sources so we can work with both.
           pairwise(),
           // Use `_changeDataSource` to disconnect from the previous data source and connect to the

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -161,7 +161,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
       this.elementScrolled()
           .pipe(
               // Start off with a fake scroll event so we properly detect our initial position.
-              startWith<Event | null>(null!),
+              startWith(null!),
               // Collect multiple events into one until the next animation frame. This way if
               // there are multiple scroll events in the same frame we only need to recheck
               // our layout once.

--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -323,8 +323,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     }
 
     return merge(
-      fromEvent<MouseEvent>(this._document, 'click'),
-      fromEvent<TouchEvent>(this._document, 'touchend')
+      fromEvent(this._document, 'click') as Observable<MouseEvent>,
+      fromEvent(this._document, 'touchend') as Observable<TouchEvent>
     )
     .pipe(filter(event => {
       const clickTarget = event.target as HTMLElement;

--- a/src/lib/core/line/line.ts
+++ b/src/lib/core/line/line.ts
@@ -34,7 +34,7 @@ export class MatLine {}
 export function setLines(lines: QueryList<MatLine>, element: ElementRef<HTMLElement>) {
   // Note: doesn't need to unsubscribe, because `changes`
   // gets completed by Angular when the view is destroyed.
-  lines.changes.pipe(startWith<QueryList<MatLine>>(lines)).subscribe(({length}) => {
+  lines.changes.pipe(startWith(lines)).subscribe(({length}) => {
     setClass(element, 'mat-2-line', false);
     setClass(element, 'mat-3-line', false);
     setClass(element, 'mat-multi-line', false);

--- a/src/lib/dialog/dialog.ts
+++ b/src/lib/dialog/dialog.ts
@@ -103,9 +103,9 @@ export class MatDialog implements OnDestroy {
    * Stream that emits when all open dialog have finished closing.
    * Will emit on subscribe if there are no open dialogs to begin with.
    */
-  readonly afterAllClosed: Observable<void> = defer<any>(() => this.openDialogs.length ?
+  readonly afterAllClosed: Observable<void> = defer(() => this.openDialogs.length ?
       this._afterAllClosed :
-      this._afterAllClosed.pipe(startWith(undefined as void))) as Observable<any>;
+      this._afterAllClosed.pipe(startWith(undefined))) as Observable<any>;
 
   constructor(
       private _overlay: Overlay,

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -194,7 +194,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     if (this._lazyContent) {
       // Render the content as soon as the panel becomes open.
       this.opened.pipe(
-        startWith<void>(null!),
+        startWith(null!),
         filter(() => this.expanded && !this._portal),
         take(1)
       ).subscribe(() => {

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -287,7 +287,7 @@ export class MatFormField extends _MatFormFieldMixinBase
     }
 
     // Subscribe to changes in the child control state in order to update the form field UI.
-    control.stateChanges.pipe(startWith<void>(null!)).subscribe(() => {
+    control.stateChanges.pipe(startWith(null!)).subscribe(() => {
       this._validatePlaceholders();
       this._syncDescribedByIds();
       this._changeDetectorRef.markForCheck();

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -22,7 +22,7 @@ import {
   InjectionToken,
   inject,
 } from '@angular/core';
-import {fromEvent, Subscription} from 'rxjs';
+import {fromEvent, Subscription, Observable} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
@@ -195,11 +195,12 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
       // Run outside angular so change detection didn't get triggered on every transition end
       // instead only on the animation that we care about (primary value bar's transitionend)
       this._ngZone.runOutsideAngular((() => {
+        const element = this._primaryValueBar.nativeElement;
+
         this._animationEndSubscription =
-            fromEvent<TransitionEvent>(this._primaryValueBar.nativeElement, 'transitionend')
-            .pipe(filter(((e: TransitionEvent) =>
-              e.target === this._primaryValueBar.nativeElement)))
-            .subscribe(_ => this._ngZone.run(() => this.emitAnimationEnd()));
+            (fromEvent(element, 'transitionend') as Observable<TransitionEvent>)
+              .pipe(filter(((e: TransitionEvent) => e.target === element)))
+              .subscribe(() => this._ngZone.run(() => this.emitAnimationEnd()));
       }));
     }
   }

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -262,7 +262,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
      * and we don't have close disabled.
      */
     this._ngZone.runOutsideAngular(() => {
-        fromEvent<KeyboardEvent>(this._elementRef.nativeElement, 'keydown').pipe(
+        (fromEvent(this._elementRef.nativeElement, 'keydown') as Observable<KeyboardEvent>).pipe(
             filter(event => event.keyCode === ESCAPE && !this.disableClose),
             takeUntil(this._destroyed)
         ).subscribe(event => this._ngZone.run(() => {

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -212,11 +212,14 @@ export class MatTableDataSource<T> extends DataSource<T> {
     // pipeline can progress to the next step. Note that the value from these streams are not used,
     // they purely act as a signal to progress in the pipeline.
     const sortChange: Observable<Sort|null|void> = this._sort ?
-        merge<Sort|void>(this._sort.sortChange, this._sort.initialized) :
+        merge(this._sort.sortChange, this._sort.initialized) as Observable<Sort|void> :
         observableOf(null);
     const pageChange: Observable<PageEvent|null|void> = this._paginator ?
-        merge<PageEvent|void>(
-          this._paginator.page, this._internalPageChanges, this._paginator.initialized) :
+        merge(
+          this._paginator.page,
+          this._internalPageChanges,
+          this._paginator.initialized
+        ) as Observable<PageEvent|void> :
         observableOf(null);
     const dataStream = this._data;
     // Watch for base data or filter changes to provide a filtered set of data.

--- a/src/material-examples/autocomplete-display/autocomplete-display-example.ts
+++ b/src/material-examples/autocomplete-display/autocomplete-display-example.ts
@@ -27,7 +27,7 @@ export class AutocompleteDisplayExample implements OnInit {
   ngOnInit() {
     this.filteredOptions = this.myControl.valueChanges
       .pipe(
-        startWith<string | User>(''),
+        startWith(''),
         map(value => typeof value === 'string' ? value : value.name),
         map(name => name ? this._filter(name) : this.options.slice())
       );


### PR DESCRIPTION
Removes all the places where we set generic explicitly for rxjs objects, in order to avoid potential issues with rxjs 6.4.

Fixes #15307.