### PR TITLE
fix(table): use default change detection strategy on table

### DIFF
--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -18,7 +18,7 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
-  ViewEncapsulation,
+  ViewEncapsulation
 } from '@angular/core';
 import {CanStick, CanStickCtor, mixinHasStickyInput} from './can-stick';
 import {CdkCellDef, CdkColumnDef} from './cell';
@@ -40,8 +40,9 @@ export abstract class BaseRowDef implements OnChanges {
   /** Differ used to check if any changes were made to the columns. */
   protected _columnsDiffer: IterableDiffer<any>;
 
-  constructor(/** @docs-private */ public template: TemplateRef<any>,
-              protected _differs: IterableDiffers) { }
+  constructor(
+      /** @docs-private */ public template: TemplateRef<any>, protected _differs: IterableDiffers) {
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
@@ -57,7 +58,7 @@ export abstract class BaseRowDef implements OnChanges {
    * Returns the difference between the current columns and the columns from the last diff, or null
    * if there is no difference.
    */
-  getColumnsDiff(): IterableChanges<any> | null {
+  getColumnsDiff(): IterableChanges<any>|null {
     return this._columnsDiffer.diff(this.columns);
   }
 
@@ -65,7 +66,8 @@ export abstract class BaseRowDef implements OnChanges {
   extractCellTemplate(column: CdkColumnDef): TemplateRef<any> {
     if (this instanceof CdkHeaderRowDef) {
       return column.headerCell.template;
-    } if (this instanceof CdkFooterRowDef) {
+    }
+    if (this instanceof CdkFooterRowDef) {
       return column.footerCell.template;
     } else {
       return column.cell.template;
@@ -76,7 +78,7 @@ export abstract class BaseRowDef implements OnChanges {
 // Boilerplate for applying mixins to CdkHeaderRowDef.
 /** @docs-private */
 export class CdkHeaderRowDefBase extends BaseRowDef {}
-export const _CdkHeaderRowDefBase: CanStickCtor & typeof CdkHeaderRowDefBase =
+export const _CdkHeaderRowDefBase: CanStickCtor&typeof CdkHeaderRowDefBase =
     mixinHasStickyInput(CdkHeaderRowDefBase);
 
 /**
@@ -102,7 +104,7 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
 // Boilerplate for applying mixins to CdkFooterRowDef.
 /** @docs-private */
 export class CdkFooterRowDefBase extends BaseRowDef {}
-export const _CdkFooterRowDefBase: CanStickCtor & typeof CdkFooterRowDefBase =
+export const _CdkFooterRowDefBase: CanStickCtor&typeof CdkFooterRowDefBase =
     mixinHasStickyInput(CdkFooterRowDefBase);
 
 /**
@@ -224,7 +226,7 @@ export class CdkCellOutlet implements OnDestroy {
    * a handle to provide that component's cells and context. After init, the CdkCellOutlet will
    * construct the cells with the provided context.
    */
-  static mostRecentCellOutlet: CdkCellOutlet | null = null;
+  static mostRecentCellOutlet: CdkCellOutlet|null = null;
 
   constructor(public _viewContainer: ViewContainerRef) {
     CdkCellOutlet.mostRecentCellOutlet = this;
@@ -248,10 +250,13 @@ export class CdkCellOutlet implements OnDestroy {
     'class': 'cdk-header-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
 })
-export class CdkHeaderRow { }
+export class CdkHeaderRow {
+}
 
 
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
@@ -263,10 +268,13 @@ export class CdkHeaderRow { }
     'class': 'cdk-footer-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
 })
-export class CdkFooterRow { }
+export class CdkFooterRow {
+}
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({
@@ -277,7 +285,10 @@ export class CdkFooterRow { }
     'class': 'cdk-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
 })
-export class CdkRow { }
+export class CdkRow {
+}

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -7,18 +7,15 @@
  */
 
 import {
-  ChangeDetectionStrategy,
-  Component,
-  Directive,
-  ViewEncapsulation
-} from '@angular/core';
-import {
-  CDK_ROW_TEMPLATE, CdkFooterRow, CdkFooterRowDef,
+  CDK_ROW_TEMPLATE,
+  CdkFooterRow,
+  CdkFooterRowDef,
   CdkHeaderRow,
   CdkHeaderRowDef,
   CdkRow,
-  CdkRowDef,
+  CdkRowDef
 } from '@angular/cdk/table';
+import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '@angular/core';
 
 /**
  * Header row definition for the mat-table.
@@ -29,7 +26,8 @@ import {
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
   inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
 })
-export class MatHeaderRowDef extends CdkHeaderRowDef {}
+export class MatHeaderRowDef extends CdkHeaderRowDef {
+}
 
 /**
  * Footer row definition for the mat-table.
@@ -40,7 +38,8 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {}
   providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
   inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
 })
-export class MatFooterRowDef extends CdkFooterRowDef {}
+export class MatFooterRowDef extends CdkFooterRowDef {
+}
 
 /**
  * Data row definition for the mat-table.
@@ -52,7 +51,8 @@ export class MatFooterRowDef extends CdkFooterRowDef {}
   providers: [{provide: CdkRowDef, useExisting: MatRowDef}],
   inputs: ['columns: matRowDefColumns', 'when: matRowDefWhen'],
 })
-export class MatRowDef<T> extends CdkRowDef<T> {}
+export class MatRowDef<T> extends CdkRowDef<T> {
+}
 
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
@@ -63,12 +63,15 @@ export class MatRowDef<T> extends CdkRowDef<T> {}
     'class': 'mat-header-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matHeaderRow',
   providers: [{provide: CdkHeaderRow, useExisting: MatHeaderRow}],
 })
-export class MatHeaderRow extends CdkHeaderRow { }
+export class MatHeaderRow extends CdkHeaderRow {
+}
 
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
@@ -79,12 +82,15 @@ export class MatHeaderRow extends CdkHeaderRow { }
     'class': 'mat-footer-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matFooterRow',
   providers: [{provide: CdkFooterRow, useExisting: MatFooterRow}],
 })
-export class MatFooterRow extends CdkFooterRow { }
+export class MatFooterRow extends CdkFooterRow {
+}
 
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({
@@ -95,9 +101,12 @@ export class MatFooterRow extends CdkFooterRow { }
     'class': 'mat-row',
     'role': 'row',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matRow',
   providers: [{provide: CdkRow, useExisting: MatRow}],
 })
-export class MatRow extends CdkRow { }
+export class MatRow extends CdkRow {
+}

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -22,7 +22,9 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
     'class': 'mat-table',
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTable for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class MatTable<T> extends CdkTable<T> {
   /** Overrides the sticky CSS class set by the `CdkTable`. */

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -11,9 +11,8 @@ export declare class BaseCdkCell {
 export declare abstract class BaseRowDef implements OnChanges {
     protected _columnsDiffer: IterableDiffer<any>;
     protected _differs: IterableDiffers;
-    columns: Iterable<string>;
-    template: TemplateRef<any>;
-    constructor(/** @docs-private */ template: TemplateRef<any>, _differs: IterableDiffers);
+    columns: Iterable<string>; template: TemplateRef<any>;
+    constructor( template: TemplateRef<any>, _differs: IterableDiffers);
     extractCellTemplate(column: CdkColumnDef): TemplateRef<any>;
     getColumnsDiff(): IterableChanges<any> | null;
     ngOnChanges(changes: SimpleChanges): void;


### PR DESCRIPTION
[Note: This change includes formatting changes as well as the actual code changes. The only change is that Default change detection strategy will be used instead of OnPush for table and row components.]

This resolves an issue with Ivy where change detection was not reflecting binding changes made to the row and cell templates in the component declaring the table.

In View Engine, change detection for a dynamically created view runs in two cases:
1) When the view in which it was inserted is checked
2) When the view in which it was declared is checked

As a result, if a dynamic view is inserted into an OnPush component, that view is not actually checked only "on push". It is also checked as often as its declaration view is checked (even if the insertion view is explicitly detached from change detection).

For this reason, marking `MatTable` as "OnPush" doesn't have much of an effect. It is built almost entirely of views that are declared elsewhere, so its change detection frequency is dependent on those declaration views. It also doesn't have any bindings inside its own view that would be protected by "OnPush", so marking it this way is effectively a noop and can be removed without performance regressions.

In Ivy, this change detection loophole has been closed, so  declaration views can no longer de-optimize OnPush components. This means bindings inherited from declaration views aren't updated by default if `MatTable` is OnPush (the embedded view would need to be marked dirty explicitly).

To avoid breaking changes when we transition to Ivy, it makes more sense to perpetuate the current behavior by removing the "OnPush" marker. As delineated earlier, this has no impact on View Engine. For Ivy, it would ensure bindings inherited from the declaration view are still checked by default.