### PR TITLE
fix(schematics): use ngAfterViewInit instead of ngOnInit in table

### DIFF
--- a/src/lib/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/src/lib/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { AfterViewInit, Component, ViewChild<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
 import { MatPaginator, MatSort } from '@angular/material';
 import { <%= classify(name) %>DataSource } from './<%= dasherize(name) %>-datasource';
 
@@ -15,7 +15,7 @@ import { <%= classify(name) %>DataSource } from './<%= dasherize(name) %>-dataso
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
-export class <%= classify(name) %>Component implements OnInit {
+export class <%= classify(name) %>Component implements AfterViewInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
   dataSource: <%= classify(name) %>DataSource;
@@ -23,7 +23,7 @@ export class <%= classify(name) %>Component implements OnInit {
   /** Columns displayed in the table. Columns IDs can be added, removed, or reordered. */
   displayedColumns = ['id', 'name'];
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.dataSource = new <%= classify(name) %>DataSource(this.paginator, this.sort);
   }
 }


### PR DESCRIPTION
According to the offical doc of Angular, view queries are set before the ngAfterViewInit callback is called.
https://angular.io/api/core/ViewChild
ngOnInit works with the current version of Angular, but it can change in the future.