### PR TITLE
refactor(datepicker): adapt custom header demo for Ivy

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -10,7 +10,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  Host,
   Inject,
   ViewChild,
   Optional,
@@ -69,10 +68,9 @@ export class DatepickerDemo {
 export class CustomHeader<D> implements OnDestroy {
   private _destroyed = new Subject<void>();
 
-  constructor(@Host() private _calendar: MatCalendar<D>,
-              private _dateAdapter: DateAdapter<D>,
-              @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
-              cdr: ChangeDetectorRef) {
+  constructor(
+      private _calendar: MatCalendar<D>, private _dateAdapter: DateAdapter<D>,
+      @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats, cdr: ChangeDetectorRef) {
     _calendar.stateChanges
         .pipe(takeUntil(this._destroyed))
         .subscribe(() => cdr.markForCheck());

--- a/src/material-examples/datepicker-custom-header/datepicker-custom-header-example.ts
+++ b/src/material-examples/datepicker-custom-header/datepicker-custom-header-example.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  Host,
   Inject,
   OnDestroy
 } from '@angular/core';
@@ -66,10 +65,9 @@ export class DatepickerCustomHeaderExample {
 export class ExampleHeader<D> implements OnDestroy {
   private destroyed = new Subject<void>();
 
-  constructor(@Host() private calendar: MatCalendar<D>,
-              private dateAdapter: DateAdapter<D>,
-              @Inject(MAT_DATE_FORMATS) private dateFormats: MatDateFormats,
-              cdr: ChangeDetectorRef) {
+  constructor(
+      private calendar: MatCalendar<D>, private dateAdapter: DateAdapter<D>,
+      @Inject(MAT_DATE_FORMATS) private dateFormats: MatDateFormats, cdr: ChangeDetectorRef) {
     calendar.stateChanges
         .pipe(takeUntil(this.destroyed))
         .subscribe(() => cdr.markForCheck());


### PR DESCRIPTION
In Ivy, @Host() no longer looks in module injector. This breaks this demo.