### PR TITLE
test(input): make the type validation test to pass in Ivy

### DIFF
--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -1621,10 +1621,10 @@ class MatInputHintLabelTestController {
   label: string = '';
 }
 
-@Component({
-  template: `<mat-form-field><input matInput type="file"></mat-form-field>`
-})
-class MatInputInvalidTypeTestController {}
+@Component({template: `<mat-form-field><input matInput [type]="t"></mat-form-field>`})
+class MatInputInvalidTypeTestController {
+  t = 'file';
+}
 
 @Component({
   template: `


### PR DESCRIPTION
In Ivy, static inputs are evaluated in creation mode, just after directives for that node are created. So this test is throwing immediately when the component is created, not during the first change detection.