### PR TITLE
fix(stepper): avoid breaking change in stepControl type

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -124,12 +124,7 @@ export class CdkStep implements OnChanges {
   @ViewChild(TemplateRef) content: TemplateRef<any>;
 
   /** The top level abstract control of the step. */
-  @Input() stepControl: {
-    valid: boolean;
-    invalid: boolean;
-    pending: boolean;
-    reset: () => void;
-  };
+  @Input() stepControl: FormControlLike;
 
   /** Whether user has seen the expanded step content or not. */
   interacted = false;
@@ -515,4 +510,58 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
     const focusedElement = this._document.activeElement;
     return stepperElement === focusedElement || stepperElement.contains(focusedElement);
   }
+}
+
+
+/**
+ * Simplified representation of a FormControl from @angular/forms.
+ * Used to avoid having to bring in @angular/forms for a single optional interface.
+ * @docs-private
+ */
+interface FormControlLike {
+  asyncValidator: () => any | null;
+  dirty: boolean;
+  disabled: boolean;
+  enabled: boolean;
+  errors: {[key: string]: any} | null;
+  invalid: boolean;
+  parent: any;
+  pending: boolean;
+  pristine: boolean;
+  root: FormControlLike;
+  status: string;
+  statusChanges: Observable<any>;
+  touched: boolean;
+  untouched: boolean;
+  updateOn: any;
+  valid: boolean;
+  validator: () => any | null;
+  value: any;
+  valueChanges: Observable<any>;
+  clearAsyncValidators(): void;
+  clearValidators(): void;
+  disable(opts?: any): void;
+  enable(opts?: any): void;
+  get(path: (string | number)[] | string): FormControlLike | null;
+  getError(errorCode: string, path?: (string | number)[] | string): any;
+  hasError(errorCode: string, path?: (string | number)[] | string): boolean;
+  markAllAsTouched(): void;
+  markAsDirty(opts?: any): void;
+  markAsPending(opts?: any): void;
+  markAsPristine(opts?: any): void;
+  markAsTouched(opts?: any): void;
+  markAsUntouched(opts?: any): void;
+  patchValue(value: any, options?: Object): void;
+  reset(value?: any, options?: Object): void;
+  setAsyncValidators(newValidator: () => any | (() => any)[] | null): void;
+  setErrors(errors: {[key: string]: any} | null, opts?: any): void;
+  setParent(parent: any): void;
+  setValidators(newValidator: () => any | (() => any)[] | null): void;
+  setValue(value: any, options?: Object): void;
+  updateValueAndValidity(opts?: any): void;
+  patchValue(value: any, options?: any): void;
+  registerOnChange(fn: Function): void;
+  registerOnDisabledChange(fn: (isDisabled: boolean) => void): void;
+  reset(formState?: any, options?: any): void;
+  setValue(value: any, options?: any): void;
 }

--- a/tools/public_api_guard/cdk/stepper.d.ts
+++ b/tools/public_api_guard/cdk/stepper.d.ts
@@ -12,12 +12,7 @@ export declare class CdkStep implements OnChanges {
     label: string;
     optional: boolean;
     state: StepState;
-    stepControl: {
-        valid: boolean;
-        invalid: boolean;
-        pending: boolean;
-        reset: () => void;
-    };
+    stepControl: FormControlLike;
     stepLabel: CdkStepLabel;
     constructor(_stepper: CdkStepper, stepperOptions?: StepperOptions);
     ngOnChanges(): void;


### PR DESCRIPTION
In #15134 we reworked the stepper not to depend on `@angular/forms` under the assumption that our limited `FormControl` interface would be enough to avoid a breaking change. Some people ended up being broken by the change so this PR reworks the `stepControl` type to avoid the breaking change.

Fixes #15462.