### PR TITLE
refactor: move DOCUMENT import from platform-browser to common

### DIFF
--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -1,7 +1,7 @@
+import {DOCUMENT} from '@angular/common';
 import {async, inject, TestBed} from '@angular/core/testing';
 import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
 import {PortalModule, CdkPortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/platform-browser';
 import {Overlay, OverlayContainer, OverlayModule, FullscreenOverlayContainer} from './index';
 
 describe('FullscreenOverlayContainer', () => {


### PR DESCRIPTION
In preparation for https://github.com/angular/angular/pull/28117, we need to migrate the import for the `DOCUMENT` token to avoid using the deprecated symbol from platform-browser.