### PR TITLE
fix(stepper): content not being rendered out initially with ivy

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -122,7 +122,7 @@ export class CdkStep implements OnChanges {
   @ContentChild(CdkStepLabel) stepLabel: CdkStepLabel;
 
   /** Template for step content. */
-  @ViewChild(TemplateRef) content: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: true}) content: TemplateRef<any>;
 
   /** The top level abstract control of the step. */
   @Input() stepControl: AbstractControl;


### PR DESCRIPTION
Equivalent of https://github.com/angular/material2/pull/15485 for the Ivy branch.

Fixes the stepper's content not being shown on the first render with Ivy, because we assume that the template with be present on init.