### PR TITLE
refactor(tree): rework to account for ivy changes

### DIFF
--- a/src/cdk/tree/outlet.ts
+++ b/src/cdk/tree/outlet.ts
@@ -7,8 +7,18 @@
  */
 import {
   Directive,
+  Inject,
+  InjectionToken,
+  Optional,
   ViewContainerRef,
 } from '@angular/core';
+
+/**
+ * Injection token used to provide a `CdkTreeNode` to its outlet.
+ * Used primarily to avoid circular imports.
+ * @docs-private
+ */
+export const CDK_TREE_NODE_OUTLET_NODE = new InjectionToken<{}>('CDK_TREE_NODE_OUTLET_NODE');
 
 /**
  * Outlet for nested CdkNode. Put `[cdkTreeNodeOutlet]` on a tag to place children dataNodes
@@ -18,5 +28,7 @@ import {
   selector: '[cdkTreeNodeOutlet]'
 })
 export class CdkTreeNodeOutlet {
-  constructor(public viewContainer: ViewContainerRef) {}
+  constructor(
+      public viewContainer: ViewContainerRef,
+      @Inject(CDK_TREE_NODE_OUTLET_NODE) @Optional() public _node?: any) {}
 }

--- a/src/cdk/tree/toggle.ts
+++ b/src/cdk/tree/toggle.ts
@@ -7,21 +7,14 @@
  */
 
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {
-  Directive,
-  Input,
-} from '@angular/core';
+import {Directive, HostListener, Input} from '@angular/core';
+
 import {CdkTree, CdkTreeNode} from './tree';
 
 /**
  * Node toggle to expand/collapse the node.
  */
-@Directive({
-  selector: '[cdkTreeNodeToggle]',
-  host: {
-    '(click)': '_toggle($event)',
-  }
-})
+@Directive({selector: '[cdkTreeNodeToggle]'})
 export class CdkTreeNodeToggle<T> {
   /** Whether expand/collapse the node recursively. */
   @Input('cdkTreeNodeToggleRecursive')
@@ -32,6 +25,12 @@ export class CdkTreeNodeToggle<T> {
   constructor(protected _tree: CdkTree<T>,
               protected _treeNode: CdkTreeNode<T>) {}
 
+  // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
+  // In Ivy the `host` bindings will be merged when this class is extended, whereas in
+  // ViewEngine they're overwritten.
+  // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
+  // tslint:disable-next-line:no-host-decorator-in-concrete
+  @HostListener('click', ['$event'])
   _toggle(event: Event): void {
     this.recursive
       ? this._tree.treeControl.toggleDescendants(this._treeNode.data)

--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CdkNestedTreeNode, CdkTree, CdkTreeNode, CdkTreeNodeDef} from '@angular/cdk/tree';
+import {
+  CDK_TREE_NODE_OUTLET_NODE,
+  CdkNestedTreeNode,
+  CdkTree,
+  CdkTreeNode,
+  CdkTreeNodeDef,
+} from '@angular/cdk/tree';
 import {
   AfterContentInit,
   Attribute,
@@ -19,12 +25,14 @@ import {
   QueryList,
 } from '@angular/core';
 import {
-  CanDisable, CanDisableCtor,
+  CanDisable,
+  CanDisableCtor,
   HasTabIndex,
   HasTabIndexCtor,
   mixinDisabled,
   mixinTabIndex,
 } from '@angular/material/core';
+
 import {MatTreeNodeOutlet} from './outlet';
 
 export const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNode =
@@ -90,15 +98,21 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   inputs: ['disabled', 'tabIndex'],
   providers: [
     {provide: CdkNestedTreeNode, useExisting: MatNestedTreeNode},
-    {provide: CdkTreeNode, useExisting: MatNestedTreeNode}
+    {provide: CdkTreeNode, useExisting: MatNestedTreeNode},
+    {provide: CDK_TREE_NODE_OUTLET_NODE, useExisting: MatNestedTreeNode}
   ]
 })
-export class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T>
-    implements AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
-
+export class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T> implements
+    AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
   @Input('matNestedTreeNode') node: T;
 
-  @ContentChildren(MatTreeNodeOutlet) nodeOutlet: QueryList<MatTreeNodeOutlet>;
+  /** The children node placeholder. */
+  @ContentChildren(MatTreeNodeOutlet, {
+    // We need to use `descendants: true`, because Ivy will no longer match
+    // indirect descendants if it's left as false.
+    descendants: true
+  })
+  nodeOutlet: QueryList<MatTreeNodeOutlet>;
 
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,

--- a/src/lib/tree/outlet.ts
+++ b/src/lib/tree/outlet.ts
@@ -5,9 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CdkTreeNodeOutlet} from '@angular/cdk/tree';
+import {CDK_TREE_NODE_OUTLET_NODE, CdkTreeNodeOutlet} from '@angular/cdk/tree';
 import {
   Directive,
+  Inject,
+  Optional,
   ViewContainerRef,
 } from '@angular/core';
 
@@ -19,5 +21,7 @@ import {
   selector: '[matTreeNodeOutlet]'
 })
 export class MatTreeNodeOutlet implements CdkTreeNodeOutlet {
-  constructor(public viewContainer: ViewContainerRef) {}
+  constructor(
+      public viewContainer: ViewContainerRef,
+      @Inject(CDK_TREE_NODE_OUTLET_NODE) @Optional() public _node?: any) {}
 }

--- a/src/lib/tree/toggle.ts
+++ b/src/lib/tree/toggle.ts
@@ -14,9 +14,6 @@ import {Directive, Input} from '@angular/core';
  */
 @Directive({
   selector: '[matTreeNodeToggle]',
-  host: {
-    '(click)': '_toggle($event)',
-  },
   providers: [{provide: CdkTreeNodeToggle, useExisting: MatTreeNodeToggle}]
 })
 export class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {

--- a/src/lib/tree/tree.ts
+++ b/src/lib/tree/tree.ts
@@ -24,7 +24,9 @@ import {MatTreeNodeOutlet} from './outlet';
   },
   styleUrls: ['tree.css'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // See note on CdkTree for explanation on why this uses the default change detection strategy.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   providers: [{provide: CdkTree, useExisting: MatTree}]
 })
 export class MatTree<T> extends CdkTree<T> {

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -16,6 +16,8 @@ export declare abstract class BaseTreeControl<T> implements TreeControl<T> {
     toggleDescendants(dataNode: T): void;
 }
 
+export declare const CDK_TREE_NODE_OUTLET_NODE: InjectionToken<{}>;
+
 export declare class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContentInit, OnDestroy {
     protected _children: T[];
     protected _differs: IterableDiffers;
@@ -53,6 +55,7 @@ export declare class CdkTreeModule {
 
 export declare class CdkTreeNode<T> implements FocusableOption, OnDestroy {
     protected _data: T;
+    _dataChanges: Subject<void>;
     protected _destroyed: Subject<void>;
     protected _elementRef: ElementRef<HTMLElement>;
     protected _tree: CdkTree<T>;
@@ -75,8 +78,9 @@ export declare class CdkTreeNodeDef<T> {
 }
 
 export declare class CdkTreeNodeOutlet {
+    _node?: any;
     viewContainer: ViewContainerRef;
-    constructor(viewContainer: ViewContainerRef);
+    constructor(viewContainer: ViewContainerRef, _node?: any);
 }
 
 export declare class CdkTreeNodeOutletContext<T> {
@@ -95,7 +99,7 @@ export declare class CdkTreeNodePadding<T> implements OnDestroy {
     level: number;
     constructor(_treeNode: CdkTreeNode<T>, _tree: CdkTree<T>, _renderer: Renderer2, _element: ElementRef<HTMLElement>, _dir: Directionality);
     _paddingIndent(): string | null;
-    _setPadding(): void;
+    _setPadding(forceChange?: boolean): void;
     ngOnDestroy(): void;
 }
 

--- a/tools/public_api_guard/lib/tree.d.ts
+++ b/tools/public_api_guard/lib/tree.d.ts
@@ -61,8 +61,9 @@ export declare class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
 }
 
 export declare class MatTreeNodeOutlet implements CdkTreeNodeOutlet {
+    _node?: any;
     viewContainer: ViewContainerRef;
-    constructor(viewContainer: ViewContainerRef);
+    constructor(viewContainer: ViewContainerRef, _node?: any);
 }
 
 export declare class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {


### PR DESCRIPTION
Reworks the `MatTree` and `CdkTree` components to account for some of the changes in Ivy. This includes:

* Changing the padding directive to account for a different time at which static inputs are initialized.
* Changing the toggle directive to account for inheritance of host listeners working differently.
* Switching to `Default` change detection, because the way embedded views are checked is slightly different.
* Using `descendants: true` to find the nested node outlet in order to handle a slight difference in how indirect content children are matched.