### PR TITLE
build: do not run dgeni with  "info" log level

### DIFF
--- a/tools/dgeni/docs-package.ts
+++ b/tools/dgeni/docs-package.ts
@@ -51,7 +51,7 @@ apiDocsPackage.processor(new EntryPointGrouper());
 
 // Configure the log level of the API docs dgeni package.
 apiDocsPackage.config(function(log: any) {
-  return log.level = 'info';
+  return log.level = 'warning';
 });
 
 // Configure the processor for reading files from the file system.


### PR DESCRIPTION
With Bazel it's uncommon to print anything except failures. Currently
the Dgeni logic that runs as part of our Bazel build is the only action
that prints something for a successful build. In order to make our Bazel
output clean, we lower the log level. For debugging, it's still easy to
modify the log-level.