### PR TITLE
fix(bottom-sheet): unable to reopen same bottom sheet after closing via back button

### DIFF
--- a/src/lib/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/lib/bottom-sheet/bottom-sheet-ref.ts
@@ -58,12 +58,13 @@ export class MatBottomSheetRef<T = any, R = any> {
     });
 
     // Dispose overlay when closing animation is complete
-    containerInstance._animationStateChanged.pipe(
-      filter(event => event.phaseName === 'done' && event.toState === 'hidden'),
-      take(1)
-    )
-    .subscribe(() => {
-      this._overlayRef.dispose();
+    containerInstance._animationStateChanged
+        .pipe(filter(event => event.phaseName === 'done' && event.toState === 'hidden'), take(1))
+        .subscribe(() => {
+          _overlayRef.dispose();
+        });
+
+    _overlayRef.detachments().pipe(take(1)).subscribe(() => {
       this._afterDismissed.next(this._result);
       this._afterDismissed.complete();
     });


### PR DESCRIPTION
**Note:** this is difficult to capture in a unit test, because it depends on things from the router and animations hence why a test has been omitted here.

Fixes not being able to reopen the same bottom sheet, if the user closed it by pressing back. The issue comes from the fact that we only consider the bottom sheet as closed when its animation completes, however that might not happen if the component is destroyed. The following changes work around the issue by completing the closing sequence on detach, rather than depending on the animation.

Fixes #15510.