### PR TITLE
chore(typescript): uniformly access all index sigs with index access.

### DIFF
--- a/src/lib/dialog/dialog-content-directives.ts
+++ b/src/lib/dialog/dialog-content-directives.ts
@@ -83,8 +83,8 @@ export class MatDialogClose implements OnInit, OnChanges {
       this.dialogResult = proxiedChange.currentValue;
     }
 
-    if (changes.ariaLabel) {
-      this._hasAriaLabel = !!changes.ariaLabel.currentValue;
+    if (changes['ariaLabel']) {
+      this._hasAriaLabel = !!changes['ariaLabel'].currentValue;
     }
   }
 }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -402,8 +402,8 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const disableRippleChanges = changes.disableRipple;
-    const colorChanges = changes.color;
+    const disableRippleChanges = changes['disableRipple'];
+    const colorChanges = changes['color'];
 
     if ((disableRippleChanges && !disableRippleChanges.firstChange) ||
         (colorChanges && !colorChanges.firstChange)) {


### PR DESCRIPTION
This is a follow up to https://github.com/angular/material2/pull/15206,
with these two changes all of material in conforming.

A build-time check to enforce this is part of tsetse -
https://tsetse.info/property-renaming-safe but I don't know how to turn
it on for this repositories bazel builds.