### PR TITLE
build: decrease karma timeouts for local browsers

### DIFF
--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -12,12 +12,6 @@
       "--no-sandbox"
     ]
   },
-  "FirefoxHeadless": {
-    "base": "Firefox",
-    "flags": [
-      "-headless"
-    ]
-  },
   "SAUCELABS_CHROME": {
     "base": "SauceLabs",
     "browserName": "chrome",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -73,10 +73,8 @@ module.exports = config => {
       video: false,
     },
 
-    browserDisconnectTimeout: 180000,
-    browserDisconnectTolerance: 3,
+    browserDisconnectTolerance: 1,
     browserNoActivityTimeout: 300000,
-    captureTimeout: 180000,
 
     browsers: ['ChromeHeadlessLocal'],
     singleRun: false,
@@ -129,6 +127,15 @@ module.exports = config => {
       // Setup the saucelabs reporter so that we report back to Saucelabs once
       // our tests finished.
       config.reporters.push('saucelabs');
+    }
+
+    // If the test platform is not "local", browsers are launched externally and can take
+    // up more time to capture. Also the connection can be flaky and therefore needs a
+    // higher disconnect timeout.
+    if (testPlatform !== 'local') {
+      config.browserDisconnectTimeout = 180000;
+      config.browserDisconnectTolerance = 3;
+      config.captureTimeout = 180000;
     }
 
     const platformBrowsers = platformMap[testPlatform];


### PR DESCRIPTION
Currently the timeouts which have been adjusted for a
flaky browser connection are also used for local browser
runs. This is problematic as local browsers which do
not capture properly still wait multiple minutes, while the
browser can just be restarted without hitting any rate
limit.

Additionally removes the custom `FirefoxHeadless` browser
because the `karma-firefox-launcher` also provides the
`FirefoxHeadless` browser configuration.