### PR TITLE
refactor(snack-bar): rework to account for ivy (#15536)

### DIFF
--- a/src/lib/snack-bar/snack-bar-container.ts
+++ b/src/lib/snack-bar/snack-bar-container.ts
@@ -40,7 +40,11 @@ import {MatSnackBarConfig} from './snack-bar-config';
   selector: 'snack-bar-container',
   templateUrl: 'snack-bar-container.html',
   styleUrls: ['snack-bar-container.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // In Ivy embedded views will be change detected from their declaration place, rather than
+  // where they were stamped out. This means that we can't have the snack bar container be OnPush,
+  // because it might cause snack bars that were opened from a template not to be out of date.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   animations: [matSnackBarAnimations.snackBarState],
   host: {


### PR DESCRIPTION
This is a resubmit of #15537.

Reworks the snack bar to account for a breaking change in Ivy.