### PR TITLE
build: remove duplicate route definitions

### DIFF
--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -77,8 +77,6 @@ export const DEV_APP_ROUTES: Routes = [
   {path: 'tooltip', loadChildren: 'tooltip/tooltip-demo-module#TooltipDemoModule'},
   {path: 'tree', loadChildren: 'tree/tree-demo-module#TreeDemoModule'},
   {path: 'typography', loadChildren: 'typography/typography-demo-module#TypographyDemoModule'},
-  {path: 'expansion', loadChildren: 'expansion/expansion-demo-module#ExpansionDemoModule'},
-  {path: 'stepper', loadChildren: 'stepper/stepper-demo-module#StepperDemoModule'},
   {path: 'screen-type', loadChildren: 'screen-type/screen-type-demo-module#ScreenTypeDemoModule'},
   {
     path: 'connected-overlay',


### PR DESCRIPTION
In order to be in sync as much as possible with #15557