### PR TITLE
build: fix error in expansion panel examples

### DIFF
--- a/src/material-examples/material-module.ts
+++ b/src/material-examples/material-module.ts
@@ -14,7 +14,8 @@ import {
   MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatPaginatorModule,
   MatProgressBarModule, MatProgressSpinnerModule, MatRadioModule, MatRippleModule, MatSelectModule,
   MatSidenavModule, MatSliderModule, MatSlideToggleModule, MatSnackBarModule, MatSortModule,
-  MatStepperModule, MatTableModule, MatTabsModule, MatToolbarModule, MatTooltipModule, MatTreeModule
+  MatStepperModule, MatTableModule, MatTabsModule, MatToolbarModule, MatTooltipModule,
+  MatTreeModule, MatNativeDateModule
 } from '@angular/material';
 
 @NgModule({
@@ -61,6 +62,7 @@ import {
     MatTreeModule,
     ScrollingModule,
     PortalModule,
+    MatNativeDateModule,
   ],
   exports: [
     A11yModule,
@@ -105,6 +107,7 @@ import {
     MatTreeModule,
     ScrollingModule,
     PortalModule,
+    MatNativeDateModule,
   ]
 })
 export class ExampleMaterialModule {}


### PR DESCRIPTION
Fixes errors that started being thrown by a couple of the expansion panel examples after we started lazy-loading the routes.