### PR TITLE
build: add validation for prebuilt cdk css

### DIFF
--- a/tools/release/release-output/check-package.ts
+++ b/tools/release/release-output/check-package.ts
@@ -2,7 +2,9 @@ import {bold, red, yellow} from 'chalk';
 import {existsSync} from 'fs';
 import {sync as glob} from 'glob';
 import {join} from 'path';
+
 import {
+  checkCdkPackage,
   checkMaterialPackage,
   checkReleaseBundle,
   checkTypeDefinitionFile
@@ -51,8 +53,9 @@ export function checkReleasePackage(releasesPath: string, packageName: string): 
 
   // Special release validation checks for the "material" release package.
   if (packageName === 'material') {
-    checkMaterialPackage(join(releasesPath, packageName))
-      .forEach(message => addFailure(message));
+    checkMaterialPackage(join(releasesPath, packageName)).forEach(message => addFailure(message));
+  } else if (packageName === 'cdk') {
+    checkCdkPackage(join(releasesPath, packageName)).forEach(message => addFailure(message));
   }
 
   if (!existsSync(join(packagePath, 'LICENSE'))) {

--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -1,6 +1,6 @@
 import {existsSync, readFileSync} from 'fs';
 import {sync as glob} from 'glob';
-import {dirname, isAbsolute, join} from 'path';
+import {dirname, isAbsolute, join, basename} from 'path';
 import * as ts from 'typescript';
 
 /** RegExp that matches Angular component inline styles that contain a sourcemap reference. */
@@ -86,4 +86,15 @@ export function checkMaterialPackage(packagePath: string): string[] {
   }
 
   return failures;
+}
+
+/**
+ * Checks whether the prebuilt CDK files are part of the release output.
+ */
+export function checkCdkPackage(packagePath: string): string[] {
+  const prebuiltFiles = glob('*-prebuilt.css', {cwd: packagePath}).map(path => basename(path));
+
+  return ['overlay', 'a11y', 'text-field']
+      .filter(name => !prebuiltFiles.includes(`${name}-prebuilt.css`))
+      .map(name => `Could not find the prebuilt ${name} styles.`);
 }


### PR DESCRIPTION
Adds another check to the release validation script that ensures that the prebuilt CDK CSS has been created.