### PR TITLE
build: hammer gestures not working in lazy-loaded modules

### DIFF
--- a/src/dev-app/dev-app/dev-app-module.ts
+++ b/src/dev-app/dev-app/dev-app-module.ts
@@ -13,9 +13,11 @@ import {
   MatIconModule,
   MatListModule,
   MatSidenavModule,
-  MatToolbarModule
+  MatToolbarModule,
+  GestureConfig
 } from '@angular/material';
 import {RouterModule} from '@angular/router';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {DevApp404} from './dev-app-404';
 import {DevAppHome} from './dev-app-home';
 import {DevAppLayout} from './dev-app-layout';
@@ -32,6 +34,10 @@ import {DevAppLayout} from './dev-app-layout';
   ],
   declarations: [DevAppLayout, DevAppHome, DevApp404],
   exports: [DevAppLayout],
+
+  // We need to pass this in here, because the gesture config currently doesn't for lazy-loaded
+  // modules. See https://github.com/angular/material2/issues/4595#issuecomment-416641018.
+  providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
 })
 export class DevAppModule {
 }


### PR DESCRIPTION
Fixes the Hammer.js gestures not working after the switch to lazy-loaded modules.