### PR TITLE
fix(dialog): aria-label not being removed if text content changes after init

### DIFF
--- a/src/lib/dialog/BUILD.bazel
+++ b/src/lib/dialog/BUILD.bazel
@@ -19,6 +19,7 @@ ng_module(
     "//src/cdk/keycodes",
     "//src/cdk/overlay",
     "//src/cdk/portal",
+    "//src/cdk/observers",
     "//src/lib/core",
   ],
 )
@@ -50,6 +51,7 @@ ng_test_library(
     "//src/cdk/overlay",
     "//src/cdk/scrolling",
     "//src/cdk/testing",
+    "//src/cdk/observers",
     ":dialog",
   ]
 )

--- a/tools/public_api_guard/lib/dialog.d.ts
+++ b/tools/public_api_guard/lib/dialog.d.ts
@@ -44,14 +44,16 @@ export declare const matDialogAnimations: {
     readonly slideDialog: AnimationTriggerMetadata;
 };
 
-export declare class MatDialogClose implements OnInit, OnChanges {
+export declare class MatDialogClose implements OnInit, OnChanges, OnDestroy {
     _hasAriaLabel?: boolean;
     _matDialogClose: any;
     ariaLabel: string;
     dialogRef: MatDialogRef<any>;
     dialogResult: any;
-    constructor(dialogRef: MatDialogRef<any>, _elementRef: ElementRef<HTMLElement>, _dialog: MatDialog);
+    constructor(dialogRef: MatDialogRef<any>, _elementRef: ElementRef<HTMLElement>, _dialog: MatDialog,
+    _contentObserver?: ContentObserver | undefined, _ngZone?: NgZone | undefined, _changeDetectorRef?: ChangeDetectorRef | undefined);
     ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
     ngOnInit(): void;
 }
 


### PR DESCRIPTION
Currently we set an `aria-label` on the `mat-dialog-close` button if it's an icon button or it doesn't have text, however it wasn't accounting for the case where the text comes in at a later point.

Fixes #15542.