### PR TITLE
build: do not ship schematic data typescript sources to npm

### DIFF
--- a/tools/package-tools/gulp/build-tasks-gulp.ts
+++ b/tools/package-tools/gulp/build-tasks-gulp.ts
@@ -50,7 +50,7 @@ export function createPackageBuildTasks(buildPackage: BuildPackage, preBuildTask
 
   // Pattern matching schematics files to be copied into the output directory.
   const schematicsGlobs = [
-    join(schematicsDir, '**/+(data|files)/**/*'),
+    join(schematicsDir, '**/files/**/*'),
     join(schematicsDir, '**/+(schema|collection|migration).json'),
   ];
 


### PR DESCRIPTION
In the early stages of the schematics the upgrade data was
stored in `.json` files. We switched these data files to TypeScript
at some point, but didn't update the schematic-copy glob. Meaning
that we currently ship TypeScript source files within the `data/` folder
to NPM for the CDK and Material schematics.