### PR TITLE
fix(button): icon inside icon button not centered in IE under some conditions

### DIFF
--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -83,6 +83,9 @@
   border-radius: $mat-icon-button-border-radius;
 
   i, .mat-icon {
+    // We need to set `display: inline`, because the vertical text alignment breaks down in IE11
+    // in certain setups. See https://github.com/angular/material2/issues/15593
+    display: inline;
     line-height: $mat-icon-button-line-height;
   }
 }


### PR DESCRIPTION
Fixes the icons inside a `mat-icon-button` not centered vertically on IE in some setups. This manifested itself in the `mat-tree-node-toggle`.

Fixes #15593.