### PR TITLE
fix(form-field): correct border-radius value

### DIFF
--- a/src/lib/form-field/form-field-outline.scss
+++ b/src/lib/form-field/form-field-outline.scss
@@ -10,7 +10,7 @@ $mat-form-field-outline-subscript-font-scale: 0.75 !default;
 // The amount of overlap between the label and the outline.
 $mat-form-field-outline-label-overlap: 0.25em;
 // The border radius of the outline.
-$mat-form-field-outline-border-radius: 5px;
+$mat-form-field-outline-border-radius: 4px;
 // The width of the outline.
 $mat-form-field-outline-width: 1px;
 // The width of the thick outline (used for focus, hover, and error state).


### PR DESCRIPTION
Material Design Text Fields - Spec

Outlined text field

![Annotation 2019-03-26 163246](https://user-images.githubusercontent.com/24437654/55001040-d2d7b300-4fe4-11e9-8ef5-f89d318e08ae.png)

Correct border-radius value for outlined text field

First field (5px border-radius) - Second field (4px border-radius)
![Preview](https://user-images.githubusercontent.com/24437654/55001469-b25c2880-4fe5-11e9-9d30-5afd34af086f.png)
