### PR TITLE
refactor(overlay): inconsistent return type for FlexibleConnectedPositionStrategy.withScrollableContainers

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -304,7 +304,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     this._applyPosition(fallback!.position, fallback!.originPoint);
   }
 
-  detach() {
+  detach(): void {
     this._clearPanelClasses();
     this._lastPosition = null;
     this._previousPushAmount = null;
@@ -312,7 +312,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   }
 
   /** Cleanup after the element gets destroyed. */
-  dispose() {
+  dispose(): void {
     if (this._isDisposed) {
       return;
     }
@@ -369,8 +369,9 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
    * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
    * Scrollable must be an ancestor element of the strategy's origin element.
    */
-  withScrollableContainers(scrollables: CdkScrollable[]) {
+  withScrollableContainers(scrollables: CdkScrollable[]): this {
     this.scrollables = scrollables;
+    return this;
   }
 
   /**

--- a/src/lib/tooltip/tooltip.ts
+++ b/src/lib/tooltip/tooltip.ts
@@ -348,17 +348,16 @@ export class MatTooltip implements OnDestroy, OnInit {
       return this._overlayRef;
     }
 
+    const scrollableAncestors =
+        this._scrollDispatcher.getAncestorScrollContainers(this._elementRef);
+
     // Create connected position strategy that listens for scroll events to reposition.
     const strategy = this._overlay.position()
-      .flexibleConnectedTo(this._elementRef)
-      .withTransformOriginOn('.mat-tooltip')
-      .withFlexibleDimensions(false)
-      .withViewportMargin(8);
-
-    const scrollableAncestors = this._scrollDispatcher
-      .getAncestorScrollContainers(this._elementRef);
-
-    strategy.withScrollableContainers(scrollableAncestors);
+                         .flexibleConnectedTo(this._elementRef)
+                         .withTransformOriginOn('.mat-tooltip')
+                         .withFlexibleDimensions(false)
+                         .withViewportMargin(8)
+                         .withScrollableContainers(scrollableAncestors);
 
     strategy.positionChanges.pipe(takeUntil(this._destroyed)).subscribe(change => {
       if (this._tooltipInstance) {

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -123,7 +123,7 @@ export declare class FlexibleConnectedPositionStrategy implements PositionStrate
     withLockedPosition(isLocked?: boolean): this;
     withPositions(positions: ConnectedPosition[]): this;
     withPush(canPush?: boolean): this;
-    withScrollableContainers(scrollables: CdkScrollable[]): void;
+    withScrollableContainers(scrollables: CdkScrollable[]): this;
     withTransformOriginOn(selector: string): this;
     withViewportMargin(margin: number): this;
 }


### PR DESCRIPTION
Fixes `FlexibleConnectedPositionStrategy.withScrollableContainers` returning `void`, whereas all other `with*` public methods are returning `this`.

Fixes #15607.