### PR TITLE
build: staging script should ignore pre-commit hook

### DIFF
--- a/tools/release/git/git-client.ts
+++ b/tools/release/git/git-client.ts
@@ -61,7 +61,9 @@ export class GitClient {
 
   /** Creates a new commit within the current branch with the given commit message. */
   createNewCommit(message: string): boolean {
-    return this._spawnGitProcess(['commit', '-m', message]).status === 0;
+    // Disable pre-commit hooks when creating a commit. Developers might not have set up
+    // their Git configuration for the "git-clang-format" pre-commit hook.
+    return this._spawnGitProcess(['commit', '--no-verify', '-m', message]).status === 0;
   }
 
   /** Gets the title of a specified commit reference. */


### PR DESCRIPTION
Currently if the caretaker stages a new release but does not have the
`git-clang-format` pre-commit hook configured properly (there is some
additional configuration involved), the staging script will fail.

In order to avoid these unexpected failures, we just ignore the pre-commit hook
when a commit is created automatically by the release scripts. The release script
only makes changes which _conform_ with clang-format / the project's style
guidelines.