### PR TITLE
fix(button): update padding values with spec

### DIFF
--- a/src/lib/button/_button-base.scss
+++ b/src/lib/button/_button-base.scss
@@ -13,6 +13,9 @@ $mat-button-border-radius: 4px !default;
 $mat-button-focus-transition: opacity 200ms $swift-ease-in-out-timing-function,
                               background-color 200ms $swift-ease-in-out-timing-function !default;
 
+// Text button padding
+$mat-text-button-padding: 0 8px !default;
+
 // Stroked button padding is 1px less horizontally than default/flat/raised
 // button's padding.
 $mat-stroked-button-line-height: $mat-button-line-height - 2;
@@ -51,7 +54,6 @@ $mat-mini-fab-padding: 8px !default;
   margin: $mat-button-margin;
   min-width: $mat-button-min-width;
   line-height: $mat-button-line-height;
-  padding: $mat-button-padding;
   border-radius: $mat-button-border-radius;
 
   // Explicitly set the default overflow to `visible`. It is already set

--- a/src/lib/button/button.scss
+++ b/src/lib/button/button.scss
@@ -37,6 +37,14 @@
   @include mat-button-base;
 }
 
+.mat-button {
+  padding: $mat-text-button-padding;
+}
+
+.mat-raised-button, .mat-flat-button {
+  padding: $mat-button-padding;
+}
+
 .mat-raised-button {
   @include mat-raised-button;
 }


### PR DESCRIPTION
mat-raised, mat-flat button (0 16px)

![Default Button](https://user-images.githubusercontent.com/24437654/55038661-acd8ff80-5032-11e9-875a-abca95041771.png)

mat-button (text-button) (0 8px)

![Text Button](https://user-images.githubusercontent.com/24437654/55038663-af3b5980-5032-11e9-8ca9-0642c0e9f872.png)

OLD
![OLD](https://user-images.githubusercontent.com/24437654/55039232-713f3500-5034-11e9-990b-c7f5803d3c15.png)

NEW
![Preview](https://user-images.githubusercontent.com/24437654/55038751-f4f82200-5032-11e9-9cd9-c6e09b18149a.png)

