### PR TITLE
build: switch to rbe_autoconfig

### DIFF
--- a/.circleci/base-rbe-bazelrc
+++ b/.circleci/base-rbe-bazelrc
@@ -1,126 +1,25 @@
-# ------------------------------
-# This file is taken from the "bazel-toolchains" repository and is used in order to reduce the
-# manual configuration overhead. https://github.com/bazelbuild/bazel-toolchains/tree/master/bazelrc
-# ------------------------------
-
-# Copyright 2016 The Bazel Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Depending on how many machines are in the remote execution instance, setting
-# this higher can make builds faster by allowing more jobs to run in parallel.
-# Setting it too high can result in jobs that timeout, however, while waiting
-# for a remote machine to execute them.
-build:remote --jobs=50
-
-# Set several flags related to specifying the platform, toolchain and java
-# properties.
-# These flags are duplicated rather than imported from (for example)
-# %workspace%/configs/ubuntu16_04_clang/1.1/toolchain.bazelrc to make this
-# bazelrc a standalone file that can be copied more easily.
-# These flags should only be used as is for the rbe-ubuntu16-04 container
-# and need to be adapted to work with other toolchain containers.
-build:remote --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:remote --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/default:toolchain
-build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-# Platform flags:
-# The toolchain container used for execution is defined in the target indicated
-# by "extra_execution_platforms", "host_platform" and "platforms".
-# If you are using your own toolchain container, you need to create a platform
-# target with "constraint_values" that allow for the toolchain specified with
-# "extra_toolchains" to be selected (given constraints defined in
-# "exec_compatible_with").
-# More about platforms: https://docs.bazel.build/versions/master/platforms.html
-build:remote --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/cpp:cc-toolchain-clang-x86_64-default
-build:remote --extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ubuntu1604
-build:remote --host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ubuntu1604
-build:remote --platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ubuntu1604
-
-# Set various strategies so that all actions execute remotely. Mixing remote
-# and local execution will lead to errors unless the toolchain and remote
-# machine exactly match the host machine.
+# Setup the build strategy for various types of actions. Mixing "local" and "remote"
+# can cause unexpected results and we want to run everything remotely if possible.
 build:remote --spawn_strategy=remote
 build:remote --strategy=Javac=remote
 build:remote --strategy=Closure=remote
-build:remote --genrule_strategy=remote
+build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
-# Enable the remote cache so action results can be shared across machines,
-# developers, and workspaces.
+# Setup the remote build execution servers.
 build:remote --remote_cache=remotebuildexecution.googleapis.com
-
-# Enable remote execution so actions are performed on the remote systems.
 build:remote --remote_executor=remotebuildexecution.googleapis.com
-
-# Enable encryption.
 build:remote --tls_enabled=true
-
-# Enforce stricter environment rules, which eliminates some non-hermetic
-# behavior and therefore improves both the remote cache hit rate and the
-# correctness and repeatability of the build.
-build:remote --experimental_strict_action_env=true
-
-# Set a higher timeout value, just in case.
-build:remote --remote_timeout=3600
-
-# Enable authentication. This will pick up application default credentials by
-# default. You can use --auth_credentials=some_file.json to use a service
-# account credential instead.
 build:remote --auth_enabled=true
 
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# The following flags are only necessary for local docker sandboxing
-# with the rbe-ubuntu16-04 container. Use of these flags is still experimental.
-build:docker-sandbox --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:docker-sandbox --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:docker-sandbox --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/default:toolchain
-build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:9bd8ba020af33edb5f11eff0af2f63b3bcb168cd6566d7b27c6685e717787928
-build:docker-sandbox --spawn_strategy=docker
-build:docker-sandbox --strategy=Javac=docker
-build:docker-sandbox --strategy=Closure=docker
-build:docker-sandbox --genrule_strategy=docker
-build:docker-sandbox --define=EXECUTOR=remote
-build:docker-sandbox --experimental_docker_verbose
-build:docker-sandbox --experimental_enable_docker_sandbox
-
-# The following flags enable the remote cache so action results can be shared
-# across machines, developers, and workspaces.
-build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
-build:remote-cache --tls_enabled=true
-build:remote-cache --remote_timeout=3600
-build:remote-cache --auth_enabled=true
-build:remote-cache --spawn_strategy=standalone
-build:remote-cache --strategy=Javac=standalone
-build:remote-cache --strategy=Closure=standalone
-build:remote-cache --genrule_strategy=standalone
+# Setup the toolchain and platform for the remote build execution. The platform
+# is automatically configured by the "rbe_autoconfig" rule in the project workpsace.
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --extra_execution_platforms=//tools:rbe_platform
+build:remote --host_platform=//tools:rbe_platform
+build:remote --platforms=//tools:rbe_platform
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -10,18 +10,8 @@ build --repository_cache=/home/circleci/bazel_repository_cache
 # Remote Build Execution support on CI #
 ########################################
 
-# Load default settings for Remote Build Execution.
+# Load base settings for remote build execution.
 import %workspace%/.circleci/base-rbe-bazelrc
-
-# Custom execution platform defined in the Angular repository. See:
-# https://github.com/angular/angular/blob/master/tools/BUILD.bazel#L21
-build:remote --extra_execution_platforms=@angular//tools:rbe_ubuntu1604-angular
-build:remote --host_platform=@angular//tools:rbe_ubuntu1604-angular
-build:remote --platforms=@angular//tools:rbe_ubuntu1604-angular
-
-# Increase the amount of parallel jobs. The default RBE base configuration specifies a low
-# number of parallel jobs, but our build and testing should be parallelizable.
-build:remote --jobs=150
 
 # Use the Angular team internal GCP instance for remote execution.
 build:remote --remote_instance_name=projects/internal-200822/instances/default_instance

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,13 +87,28 @@ yarn_install(
     yarn_lock = "@angular//tools/ts-api-guardian:yarn.lock",
 )
 
-# Bring in bazel_toolchains for RBE stuff.
+# Bring in bazel_toolchains for RBE setup configuration.
 http_archive(
   name = "bazel_toolchains",
-  sha256 = "109a99384f9d08f9e75136d218ebaebc68cc810c56897aea2224c57932052d30",
-  strip_prefix = "bazel-toolchains-94d31935a2c94fe7e7c7379a0f3393e181928ff7",
-  urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/94d31935a2c94fe7e7c7379a0f3393e181928ff7.tar.gz",
-      "https://github.com/bazelbuild/bazel-toolchains/archive/94d31935a2c94fe7e7c7379a0f3393e181928ff7.tar.gz",
-  ]
+  sha256 = "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
+  strip_prefix = "bazel-toolchains-cddc376d428ada2927ad359211c3e356bd9c9fbb",
+  url = "https://github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
+)
+
+load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_repositories = "repositories")
+bazel_toolchains_repositories()
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+rbe_autoconfig(
+  name = "rbe_default",
+  # We can't use the default "ubuntu16_04" RBE image provided by the autoconfig because we need
+  # a specific Linux kernel that comes with "libx11" in order to run headless browser tests.
+  repository = "asci-toolchain/nosla-ubuntu16_04-webtest",
+  registry = "gcr.io",
+  digest = "sha256:e874885f5e3d9ac0c0d3176e5369cb5969467dbf9ad8d42b862829cec8d84b9b",
+  # Need to specify a base container digest in order to ensure that we can use the checked-in
+  # platform configurations for the "ubuntu16_04" image. Otherwise the autoconfig rule would
+  # need to pull the image and run it in order determine the toolchain configuration.
+  # See: https://github.com/bazelbuild/bazel-toolchains/blob/master/rules/rbe_repo.bzl#L229
+  base_container_digest = "sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729",
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -22,3 +22,17 @@ nodejs_binary(
   ],
   entry_point = "angular_material/tools/sass-bundle.js",
 )
+
+# Workaround for https://github.com/bazelbuild/bazel-toolchains/issues/356. We need the
+# "SYS_ADMIN" capability in order to run browsers with sandbox enabled.
+platform(
+  name = "rbe_platform",
+  parents = ["@rbe_default//config:platform"],
+    remote_execution_properties = """
+      {PARENT_REMOTE_EXECUTION_PROPERTIES}
+      properties: {
+          name: "dockerAddCapabilities"
+          value: "SYS_ADMIN"
+      }
+    """,
+)


### PR DESCRIPTION
* Switches us to the latest `rbe_autoconfig` Bazel rule. This allows us to remove the vendored base Bazel configuration. Also this drops the RBE "@angular" workspace dependency 