### PR TITLE
build: add circleci fallback caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,17 +8,22 @@
 # http://yaml-online-parser.appspot.com/
 
 var_1: &docker_image angular/ngcontainer:0.10.0
-var_2: &cache_key v2-ng-mat-{{ checksum "WORKSPACE" }}-{{ checksum "yarn.lock" }}-0.7.0
+
+# **Note**: When updating the beginning of the cache key, also update the cache key to match
+# the new cache key prefix. This allows us to take advantage of CircleCI's fallback caching.
+# Read more here: https://circleci.com/docs/2.0/caching/#restoring-cache.
+var_2: &cache_key v2-ng-mat-{{ checksum "WORKSPACE" }}-{{ checksum "yarn.lock" }}
+var_3: &cache_fallback_key v2-ng-mat-
 
 # Settings common to each job
-var_3: &job_defaults
+var_4: &job_defaults
   working_directory: ~/ng
   docker:
     - image: *docker_image
 
 # Job step for checking out the source code from GitHub. This also ensures that the source code
 # is rebased on top of master.
-var_4: &checkout_code
+var_5: &checkout_code
   checkout:
     # After checkout, rebase on top of master. By default, PRs are not rebased on top of master,
     # which we want. See https://discuss.circleci.com/t/1662
@@ -26,13 +31,15 @@ var_4: &checkout_code
 
 # Restores the cache that could be available for the current Yarn lock file. The cache usually
 # includes the node modules and the Bazel repository cache.
-var_5: &restore_cache
+var_6: &restore_cache
   restore_cache:
-    key: *cache_key
+    keys:
+      - *cache_key
+      - *cache_fallback_key
 
 # Saves the cache for the current Yarn lock file. We store the node modules and the Bazel
 # repository cache in order to make subsequent builds faster.
-var_6: &save_cache
+var_7: &save_cache
   save_cache:
     key: *cache_key
     paths:
@@ -40,38 +47,38 @@ var_6: &save_cache
       - "~/bazel_repository_cache"
 
 # Decryption token that is used to decode the GCP credentials file in ".circleci/gcp_token".
-var_7: &gcp_decrypt_token "angular"
+var_8: &gcp_decrypt_token "angular"
 
 # Job step that ensures that the node module dependencies are installed and up-to-date. We use
 # Yarn with the frozen lockfile option in order to make sure that lock file and package.json are
 # in sync. Unlike in Travis, we don't need to manually purge the node modules if stale because
 # CircleCI automatically discards the cache if the checksum of the lock file has changed.
-var_8: &yarn_install
+var_9: &yarn_install
   run: yarn install --frozen-lockfile --non-interactive
 
 # Copies the Bazel config which is specifically for CircleCI to a location where Bazel picks it
 # up and merges it with the project-wide bazel configuration (tools/bazel.rc)
-var_9: &copy_bazel_config
+var_10: &copy_bazel_config
   # Set up the CircleCI specific bazel configuration.
   run: sudo cp ./.circleci/bazel.rc /etc/bazel.bazelrc
 
 # Sets up a different Docker image that includes a moe recent Firefox version which
 # is needed for headless testing.
-var_10: &docker-firefox-image
+var_11: &docker-firefox-image
   # TODO(devversion): Temporarily use a image that includes Firefox 62 because the
   # ngcontainer image does include an old Firefox version that does not support headless.
   - image: circleci/node:11.4.0-browsers
 
 # Attaches the release output which has been stored in the workspace to the current job.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
-var_11: &attach_release_output
+var_12: &attach_release_output
   attach_workspace:
     at: dist/
 
 # Branch filter that we can specify for jobs that should only run on publish branches. This filter
 # is used to ensure that not all upstream branches will be published as Github builds
 # (e.g. revert branches, feature branches)
-var_12: &publish_branches_filter
+var_13: &publish_branches_filter
   branches:
     only:
       - master
@@ -85,7 +92,7 @@ var_12: &publish_branches_filter
 # In order to reduce duplication we use a YAML anchor that just always excludes the "_presubmit"
 # branch. We don't want to run Circle for the temporary "_presubmit" branch which is reserved
 # for the caretaker.
-var_13: &ignore_presubmit_branch_filter
+var_14: &ignore_presubmit_branch_filter
   branches:
     ignore:
       - "_presubmit"
@@ -93,7 +100,7 @@ var_13: &ignore_presubmit_branch_filter
 
 # Runs a script that sets up the Bazel remote execution. This will be used by jobs that run
 # Bazel primarily and should benefit from remote caching and execution.
-var_14: &setup_bazel_remote_execution
+var_15: &setup_bazel_remote_execution
   run:
     name: "Setup bazel RBE remote execution"
     command: ./scripts/circleci/bazel/setup-remote-execution.sh


### PR DESCRIPTION
Enables fallback caching within CircleCI. This means that all PRs or jobs
that caused a change in the cache key still run with the most recent and
closest maching cache. Meaning that we in theory never need to pull
Bazel repositories or `node_modules` from scratch (unless we explicitly
want to purge the cache).

Same has been applied to `angular/angular` as well.