### PR TITLE
build: specify runtime dependency for highlight-files binary

### DIFF
--- a/tools/highlight-files/BUILD.bazel
+++ b/tools/highlight-files/BUILD.bazel
@@ -8,7 +8,6 @@ ts_library(
   srcs = glob(["**/*.ts"]),
   deps = [
     "@npm//@types/node",
-    "@npm//highlight.js",
   ],
   tsconfig = ":tsconfig.json",
 )
@@ -17,6 +16,7 @@ nodejs_binary(
   name = "highlight-files",
   entry_point = "angular_material/tools/highlight-files/highlight-files.js",
   data = [
+    "@npm//highlight.js",
     ":sources",
   ],
 )

--- a/tools/markdown-to-html/BUILD.bazel
+++ b/tools/markdown-to-html/BUILD.bazel
@@ -19,6 +19,7 @@ nodejs_binary(
   entry_point = "angular_material/tools/markdown-to-html/transform-markdown.js",
   data = [
     "@npm//marked",
+    "@npm//highlight.js",
     ":transform-markdown",
   ],
 )


### PR DESCRIPTION
@jelbourn This should fix the publish snapshots job again.. Unfortunately I'm not able to catch such failures on Windows as there is no real sandbox support..