### PR TITLE
refactor: constructor breaking changes for 8.0

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -7,7 +7,6 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
 import {
   AfterViewInit,
@@ -33,7 +32,6 @@ import {
 import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {Observable, Observer, Subject, merge} from 'rxjs';
 import {startWith, take, map, takeUntil, switchMap, tap} from 'rxjs/operators';
-import {DragDropRegistry} from '../drag-drop-registry';
 import {
   CdkDragDrop,
   CdkDragEnd,
@@ -49,7 +47,6 @@ import {CdkDragPreview} from './drag-preview';
 import {CDK_DROP_LIST} from '../drop-list-container';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {DragRef, DragRefConfig, Point} from '../drag-ref';
-import {DropListRef} from '../drop-list-ref';
 import {CdkDropListInternal as CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
 
@@ -182,36 +179,15 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       });
 
   constructor(
-    /** Element that the draggable is attached to. */
-    public element: ElementRef<HTMLElement>,
-    /** Droppable container that the draggable is a part of. */
-    @Inject(CDK_DROP_LIST) @Optional() @SkipSelf()
-    public dropContainer: CdkDropList,
-    @Inject(DOCUMENT) private _document: any,
-    private _ngZone: NgZone,
-    private _viewContainerRef: ViewContainerRef,
-    viewportRuler: ViewportRuler,
-    dragDropRegistry: DragDropRegistry<DragRef, DropListRef>,
-    @Inject(CDK_DRAG_CONFIG) config: DragRefConfig,
-    @Optional() private _dir: Directionality,
-
-    /**
-     * @deprecated `viewportRuler`, `dragDropRegistry` and `_changeDetectorRef` parameters
-     * to be removed. Also `dragDrop` parameter to be made required.
-     * @breaking-change 8.0.0.
-     */
-    dragDrop?: DragDrop,
-    private _changeDetectorRef?: ChangeDetectorRef) {
-
-
-    // @breaking-change 8.0.0 Remove null check once the paramter is made required.
-    if (dragDrop) {
-      this._dragRef = dragDrop.createDrag(element, config);
-    } else {
-      this._dragRef = new DragRef(element, config, _document, _ngZone, viewportRuler,
-          dragDropRegistry);
-    }
-
+      /** Element that the draggable is attached to. */
+      public element: ElementRef<HTMLElement>,
+      /** Droppable container that the draggable is a part of. */
+      @Inject(CDK_DROP_LIST) @Optional() @SkipSelf() public dropContainer: CdkDropList,
+      @Inject(DOCUMENT) private _document: any, private _ngZone: NgZone,
+      private _viewContainerRef: ViewContainerRef, @Inject(CDK_DRAG_CONFIG) config: DragRefConfig,
+      @Optional() private _dir: Directionality, dragDrop: DragDrop,
+      private _changeDetectorRef: ChangeDetectorRef) {
+    this._dragRef = dragDrop.createDrag(element, config);
     this._dragRef.data = this;
     this._syncInputs(this._dragRef);
     this._handleEvents(this._dragRef);
@@ -361,10 +337,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
       // Since all of these events run outside of change detection,
       // we need to ensure that everything is marked correctly.
-      if (this._changeDetectorRef) {
-        // @breaking-change 8.0.0 Remove null check for _changeDetectorRef
-        this._changeDetectorRef.markForCheck();
-      }
+      this._changeDetectorRef.markForCheck();
     });
 
     ref.released.subscribe(() => {
@@ -376,10 +349,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
       // Since all of these events run outside of change detection,
       // we need to ensure that everything is marked correctly.
-      if (this._changeDetectorRef) {
-        // @breaking-change 8.0.0 Remove null check for _changeDetectorRef
-        this._changeDetectorRef.markForCheck();
-      }
+      this._changeDetectorRef.markForCheck();
     });
 
     ref.entered.subscribe(event => {

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -20,13 +20,10 @@ import {
   Directive,
   ChangeDetectorRef,
   SkipSelf,
-  Inject,
   AfterContentInit,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
 import {Directionality} from '@angular/cdk/bidi';
 import {CdkDrag} from './drag';
-import {DragDropRegistry} from '../drag-drop-registry';
 import {CdkDragDrop, CdkDragEnter, CdkDragExit, CdkDragSortEvent} from '../drag-events';
 import {CDK_DROP_LIST_CONTAINER, CdkDropListContainer} from '../drop-list-container';
 import {CdkDropListGroup} from './drop-list-group';
@@ -154,28 +151,11 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
   sorted: EventEmitter<CdkDragSortEvent<T>> = new EventEmitter<CdkDragSortEvent<T>>();
 
   constructor(
-    /** Element that the drop list is attached to. */
-    public element: ElementRef<HTMLElement>,
-    dragDropRegistry: DragDropRegistry<DragRef, DropListRef>,
-    private _changeDetectorRef: ChangeDetectorRef,
-    @Optional() private _dir?: Directionality,
-    @Optional() @SkipSelf() private _group?: CdkDropListGroup<CdkDropList>,
-    @Optional() @Inject(DOCUMENT) _document?: any,
-
-    /**
-     * @deprecated `dragDropRegistry` and `_document` parameters to be removed.
-     * Also `dragDrop` parameter to be made required.
-     * @breaking-change 8.0.0.
-     */
-    dragDrop?: DragDrop) {
-
-    // @breaking-change 8.0.0 Remove null check once `dragDrop` parameter is made required.
-    if (dragDrop) {
-      this._dropListRef = dragDrop.createDropList(element);
-    } else {
-      this._dropListRef = new DropListRef(element, dragDropRegistry, _document || document);
-    }
-
+      /** Element that the drop list is attached to. */
+      public element: ElementRef<HTMLElement>, dragDrop: DragDrop,
+      private _changeDetectorRef: ChangeDetectorRef, @Optional() private _dir?: Directionality,
+      @Optional() @SkipSelf() private _group?: CdkDropListGroup<CdkDropList>) {
+    this._dropListRef = dragDrop.createDropList(element);
     this._dropListRef.data = this;
     this._dropListRef.enterPredicate = (drag: DragRef<CdkDrag>, drop: DropListRef<CdkDropList>) => {
       return this.enterPredicate(drag.data, drop.data);

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -7,9 +7,14 @@
  */
 
 import {Direction} from '@angular/cdk/bidi';
+import {Platform} from '@angular/cdk/platform';
 import {CdkScrollable, ViewportRuler} from '@angular/cdk/scrolling';
 import {ElementRef} from '@angular/core';
 import {Observable} from 'rxjs';
+
+import {OverlayContainer} from '../overlay-container';
+import {OverlayReference} from '../overlay-reference';
+
 import {
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
@@ -18,8 +23,6 @@ import {
 } from './connected-position';
 import {FlexibleConnectedPositionStrategy} from './flexible-connected-position-strategy';
 import {PositionStrategy} from './position-strategy';
-import {Platform} from '@angular/cdk/platform';
-import {OverlayReference} from '../overlay-reference';
 
 /**
  * A strategy for positioning overlays. Using this strategy, an overlay is given an
@@ -56,23 +59,18 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   }
 
   constructor(
-      originPos: OriginConnectionPosition,
-      overlayPos: OverlayConnectionPosition,
-      connectedTo: ElementRef<HTMLElement>,
-      viewportRuler: ViewportRuler,
-      document: Document,
-      // @breaking-change 8.0.0 `platform` parameter to be made required.
-      platform?: Platform) {
-
+      originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition,
+      connectedTo: ElementRef<HTMLElement>, viewportRuler: ViewportRuler, document: Document,
+      platform: Platform, overlayContainer: OverlayContainer) {
     // Since the `ConnectedPositionStrategy` is deprecated and we don't want to maintain
     // the extra logic, we create an instance of the positioning strategy that has some
     // defaults that make it behave as the old position strategy and to which we'll
     // proxy all of the API calls.
-    this._positionStrategy =
-      new FlexibleConnectedPositionStrategy(connectedTo, viewportRuler, document, platform)
-        .withFlexibleDimensions(false)
-        .withPush(false)
-        .withViewportMargin(0);
+    this._positionStrategy = new FlexibleConnectedPositionStrategy(
+                                 connectedTo, viewportRuler, document, platform, overlayContainer)
+                                 .withFlexibleDimensions(false)
+                                 .withPush(false)
+                                 .withViewportMargin(0);
 
     this.withFallbackPosition(originPos, overlayPos);
   }

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -142,12 +142,9 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   }
 
   constructor(
-    connectedTo: FlexibleConnectedPositionStrategyOrigin,
-    private _viewportRuler: ViewportRuler,
-    private _document: Document,
-    // @breaking-change 8.0.0 `_platform` and `_overlayContainer` parameters to be made required.
-    private _platform?: Platform,
-    private _overlayContainer?: OverlayContainer) {
+      connectedTo: FlexibleConnectedPositionStrategyOrigin, private _viewportRuler: ViewportRuler,
+      private _document: Document, private _platform: Platform,
+      private _overlayContainer: OverlayContainer) {
     this.setOrigin(connectedTo);
   }
 
@@ -193,8 +190,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
    */
   apply(): void {
     // We shouldn't do anything if the strategy was disposed or we're on the server.
-    // @breaking-change 8.0.0 Remove `_platform` null check once it's guaranteed to be defined.
-    if (this._isDisposed || (this._platform && !this._platform.isBrowser)) {
+    if (this._isDisposed || !this._platform.isBrowser) {
       return;
     }
 
@@ -926,11 +922,8 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       overlayPoint = this._pushOverlayOnScreen(overlayPoint, this._overlayRect, scrollPosition);
     }
 
-    // @breaking-change 8.0.0 Currently the `_overlayContainer` is optional in order to avoid a
-    // breaking change. The null check here can be removed once the `_overlayContainer` becomes
-    // a required parameter.
-    let virtualKeyboardOffset = this._overlayContainer ?
-        this._overlayContainer.getContainerElement().getBoundingClientRect().top : 0;
+    let virtualKeyboardOffset =
+        this._overlayContainer.getContainerElement().getBoundingClientRect().top;
 
     // Normally this would be zero, however when the overlay is attached to an input (e.g. in an
     // autocomplete), mobile browsers will shift everything in order to put the input in the middle

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
-import {ElementRef, Inject, Injectable, Optional} from '@angular/core';
+import {ElementRef, Inject, Injectable} from '@angular/core';
+
+import {OverlayContainer} from '../overlay-container';
+
 import {OriginConnectionPosition, OverlayConnectionPosition} from './connected-position';
 import {ConnectedPositionStrategy} from './connected-position-strategy';
 import {
@@ -16,19 +20,14 @@ import {
   FlexibleConnectedPositionStrategyOrigin,
 } from './flexible-connected-position-strategy';
 import {GlobalPositionStrategy} from './global-position-strategy';
-import {Platform} from '@angular/cdk/platform';
-import {OverlayContainer} from '../overlay-container';
 
 
 /** Builder for overlay position strategy. */
 @Injectable({providedIn: 'root'})
 export class OverlayPositionBuilder {
   constructor(
-    private _viewportRuler: ViewportRuler,
-    @Inject(DOCUMENT) private _document: any,
-    // @breaking-change 8.0.0 `_platform` and `_overlayContainer` parameters to be made required.
-    @Optional() private _platform?: Platform,
-    @Optional() private _overlayContainer?: OverlayContainer) { }
+      private _viewportRuler: ViewportRuler, @Inject(DOCUMENT) private _document: any,
+      private _platform: Platform, private _overlayContainer: OverlayContainer) {}
 
   /**
    * Creates a global position strategy.
@@ -49,9 +48,9 @@ export class OverlayPositionBuilder {
       elementRef: ElementRef,
       originPos: OriginConnectionPosition,
       overlayPos: OverlayConnectionPosition): ConnectedPositionStrategy {
-
-    return new ConnectedPositionStrategy(originPos, overlayPos, elementRef, this._viewportRuler,
-        this._document);
+    return new ConnectedPositionStrategy(
+        originPos, overlayPos, elementRef, this._viewportRuler, this._document, this._platform,
+        this._overlayContainer);
   }
 
   /**

--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -17,6 +17,15 @@ export type ConstructorChecksUpgradeData = string;
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V8]: [
+    {
+      pr: 'https://github.com/angular/material2/pull/15647',
+      changes: [
+        'CdkDrag', 'CdkDropList', 'ConnectedPositionStrategy', 'FlexibleConnectedPositionStrategy',
+        'OverlayPositionBuilder', 'CdkTable'
+      ]
+    }
+  ],
   [TargetVersion.V7]: [],
   [TargetVersion.V6]: []
 };

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -387,13 +387,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       protected readonly _differs: IterableDiffers,
       protected readonly _changeDetectorRef: ChangeDetectorRef,
       protected readonly _elementRef: ElementRef, @Attribute('role') role: string,
-      @Optional() protected readonly _dir: Directionality,
-      /**
-       * @deprecated
-       * @breaking-change 8.0.0 `_document` and `_platform` to
-       *    be made into a required parameters.
-       */
-      @Inject(DOCUMENT) _document?: any, private _platform?: Platform) {
+      @Optional() protected readonly _dir: Directionality, @Inject(DOCUMENT) _document: any,
+      private _platform: Platform) {
     if (!role) {
       this._elementRef.nativeElement.setAttribute('role', 'grid');
     }
@@ -1002,9 +997,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
 
   /** Adds native table sections (e.g. tbody) and moves the row outlets into them. */
   private _applyNativeTableSections() {
-    // @breaking-change 8.0.0 remove the `|| document` once the `_document` is a required param.
-    const documentRef = this._document || document;
-    const documentFragment = documentRef.createDocumentFragment();
+    const documentFragment = this._document.createDocumentFragment();
     const sections = [
       {tag: 'thead', outlet: this._headerRowOutlet},
       {tag: 'tbody', outlet: this._rowOutlet},
@@ -1012,7 +1005,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     ];
 
     for (const section of sections) {
-      const element = documentRef.createElement(section.tag);
+      const element = this._document.createElement(section.tag);
       element.setAttribute('role', 'rowgroup');
       element.appendChild(section.outlet.elementRef.nativeElement);
       documentFragment.appendChild(element);
@@ -1069,9 +1062,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   private _setupStickyStyler() {
     const direction: Direction = this._dir ? this._dir.value : 'ltr';
     this._stickyStyler = new StickyStyler(
-        this._isNativeHtmlTable,
-        // @breaking-change 8.0.0 remove the null check for `this._platform`.
-        this.stickyCssClass, direction, this._platform ? this._platform.isBrowser : true);
+        this._isNativeHtmlTable, this.stickyCssClass, direction, this._platform.isBrowser);
     (this._dir ? this._dir.change : observableOf<Direction>())
         .pipe(takeUntil(this._onDestroy))
         .subscribe(value => {

--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -166,7 +166,7 @@ export class MatFormField extends _MatFormFieldMixinBase
     this._appearance = value || (this._defaults && this._defaults.appearance) || 'legacy';
 
     if (this._appearance === 'outline' && oldValue !== value) {
-      this._updateOutlineGapOnStable();
+      this._outlineGapCalculationNeededOnStable = true;
     }
   }
   _appearance: MatFormFieldAppearance;
@@ -249,16 +249,12 @@ export class MatFormField extends _MatFormFieldMixinBase
   @ContentChildren(MatSuffix) _suffixChildren: QueryList<MatSuffix>;
 
   constructor(
-      public _elementRef: ElementRef,
-      private _changeDetectorRef: ChangeDetectorRef,
+      public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,
       @Optional() @Inject(MAT_LABEL_GLOBAL_OPTIONS) labelOptions: LabelOptions,
       @Optional() private _dir: Directionality,
-      @Optional() @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS)
-          private _defaults: MatFormFieldDefaultOptions,
-      // @breaking-change 8.0.0 _platform, _ngZone and _animationMode to be made required.
-      private _platform?: Platform,
-      private _ngZone?: NgZone,
-      @Optional() @Inject(ANIMATION_MODULE_TYPE) _animationMode?: string) {
+      @Optional() @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS) private _defaults:
+          MatFormFieldDefaultOptions, private _platform: Platform, private _ngZone: NgZone,
+      @Optional() @Inject(ANIMATION_MODULE_TYPE) _animationMode: string) {
     super(_elementRef);
 
     this._labelOptions = labelOptions ? labelOptions : {};
@@ -300,26 +296,20 @@ export class MatFormField extends _MatFormFieldMixinBase
         .subscribe(() => this._changeDetectorRef.markForCheck());
     }
 
-    // @breaking-change 7.0.0 Remove this check once _ngZone is required. Also reconsider
-    // whether the `ngAfterContentChecked` below is still necessary.
-    const zone = this._ngZone;
-
-    if (zone) {
-      // Note that we have to run outside of the `NgZone` explicitly,
-      // in order to avoid throwing users into an infinite loop
-      // if `zone-patch-rxjs` is included.
-      zone.runOutsideAngular(() => {
-        zone.onStable.asObservable().pipe(takeUntil(this._destroyed)).subscribe(() => {
-          if (this._outlineGapCalculationNeededOnStable) {
-            this.updateOutlineGap();
-          }
-        });
+    // Note that we have to run outside of the `NgZone` explicitly,
+    // in order to avoid throwing users into an infinite loop
+    // if `zone-patch-rxjs` is included.
+    this._ngZone.runOutsideAngular(() => {
+      this._ngZone.onStable.asObservable().pipe(takeUntil(this._destroyed)).subscribe(() => {
+        if (this._outlineGapCalculationNeededOnStable) {
+          this.updateOutlineGap();
+        }
       });
-    }
+    });
 
     // Run change detection and update the outline if the suffix or prefix changes.
     merge(this._prefixChildren.changes, this._suffixChildren.changes).subscribe(() => {
-      this._updateOutlineGapOnStable();
+      this._outlineGapCalculationNeededOnStable = true;
       this._changeDetectorRef.markForCheck();
     });
 
@@ -501,7 +491,7 @@ export class MatFormField extends _MatFormFieldMixinBase
       return;
     }
 
-    if (this._platform && !this._platform.isBrowser) {
+    if (!this._platform.isBrowser) {
       // getBoundingClientRect isn't available on the server.
       return;
     }
@@ -559,18 +549,5 @@ export class MatFormField extends _MatFormFieldMixinBase
   /** Gets the start end of the rect considering the current directionality. */
   private _getStartEnd(rect: ClientRect): number {
     return this._dir && this._dir.value === 'rtl' ? rect.right : rect.left;
-  }
-
-  /**
-   * Updates the outline gap the new time the zone stabilizes.
-   * @breaking-change 7.0.0 Remove this method and only set the property once `_ngZone` is required.
-   */
-  private _updateOutlineGapOnStable() {
-    // @breaking-change 8.0.0 Remove this check and else block once _ngZone is required.
-    if (this._ngZone) {
-      this._outlineGapCalculationNeededOnStable = true;
-    } else {
-      Promise.resolve().then(() => this.updateOutlineGap());
-    }
   }
 }

--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,13 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V8]: [
+    {
+      pr: 'https://github.com/angular/material2/pull/15647',
+      changes: ['MatFormField', 'MatTabLink', 'MatVerticalStepper']
+    }
+  ],
+
   [TargetVersion.V7]: [
     {
       pr: 'https://github.com/angular/material2/pull/11706',

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -218,18 +218,11 @@ export class MatTabLink extends _MatTabLinkMixinBase
       !!this.rippleConfig.disabled;
   }
 
-  constructor(private _tabNavBar: MatTabNav,
-              public _elementRef: ElementRef,
-              ngZone: NgZone,
-              platform: Platform,
-              @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
-              globalRippleOptions: RippleGlobalOptions | null,
-              @Attribute('tabindex') tabIndex: string,
-              /**
-               * @deprecated
-               * @breaking-change 8.0.0 `_focusMonitor` parameter to be made required.
-               */
-              private _focusMonitor?: FocusMonitor) {
+  constructor(
+      private _tabNavBar: MatTabNav, public _elementRef: ElementRef, ngZone: NgZone,
+      platform: Platform,
+      @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions: RippleGlobalOptions|null,
+      @Attribute('tabindex') tabIndex: string, private _focusMonitor: FocusMonitor) {
     super();
 
     this._tabLinkRipple = new RippleRenderer(this, ngZone, _elementRef, platform);
@@ -237,17 +230,11 @@ export class MatTabLink extends _MatTabLinkMixinBase
     this.rippleConfig = globalRippleOptions || {};
 
     this.tabIndex = parseInt(tabIndex) || 0;
-
-    if (_focusMonitor) {
-      _focusMonitor.monitor(_elementRef);
-    }
+    _focusMonitor.monitor(_elementRef);
   }
 
   ngOnDestroy() {
     this._tabLinkRipple._removeTriggerEvents();
-
-    if (this._focusMonitor) {
-      this._focusMonitor.stopMonitoring(this._elementRef);
-    }
+    this._focusMonitor.stopMonitoring(this._elementRef);
   }
 }

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -33,8 +33,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     started: EventEmitter<CdkDragStart>;
     constructor(
     element: ElementRef<HTMLElement>,
-    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, viewportRuler: ViewportRuler, dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, config: DragRefConfig, _dir: Directionality,
-    dragDrop?: DragDrop, _changeDetectorRef?: ChangeDetectorRef | undefined);
+    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragRefConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef);
     getFreeDragPosition(): {
         readonly x: number;
         readonly y: number;
@@ -139,8 +138,7 @@ export declare class CdkDropList<T = any> implements CdkDropListContainer, After
     sorted: EventEmitter<CdkDragSortEvent<T>>;
     sortingDisabled: boolean;
     constructor(
-    element: ElementRef<HTMLElement>, dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined, _document?: any,
-    dragDrop?: DragDrop);
+    element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined);
     _getSiblingContainerFromPosition(item: CdkDrag, x: number, y: number): CdkDropListContainer | null;
     _isOverContainer(x: number, y: number): boolean;
     _sortItem(item: CdkDrag, pointerX: number, pointerY: number, pointerDelta: {

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -75,7 +75,7 @@ export declare class ConnectedPositionStrategy implements PositionStrategy {
     _preferredPositions: ConnectionPositionPair[];
     readonly onPositionChange: Observable<ConnectedOverlayPositionChange>;
     readonly positions: ConnectionPositionPair[];
-    constructor(originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition, connectedTo: ElementRef<HTMLElement>, viewportRuler: ViewportRuler, document: Document, platform?: Platform);
+    constructor(originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition, connectedTo: ElementRef<HTMLElement>, viewportRuler: ViewportRuler, document: Document, platform: Platform, overlayContainer: OverlayContainer);
     apply(): void;
     attach(overlayRef: OverlayReference): void;
     detach(): void;
@@ -109,7 +109,7 @@ export declare class FlexibleConnectedPositionStrategy implements PositionStrate
     _preferredPositions: ConnectionPositionPair[];
     positionChanges: Observable<ConnectedOverlayPositionChange>;
     readonly positions: ConnectionPositionPair[];
-    constructor(connectedTo: FlexibleConnectedPositionStrategyOrigin, _viewportRuler: ViewportRuler, _document: Document, _platform?: Platform | undefined, _overlayContainer?: OverlayContainer | undefined);
+    constructor(connectedTo: FlexibleConnectedPositionStrategyOrigin, _viewportRuler: ViewportRuler, _document: Document, _platform: Platform, _overlayContainer: OverlayContainer);
     apply(): void;
     attach(overlayRef: OverlayReference): void;
     detach(): void;
@@ -215,7 +215,7 @@ export declare class OverlayModule {
 }
 
 export declare class OverlayPositionBuilder {
-    constructor(_viewportRuler: ViewportRuler, _document: any, _platform?: Platform | undefined, _overlayContainer?: OverlayContainer | undefined);
+    constructor(_viewportRuler: ViewportRuler, _document: any, _platform: Platform, _overlayContainer: OverlayContainer);
     connectedTo(elementRef: ElementRef, originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition): ConnectedPositionStrategy;
     flexibleConnectedTo(origin: FlexibleConnectedPositionStrategyOrigin): FlexibleConnectedPositionStrategy;
     global(): GlobalPositionStrategy;

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -154,8 +154,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
         start: number;
         end: number;
     }>;
-    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality,
-    _document?: any, _platform?: Platform | undefined);
+    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform);
     _getRenderedRows(rowOutlet: RowOutlet): HTMLElement[];
     _getRowDefs(data: T, dataIndex: number): CdkRowDef<T>[];
     addColumnDef(columnDef: CdkColumnDef): void;

--- a/tools/public_api_guard/lib/form-field.d.ts
+++ b/tools/public_api_guard/lib/form-field.d.ts
@@ -35,7 +35,7 @@ export declare class MatFormField extends _MatFormFieldMixinBase implements Afte
     hideRequiredMarker: boolean;
     hintLabel: string;
     underlineRef: ElementRef;
-    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, labelOptions: LabelOptions, _dir: Directionality, _defaults: MatFormFieldDefaultOptions, _platform?: Platform | undefined, _ngZone?: NgZone | undefined, _animationMode?: string);
+    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, labelOptions: LabelOptions, _dir: Directionality, _defaults: MatFormFieldDefaultOptions, _platform: Platform, _ngZone: NgZone, _animationMode: string);
     _animateAndLockLabel(): void;
     _getDisplayedMessages(): 'error' | 'hint';
     _hasFloatingLabel(): boolean;

--- a/tools/public_api_guard/lib/tabs.d.ts
+++ b/tools/public_api_guard/lib/tabs.d.ts
@@ -170,8 +170,7 @@ export declare class MatTabLink extends _MatTabLinkMixinBase implements OnDestro
     active: boolean;
     rippleConfig: RippleConfig & RippleGlobalOptions;
     readonly rippleDisabled: boolean;
-    constructor(_tabNavBar: MatTabNav, _elementRef: ElementRef, ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string,
-    _focusMonitor?: FocusMonitor | undefined);
+    constructor(_tabNavBar: MatTabNav, _elementRef: ElementRef, ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor);
     ngOnDestroy(): void;
 }
 


### PR DESCRIPTION
Goes through the constructor-related breaking changes for 8.0 in all of the CDK symbols plus `material/form-field` and `material/tabs`.

BREAKING CHANGES:

* `CdkDrag`: `viewportRuler` and `dragDropRegistry` parameters have been removed from the constructor. Furthermore the `dragDrop` and `_changeDetectorRef` parameters in are now required.
* `CdkDropList`:  `dragDropRegistry` and `_documents` parameters have been removed, and `dragDrop` parameter is now required.
* `ConnectedPositionStrategy`: `platform` parameter is now required and a new `overlayContainer` parameter has been added.
* `FlexibleConnectedPositionStrategy`: `_platform` and `_overlayContainer` parameters are now required.
* `OverlayPositionBuilder`: `_platform` and `_overlayContainer` parameters are now required.
* `CdkTable`: `_document` and `_platform` parameters are now required.
* `MatFormField`: `_platform`, `_ngZone` and `_animationMode` parameters are now required.
* `MatTabLink`: `_focusMonitor` parameter is now required.
