### PR TITLE
build: dgeni bazel target misses runtime fine-grained dep

### DIFF
--- a/tools/dgeni/BUILD.bazel
+++ b/tools/dgeni/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
     "@npm//@types/node",
     "@npm//dgeni",
     "@npm//dgeni-packages",
+    "@npm//highlight.js",
     "//tools/highlight-files:sources",
   ],
   tsconfig = ":tsconfig.json",


### PR DESCRIPTION
Due to the fact that various targets only depend on their TypeScript
source Bazel target, the logic that is reponsible for determining the
Bazel managed dependency path is not working because the
`nodejs_binary` rule is not able to determine the `NodeModuleInfo`
Bazel provider from the TypeScript compilation provider output.

See: https://github.com/bazelbuild/rules_nodejs/blob/fe1d1c03630f999c57a63dc3fe1f6ad52ff61c6a/internal/node/node.bzl#L60

Therefore we need to make sure that we don't transitively depend on
fine-grained dependencies (such as `@npm//highlight.js`) which
*seem* to be transitively brought in by the TypeScript target. This is not
correct and prone to unexpected failures (as we experienced on `master`)