### PR TITLE
refactor: explicitly set static flag on all queries

### DIFF
--- a/src/a11y-demo/a11y-demo.ts
+++ b/src/a11y-demo/a11y-demo.ts
@@ -21,8 +21,8 @@ export class AccessibilityDemoRoot implements OnDestroy {
 
   private _routerSubscription = Subscription.EMPTY;
 
-  @ViewChild('maincontent') mainContent: ElementRef<HTMLElement>;
-  @ViewChild('header') sectionHeader: ElementRef<HTMLElement>;
+  @ViewChild('maincontent', {static: false}) mainContent: ElementRef<HTMLElement>;
+  @ViewChild('header', {static: false}) sectionHeader: ElementRef<HTMLElement>;
 
   navItems = [
     {name: 'Home', route: '.'},

--- a/src/a11y-demo/table/table-a11y.ts
+++ b/src/a11y-demo/table/table-a11y.ts
@@ -35,8 +35,8 @@ const exampleData = [
   styleUrls: ['table-a11y.css'],
 })
 export class TableAccessibilityDemo implements OnInit {
-  @ViewChild(MatSort) sort: MatSort;
-  @ViewChild(MatPaginator) pager: MatPaginator;
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatPaginator, {static: true}) pager: MatPaginator;
 
   displayedColumns = ['name', 'color', 'age'];
   basicDataSource: BasicDataSource;

--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -1079,7 +1079,9 @@ class ComponentWithOnPushViewContainer {
   template: `<dir-with-view-container></dir-with-view-container>`,
 })
 class ComponentWithChildViewContainer {
-  @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+  @ViewChild(DirectiveWithViewContainer, {
+    static: false
+  }) childWithViewContainer: DirectiveWithViewContainer;
 
   get childViewContainer() {
     return this.childWithViewContainer.viewContainerRef;
@@ -1095,7 +1097,7 @@ class ComponentWithTemplateRef {
   localValue: string;
   dialogRef: DialogRef<any>;
 
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
 
   setDialogRef(dialogRef: DialogRef<any>): string {
     this.dialogRef = dialogRef;

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -91,7 +91,7 @@ function finishInit(fixture: ComponentFixture<any>) {
   encapsulation: ViewEncapsulation.None,
 })
 class AutoSizeVirtualScroll {
-  @ViewChild(CdkVirtualScrollViewport) viewport: CdkVirtualScrollViewport;
+  @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
 
   @Input() orientation = 'vertical';
   @Input() viewportSize = 200;

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -189,16 +189,16 @@ function expectMessage(el: Element, message: string) {
   `,
 })
 class TestApp {
-  @ViewChild('element1') _element1: ElementRef<HTMLElement>;
+  @ViewChild('element1', {static: false}) _element1: ElementRef<HTMLElement>;
   get element1(): Element { return this._element1.nativeElement; }
 
-  @ViewChild('element2') _element2: ElementRef<HTMLElement>;
+  @ViewChild('element2', {static: false}) _element2: ElementRef<HTMLElement>;
   get element2(): Element { return this._element2.nativeElement; }
 
-  @ViewChild('element3') _element3: ElementRef<HTMLElement>;
+  @ViewChild('element3', {static: false}) _element3: ElementRef<HTMLElement>;
   get element3(): Element { return this._element3.nativeElement; }
 
-  @ViewChild('element4') _element4: ElementRef<HTMLElement>;
+  @ViewChild('element4', {static: false}) _element4: ElementRef<HTMLElement>;
   get element4(): Element { return this._element4.nativeElement; }
 
 

--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -199,7 +199,7 @@ describe('FocusTrap', () => {
     `
 })
 class SimpleFocusTrap {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
 }
 
 @Component({
@@ -212,7 +212,7 @@ class SimpleFocusTrap {
     `
 })
 class FocusTrapWithAutoCapture {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
   showTrappedRegion = false;
 }
 
@@ -226,7 +226,7 @@ class FocusTrapWithAutoCapture {
     `
 })
 class FocusTrapWithBindings {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
   renderFocusTrap = true;
   _isFocusTrapEnabled = true;
 }
@@ -246,7 +246,7 @@ class FocusTrapWithBindings {
     `
 })
 class FocusTrapTargets {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
 }
 
 @Component({
@@ -257,7 +257,7 @@ class FocusTrapTargets {
     `
 })
 class FocusTrapUnfocusableTarget {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
 }
 
 @Component({
@@ -270,7 +270,7 @@ class FocusTrapUnfocusableTarget {
     `
 })
 class FocusTrapWithSvg {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
 }
 
 @Component({
@@ -281,5 +281,5 @@ class FocusTrapWithSvg {
     `
 })
 class FocusTrapWithoutFocusableElements {
-  @ViewChild(CdkTrapFocus) focusTrapDirective: CdkTrapFocus;
+  @ViewChild(CdkTrapFocus, {static: false}) focusTrapDirective: CdkTrapFocus;
 }

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -158,7 +158,7 @@ describe('Directionality', () => {
   `
 })
 class ElementWithDir {
-  @ViewChild(Dir) dir: Dir;
+  @ViewChild(Dir, {static: false}) dir: Dir;
   direction = 'rtl';
   changeCount = 0;
 }
@@ -167,14 +167,14 @@ class ElementWithDir {
   template: '<div dir="auto"></div>'
 })
 class ElementWithPredefinedAutoDir {
-  @ViewChild(Dir) dir: Dir;
+  @ViewChild(Dir, {static: false}) dir: Dir;
 }
 
 @Component({
   template: '<div dir="RTL"></div>'
 })
 class ElementWithPredefinedUppercaseDir {
-  @ViewChild(Dir) dir: Dir;
+  @ViewChild(Dir, {static: false}) dir: Dir;
 }
 
 

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3196,8 +3196,8 @@ describe('CdkDrag', () => {
   `
 })
 class StandaloneDraggable {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag, {static: false}) dragInstance: CdkDrag;
   startedSpy = jasmine.createSpy('started spy');
   endedSpy = jasmine.createSpy('ended spy');
   releasedSpy = jasmine.createSpy('released spy');
@@ -3213,8 +3213,8 @@ class StandaloneDraggable {
   `
 })
 class StandaloneDraggableWithOnPush {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag, {static: false}) dragInstance: CdkDrag;
 }
 
 @Component({
@@ -3227,7 +3227,7 @@ class StandaloneDraggableWithOnPush {
   `
 })
 class StandaloneDraggableSvg {
-  @ViewChild('dragElement') dragElement: ElementRef<SVGElement>;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<SVGElement>;
 }
 
 @Component({
@@ -3239,10 +3239,10 @@ class StandaloneDraggableSvg {
   `
 })
 class StandaloneDraggableWithHandle {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild('handleElement') handleElement: ElementRef<HTMLElement>;
-  @ViewChild(CdkDrag) dragInstance: CdkDrag;
-  @ViewChild(CdkDragHandle) handleInstance: CdkDragHandle;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild('handleElement', {static: false}) handleElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag, {static: false}) dragInstance: CdkDrag;
+  @ViewChild(CdkDragHandle, {static: false}) handleInstance: CdkDragHandle;
 }
 
 @Component({
@@ -3257,8 +3257,8 @@ class StandaloneDraggableWithHandle {
   `
 })
 class StandaloneDraggableWithDelayedHandle {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild('handleElement') handleElement: ElementRef<HTMLElement>;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild('handleElement', {static: false}) handleElement: ElementRef<HTMLElement>;
   showHandle = false;
 }
 
@@ -3277,8 +3277,8 @@ class StandaloneDraggableWithDelayedHandle {
   `
 })
 class StandaloneDraggableWithIndirectHandle {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild('handleElement') handleElement: ElementRef<HTMLElement>;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild('handleElement', {static: false}) handleElement: ElementRef<HTMLElement>;
 }
 
 
@@ -3302,7 +3302,7 @@ class StandaloneDraggableWithIndirectHandle {
   `
 })
 class StandaloneDraggableWithMultipleHandles {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
   @ViewChildren(CdkDragHandle) handles: QueryList<CdkDragHandle>;
 }
 
@@ -3328,7 +3328,7 @@ const DROP_ZONE_FIXTURE_TEMPLATE = `
 @Component({template: DROP_ZONE_FIXTURE_TEMPLATE})
 class DraggableInDropZone {
   @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
-  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  @ViewChild(CdkDropList, {static: false}) dropInstance: CdkDropList;
   items = [
     {value: 'Zero', height: ITEM_HEIGHT, margin: 0},
     {value: 'One', height: ITEM_HEIGHT, margin: 0},
@@ -3384,7 +3384,7 @@ class DraggableInOnPushDropZone extends DraggableInDropZone {}
 })
 class DraggableInHorizontalDropZone {
   @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
-  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  @ViewChild(CdkDropList, {static: false}) dropInstance: CdkDropList;
   items = [
     {value: 'Zero', width: ITEM_WIDTH, margin: 0},
     {value: 'One', width: ITEM_WIDTH, margin: 0},
@@ -3418,7 +3418,7 @@ class DraggableInHorizontalDropZone {
   `
 })
 class DraggableInDropZoneWithCustomPreview {
-  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  @ViewChild(CdkDropList, {static: false}) dropInstance: CdkDropList;
   @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
   items = ['Zero', 'One', 'Two', 'Three'];
   boundarySelector: string;
@@ -3563,9 +3563,9 @@ class ConnectedDropZonesViaGroupDirective extends ConnectedDropZones {
   `
 })
 class DraggableWithAlternateRoot {
-  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
-  @ViewChild('dragRoot') dragRoot: ElementRef<HTMLElement>;
-  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
+  @ViewChild('dragRoot', {static: false}) dragRoot: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag, {static: false}) dragInstance: CdkDrag;
   rootElementSelector: string;
 }
 
@@ -3624,9 +3624,9 @@ class ConnectedDropZonesWithSingleItems {
   `
 })
 class NestedDropListGroups {
-  @ViewChild('group') group: CdkDropListGroup<CdkDropList>;
-  @ViewChild('listOne') listOne: CdkDropList;
-  @ViewChild('listTwo') listTwo: CdkDropList;
+  @ViewChild('group', {static: false}) group: CdkDropListGroup<CdkDropList>;
+  @ViewChild('listOne', {static: false}) listOne: CdkDropList;
+  @ViewChild('listTwo', {static: false}) listTwo: CdkDropList;
 }
 
 
@@ -3651,7 +3651,7 @@ class DraggableOnNgContainer {}
 })
 class DraggableInDropZoneWithoutEvents {
   @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
-  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  @ViewChild(CdkDropList, {static: false}) dropInstance: CdkDropList;
   items = [
     {value: 'Zero', height: ITEM_HEIGHT},
     {value: 'One', height: ITEM_HEIGHT},

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -85,10 +85,10 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   @ContentChildren(CdkDragHandle, {descendants: true}) _handles: QueryList<CdkDragHandle>;
 
   /** Element that will be used as a template to create the draggable item's preview. */
-  @ContentChild(CdkDragPreview) _previewTemplate: CdkDragPreview;
+  @ContentChild(CdkDragPreview, {static: false}) _previewTemplate: CdkDragPreview;
 
   /** Template for placeholder element rendered to show where a draggable would be dropped. */
-  @ContentChild(CdkDragPlaceholder) _placeholderTemplate: CdkDragPlaceholder;
+  @ContentChild(CdkDragPlaceholder, {static: false}) _placeholderTemplate: CdkDragPlaceholder;
 
   /** Arbitrary data to attach to this drag instance. */
   @Input('cdkDragData') data: T;

--- a/src/cdk/observers/observe-content.spec.ts
+++ b/src/cdk/observers/observe-content.spec.ts
@@ -228,6 +228,6 @@ class ComponentWithDebouncedListener {
   template: `<div #contentEl>{{text}}</div>`
 })
 class UnobservedComponentWithTextContent {
-  @ViewChild('contentEl') contentEl: ElementRef;
+  @ViewChild('contentEl', {static: false}) contentEl: ElementRef;
   text = '';
 }

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -539,9 +539,9 @@ describe('Overlay directives', () => {
   </ng-template>`,
 })
 class ConnectedOverlayDirectiveTest {
-  @ViewChild(CdkConnectedOverlay) connectedOverlayDirective: CdkConnectedOverlay;
-  @ViewChild('trigger') trigger: CdkOverlayOrigin;
-  @ViewChild('otherTrigger') otherTrigger: CdkOverlayOrigin;
+  @ViewChild(CdkConnectedOverlay, {static: false}) connectedOverlayDirective: CdkConnectedOverlay;
+  @ViewChild('trigger', {static: false}) trigger: CdkOverlayOrigin;
+  @ViewChild('otherTrigger', {static: false}) otherTrigger: CdkOverlayOrigin;
 
   isOpen = false;
   width: number | string;
@@ -574,6 +574,6 @@ class ConnectedOverlayDirectiveTest {
   <ng-template cdk-connected-overlay>Menu content</ng-template>`,
 })
 class ConnectedOverlayPropertyInitOrder {
-  @ViewChild(CdkConnectedOverlay) connectedOverlayDirective: CdkConnectedOverlay;
-  @ViewChild('trigger') trigger: CdkOverlayOrigin;
+  @ViewChild(CdkConnectedOverlay, {static: false}) connectedOverlayDirective: CdkConnectedOverlay;
+  @ViewChild('trigger', {static: false}) trigger: CdkOverlayOrigin;
 }

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -948,7 +948,7 @@ class PizzaMsg { }
 /** Test-bed component that contains a TempatePortal and an ElementRef. */
 @Component({template: `<ng-template cdk-portal>Cake</ng-template>`})
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  @ViewChild(CdkPortal, {static: false}) templatePortal: CdkPortal;
 
   constructor(public viewContainerRef: ViewContainerRef) { }
 }

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -244,8 +244,8 @@ describe('ScrollDispatcher', () => {
   template: `<div #scrollingElement cdk-scrollable style="height: 9999px"></div>`
 })
 class ScrollingComponent {
-  @ViewChild(CdkScrollable) scrollable: CdkScrollable;
-  @ViewChild('scrollingElement') scrollingElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkScrollable, {static: false}) scrollable: CdkScrollable;
+  @ViewChild('scrollingElement', {static: false}) scrollingElement: ElementRef<HTMLElement>;
 }
 
 
@@ -262,7 +262,7 @@ class ScrollingComponent {
   `
 })
 class NestedScrollingComponent {
-  @ViewChild('interestingElement') interestingElement: ElementRef<HTMLElement>;
+  @ViewChild('interestingElement', {static: false}) interestingElement: ElementRef<HTMLElement>;
 }
 
 const TEST_COMPONENTS = [ScrollingComponent, NestedScrollingComponent];

--- a/src/cdk/scrolling/scrollable.spec.ts
+++ b/src/cdk/scrolling/scrollable.spec.ts
@@ -241,10 +241,10 @@ describe('CdkScrollable', () => {
 })
 class ScrollableViewport {
   @Input() dir: Direction;
-  @ViewChild(CdkScrollable) scrollable: CdkScrollable;
-  @ViewChild('scrollContainer') scrollContainer: ElementRef<Element>;
-  @ViewChild('firstRowStart') firstRowStart: ElementRef<Element>;
-  @ViewChild('firstRowEnd') firstRowEnd: ElementRef<Element>;
-  @ViewChild('lastRowStart') lastRowStart: ElementRef<Element>;
-  @ViewChild('lastRowEnd') lastRowEnd: ElementRef<Element>;
+  @ViewChild(CdkScrollable, {static: false}) scrollable: CdkScrollable;
+  @ViewChild('scrollContainer', {static: false}) scrollContainer: ElementRef<Element>;
+  @ViewChild('firstRowStart', {static: false}) firstRowStart: ElementRef<Element>;
+  @ViewChild('firstRowEnd', {static: false}) firstRowEnd: ElementRef<Element>;
+  @ViewChild('lastRowStart', {static: false}) lastRowStart: ElementRef<Element>;
+  @ViewChild('lastRowEnd', {static: false}) lastRowEnd: ElementRef<Element>;
 }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -118,7 +118,7 @@ export class CdkStep implements OnChanges {
   _displayDefaultIndicatorType: boolean;
 
   /** Template for step label if it exists. */
-  @ContentChild(CdkStepLabel) stepLabel: CdkStepLabel;
+  @ContentChild(CdkStepLabel, {static: false}) stepLabel: CdkStepLabel;
 
   /** Template for step content. */
   @ViewChild(TemplateRef, {static: true}) content: TemplateRef<any>;

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -90,13 +90,13 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
   _stickyEnd: boolean = false;
 
   /** @docs-private */
-  @ContentChild(CdkCellDef) cell: CdkCellDef;
+  @ContentChild(CdkCellDef, {static: false}) cell: CdkCellDef;
 
   /** @docs-private */
-  @ContentChild(CdkHeaderCellDef) headerCell: CdkHeaderCellDef;
+  @ContentChild(CdkHeaderCellDef, {static: false}) headerCell: CdkHeaderCellDef;
 
   /** @docs-private */
-  @ContentChild(CdkFooterCellDef) footerCell: CdkFooterCellDef;
+  @ContentChild(CdkFooterCellDef, {static: false}) footerCell: CdkFooterCellDef;
 
   /**
    * Transformed version of the column name that can be used as part of a CSS classname. Excludes

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1454,7 +1454,7 @@ class SimpleCdkTableApp {
   dataSource: FakeDataSource | undefined = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1484,7 +1484,7 @@ class CdkTableWithDifferentDataInputsApp {
   dataSource: DataSource<TestData> | Observable<TestData[]> | TestData[] | any = null;
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1615,7 +1615,7 @@ class WhenRowCdkTableApp {
     this.dataSource.addData();
   }
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 
   showIndexColumns() {
     const indexColumns = ['index', 'dataIndex', 'renderIndex'];
@@ -1665,7 +1665,7 @@ class WhenRowWithoutDefaultCdkTableApp {
   isIndex1 = (index: number, _rowData: TestData) => index == 1;
   hasC3 = (_index: number, rowData: TestData) => rowData.c == 'c_3';
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1708,7 +1708,7 @@ class WhenRowMultipleDefaultsCdkTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
   hasC3 = (_index: number, rowData: TestData) => rowData.c == 'c_3';
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1728,7 +1728,7 @@ class DynamicDataSourceCdkTableApp {
   dataSource: FakeDataSource | undefined;
   columnsToRender = ['column_a'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1755,7 +1755,7 @@ class TrackByCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 
   trackBy = (index: number, item: TestData) => {
     switch (this.trackByStrategy) {
@@ -1805,7 +1805,7 @@ class StickyFlexLayoutCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
   columns = ['column-1', 'column-2', 'column-3', 'column-4', 'column-5', 'column-6'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 
   dir = 'ltr';
   stickyHeaders: string[] = [];
@@ -1858,7 +1858,7 @@ class StickyNativeLayoutCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
   columns = ['column-1', 'column-2', 'column-3', 'column-4', 'column-5', 'column-6'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 
   stickyHeaders: string[] = [];
   stickyFooters: string[] = [];
@@ -1887,7 +1887,7 @@ class DynamicColumnDefinitionsCdkTableApp {
   dynamicColumns: any[] = [];
   dataSource: FakeDataSource = new FakeDataSource();
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1907,7 +1907,7 @@ class CustomRoleCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['column_a'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -1927,7 +1927,7 @@ class CrazyColumnNameCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();
   columnsToRender = ['crazy-column-NAME-1!@#$%^-_&*()2'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -2134,7 +2134,7 @@ class RowContextCdkTableApp {
 })
 class WrapperCdkTableApp<T> implements AfterContentInit {
   @ContentChildren(CdkColumnDef) columnDefs: QueryList<CdkColumnDef>;
-  @ContentChild(CdkHeaderRowDef) headerRowDef: CdkHeaderRowDef;
+  @ContentChild(CdkHeaderRowDef, {static: false}) headerRowDef: CdkHeaderRowDef;
   @ContentChildren(CdkRowDef) rowDefs: QueryList<CdkRowDef<T>>;
 
   @ViewChild(CdkTable, {static: true}) table: CdkTable<T>;
@@ -2208,7 +2208,7 @@ class NativeHtmlTableApp {
   dataSource: FakeDataSource | undefined = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -2237,7 +2237,7 @@ class NativeTableWithNoHeaderOrFooterRows {
   dataSource: FakeDataSource | undefined = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 @Component({
@@ -2258,7 +2258,7 @@ class NativeHtmlTableWithCaptionApp {
   dataSource: FakeDataSource | undefined = new FakeDataSource();
   columnsToRender = ['column_a'];
 
-  @ViewChild(CdkTable) table: CdkTable<TestData>;
+  @ViewChild(CdkTable, {static: false}) table: CdkTable<TestData>;
 }
 
 function getElements(element: Element, query: string): Element[] {

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -227,5 +227,5 @@ class Inputs {
 })
 class InputWithCdkAutofilled {
   // Cast to `any` so we can stub out some methods in the tests.
-  @ViewChild('input') input: ElementRef<any>;
+  @ViewChild('input', {static: false}) input: ElementRef<any>;
 }

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -295,7 +295,7 @@ const textareaStyleReset = `
   styles: [textareaStyleReset],
 })
 class AutosizeTextAreaWithContent {
-  @ViewChild('autosize') autosize: CdkTextareaAutosize;
+  @ViewChild('autosize', {static: false}) autosize: CdkTextareaAutosize;
   minRows: number | null = null;
   maxRows: number | null = null;
   content: string = '';

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -1131,7 +1131,7 @@ class SimpleCdkTreeApp {
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
   indent: number | string = 28;
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 
 }
 
@@ -1152,7 +1152,7 @@ class NestedCdkTreeApp {
 
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1172,7 +1172,7 @@ class StaticNestedCdkTreeApp {
 
   dataSource: FakeDataSource;
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 
   constructor() {
     const dataSource = new FakeDataSource(this.treeControl);
@@ -1208,7 +1208,7 @@ class WhenNodeNestedCdkTreeApp {
 
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 
@@ -1232,7 +1232,7 @@ class CdkTreeAppWithToggle {
   treeControl: TreeControl<TestData> = new FlatTreeControl(this.getLevel, this.isExpandable);
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1256,7 +1256,7 @@ class NestedCdkTreeAppWithToggle {
   treeControl: TreeControl<TestData> = new NestedTreeControl(this.getChildren);
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1284,7 +1284,7 @@ class WhenNodeCdkTreeApp {
 
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1310,7 +1310,7 @@ class ArrayDataSourceCdkTreeApp {
     return this.dataSource.data;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1336,7 +1336,7 @@ class ObservableDataSourceCdkTreeApp {
     return this.dataSource._dataChange;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1361,7 +1361,7 @@ class ArrayDataSourceNestedCdkTreeApp {
     return this.dataSource.data;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1386,7 +1386,7 @@ class ObservableDataSourceNestedCdkTreeApp {
     return this.dataSource._dataChange;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1408,7 +1408,7 @@ class NestedCdkErrorTreeApp {
 
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 class FakeTreeControl extends BaseTreeControl<TestData> {
@@ -1440,7 +1440,7 @@ class FlatCdkErrorTreeApp {
 
   dataSource: FakeDataSource | null = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 
@@ -1467,7 +1467,7 @@ class DepthNestedCdkTreeApp {
     return this.dataSource.data;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1496,7 +1496,7 @@ class CdkTreeAppWithTrackBy {
   treeControl: TreeControl<TestData> = new FlatTreeControl(this.getLevel, this.isExpandable);
   dataSource: FakeDataSource = new FakeDataSource(this.treeControl);
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }
 
 @Component({
@@ -1530,5 +1530,5 @@ class NestedCdkTreeAppWithTrackBy {
     return this.dataSource.data;
   }
 
-  @ViewChild(CdkTree) tree: CdkTree<TestData>;
+  @ViewChild(CdkTree, {static: false}) tree: CdkTree<TestData>;
 }

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -39,7 +39,7 @@ export class AutocompleteDemo {
 
   tdDisabled = false;
 
-  @ViewChild(NgModel) modelDir: NgModel;
+  @ViewChild(NgModel, {static: false}) modelDir: NgModel;
 
   groupedStates: StateGroup[];
   filteredGroupedStates: StateGroup[];

--- a/src/dev-app/bottom-sheet/bottom-sheet-demo.ts
+++ b/src/dev-app/bottom-sheet/bottom-sheet-demo.ts
@@ -30,7 +30,7 @@ export class BottomSheetDemo {
     direction: 'ltr'
   };
 
-  @ViewChild(TemplateRef) template: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) template: TemplateRef<any>;
 
   constructor(private _bottomSheet: MatBottomSheet) {}
 

--- a/src/dev-app/connected-overlay/connected-overlay-demo.ts
+++ b/src/dev-app/connected-overlay/connected-overlay-demo.ts
@@ -25,8 +25,8 @@ import {Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core
   styleUrls: ['connected-overlay-demo.css'],
 })
 export class ConnectedOverlayDemo {
-  @ViewChild(CdkOverlayOrigin) _overlayOrigin: CdkOverlayOrigin;
-  @ViewChild('overlay') overlayTemplate: TemplateRef<any>;
+  @ViewChild(CdkOverlayOrigin, {static: false}) _overlayOrigin: CdkOverlayOrigin;
+  @ViewChild('overlay', {static: false}) overlayTemplate: TemplateRef<any>;
 
   originX: HorizontalConnectionPos = 'start';
   originY: VerticalConnectionPos = 'bottom';

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -111,7 +111,7 @@ export class CustomHeader<D> implements OnDestroy {
 })
 export class CustomHeaderNgContent<D> {
 
-  @ViewChild(MatCalendarHeader)
+  @ViewChild(MatCalendarHeader, {static: false})
   header: MatCalendarHeader<D>;
 
   constructor(@Optional() private _dateAdapter: DateAdapter<D>) {}

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -47,7 +47,7 @@ export class DialogDemo {
   };
   numTemplateOpens = 0;
 
-  @ViewChild(TemplateRef) template: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) template: TemplateRef<any>;
 
   constructor(public dialog: MatDialog, @Inject(DOCUMENT) doc: any) {
     // Possible useful example for the open and closeAll events.

--- a/src/dev-app/expansion/expansion-demo.ts
+++ b/src/dev-app/expansion/expansion-demo.ts
@@ -17,7 +17,7 @@ import {MatAccordion} from '@angular/material';
   templateUrl: 'expansion-demo.html',
 })
 export class ExpansionDemo {
-  @ViewChild(MatAccordion) accordion: MatAccordion;
+  @ViewChild(MatAccordion, {static: false}) accordion: MatAccordion;
 
   displayMode = 'default';
   multi = false;

--- a/src/dev-app/ripple/ripple-demo.ts
+++ b/src/dev-app/ripple/ripple-demo.ts
@@ -17,7 +17,7 @@ import {MatRipple} from '@angular/material';
   styleUrls: ['ripple-demo.css'],
 })
 export class RippleDemo {
-  @ViewChild(MatRipple) ripple: MatRipple;
+  @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
 
   centered = false;
   disabled = false;

--- a/src/dev-app/snack-bar/snack-bar-demo.ts
+++ b/src/dev-app/snack-bar/snack-bar-demo.ts
@@ -23,7 +23,7 @@ import {
   templateUrl: 'snack-bar-demo.html',
 })
 export class SnackBarDemo {
-  @ViewChild('template') template: TemplateRef<any>;
+  @ViewChild('template', {static: false}) template: TemplateRef<any>;
   message = 'Snack Bar opened.';
   actionButtonLabel = 'Retry';
   action = false;

--- a/src/e2e-app/dialog/dialog-e2e.ts
+++ b/src/e2e-app/dialog/dialog-e2e.ts
@@ -9,7 +9,7 @@ import {MatDialog, MatDialogRef, MatDialogConfig} from '@angular/material';
 export class DialogE2E {
   dialogRef: MatDialogRef<TestDialog> | null;
 
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
 
   constructor (private _dialog: MatDialog) { }
 

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -2353,8 +2353,8 @@ class SimpleAutocomplete implements OnDestroy {
   closedSpy = jasmine.createSpy('autocomplete closed spy');
 
   @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
-  @ViewChild(MatAutocomplete) panel: MatAutocomplete;
-  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChild(MatAutocomplete, {static: false}) panel: MatAutocomplete;
+  @ViewChild(MatFormField, {static: false}) formField: MatFormField;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 
   states = [
@@ -2408,7 +2408,7 @@ class NgIfAutocomplete {
   isVisible = true;
   options = ['One', 'Two', 'Three'];
 
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
   @ViewChildren(MatOption) matOptions: QueryList<MatOption>;
 
   constructor() {
@@ -2509,7 +2509,7 @@ class AutocompleteWithNumbers {
   `
 })
 class AutocompleteWithOnPushDelay implements OnInit {
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
   options: string[];
 
   ngOnInit() {
@@ -2535,7 +2535,7 @@ class AutocompleteWithNativeInput {
   filteredOptions: Observable<any>;
   options = ['En', 'To', 'Tre', 'Fire', 'Fem'];
 
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
   @ViewChildren(MatOption) matOptions: QueryList<MatOption>;
 
   constructor() {
@@ -2553,7 +2553,7 @@ class AutocompleteWithNativeInput {
   template: `<input placeholder="Choose" [matAutocomplete]="auto" [formControl]="control">`
 })
 class AutocompleteWithoutPanel {
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
   control = new FormControl();
 }
 
@@ -2590,7 +2590,7 @@ class AutocompleteWithFormsAndNonfloatingLabel {
   `
 })
 class AutocompleteWithGroups {
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
   selectedState: string;
   stateGroups = [
     {
@@ -2626,8 +2626,8 @@ class AutocompleteWithSelectEvent {
   states = ['New York', 'Washington', 'Oregon'];
   optionSelected = jasmine.createSpy('optionSelected callback');
 
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
-  @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete, {static: false}) autocomplete: MatAutocomplete;
 }
 
 
@@ -2685,8 +2685,8 @@ class AutocompleteWithNumberInputAndNgModel {
   `
 })
 class AutocompleteWithDifferentOrigin {
-  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
-  @ViewChild(MatAutocompleteOrigin) alternateOrigin: MatAutocompleteOrigin;
+  @ViewChild(MatAutocompleteTrigger, {static: false}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteOrigin, {static: false}) alternateOrigin: MatAutocompleteOrigin;
   selectedValue: string;
   values = ['one', 'two', 'three'];
   connectedTo?: MatAutocompleteOrigin;

--- a/src/lib/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/lib/bottom-sheet/bottom-sheet.spec.ts
@@ -814,7 +814,9 @@ class DirectiveWithViewContainer {
 
 @Component({template: `<dir-with-view-container></dir-with-view-container>`})
 class ComponentWithChildViewContainer {
-  @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+  @ViewChild(DirectiveWithViewContainer, {
+    static: false
+  }) childWithViewContainer: DirectiveWithViewContainer;
 
   get childViewContainer() {
     return this.childWithViewContainer.viewContainerRef;
@@ -830,7 +832,7 @@ class ComponentWithTemplateRef {
   localValue: string;
   bottomSheetRef: MatBottomSheetRef<any>;
 
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
 
   setRef(bottomSheetRef: MatBottomSheetRef<any>): string {
     this.bottomSheetRef = bottomSheetRef;

--- a/src/lib/button-toggle/button-toggle.spec.ts
+++ b/src/lib/button-toggle/button-toggle.spec.ts
@@ -938,7 +938,7 @@ class ButtonToggleWithAriaLabelledby {}
   `
 })
 class RepeatedButtonTogglesWithPreselectedValue {
-  @ViewChild(MatButtonToggleGroup) toggleGroup: MatButtonToggleGroup;
+  @ViewChild(MatButtonToggleGroup, {static: false}) toggleGroup: MatButtonToggleGroup;
   @ViewChildren(MatButtonToggle) toggles: QueryList<MatButtonToggle>;
 
   possibleValues = ['One', 'Two', 'Three'];

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -395,7 +395,7 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
   /** Type of the button toggle. Either 'radio' or 'checkbox'. */
   _type: ToggleType;
 
-  @ViewChild('button') _buttonElement: ElementRef<HTMLButtonElement>;
+  @ViewChild('button', {static: false}) _buttonElement: ElementRef<HTMLButtonElement>;
 
   /** The parent button toggle group (exclusive selection). Optional. */
   buttonToggleGroup: MatButtonToggleGroup;

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -89,7 +89,7 @@ export class MatButton extends _MatButtonMixinBase
   readonly isIconButton: boolean = this._hasHostAttributes('mat-icon-button');
 
   /** Reference to the MatRipple instance of the button. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
 
   constructor(elementRef: ElementRef,
               /**

--- a/src/lib/checkbox/checkbox.spec.ts
+++ b/src/lib/checkbox/checkbox.spec.ts
@@ -1237,7 +1237,7 @@ class CheckboxWithTabIndex {
     <mat-checkbox></mat-checkbox>`,
 })
 class CheckboxUsingViewChild {
-  @ViewChild(MatCheckbox) checkbox: MatCheckbox;
+  @ViewChild(MatCheckbox, {static: false}) checkbox: MatCheckbox;
 
   set isDisabled(value: boolean) {
     this.checkbox.disabled = value;

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -171,10 +171,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   @Input() value: string;
 
   /** The native `<input type="checkbox">` element */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  @ViewChild('input', {static: false}) _inputElement: ElementRef<HTMLInputElement>;
 
   /** Reference to the ripple instance of the checkbox. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
 
   /**
    * Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor.

--- a/src/lib/chips/chip-input.spec.ts
+++ b/src/lib/chips/chip-input.spec.ts
@@ -214,7 +214,7 @@ describe('MatChipInput', () => {
   `
 })
 class TestChipInput {
-  @ViewChild(MatChipList) chipListInstance: MatChipList;
+  @ViewChild(MatChipList, {static: false}) chipListInstance: MatChipList;
   addOnBlur: boolean = false;
   placeholder = '';
 

--- a/src/lib/chips/chip-list.spec.ts
+++ b/src/lib/chips/chip-list.spec.ts
@@ -1389,7 +1389,7 @@ class BasicChipList {
   tabIndexOverride: number;
   selectable: boolean;
 
-  @ViewChild(MatChipList) chipList: MatChipList;
+  @ViewChild(MatChipList, {static: false}) chipList: MatChipList;
   @ViewChildren(MatChip) chips: QueryList<MatChip>;
 }
 
@@ -1424,7 +1424,7 @@ class MultiSelectionChipList {
   tabIndexOverride: number;
   selectable: boolean;
 
-  @ViewChild(MatChipList) chipList: MatChipList;
+  @ViewChild(MatChipList, {static: false}) chipList: MatChipList;
   @ViewChildren(MatChip) chips: QueryList<MatChip>;
 }
 
@@ -1489,7 +1489,7 @@ class InputChipList {
     }
   }
 
-  @ViewChild(MatChipList) chipList: MatChipList;
+  @ViewChild(MatChipList, {static: false}) chipList: MatChipList;
   @ViewChildren(MatChip) chips: QueryList<MatChip>;
 }
 
@@ -1552,7 +1552,7 @@ class ChipListWithFormErrorMessages {
   ];
   @ViewChildren(MatChip) chips: QueryList<MatChip>;
 
-  @ViewChild('form') form: NgForm;
+  @ViewChild('form', {static: false}) form: NgForm;
   formControl = new FormControl('', Validators.required);
 }
 

--- a/src/lib/chips/chip.spec.ts
+++ b/src/lib/chips/chip.spec.ts
@@ -403,7 +403,7 @@ describe('Chips', () => {
     </mat-chip-list>`
 })
 class SingleChip {
-  @ViewChild(MatChipList) chipList: MatChipList;
+  @ViewChild(MatChipList, {static: false}) chipList: MatChipList;
   disabled: boolean = false;
   name: string = 'Test';
   color: string = 'primary';

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -149,13 +149,13 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   _chipListMultiple: boolean = false;
 
   /** The chip avatar */
-  @ContentChild(MatChipAvatar) avatar: MatChipAvatar;
+  @ContentChild(MatChipAvatar, {static: false}) avatar: MatChipAvatar;
 
   /** The chip's trailing icon. */
-  @ContentChild(MatChipTrailingIcon) trailingIcon: MatChipTrailingIcon;
+  @ContentChild(MatChipTrailingIcon, {static: false}) trailingIcon: MatChipTrailingIcon;
 
   /** The chip's remove toggler. */
-  @ContentChild(forwardRef(() => MatChipRemove)) removeIcon: MatChipRemove;
+  @ContentChild(forwardRef(() => MatChipRemove), {static: false}) removeIcon: MatChipRemove;
 
   /** Whether the chip is selected. */
   @Input()

--- a/src/lib/core/ripple/ripple.spec.ts
+++ b/src/lib/core/ripple/ripple.spec.ts
@@ -728,7 +728,7 @@ describe('MatRipple', () => {
   `,
 })
 class BasicRippleContainer {
-  @ViewChild('ripple') ripple: MatRipple;
+  @ViewChild('ripple', {static: false}) ripple: MatRipple;
 }
 
 @Component({
@@ -752,7 +752,7 @@ class RippleContainerWithInputBindings {
   disabled = false;
   radius = 0;
   color = '';
-  @ViewChild(MatRipple) ripple: MatRipple;
+  @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
 }
 
 @Component({
@@ -763,6 +763,6 @@ class RippleContainerWithoutBindings {}
 @Component({ template: `<div id="container" matRipple
                              *ngIf="!isDestroyed"></div>` })
 class RippleContainerWithNgIf {
-  @ViewChild(MatRipple) ripple: MatRipple;
+  @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
   isDestroyed = false;
 }

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -246,13 +246,13 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   @Output() readonly _userSelection: EventEmitter<void> = new EventEmitter<void>();
 
   /** Reference to the current month view component. */
-  @ViewChild(MatMonthView) monthView: MatMonthView<D>;
+  @ViewChild(MatMonthView, {static: false}) monthView: MatMonthView<D>;
 
   /** Reference to the current year view component. */
-  @ViewChild(MatYearView) yearView: MatYearView<D>;
+  @ViewChild(MatYearView, {static: false}) yearView: MatYearView<D>;
 
   /** Reference to the current multi-year view component. */
-  @ViewChild(MatMultiYearView) multiYearView: MatMultiYearView<D>;
+  @ViewChild(MatMultiYearView, {static: false}) multiYearView: MatMultiYearView<D>;
 
   /**
    * The current active date. This determines which time period is shown and which date is

--- a/src/lib/datepicker/datepicker-toggle.ts
+++ b/src/lib/datepicker/datepicker-toggle.ts
@@ -81,10 +81,10 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   @Input() disableRipple: boolean;
 
   /** Custom icon set by the consumer. */
-  @ContentChild(MatDatepickerToggleIcon) _customIcon: MatDatepickerToggleIcon;
+  @ContentChild(MatDatepickerToggleIcon, {static: false}) _customIcon: MatDatepickerToggleIcon;
 
   /** Underlying button element. */
-  @ViewChild('button') _button: MatButton;
+  @ViewChild('button', {static: false}) _button: MatButton;
 
   constructor(
     public _intl: MatDatepickerIntl,

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -1703,8 +1703,8 @@ class StandardDatepicker {
   touch = false;
   disabled = false;
   date: Date | null = new Date(2020, JAN, 1);
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
 }
 
 
@@ -1720,7 +1720,7 @@ class MultiInputDatepicker {}
   template: `<mat-datepicker #d></mat-datepicker>`,
 })
 class NoInputDatepicker {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 }
 
 
@@ -1733,7 +1733,7 @@ class NoInputDatepicker {
 class DatepickerWithStartAt {
   date = new Date(2020, JAN, 1);
   startDate = new Date(2010, JAN, 1);
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 }
 
 
@@ -1745,7 +1745,7 @@ class DatepickerWithStartAt {
 })
 class DatepickerWithStartViewYear {
   date = new Date(2020, JAN, 1);
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 
   onYearSelection() {}
 }
@@ -1760,7 +1760,7 @@ class DatepickerWithStartViewYear {
 })
 class DatepickerWithStartViewMultiYear {
   date = new Date(2020, JAN, 1);
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 
   onMultiYearSelection() {}
 }
@@ -1774,8 +1774,8 @@ class DatepickerWithStartViewMultiYear {
 })
 class DatepickerWithNgModel {
   selected: Date | null = null;
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
 }
 
 
@@ -1788,9 +1788,9 @@ class DatepickerWithNgModel {
 })
 class DatepickerWithFormControl {
   formControl = new FormControl();
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
-  @ViewChild(MatDatepickerToggle) datepickerToggle: MatDatepickerToggle<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild(MatDatepickerToggle, {static: false}) datepickerToggle: MatDatepickerToggle<Date>;
 }
 
 
@@ -1802,8 +1802,8 @@ class DatepickerWithFormControl {
   `,
 })
 class DatepickerWithToggle {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) input: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) input: MatDatepickerInput<Date>;
   touchUI = true;
 }
 
@@ -1829,9 +1829,9 @@ class DatepickerWithCustomIcon {}
   `,
 })
 class FormFieldDatepicker {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
-  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild(MatFormField, {static: false}) formField: MatFormField;
 }
 
 
@@ -1843,8 +1843,8 @@ class FormFieldDatepicker {
   `,
 })
 class DatepickerWithMinAndMaxValidation {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(NgModel) model: NgModel;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(NgModel, {static: false}) model: NgModel;
   date: Date | null;
   minDate = new Date(2010, JAN, 1);
   maxDate = new Date(2020, JAN, 1);
@@ -1859,7 +1859,7 @@ class DatepickerWithMinAndMaxValidation {
   `,
 })
 class DatepickerWithFilterAndValidation {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
   date: Date;
   filter = (date: Date) => date.getDate() != 1;
 }
@@ -1873,7 +1873,7 @@ class DatepickerWithFilterAndValidation {
   `
 })
 class DatepickerWithChangeAndInputEvents {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 
   onChange() {}
 
@@ -1893,8 +1893,8 @@ class DatepickerWithChangeAndInputEvents {
 })
 class DatepickerWithi18n {
   date: Date | null = new Date(2010, JAN, 1);
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
 }
 
 
@@ -1909,8 +1909,8 @@ class DatepickerWithISOStrings {
   min = new Date(2017, JAN, 1).toISOString();
   max = new Date (2017, DEC, 31).toISOString();
   startAt = new Date(2017, JUL, 1).toISOString();
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
 }
 
 
@@ -1924,7 +1924,7 @@ class DatepickerWithEvents {
   selected: Date | null = null;
   openedSpy = jasmine.createSpy('opened spy');
   closedSpy = jasmine.createSpy('closed spy');
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
 }
 
 
@@ -1935,7 +1935,7 @@ class DatepickerWithEvents {
   `,
 })
 class DatepickerOpeningOnFocus {
-  @ViewChild(MatDatepicker) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepicker, {static: false}) datepicker: MatDatepicker<Date>;
 }
 
 
@@ -1946,7 +1946,7 @@ class DatepickerOpeningOnFocus {
   `,
 })
 class DatepickerWithCustomHeader {
-  @ViewChild('ch') datepicker: MatDatepicker<Date>;
+  @ViewChild('ch', {static: false}) datepicker: MatDatepicker<Date>;
   customHeaderForDatePicker = CustomHeaderForDatepicker;
 }
 
@@ -1965,8 +1965,8 @@ class CustomHeaderForDatepicker {}
   `,
 })
 class DelayedDatepicker {
-  @ViewChild('d') datepicker: MatDatepicker<Date>;
-  @ViewChild(MatDatepickerInput) datepickerInput: MatDatepickerInput<Date>;
+  @ViewChild('d', {static: false}) datepicker: MatDatepicker<Date>;
+  @ViewChild(MatDatepickerInput, {static: false}) datepickerInput: MatDatepickerInput<Date>;
   date: Date | null;
   assignedDatepicker: MatDatepicker<Date>;
 }

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -109,7 +109,7 @@ export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
   implements AfterViewInit, CanColor {
 
   /** Reference to the internal calendar component. */
-  @ViewChild(MatCalendar) _calendar: MatCalendar<D>;
+  @ViewChild(MatCalendar, {static: false}) _calendar: MatCalendar<D>;
 
   /** Reference to the datepicker that created the overlay. */
   datepicker: MatDatepicker<D>;

--- a/src/lib/datepicker/month-view.ts
+++ b/src/lib/datepicker/month-view.ts
@@ -110,7 +110,7 @@ export class MatMonthView<D> implements AfterContentInit {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  @ViewChild(MatCalendarBody, {static: false}) _matCalendarBody: MatCalendarBody;
 
   /** The label for this month (e.g. "January 2017"). */
   _monthLabel: string;

--- a/src/lib/datepicker/multi-year-view.spec.ts
+++ b/src/lib/datepicker/multi-year-view.spec.ts
@@ -255,7 +255,7 @@ class StandardMultiYearView {
   selected = new Date(2020, JAN, 1);
   selectedYear: Date;
 
-  @ViewChild(MatMultiYearView) multiYearView: MatMultiYearView<Date>;
+  @ViewChild(MatMultiYearView, {static: false}) multiYearView: MatMultiYearView<Date>;
 }
 
 @Component({

--- a/src/lib/datepicker/multi-year-view.ts
+++ b/src/lib/datepicker/multi-year-view.ts
@@ -106,7 +106,7 @@ export class MatMultiYearView<D> implements AfterContentInit {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  @ViewChild(MatCalendarBody, {static: false}) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the currently displayed years. */
   _years: MatCalendarCell[][];

--- a/src/lib/datepicker/year-view.spec.ts
+++ b/src/lib/datepicker/year-view.spec.ts
@@ -322,7 +322,7 @@ class StandardYearView {
   selected = new Date(2017, MAR, 10);
   selectedMonth: Date;
 
-  @ViewChild(MatYearView) yearView: MatYearView<Date>;
+  @ViewChild(MatYearView, {static: false}) yearView: MatYearView<Date>;
 }
 
 

--- a/src/lib/datepicker/year-view.ts
+++ b/src/lib/datepicker/year-view.ts
@@ -101,7 +101,7 @@ export class MatYearView<D> implements AfterContentInit {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  @ViewChild(MatCalendarBody, {static: false}) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the months of the year. */
   _months: MatCalendarCell[][];

--- a/src/lib/dialog/dialog.spec.ts
+++ b/src/lib/dialog/dialog.spec.ts
@@ -1470,7 +1470,9 @@ class ComponentWithOnPushViewContainer {
   template: `<dir-with-view-container></dir-with-view-container>`,
 })
 class ComponentWithChildViewContainer {
-  @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+  @ViewChild(DirectiveWithViewContainer, {
+    static: false
+  }) childWithViewContainer: DirectiveWithViewContainer;
 
   get childViewContainer() {
     return this.childWithViewContainer.viewContainerRef;
@@ -1486,7 +1488,7 @@ class ComponentWithTemplateRef {
   localValue: string;
   dialogRef: MatDialogRef<any>;
 
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
 
   setDialogRef(dialogRef: MatDialogRef<any>): string {
     this.dialogRef = dialogRef;
@@ -1541,7 +1543,9 @@ class ContentElementDialog {}
   `
 })
 class ComponentWithContentElementTemplateRef {
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {
+    static: false
+  }) templateRef: TemplateRef<any>;
 }
 
 @Component({

--- a/src/lib/expansion/accordion.spec.ts
+++ b/src/lib/expansion/accordion.spec.ts
@@ -232,7 +232,7 @@ describe('MatAccordion', () => {
     </mat-expansion-panel>
   </mat-accordion>`})
 class SetOfItems {
-  @ViewChild(MatAccordion) accordion: MatAccordion;
+  @ViewChild(MatAccordion, {static: false}) accordion: MatAccordion;
   @ViewChildren(MatExpansionPanel) panels: QueryList<MatExpansionPanel>;
   @ViewChildren(MatExpansionPanelHeader) headers: QueryList<MatExpansionPanelHeader>;
 
@@ -250,8 +250,8 @@ class SetOfItems {
     </mat-expansion-panel>
   </mat-accordion>`})
 class NestedPanel {
-  @ViewChild('outerPanel') outerPanel: MatExpansionPanel;
-  @ViewChild('innerPanel') innerPanel: MatExpansionPanel;
+  @ViewChild('outerPanel', {static: false}) outerPanel: MatExpansionPanel;
+  @ViewChild('innerPanel', {static: false}) innerPanel: MatExpansionPanel;
 }
 
 @Component({template: `

--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -128,10 +128,10 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   accordion: MatAccordionBase;
 
   /** Content that will be rendered lazily. */
-  @ContentChild(MatExpansionPanelContent) _lazyContent: MatExpansionPanelContent;
+  @ContentChild(MatExpansionPanelContent, {static: false}) _lazyContent: MatExpansionPanelContent;
 
   /** Element containing the panel's user-provided content. */
-  @ViewChild('body') _body: ElementRef<HTMLElement>;
+  @ViewChild('body', {static: false}) _body: ElementRef<HTMLElement>;
 
   /** Portal holding the user's content. */
   _portal: TemplatePortal;

--- a/src/lib/expansion/expansion.spec.ts
+++ b/src/lib/expansion/expansion.spec.ts
@@ -421,7 +421,7 @@ class PanelWithContent {
   disabled = false;
   openCallback = jasmine.createSpy('openCallback');
   closeCallback = jasmine.createSpy('closeCallback');
-  @ViewChild(MatExpansionPanel) panel: MatExpansionPanel;
+  @ViewChild(MatExpansionPanel, {static: false}) panel: MatExpansionPanel;
 }
 
 @Component({
@@ -434,7 +434,7 @@ class PanelWithContent {
 })
 class PanelWithContentInNgIf {
   expansionShown = true;
-  @ViewChild(MatExpansionPanel) panel: MatExpansionPanel;
+  @ViewChild(MatExpansionPanel, {static: false}) panel: MatExpansionPanel;
 }
 
 @Component({

--- a/src/lib/grid-list/grid-list.spec.ts
+++ b/src/lib/grid-list/grid-list.spec.ts
@@ -484,7 +484,7 @@ class GridListWithTooWideColspan { }
 
 @Component({template: '<mat-grid-list [cols]="cols"></mat-grid-list>'})
 class GridListWithDynamicCols {
-  @ViewChild(MatGridList) gridList: MatGridList;
+  @ViewChild(MatGridList, {static: false}) gridList: MatGridList;
   cols = 2;
 }
 

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -1777,7 +1777,7 @@ class MatInputMissingMatInputTestController {}
   `
 })
 class MatInputWithFormErrorMessages {
-  @ViewChild('form') form: NgForm;
+  @ViewChild('form', {static: false}) form: NgForm;
   formControl = new FormControl('', Validators.required);
   renderError = true;
 }
@@ -1819,7 +1819,7 @@ class MatInputWithCustomErrorStateMatcher {
   `
 })
 class MatInputWithFormGroupErrorMessages {
-  @ViewChild(FormGroupDirective) formGroupDirective: FormGroupDirective;
+  @ViewChild(FormGroupDirective, {static: false}) formGroupDirective: FormGroupDirective;
   formGroup = new FormGroup({
     name: new FormControl('', Validators.required)
   });
@@ -1900,7 +1900,7 @@ class MatInputWithLabelAndPlaceholder {
   `
 })
 class MatInputWithAppearance {
-  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChild(MatFormField, {static: false}) formField: MatFormField;
   appearance: MatFormFieldAppearance;
 }
 
@@ -1914,7 +1914,7 @@ class MatInputWithAppearance {
   `
 })
 class MatInputWithAppearanceAndLabel {
-  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChild(MatFormField, {static: false}) formField: MatFormField;
   appearance: MatFormFieldAppearance;
   showPrefix: boolean;
   labelContent = 'Label';
@@ -1958,7 +1958,7 @@ const textareaStyleReset = `
 })
 class AutosizeTextareaWithLongPlaceholder {
   placeholder = 'Long Long Long Long Long Long Long Long Placeholder';
-  @ViewChild(MatTextareaAutosize) autosize: MatTextareaAutosize;
+  @ViewChild(MatTextareaAutosize, {static: false}) autosize: MatTextareaAutosize;
 }
 
 @Component({

--- a/src/lib/list/list.ts
+++ b/src/lib/list/list.ts
@@ -181,8 +181,8 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
   private _destroyed = new Subject<void>();
 
   @ContentChildren(MatLine) _lines: QueryList<MatLine>;
-  @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
-  @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
+  @ContentChild(MatListAvatarCssMatStyler, {static: false}) _avatar: MatListAvatarCssMatStyler;
+  @ContentChild(MatListIconCssMatStyler, {static: false}) _icon: MatListIconCssMatStyler;
 
   constructor(private _element: ElementRef<HTMLElement>,
               @Optional() navList?: MatNavList,

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -117,12 +117,12 @@ export class MatListOption extends _MatListOptionMixinBase
   private _disabled = false;
   private _hasFocus = false;
 
-  @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
-  @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
+  @ContentChild(MatListAvatarCssMatStyler, {static: false}) _avatar: MatListAvatarCssMatStyler;
+  @ContentChild(MatListIconCssMatStyler, {static: false}) _icon: MatListIconCssMatStyler;
   @ContentChildren(MatLine) _lines: QueryList<MatLine>;
 
   /** DOM element containing the item's text. */
-  @ViewChild('text') _text: ElementRef;
+  @ViewChild('text', {static: false}) _text: ElementRef;
 
   /** Whether the label should appear before or after the checkbox. Defaults to 'after' */
   @Input() checkboxPosition: 'before' | 'after' = 'after';

--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -166,7 +166,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   }
 
   /** @docs-private */
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
 
   /**
    * List of the items inside of a menu.
@@ -179,7 +179,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
    * Menu content that will be rendered lazily.
    * @docs-private
    */
-  @ContentChild(MatMenuContent) lazyContent: MatMenuContent;
+  @ContentChild(MatMenuContent, {static: false}) lazyContent: MatMenuContent;
 
   /** Whether the menu should overlap its trigger. */
   @Input()

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -2018,9 +2018,9 @@ describe('MatMenu default overrides', () => {
   `
 })
 class SimpleMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
-  @ViewChild(MatMenu) menu: MatMenu;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild('triggerEl', {static: false}) triggerEl: ElementRef<HTMLElement>;
+  @ViewChild(MatMenu, {static: false}) menu: MatMenu;
   @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
   extraItems: string[] = [];
   closeCallback = jasmine.createSpy('menu closed callback');
@@ -2038,8 +2038,8 @@ class SimpleMenu {
   `
 })
 class PositionedMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild('triggerEl', {static: false}) triggerEl: ElementRef<HTMLElement>;
   xPosition: MenuPositionX = 'before';
   yPosition: MenuPositionY = 'above';
 }
@@ -2058,8 +2058,8 @@ interface TestableMenu {
 })
 class OverlapMenu implements TestableMenu {
   @Input() overlapTrigger: boolean;
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild('triggerEl', {static: false}) triggerEl: ElementRef<HTMLElement>;
 }
 
 @Component({
@@ -2079,7 +2079,7 @@ class CustomMenuPanel implements MatMenuPanel {
   overlapTrigger = true;
   parentMenu: MatMenuPanel;
 
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
   @Output() close = new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
   focusFirstItem = () => {};
   resetActiveItem = () => {};
@@ -2095,7 +2095,7 @@ class CustomMenuPanel implements MatMenuPanel {
   `
 })
 class CustomMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
 }
 
 
@@ -2146,22 +2146,22 @@ class CustomMenu {
   `
 })
 class NestedMenu {
-  @ViewChild('root') rootMenu: MatMenu;
-  @ViewChild('rootTrigger') rootTrigger: MatMenuTrigger;
-  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef<HTMLElement>;
-  @ViewChild('alternateTrigger') alternateTrigger: MatMenuTrigger;
+  @ViewChild('root', {static: false}) rootMenu: MatMenu;
+  @ViewChild('rootTrigger', {static: false}) rootTrigger: MatMenuTrigger;
+  @ViewChild('rootTriggerEl', {static: false}) rootTriggerEl: ElementRef<HTMLElement>;
+  @ViewChild('alternateTrigger', {static: false}) alternateTrigger: MatMenuTrigger;
   readonly rootCloseCallback = jasmine.createSpy('root menu closed callback');
 
-  @ViewChild('levelOne') levelOneMenu: MatMenu;
-  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+  @ViewChild('levelOne', {static: false}) levelOneMenu: MatMenu;
+  @ViewChild('levelOneTrigger', {static: false}) levelOneTrigger: MatMenuTrigger;
   readonly levelOneCloseCallback = jasmine.createSpy('level one menu closed callback');
 
-  @ViewChild('levelTwo') levelTwoMenu: MatMenu;
-  @ViewChild('levelTwoTrigger') levelTwoTrigger: MatMenuTrigger;
+  @ViewChild('levelTwo', {static: false}) levelTwoMenu: MatMenu;
+  @ViewChild('levelTwoTrigger', {static: false}) levelTwoTrigger: MatMenuTrigger;
   readonly levelTwoCloseCallback = jasmine.createSpy('level one menu closed callback');
 
-  @ViewChild('lazy') lazyMenu: MatMenu;
-  @ViewChild('lazyTrigger') lazyTrigger: MatMenuTrigger;
+  @ViewChild('lazy', {static: false}) lazyMenu: MatMenu;
+  @ViewChild('lazyTrigger', {static: false}) lazyTrigger: MatMenuTrigger;
   showLazy = false;
 }
 
@@ -2181,8 +2181,8 @@ class NestedMenu {
   `
 })
 class NestedMenuCustomElevation {
-  @ViewChild('rootTrigger') rootTrigger: MatMenuTrigger;
-  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+  @ViewChild('rootTrigger', {static: false}) rootTrigger: MatMenuTrigger;
+  @ViewChild('levelOneTrigger', {static: false}) levelOneTrigger: MatMenuTrigger;
 }
 
 
@@ -2204,8 +2204,8 @@ class NestedMenuCustomElevation {
   `
 })
 class NestedMenuRepeater {
-  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef<HTMLElement>;
-  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
+  @ViewChild('rootTriggerEl', {static: false}) rootTriggerEl: ElementRef<HTMLElement>;
+  @ViewChild('levelOneTrigger', {static: false}) levelOneTrigger: MatMenuTrigger;
 
   items = ['one', 'two', 'three'];
 }
@@ -2225,7 +2225,7 @@ class NestedMenuRepeater {
   `
 })
 class SubmenuDeclaredInsideParentMenu {
-  @ViewChild('rootTriggerEl') rootTriggerEl: ElementRef;
+  @ViewChild('rootTriggerEl', {static: false}) rootTriggerEl: ElementRef;
 }
 
 
@@ -2249,8 +2249,8 @@ class FakeIcon {}
   `
 })
 class SimpleLazyMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('triggerEl') triggerEl: ElementRef<HTMLElement>;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild('triggerEl', {static: false}) triggerEl: ElementRef<HTMLElement>;
   @ViewChildren(MatMenuItem) items: QueryList<MatMenuItem>;
 }
 
@@ -2275,8 +2275,8 @@ class SimpleLazyMenu {
   `
 })
 class LazyMenuWithContext {
-  @ViewChild('triggerOne') triggerOne: MatMenuTrigger;
-  @ViewChild('triggerTwo') triggerTwo: MatMenuTrigger;
+  @ViewChild('triggerOne', {static: false}) triggerOne: MatMenuTrigger;
+  @ViewChild('triggerTwo', {static: false}) triggerTwo: MatMenuTrigger;
 }
 
 
@@ -2294,9 +2294,9 @@ class LazyMenuWithContext {
   `
 })
 class DynamicPanelMenu {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  @ViewChild('one') firstMenu: MatMenu;
-  @ViewChild('two') secondMenu: MatMenu;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild('one', {static: false}) firstMenu: MatMenu;
+  @ViewChild('two', {static: false}) secondMenu: MatMenu;
 }
 
 
@@ -2311,5 +2311,5 @@ class DynamicPanelMenu {
   `
 })
 class MenuWithCheckboxItems {
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
 }

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -456,7 +456,7 @@ class MatPaginatorApp {
   pageEvent = jasmine.createSpy('page event');
   color: ThemePalette;
 
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 
   goToLastPage() {
     this.pageIndex = Math.ceil(this.length / this.pageSize) - 1;
@@ -469,7 +469,7 @@ class MatPaginatorApp {
   `,
 })
 class MatPaginatorWithoutInputsApp {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 }
 
 @Component({
@@ -478,7 +478,7 @@ class MatPaginatorWithoutInputsApp {
   `,
 })
 class MatPaginatorWithoutPageSizeApp {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 }
 
 @Component({
@@ -487,7 +487,7 @@ class MatPaginatorWithoutPageSizeApp {
   `,
 })
 class MatPaginatorWithoutOptionsApp {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 }
 
 @Component({
@@ -500,5 +500,5 @@ class MatPaginatorWithoutOptionsApp {
   `
   })
 class MatPaginatorWithStringValues {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 }

--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -146,7 +146,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
   set bufferValue(v: number) { this._bufferValue = clamp(v || 0); }
   private _bufferValue: number = 0;
 
-  @ViewChild('primaryValueBar') _primaryValueBar: ElementRef;
+  @ViewChild('primaryValueBar', {static: false}) _primaryValueBar: ElementRef;
 
   /**
    * Event emitted when animation of the primary progress bar completes. This event will not

--- a/src/lib/radio/radio.spec.ts
+++ b/src/lib/radio/radio.spec.ts
@@ -858,7 +858,7 @@ class RadioGroupWithNgModel {
   template: `<mat-radio-button>One</mat-radio-button>`
 })
 class DisableableRadioButton {
-  @ViewChild(MatRadioButton) matRadioButton: MatRadioButton;
+  @ViewChild(MatRadioButton, {static: false}) matRadioButton: MatRadioButton;
 
   set disabled(value: boolean) {
     this.matRadioButton.disabled = value;

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -455,7 +455,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
   private _removeUniqueSelectionListener: () => void = () => {};
 
   /** The native `<input type=radio>` element */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  @ViewChild('input', {static: false}) _inputElement: ElementRef<HTMLInputElement>;
 
   constructor(@Optional() radioGroup: MatRadioGroup,
               elementRef: ElementRef,

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -4257,7 +4257,7 @@ class NgModelSelect {
   ];
   isDisabled: boolean;
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 }
 
@@ -4303,7 +4303,7 @@ class NgIfSelect {
   ];
   control = new FormControl('pizza-1');
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4347,7 +4347,7 @@ class SelectInitWithoutOptions {
   foods: any[];
   control = new FormControl('pizza-1');
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 
   addOptions() {
@@ -4369,7 +4369,7 @@ class SelectInitWithoutOptions {
   }]
 })
 class CustomSelectAccessor implements ControlValueAccessor {
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 
   writeValue: (value?: any) => void = () => {};
   registerOnChange: (changeFn?: (value: any) => void) => void = () => {};
@@ -4478,7 +4478,7 @@ class FloatLabelSelect {
     { value: 'tacos-2', viewValue: 'Tacos'}
   ];
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4507,7 +4507,7 @@ class MultiSelect {
   ];
   control = new FormControl();
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
   sortComparator: (a: MatOption, b: MatOption, options: MatOption[]) => number;
 }
@@ -4567,7 +4567,7 @@ class BasicSelectNoPlaceholder { }
   `
 })
 class BasicSelectWithTheming {
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   theme: string;
 }
 
@@ -4595,7 +4595,7 @@ class ResetValuesSelect {
   ];
   control = new FormControl();
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4671,7 +4671,7 @@ class SelectWithGroups {
     }
   ];
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 }
 
@@ -4728,8 +4728,8 @@ class InvalidSelectInForm {
   `
 })
 class SelectInsideFormGroup {
-  @ViewChild(FormGroupDirective) formGroupDirective: FormGroupDirective;
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(FormGroupDirective, {static: false}) formGroupDirective: FormGroupDirective;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   options = [
     {value: 'steak-0', viewValue: 'Steak'},
     {value: 'pizza-1', viewValue: 'Pizza'},
@@ -4759,7 +4759,7 @@ class BasicSelectWithoutForms {
     { value: 'sandwich-2', viewValue: 'Sandwich' },
   ];
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4780,7 +4780,7 @@ class BasicSelectWithoutFormsPreselected {
     { value: 'pizza-1', viewValue: 'Pizza' },
   ];
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4802,7 +4802,7 @@ class BasicSelectWithoutFormsMultiple {
     { value: 'sandwich-2', viewValue: 'Sandwich' },
   ];
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
 }
 
 @Component({
@@ -4848,7 +4848,7 @@ class NgModelCompareWithSelect {
   selectedFood: {value: string, viewValue: string} = { value: 'pizza-1', viewValue: 'Pizza' };
   comparator: ((f1: any, f2: any) => boolean)|null = this.compareByValue;
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 
   useCompareByValue() { this.comparator = this.compareByValue; }
@@ -4876,7 +4876,7 @@ class NgModelCompareWithSelect {
   `
 })
 class CustomErrorBehaviorSelect {
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   control = new FormControl();
   foods: any[] = [
     { value: 'steak-0', viewValue: 'Steak' },
@@ -4905,7 +4905,7 @@ class SingleSelectWithPreselectedArrayValues {
 
   selectedFoods = this.foods[1].value;
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 }
 
@@ -4934,7 +4934,7 @@ class SelectWithoutOptionCentering {
   ];
   control = new FormControl('pizza-1');
 
-  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChild(MatSelect, {static: false}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 }
 

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -334,13 +334,13 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   controlType = 'mat-select';
 
   /** Trigger that opens the select. */
-  @ViewChild('trigger') trigger: ElementRef;
+  @ViewChild('trigger', {static: false}) trigger: ElementRef;
 
   /** Panel containing the select options. */
-  @ViewChild('panel') panel: ElementRef;
+  @ViewChild('panel', {static: false}) panel: ElementRef;
 
   /** Overlay pane containing the options. */
-  @ViewChild(CdkConnectedOverlay) overlayDir: CdkConnectedOverlay;
+  @ViewChild(CdkConnectedOverlay, {static: false}) overlayDir: CdkConnectedOverlay;
 
   /** All of the defined select options. */
   @ContentChildren(MatOption, { descendants: true }) options: QueryList<MatOption>;
@@ -352,7 +352,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   @Input() panelClass: string|string[]|Set<string>|{[key: string]: any};
 
   /** User-supplied override of the trigger element. */
-  @ContentChild(MatSelectTrigger) customTrigger: MatSelectTrigger;
+  @ContentChild(MatSelectTrigger, {static: false}) customTrigger: MatSelectTrigger;
 
   /** Placeholder to be shown if no value has been selected. */
   @Input()

--- a/src/lib/sidenav/drawer.spec.ts
+++ b/src/lib/sidenav/drawer.spec.ts
@@ -763,7 +763,7 @@ class DrawerContainerNoDrawerTestApp { }
     </mat-drawer-container>`,
 })
 class DrawerContainerTwoDrawerTestApp {
-  @ViewChild(MatDrawerContainer) drawerContainer: MatDrawerContainer;
+  @ViewChild(MatDrawerContainer, {static: false}) drawerContainer: MatDrawerContainer;
 }
 
 /** Test component that contains an MatDrawerContainer and one MatDrawer. */
@@ -789,10 +789,10 @@ class BasicTestApp {
   backdropClickedCount = 0;
   hasBackdrop: boolean | null = null;
 
-  @ViewChild('drawer') drawer: MatDrawer;
-  @ViewChild('drawerButton') drawerButton: ElementRef<HTMLButtonElement>;
-  @ViewChild('openButton') openButton: ElementRef<HTMLButtonElement>;
-  @ViewChild('closeButton') closeButton: ElementRef<HTMLButtonElement>;
+  @ViewChild('drawer', {static: false}) drawer: MatDrawer;
+  @ViewChild('drawerButton', {static: false}) drawerButton: ElementRef<HTMLButtonElement>;
+  @ViewChild('openButton', {static: false}) openButton: ElementRef<HTMLButtonElement>;
+  @ViewChild('closeButton', {static: false}) closeButton: ElementRef<HTMLButtonElement>;
 
   open() {
     this.openCount++;
@@ -895,7 +895,7 @@ class DrawerWithoutFocusableElements {}
   `,
 })
 class DrawerDelayed {
-  @ViewChild(MatDrawer) drawer: MatDrawer;
+  @ViewChild(MatDrawer, {static: false}) drawer: MatDrawer;
   showDrawer = false;
 }
 
@@ -907,8 +907,8 @@ class DrawerDelayed {
     </mat-drawer-container>`,
 })
 class DrawerContainerStateChangesTestApp {
-  @ViewChild(MatDrawer) drawer: MatDrawer;
-  @ViewChild(MatDrawerContainer) drawerContainer: MatDrawerContainer;
+  @ViewChild(MatDrawer, {static: false}) drawer: MatDrawer;
+  @ViewChild(MatDrawerContainer, {static: false}) drawerContainer: MatDrawerContainer;
 
   direction: Direction = 'ltr';
   mode = 'side';
@@ -926,7 +926,7 @@ class DrawerContainerStateChangesTestApp {
     </mat-drawer-container>`,
 })
 class AutosizeDrawer {
-  @ViewChild(MatDrawer) drawer: MatDrawer;
+  @ViewChild(MatDrawer, {static: false}) drawer: MatDrawer;
   fillerWidth = 0;
 }
 
@@ -940,5 +940,5 @@ class AutosizeDrawer {
   `,
 })
 class DrawerContainerWithContent {
-  @ViewChild(MatDrawerContainer) drawerContainer: MatDrawerContainer;
+  @ViewChild(MatDrawerContainer, {static: false}) drawerContainer: MatDrawerContainer;
 }

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -428,8 +428,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 })
 export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy {
   @ContentChildren(MatDrawer) _drawers: QueryList<MatDrawer>;
-  @ContentChild(MatDrawerContent) _content: MatDrawerContent;
-  @ViewChild(MatDrawerContent) _userContent: MatDrawerContent;
+  @ContentChild(MatDrawerContent, {static: false}) _content: MatDrawerContent;
+  @ViewChild(MatDrawerContent, {static: false}) _userContent: MatDrawerContent;
 
   /** The drawer child with the `start` position. */
   get start(): MatDrawer | null { return this._start; }

--- a/src/lib/sidenav/sidenav.ts
+++ b/src/lib/sidenav/sidenav.ts
@@ -117,5 +117,5 @@ export class MatSidenav extends MatDrawer {
 })
 export class MatSidenavContainer extends MatDrawerContainer {
   @ContentChildren(MatSidenav) _drawers: QueryList<MatSidenav>;
-  @ContentChild(MatSidenavContent) _content: MatSidenavContent;
+  @ContentChild(MatSidenavContent, {static: false}) _content: MatSidenavContent;
 }

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -126,10 +126,10 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   private _dragPercentage: number;
 
   /** Reference to the thumb HTMLElement. */
-  @ViewChild('thumbContainer') _thumbEl: ElementRef;
+  @ViewChild('thumbContainer', {static: false}) _thumbEl: ElementRef;
 
   /** Reference to the thumb bar HTMLElement. */
-  @ViewChild('toggleBar') _thumbBarEl: ElementRef;
+  @ViewChild('toggleBar', {static: false}) _thumbBarEl: ElementRef;
 
   /** Name value will be applied to the input element if present. */
   @Input() name: string | null = null;
@@ -182,7 +182,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
   /** Reference to the underlying input element. */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  @ViewChild('input', {static: false}) _inputElement: ElementRef<HTMLInputElement>;
 
   constructor(elementRef: ElementRef,
               /**

--- a/src/lib/slider/slider.spec.ts
+++ b/src/lib/slider/slider.spec.ts
@@ -1559,7 +1559,7 @@ class SliderWithFormControl {
   styles: [styles],
 })
 class SliderWithNgModel {
-  @ViewChild(MatSlider) slider: MatSlider;
+  @ViewChild(MatSlider, {static: false}) slider: MatSlider;
   val: number | undefined = 0;
 }
 
@@ -1583,7 +1583,7 @@ class SliderWithChangeHandler {
   onChange() { }
   onInput() { }
 
-  @ViewChild(MatSlider) slider: MatSlider;
+  @ViewChild(MatSlider, {static: false}) slider: MatSlider;
 }
 
 @Component({
@@ -1624,7 +1624,7 @@ class SliderWithNativeTabindexAttr {
   styles: [styles],
 })
 class SliderWithTwoWayBinding {
-  @ViewChild(MatSlider) slider: MatSlider;
+  @ViewChild(MatSlider, {static: false}) slider: MatSlider;
   value = 0;
 }
 

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -445,7 +445,7 @@ export class MatSlider extends _MatSliderMixinBase
   private _valueOnSlideStart: number | null;
 
   /** Reference to the inner slider wrapper element. */
-  @ViewChild('sliderWrapper') private _sliderWrapper: ElementRef;
+  @ViewChild('sliderWrapper', {static: false}) private _sliderWrapper: ElementRef;
 
   /**
    * Whether mouse events should be converted to a slider position by calculating their distance

--- a/src/lib/snack-bar/snack-bar.spec.ts
+++ b/src/lib/snack-bar/snack-bar.spec.ts
@@ -931,7 +931,9 @@ class DirectiveWithViewContainer {
   template: `<dir-with-view-container *ngIf="childComponentExists"></dir-with-view-container>`,
 })
 class ComponentWithChildViewContainer {
-  @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
+  @ViewChild(DirectiveWithViewContainer, {
+    static: false
+  }) childWithViewContainer: DirectiveWithViewContainer;
 
   childComponentExists: boolean = true;
 
@@ -949,7 +951,7 @@ class ComponentWithChildViewContainer {
   `,
 })
 class ComponentWithTemplateRef {
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) templateRef: TemplateRef<any>;
   localValue: string;
 }
 

--- a/src/lib/sort/sort.spec.ts
+++ b/src/lib/sort/sort.spec.ts
@@ -493,11 +493,11 @@ class SimpleMatSortApp {
   disabledColumnSort = false;
   disableAllSort = false;
 
-  @ViewChild(MatSort) matSort: MatSort;
-  @ViewChild('defaultA') defaultA: MatSortHeader;
-  @ViewChild('defaultB') defaultB: MatSortHeader;
-  @ViewChild('overrideStart') overrideStart: MatSortHeader;
-  @ViewChild('overrideDisableClear') overrideDisableClear: MatSortHeader;
+  @ViewChild(MatSort, {static: false}) matSort: MatSort;
+  @ViewChild('defaultA', {static: false}) defaultA: MatSortHeader;
+  @ViewChild('defaultB', {static: false}) defaultB: MatSortHeader;
+  @ViewChild('overrideStart', {static: false}) overrideStart: MatSortHeader;
+  @ViewChild('overrideDisableClear', {static: false}) overrideDisableClear: MatSortHeader;
 
   constructor (public elementRef: ElementRef<HTMLElement>) { }
 
@@ -563,7 +563,7 @@ class FakeDataSource extends DataSource<any> {
   `
 })
 class CdkTableMatSortApp {
-  @ViewChild(MatSort) matSort: MatSort;
+  @ViewChild(MatSort, {static: false}) matSort: MatSort;
 
   dataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
@@ -593,7 +593,7 @@ class CdkTableMatSortApp {
   `
 })
 class MatTableMatSortApp {
-  @ViewChild(MatSort) matSort: MatSort;
+  @ViewChild(MatSort, {static: false}) matSort: MatSort;
 
   dataSource = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -58,7 +58,7 @@ import {MatStepperIcon, MatStepperIconContext} from './stepper-icon';
 })
 export class MatStep extends CdkStep implements ErrorStateMatcher {
   /** Content for step label given by `<ng-template matStepLabel>`. */
-  @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
+  @ContentChild(MatStepLabel, {static: false}) stepLabel: MatStepLabel;
 
   /** @breaking-change 8.0.0 remove the `?` after `stepperOptions` */
   constructor(@Inject(forwardRef(() => MatStepper)) stepper: MatStepper,

--- a/src/lib/table/table.spec.ts
+++ b/src/lib/table/table.spec.ts
@@ -644,7 +644,7 @@ class MatTableWithWhenRowApp {
   dataSource: FakeDataSource | null = new FakeDataSource();
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 
-  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatTable, {static: false}) table: MatTable<TestData>;
 }
 
 
@@ -685,7 +685,7 @@ class ArrayDataSourceMatTableApp implements AfterViewInit {
   @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
   @ViewChild(MatSort, {static: true}) sort: MatSort;
-  @ViewChild(MatSortHeader) sortHeader: MatSortHeader;
+  @ViewChild(MatSortHeader, {static: false}) sortHeader: MatSortHeader;
 
   constructor() {
     this.underlyingDataSource.data = [];

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -192,8 +192,8 @@ class SimpleTabBodyApp implements AfterContentInit {
   position: number;
   origin: number | null;
 
-  @ViewChild(MatTabBody) tabBody: MatTabBody;
-  @ViewChild(TemplateRef) template: TemplateRef<any>;
+  @ViewChild(MatTabBody, {static: false}) tabBody: MatTabBody;
+  @ViewChild(TemplateRef, {static: true}) template: TemplateRef<any>;
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -141,7 +141,7 @@ export class MatTabBody implements OnInit, OnDestroy {
   @Output() readonly _onCentered: EventEmitter<void> = new EventEmitter<void>(true);
 
    /** The portal host inside of this container into which the tab body content will be loaded. */
-  @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
+  @ViewChild(PortalHostDirective, {static: false}) _portalHost: PortalHostDirective;
 
   /** The tab body content to display. */
   @Input('content') _content: TemplatePortal;

--- a/src/lib/tabs/tab-group.spec.ts
+++ b/src/lib/tabs/tab-group.spec.ts
@@ -805,7 +805,7 @@ class AsyncTabsTestApp implements OnInit {
 class TabGroupWithSimpleApi {
   otherLabel = 'Fruit';
   otherContent = 'Apples, grapes';
-  @ViewChild('legumes') legumes: any;
+  @ViewChild('legumes', {static: false}) legumes: any;
 }
 
 

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -96,9 +96,9 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
 
   @ContentChildren(MatTab) _tabs: QueryList<MatTab>;
 
-  @ViewChild('tabBodyWrapper') _tabBodyWrapper: ElementRef;
+  @ViewChild('tabBodyWrapper', {static: false}) _tabBodyWrapper: ElementRef;
 
-  @ViewChild('tabHeader') _tabHeader: MatTabHeader;
+  @ViewChild('tabHeader', {static: false}) _tabHeader: MatTabHeader;
 
   /** The tab index that should be selected after the content has been checked. */
   private _indexToSelect: number | null = 0;

--- a/src/lib/tabs/tab-header.ts
+++ b/src/lib/tabs/tab-header.ts
@@ -101,8 +101,8 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
   @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
   @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
   @ViewChild('tabList', {static: true}) _tabList: ElementRef;
-  @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
-  @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
+  @ViewChild('nextPaginator', {static: false}) _nextPaginator: ElementRef<HTMLElement>;
+  @ViewChild('previousPaginator', {static: false}) _previousPaginator: ElementRef<HTMLElement>;
 
   /** The distance in pixels that the tab labels should be translated to the left. */
   private _scrollDistance = 0;

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -324,7 +324,7 @@ describe('MatTabNavBar', () => {
   `
 })
 class SimpleTabNavBarTestApp {
-  @ViewChild(MatTabNav) tabNavBar: MatTabNav;
+  @ViewChild(MatTabNav, {static: false}) tabNavBar: MatTabNav;
   @ViewChildren(MatTabLink) tabLinks: QueryList<MatTabLink>;
 
   label = '';

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -44,7 +44,7 @@ export const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
 })
 export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
-  @ContentChild(MatTabLabel) templateLabel: MatTabLabel;
+  @ContentChild(MatTabLabel, {static: false}) templateLabel: MatTabLabel;
 
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -924,8 +924,8 @@ class BasicTooltipDemo {
   message: any = initialTooltipMessage;
   showButton: boolean = true;
   showTooltipClass = false;
-  @ViewChild(MatTooltip) tooltip: MatTooltip;
-  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
+  @ViewChild(MatTooltip, {static: false}) tooltip: MatTooltip;
+  @ViewChild('button', {static: false}) button: ElementRef<HTMLButtonElement>;
 }
 
 @Component({
@@ -945,7 +945,7 @@ class ScrollableTooltipDemo {
  message: string = initialTooltipMessage;
  showButton: boolean = true;
 
- @ViewChild(CdkScrollable) scrollingContainer: CdkScrollable;
+ @ViewChild(CdkScrollable, {static: false}) scrollingContainer: CdkScrollable;
 
  scrollDown() {
      const scrollingContainerEl = this.scrollingContainer.getElementRef().nativeElement;
@@ -1005,8 +1005,8 @@ class DynamicTooltipsDemo {
   `,
 })
 class TooltipOnTextFields {
-  @ViewChild('input') input: ElementRef<HTMLInputElement>;
-  @ViewChild('textarea') textarea: ElementRef<HTMLTextAreaElement>;
+  @ViewChild('input', {static: false}) input: ElementRef<HTMLInputElement>;
+  @ViewChild('textarea', {static: false}) textarea: ElementRef<HTMLTextAreaElement>;
 }
 
 @Component({
@@ -1019,7 +1019,7 @@ class TooltipOnTextFields {
   `,
 })
 class TooltipOnDraggableElement {
-  @ViewChild('button') button: ElementRef;
+  @ViewChild('button', {static: false}) button: ElementRef;
 }
 
 @Component({
@@ -1028,8 +1028,8 @@ class TooltipOnDraggableElement {
 })
 class TooltipDemoWithoutPositionBinding {
   message: any = initialTooltipMessage;
-  @ViewChild(MatTooltip) tooltip: MatTooltip;
-  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
+  @ViewChild(MatTooltip, {static: false}) tooltip: MatTooltip;
+  @ViewChild('button', {static: false}) button: ElementRef<HTMLButtonElement>;
 }
 
 /** Asserts whether a tooltip directive has a tooltip instance. */

--- a/src/lib/tree/tree.spec.ts
+++ b/src/lib/tree/tree.spec.ts
@@ -642,7 +642,7 @@ class SimpleMatTreeApp {
 
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {
@@ -771,7 +771,7 @@ class NestedMatTreeApp {
   dataSource = new MatTreeNestedDataSource();
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {
@@ -807,7 +807,7 @@ class WhenNodeNestedMatTreeApp {
   dataSource = new MatTreeNestedDataSource();
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {
@@ -847,7 +847,7 @@ class MatTreeAppWithToggle {
   dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {
@@ -878,7 +878,7 @@ class NestedMatTreeAppWithToggle {
   dataSource = new MatTreeNestedDataSource();
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {
@@ -922,7 +922,7 @@ class WhenNodeMatTreeApp {
   dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
   underlyingDataSource = new FakeDataSource();
 
-  @ViewChild(MatTree) tree: MatTree<TestData>;
+  @ViewChild(MatTree, {static: false}) tree: MatTree<TestData>;
 
   constructor() {
     this.underlyingDataSource.connect().subscribe(data => {

--- a/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.ts
+++ b/src/material-examples/cdk-drag-drop-root-element/cdk-drag-drop-root-element-example.ts
@@ -18,7 +18,7 @@ import {TemplatePortal} from '@angular/cdk/portal';
   styleUrls: ['cdk-drag-drop-root-element-example.css'],
 })
 export class CdkDragDropRootElementExample implements AfterViewInit, OnDestroy {
-  @ViewChild(TemplateRef) _dialogTemplate: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) _dialogTemplate: TemplateRef<any>;
   private _overlayRef: OverlayRef;
   private _portal: TemplatePortal;
 

--- a/src/material-examples/cdk-portal-overview/cdk-portal-overview-example.ts
+++ b/src/material-examples/cdk-portal-overview/cdk-portal-overview-example.ts
@@ -10,7 +10,7 @@ import {ComponentPortal, Portal, TemplatePortal} from '@angular/cdk/portal';
   styleUrls: ['cdk-portal-overview-example.css'],
 })
 export class CdkPortalOverviewExample implements AfterViewInit {
-  @ViewChild('templatePortalContent') templatePortalContent: TemplateRef<any>;
+  @ViewChild('templatePortalContent', {static: false}) templatePortalContent: TemplateRef<any>;
   selectedPortal: Portal<any>;
   componentPortal: ComponentPortal<ComponentPortalExample>;
   templatePortal: TemplatePortal<any>;

--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -24,8 +24,8 @@ export class ChipsAutocompleteExample {
   fruits: string[] = ['Lemon'];
   allFruits: string[] = ['Apple', 'Lemon', 'Lime', 'Orange', 'Strawberry'];
 
-  @ViewChild('fruitInput') fruitInput: ElementRef<HTMLInputElement>;
-  @ViewChild('auto') matAutocomplete: MatAutocomplete;
+  @ViewChild('fruitInput', {static: false}) fruitInput: ElementRef<HTMLInputElement>;
+  @ViewChild('auto', {static: false}) matAutocomplete: MatAutocomplete;
 
   constructor() {
     this.filteredFruits = this.fruitCtrl.valueChanges.pipe(

--- a/src/material-examples/expansion-expand-collapse-all/expansion-expand-collapse-all-example.ts
+++ b/src/material-examples/expansion-expand-collapse-all/expansion-expand-collapse-all-example.ts
@@ -10,5 +10,5 @@ import {MatAccordion} from '@angular/material';
   styleUrls: ['expansion-expand-collapse-all-example.css'],
 })
 export class ExpansionExpandCollapseAllExample {
-  @ViewChild(MatAccordion) accordion: MatAccordion;
+  @ViewChild(MatAccordion, {static: false}) accordion: MatAccordion;
 }

--- a/src/material-examples/focus-monitor-focus-via/focus-monitor-focus-via-example.ts
+++ b/src/material-examples/focus-monitor-focus-via/focus-monitor-focus-via-example.ts
@@ -16,7 +16,7 @@ import {
   styleUrls: ['focus-monitor-focus-via-example.css']
 })
 export class FocusMonitorFocusViaExample implements OnDestroy, AfterViewInit {
-  @ViewChild('monitored') monitoredEl: ElementRef<HTMLElement>;
+  @ViewChild('monitored', {static: false}) monitoredEl: ElementRef<HTMLElement>;
 
   origin = this.formatOrigin(null);
 

--- a/src/material-examples/focus-monitor-overview/focus-monitor-overview-example.ts
+++ b/src/material-examples/focus-monitor-overview/focus-monitor-overview-example.ts
@@ -16,8 +16,8 @@ import {
   styleUrls: ['focus-monitor-overview-example.css']
 })
 export class FocusMonitorOverviewExample implements OnDestroy, AfterViewInit {
-  @ViewChild('element') element: ElementRef<HTMLElement>;
-  @ViewChild('subtree') subtree: ElementRef<HTMLElement>;
+  @ViewChild('element', {static: false}) element: ElementRef<HTMLElement>;
+  @ViewChild('subtree', {static: false}) subtree: ElementRef<HTMLElement>;
 
   elementOrigin = this.formatOrigin(null);
   subtreeOrigin = this.formatOrigin(null);

--- a/src/material-examples/sidenav-disable-close/sidenav-disable-close-example.ts
+++ b/src/material-examples/sidenav-disable-close/sidenav-disable-close-example.ts
@@ -8,7 +8,7 @@ import {MatSidenav} from '@angular/material/sidenav';
   styleUrls: ['sidenav-disable-close-example.css'],
 })
 export class SidenavDisableCloseExample {
-  @ViewChild('sidenav') sidenav: MatSidenav;
+  @ViewChild('sidenav', {static: false}) sidenav: MatSidenav;
 
   reason = '';
 

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -21,8 +21,8 @@ export class TableHttpExample implements AfterViewInit {
   isLoadingResults = true;
   isRateLimitReached = false;
 
-  @ViewChild(MatPaginator) paginator: MatPaginator;
-  @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
+  @ViewChild(MatSort, {static: false}) sort: MatSort;
 
   constructor(private http: HttpClient) {}
 

--- a/src/material-examples/table-simple-column/table-simple-column-example.ts
+++ b/src/material-examples/table-simple-column/table-simple-column-example.ts
@@ -112,7 +112,7 @@ export class SimpleColumn<T> implements OnDestroy, OnInit {
 
   @ViewChild(MatColumnDef, {static: true}) columnDef: MatColumnDef;
 
-  @ViewChild(MatSortHeader) sortHeader: MatSortHeader;
+  @ViewChild(MatSortHeader, {static: false}) sortHeader: MatSortHeader;
 
   constructor(@Optional() public table: MatTable<any>) {}
 

--- a/src/material-examples/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
+++ b/src/material-examples/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
@@ -8,8 +8,8 @@ import {AfterViewInit, Component, ElementRef, OnDestroy, ViewChild} from '@angul
   styleUrls: ['./text-field-autofill-monitor-example.css'],
 })
 export class TextFieldAutofillMonitorExample implements AfterViewInit, OnDestroy {
-  @ViewChild('first', {read: ElementRef}) firstName: ElementRef<HTMLElement>;
-  @ViewChild('last', {read: ElementRef}) lastName: ElementRef<HTMLElement>;
+  @ViewChild('first', { read: ElementRef, static: false }) firstName: ElementRef<HTMLElement>;
+  @ViewChild('last', { read: ElementRef, static: false }) lastName: ElementRef<HTMLElement>;
   firstNameAutofilled: boolean;
   lastNameAutofilled: boolean;
 

--- a/src/material-examples/text-field-autosize-textarea/text-field-autosize-textarea-example.ts
+++ b/src/material-examples/text-field-autosize-textarea/text-field-autosize-textarea-example.ts
@@ -11,7 +11,7 @@ import {take} from 'rxjs/operators';
 export class TextFieldAutosizeTextareaExample {
   constructor(private ngZone: NgZone) {}
 
-  @ViewChild('autosize') autosize: CdkTextareaAutosize;
+  @ViewChild('autosize', {static: false}) autosize: CdkTextareaAutosize;
 
   triggerResize() {
     // Wait for changes to be applied, then trigger textarea resize.


### PR DESCRIPTION
Explicitly marks all `ViewChild` and `ContentChild` queries so that the timing is consistent for apps using Ivy or ViewEngine.

This PR resolves FW-1212.