### PR TITLE
docs(layout): fix breakpoint url to material.io

### DIFF
--- a/src/cdk/layout/layout.md
+++ b/src/cdk/layout/layout.md
@@ -48,7 +48,7 @@ class MyComponent {
 ```
 
 The built-in breakpoints based on [Google's Material Design
-specification](https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints).
+specification](https://material.io/design/layout/responsive-layout-grid.html#breakpoints).
 The available values are:
 * Handset
 * Tablet


### PR DESCRIPTION
The URL has changed and while it does correctly redirect to the right docs, it does not correctly anchor to the breakpoint section