### PR TITLE
fix: error when attempting to access Intl API on some versions of Windows

### DIFF
--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -9,10 +9,20 @@
 import {Inject, Injectable, Optional, PLATFORM_ID} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 
-
 // Whether the current platform supports the V8 Break Iterator. The V8 check
 // is necessary to detect all Blink based browsers.
-const hasV8BreakIterator = (typeof Intl !== 'undefined' && (Intl as any).v8BreakIterator);
+let hasV8BreakIterator: boolean;
+
+// We need a try/catch around the reference to `Intl`, because accessing it in some cases can
+// cause IE to throw. These cases are tied to particular versions of Windows and can happen if
+// the consumer is providing a polyfilled `Map`. See:
+// https://github.com/Microsoft/ChakraCore/issues/3189
+// https://github.com/angular/material2/issues/15687
+try {
+  hasV8BreakIterator = (typeof Intl !== 'undefined' && (Intl as any).v8BreakIterator);
+} catch {
+  hasV8BreakIterator = false;
+}
 
 /**
  * Service to detect the current platform by comparing the userAgent strings and
@@ -71,6 +81,6 @@ export class Platform {
    * @breaking-change 8.0.0 remove optional decorator
    */
   constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {
-  }
+}
 }
 

--- a/src/lib/core/datetime/native-date-adapter.ts
+++ b/src/lib/core/datetime/native-date-adapter.ts
@@ -12,8 +12,18 @@ import {DateAdapter, MAT_DATE_LOCALE} from './date-adapter';
 
 // TODO(mmalerba): Remove when we no longer support safari 9.
 /** Whether the browser supports the Intl API. */
-const SUPPORTS_INTL_API = typeof Intl != 'undefined';
+let SUPPORTS_INTL_API: boolean;
 
+// We need a try/catch around the reference to `Intl`, because accessing it in some cases can
+// cause IE to throw. These cases are tied to particular versions of Windows and can happen if
+// the consumer is providing a polyfilled `Map`. See:
+// https://github.com/Microsoft/ChakraCore/issues/3189
+// https://github.com/angular/material2/issues/15687
+try {
+  SUPPORTS_INTL_API = typeof Intl != 'undefined';
+} catch {
+  SUPPORTS_INTL_API = false;
+}
 
 /** The default month names to use if Intl API is not available. */
 const DEFAULT_MONTH_NAMES = {


### PR DESCRIPTION
On some versions of Windows merely trying to access the `Intl` object can cause IE to throw an error, if the default `Map` object has been overwritten (e.g. when polyfilling). These changes add a `try/catch` around our usages so that users' apps don't crash completely on load.

Fixes #15687.