### PR TITLE
fix: missing tag in footer-row of material table

### DIFF
--- a/src/lib/table/table.md
+++ b/src/lib/table/table.md
@@ -287,7 +287,7 @@ data rows.
 
 <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
 <tr mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></tr>
-<tr mat-footer-row *matFooterRowDef="columnsToDisplay"></tr
+<tr mat-footer-row *matFooterRowDef="columnsToDisplay"></tr>
 ```
 
 <!--- example(table-footer-row) -->


### PR DESCRIPTION
Add the closing tag in footer row of the material table. This change will reflect directly on https://material.angular.io/components/table/overview#footer-row