### PR TITLE
refactor(autocomplete): explicitly set static flag on all queries

### DIFF
--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -105,13 +105,13 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   _isOpen: boolean = false;
 
   /** @docs-private */
-  @ViewChild(TemplateRef) template: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: false}) template: TemplateRef<any>;
 
   /** Element for the panel containing the autocomplete options. */
-  @ViewChild('panel') panel: ElementRef;
+  @ViewChild('panel', {static: false}) panel: ElementRef;
 
   /** @docs-private */
-  @ContentChildren(MatOption, { descendants: true }) options: QueryList<MatOption>;
+  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
 
   /** @docs-private */
   @ContentChildren(MatOptgroup) optionGroups: QueryList<MatOptgroup>;


### PR DESCRIPTION
This is a continuation of #15680.

Explicitly marks all ViewChild and ContentChild queries so that the timing is consistent for apps using Ivy or ViewEngine.