### PR TITLE
refactor(expansion): constructor breaking changes for 8.0

### DIFF
--- a/src/lib/expansion/expansion-panel.ts
+++ b/src/lib/expansion/expansion-panel.ts
@@ -101,9 +101,7 @@ export const MAT_EXPANSION_PANEL_DEFAULT_OPTIONS =
 export class MatExpansionPanel extends CdkAccordionItem implements AfterContentInit, OnChanges,
   OnDestroy {
 
-  // @breaking-change 8.0.0 Remove `| undefined` from here
-  // when the `_document` constructor param is required.
-  private _document: Document | undefined;
+  private _document: Document;
 
   /** Whether the toggle indicator should be hidden. */
   @Input()
@@ -146,9 +144,8 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
               _changeDetectorRef: ChangeDetectorRef,
               _uniqueSelectionDispatcher: UniqueSelectionDispatcher,
               private _viewContainerRef: ViewContainerRef,
-              // @breaking-change 8.0.0 _document and _animationMode to be made required
-              @Inject(DOCUMENT) _document?: any,
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
+              @Inject(DOCUMENT) _document: any,
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode: string,
               @Inject(MAT_EXPANSION_PANEL_DEFAULT_OPTIONS) @Optional()
                   defaultOptions?: MatExpansionPanelDefaultOptions) {
     super(accordion, _changeDetectorRef, _uniqueSelectionDispatcher);
@@ -215,7 +212,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
 
   /** Checks whether the expansion panel's content contains the currently-focused element. */
   _containsFocus(): boolean {
-    if (this._body && this._document) {
+    if (this._body) {
       const focusedElement = this._document.activeElement;
       const bodyElement = this._body.nativeElement;
       return focusedElement === bodyElement || bodyElement.contains(focusedElement);

--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -34,6 +34,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15723',
       changes: ['MatList', 'MatListItem']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15722',
+      changes: ['MatExpansionPanel']
     }
   ],
 

--- a/tools/public_api_guard/lib/expansion.d.ts
+++ b/tools/public_api_guard/lib/expansion.d.ts
@@ -32,7 +32,7 @@ export declare class MatExpansionModule {
 }
 
 export declare class MatExpansionPanel extends CdkAccordionItem implements AfterContentInit, OnChanges, OnDestroy {
-    _animationMode?: string | undefined;
+    _animationMode: string;
     _body: ElementRef<HTMLElement>;
     _bodyAnimationDone: Subject<AnimationEvent>;
     _headerId: string;
@@ -43,7 +43,7 @@ export declare class MatExpansionPanel extends CdkAccordionItem implements After
     afterCollapse: EventEmitter<void>;
     afterExpand: EventEmitter<void>;
     hideToggle: boolean;
-    constructor(accordion: MatAccordionBase, _changeDetectorRef: ChangeDetectorRef, _uniqueSelectionDispatcher: UniqueSelectionDispatcher, _viewContainerRef: ViewContainerRef, _document?: any, _animationMode?: string | undefined, defaultOptions?: MatExpansionPanelDefaultOptions);
+    constructor(accordion: MatAccordionBase, _changeDetectorRef: ChangeDetectorRef, _uniqueSelectionDispatcher: UniqueSelectionDispatcher, _viewContainerRef: ViewContainerRef, _document: any, _animationMode: string, defaultOptions?: MatExpansionPanelDefaultOptions);
     _containsFocus(): boolean;
     _getExpandedState(): MatExpansionPanelState;
     _hasSpacing(): boolean;


### PR DESCRIPTION
* Applies the breaking changes for `material/expansion` for 8.0.
* Fixes a symbol that made it into the upgrade schematic by accident.

BREAKING CHANGES:
* The `_document` and `_animationMode` parameters are now required.