### PR TITLE
refactor(button): constructor changes for 8.0

### DIFF
--- a/src/lib/button/BUILD.bazel
+++ b/src/lib/button/BUILD.bazel
@@ -14,7 +14,6 @@ ng_module(
     "@npm//@angular/core",
     "@npm//@angular/platform-browser",
     "@npm//@angular/animations",
-    "//src/cdk/platform",
     "//src/cdk/a11y",
     "//src/lib/core",
   ],

--- a/src/lib/button/button.ts
+++ b/src/lib/button/button.ts
@@ -7,7 +7,6 @@
  */
 
 import {FocusMonitor} from '@angular/cdk/a11y';
-import {Platform} from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -92,14 +91,8 @@ export class MatButton extends _MatButtonMixinBase
   @ViewChild(MatRipple, {static: false}) ripple: MatRipple;
 
   constructor(elementRef: ElementRef,
-              /**
-               * @deprecated Platform checks for SSR are no longer needed
-               * @breaking-change 8.0.0
-               */
-              _platform: Platform,
               private _focusMonitor: FocusMonitor,
-              // @breaking-change 8.0.0 `_animationMode` parameter to be made required.
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode: string) {
     super(elementRef);
 
     // For each of the variant selectors that is prevent in the button's host
@@ -169,12 +162,10 @@ export class MatAnchor extends MatButton {
   @Input() tabIndex: number;
 
   constructor(
-    platform: Platform,
     focusMonitor: FocusMonitor,
     elementRef: ElementRef,
-    // @breaking-change 8.0.0 `animationMode` parameter to be made required.
-    @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
-    super(elementRef, platform, focusMonitor, animationMode);
+    @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string) {
+    super(elementRef, focusMonitor, animationMode);
   }
 
   _haltDisabledEvents(event: Event) {

--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -22,6 +22,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15757',
       changes: ['MatBadge']
+    },
+    {
+      pr: 'https://github.com/angular/material2/issues/15734',
+      changes: ['MatButton', 'MatAnchor']
     }
   ],
 

--- a/tools/public_api_guard/lib/button.d.ts
+++ b/tools/public_api_guard/lib/button.d.ts
@@ -2,17 +2,16 @@ export declare const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor 
 
 export declare class MatAnchor extends MatButton {
     tabIndex: number;
-    constructor(platform: Platform, focusMonitor: FocusMonitor, elementRef: ElementRef, animationMode?: string);
+    constructor(focusMonitor: FocusMonitor, elementRef: ElementRef, animationMode: string);
     _haltDisabledEvents(event: Event): void;
 }
 
 export declare class MatButton extends _MatButtonMixinBase implements OnDestroy, CanDisable, CanColor, CanDisableRipple {
-    _animationMode?: string | undefined;
+    _animationMode: string;
     readonly isIconButton: boolean;
     readonly isRoundButton: boolean;
     ripple: MatRipple;
-    constructor(elementRef: ElementRef,
-    _platform: Platform, _focusMonitor: FocusMonitor, _animationMode?: string | undefined);
+    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _animationMode: string);
     _getHostElement(): any;
     _hasHostAttributes(...attributes: string[]): boolean;
     _isRippleDisabled(): boolean;


### PR DESCRIPTION
Handles the constructor breaking changes for 8.0 in `material/button`.

BREAKING CHANGES:
* `_platform` parameter has been removed from the `MatButton` constructor and the `_animationMode` is now required.
* `platform` parameter has been removed from the `MatAnchor` constructor and the `animationMode` is now required.