### PR TITLE
refactor(tabs): constructor breaking changes for 8.0

### DIFF
--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -38,6 +38,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15722',
       changes: ['MatExpansionPanel']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15737',
+      changes: ['MatTabHeader', 'MatTabBody']
     }
   ],
 

--- a/src/lib/tabs/tab-body.ts
+++ b/src/lib/tabs/tab-body.ts
@@ -163,13 +163,10 @@ export class MatTabBody implements OnInit, OnDestroy {
 
   constructor(private _elementRef: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality,
-              /**
-               * @breaking-change 8.0.0 changeDetectorRef to be made required.
-               */
-              changeDetectorRef?: ChangeDetectorRef) {
+              changeDetectorRef: ChangeDetectorRef) {
 
-    if (this._dir && changeDetectorRef) {
-      this._dirChangeSubscription = this._dir.change.subscribe((dir: Direction) => {
+    if (_dir) {
+      this._dirChangeSubscription = _dir.change.subscribe((dir: Direction) => {
         this._computePositionAnimationState(dir);
         changeDetectorRef.markForCheck();
       });

--- a/tools/public_api_guard/lib/tabs.d.ts
+++ b/tools/public_api_guard/lib/tabs.d.ts
@@ -48,8 +48,7 @@ export declare class MatTabBody implements OnInit, OnDestroy {
     animationDuration: string;
     origin: number;
     position: number;
-    constructor(_elementRef: ElementRef<HTMLElement>, _dir: Directionality,
-    changeDetectorRef?: ChangeDetectorRef);
+    constructor(_elementRef: ElementRef<HTMLElement>, _dir: Directionality, changeDetectorRef: ChangeDetectorRef);
     _getLayoutDirection(): Direction;
     _isCenterPosition(position: MatTabBodyPositionState | string): boolean;
     _onTranslateTabStarted(event: AnimationEvent): void;
@@ -124,7 +123,7 @@ export declare class MatTabHeader extends _MatTabHeaderMixinBase implements Afte
     scrollDistance: number;
     readonly selectFocusedIndex: EventEmitter<number>;
     selectedIndex: number;
-    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _viewportRuler: ViewportRuler, _dir: Directionality, _ngZone?: NgZone | undefined, _platform?: Platform | undefined);
+    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _viewportRuler: ViewportRuler, _dir: Directionality, _ngZone: NgZone, _platform: Platform);
     _alignInkBarToSelectedTab(): void;
     _checkPaginationEnabled(): void;
     _checkScrollingControls(): void;


### PR DESCRIPTION
Handles the constructor-related breaking changes for 8.0.

BREAKING CHANGES:
* `_ngZone` and `_platform` parameters in `MatTabHeader` constructor are now required.
* `changeDetectorRef` parameter in `MatTabBody` constructor is now required.