### PR TITLE
refactor: remove mixin classes from public api

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -45,8 +45,8 @@ export class CdkFooterCellDef implements CellDef {
 
 // Boilerplate for applying mixins to CdkColumnDef.
 /** @docs-private */
-export class CdkColumnDefBase {}
-export const _CdkColumnDefBase: CanStickCtor&typeof CdkColumnDefBase =
+class CdkColumnDefBase {}
+const _CdkColumnDefBase: CanStickCtor&typeof CdkColumnDefBase =
     mixinHasStickyInput(CdkColumnDefBase);
 
 /**

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -77,8 +77,8 @@ export abstract class BaseRowDef implements OnChanges {
 
 // Boilerplate for applying mixins to CdkHeaderRowDef.
 /** @docs-private */
-export class CdkHeaderRowDefBase extends BaseRowDef {}
-export const _CdkHeaderRowDefBase: CanStickCtor&typeof CdkHeaderRowDefBase =
+class CdkHeaderRowDefBase extends BaseRowDef {}
+const _CdkHeaderRowDefBase: CanStickCtor&typeof CdkHeaderRowDefBase =
     mixinHasStickyInput(CdkHeaderRowDefBase);
 
 /**
@@ -103,8 +103,8 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
 
 // Boilerplate for applying mixins to CdkFooterRowDef.
 /** @docs-private */
-export class CdkFooterRowDefBase extends BaseRowDef {}
-export const _CdkFooterRowDefBase: CanStickCtor&typeof CdkFooterRowDefBase =
+class CdkFooterRowDefBase extends BaseRowDef {}
+const _CdkFooterRowDefBase: CanStickCtor&typeof CdkFooterRowDefBase =
     mixinHasStickyInput(CdkFooterRowDefBase);
 
 /**

--- a/src/material-experimental/mdc-checkbox/public-api.ts
+++ b/src/material-experimental/mdc-checkbox/public-api.ts
@@ -21,10 +21,5 @@ export {
    * @deprecated
    * @breaking-change 9.0.0
    */
-  MatCheckboxBase,
-  /**
-   * @deprecated
-   * @breaking-change 9.0.0
-   */
   TransitionCheckState,
 } from '@angular/material/checkbox';

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -53,8 +53,8 @@ export class MatAutocompleteSelectedEvent {
 
 // Boilerplate for applying mixins to MatAutocomplete.
 /** @docs-private */
-export class MatAutocompleteBase {}
-export const _MatAutocompleteMixinBase: CanDisableRippleCtor & typeof MatAutocompleteBase =
+class MatAutocompleteBase {}
+const _MatAutocompleteMixinBase: CanDisableRippleCtor & typeof MatAutocompleteBase =
     mixinDisableRipple(MatAutocompleteBase);
 
 /** Default `mat-autocomplete` options that can be overridden. */

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -28,9 +28,9 @@ let nextId = 0;
 
 // Boilerplate for applying mixins to MatBadge.
 /** @docs-private */
-export class MatBadgeBase {}
+class MatBadgeBase {}
 
-export const _MatBadgeMixinBase:
+const _MatBadgeMixinBase:
     CanDisableCtor & typeof MatBadgeBase = mixinDisabled(MatBadgeBase);
 
 export type MatBadgePosition = 'above after' | 'above before' | 'below before' | 'below after';

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -348,8 +348,8 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
 
 // Boilerplate for applying mixins to the MatButtonToggle class.
 /** @docs-private */
-export class MatButtonToggleBase {}
-export const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBase =
+class MatButtonToggleBase {}
+const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBase =
     mixinDisableRipple(MatButtonToggleBase);
 
 /** Single button inside of a toggle group. */

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -51,13 +51,12 @@ const BUTTON_HOST_ATTRIBUTES = [
 
 // Boilerplate for applying mixins to MatButton.
 /** @docs-private */
-export class MatButtonBase {
+class MatButtonBase {
   constructor(public _elementRef: ElementRef) {}
 }
 
-export const _MatButtonMixinBase:
-    CanDisableRippleCtor & CanDisableCtor & CanColorCtor & typeof MatButtonBase =
-        mixinColor(mixinDisabled(mixinDisableRipple(MatButtonBase)));
+const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor & CanColorCtor &
+    typeof MatButtonBase = mixinColor(mixinDisabled(mixinDisableRipple(MatButtonBase)));
 
 /**
  * Material design button.

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -85,10 +85,10 @@ export class MatCheckboxChange {
 
 // Boilerplate for applying mixins to MatCheckbox.
 /** @docs-private */
-export class MatCheckboxBase {
+class MatCheckboxBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatCheckboxMixinBase:
+const _MatCheckboxMixinBase:
     HasTabIndexCtor &
     CanColorCtor &
     CanDisableRippleCtor &

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -45,14 +45,14 @@ import {MatChipTextControl} from './chip-text-control';
 
 // Boilerplate for applying mixins to MatChipList.
 /** @docs-private */
-export class MatChipListBase {
+class MatChipListBase {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
               /** @docs-private */
               public ngControl: NgControl) {}
 }
-export const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase =
+const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase =
     mixinErrorState(MatChipListBase);
 
 

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -63,15 +63,12 @@ export class MatChipSelectionChange {
 
 // Boilerplate for applying mixins to MatChip.
 /** @docs-private */
-export class MatChipBase {
+class MatChipBase {
   constructor(public _elementRef: ElementRef) {}
 }
 
-export const _MatChipMixinBase:
-    CanColorCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatChipBase =
-        mixinColor(mixinDisableRipple(mixinDisabled(MatChipBase)), 'primary');
-
-const CHIP_ATTRIBUTE_NAMES = ['mat-basic-chip'];
+const _MatChipMixinBase: CanColorCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatChipBase =
+    mixinColor(mixinDisableRipple(mixinDisabled(MatChipBase)), 'primary');
 
 /**
  * Dummy directive to add CSS class to chip avatar.
@@ -242,15 +239,16 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   }
 
   _addHostClassName() {
-    // Add class for the different chips
-    for (const attr of CHIP_ATTRIBUTE_NAMES) {
-      if (this._elementRef.nativeElement.hasAttribute(attr) ||
-        this._elementRef.nativeElement.tagName.toLowerCase() === attr) {
-        (this._elementRef.nativeElement as HTMLElement).classList.add(attr);
-        return;
-      }
+    const basicChipAttrName = 'mat-basic-chip';
+    const element = this._elementRef.nativeElement as HTMLElement;
+
+    if (element.hasAttribute(basicChipAttrName) ||
+        element.tagName.toLowerCase() === basicChipAttrName) {
+      element.classList.add(basicChipAttrName);
+      return;
+    } else {
+      element.classList.add('mat-standard-chip');
     }
-    (this._elementRef.nativeElement as HTMLElement).classList.add('mat-standard-chip');
   }
 
   ngOnDestroy() {

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -12,8 +12,8 @@ import {CanDisable, CanDisableCtor, mixinDisabled} from '../common-behaviors/dis
 
 // Boilerplate for applying mixins to MatOptgroup.
 /** @docs-private */
-export class MatOptgroupBase { }
-export const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
+class MatOptgroupBase { }
+const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
     mixinDisabled(MatOptgroupBase);
 
 // Counter for unique group ids.

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -73,10 +73,10 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 
 // Boilerplate for applying mixins to MatDatepickerContent.
 /** @docs-private */
-export class MatDatepickerContentBase {
+class MatDatepickerContentBase {
   constructor(public _elementRef: ElementRef) { }
 }
-export const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContentBase =
+const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContentBase =
     mixinColor(MatDatepickerContentBase);
 
 /**

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -64,7 +64,7 @@ const outlineGapPadding = 5;
  * Boilerplate for applying mixins to MatFormField.
  * @docs-private
  */
-export class MatFormFieldBase {
+class MatFormFieldBase {
   constructor(public _elementRef: ElementRef) { }
 }
 
@@ -72,7 +72,7 @@ export class MatFormFieldBase {
  * Base class to which we're applying the form field mixins.
  * @docs-private
  */
-export const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase =
+const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase =
     mixinColor(MatFormFieldBase, 'primary');
 
 /** Possible appearance styles for the form field. */

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -32,11 +32,10 @@ import {MatIconRegistry} from './icon-registry';
 
 // Boilerplate for applying mixins to MatIcon.
 /** @docs-private */
-export class MatIconBase {
+class MatIconBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatIconMixinBase: CanColorCtor & typeof MatIconBase =
-    mixinColor(MatIconBase);
+const _MatIconMixinBase: CanColorCtor & typeof MatIconBase = mixinColor(MatIconBase);
 
 /**
  * Injection token used to provide the current location to `MatIcon`.

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -52,14 +52,14 @@ let nextUniqueId = 0;
 
 // Boilerplate for applying mixins to MatInput.
 /** @docs-private */
-export class MatInputBase {
+class MatInputBase {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
               /** @docs-private */
               public ngControl: NgControl) {}
 }
-export const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
+const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
     mixinErrorState(MatInputBase);
 
 /** Directive that allows a native input to work inside a `MatFormField`. */

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -33,14 +33,14 @@ import {takeUntil} from 'rxjs/operators';
 
 // Boilerplate for applying mixins to MatList.
 /** @docs-private */
-export class MatListBase {}
-export const _MatListMixinBase: CanDisableRippleCtor & typeof MatListBase =
+class MatListBase {}
+const _MatListMixinBase: CanDisableRippleCtor & typeof MatListBase =
     mixinDisableRipple(MatListBase);
 
 // Boilerplate for applying mixins to MatListItem.
 /** @docs-private */
-export class MatListItemBase {}
-export const _MatListItemMixinBase: CanDisableRippleCtor & typeof MatListItemBase =
+class MatListItemBase {}
+const _MatListItemMixinBase: CanDisableRippleCtor & typeof MatListItemBase =
     mixinDisableRipple(MatListItemBase);
 
 @Component({

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -54,13 +54,13 @@ import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
 
 
 /** @docs-private */
-export class MatSelectionListBase {}
-export const _MatSelectionListMixinBase: CanDisableRippleCtor & typeof MatSelectionListBase =
+class MatSelectionListBase {}
+const _MatSelectionListMixinBase: CanDisableRippleCtor & typeof MatSelectionListBase =
     mixinDisableRipple(MatSelectionListBase);
 
 /** @docs-private */
-export class MatListOptionBase {}
-export const _MatListOptionMixinBase: CanDisableRippleCtor & typeof MatListOptionBase =
+class MatListOptionBase {}
+const _MatListOptionMixinBase: CanDisableRippleCtor & typeof MatListOptionBase =
     mixinDisableRipple(MatListOptionBase);
 
 /** @docs-private */

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -30,8 +30,8 @@ import {MAT_MENU_PANEL, MatMenuPanel} from './menu-panel';
 
 // Boilerplate for applying mixins to MatMenuItem.
 /** @docs-private */
-export class MatMenuItemBase {}
-export const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatMenuItemBase =
+class MatMenuItemBase {}
+const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatMenuItemBase =
     mixinDisableRipple(mixinDisabled(MatMenuItemBase));
 
 /**

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -56,8 +56,8 @@ export class PageEvent {
 
 // Boilerplate for applying mixins to MatPaginator.
 /** @docs-private */
-export class MatPaginatorBase {}
-export const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorBase =
+class MatPaginatorBase {}
+const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorBase =
     mixinDisabled(mixinInitialized(MatPaginatorBase));
 
 /**

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -31,18 +31,18 @@ import {DOCUMENT} from '@angular/common';
 // TODO(josephperrott): Benchpress tests.
 // TODO(josephperrott): Add ARIA attributes for progress bar "for".
 
-// Boilerplate for applying mixins to MatProgressBar.
-/** @docs-private */
-export class MatProgressBarBase {
-  constructor(public _elementRef: ElementRef) { }
-}
-
 /** Last animation end data. */
 export interface ProgressAnimationEnd {
   value: number;
 }
 
-export const _MatProgressBarMixinBase: CanColorCtor & typeof MatProgressBarBase =
+// Boilerplate for applying mixins to MatProgressBar.
+/** @docs-private */
+class MatProgressBarBase {
+  constructor(public _elementRef: ElementRef) { }
+}
+
+const _MatProgressBarMixinBase: CanColorCtor & typeof MatProgressBarBase =
     mixinColor(MatProgressBarBase, 'primary');
 
 /**

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -40,10 +40,10 @@ const BASE_STROKE_WIDTH = 10;
 
 // Boilerplate for applying mixins to MatProgressSpinner.
 /** @docs-private */
-export class MatProgressSpinnerBase {
+class MatProgressSpinnerBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatProgressSpinnerMixinBase: CanColorCtor & typeof MatProgressSpinnerBase =
+const _MatProgressSpinnerMixinBase: CanColorCtor & typeof MatProgressSpinnerBase =
     mixinColor(MatProgressSpinnerBase, 'primary');
 
 /** Default `mat-progress-spinner` options that can be overridden. */

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -292,7 +292,7 @@ export class MatRadioGroup implements AfterContentInit, ControlValueAccessor {
 
 // Boilerplate for applying mixins to MatRadioButton.
 /** @docs-private */
-export class MatRadioButtonBase {
+class MatRadioButtonBase {
   // Since the disabled property is manually defined for the MatRadioButton and isn't set up in
   // the mixin base class. To be able to use the tabindex mixin, a disabled property must be
   // defined to properly work.
@@ -302,8 +302,8 @@ export class MatRadioButtonBase {
 }
 // As per Material design specifications the selection control radio should use the accent color
 // palette by default. https://material.io/guidelines/components/selection-controls.html
-export const _MatRadioButtonMixinBase:
-    CanColorCtor & CanDisableRippleCtor & HasTabIndexCtor & typeof MatRadioButtonBase =
+const _MatRadioButtonMixinBase: CanColorCtor & CanDisableRippleCtor & HasTabIndexCtor &
+    typeof MatRadioButtonBase =
         mixinColor(mixinDisableRipple(mixinTabIndex(MatRadioButtonBase)), 'accent');
 
 /**

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -159,14 +159,14 @@ export class MatSelectChange {
 
 // Boilerplate for applying mixins to MatSelect.
 /** @docs-private */
-export class MatSelectBase {
+class MatSelectBase {
   constructor(public _elementRef: ElementRef,
               public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
               public ngControl: NgControl) {}
 }
-export const _MatSelectMixinBase:
+const _MatSelectMixinBase:
     CanDisableCtor &
     HasTabIndexCtor &
     CanDisableRippleCtor &

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -66,10 +66,10 @@ export class MatSlideToggleChange {
 
 // Boilerplate for applying mixins to MatSlideToggle.
 /** @docs-private */
-export class MatSlideToggleBase {
+class MatSlideToggleBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatSlideToggleMixinBase:
+const _MatSlideToggleMixinBase:
     HasTabIndexCtor &
     CanColorCtor &
     CanDisableRippleCtor &

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -91,10 +91,10 @@ export class MatSliderChange {
 
 // Boilerplate for applying mixins to MatSlider.
 /** @docs-private */
-export class MatSliderBase {
+class MatSliderBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatSliderMixinBase:
+const _MatSliderMixinBase:
     HasTabIndexCtor &
     CanColorCtor &
     CanDisableCtor &

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -29,8 +29,8 @@ import {MatSortHeaderIntl} from './sort-header-intl';
 
 // Boilerplate for applying mixins to the sort header.
 /** @docs-private */
-export class MatSortHeaderBase {}
-export const _MatSortHeaderMixinBase: CanDisableCtor & typeof MatSortHeaderBase =
+class MatSortHeaderBase {}
+const _MatSortHeaderMixinBase: CanDisableCtor & typeof MatSortHeaderBase =
     mixinDisabled(MatSortHeaderBase);
 
 /**

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -56,8 +56,8 @@ export interface Sort {
 
 // Boilerplate for applying mixins to MatSort.
 /** @docs-private */
-export class MatSortBase {}
-export const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBase =
+class MatSortBase {}
+const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBase =
     mixinInitialized(mixinDisabled(MatSortBase));
 
 /** Container for MatSortables to manage the sort state and provide default sort parameters. */

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -65,10 +65,10 @@ export const MAT_TABS_CONFIG = new InjectionToken('MAT_TABS_CONFIG');
 
 // Boilerplate for applying mixins to MatTabGroup.
 /** @docs-private */
-export class MatTabGroupBase {
+class MatTabGroupBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatTabGroupMixinBase: CanColorCtor & CanDisableRippleCtor & typeof MatTabGroupBase =
+const _MatTabGroupMixinBase: CanColorCtor & CanDisableRippleCtor & typeof MatTabGroupBase =
     mixinColor(mixinDisableRipple(MatTabGroupBase), 'primary');
 
 /**

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -69,8 +69,8 @@ const HEADER_SCROLL_INTERVAL = 100;
 
 // Boilerplate for applying mixins to MatTabHeader.
 /** @docs-private */
-export class MatTabHeaderBase {}
-export const _MatTabHeaderMixinBase: CanDisableRippleCtor & typeof MatTabHeaderBase =
+class MatTabHeaderBase {}
+const _MatTabHeaderMixinBase: CanDisableRippleCtor & typeof MatTabHeaderBase =
     mixinDisableRipple(MatTabHeaderBase);
 
 /**

--- a/src/material/tabs/tab-label-wrapper.ts
+++ b/src/material/tabs/tab-label-wrapper.ts
@@ -12,8 +12,8 @@ import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core'
 
 // Boilerplate for applying mixins to MatTabLabelWrapper.
 /** @docs-private */
-export class MatTabLabelWrapperBase {}
-export const _MatTabLabelWrapperMixinBase: CanDisableCtor & typeof MatTabLabelWrapperBase =
+class MatTabLabelWrapperBase {}
+const _MatTabLabelWrapperMixinBase: CanDisableCtor & typeof MatTabLabelWrapperBase =
     mixinDisabled(MatTabLabelWrapperBase);
 
 /**

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -51,10 +51,10 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 
 // Boilerplate for applying mixins to MatTabNav.
 /** @docs-private */
-export class MatTabNavBase {
+class MatTabNavBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatTabNavMixinBase: CanDisableRippleCtor & CanColorCtor & typeof MatTabNavBase =
+const _MatTabNavMixinBase: CanDisableRippleCtor & CanColorCtor & typeof MatTabNavBase =
     mixinDisableRipple(mixinColor(MatTabNavBase, 'primary'));
 
 /**
@@ -161,8 +161,8 @@ export class MatTabNav extends _MatTabNavMixinBase
 
 
 // Boilerplate for applying mixins to MatTabLink.
-export class MatTabLinkBase {}
-export const _MatTabLinkMixinBase:
+class MatTabLinkBase {}
+const _MatTabLinkMixinBase:
     HasTabIndexCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatTabLinkBase =
         mixinTabIndex(mixinDisableRipple(mixinDisabled(MatTabLinkBase)));
 

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -29,8 +29,8 @@ import {MatTabLabel} from './tab-label';
 
 // Boilerplate for applying mixins to MatTab.
 /** @docs-private */
-export class MatTabBase {}
-export const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
+class MatTabBase {}
+const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
     mixinDisabled(MatTabBase);
 
 @Component({

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -25,11 +25,10 @@ import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
 
 // Boilerplate for applying mixins to MatToolbar.
 /** @docs-private */
-export class MatToolbarBase {
+class MatToolbarBase {
   constructor(public _elementRef: ElementRef) {}
 }
-export const _MatToolbarMixinBase: CanColorCtor & typeof MatToolbarBase =
-    mixinColor(MatToolbarBase);
+const _MatToolbarMixinBase: CanColorCtor & typeof MatToolbarBase = mixinColor(MatToolbarBase);
 
 @Directive({
   selector: 'mat-toolbar-row',

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -35,10 +35,10 @@ import {
 
 import {MatTreeNodeOutlet} from './outlet';
 
-export const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNode =
+const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNode =
     mixinTabIndex(mixinDisabled(CdkTreeNode));
 
-export const _MatNestedTreeNodeMixinBase:
+const _MatNestedTreeNodeMixinBase:
     HasTabIndexCtor & CanDisableCtor & typeof CdkNestedTreeNode =
         mixinTabIndex(mixinDisabled(CdkNestedTreeNode));
 

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -1,9 +1,3 @@
-export declare const _CdkColumnDefBase: CanStickCtor & typeof CdkColumnDefBase;
-
-export declare const _CdkFooterRowDefBase: CanStickCtor & typeof CdkFooterRowDefBase;
-
-export declare const _CdkHeaderRowDefBase: CanStickCtor & typeof CdkHeaderRowDefBase;
-
 export declare class BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
 }
@@ -81,9 +75,6 @@ export declare class CdkColumnDef extends _CdkColumnDefBase implements CanStick 
     stickyEnd: boolean;
 }
 
-export declare class CdkColumnDefBase {
-}
-
 export declare class CdkFooterCell extends BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
 }
@@ -101,9 +92,6 @@ export declare class CdkFooterRowDef extends _CdkFooterRowDefBase implements Can
     ngOnChanges(changes: SimpleChanges): void;
 }
 
-export declare class CdkFooterRowDefBase extends BaseRowDef {
-}
-
 export declare class CdkHeaderCell extends BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
 }
@@ -119,9 +107,6 @@ export declare class CdkHeaderRow {
 export declare class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
     constructor(template: TemplateRef<any>, _differs: IterableDiffers);
     ngOnChanges(changes: SimpleChanges): void;
-}
-
-export declare class CdkHeaderRowDefBase extends BaseRowDef {
 }
 
 export declare class CdkRow {

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatAutocompleteMixinBase: CanDisableRippleCtor & typeof MatAutocompleteBase;
-
 export declare const AUTOCOMPLETE_OPTION_HEIGHT = 48;
 
 export declare const AUTOCOMPLETE_PANEL_HEIGHT = 256;
@@ -48,9 +46,6 @@ export declare class MatAutocomplete extends _MatAutocompleteMixinBase implement
     _setScrollTop(scrollTop: number): void;
     _setVisibility(): void;
     ngAfterContentInit(): void;
-}
-
-export declare class MatAutocompleteBase {
 }
 
 export interface MatAutocompleteDefaultOptions {

--- a/tools/public_api_guard/material/badge.d.ts
+++ b/tools/public_api_guard/material/badge.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatBadgeMixinBase: CanDisableCtor & typeof MatBadgeBase;
-
 export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges, CanDisable {
     _hasContent: boolean;
     _id: number;
@@ -15,9 +13,6 @@ export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, O
     isAfter(): boolean;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-}
-
-export declare class MatBadgeBase {
 }
 
 export declare class MatBadgeModule {

--- a/tools/public_api_guard/material/button-toggle.d.ts
+++ b/tools/public_api_guard/material/button-toggle.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBase;
-
 export declare const MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatButtonToggleDefaultOptions>;
 
 export declare const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
@@ -28,9 +26,6 @@ export declare class MatButtonToggle extends _MatButtonToggleMixinBase implement
 }
 
 export declare type MatButtonToggleAppearance = 'legacy' | 'standard';
-
-export declare class MatButtonToggleBase {
-}
 
 export declare class MatButtonToggleChange {
     source: MatButtonToggle;

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor & CanColorCtor & typeof MatButtonBase;
-
 export declare class MatAnchor extends MatButton {
     tabIndex: number;
     constructor(focusMonitor: FocusMonitor, elementRef: ElementRef, animationMode: string);
@@ -17,11 +15,6 @@ export declare class MatButton extends _MatButtonMixinBase implements OnDestroy,
     _isRippleDisabled(): boolean;
     focus(): void;
     ngOnDestroy(): void;
-}
-
-export declare class MatButtonBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatButtonModule {

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatCheckboxMixinBase: HasTabIndexCtor & CanColorCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatCheckboxBase;
-
 export declare class _MatCheckboxRequiredValidatorModule {
 }
 
@@ -41,11 +39,6 @@ export declare class MatCheckbox extends _MatCheckboxMixinBase implements Contro
     setDisabledState(isDisabled: boolean): void;
     toggle(): void;
     writeValue(value: any): void;
-}
-
-export declare class MatCheckboxBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatCheckboxChange {

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -1,7 +1,3 @@
-export declare const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase;
-
-export declare const _MatChipMixinBase: CanColorCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatChipBase;
-
 export declare const MAT_CHIPS_DEFAULT_OPTIONS: InjectionToken<MatChipsDefaultOptions>;
 
 export declare class MatChip extends _MatChipMixinBase implements FocusableOption, OnDestroy, CanColor, CanDisable, CanDisableRipple, RippleTarget {
@@ -43,11 +39,6 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
 }
 
 export declare class MatChipAvatar {
-}
-
-export declare class MatChipBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export interface MatChipEvent {
@@ -145,15 +136,6 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     setDescribedByIds(ids: string[]): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-}
-
-export declare class MatChipListBase {
-    _defaultErrorStateMatcher: ErrorStateMatcher;
-    _parentForm: NgForm;
-    _parentFormGroup: FormGroupDirective;
-    ngControl: NgControl;
-    constructor(_defaultErrorStateMatcher: ErrorStateMatcher, _parentForm: NgForm, _parentFormGroup: FormGroupDirective,
-    ngControl: NgControl);
 }
 
 export declare class MatChipListChange {

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -2,8 +2,6 @@ export declare function _countGroupLabelsBeforeOption(optionIndex: number, optio
 
 export declare function _getOptionScrollPosition(optionIndex: number, optionHeight: number, currentScrollPosition: number, panelHeight: number): number;
 
-export declare const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase;
-
 export declare class AnimationCurves {
     static ACCELERATION_CURVE: string;
     static DECELERATION_CURVE: string;
@@ -226,9 +224,6 @@ export declare class MatNativeDateModule {
 export declare class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
     _labelId: string;
     label: string;
-}
-
-export declare class MatOptgroupBase {
 }
 
 export declare class MatOption implements AfterViewChecked, OnDestroy {

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContentBase;
-
 export declare const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare function MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;
@@ -146,11 +144,6 @@ export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinB
     datepicker: MatDatepicker<D>;
     constructor(elementRef: ElementRef);
     ngAfterViewInit(): void;
-}
-
-export declare class MatDatepickerContentBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase;
-
 export declare function getMatFormFieldDuplicatedHintError(align: string): Error;
 
 export declare function getMatFormFieldMissingControlError(): Error;
@@ -62,11 +60,6 @@ export declare const matFormFieldAnimations: {
 };
 
 export declare type MatFormFieldAppearance = 'legacy' | 'standard' | 'fill' | 'outline';
-
-export declare class MatFormFieldBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
-}
 
 export declare abstract class MatFormFieldControl<T> {
     readonly autofilled?: boolean;

--- a/tools/public_api_guard/material/icon.d.ts
+++ b/tools/public_api_guard/material/icon.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatIconMixinBase: CanColorCtor & typeof MatIconBase;
-
 export declare function getMatIconFailedToSanitizeLiteralError(literal: SafeHtml): Error;
 
 export declare function getMatIconFailedToSanitizeUrlError(url: SafeResourceUrl): Error;
@@ -31,11 +29,6 @@ export declare class MatIcon extends _MatIconMixinBase implements OnChanges, OnI
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-}
-
-export declare class MatIconBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export interface MatIconLocation {

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase;
-
 export declare function getMatInputUnsupportedTypeError(type: string): Error;
 
 export declare const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
@@ -50,15 +48,6 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     ngOnInit(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;
-}
-
-export declare class MatInputBase {
-    _defaultErrorStateMatcher: ErrorStateMatcher;
-    _parentForm: NgForm;
-    _parentFormGroup: FormGroupDirective;
-    ngControl: NgControl;
-    constructor(_defaultErrorStateMatcher: ErrorStateMatcher, _parentForm: NgForm, _parentFormGroup: FormGroupDirective,
-    ngControl: NgControl);
 }
 
 export declare class MatInputModule {

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -1,11 +1,3 @@
-export declare const _MatListItemMixinBase: CanDisableRippleCtor & typeof MatListItemBase;
-
-export declare const _MatListMixinBase: CanDisableRippleCtor & typeof MatListBase;
-
-export declare const _MatListOptionMixinBase: CanDisableRippleCtor & typeof MatListOptionBase;
-
-export declare const _MatSelectionListMixinBase: CanDisableRippleCtor & typeof MatSelectionListBase;
-
 export declare const MAT_SELECTION_LIST_VALUE_ACCESSOR: any;
 
 export declare class MatList extends _MatListMixinBase implements CanDisableRipple, OnChanges, OnDestroy {
@@ -17,9 +9,6 @@ export declare class MatList extends _MatListMixinBase implements CanDisableRipp
 }
 
 export declare class MatListAvatarCssMatStyler {
-}
-
-export declare class MatListBase {
 }
 
 export declare class MatListIconCssMatStyler {
@@ -34,9 +23,6 @@ export declare class MatListItem extends _MatListItemMixinBase implements AfterC
     _isRippleDisabled(): boolean;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-}
-
-export declare class MatListItemBase {
 }
 
 export declare class MatListModule {
@@ -68,9 +54,6 @@ export declare class MatListOption extends _MatListOptionMixinBase implements Af
     ngOnDestroy(): void;
     ngOnInit(): void;
     toggle(): void;
-}
-
-export declare class MatListOptionBase {
 }
 
 export declare class MatListSubheaderCssMatStyler {
@@ -108,9 +91,6 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     selectAll(): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(values: string[]): void;
-}
-
-export declare class MatSelectionListBase {
 }
 
 export declare class MatSelectionListChange {

--- a/tools/public_api_guard/material/paginator.d.ts
+++ b/tools/public_api_guard/material/paginator.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorBase;
-
 export declare const MAT_PAGINATOR_INTL_PROVIDER: {
     provide: typeof MatPaginatorIntl;
     deps: Optional[][];
@@ -32,9 +30,6 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     ngOnDestroy(): void;
     ngOnInit(): void;
     previousPage(): void;
-}
-
-export declare class MatPaginatorBase {
 }
 
 export declare class MatPaginatorIntl {

--- a/tools/public_api_guard/material/progress-bar.d.ts
+++ b/tools/public_api_guard/material/progress-bar.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatProgressBarMixinBase: CanColorCtor & typeof MatProgressBarBase;
-
 export declare const MAT_PROGRESS_BAR_LOCATION: InjectionToken<MatProgressBarLocation>;
 
 export declare function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation;
@@ -25,11 +23,6 @@ export declare class MatProgressBar extends _MatProgressBarMixinBase implements 
     };
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
-}
-
-export declare class MatProgressBarBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export interface MatProgressBarLocation {

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatProgressSpinnerMixinBase: CanColorCtor & typeof MatProgressSpinnerBase;
-
 export declare const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpinnerDefaultOptions>;
 
 export declare function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
@@ -17,11 +15,6 @@ export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase imp
     strokeWidth: number;
     value: number;
     constructor(_elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
-}
-
-export declare class MatProgressSpinnerBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export interface MatProgressSpinnerDefaultOptions {

--- a/tools/public_api_guard/material/radio.d.ts
+++ b/tools/public_api_guard/material/radio.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatRadioButtonMixinBase: CanColorCtor & CanDisableRippleCtor & HasTabIndexCtor & typeof MatRadioButtonBase;
-
 export declare const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any;
 
 export declare class MatRadioButton extends _MatRadioButtonMixinBase implements OnInit, AfterViewInit, OnDestroy, CanColor, CanDisableRipple, HasTabIndex {
@@ -27,12 +25,6 @@ export declare class MatRadioButton extends _MatRadioButtonMixinBase implements 
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-}
-
-export declare class MatRadioButtonBase {
-    _elementRef: ElementRef;
-    disabled: boolean;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatRadioChange {

--- a/tools/public_api_guard/material/select.d.ts
+++ b/tools/public_api_guard/material/select.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatSelectMixinBase: CanDisableCtor & HasTabIndexCtor & CanDisableRippleCtor & CanUpdateErrorStateCtor & typeof MatSelectBase;
-
 export declare const fadeInContent: AnimationTriggerMetadata;
 
 export declare const MAT_SELECT_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
@@ -99,15 +97,6 @@ export declare const matSelectAnimations: {
     readonly transformPanel: AnimationTriggerMetadata;
     readonly fadeInContent: AnimationTriggerMetadata;
 };
-
-export declare class MatSelectBase {
-    _defaultErrorStateMatcher: ErrorStateMatcher;
-    _elementRef: ElementRef;
-    _parentForm: NgForm;
-    _parentFormGroup: FormGroupDirective;
-    ngControl: NgControl;
-    constructor(_elementRef: ElementRef, _defaultErrorStateMatcher: ErrorStateMatcher, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, ngControl: NgControl);
-}
 
 export declare class MatSelectChange {
     source: MatSelect;

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatSlideToggleMixinBase: HasTabIndexCtor & CanColorCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatSlideToggleBase;
-
 export declare const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatSlideToggleDefaultOptions>;
 
 export declare const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any;
@@ -36,11 +34,6 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     setDisabledState(isDisabled: boolean): void;
     toggle(): void;
     writeValue(value: any): void;
-}
-
-export declare class MatSlideToggleBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatSlideToggleChange {

--- a/tools/public_api_guard/material/slider.d.ts
+++ b/tools/public_api_guard/material/slider.d.ts
@@ -1,5 +1,3 @@
-export declare const _MatSliderMixinBase: HasTabIndexCtor & CanColorCtor & CanDisableCtor & typeof MatSliderBase;
-
 export declare const MAT_SLIDER_VALUE_ACCESSOR: any;
 
 export declare class MatSlider extends _MatSliderMixinBase implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit, HasTabIndex {
@@ -57,11 +55,6 @@ export declare class MatSlider extends _MatSliderMixinBase implements ControlVal
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-}
-
-export declare class MatSliderBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatSliderChange {

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -1,7 +1,3 @@
-export declare const _MatSortHeaderMixinBase: CanDisableCtor & typeof MatSortHeaderBase;
-
-export declare const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBase;
-
 export declare type ArrowViewState = SortDirection | 'hint' | 'active';
 
 export interface ArrowViewStateTransition {
@@ -49,9 +45,6 @@ export declare const matSortAnimations: {
     readonly allowChildren: AnimationTriggerMetadata;
 };
 
-export declare class MatSortBase {
-}
-
 export declare class MatSortHeader extends _MatSortHeaderMixinBase implements CanDisable, MatSortable, OnDestroy, OnInit {
     _arrowDirection: SortDirection;
     _columnDef: MatSortHeaderColumnDef;
@@ -77,9 +70,6 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     _updateArrowDirection(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-}
-
-export declare class MatSortHeaderBase {
 }
 
 export declare class MatSortHeaderIntl {

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -7,8 +7,6 @@ export interface _MatInkBarPositioner {
     };
 }
 
-export declare const _MatTabGroupMixinBase: CanColorCtor & CanDisableRippleCtor & typeof MatTabGroupBase;
-
 export declare const MAT_TABS_CONFIG: InjectionToken<{}>;
 
 export declare class MatInkBar {
@@ -101,11 +99,6 @@ export declare class MatTabGroup extends _MatTabGroupMixinBase implements AfterC
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     realignInkBar(): void;
-}
-
-export declare class MatTabGroupBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatTabHeader extends _MatTabHeaderMixinBase implements AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy, CanDisableRipple {

--- a/tools/public_api_guard/material/toolbar.d.ts
+++ b/tools/public_api_guard/material/toolbar.d.ts
@@ -1,14 +1,7 @@
-export declare const _MatToolbarMixinBase: CanColorCtor & typeof MatToolbarBase;
-
 export declare class MatToolbar extends _MatToolbarMixinBase implements CanColor, AfterViewInit {
     _toolbarRows: QueryList<MatToolbarRow>;
     constructor(elementRef: ElementRef, _platform: Platform, document?: any);
     ngAfterViewInit(): void;
-}
-
-export declare class MatToolbarBase {
-    _elementRef: ElementRef;
-    constructor(_elementRef: ElementRef);
 }
 
 export declare class MatToolbarModule {

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -1,7 +1,3 @@
-export declare const _MatNestedTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkNestedTreeNode;
-
-export declare const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNode;
-
 export declare class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T> implements AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
     protected _differs: IterableDiffers;
     protected _elementRef: ElementRef<HTMLElement>;


### PR DESCRIPTION
Removes the base classes that are being used to apply mixins from the public API. These classes can't really be consumed outside of Material and exposing them bloats up the public API.