### PR TITLE
feat: run v8 migration schematics for v8 beta and rc releases

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -12,7 +12,7 @@
       "factory": "./ng-update/index#updateToV7"
     },
     "migration-v8": {
-      "version": "8",
+      "version": "8-beta",
       "description": "Updates the Angular CDK to v8",
       "factory": "./ng-update/index#updateToV8"
     },

--- a/src/lib/schematics/migration.json
+++ b/src/lib/schematics/migration.json
@@ -12,7 +12,7 @@
       "factory": "./ng-update/index#updateToV7"
     },
     "migration-v8": {
-      "version": "8",
+      "version": "8-beta",
       "description": "Updates Angular Material to v8",
       "factory": "./ng-update/index#updateToV8"
     },


### PR DESCRIPTION
Currently the V8 schematic migrations only run for `8.0.0` which does not
include any betas or release candidates. We want to run the schematic in
the beta's and RC in order to get early feedback about the schematics. Enabling
it promptly with V8 stable release can result in accidental breakages that we would
like to fix/identify before.