### PR TITLE
refactor(badge): breaking constructor changes for 8.0

### DIFF
--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -8,7 +8,6 @@
 
 import {AriaDescriber} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {DOCUMENT} from '@angular/common';
 import {
   Directive,
   ElementRef,
@@ -119,12 +118,10 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
   private _badgeElement: HTMLElement;
 
   constructor(
-      @Optional() @Inject(DOCUMENT) private _document: any,
       private _ngZone: NgZone,
       private _elementRef: ElementRef<HTMLElement>,
       private _ariaDescriber: AriaDescriber,
-      /** @breaking-change 8.0.0 Make _renderer a required param and remove _document. */
-      private _renderer?: Renderer2,
+      private _renderer: Renderer2,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string) {
       super();
     }
@@ -159,8 +156,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
 
       // When creating a badge through the Renderer, Angular will keep it in an index.
       // We have to destroy it ourselves, otherwise it'll be retained in memory.
-      // @breaking-change 8.0.0 remove _renderer from null.
-      if (this._renderer && this._renderer.destroyNode) {
+      if (this._renderer.destroyNode) {
         this._renderer.destroyNode(badgeElement);
       }
     }
@@ -178,9 +174,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
 
   /** Creates the badge element */
   private _createBadgeElement(): HTMLElement {
-    // @breaking-change 8.0.0 Remove null check for _renderer
-    const rootNode = this._renderer || this._document;
-    const badgeElement = rootNode.createElement('span');
+    const badgeElement = this._renderer.createElement('span');
     const activeClass = 'mat-badge-active';
     const contentClass = 'mat-badge-content';
 

--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -18,6 +18,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15647',
       changes: ['MatFormField', 'MatTabLink', 'MatVerticalStepper']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15757',
+      changes: ['MatBadge']
     }
   ],
 

--- a/tools/public_api_guard/lib/badge.d.ts
+++ b/tools/public_api_guard/lib/badge.d.ts
@@ -10,8 +10,7 @@ export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, O
     overlap: boolean;
     position: MatBadgePosition;
     size: MatBadgeSize;
-    constructor(_document: any, _ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _ariaDescriber: AriaDescriber,
-    _renderer?: Renderer2 | undefined, _animationMode?: string | undefined);
+    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _ariaDescriber: AriaDescriber, _renderer: Renderer2, _animationMode?: string | undefined);
     isAbove(): boolean;
     isAfter(): boolean;
     ngOnChanges(changes: SimpleChanges): void;


### PR DESCRIPTION
Handles the breaking changes in the badge constructor for 8.0.

BREAKING CHANGES:
* `_document` parameter has been removed and the `_renderer` parameter is now required in the `MatBadge` constructor.