### PR TITLE
refactor(progress-spinner): breaking constructor changes for 8.0

### DIFF
--- a/src/lib/progress-spinner/progress-spinner.ts
+++ b/src/lib/progress-spinner/progress-spinner.ts
@@ -139,8 +139,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   private static styleTag: HTMLStyleElement|null = null;
 
   /** Whether the _mat-animation-noopable class should be applied, disabling animations.  */
-  _noopAnimations: boolean = this.animationMode === 'NoopAnimations' && (
-      !!this.defaults && !this.defaults._forceAnimations);
+  _noopAnimations: boolean;
 
   /** The diameter of the progress spinner (will set width and height of svg). */
   @Input()
@@ -175,16 +174,17 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
     this._value = Math.max(0, Math.min(100, coerceNumberProperty(newValue)));
   }
 
-  constructor(public _elementRef: ElementRef,
+  constructor(public _elementRef: ElementRef<HTMLElement>,
               platform: Platform,
               @Optional() @Inject(DOCUMENT) private _document: any,
-              // @breaking-change 8.0.0 animationMode and defaults parameters to be made required.
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) private animationMode?: string,
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
-                  private defaults?: MatProgressSpinnerDefaultOptions) {
+                  defaults?: MatProgressSpinnerDefaultOptions) {
 
     super(_elementRef);
     this._fallbackAnimation = platform.EDGE || platform.TRIDENT;
+    this._noopAnimations = animationMode === 'NoopAnimations' &&
+        (!!defaults && !defaults._forceAnimations);
 
     if (defaults) {
       if (defaults.diameter) {
@@ -291,10 +291,9 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   encapsulation: ViewEncapsulation.None,
 })
 export class MatSpinner extends MatProgressSpinner {
-  constructor(elementRef: ElementRef, platform: Platform,
+  constructor(elementRef: ElementRef<HTMLElement>, platform: Platform,
               @Optional() @Inject(DOCUMENT) document: any,
-              // @breaking-change 8.0.0 animationMode and defaults parameters to be made required.
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
                   defaults?: MatProgressSpinnerDefaultOptions) {
     super(elementRef, platform, document, animationMode, defaults);

--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -26,6 +26,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/issues/15734',
       changes: ['MatButton', 'MatAnchor']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15761',
+      changes: ['MatSpinner', 'MatProgressSpinner']
     }
   ],
 

--- a/tools/public_api_guard/lib/progress-spinner.d.ts
+++ b/tools/public_api_guard/lib/progress-spinner.d.ts
@@ -7,7 +7,7 @@ export declare function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgr
 export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements CanColor {
     readonly _circleRadius: number;
     readonly _circleStrokeWidth: number;
-    _elementRef: ElementRef;
+    _elementRef: ElementRef<HTMLElement>;
     _noopAnimations: boolean;
     readonly _strokeCircumference: number;
     readonly _strokeDashOffset: number | null;
@@ -16,7 +16,7 @@ export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase imp
     mode: ProgressSpinnerMode;
     strokeWidth: number;
     value: number;
-    constructor(_elementRef: ElementRef, platform: Platform, _document: any, animationMode?: string | undefined, defaults?: MatProgressSpinnerDefaultOptions | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
 }
 
 export declare class MatProgressSpinnerBase {
@@ -31,7 +31,7 @@ export interface MatProgressSpinnerDefaultOptions {
 }
 
 export declare class MatSpinner extends MatProgressSpinner {
-    constructor(elementRef: ElementRef, platform: Platform, document: any, animationMode?: string, defaults?: MatProgressSpinnerDefaultOptions);
+    constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
 }
 
 export declare type ProgressSpinnerMode = 'determinate' | 'indeterminate';


### PR DESCRIPTION
Handles the breaking constructor changes for `MatProgressSpinner` and `MatSpinner`. Also takes the chance to remove some unnecessary private properties.

BREAKING CHANGES:
* The `animationMode` mode parameter is now required in the `MatProgressSpinner` and `MatSpinner` constructors.
* The `_elementRef` parameter has changed from `ElementRef<any>` to `ElementRef<HTMLElement>` in the `MatProgressSpinner` and `MatSpinner` constructors.