### PR TITLE
build: disable branch manager check

### DIFF
--- a/.github/branch-manager.yml
+++ b/.github/branch-manager.yml
@@ -1,4 +1,4 @@
-enabled: true
+enabled: false
 
 branches:
   - branchName: 7.3.x


### PR DESCRIPTION
As discussed during the sync, these changes disable the branch manager since it adds a lot of noise.