### PR TITLE
refactor(sidenav): constructor breaking changes for 8.0

### DIFF
--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -46,6 +46,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15806',
       changes: ['MatSlideToggle']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15773',
+      changes: ['MatDrawerContainer']
     }
   ],
 

--- a/src/lib/sidenav/drawer.ts
+++ b/src/lib/sidenav/drawer.ts
@@ -527,13 +527,9 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
               private _element: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
               private _changeDetectorRef: ChangeDetectorRef,
+              viewportRuler: ViewportRuler,
               @Inject(MAT_DRAWER_DEFAULT_AUTOSIZE) defaultAutosize = false,
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string,
-              /**
-               * @deprecated viewportRuler to become a required parameter.
-               * @breaking-change 8.0.0
-               */
-              @Optional() viewportRuler?: ViewportRuler) {
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string) {
 
     // If a `Dir` directive exists up the tree, listen direction changes
     // and update the left/right properties to point to the proper start/end.
@@ -546,11 +542,9 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
 
     // Since the minimum width of the sidenav depends on the viewport width,
     // we need to recompute the margins if the viewport changes.
-    if (viewportRuler) {
-      viewportRuler.change()
-        .pipe(takeUntil(this._destroyed))
-        .subscribe(() => this._updateContentMargins());
-    }
+    viewportRuler.change()
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(() => this._updateContentMargins());
 
     this._autosize = defaultAutosize;
   }

--- a/tools/public_api_guard/lib/sidenav.d.ts
+++ b/tools/public_api_guard/lib/sidenav.d.ts
@@ -54,8 +54,7 @@ export declare class MatDrawerContainer implements AfterContentInit, DoCheck, On
     hasBackdrop: any;
     readonly scrollable: CdkScrollable;
     readonly start: MatDrawer | null;
-    constructor(_dir: Directionality, _element: ElementRef<HTMLElement>, _ngZone: NgZone, _changeDetectorRef: ChangeDetectorRef, defaultAutosize?: boolean, _animationMode?: string | undefined,
-    viewportRuler?: ViewportRuler);
+    constructor(_dir: Directionality, _element: ElementRef<HTMLElement>, _ngZone: NgZone, _changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, defaultAutosize?: boolean, _animationMode?: string | undefined);
     _closeModalDrawer(): void;
     _isShowingBackdrop(): boolean;
     _onBackdropClicked(): void;


### PR DESCRIPTION
Handles the breaking constructor changes for 8.0 in `material/sidenav`.

BREAKING CHANGES:
* `viewportRuler` parameter in `MatDrawerContainer` constructor is now required. Also the parameter order has changed as a result.