### PR TITLE
chore: fix miscellaneous typos in comments

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -46,7 +46,7 @@ type MonitoredElementInfo = {
 
 /**
  * Event listener options that enable capturing and also
- * mark the the listener as passive if the browser supports it.
+ * mark the listener as passive if the browser supports it.
  */
 const captureEventListenerOptions = normalizePassiveListenerOptions({
   passive: true,

--- a/src/cdk/scrolling/virtual-scroll-viewport.scss
+++ b/src/cdk/scrolling/virtual-scroll-viewport.scss
@@ -1,7 +1,7 @@
 // When elements such as `<tr>` or `<li>` are repeated inside the cdk-virtual-scroll-viewport,
 // their container element (e.g. `<table>`, `<ul>`, etc.) needs to be placed in the viewport as
 // well. We reset some properties here to prevent these container elements from introducing
-// additional space that would throw off the the scrolling calculations.
+// additional space that would throw off the scrolling calculations.
 @mixin _cdk-virtual-scroll-clear-container-space($direction) {
   $start: if($direction == horizontal, 'left', 'top');
   $end: if($direction == horizontal, 'right', 'bottom');

--- a/src/module-typings.d.ts
+++ b/src/module-typings.d.ts
@@ -2,7 +2,7 @@
  * Declares the global `module` variable that can be used outside of NodeJS.
  *
  * The module variable will be provided by given module bundlers (like Webpack) and helps
- * Angular to determine assets relatively to the the original file location. All components
+ * Angular to determine assets relatively to the original file location. All components
  * within the CDK and Material specify the `module.id`.
  *
  * **Note**: This file is used by Bazel to build all `ng_module` rules. See `tools/defaults.bzl`.


### PR DESCRIPTION
Fixes a handful of comments where we made some typos by saying "the the".