### PR TITLE
 feat(popover-edit): allow tabbing from popup to next/previous cell

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
+++ b/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
@@ -12,6 +12,7 @@ import {audit, distinctUntilChanged, filter, map, share} from 'rxjs/operators';
 
 import {CELL_SELECTOR, ROW_SELECTOR} from './constants';
 import {closest} from './polyfill';
+import {EditRef} from './edit-ref';
 
 /** The delay between mouse out events and hiding hover content. */
 const DEFAULT_MOUSE_OUT_DELAY_MS = 30;
@@ -29,6 +30,12 @@ export class EditEventDispatcher {
 
   /** A subject that emits mouse move events for table rows. */
   readonly mouseMove = new Subject<Element|null>();
+
+  /** The EditRef for the currently active edit lens (if any). */
+  get editRef(): EditRef<any>|null {
+    return this._editRef;
+  }
+  private _editRef: EditRef<any>|null = null;
 
   /** The table cell that has an active edit lens (or null). */
   private _currentlyEditing: Element|null = null;
@@ -65,6 +72,20 @@ export class EditEventDispatcher {
     if (this._currentlyEditing === cell) {
       this.editing.next(null);
     }
+  }
+
+  /** Sets the currently active EditRef. */
+  setActiveEditRef(ref: EditRef<any>) {
+    this._editRef = ref;
+  }
+
+  /** Unsets the currently active EditRef, if the specified editRef is active. */
+  unsetActiveEditRef(ref: EditRef<any>) {
+    if (this._editRef !== ref) {
+      return;
+    }
+
+    this._editRef = null;
   }
 
   /**

--- a/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
+++ b/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Inject, Injectable, NgZone} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {FocusTrap, InteractivityChecker} from '@angular/cdk/a11y';
+import {Observable, Subject} from 'rxjs';
+
+/** Value indicating whether focus left the target area before or after the enclosed elements. */
+export const enum FocusEscapeNotifierDirection {
+  START,
+  END,
+}
+
+/**
+ * Like FocusTrap, but rather than trapping focus within a dom region, notifies subscribers when
+ * focus leaves the region.
+ */
+export class FocusEscapeNotifier extends FocusTrap {
+  private _escapeSubject = new Subject<FocusEscapeNotifierDirection>();
+
+  constructor(
+      element: HTMLElement,
+      checker: InteractivityChecker,
+      ngZone: NgZone,
+      document: Document) {
+    super(element, checker, ngZone, document, true /* deferAnchors */);
+
+    // The focus trap adds "anchors" at the beginning and end of a trapped region that redirect
+    // focus. We override that redirect behavior here with simply emitting on a stream.
+    this.startAnchorListener = () => {
+      this._escapeSubject.next(FocusEscapeNotifierDirection.START);
+      return true;
+    };
+    this.endAnchorListener = () => {
+      this._escapeSubject.next(FocusEscapeNotifierDirection.END);
+      return true;
+    };
+
+    this.attachAnchors();
+  }
+
+  escapes(): Observable<FocusEscapeNotifierDirection> {
+    return this._escapeSubject.asObservable();
+  }
+}
+
+/** Factory that allows easy instantiation of focus escape notifiers. */
+@Injectable({providedIn: 'root'})
+export class FocusEscapeNotifierFactory {
+  private _document: Document;
+
+  constructor(
+      private _checker: InteractivityChecker,
+      private _ngZone: NgZone,
+      @Inject(DOCUMENT) _document: any) {
+
+    this._document = _document;
+  }
+
+  /**
+   * Creates a focus escape notifier region around the given element.
+   * @param element The element around which focus will be monitored.
+   * @returns The created focus escape notifier instance.
+   */
+  create(element: HTMLElement): FocusEscapeNotifier {
+    return new FocusEscapeNotifier(element, this._checker, this._ngZone, this._document);
+  }
+}

--- a/src/cdk-experimental/popover-edit/lens-directives.ts
+++ b/src/cdk-experimental/popover-edit/lens-directives.ts
@@ -61,6 +61,7 @@ export class CdkEditControl<FormValue> implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.editRef.init(this.preservedFormValue);
     this.editRef.finalValue.subscribe(this.preservedFormValueChange);
+    this.editRef.blurred.subscribe(() => this._handleBlur());
   }
 
   ngOnDestroy(): void {
@@ -97,7 +98,7 @@ export class CdkEditControl<FormValue> implements OnDestroy, OnInit {
     switch (this.clickOutBehavior) {
       case 'submit':
         // Manually cause the form to submit before closing.
-        this.elementRef.nativeElement!.dispatchEvent(new Event('submit'));
+        this._triggerFormSubmit();
         // Fall through
       case 'close':
         this.editRef.close();
@@ -105,6 +106,18 @@ export class CdkEditControl<FormValue> implements OnDestroy, OnInit {
       default:
         break;
     }
+  }
+
+  /** Triggers submit on tab out if clickOutBehavior is 'submit'. */
+  private _handleBlur(): void {
+    if (this.clickOutBehavior === 'submit') {
+      // Manually cause the form to submit before closing.
+      this._triggerFormSubmit();
+    }
+  }
+
+  private _triggerFormSubmit() {
+    this.elementRef.nativeElement!.dispatchEvent(new Event('submit'));
   }
 }
 

--- a/src/cdk-experimental/popover-edit/popover-edit-module.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit-module.ts
@@ -10,6 +10,7 @@ import {NgModule} from '@angular/core';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {
   CdkPopoverEdit,
+  CdkPopoverEditTabOut,
   CdkRowHoverContent,
   CdkEditable,
   CdkEditOpen,
@@ -26,6 +27,7 @@ import {
 
 const EXPORTED_DECLARATIONS = [
   CdkPopoverEdit,
+  CdkPopoverEditTabOut,
   CdkRowHoverContent,
   CdkEditControl,
   CdkEditRevert,

--- a/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.css
+++ b/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.css
@@ -1,0 +1,13 @@
+.example-table {
+  width: 100%;
+}
+
+.example-table th {
+  text-align: left;
+}
+
+.example-table td,
+.example-table th {
+  min-width: 300px;
+  width: 25%;
+}

--- a/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.html
+++ b/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.html
@@ -1,0 +1,56 @@
+<table editable class="example-table">
+  <!--
+    This edit lens is specified outside of the cell and must explicitly declare
+    its context. It could be reused in multiple cells.
+  -->
+  <ng-template #weightEdit let-element>
+    <div style="background-color: white; width: 100%">
+      <form #f="ngForm"
+          cdkEditControl
+          cdkEditControlClickOutBehavior="submit"
+          (ngSubmit)="onSubmitWeight(element, f)"
+          [cdkEditControlPreservedFormValue]="preservedWeightValues.get(element)"
+          (cdkEditControlPreservedFormValueChange)="preservedWeightValues.set(element, $event)">
+        <input type="number" [ngModel]="element.weight" name="weight" required>
+      </form>
+    </div>
+  </ng-template>
+  
+  <tr>
+    <th> No. </th>
+    <th> Name </th>
+    <th> Weight </th>
+    <th> Symbol </th>
+  </tr>
+  
+  <tr *ngFor="let element of elements">
+    <td> {{element.position}} </td>
+    
+    <td [cdkPopoverEdit]="nameEdit" cdkPopoverEditTabOut cdkEditOpen>
+      {{element.name}}
+      
+      <!-- This edit is defined in the cell and can implicitly access element -->
+      <ng-template #nameEdit>
+        <div style="background-color: white; width: 100%">
+          <form #f="ngForm"
+              cdkEditControl
+              cdkEditControlClickOutBehavior="submit"
+              (ngSubmit)="onSubmitName(element, f)"
+              [cdkEditControlPreservedFormValue]="preservedNameValues.get(element)"
+              (cdkEditControlPreservedFormValueChange)="preservedNameValues.set(element, $event)">
+            <input [ngModel]="element.name" name="name" required>
+            <br>
+            <button type="submit">Confirm</button>
+          </form>
+        </div>
+      </ng-template>
+    </td>
+
+    <td [cdkPopoverEdit]="weightEdit" [cdkPopoverEditContext]="element"
+        cdkPopoverEditTabOut cdkEditOpen>
+      {{element.weight}}
+    </td>
+
+    <td> {{element.symbol}} </td>
+  </tr>
+</table>

--- a/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.ts
+++ b/src/material-examples/cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example.ts
@@ -1,0 +1,59 @@
+import {Component} from '@angular/core';
+import {NgForm} from '@angular/forms';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+  {position: 11, name: 'Sodium', weight: 22.9897, symbol: 'Na'},
+  {position: 12, name: 'Magnesium', weight: 24.305, symbol: 'Mg'},
+  {position: 13, name: 'Aluminum', weight: 26.9815, symbol: 'Al'},
+  {position: 14, name: 'Silicon', weight: 28.0855, symbol: 'Si'},
+  {position: 15, name: 'Phosphorus', weight: 30.9738, symbol: 'P'},
+  {position: 16, name: 'Sulfur', weight: 32.065, symbol: 'S'},
+  {position: 17, name: 'Chlorine', weight: 35.453, symbol: 'Cl'},
+  {position: 18, name: 'Argon', weight: 39.948, symbol: 'Ar'},
+  {position: 19, name: 'Potassium', weight: 39.0983, symbol: 'K'},
+  {position: 20, name: 'Calcium', weight: 40.078, symbol: 'Ca'},
+];
+
+/**
+ * @title CDK Popover Edit with spreadsheet-like configuration on an HTML data-table
+ */
+@Component({
+  selector: 'cdk-popover-edit-tab-out-vanilla-table-example',
+  styleUrls: ['cdk-popover-edit-tab-out-vanilla-table-example.css'],
+  templateUrl: 'cdk-popover-edit-tab-out-vanilla-table-example.html',
+})
+export class CdkPopoverEditTabOutVanillaTableExample {
+  readonly preservedNameValues = new WeakMap<PeriodicElement, any>();
+  readonly preservedWeightValues = new WeakMap<PeriodicElement, any>();
+
+  readonly elements = ELEMENT_DATA;
+
+  onSubmitName(element: PeriodicElement, f: NgForm) {
+    if (!f.valid) { return; }
+
+    element.name = f.value.name;
+  }
+
+  onSubmitWeight(element: PeriodicElement, f: NgForm) {
+    if (!f.valid) { return; }
+
+    element.weight = f.value.weight;
+  }
+}


### PR DESCRIPTION
Includes a demo of how this allows a more spreadsheet-like set of user interactions when combined with some of Popover Edit's other features.