### PR TITLE
 perf(popover-edit): collect common services into a single class for dependency injection

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-services.ts
+++ b/src/cdk-experimental/popover-edit/edit-services.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, NgZone} from '@angular/core';
+import {FocusTrapFactory} from '@angular/cdk/a11y';
+import {Overlay} from '@angular/cdk/overlay';
+import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
+
+import {EditEventDispatcher} from './edit-event-dispatcher';
+import {FocusDispatcher} from './focus-dispatcher';
+import {PopoverEditPositionStrategyFactory} from './popover-edit-position-strategy-factory';
+
+/**
+ * Optimization
+ * Collects multiple Injectables into a singleton shared across the table. By reducing the
+ * number of services injected into each CdkPopoverEdit, this saves about 0.023ms of cpu time
+ * and 56 bytes of memory per instance.
+ */
+@Injectable()
+export class EditServices {
+  constructor(
+      readonly editEventDispatcher: EditEventDispatcher, readonly focusDispatcher: FocusDispatcher,
+      readonly focusTrapFactory: FocusTrapFactory, readonly ngZone: NgZone,
+      readonly overlay: Overlay, readonly positionFactory: PopoverEditPositionStrategyFactory,
+      readonly scrollDispatcher: ScrollDispatcher, readonly viewportRuler: ViewportRuler) {}
+}

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -316,7 +316,7 @@ const testCases: ReadonlyArray<[Type<BaseTestComponent>, string]> = [
 ];
 
 describe('CDK Popover Edit', () => {
-  for (const [componentClass, label] of testCases.slice(0, 1)) {
+  for (const [componentClass, label] of testCases) {
     describe(label, () => {
       let component: BaseTestComponent;
       let fixture: ComponentFixture<BaseTestComponent>;


### PR DESCRIPTION
I measured a savings of 0.023ms per CdkPopoverEdit instance at startup, roughly a 10% improvement in script time. There should
be additional savings in CdkRowHoverContent that I did not measure.