### PR TITLE
fix(drag-drop): not reacting to changes in the cdkDragFreeDragPosition

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -816,6 +816,21 @@ describe('CdkDrag', () => {
       expect(dragInstance.getFreeDragPosition()).toEqual({x: 50, y: 100});
     }));
 
+    it('should react to changes in the free drag position', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.componentInstance.freeDragPosition = {x: 50, y: 100};
+      fixture.detectChanges();
+
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      expect(dragElement.style.transform).toBe('translate3d(50px, 100px, 0px)');
+
+      fixture.componentInstance.freeDragPosition = {x: 100, y: 200};
+      fixture.detectChanges();
+
+      expect(dragElement.style.transform).toBe('translate3d(100px, 200px, 0px)');
+    }));
+
     it('should be able to continue dragging after the current position was set', fakeAsync(() => {
       const fixture = createComponent(StandaloneDraggable);
       fixture.componentInstance.freeDragPosition = {x: 50, y: 100};

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -258,7 +258,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges) {
     const rootSelectorChange = changes['rootElementSelector'];
-    const positionChange = changes['positionChange'];
+    const positionChange = changes['freeDragPosition'];
 
     // We don't have to react to the first change since it's being
     // handled in `ngAfterViewInit` where it needs to be deferred.


### PR DESCRIPTION
Fixes the `CdkDrag` not reacting to changes in the `cdkDragFreeDragPosition` input, because we had mispelled something and it wasn't caught by TS since `SimpleChanges` isn't typed.

Fixes #15765.

**Note:** marking as P2, because this one of the new features in 8.0 that has been requested a lot and the fix should be fairly safe to presubmit.