### PR TITLE
refactor(slide-toggle): constructor breaking changes for 8.0

### DIFF
--- a/src/lib/schematics/ng-update/data/constructor-checks.ts
+++ b/src/lib/schematics/ng-update/data/constructor-checks.ts
@@ -42,6 +42,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/material2/pull/15737',
       changes: ['MatTabHeader', 'MatTabBody']
+    },
+    {
+      pr: 'https://github.com/angular/material2/pull/15806',
+      changes: ['MatSlideToggle']
     }
   ],
 

--- a/src/lib/slide-toggle/BUILD.bazel
+++ b/src/lib/slide-toggle/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
     "//src/cdk/bidi",
     "//src/cdk/coercion",
     "//src/cdk/observers",
-    "//src/cdk/platform",
     "//src/lib/core",
   ],
 )

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -9,7 +9,6 @@
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Platform} from '@angular/cdk/platform';
 import {
   AfterContentInit,
   Attribute,
@@ -185,11 +184,6 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   @ViewChild('input', {static: false}) _inputElement: ElementRef<HTMLInputElement>;
 
   constructor(elementRef: ElementRef,
-              /**
-               * @deprecated The `_platform` parameter to be removed.
-               * @breaking-change 8.0.0
-               */
-              _platform: Platform,
               private _focusMonitor: FocusMonitor,
               private _changeDetectorRef: ChangeDetectorRef,
               @Attribute('tabindex') tabIndex: string,

--- a/tools/public_api_guard/lib/slide-toggle.d.ts
+++ b/tools/public_api_guard/lib/slide-toggle.d.ts
@@ -21,8 +21,7 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     name: string | null;
     required: boolean;
     readonly toggleChange: EventEmitter<void>;
-    constructor(elementRef: ElementRef,
-    _platform: Platform, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, _ngZone: NgZone, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined, _dir?: Directionality | undefined);
+    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, _ngZone: NgZone, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined, _dir?: Directionality | undefined);
     _onChangeEvent(event: Event): void;
     _onDrag(event: HammerInput): void;
     _onDragEnd(): void;


### PR DESCRIPTION
Goes through the breaking constructor changes in `material/slide-toggle` for 8.0

BREAKING CHANGES:
* `_platform` parameter has been removed from the `MatSlideToggle` constructor.