### PR TITLE
build: wire up dev-server for ivy demo-app

### DIFF
--- a/scripts/ivy/README.md
+++ b/scripts/ivy/README.md
@@ -21,7 +21,7 @@ Once that step is complete, the demo application can be built.
 # Build the demo-app with Ivy
 $ ./scripts/ivy/build.sh
 # And serve it
-$ cd dist/demo && http-server
+$ yarn gulp ivy-serve
 ```
 
 ## Known issues

--- a/scripts/ivy/build.sh
+++ b/scripts/ivy/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+distPath="dist/ivy-demo-app"
+
 echo ">>> Build Material"
 rm -rf dist
 yarn gulp build:devapp
@@ -13,13 +15,14 @@ echo ">>> Bundling dev-app with Rollup"
 node ./src/dev-app/rollup-bundles.js
 
 echo ">>> Copying assets to output"
-cp src/dev-app/index.html dist/demo
-cp dist/packages/dev-app/theme.css dist/demo
-cp 'node_modules/@webcomponents/custom-elements/custom-elements.min.js' dist/demo
-cp node_modules/core-js/client/core.js dist/demo
-cp node_modules/requirejs/require.js dist/demo
-cp node_modules/zone.js/dist/zone.js dist/demo
-cp node_modules/hammerjs/hammer.min.js dist/demo
+cp src/dev-app/index.html ${distPath}
+cp dist/packages/dev-app/theme.css ${distPath}
+cp 'node_modules/@webcomponents/custom-elements/custom-elements.min.js' ${distPath}
+cp node_modules/core-js/client/core.js ${distPath}
+cp node_modules/requirejs/require.js ${distPath}
+cp node_modules/zone.js/dist/zone.js ${distPath}
+cp node_modules/hammerjs/hammer.min.js ${distPath}
 
 echo ">>> Done."
-echo "Output: $(pwd)/dist/demo"
+echo "Output: $(pwd)/${distPath}"
+echo "Serve the Ivy demo-app with: yarn gulp ivy-serve"

--- a/src/dev-app/rollup-bundles.js
+++ b/src/dev-app/rollup-bundles.js
@@ -60,7 +60,7 @@ async function main() {
   await build.write({
     format: 'amd',
     name: 'dev-app',
-    dir: 'dist/demo/',
+    dir: 'dist/ivy-demo-app/',
     entryFileNames: '[name].js',
     exports: 'named',
   });

--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -28,6 +28,7 @@ import './tasks/lint';
 import './tasks/material-release';
 import './tasks/unit-test';
 import './tasks/universal';
+import './tasks/ivy-serve';
 
 /** Task that builds all available release packages. */
 task('build-release-packages', sequenceTask(

--- a/tools/gulp/tasks/ivy-serve.ts
+++ b/tools/gulp/tasks/ivy-serve.ts
@@ -1,0 +1,7 @@
+import {buildConfig} from '../../package-tools';
+import {serverTask} from '../util/task-helpers';
+import {join} from 'path';
+import {task} from 'gulp';
+
+/** Serves the previously built Ivy demo-app in the output directory. */
+task('ivy-serve', serverTask(join(buildConfig.outputDir, 'ivy-demo-app')));


### PR DESCRIPTION
Currently everyone uses their own http-server in order to serve
the ivy demo-app. The issue is that most of these http-servers do
not support the HTML5 history API and therfore reloading examples
is not possible as it would result in the http-server directory listing.