### PR TITLE
Add max value to matBadge, closes #15829

### DIFF
--- a/src/dev-app/badge/badge-demo.html
+++ b/src/dev-app/badge/badge-demo.html
@@ -30,6 +30,10 @@
       Hidden
     </span>
 
+    <span [matBadge]="badgeContent" [matBadgeMax]="badgeMax">
+      Max value
+    </span>
+
     <input type="text" [(ngModel)]="badgeContent" />
     <button (click)="visible = !visible">Toggle</button>
   </div>

--- a/src/dev-app/badge/badge-demo.ts
+++ b/src/dev-app/badge/badge-demo.ts
@@ -17,4 +17,5 @@ import {Component} from '@angular/core';
 export class BadgeDemo {
   visible = true;
   badgeContent = '0';
+  badgeMax = 99;
 }

--- a/src/lib/badge/badge.md
+++ b/src/lib/badge/badge.md
@@ -51,6 +51,22 @@ background color to `primary`, `accent`, or `warn`.
 </mat-icon>
 ```
 
+### Badge max value
+The max value badge can display can be set via `matBadgeMax` tag. Max property will be applied only
+when the badge's content is numeric. If `matBadgeMax` tag is applied and contend exceed the max value
+badge will show max value and plus symbol
+```html
+<mat-icon matBadge="22" matBadgeMax=99>
+  home
+</mat-icon>
+```
+
+```html
+<mat-icon matBadge="22" matBadgeColor="accent">
+  home
+</mat-icon>
+```
+
 ### Accessibility
 Badges should be given a meaningful description via `matBadgeDescription`. This description will be
 applied, via `aria-describedby` to the element decorated by `matBadge`.

--- a/src/lib/badge/badge.md
+++ b/src/lib/badge/badge.md
@@ -52,9 +52,9 @@ background color to `primary`, `accent`, or `warn`.
 ```
 
 ### Badge max value
-The max value badge can display can be set via `matBadgeMax` tag. Max property will be applied only
-when the badge's content is numeric. If `matBadgeMax` tag is applied and contend exceed the max value
-badge will show max value and plus symbol
+The `max` value badge can display can be set via `matBadgeMax` tag. `max` property will be applied only
+when the badge's content is numeric. If `matBadgeMax` tag is applied and contend exceed the `max` value
+badge will show `max` value and plus symbol
 ```html
 <mat-icon matBadge="22" matBadgeMax=99>
   home

--- a/src/lib/badge/badge.spec.ts
+++ b/src/lib/badge/badge.spec.ts
@@ -4,7 +4,7 @@ import {By} from '@angular/platform-browser';
 import {MatBadge, MatBadgeModule} from './index';
 import {ThemePalette} from '@angular/material/core';
 
-fdescribe('MatBadge', () => {
+describe('MatBadge', () => {
   let fixture: ComponentFixture<any>;
   let testComponent: BadgeTestApp;
   let badgeNativeElement: HTMLElement;

--- a/src/lib/badge/badge.spec.ts
+++ b/src/lib/badge/badge.spec.ts
@@ -4,7 +4,7 @@ import {By} from '@angular/platform-browser';
 import {MatBadge, MatBadgeModule} from './index';
 import {ThemePalette} from '@angular/material/core';
 
-describe('MatBadge', () => {
+fdescribe('MatBadge', () => {
   let fixture: ComponentFixture<any>;
   let testComponent: BadgeTestApp;
   let badgeNativeElement: HTMLElement;
@@ -200,6 +200,44 @@ describe('MatBadge', () => {
     expect(preExistingFixture.nativeElement.querySelectorAll('.mat-badge-content').length).toBe(2);
   });
 
+  it('should update badge based on max value', () => {
+    let badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+
+    expect(badgeContentDebugElement.textContent).toContain('1');
+
+    testComponent.badgeMax = 99;
+    testComponent.badgeContent = '90';
+    fixture.detectChanges();
+
+    badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+    expect(badgeContentDebugElement.textContent).toContain('90');
+
+    testComponent.badgeContent = '100';
+    fixture.detectChanges();
+
+    badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+    expect(badgeContentDebugElement.textContent).toContain('99+');
+  });
+
+  it('should not update badge based on max value when content in not numeric', () => {
+    let badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+
+    expect(badgeContentDebugElement.textContent).toContain('1');
+
+    testComponent.badgeMax = 99;
+    testComponent.badgeContent = 'MVP';
+    fixture.detectChanges();
+
+    badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+    expect(badgeContentDebugElement.textContent).toContain('MVP');
+
+    testComponent.badgeContent = '100A';
+    fixture.detectChanges();
+
+    badgeContentDebugElement = badgeNativeElement.querySelector('.mat-badge-content')!;
+    expect(badgeContentDebugElement.textContent).toContain('100A');
+  });
+
 });
 
 /** Test component that contains a MatBadge. */
@@ -215,7 +253,8 @@ describe('MatBadge', () => {
           [matBadgeSize]="badgeSize"
           [matBadgeOverlap]="badgeOverlap"
           [matBadgeDescription]="badgeDescription"
-          [matBadgeDisabled]="badgeDisabled">
+          [matBadgeDisabled]="badgeDisabled"
+          [matBadgeMax]="badgeMax">
       home
     </span>
   `
@@ -229,6 +268,7 @@ class BadgeTestApp {
   badgeOverlap = false;
   badgeDescription: string;
   badgeDisabled = false;
+  badgeMax: number;
 }
 
 

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { AriaDescriber } from '@angular/cdk/a11y';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import {AriaDescriber} from '@angular/cdk/a11y';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
@@ -20,8 +20,8 @@ import {
   Renderer2,
   SimpleChanges,
 } from '@angular/core';
-import { CanDisable, CanDisableCtor, mixinDisabled, ThemePalette } from '@angular/material/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
+import {CanDisable, CanDisableCtor, mixinDisabled, ThemePalette} from '@angular/material/core';
+import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
 let nextId = 0;

--- a/src/lib/badge/badge.ts
+++ b/src/lib/badge/badge.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AriaDescriber} from '@angular/cdk/a11y';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import { AriaDescriber } from '@angular/cdk/a11y';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
@@ -20,18 +20,18 @@ import {
   Renderer2,
   SimpleChanges,
 } from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled, ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
+import { CanDisable, CanDisableCtor, mixinDisabled, ThemePalette } from '@angular/material/core';
+import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 
 
 let nextId = 0;
 
 // Boilerplate for applying mixins to MatBadge.
 /** @docs-private */
-export class MatBadgeBase {}
+export class MatBadgeBase { }
 
 export const _MatBadgeMixinBase:
-    CanDisableCtor & typeof MatBadgeBase = mixinDisabled(MatBadgeBase);
+  CanDisableCtor & typeof MatBadgeBase = mixinDisabled(MatBadgeBase);
 
 export type MatBadgePosition = 'above after' | 'above before' | 'below before' | 'below after';
 export type MatBadgeSize = 'small' | 'medium' | 'large';
@@ -95,7 +95,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
 
       if (badgeElement) {
         newDescription ? badgeElement.setAttribute('aria-label', newDescription) :
-            badgeElement.removeAttribute('aria-label');
+          badgeElement.removeAttribute('aria-label');
       }
     }
   }
@@ -112,19 +112,22 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
   }
   private _hidden: boolean;
 
+  /** Max value to show in the badge */
+  @Input('matBadgeMax') max: number;
+
   /** Unique id for the badge */
   _id: number = nextId++;
 
   private _badgeElement: HTMLElement;
 
   constructor(
-      private _ngZone: NgZone,
-      private _elementRef: ElementRef<HTMLElement>,
-      private _ariaDescriber: AriaDescriber,
-      private _renderer: Renderer2,
-      @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string) {
-      super();
-    }
+    private _ngZone: NgZone,
+    private _elementRef: ElementRef<HTMLElement>,
+    private _ariaDescriber: AriaDescriber,
+    private _renderer: Renderer2,
+    @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string) {
+    super();
+  }
 
   /** Whether the badge is above the host or not */
   isAbove(): boolean {
@@ -167,7 +170,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
     if (!this._badgeElement) {
       this._badgeElement = this._createBadgeElement();
     } else {
-      this._badgeElement.textContent = this.content;
+      this._badgeElement.textContent = this._applyMax();
     }
     return this._badgeElement;
   }
@@ -182,7 +185,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
     this._clearExistingBadges(contentClass);
     badgeElement.setAttribute('id', `mat-badge-content-${this._id}`);
     badgeElement.classList.add(contentClass);
-    badgeElement.textContent = this.content;
+    badgeElement.textContent = this._applyMax();
 
     if (this._animationMode === 'NoopAnimations') {
       badgeElement.classList.add('_mat-animation-noopable');
@@ -247,5 +250,18 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
         element.removeChild(currentChild);
       }
     }
+  }
+
+  /** Creates string according to max value if one is set */
+  private _applyMax(): string {
+    let numericContent: number = Number(this.content);
+    let result = this.content;
+    if (this.max && this.content.length > 0 && !isNaN(numericContent)) {
+      if (this.max < numericContent) {
+        result = `${this.max}+`;
+      }
+    }
+
+    return result;
   }
 }

--- a/tools/public_api_guard/lib/badge.d.ts
+++ b/tools/public_api_guard/lib/badge.d.ts
@@ -7,10 +7,10 @@ export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, O
     content: string;
     description: string;
     hidden: boolean;
+    max: number;
     overlap: boolean;
     position: MatBadgePosition;
     size: MatBadgeSize;
-    max: number;
     constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _ariaDescriber: AriaDescriber, _renderer: Renderer2, _animationMode?: string | undefined);
     isAbove(): boolean;
     isAfter(): boolean;

--- a/tools/public_api_guard/lib/badge.d.ts
+++ b/tools/public_api_guard/lib/badge.d.ts
@@ -10,6 +10,7 @@ export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, O
     overlap: boolean;
     position: MatBadgePosition;
     size: MatBadgeSize;
+    max: number;
     constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _ariaDescriber: AriaDescriber, _renderer: Renderer2, _animationMode?: string | undefined);
     isAbove(): boolean;
     isAfter(): boolean;


### PR DESCRIPTION
Add `max` input to `matBadge`. This will allow developer to set max value for the component. If `content` of `matBadge` exceeds the `max` the `matBadge` will show `{max}+`, e.g. 99+.

Closes: #15829 