### PR TITLE
bugfix(mat-tab-label) align min-width with specification

### DIFF
--- a/src/lib/tabs/_tabs-common.scss
+++ b/src/lib/tabs/_tabs-common.scss
@@ -2,6 +2,7 @@
 @import '../../cdk/a11y/a11y';
 
 $mat-tab-bar-height: 48px !default;
+$mat-min-width-height: 90px !default;
 $mat-tab-animation-duration: 500ms !default;
 
 // Mixin styles for labels that are contained within the tab header.
@@ -11,7 +12,7 @@ $mat-tab-animation-duration: 500ms !default;
   cursor: pointer;
   box-sizing: border-box;
   opacity: 0.6;
-  min-width: 160px;
+  min-width: $mat-min-width-height;
   text-align: center;
   display: inline-flex;
   justify-content: center;

--- a/src/lib/tabs/tab-header.scss
+++ b/src/lib/tabs/tab-header.scss
@@ -14,12 +14,6 @@
   position: relative;
 }
 
-@media ($mat-xsmall) {
-  .mat-tab-label {
-    min-width: 72px;
-  }
-}
-
 // The ink bar that displays under the active tab label
 .mat-ink-bar {
   @include ink-bar;

--- a/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/lib/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -42,13 +42,6 @@
   }
 }
 
-
-@media ($mat-xsmall) {
-  .mat-tab-link {
-    min-width: 72px;
-  }
-}
-
 // Styling for the ink bar that displays near the activated anchor
 .mat-ink-bar {
   @include ink-bar;


### PR DESCRIPTION
align `tab-label` `min-width` property with component specification

fixes issue: https://github.com/angular/material2/issues/15864