### PR TITLE
fix(autocomplete): make template ViewChild query `static: true`

### DIFF
--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -104,8 +104,12 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   get isOpen(): boolean { return this._isOpen && this.showPanel; }
   _isOpen: boolean = false;
 
+  // The @ViewChild query for TemplateRef here needs to be static because some code paths
+  // lead to the overlay being created before change detection has finished for this component.
+  // Notably, another component may trigger `focus` on the autocomplete-trigger.
+
   /** @docs-private */
-  @ViewChild(TemplateRef, {static: false}) template: TemplateRef<any>;
+  @ViewChild(TemplateRef, {static: true}) template: TemplateRef<any>;
 
   /** Element for the panel containing the autocomplete options. */
   @ViewChild('panel', {static: false}) panel: ElementRef;


### PR DESCRIPTION
The `@ViewChild` query for TemplateRef here needs to be static because some code paths lead to the overlay being created before change detection has finished for this component. Notably, another component may trigger `focus` on the autocomplete-trigger.